### PR TITLE
Rollup of 16 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2254,7 @@ dependencies = [
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-workspace-hack 1.0.0",
  "rustc_tools_util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustfmt-nightly 1.2.0",
+ "rustfmt-nightly 1.2.1",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_ignored 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3038,8 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
+ "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo_metadata 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3049,6 +3058,7 @@ dependencies = [
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3061,7 +3071,7 @@ dependencies = [
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3987,6 +3997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ammonia 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd4c682378117e4186a492b2252b9537990e1617f44aed9788b9a1149de45477"
+"checksum annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1268,11 +1268,11 @@ impl Step for Compiletest {
         builder.add_rust_test_threads(&mut cmd);
 
         if builder.config.sanitizers {
-            cmd.env("SANITIZER_SUPPORT", "1");
+            cmd.env("RUSTC_SANITIZER_SUPPORT", "1");
         }
 
         if builder.config.profiler {
-            cmd.env("PROFILER_SUPPORT", "1");
+            cmd.env("RUSTC_PROFILER_SUPPORT", "1");
         }
 
         cmd.env("RUST_TEST_TMPDIR", builder.out.join("tmp"));

--- a/src/liballoc/fmt.rs
+++ b/src/liballoc/fmt.rs
@@ -343,9 +343,10 @@
 //! * `^` - the argument is center-aligned in `width` columns
 //! * `>` - the argument is right-aligned in `width` columns
 //!
-//! Note that alignment may not be implemented by some types. A good way
-//! to ensure padding is applied is to format your input, then use this
-//! resulting string to pad your output.
+//! Note that alignment may not be implemented by some types. In particular, it
+//! is not generally implemented for the `Debug` trait.  A good way to ensure
+//! padding is applied is to format your input, then use this resulting string
+//! to pad your output.
 //!
 //! ## Sign/`#`/`0`
 //!

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1790,6 +1790,17 @@ impl<I> DoubleEndedIterator for Fuse<I> where I: DoubleEndedIterator {
     }
 
     #[inline]
+    default fn nth_back(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
+        if self.done {
+            None
+        } else {
+            let nth = self.iter.nth_back(n);
+            self.done = nth.is_none();
+            nth
+        }
+    }
+
+    #[inline]
     default fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R where
         Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
     {
@@ -1875,6 +1886,11 @@ impl<I> DoubleEndedIterator for Fuse<I>
     #[inline]
     fn next_back(&mut self) -> Option<<I as Iterator>::Item> {
         self.iter.next_back()
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<<I as Iterator>::Item> {
+        self.iter.nth_back(n)
     }
 
     #[inline]

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -981,6 +981,16 @@ impl<I> DoubleEndedIterator for Enumerate<I> where
     }
 
     #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<(usize, <I as Iterator>::Item)> {
+        self.iter.nth_back(n).map(|a| {
+            let len = self.iter.len();
+            // Can safely add, `ExactSizeIterator` promises that the number of
+            // elements fits into a `usize`.
+            (self.count + len, a)
+        })
+    }
+
+    #[inline]
     fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, mut fold: Fold) -> R where
         Self: Sized, Fold: FnMut(Acc, Self::Item) -> R, R: Try<Ok=Acc>
     {

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -838,7 +838,7 @@ impl<T> [T] {
     }
 
     /// Returns an iterator over `chunk_size` elements of the slice at a time, starting at the
-    /// beginning of the slice.
+    /// end of the slice.
     ///
     /// The chunks are slices and do not overlap. If `chunk_size` does not divide the length of the
     /// slice, then the last up to `chunk_size-1` elements will be omitted and can be retrieved
@@ -849,7 +849,7 @@ impl<T> [T] {
     ///
     /// See [`rchunks`] for a variant of this iterator that also returns the remainder as a smaller
     /// chunk, and [`chunks_exact`] for the same iterator but starting at the beginning of the
-    /// slice of the slice.
+    /// slice.
     ///
     /// # Panics
     ///
@@ -890,7 +890,7 @@ impl<T> [T] {
     ///
     /// See [`rchunks_mut`] for a variant of this iterator that also returns the remainder as a
     /// smaller chunk, and [`chunks_exact_mut`] for the same iterator but starting at the beginning
-    /// of the slice of the slice.
+    /// of the slice.
     ///
     /// # Panics
     ///

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -796,6 +796,11 @@ impl DoubleEndedIterator for Bytes<'_> {
     }
 
     #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.0.nth_back(n)
+    }
+
+    #[inline]
     fn rfind<P>(&mut self, predicate: P) -> Option<Self::Item> where
         P: FnMut(&Self::Item) -> bool
     {

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -390,6 +390,24 @@ fn test_iterator_enumerate_nth() {
 }
 
 #[test]
+fn test_iterator_enumerate_nth_back() {
+    let xs = [0, 1, 2, 3, 4, 5];
+    let mut it = xs.iter().enumerate();
+    while let Some((i, &x)) = it.nth_back(0) {
+        assert_eq!(i, x);
+    }
+
+    let mut it = xs.iter().enumerate();
+    while let Some((i, &x)) = it.nth_back(1) {
+        assert_eq!(i, x);
+    }
+
+    let (i, &x) = xs.iter().enumerate().nth_back(3).unwrap();
+    assert_eq!(i, x);
+    assert_eq!(i, 2);
+}
+
+#[test]
 fn test_iterator_enumerate_count() {
     let xs = [0, 1, 2, 3, 4, 5];
     assert_eq!(xs.iter().enumerate().count(), 6);

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -57,6 +57,14 @@ impl<'a> FnKind<'a> {
             FnKind::Closure(attrs) => attrs,
         }
     }
+
+    pub fn header(&self) -> Option<FnHeader> {
+        match *self {
+            FnKind::ItemFn(_, _, header, _, _) => Some(header),
+            FnKind::Method(_, sig, _, _) => Some(sig.header),
+            FnKind::Closure(_) => None,
+        }
+    }
 }
 
 /// Specifies what nested things a visitor wants to visit. The most

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -175,27 +175,15 @@ impl<'a> FnLikeNode<'a> {
     }
 
     pub fn constness(self) -> ast::Constness {
-        match self.kind() {
-            FnKind::ItemFn(_, _, header, ..) => header.constness,
-            FnKind::Method(_, m, ..) => m.header.constness,
-            _ => ast::Constness::NotConst
-        }
+        self.kind().header().map_or(ast::Constness::NotConst, |header| header.constness)
     }
 
     pub fn asyncness(self) -> ast::IsAsync {
-        match self.kind() {
-            FnKind::ItemFn(_, _, header, ..) => header.asyncness,
-            FnKind::Method(_, m, ..) => m.header.asyncness,
-            _ => ast::IsAsync::NotAsync
-        }
+        self.kind().header().map_or(ast::IsAsync::NotAsync, |header| header.asyncness)
     }
 
     pub fn unsafety(self) -> ast::Unsafety {
-        match self.kind() {
-            FnKind::ItemFn(_, _, header, ..) => header.unsafety,
-            FnKind::Method(_, m, ..) => m.header.unsafety,
-            _ => ast::Unsafety::Normal
-        }
+        self.kind().header().map_or(ast::Unsafety::Normal, |header| header.unsafety)
     }
 
     pub fn kind(self) -> FnKind<'a> {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -165,6 +165,10 @@ pub struct Session {
 
     /// `Span`s of trait methods that weren't found to avoid emitting object safety errors
     pub trait_methods_not_found: Lock<FxHashSet<Span>>,
+
+    /// Mapping from ident span to path span for paths that don't exist as written, but that
+    /// exist under `std`. For example, wrote `str::from_utf8` instead of `std::str::from_utf8`.
+    pub confused_type_with_std_module: Lock<FxHashMap<Span, Span>>,
 }
 
 pub struct PerfStats {
@@ -1248,6 +1252,7 @@ fn build_session_(
         has_panic_handler: Once::new(),
         driver_lint_caps,
         trait_methods_not_found: Lock::new(Default::default()),
+        confused_type_with_std_module: Lock::new(Default::default()),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -638,6 +638,18 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         let OnUnimplementedNote { message, label, note }
                             = self.on_unimplemented_note(trait_ref, obligation);
                         let have_alt_message = message.is_some() || label.is_some();
+                        let is_try = self.tcx.sess.source_map().span_to_snippet(span)
+                            .map(|s| &s == "?")
+                            .unwrap_or(false);
+                        let is_from = format!("{}", trait_ref).starts_with("std::convert::From<");
+                        let message = if is_try && is_from {
+                            Some(format!(
+                                "`?` couldn't convert the error to `{}`",
+                                trait_ref.self_ty(),
+                            ))
+                        } else {
+                            message
+                        };
 
                         let mut err = struct_span_err!(
                             self.tcx.sess,

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1382,7 +1382,6 @@ extern "C" {
     pub fn LLVMRustDebugMetadataVersion() -> u32;
     pub fn LLVMRustVersionMajor() -> u32;
     pub fn LLVMRustVersionMinor() -> u32;
-    pub fn LLVMRustIsRustLLVM() -> bool;
 
     pub fn LLVMRustAddModuleFlag(M: &Module, name: *const c_char, value: u32);
 

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -154,6 +154,7 @@ const X86_WHITELIST: &[(&str, Option<&str>)] = &[
     ("popcnt", None),
     ("rdrand", None),
     ("rdseed", None),
+    ("rtm", Some("rtm_target_feature")),
     ("sha", None),
     ("sse", None),
     ("sse2", None),

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -61,7 +61,7 @@ unsafe fn configure_llvm(sess: &Session) {
         if sess.opts.debugging_opts.disable_instrumentation_preinliner {
             add("-disable-preinline");
         }
-        if llvm::LLVMRustIsRustLLVM() {
+        if get_major_version() >= 8 {
             match sess.opts.debugging_opts.merge_functions
                   .unwrap_or(sess.target.target.options.merge_functions) {
                 MergeFunctions::Disabled |

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -166,16 +166,18 @@ impl<'a> Resolver<'a> {
                 let self_is_available = self.self_value_is_available(path[0].ident.span, span);
                 match candidate {
                     AssocSuggestion::Field => {
-                        err.span_suggestion(
-                            span,
-                            "try",
-                            format!("self.{}", path_str),
-                            Applicability::MachineApplicable,
-                        );
-                        if !self_is_available {
-                            err.span_label(span, format!("`self` value is a keyword \
-                                                         only available in \
-                                                         methods with `self` parameter"));
+                        if self_is_available {
+                            err.span_suggestion(
+                                span,
+                                "you might have meant to use the available field",
+                                format!("self.{}", path_str),
+                                Applicability::MachineApplicable,
+                            );
+                        } else {
+                            err.span_label(
+                                span,
+                                format!("a field by this name exists in `Self::{}`", path_str),
+                            );
                         }
                     }
                     AssocSuggestion::MethodWithSelf if self_is_available => {

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -176,7 +176,7 @@ impl<'a> Resolver<'a> {
                         } else {
                             err.span_label(
                                 span,
-                                format!("a field by this name exists in `Self::{}`", path_str),
+                                "a field by this name exists in `Self`",
                             );
                         }
                     }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -938,10 +938,12 @@ fn check_variances_for_type_defn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                         .map(|(index, _)| Parameter(index as u32))
                         .collect();
 
-    identify_constrained_generic_params(tcx,
-                                     &ty_predicates,
-                                     None,
-                                     &mut constrained_parameters);
+    identify_constrained_generic_params(
+        tcx,
+        &ty_predicates,
+        None,
+        &mut constrained_parameters,
+    );
 
     for (index, _) in variances.iter().enumerate() {
         if constrained_parameters.contains(&Parameter(index as u32)) {
@@ -949,6 +951,7 @@ fn check_variances_for_type_defn<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
 
         let param = &hir_generics.params[index];
+
         match param.name {
             hir::ParamName::Error => { }
             _ => report_bivariance(tcx, param.span, param.name.ident().name),
@@ -1123,7 +1126,7 @@ fn error_392<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, span: Span, param_name: ast:
                        -> DiagnosticBuilder<'tcx> {
     let mut err = struct_span_err!(tcx.sess, span, E0392,
                   "parameter `{}` is never used", param_name);
-    err.span_label(span, "unused type parameter");
+    err.span_label(span, "unused parameter");
     err
 }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2432,6 +2432,7 @@ fn from_target_feature(
                 Some("cmpxchg16b_target_feature") => rust_features.cmpxchg16b_target_feature,
                 Some("adx_target_feature") => rust_features.adx_target_feature,
                 Some("movbe_target_feature") => rust_features.movbe_target_feature,
+                Some("rtm_target_feature") => rust_features.rtm_target_feature,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -166,7 +166,6 @@ nav.sub {
 	top: 0;
 	height: 100vh;
 	overflow: auto;
-	z-index: 1;
 }
 
 .sidebar .block > ul > li {

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -901,8 +901,7 @@ impl OpenOptions {
     }
 
     fn _open(&self, path: &Path) -> io::Result<File> {
-        let inner = fs_imp::File::open(path, &self.0)?;
-        Ok(File { inner })
+        fs_imp::File::open(path, &self.0).map(|inner| File { inner })
     }
 }
 

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -269,7 +269,7 @@ impl Builder {
     ///
     /// let builder = thread::Builder::new()
     ///                               .name("foo".into())
-    ///                               .stack_size(10);
+    ///                               .stack_size(32 * 1024);
     ///
     /// let handler = builder.spawn(|| {
     ///     // thread code

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -402,6 +402,7 @@ declare_features! (
     (active, adx_target_feature, "1.32.0", Some(44839), None),
     (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
     (active, movbe_target_feature, "1.34.0", Some(44839), None),
+    (active, rtm_target_feature, "1.35.0", Some(44839), None),
 
     // Allows macro invocations on modules expressions and statements and
     // procedural macros to expand to non-items.

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2067,6 +2067,9 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 if block.is_none() {
                     self.check_abi(sig.header.abi, ti.span);
                 }
+                if sig.header.asyncness.node.is_async() {
+                    gate_feature_post!(&self, async_await, ti.span, "async fn is unstable");
+                }
                 if sig.decl.c_variadic {
                     gate_feature_post!(&self, c_variadic, ti.span,
                                        "C-variadic functions are unstable");

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2034,28 +2034,22 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 fn_decl: &'a ast::FnDecl,
                 span: Span,
                 _node_id: NodeId) {
-        match fn_kind {
-            FnKind::ItemFn(_, header, _, _) => {
-                // Check for const fn and async fn declarations.
-                if header.asyncness.node.is_async() {
-                    gate_feature_post!(&self, async_await, span, "async fn is unstable");
-                }
-
-                if fn_decl.c_variadic {
-                    gate_feature_post!(&self, c_variadic, span,
-                                       "C-varaidic functions are unstable");
-                }
-                // Stability of const fn methods are covered in
-                // `visit_trait_item` and `visit_impl_item` below; this is
-                // because default methods don't pass through this point.
-
-                self.check_abi(header.abi, span);
+        if let Some(header) = fn_kind.header() {
+            // Check for const fn and async fn declarations.
+            if header.asyncness.node.is_async() {
+                gate_feature_post!(&self, async_await, span, "async fn is unstable");
             }
-            FnKind::Method(_, sig, _, _) => {
-                self.check_abi(sig.header.abi, span);
-            }
-            _ => {}
+
+            // Stability of const fn methods are covered in
+            // `visit_trait_item` and `visit_impl_item` below; this is
+            // because default methods don't pass through this point.
+            self.check_abi(header.abi, span);
         }
+
+        if fn_decl.c_variadic {
+            gate_feature_post!(&self, c_variadic, span, "C-varaidic functions are unstable");
+        }
+
         visit::walk_fn(self, fn_kind, fn_decl, span);
     }
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2069,7 +2069,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
                 if sig.decl.c_variadic {
                     gate_feature_post!(&self, c_variadic, ti.span,
-                                       "C-varaidic functions are unstable");
+                                       "C-variadic functions are unstable");
                 }
                 if sig.header.constness.node == ast::Constness::Const {
                     gate_feature_post!(&self, const_fn, ti.span, "const fn is unstable");

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2047,7 +2047,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
 
         if fn_decl.c_variadic {
-            gate_feature_post!(&self, c_variadic, span, "C-varaidic functions are unstable");
+            gate_feature_post!(&self, c_variadic, span, "C-variadic functions are unstable");
         }
 
         visit::walk_fn(self, fn_kind, fn_decl, span);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -31,6 +31,16 @@ pub enum FnKind<'a> {
     Closure(&'a Expr),
 }
 
+impl<'a> FnKind<'a> {
+    pub fn header(&self) -> Option<&'a FnHeader> {
+        match *self {
+            FnKind::ItemFn(_, header, _, _) => Some(header),
+            FnKind::Method(_, sig, _, _) => Some(&sig.header),
+            FnKind::Closure(_) => None,
+        }
+    }
+}
+
 /// Each method of the Visitor trait is a hook to be potentially
 /// overridden. Each method's default implementation recursively visits
 /// the substructure of the input via the corresponding `walk` method;

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -613,14 +613,6 @@ extern "C" uint32_t LLVMRustVersionMinor() { return LLVM_VERSION_MINOR; }
 
 extern "C" uint32_t LLVMRustVersionMajor() { return LLVM_VERSION_MAJOR; }
 
-extern "C" bool LLVMRustIsRustLLVM() {
-#ifdef LLVM_RUSTLLVM
-  return 1;
-#else
-  return 0;
-#endif
-}
-
 extern "C" void LLVMRustAddModuleFlag(LLVMModuleRef M, const char *Name,
                                       uint32_t Value) {
   unwrap(M)->addModuleFlag(Module::Warning, Name, Value);

--- a/src/test/codegen/pgo-instrumentation.rs
+++ b/src/test/codegen/pgo-instrumentation.rs
@@ -1,0 +1,20 @@
+// Test that `-Zpgo-gen` creates expected instrumentation artifacts in LLVM IR.
+
+// needs-profiler-support
+// compile-flags: -Z pgo-gen -Ccodegen-units=1
+
+// CHECK: @__llvm_profile_raw_version =
+// CHECK: @__profc_{{.*}}pgo_instrumentation{{.*}}some_function{{.*}} = private global
+// CHECK: @__profd_{{.*}}pgo_instrumentation{{.*}}some_function{{.*}} = private global
+// CHECK: @__profc_{{.*}}pgo_instrumentation{{.*}}main{{.*}} = private global
+// CHECK: @__profd_{{.*}}pgo_instrumentation{{.*}}main{{.*}} = private global
+// CHECK: @__llvm_profile_filename = {{.*}}"default_%m.profraw\00"{{.*}}
+
+#[inline(never)]
+fn some_function() {
+
+}
+
+fn main() {
+    some_function();
+}

--- a/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-ifeq ($(PROFILER_SUPPORT),1)
+ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -Copt-level=3 -Clto=fat -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)

--- a/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-lto/Makefile
@@ -1,8 +1,8 @@
+# needs-profiler-support
+
 -include ../tools.mk
 
 all:
-ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -Copt-level=3 -Clto=fat -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)
-endif

--- a/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
@@ -1,11 +1,11 @@
+# needs-profiler-support
+
 -include ../tools.mk
 
 all:
-ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -O -Ccodegen-units=1 -Z pgo-gen="$(TMPDIR)" --emit=llvm-ir test.rs
 	# We expect symbols starting with "__llvm_profile_".
 	$(CGREP) "__llvm_profile_" < $(TMPDIR)/test.ll
 	# We do NOT expect the "__imp_" version of these symbols.
 	$(CGREP) -v "__imp___llvm_profile_" < $(TMPDIR)/test.ll # 64 bit
 	$(CGREP) -v "__imp____llvm_profile_" < $(TMPDIR)/test.ll # 32 bit
-endif

--- a/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-ifeq ($(PROFILER_SUPPORT),1)
+ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -O -Ccodegen-units=1 -Z pgo-gen="$(TMPDIR)" --emit=llvm-ir test.rs
 	# We expect symbols starting with "__llvm_profile_".
 	$(CGREP) "__llvm_profile_" < $(TMPDIR)/test.ll

--- a/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen-no-imp-symbols/Makefile
@@ -2,7 +2,7 @@
 
 all:
 ifeq ($(PROFILER_SUPPORT),1)
-	$(RUSTC) -O -Ccodegen-units=1 -Z pgo-gen="$(TMPDIR)/test.profraw" --emit=llvm-ir test.rs
+	$(RUSTC) -O -Ccodegen-units=1 -Z pgo-gen="$(TMPDIR)" --emit=llvm-ir test.rs
 	# We expect symbols starting with "__llvm_profile_".
 	$(CGREP) "__llvm_profile_" < $(TMPDIR)/test.ll
 	# We do NOT expect the "__imp_" version of these symbols.

--- a/src/test/run-make-fulldeps/pgo-gen/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen/Makefile
@@ -1,8 +1,8 @@
+# needs-profiler-support
+
 -include ../tools.mk
 
 all:
-ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -g -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)
-endif

--- a/src/test/run-make-fulldeps/pgo-gen/Makefile
+++ b/src/test/run-make-fulldeps/pgo-gen/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-ifeq ($(PROFILER_SUPPORT),1)
+ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -g -Z pgo-gen="$(TMPDIR)" test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)"/default_*.profraw ] || (echo "No .profraw file"; exit 1)

--- a/src/test/run-make-fulldeps/profile/Makefile
+++ b/src/test/run-make-fulldeps/profile/Makefile
@@ -1,9 +1,9 @@
+# needs-profiler-support
+
 -include ../tools.mk
 
 all:
-ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -g -Z profile test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)/test.gcno" ] || (echo "No .gcno file"; exit 1)
 	[ -e "$(TMPDIR)/test.gcda" ] || (echo "No .gcda file"; exit 1)
-endif

--- a/src/test/run-make-fulldeps/profile/Makefile
+++ b/src/test/run-make-fulldeps/profile/Makefile
@@ -1,7 +1,7 @@
 -include ../tools.mk
 
 all:
-ifeq ($(PROFILER_SUPPORT),1)
+ifeq ($(RUSTC_PROFILER_SUPPORT),1)
 	$(RUSTC) -g -Z profile test.rs
 	$(call RUN,test) || exit 1
 	[ -e "$(TMPDIR)/test.gcno" ] || (echo "No .gcno file"; exit 1)

--- a/src/test/run-make-fulldeps/sanitizer-address/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-address/Makefile
@@ -1,3 +1,5 @@
+# needs-sanitizer-support
+
 -include ../tools.mk
 
 LOG := $(TMPDIR)/log.txt
@@ -5,11 +7,9 @@ LOG := $(TMPDIR)/log.txt
 # NOTE the address sanitizer only supports x86_64 linux and macOS
 
 ifeq ($(TARGET),x86_64-apple-darwin)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=-C rpath
 else
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 
 # Apparently there are very specific Linux kernels, notably the one that's
 # currently on Travis CI, which contain a buggy commit that triggers failures in
@@ -23,7 +23,5 @@ endif
 endif
 
 all:
-ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address -Z print-link-args $(EXTRA_RUSTFLAG) overflow.rs | $(CGREP) librustc_asan
 	$(TMPDIR)/overflow 2>&1 | $(CGREP) stack-buffer-overflow
-endif

--- a/src/test/run-make-fulldeps/sanitizer-address/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-address/Makefile
@@ -5,11 +5,11 @@ LOG := $(TMPDIR)/log.txt
 # NOTE the address sanitizer only supports x86_64 linux and macOS
 
 ifeq ($(TARGET),x86_64-apple-darwin)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=-C rpath
 else
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 
 # Apparently there are very specific Linux kernels, notably the one that's
 # currently on Travis CI, which contain a buggy commit that triggers failures in

--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
@@ -8,7 +8,7 @@ LOG := $(TMPDIR)/log.txt
 # is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 
 # See comment in sanitizer-address/Makefile for why this is here
 EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic

--- a/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-cdylib-link/Makefile
@@ -1,3 +1,5 @@
+# needs-sanitizer-support
+
 -include ../tools.mk
 
 LOG := $(TMPDIR)/log.txt
@@ -8,15 +10,12 @@ LOG := $(TMPDIR)/log.txt
 # is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 
 # See comment in sanitizer-address/Makefile for why this is here
 EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic
 endif
 
 all:
-ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type cdylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
 	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
 	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
-endif

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
@@ -8,7 +8,7 @@ LOG := $(TMPDIR)/log.txt
 # is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 
 # See comment in sanitizer-address/Makefile for why this is here
 EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic

--- a/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-dylib-link/Makefile
@@ -1,3 +1,5 @@
+# needs-sanitizer-support
+
 -include ../tools.mk
 
 LOG := $(TMPDIR)/log.txt
@@ -8,15 +10,11 @@ LOG := $(TMPDIR)/log.txt
 # is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
-
 # See comment in sanitizer-address/Makefile for why this is here
 EXTRA_RUSTFLAG=-C relocation-model=dynamic-no-pic
 endif
 
 all:
-ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type dylib --target $(TARGET) $(EXTRA_RUSTFLAG) library.rs
 	$(RUSTC) -g -Z sanitizer=address --crate-type bin --target $(TARGET) $(EXTRA_RUSTFLAG) -llibrary program.rs
 	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
-endif

--- a/src/test/run-make-fulldeps/sanitizer-invalid-cratetype/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-invalid-cratetype/Makefile
@@ -1,18 +1,16 @@
+# needs-sanitizer-support
+
 -include ../tools.mk
 
 # NOTE the address sanitizer only supports x86_64 linux and macOS
 
 ifeq ($(TARGET),x86_64-apple-darwin)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=-C rpath
 else
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=
 endif
 endif
 
 all:
-ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -Z sanitizer=address --crate-type proc-macro --target $(TARGET) hello.rs 2>&1 | $(CGREP) '-Z sanitizer'
-endif

--- a/src/test/run-make-fulldeps/sanitizer-invalid-cratetype/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-invalid-cratetype/Makefile
@@ -3,11 +3,11 @@
 # NOTE the address sanitizer only supports x86_64 linux and macOS
 
 ifeq ($(TARGET),x86_64-apple-darwin)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=-C rpath
 else
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=
 endif
 endif

--- a/src/test/run-make-fulldeps/sanitizer-leak/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-leak/Makefile
@@ -1,12 +1,11 @@
 -include ../tools.mk
 
+# needs-sanitizer-support
 # only-linux
 # only-x86_64
 # ignore-test
 # FIXME(#46126) ThinLTO for libstd broke this test
 
 all:
-ifdef RUSTC_SANITIZER_SUPPORT
 	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) librustc_lsan
 	$(TMPDIR)/leak 2>&1 | $(CGREP) 'detected memory leaks'
-endif

--- a/src/test/run-make-fulldeps/sanitizer-leak/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-leak/Makefile
@@ -6,7 +6,7 @@
 # FIXME(#46126) ThinLTO for libstd broke this test
 
 all:
-ifdef SANITIZER_SUPPORT
+ifdef RUSTC_SANITIZER_SUPPORT
 	$(RUSTC) -C opt-level=1 -g -Z sanitizer=leak -Z print-link-args leak.rs | $(CGREP) librustc_lsan
 	$(TMPDIR)/leak 2>&1 | $(CGREP) 'detected memory leaks'
 endif

--- a/src/test/run-make-fulldeps/sanitizer-memory/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-memory/Makefile
@@ -4,7 +4,7 @@
 # only-x86_64
 
 all:
-ifdef SANITIZER_SUPPORT
+ifdef RUSTC_SANITIZER_SUPPORT
 	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | $(CGREP) librustc_msan
 	$(TMPDIR)/uninit 2>&1 | $(CGREP) use-of-uninitialized-value
 endif

--- a/src/test/run-make-fulldeps/sanitizer-memory/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-memory/Makefile
@@ -1,10 +1,9 @@
 -include ../tools.mk
 
+# needs-sanitizer-support
 # only-linux
 # only-x86_64
 
 all:
-ifdef RUSTC_SANITIZER_SUPPORT
 	$(RUSTC) -g -Z sanitizer=memory -Z print-link-args uninit.rs | $(CGREP) librustc_msan
 	$(TMPDIR)/uninit 2>&1 | $(CGREP) use-of-uninitialized-value
-endif

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
@@ -1,3 +1,5 @@
+# needs-sanitizer-support
+
 -include ../tools.mk
 
 # This test builds a staticlib, then an executable that links to it.
@@ -5,14 +7,11 @@
 # and we assert that a fault in the staticlib is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=
 endif
 
 all:
-ifeq ($(ASAN_SUPPORT),1)
 	$(RUSTC) -g -Z sanitizer=address --crate-type staticlib --target $(TARGET) library.rs
 	$(CC) program.c $(call STATICLIB,library) $(call OUT_EXE,program) $(EXTRACFLAGS) $(EXTRACXXFLAGS)
 	LD_LIBRARY_PATH=$(TMPDIR) $(TMPDIR)/program 2>&1 | $(CGREP) stack-buffer-overflow
-endif
 

--- a/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
+++ b/src/test/run-make-fulldeps/sanitizer-staticlib-link/Makefile
@@ -1,11 +1,11 @@
 -include ../tools.mk
 
 # This test builds a staticlib, then an executable that links to it.
-# The staticlib and executable both  are compiled with address sanitizer, 
+# The staticlib and executable both  are compiled with address sanitizer,
 # and we assert that a fault in the staticlib is correctly detected.
 
 ifeq ($(TARGET),x86_64-unknown-linux-gnu)
-ASAN_SUPPORT=$(SANITIZER_SUPPORT)
+ASAN_SUPPORT=$(RUSTC_SANITIZER_SUPPORT)
 EXTRA_RUSTFLAG=
 endif
 

--- a/src/test/ui/class-missing-self.stderr
+++ b/src/test/ui/class-missing-self.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `meows` in this scope
   --> $DIR/class-missing-self.rs:9:7
    |
 LL |       meows += 1;
-   |       ^^^^^ help: try: `self.meows`
+   |       ^^^^^ help: you might have meant to use the available field: `self.meows`
 
 error[E0425]: cannot find function `sleep` in this scope
   --> $DIR/class-missing-self.rs:10:7

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/E0392.rs:1:10
    |
 LL | enum Foo<T> { Bar }
-   |          ^ unused type parameter
+   |          ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/feature-gate/feature-gate-c_variadic.rs
+++ b/src/test/ui/feature-gate/feature-gate-c_variadic.rs
@@ -1,4 +1,4 @@
 #![crate_type="lib"]
 
 pub unsafe extern "C" fn test(_: i32, ap: ...) { }
-//~^ C-varaidic functions are unstable
+//~^ C-variadic functions are unstable

--- a/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
+++ b/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
@@ -1,4 +1,4 @@
-error[E0658]: C-varaidic functions are unstable
+error[E0658]: C-variadic functions are unstable
   --> $DIR/feature-gate-c_variadic.rs:3:1
    |
 LL | pub unsafe extern "C" fn test(_: i32, ap: ...) { }

--- a/src/test/ui/feature-gates/feature-gate-async-await.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await.rs
@@ -2,6 +2,12 @@
 
 #![feature(futures_api)]
 
+struct S;
+
+impl S {
+    async fn foo() {} //~ ERROR async fn is unstable
+}
+
 async fn foo() {} //~ ERROR async fn is unstable
 
 fn main() {

--- a/src/test/ui/feature-gates/feature-gate-async-await.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await.rs
@@ -8,6 +8,11 @@ impl S {
     async fn foo() {} //~ ERROR async fn is unstable
 }
 
+trait T {
+    async fn foo(); //~ ERROR trait fns cannot be declared `async`
+    //~^ ERROR async fn is unstable
+}
+
 async fn foo() {} //~ ERROR async fn is unstable
 
 fn main() {

--- a/src/test/ui/feature-gates/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await.stderr
@@ -1,3 +1,9 @@
+error[E0706]: trait fns cannot be declared `async`
+  --> $DIR/feature-gate-async-await.rs:12:5
+   |
+LL |     async fn foo();
+   |     ^^^^^^^^^^^^^^^
+
 error[E0658]: async fn is unstable
   --> $DIR/feature-gate-async-await.rs:8:5
    |
@@ -8,7 +14,16 @@ LL |     async fn foo() {}
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await.rs:11:1
+  --> $DIR/feature-gate-async-await.rs:12:5
+   |
+LL |     async fn foo();
+   |     ^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/50547
+   = help: add #![feature(async_await)] to the crate attributes to enable
+
+error[E0658]: async fn is unstable
+  --> $DIR/feature-gate-async-await.rs:16:1
    |
 LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^
@@ -17,7 +32,7 @@ LL | async fn foo() {}
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async blocks are unstable
-  --> $DIR/feature-gate-async-await.rs:14:13
+  --> $DIR/feature-gate-async-await.rs:19:13
    |
 LL |     let _ = async {};
    |             ^^^^^^^^
@@ -26,7 +41,7 @@ LL |     let _ = async {};
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async closures are unstable
-  --> $DIR/feature-gate-async-await.rs:15:13
+  --> $DIR/feature-gate-async-await.rs:20:13
    |
 LL |     let _ = async || {};
    |             ^^^^^^^^^^^
@@ -34,6 +49,7 @@ LL |     let _ = async || {};
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
    = help: add #![feature(async_await)] to the crate attributes to enable
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+Some errors occurred: E0658, E0706.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await.stderr
@@ -1,5 +1,14 @@
 error[E0658]: async fn is unstable
-  --> $DIR/feature-gate-async-await.rs:5:1
+  --> $DIR/feature-gate-async-await.rs:8:5
+   |
+LL |     async fn foo() {}
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/50547
+   = help: add #![feature(async_await)] to the crate attributes to enable
+
+error[E0658]: async fn is unstable
+  --> $DIR/feature-gate-async-await.rs:11:1
    |
 LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^
@@ -8,7 +17,7 @@ LL | async fn foo() {}
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async blocks are unstable
-  --> $DIR/feature-gate-async-await.rs:8:13
+  --> $DIR/feature-gate-async-await.rs:14:13
    |
 LL |     let _ = async {};
    |             ^^^^^^^^
@@ -17,7 +26,7 @@ LL |     let _ = async {};
    = help: add #![feature(async_await)] to the crate attributes to enable
 
 error[E0658]: async closures are unstable
-  --> $DIR/feature-gate-async-await.rs:9:13
+  --> $DIR/feature-gate-async-await.rs:15:13
    |
 LL |     let _ = async || {};
    |             ^^^^^^^^^^^
@@ -25,6 +34,6 @@ LL |     let _ = async || {};
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
    = help: add #![feature(async_await)] to the crate attributes to enable
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -12,7 +12,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/inner-static-type-parameter.rs:3:10
    |
 LL | enum Bar<T> { What }
-   |          ^ unused type parameter
+   |          ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-17904-2.rs:4:12
    |
 LL | struct Foo<T> where T: Copy;
-   |            ^ unused type parameter
+   |            ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-20413.rs:5:15
    |
 LL | struct NoData<T>;
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-22933-3.stderr
+++ b/src/test/ui/issues/issue-22933-3.stderr
@@ -3,6 +3,10 @@ error[E0599]: no associated item named `MIN` found for type `u8` in the current 
    |
 LL | const FOO: [u32; u8::MIN as usize] = [];
    |                      ^^^ associated item not found in `u8`
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL | const FOO: [u32; std::u8::MIN as usize] = [];
+   |                  ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): std::convert::From<{integer}>` is not satisfied
-  --> $DIR/issue-32709.rs:4:5
+  --> $DIR/issue-32709.rs:4:11
    |
 LL |     Err(5)?;
-   |     ^^^^^^^ the trait `std::convert::From<{integer}>` is not implemented for `()`
+   |           ^ the trait `std::convert::From<{integer}>` is not implemented for `()`
    |
    = note: required by `std::convert::From::from`
 

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `(): std::convert::From<{integer}>` is not satisfied
+error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/issue-32709.rs:4:11
    |
 LL |     Err(5)?;

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/issue-36299.rs:1:12
    |
 LL | struct Foo<'a, A> {}
-   |            ^^ unused type parameter
+   |            ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
    |
 LL | struct Foo<'a, A> {}
-   |                ^ unused type parameter
+   |                ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `Self` is never used
   --> $DIR/issue-36638.rs:3:12
    |
 LL | struct Foo<Self>(Self);
-   |            ^^^^ unused type parameter
+   |            ^^^^ unused parameter
    |
    = help: consider removing `Self` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/issue-37534.rs:1:12
    |
 LL | struct Foo<T: ?Hash> { }
-   |            ^ unused type parameter
+   |            ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/issues/issue-60057.rs
+++ b/src/test/ui/issues/issue-60057.rs
@@ -1,0 +1,17 @@
+struct A {
+    banana: u8,
+}
+
+impl A {
+    fn new(peach: u8) -> A {
+        A {
+            banana: banana //~ ERROR cannot find value `banana` in this scope
+        }
+    }
+
+    fn foo(&self, peach: u8) -> A {
+        A {
+            banana: banana //~ ERROR cannot find value `banana` in this scope
+        }
+    }
+}

--- a/src/test/ui/issues/issue-60057.stderr
+++ b/src/test/ui/issues/issue-60057.stderr
@@ -1,0 +1,20 @@
+error[E0425]: cannot find value `banana` in this scope
+  --> $DIR/issue-60057.rs:8:21
+   |
+LL |             banana: banana
+   |                     ^^^^^^ a field by this name exists in `Self::banana`
+
+error[E0425]: cannot find value `banana` in this scope
+  --> $DIR/issue-60057.rs:14:21
+   |
+LL |             banana: banana
+   |                     ^^^^^^ help: you might have meant to use the available field: `self.banana`
+
+error[E0601]: `main` function not found in crate `issue_60057`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-60057.rs`
+
+error: aborting due to 3 previous errors
+
+Some errors occurred: E0425, E0601.
+For more information about an error, try `rustc --explain E0425`.

--- a/src/test/ui/issues/issue-60057.stderr
+++ b/src/test/ui/issues/issue-60057.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:8:21
    |
 LL |             banana: banana
-   |                     ^^^^^^ a field by this name exists in `Self::banana`
+   |                     ^^^^^^ a field by this name exists in `Self`
 
 error[E0425]: cannot find value `banana` in this scope
   --> $DIR/issue-60057.rs:14:21

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -25,7 +25,7 @@ error[E0392]: parameter `'c` is never used
   --> $DIR/region-bounds-on-objects-and-type-parameters.rs:11:18
    |
 LL | struct Foo<'a,'b,'c> {
-   |                  ^^ unused type parameter
+   |                  ^^ unused parameter
    |
    = help: consider removing `'c` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/resolve/issue-14254.stderr
+++ b/src/test/ui/resolve/issue-14254.stderr
@@ -20,13 +20,13 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:30:9
    |
 LL |         x;
-   |         ^ help: try: `self.x`
+   |         ^ help: you might have meant to use the available field: `self.x`
 
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:32:9
    |
 LL |         y;
-   |         ^ help: try: `self.y`
+   |         ^ help: you might have meant to use the available field: `self.y`
 
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:34:9
@@ -56,13 +56,13 @@ error[E0425]: cannot find value `x` in this scope
   --> $DIR/issue-14254.rs:47:9
    |
 LL |         x;
-   |         ^ help: try: `self.x`
+   |         ^ help: you might have meant to use the available field: `self.x`
 
 error[E0425]: cannot find value `y` in this scope
   --> $DIR/issue-14254.rs:49:9
    |
 LL |         y;
-   |         ^ help: try: `self.y`
+   |         ^ help: you might have meant to use the available field: `self.y`
 
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/issue-14254.rs:51:9

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -20,10 +20,7 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:39:5
    |
 LL |     whiskers -= other;
-   |     ^^^^^^^^
-   |     |
-   |     `self` value is a keyword only available in methods with `self` parameter
-   |     help: try: `self.whiskers`
+   |     ^^^^^^^^ a field by this name exists in `Self::whiskers`
 
 error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:41:5
@@ -83,16 +80,13 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:79:5
    |
 LL |     whiskers = 0;
-   |     ^^^^^^^^ help: try: `self.whiskers`
+   |     ^^^^^^^^ help: you might have meant to use the available field: `self.whiskers`
 
 error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:84:5
    |
 LL |     whiskers = 4;
-   |     ^^^^^^^^
-   |     |
-   |     `self` value is a keyword only available in methods with `self` parameter
-   |     help: try: `self.whiskers`
+   |     ^^^^^^^^ a field by this name exists in `Self::whiskers`
 
 error[E0425]: cannot find function `purr_louder` in this scope
   --> $DIR/issue-2356.rs:86:5

--- a/src/test/ui/resolve/issue-2356.stderr
+++ b/src/test/ui/resolve/issue-2356.stderr
@@ -20,7 +20,7 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:39:5
    |
 LL |     whiskers -= other;
-   |     ^^^^^^^^ a field by this name exists in `Self::whiskers`
+   |     ^^^^^^^^ a field by this name exists in `Self`
 
 error[E0425]: cannot find function `shave` in this scope
   --> $DIR/issue-2356.rs:41:5
@@ -86,7 +86,7 @@ error[E0425]: cannot find value `whiskers` in this scope
   --> $DIR/issue-2356.rs:84:5
    |
 LL |     whiskers = 4;
-   |     ^^^^^^^^ a field by this name exists in `Self::whiskers`
+   |     ^^^^^^^^ a field by this name exists in `Self`
 
 error[E0425]: cannot find function `purr_louder` in this scope
   --> $DIR/issue-2356.rs:86:5

--- a/src/test/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:20:9
    |
 LL |         field;
-   |         ^^^^^ help: try: `self.field`
+   |         ^^^^^ help: you might have meant to use the available field: `self.field`
 
 error[E0412]: cannot find type `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:23:16

--- a/src/test/ui/resolve/resolve-speculative-adjustment.stderr
+++ b/src/test/ui/resolve/resolve-speculative-adjustment.stderr
@@ -14,7 +14,7 @@ error[E0425]: cannot find value `field` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:23:9
    |
 LL |         field;
-   |         ^^^^^ help: try: `self.field`
+   |         ^^^^^ help: you might have meant to use the available field: `self.field`
 
 error[E0425]: cannot find function `method` in this scope
   --> $DIR/resolve-speculative-adjustment.rs:25:9

--- a/src/test/ui/resolve/unresolved_static_type_field.stderr
+++ b/src/test/ui/resolve/unresolved_static_type_field.stderr
@@ -2,10 +2,7 @@ error[E0425]: cannot find value `cx` in this scope
   --> $DIR/unresolved_static_type_field.rs:9:11
    |
 LL |         f(cx);
-   |           ^^
-   |           |
-   |           `self` value is a keyword only available in methods with `self` parameter
-   |           help: try: `self.cx`
+   |           ^^ a field by this name exists in `Self::cx`
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/unresolved_static_type_field.stderr
+++ b/src/test/ui/resolve/unresolved_static_type_field.stderr
@@ -2,7 +2,7 @@ error[E0425]: cannot find value `cx` in this scope
   --> $DIR/unresolved_static_type_field.rs:9:11
    |
 LL |         f(cx);
-   |           ^^ a field by this name exists in `Self::cx`
+   |           ^^ a field by this name exists in `Self`
 
 error: aborting due to previous error
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -62,7 +62,7 @@ error[E0392]: parameter `'Self` is never used
   --> $DIR/self_type_keyword.rs:8:12
    |
 LL | struct Bar<'Self>;
-   |            ^^^^^ unused type parameter
+   |            ^^^^^ unused parameter
    |
    = help: consider removing `'Self` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/suggestions/suggest-std-when-using-type.rs
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let pi = f32::consts::PI; //~ ERROR ambiguous associated type
+    let bytes = "hello world".as_bytes();
+    let string = unsafe {
+        str::from_utf8(bytes) //~ ERROR no function or associated item named `from_utf8` found
+    };
+}

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -1,0 +1,24 @@
+error[E0223]: ambiguous associated type
+  --> $DIR/suggest-std-when-using-type.rs:2:14
+   |
+LL |     let pi = f32::consts::PI;
+   |              ^^^^^^^^^^^^^^^
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL |     let pi = std::f32::consts::PI;
+   |              ^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
+  --> $DIR/suggest-std-when-using-type.rs:5:14
+   |
+LL |         str::from_utf8(bytes)
+   |              ^^^^^^^^^ function or associated item not found in `str`
+help: you are looking for the module in `std`, not the primitive type
+   |
+LL |         std::str::from_utf8(bytes)
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0223, E0599.
+For more information about an error, try `rustc --explain E0223`.

--- a/src/test/ui/target-feature-gate.rs
+++ b/src/test/ui/target-feature-gate.rs
@@ -23,6 +23,7 @@
 // gate-test-adx_target_feature
 // gate-test-cmpxchg16b_target_feature
 // gate-test-movbe_target_feature
+// gate-test-rtm_target_feature
 // min-llvm-version 6.0
 
 #[target_feature(enable = "avx512bw")]

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the target feature `avx512bw` is currently unstable
-  --> $DIR/target-feature-gate.rs:28:18
+  --> $DIR/target-feature-gate.rs:29:18
    |
 LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/try-block/try-block-bad-type.rs
+++ b/src/test/ui/try-block/try-block-bad-type.rs
@@ -4,7 +4,7 @@
 
 pub fn main() {
     let res: Result<u32, i32> = try {
-        Err("")?; //~ ERROR the trait bound `i32: std::convert::From<&str>` is not satisfied
+        Err("")?; //~ ERROR `?` couldn't convert the error
         5
     };
 

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `i32: std::convert::From<&str>` is not satisfied
-  --> $DIR/try-block-bad-type.rs:7:9
+  --> $DIR/try-block-bad-type.rs:7:16
    |
 LL |         Err("")?;
-   |         ^^^^^^^^ the trait `std::convert::From<&str>` is not implemented for `i32`
+   |                ^ the trait `std::convert::From<&str>` is not implemented for `i32`
    |
    = help: the following implementations were found:
              <i32 as std::convert::From<bool>>

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `i32: std::convert::From<&str>` is not satisfied
+error[E0277]: `?` couldn't convert the error to `i32`
   --> $DIR/try-block-bad-type.rs:7:16
    |
 LL |         Err("")?;

--- a/src/test/ui/try-on-option.rs
+++ b/src/test/ui/try-on-option.rs
@@ -4,12 +4,12 @@ fn main() {}
 
 fn foo() -> Result<u32, ()> {
     let x: Option<u32> = None;
-    x?; //~ the trait bound
+    x?; //~ ERROR `?` couldn't convert the error
     Ok(22)
 }
 
 fn bar() -> u32 {
     let x: Option<u32> = None;
-    x?; //~ the `?` operator
+    x?; //~ ERROR the `?` operator
     22
 }

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): std::convert::From<std::option::NoneError>` is not satisfied
-  --> $DIR/try-on-option.rs:7:5
+  --> $DIR/try-on-option.rs:7:6
    |
 LL |     x?;
-   |     ^^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
+   |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |
    = note: required by `std::convert::From::from`
 

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `(): std::convert::From<std::option::NoneError>` is not satisfied
+error[E0277]: `?` couldn't convert the error to `()`
   --> $DIR/try-on-option.rs:7:6
    |
 LL |     x?;

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-direct.rs:5:18
    |
 LL | struct Bivariant<'a>;
-   |                  ^^ unused type parameter
+   |                  ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
    |
 LL | struct Struct<'a, 'd> {
-   |                   ^^ unused type parameter
+   |                   ^^ unused parameter
    |
    = help: consider removing `'d` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:3:10
    |
 LL | enum Foo<'a> {
-   |          ^^ unused type parameter
+   |          ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
    |
 LL | enum Bar<'a> {
-   |          ^^ unused type parameter
+   |          ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:3:19
    |
 LL | struct SomeStruct<'a> { x: u32 }
-   |                   ^^ unused type parameter
+   |                   ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
    |
 LL | enum SomeEnum<'a> { Nothing }
-   |               ^^ unused type parameter
+   |               ^^ unused parameter
    |
    = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -2,7 +2,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:6:19
    |
 LL | struct SomeStruct<A> { x: u32 }
-   |                   ^ unused type parameter
+   |                   ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 
@@ -10,7 +10,7 @@ error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
    |
 LL | enum SomeEnum<A> { Nothing }
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
 
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
    |
 LL | enum ListCell<T> {
-   |               ^ unused type parameter
+   |               ^ unused parameter
    |
    = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -88,6 +88,9 @@ impl EarlyProps {
             }
         }
 
+        let rustc_has_profiler_support = env::var_os("RUSTC_PROFILER_SUPPORT").is_some();
+        let rustc_has_sanitizer_support = env::var_os("RUSTC_SANITIZER_SUPPORT").is_some();
+
         iter_header(testfile, None, &mut |ln| {
             // we should check if any only-<platform> exists and if it exists
             // and does not matches the current platform, skip the test
@@ -114,6 +117,16 @@ impl EarlyProps {
 
                 if config.run_clang_based_tests_with.is_none() &&
                    config.parse_needs_matching_clang(ln) {
+                    props.ignore = Ignore::Ignore;
+                }
+
+                if !rustc_has_profiler_support &&
+                   config.parse_needs_profiler_support(ln) {
+                    props.ignore = Ignore::Ignore;
+                }
+
+                if !rustc_has_sanitizer_support &&
+                   config.parse_needs_sanitizer_support(ln) {
                     props.ignore = Ignore::Ignore;
                 }
             }
@@ -746,6 +759,14 @@ impl Config {
 
     fn parse_needs_matching_clang(&self, line: &str) -> bool {
         self.parse_name_directive(line, "needs-matching-clang")
+    }
+
+    fn parse_needs_profiler_support(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "needs-profiler-support")
+    }
+
+    fn parse_needs_sanitizer_support(&self, line: &str) -> bool {
+        self.parse_name_directive(line, "needs-sanitizer-support")
     }
 
     /// Parses a name-value directive which contains config-specific information, e.g., `ignore-x86`


### PR DESCRIPTION
Successful merges:

 - #59933 (Make clear that format padding doesn't work for Debug)
 - #60023 (implement specialized nth_back() for Bytes, Fuse and Enumerate)
 - #60032 (Remove unwanted z-index change)
 - #60038 (Add codegen test for PGO instrumentation.)
 - #60041 (Simplify the returning of a Result a bit)
 - #60045 (Suggest appropriate path when calling associated item on bare types)
 - #60052 (Correct unused parameter diagnostic)
 - #60056 (Update rustfmt to 1.2.1)
 - #60060 (whitelist RTM x86 target cpu feature)
 - #60061 (Change suggestion of field when not in self context)
 - #60064 (Point at try `?` on errors affecting the err match arm of the desugared code)
 - #60078 (Use more realistic example for thread builder)
 - #60080 (Fix small errors in docs for `rchunks_exact` and `rchunks_exact_mut`.)
 - #60082 (Update miri)
 - #60088 (Feature gate async methods)
 - #60097 (Use -mergefunc-use-aliases for any LLVM >= 8)

Failed merges:

 - #59981 (Emit specific error for struct literal in conditions)

r? @ghost