### PR TITLE
Proposal: `fold_self` and `try_fold_self` for Iterators

### DIFF
--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1617,7 +1617,7 @@ pub trait Iterator {
     /// assert_eq!(find_max(c.iter()), None);
     /// ```
     #[inline]
-    #[unstable(feature = "iterator_try_fold_self", issue = "0")]
+    #[unstable(feature = "iterator_fold_self", issue = "60103")]
     fn try_fold_self<F, R>(&mut self, mut f: F) -> Option<R>
         where Self: Sized,
               F: FnMut(Self::Item, Self::Item) -> R,
@@ -1764,7 +1764,7 @@ pub trait Iterator {
     /// assert_eq!(find_max(b.iter()), None));
     /// ```
     #[inline]
-    #[unstable(feature = "iterator_try_fold_self", issue = "0")]
+    #[unstable(feature = "iterator_fold_self", issue = "60103")]
     fn fold_self<F>(mut self, mut f: F) -> Option<Self::Item>
         where Self: Sized, F: FnMut(Self::Item, Self::Item) -> Self::Item
     {

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1617,6 +1617,7 @@ pub trait Iterator {
     /// assert_eq!(find_max(c.iter()), None);
     /// ```
     #[inline]
+    #[unstable(feature = "iterator_try_fold_self", issue = "0")]
     fn try_fold_self<F, R>(&mut self, mut f: F) -> Option<R>
         where Self: Sized,
               F: FnMut(Self::Item, Self::Item) -> R,
@@ -1763,6 +1764,7 @@ pub trait Iterator {
     /// assert_eq!(find_max(b.iter()), None));
     /// ```
     #[inline]
+    #[unstable(feature = "iterator_try_fold_self", issue = "0")]
     fn fold_self<F>(mut self, mut f: F) -> Option<Self::Item>
         where Self: Sized, F: FnMut(Self::Item, Self::Item) -> Self::Item
     {

--- a/src/libcore/iter/iterator.rs
+++ b/src/libcore/iter/iterator.rs
@@ -1621,7 +1621,7 @@ pub trait Iterator {
     fn try_fold_self<F, R>(&mut self, mut f: F) -> Option<R>
         where Self: Sized,
               F: FnMut(Self::Item, Self::Item) -> R,
-              R: Try<Ok=Self::Item>
+              R: Try<Ok = Self::Item>
     {
         self.next().map(move |first| self.try_fold(first, f))
     }


### PR DESCRIPTION
This pull request proposes & implements two new methods on Iterators: `fold_self` and `try_fold_self`. These are variants of `fold` and `try_fold` that use the first element in the iterator as the initial accumulator.

Let me know if a public feature like this requires an RFC, or if this pull request is sufficient as place for discussion.