### PR TITLE
Add Span::unique_site

### DIFF
--- a/src/libproc_macro/bridge/mod.rs
+++ b/src/libproc_macro/bridge/mod.rs
@@ -146,6 +146,7 @@ macro_rules! with_api {
             },
             Span {
                 fn debug($self: $S::Span) -> String;
+                fn unique_site() -> $S::Span;
                 fn def_site() -> $S::Span;
                 fn call_site() -> $S::Span;
                 fn source_file($self: $S::Span) -> $S::SourceFile;

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -255,6 +255,13 @@ macro_rules! diagnostic_method {
 }
 
 impl Span {
+    /// A span that resolves at a unique site. Each call to this method will return a new unique
+    /// span that is inaccessible from other sites.
+    #[unstable(feature = "proc_macro_unique_site", issue = "54725")]
+    pub fn unique_site() -> Span {
+        Span(bridge::client::Span::unique_site())
+    }
+
     /// A span that resolves at the macro definition site.
     #[unstable(feature = "proc_macro_def_site", issue = "54724")]
     pub fn def_site() -> Span {

--- a/src/libproc_macro/lib.rs
+++ b/src/libproc_macro/lib.rs
@@ -256,7 +256,8 @@ macro_rules! diagnostic_method {
 
 impl Span {
     /// A span that resolves at a unique site. Each call to this method will return a new unique
-    /// span that is inaccessible from other sites.
+    /// span that is inaccessible from other sites. For those familiar with Lisp, this is similar to
+    /// [gensym](http://www.lispworks.com/documentation/lw50/CLHS/Body/f_gensym.htm).
     #[unstable(feature = "proc_macro_unique_site", issue = "54725")]
     pub fn unique_site() -> Span {
         Span(bridge::client::Span::unique_site())

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2306,7 +2306,7 @@ impl<'a> Resolver<'a> {
             let mut result = None;
             // Find the last modern mark from the end if it exists.
             while let Some(&(mark, transparency)) = iter.peek() {
-                if transparency == Transparency::Opaque {
+                if transparency >= Transparency::Opaque {
                     result = Some(mark);
                     iter.next();
                 } else {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -60,6 +60,7 @@ pub enum Transparency {
     /// Identifier produced by an opaque expansion is always resolved at definition-site.
     /// Def-site spans in procedural macros, identifiers from `macro` by default use this.
     Opaque,
+    Unique(u64),
 }
 
 impl Mark {
@@ -273,7 +274,7 @@ impl SyntaxContext {
     pub fn apply_mark_with_transparency(self, mark: Mark, transparency: Transparency)
                                         -> SyntaxContext {
         assert_ne!(mark, Mark::root());
-        if transparency == Transparency::Opaque {
+        if transparency >= Transparency::Opaque {
             return self.apply_mark_internal(mark, transparency);
         }
 


### PR DESCRIPTION
A little bit of background: [Feedback on Span::def_site](https://internals.rust-lang.org/t/feedback-on-span-def-site/9831)

`Span::def_site` is useful in that call-site code cannot access identifiers which use it. But it doesn't prevent identifier clashes within the macro, particularly when the macro is implemented using several subcomponents, each of which generates a portion of the macro. These subcomponents may use conflicting identifiers.

The new `Span::unique_site` solves this problem. Each call to `Span::unique_site` generates a new span that resolves at a unique site. It allows a macro to isolate parts of its expansion from each other.