### PR TITLE
Stabilize ADX, TBM, and SSE4a target features

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -124,6 +124,9 @@
 #![feature(abi_unadjusted)]
 #![feature(maybe_uninit_slice, maybe_uninit_array)]
 #![feature(external_doc)]
+#![cfg_attr(bootstrap, feature(sse4a_target_feature))]
+#![cfg_attr(bootstrap, feature(tbm_target_feature))]
+#![cfg_attr(bootstrap, feature(adx_target_feature))]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -107,8 +107,6 @@
 #![feature(unwind_attributes)]
 #![feature(doc_alias)]
 #![feature(mmx_target_feature)]
-#![feature(tbm_target_feature)]
-#![feature(sse4a_target_feature)]
 #![feature(arm_target_feature)]
 #![feature(powerpc_target_feature)]
 #![feature(mips_target_feature)]
@@ -124,7 +122,6 @@
 #![feature(non_exhaustive)]
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]
-#![feature(adx_target_feature)]
 #![feature(maybe_uninit_slice, maybe_uninit_array)]
 #![feature(external_doc)]
 

--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -129,7 +129,7 @@ const AARCH64_WHITELIST: &[(&str, Option<Symbol>)] = &[
 ];
 
 const X86_WHITELIST: &[(&str, Option<Symbol>)] = &[
-    ("adx", Some(sym::adx_target_feature)),
+    ("adx", None),
     ("aes", None),
     ("avx", None),
     ("avx2", None),
@@ -163,9 +163,9 @@ const X86_WHITELIST: &[(&str, Option<Symbol>)] = &[
     ("sse3", None),
     ("sse4.1", None),
     ("sse4.2", None),
-    ("sse4a", Some(sym::sse4a_target_feature)),
+    ("sse4a", None),
     ("ssse3", None),
-    ("tbm", Some(sym::tbm_target_feature)),
+    ("tbm", None),
     ("xsave", None),
     ("xsavec", None),
     ("xsaveopt", None),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2367,11 +2367,6 @@ fn from_target_feature(
                 Some(sym::movbe_target_feature) => rust_features.movbe_target_feature,
                 Some(sym::rtm_target_feature) => rust_features.rtm_target_feature,
                 Some(sym::f16c_target_feature) => rust_features.f16c_target_feature,
-                // These are stable:
-                | Some(sym::sse4a_target_feature)
-                | Some(sym::tbm_target_feature)
-                | Some(sym::adx_target_feature)
-                    => true,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2362,14 +2362,16 @@ fn from_target_feature(
                 Some(sym::mips_target_feature) => rust_features.mips_target_feature,
                 Some(sym::avx512_target_feature) => rust_features.avx512_target_feature,
                 Some(sym::mmx_target_feature) => rust_features.mmx_target_feature,
-                Some(sym::sse4a_target_feature) => rust_features.sse4a_target_feature,
-                Some(sym::tbm_target_feature) => rust_features.tbm_target_feature,
                 Some(sym::wasm_target_feature) => rust_features.wasm_target_feature,
                 Some(sym::cmpxchg16b_target_feature) => rust_features.cmpxchg16b_target_feature,
-                Some(sym::adx_target_feature) => rust_features.adx_target_feature,
                 Some(sym::movbe_target_feature) => rust_features.movbe_target_feature,
                 Some(sym::rtm_target_feature) => rust_features.rtm_target_feature,
                 Some(sym::f16c_target_feature) => rust_features.f16c_target_feature,
+                // These are stable:
+                | Some(sym::sse4a_target_feature)
+                | Some(sym::tbm_target_feature)
+                | Some(sym::adx_target_feature)
+                    => true,
                 Some(name) => bug!("unknown target feature gate {}", name),
                 None => true,
             };

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -268,10 +268,7 @@ declare_features! (
     (active, mips_target_feature, "1.27.0", Some(44839), None),
     (active, avx512_target_feature, "1.27.0", Some(44839), None),
     (active, mmx_target_feature, "1.27.0", Some(44839), None),
-    (active, sse4a_target_feature, "1.27.0", Some(44839), None),
-    (active, tbm_target_feature, "1.27.0", Some(44839), None),
     (active, wasm_target_feature, "1.30.0", Some(44839), None),
-    (active, adx_target_feature, "1.32.0", Some(44839), None),
     (active, cmpxchg16b_target_feature, "1.32.0", Some(44839), None),
     (active, movbe_target_feature, "1.34.0", Some(44839), None),
     (active, rtm_target_feature, "1.35.0", Some(44839), None),
@@ -850,6 +847,12 @@ declare_features! (
     (accepted, repr_align_enum, "1.37.0", Some(57996), None),
     // Allows `const _: TYPE = VALUE`.
     (accepted, underscore_const_names, "1.37.0", Some(54912), None),
+    // Allows using SSE4A intrinsics from `core::arch::{x86, x86_64}`.
+    (accepted, sse4a_target_feature, "1.37.0", Some(44839), None),
+    // Allows using TBM intrinsics from `core::arch::{x86, x86_64}`.
+    (accepted, tbm_target_feature, "1.37.0", Some(44839), None),
+    // Allows using ADX intrinsics from `core::arch::{x86, x86_64}`.
+    (accepted, adx_target_feature, "1.37.0", Some(44839), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: accepted features


### PR DESCRIPTION
This PR stabilizes the ADX, TBM, and SSE4a target features. 

We stabilized the ADX `core::arch` intrinsics in Rust 1.33, and the TBM and SSE4a intrinsics have been accidentally stabilized since Rust 1.27. AFAICT there is no good reason to leave those as stabilized (we got lucky I guess), and while we could unstabilize them, it seems that they are worth stabilizing right after, so that would just introduce unnecessary churn.

It seems that when we stabilized the ADX intrinsics, we just forgot to also stabilize the ADX target feature attribute. 

r? @alexcrichton 

cc @jethrogb @Centril @rust-lang/libs (for the decision of not unstabilizing the accidentally stabilized intrinsics) @rust-lang/lang (for the decision of stabilizing the `#[target_feature(enable = "adx,sse4a,tbm")]` target features). 

cc #44839 - tracking issue for target feature