### PR TITLE
Split {ast,hir,...}::Static(Mutability) into Static and StaticMut.

### DIFF
--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -16,9 +16,11 @@ use syntax_pos::Span;
 
 #[derive(Copy, Clone, PartialEq)]
 pub(crate) enum Target {
+    // FIXME(eddyb) replace most of this with `DefKind`.
     ExternCrate,
     Use,
     Static,
+    StaticMut,
     Const,
     Fn,
     Closure,
@@ -43,6 +45,7 @@ impl Display for Target {
             Target::ExternCrate => "extern crate",
             Target::Use => "use",
             Target::Static => "static item",
+            Target::StaticMut => "mutable static item",
             Target::Const => "constant item",
             Target::Fn => "function",
             Target::Closure => "closure",
@@ -69,6 +72,7 @@ impl Target {
             hir::ItemKind::ExternCrate(..) => Target::ExternCrate,
             hir::ItemKind::Use(..) => Target::Use,
             hir::ItemKind::Static(..) => Target::Static,
+            hir::ItemKind::StaticMut(..) => Target::StaticMut,
             hir::ItemKind::Const(..) => Target::Const,
             hir::ItemKind::Fn(..) => Target::Fn,
             hir::ItemKind::Mod(..) => Target::Mod,

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -73,7 +73,8 @@ pub enum Def<Id = hir::HirId> {
     Fn(DefId),
     Const(DefId),
     ConstParam(DefId),
-    Static(DefId, bool /* is_mutbl */),
+    Static(DefId),
+    StaticMut(DefId),
     /// `DefId` refers to the struct or enum variant's constructor.
     Ctor(DefId, CtorOf, CtorKind),
     SelfCtor(DefId /* impl */),  // `DefId` refers to the impl
@@ -291,7 +292,7 @@ impl<Id> Def<Id> {
     /// Return `Some(..)` with the `DefId` of this `Def` if it has a id, else `None`.
     pub fn opt_def_id(&self) -> Option<DefId> {
         match *self {
-            Def::Fn(id) | Def::Mod(id) | Def::Static(id, _) |
+            Def::Fn(id) | Def::Mod(id) | Def::Static(id) | Def::StaticMut(id) |
             Def::Variant(id) | Def::Ctor(id, ..) | Def::Enum(id) |
             Def::TyAlias(id) | Def::TraitAlias(id) |
             Def::AssociatedTy(id) | Def::TyParam(id) | Def::ConstParam(id) | Def::Struct(id) |
@@ -329,6 +330,7 @@ impl<Id> Def<Id> {
             Def::Fn(..) => "function",
             Def::Mod(..) => "module",
             Def::Static(..) => "static",
+            Def::StaticMut(..) => "mutable static",
             Def::Enum(..) => "enum",
             Def::Variant(..) => "variant",
             Def::Ctor(_, CtorOf::Variant, CtorKind::Fn) => "tuple variant",
@@ -379,7 +381,8 @@ impl<Id> Def<Id> {
         match self {
             Def::Fn(id) => Def::Fn(id),
             Def::Mod(id) => Def::Mod(id),
-            Def::Static(id, is_mutbl) => Def::Static(id, is_mutbl),
+            Def::Static(id) => Def::Static(id),
+            Def::StaticMut(id) => Def::StaticMut(id),
             Def::Enum(id) => Def::Enum(id),
             Def::Variant(id) => Def::Variant(id),
             Def::Ctor(a, b, c) => Def::Ctor(a, b, c),

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -457,8 +457,9 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
         ItemKind::Use(ref path, _) => {
             visitor.visit_use(path, item.hir_id);
         }
-        ItemKind::Static(ref typ, _, body) |
-        ItemKind::Const(ref typ, body) => {
+        ItemKind::Const(ref typ, body)
+        | ItemKind::Static(ref typ, body)
+        | ItemKind::StaticMut(ref typ, body) => {
             visitor.visit_id(item.hir_id);
             visitor.visit_ty(typ);
             visitor.visit_nested_body(body);
@@ -725,7 +726,8 @@ pub fn walk_foreign_item<'v, V: Visitor<'v>>(visitor: &mut V, foreign_item: &'v 
                 visitor.visit_ident(param_name);
             }
         }
-        ForeignItemKind::Static(ref typ, _) => visitor.visit_ty(typ),
+        ForeignItemKind::Static(ref typ)
+        | ForeignItemKind::StaticMut(ref typ) => visitor.visit_ty(typ),
         ForeignItemKind::Type => (),
     }
 

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -144,8 +144,10 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                 )
             }
             ItemKind::Mod(..) => DefPathData::Module(i.ident.as_interned_str()),
-            ItemKind::Static(..) | ItemKind::Const(..) | ItemKind::Fn(..) =>
-                DefPathData::ValueNs(i.ident.as_interned_str()),
+            ItemKind::Const(..)
+            | ItemKind::Static(..)
+            | ItemKind::StaticMut(..)
+            | ItemKind::Fn(..) => DefPathData::ValueNs(i.ident.as_interned_str()),
             ItemKind::MacroDef(..) => DefPathData::MacroDef(i.ident.as_interned_str()),
             ItemKind::Mac(..) => return self.visit_macro_invoc(i.id),
             ItemKind::GlobalAsm(..) => DefPathData::Misc,

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -464,11 +464,18 @@ impl<'a> State<'a> {
                 self.s.word(";")?;
                 self.end() // end the outer fn box
             }
-            hir::ForeignItemKind::Static(ref t, m) => {
+            hir::ForeignItemKind::Static(ref t) => {
                 self.head(visibility_qualified(&item.vis, "static"))?;
-                if m {
-                    self.word_space("mut")?;
-                }
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(&t)?;
+                self.s.word(";")?;
+                self.end()?; // end the head-ibox
+                self.end() // end the outer cbox
+            }
+            hir::ForeignItemKind::StaticMut(ref t) => {
+                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.word_space("mut")?;
                 self.print_ident(item.ident)?;
                 self.word_space(":")?;
                 self.print_type(&t)?;
@@ -562,11 +569,22 @@ impl<'a> State<'a> {
                 self.end()?; // end inner head-block
                 self.end()?; // end outer head-block
             }
-            hir::ItemKind::Static(ref ty, m, expr) => {
+            hir::ItemKind::Static(ref ty, expr) => {
                 self.head(visibility_qualified(&item.vis, "static"))?;
-                if m == hir::MutMutable {
-                    self.word_space("mut")?;
-                }
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(&ty)?;
+                self.s.space()?;
+                self.end()?; // end the head-ibox
+
+                self.word_space("=")?;
+                self.ann.nested(self, Nested::Body(expr))?;
+                self.s.word(";")?;
+                self.end()?; // end the outer cbox
+            }
+            hir::ItemKind::StaticMut(ref ty, expr) => {
+                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.word_space("mut")?;
                 self.print_ident(item.ident)?;
                 self.word_space(":")?;
                 self.print_type(&ty)?;

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -477,6 +477,7 @@ impl<'a, 'tcx> DeadVisitor<'a, 'tcx> {
     fn should_warn_about_item(&mut self, item: &hir::Item) -> bool {
         let should_warn = match item.node {
             hir::ItemKind::Static(..)
+            | hir::ItemKind::StaticMut(..)
             | hir::ItemKind::Const(..)
             | hir::ItemKind::Fn(..)
             | hir::ItemKind::Ty(..)

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -709,7 +709,8 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                 Ok(self.cat_rvalue_node(hir_id, span, expr_ty))
             }
 
-            Def::Static(def_id, mutbl) => {
+            Def::Static(def_id)
+            | Def::StaticMut(def_id) => {
                 // `#[thread_local]` statics may not outlive the current function, but
                 // they also cannot be moved out of.
                 let is_thread_local = self.tcx.get_attrs(def_id)[..]
@@ -727,7 +728,7 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                     hir_id,
                     span,
                     cat,
-                    mutbl: if mutbl { McDeclared } else { McImmutable},
+                    mutbl: if let Def::StaticMut(_) = def { McDeclared } else { McImmutable},
                     ty:expr_ty,
                     note: NoteNone
                 })

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -265,6 +265,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
                     hir::ItemKind::Existential(..) |
                     hir::ItemKind::Ty(..) |
                     hir::ItemKind::Static(..) |
+                    hir::ItemKind::StaticMut(..) |
                     hir::ItemKind::Mod(..) |
                     hir::ItemKind::ForeignMod(..) |
                     hir::ItemKind::Impl(..) |

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -485,7 +485,9 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 // These sorts of items have no lifetime parameters at all.
                 intravisit::walk_item(self, item);
             }
-            hir::ItemKind::Static(..) | hir::ItemKind::Const(..) => {
+            hir::ItemKind::Const(..)
+            | hir::ItemKind::Static(..)
+            | hir::ItemKind::StaticMut(..) => {
                 // No lifetime parameters, but implied 'static.
                 let scope = Scope::Elision {
                     elide: Elide::Exact(Region::Static),
@@ -558,10 +560,9 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                     intravisit::walk_foreign_item(this, item);
                 })
             }
-            hir::ForeignItemKind::Static(..) => {
-                intravisit::walk_foreign_item(self, item);
-            }
-            hir::ForeignItemKind::Type => {
+            hir::ForeignItemKind::Static(..)
+            | hir::ForeignItemKind::StaticMut(..)
+            | hir::ForeignItemKind::Type => {
                 intravisit::walk_foreign_item(self, item);
             }
         }

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -618,26 +618,23 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         if let Some(node) = self.hir().get_if_local(def_id) {
             match node {
                 Node::Item(&hir::Item {
-                    node: hir::ItemKind::Static(_, mutbl, _), ..
-                }) => Some(mutbl),
-                Node::ForeignItem(&hir::ForeignItem {
-                    node: hir::ForeignItemKind::Static(_, is_mutbl), ..
-                }) =>
-                    Some(if is_mutbl {
-                        hir::Mutability::MutMutable
-                    } else {
-                        hir::Mutability::MutImmutable
-                    }),
+                    node: hir::ItemKind::Static(..), ..
+                })
+                | Node::ForeignItem(&hir::ForeignItem {
+                    node: hir::ForeignItemKind::Static(_), ..
+                }) => Some(hir::Mutability::MutImmutable),
+                Node::Item(&hir::Item {
+                    node: hir::ItemKind::StaticMut(..), ..
+                })
+                | Node::ForeignItem(&hir::ForeignItem {
+                    node: hir::ForeignItemKind::StaticMut(_), ..
+                }) => Some(hir::Mutability::MutMutable),
                 _ => None
             }
         } else {
             match self.describe_def(def_id) {
-                Some(Def::Static(_, is_mutbl)) =>
-                    Some(if is_mutbl {
-                        hir::Mutability::MutMutable
-                    } else {
-                        hir::Mutability::MutImmutable
-                    }),
+                Some(Def::Static(_)) => Some(hir::Mutability::MutImmutable),
+                Some(Def::StaticMut(_)) => Some(hir::Mutability::MutMutable),
                 _ => None
             }
         }

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -64,7 +64,8 @@ impl MutVisitor for ExpandAllocatorDirectives<'_> {
             return mut_visit::noop_flat_map_item(item, self);
         };
         match item.node {
-            ItemKind::Static(..) => {}
+            ItemKind::Static(..)
+            | ItemKind::StaticMut(..) => {}
             _ => {
                 self.handler
                     .span_err(item.span, "allocators must be statics");

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -219,7 +219,10 @@ impl CodegenCx<'ll, 'tcx> {
             let (g, attrs) = match self.tcx.hir().get_by_hir_id(id) {
                 Node::Item(&hir::Item {
                     ref attrs, span, node: hir::ItemKind::Static(..), ..
-                }) => {
+                })
+                | Node::Item(&hir::Item {
+                    ref attrs, span, node: hir::ItemKind::StaticMut(..), ..
+                })=> {
                     if self.get_declared_value(&sym[..]).is_some() {
                         span_bug!(span, "Conflicting symbol names for static?");
                     }
@@ -237,6 +240,9 @@ impl CodegenCx<'ll, 'tcx> {
 
                 Node::ForeignItem(&hir::ForeignItem {
                     ref attrs, span, node: hir::ForeignItemKind::Static(..), ..
+                })
+                | Node::ForeignItem(&hir::ForeignItem {
+                    ref attrs, span, node: hir::ForeignItemKind::StaticMut(..), ..
                 }) => {
                     let fn_attrs = self.tcx.codegen_fn_attrs(def_id);
                     (check_and_apply_linkage(&self, &fn_attrs, ty, sym, Some(span)), attrs)

--- a/src/librustc_codegen_ssa/mono_item.rs
+++ b/src/librustc_codegen_ssa/mono_item.rs
@@ -21,7 +21,8 @@ pub trait MonoItemExt<'a, 'tcx: 'a>: fmt::Debug + BaseMonoItemExt<'a, 'tcx> {
             MonoItem::Static(def_id) => {
                 let tcx = cx.tcx();
                 let is_mutable = match tcx.describe_def(def_id) {
-                    Some(Def::Static(_, is_mutable)) => is_mutable,
+                    Some(Def::Static(_)) => false,
+                    Some(Def::StaticMut(_)) => true,
                     Some(other) => {
                         bug!("Expected Def::Static, found {:?}", other)
                     }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -740,7 +740,9 @@ impl<'a> ReplaceBodyWithLoop<'a> {
 impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn visit_item_kind(&mut self, i: &mut ast::ItemKind) {
         let is_const = match i {
-            ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => true,
+            ast::ItemKind::Const(..)
+            | ast::ItemKind::Static(..)
+            | ast::ItemKind::StaticMut(..) => true,
             ast::ItemKind::Fn(ref decl, ref header, _, _) =>
                 header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
             _ => false,

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -421,6 +421,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDoc {
             }
             hir::ItemKind::Const(..) => "a constant",
             hir::ItemKind::Static(..) => "a static",
+            hir::ItemKind::StaticMut(..) => "a mutable static",
             _ => return,
         };
 
@@ -1190,13 +1191,12 @@ fn check_const(cx: &LateContext<'_, '_>, body_id: hir::BodyId) {
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedBrokenConst {
     fn check_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::Item) {
         match it.node {
-            hir::ItemKind::Const(_, body_id) => {
+            hir::ItemKind::Const(_, body_id)
+            | hir::ItemKind::Static(_, body_id)
+            | hir::ItemKind::StaticMut(_, body_id) => {
                 check_const(cx, body_id);
-            },
-            hir::ItemKind::Static(_, _, body_id) => {
-                check_const(cx, body_id);
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 }

--- a/src/librustc_lint/nonstandard_style.rs
+++ b/src/librustc_lint/nonstandard_style.rs
@@ -393,6 +393,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for NonUpperCaseGlobals {
             hir::ItemKind::Static(..) if !attr::contains_name(&it.attrs, "no_mangle") => {
                 NonUpperCaseGlobals::check_upper_case(cx, "static variable", &it.ident);
             }
+            hir::ItemKind::StaticMut(..) if !attr::contains_name(&it.attrs, "no_mangle") => {
+                NonUpperCaseGlobals::check_upper_case(cx, "mutable static variable", &it.ident);
+            }
             hir::ItemKind::Const(..) => {
                 NonUpperCaseGlobals::check_upper_case(cx, "constant", &it.ident);
             }

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -791,7 +791,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImproperCTypes {
                 hir::ForeignItemKind::Fn(ref decl, _, _) => {
                     vis.check_foreign_fn(it.hir_id, decl);
                 }
-                hir::ForeignItemKind::Static(ref ty, _) => {
+                hir::ForeignItemKind::Static(ref ty)
+                | hir::ForeignItemKind::StaticMut(ref ty) => {
                     vis.check_foreign_static(it.hir_id, ty.span);
                 }
                 hir::ForeignItemKind::Type => ()

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -404,9 +404,9 @@ impl<'tcx> EntryKind<'tcx> {
             EntryKind::Const(..) => Def::Const(did),
             EntryKind::AssociatedConst(..) => Def::AssociatedConst(did),
             EntryKind::ImmStatic |
-            EntryKind::ForeignImmStatic => Def::Static(did, false),
+            EntryKind::ForeignImmStatic => Def::Static(did),
             EntryKind::MutStatic |
-            EntryKind::ForeignMutStatic => Def::Static(did, true),
+            EntryKind::ForeignMutStatic => Def::StaticMut(did),
             EntryKind::Struct(_, _) => Def::Struct(did),
             EntryKind::Union(_, _) => Def::Union(did),
             EntryKind::Fn(_) |

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1094,8 +1094,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         debug!("IsolatedEncoder::encode_info_for_item({:?})", def_id);
 
         let kind = match item.node {
-            hir::ItemKind::Static(_, hir::MutMutable, _) => EntryKind::MutStatic,
-            hir::ItemKind::Static(_, hir::MutImmutable, _) => EntryKind::ImmStatic,
+            hir::ItemKind::Static(..) => EntryKind::ImmStatic,
+            hir::ItemKind::StaticMut(..) => EntryKind::MutStatic,
             hir::ItemKind::Const(_, body_id) => {
                 let mir = tcx.at(item.span).mir_const_qualif(def_id).0;
                 EntryKind::Const(
@@ -1248,6 +1248,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
 
             ty: match item.node {
                 hir::ItemKind::Static(..) |
+                hir::ItemKind::StaticMut(..) |
                 hir::ItemKind::Const(..) |
                 hir::ItemKind::Fn(..) |
                 hir::ItemKind::Ty(..) |
@@ -1268,6 +1269,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             },
             generics: match item.node {
                 hir::ItemKind::Static(..) |
+                hir::ItemKind::StaticMut(..) |
                 hir::ItemKind::Const(..) |
                 hir::ItemKind::Fn(..) |
                 hir::ItemKind::Ty(..) |
@@ -1282,6 +1284,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             },
             predicates: match item.node {
                 hir::ItemKind::Static(..) |
+                hir::ItemKind::StaticMut(..) |
                 hir::ItemKind::Const(..) |
                 hir::ItemKind::Fn(..) |
                 hir::ItemKind::Ty(..) |
@@ -1307,7 +1310,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             },
 
             mir: match item.node {
-                hir::ItemKind::Static(..) => {
+                hir::ItemKind::Static(..)
+                | hir::ItemKind::StaticMut(..) => {
                     self.encode_optimized_mir(def_id)
                 }
                 hir::ItemKind::Const(..) => self.encode_optimized_mir(def_id),
@@ -1647,8 +1651,8 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 };
                 EntryKind::ForeignFn(self.lazy(&data))
             }
-            hir::ForeignItemKind::Static(_, true) => EntryKind::ForeignMutStatic,
-            hir::ForeignItemKind::Static(_, false) => EntryKind::ForeignImmStatic,
+            hir::ForeignItemKind::Static(_) => EntryKind::ForeignImmStatic,
+            hir::ForeignItemKind::StaticMut(_) => EntryKind::ForeignMutStatic,
             hir::ForeignItemKind::Type => EntryKind::ForeignType,
         };
 
@@ -1789,6 +1793,7 @@ impl<'a, 'b, 'tcx> IndexBuilder<'a, 'b, 'tcx> {
         let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
         match item.node {
             hir::ItemKind::Static(..) |
+            hir::ItemKind::StaticMut(..) |
             hir::ItemKind::Const(..) |
             hir::ItemKind::Fn(..) |
             hir::ItemKind::Mod(..) |

--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -501,7 +501,9 @@ impl<'cx, 'gcx, 'tcx> UniversalRegionsBuilder<'cx, 'gcx, 'tcx> {
                 }
             }
 
-            BodyOwnerKind::Const | BodyOwnerKind::Static(..) => {
+            BodyOwnerKind::Const
+            | BodyOwnerKind::Static
+            | BodyOwnerKind::StaticMut => {
                 assert_eq!(closure_base_def_id, self.mir_def_id);
                 let identity_substs = InternalSubsts::identity_for_item(tcx, closure_base_def_id);
                 let substs = self.infcx

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -52,8 +52,9 @@ pub fn mir_build<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> Mir<'t
         ) => {
             (*body_id, decl.output.span())
         }
-        Node::Item(hir::Item { node: hir::ItemKind::Static(ty, _, body_id), .. })
-        | Node::Item(hir::Item { node: hir::ItemKind::Const(ty, body_id), .. })
+        Node::Item(hir::Item { node: hir::ItemKind::Const(ty, body_id), .. })
+        | Node::Item(hir::Item { node: hir::ItemKind::Static(ty, body_id), .. })
+        | Node::Item(hir::Item { node: hir::ItemKind::StaticMut(ty, body_id), .. })
         | Node::ImplItem(hir::ImplItem { node: hir::ImplItemKind::Const(ty, body_id), .. })
         | Node::TraitItem(
             hir::TraitItem { node: hir::TraitItemKind::Const(ty, Some(body_id)), .. }

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -611,8 +611,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
     /// intermediate values do not have to be dropped in that case.
     pub fn local_scope(&self) -> Option<region::Scope> {
         match self.hir.body_owner_kind {
-            hir::BodyOwnerKind::Const |
-            hir::BodyOwnerKind::Static(_) =>
+            hir::BodyOwnerKind::Const
+            | hir::BodyOwnerKind::Static
+            | hir::BodyOwnerKind::StaticMut =>
                 // No need to free storage in this context.
                 None,
             hir::BodyOwnerKind::Closure |

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -971,7 +971,8 @@ fn convert_path_expr<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             }
         }
 
-        Def::Static(node_id, _) => ExprKind::StaticRef { id: node_id },
+        Def::Static(node_id)
+        | Def::StaticMut(node_id) => ExprKind::StaticRef { id: node_id },
 
         Def::Local(..) | Def::Upvar(..) => convert_var(cx, expr, def),
 

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -57,8 +57,9 @@ impl<'a, 'gcx, 'tcx> Cx<'a, 'gcx, 'tcx> {
         let body_owner_kind = tcx.hir().body_owner_kind_by_hir_id(src_id);
 
         let constness = match body_owner_kind {
-            hir::BodyOwnerKind::Const |
-            hir::BodyOwnerKind::Static(_) => hir::Constness::Const,
+            hir::BodyOwnerKind::Const
+            | hir::BodyOwnerKind::Static
+            | hir::BodyOwnerKind::StaticMut => hir::Constness::Const,
             hir::BodyOwnerKind::Closure |
             hir::BodyOwnerKind::Fn => hir::Constness::NotConst,
         };

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -503,7 +503,10 @@ impl<'a, 'mir, 'tcx: 'mir, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tc
             // Now mark those locals as dead that we do not want to initialize
             match self.tcx.describe_def(instance.def_id()) {
                 // statics and constants don't have `Storage*` statements, no need to look for them
-                Some(Def::Static(..)) | Some(Def::Const(..)) | Some(Def::AssociatedConst(..)) => {},
+                Some(Def::Const(..))
+                | Some(Def::AssociatedConst(..))
+                | Some(Def::Static(..))
+                | Some(Def::StaticMut(..)) => {},
                 _ => {
                     trace!("push_stack_frame: {:?}: num_bbs: {}", span, mir.basic_blocks().len());
                     for block in mir.basic_blocks() {

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -990,7 +990,8 @@ impl<'b, 'a, 'v> ItemLikeVisitor<'v> for RootCollector<'b, 'a, 'v> {
                                         self.tcx.hir().local_def_id_from_hir_id(item.hir_id)));
                 self.output.push(MonoItem::GlobalAsm(item.hir_id));
             }
-            hir::ItemKind::Static(..) => {
+            hir::ItemKind::Static(..)
+            | hir::ItemKind::StaticMut(..) => {
                 let def_id = self.tcx.hir().local_def_id_from_hir_id(item.hir_id);
                 debug!("RootCollector: ItemKind::Static({})",
                        def_id_to_string(self.tcx, def_id));

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -539,8 +539,9 @@ fn unsafety_check_result<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId)
     let (const_context, min_const_fn) = match tcx.hir().body_owner_kind_by_hir_id(id) {
         hir::BodyOwnerKind::Closure => (false, false),
         hir::BodyOwnerKind::Fn => (tcx.is_const_fn(def_id), tcx.is_min_const_fn(def_id)),
-        hir::BodyOwnerKind::Const |
-        hir::BodyOwnerKind::Static(_) => (true, false),
+        hir::BodyOwnerKind::Const
+        | hir::BodyOwnerKind::Static
+        | hir::BodyOwnerKind::StaticMut => (true, false),
     };
     let mut checker = UnsafetyChecker::new(
         const_context, min_const_fn,

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1485,8 +1485,8 @@ impl MirPass for QualifyAndPromoteConstants {
                 const_promoted_temps = Some(tcx.mir_const_qualif(def_id).1);
                 Mode::Const
             }
-            hir::BodyOwnerKind::Static(hir::MutImmutable) => Mode::Static,
-            hir::BodyOwnerKind::Static(hir::MutMutable) => Mode::StaticMut,
+            hir::BodyOwnerKind::Static => Mode::Static,
+            hir::BodyOwnerKind::StaticMut => Mode::StaticMut,
         };
 
         debug!("run_pass: mode={:?}", mode);

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -592,8 +592,8 @@ fn write_mir_sig(
     match (descr, src.promoted) {
         (_, Some(i)) => write!(w, "{:?} in ", i)?,
         (Some(Def::Const(_)), _) | (Some(Def::AssociatedConst(_)), _) => write!(w, "const ")?,
-        (Some(Def::Static(_, /*is_mutbl*/false)), _) => write!(w, "static ")?,
-        (Some(Def::Static(_, /*is_mutbl*/true)), _) => write!(w, "static mut ")?,
+        (Some(Def::Static(_)), _) => write!(w, "static ")?,
+        (Some(Def::StaticMut(_)), _) => write!(w, "static mut ")?,
         (_, _) if is_function => write!(w, "fn ")?,
         (None, _) => {}, // things like anon const, not an item
         _ => bug!("Unexpected def description {:?}", descr),

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -694,7 +694,10 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         .span_label(span, "pattern not allowed in foreign function").emit();
                 });
             }
-            ForeignItemKind::Static(..) | ForeignItemKind::Ty | ForeignItemKind::Macro(..) => {}
+            ForeignItemKind::Static(..)
+            | ForeignItemKind::StaticMut(..)
+            | ForeignItemKind::Ty
+            | ForeignItemKind::Macro(..) => {}
         }
 
         visit::walk_foreign_item(self, fi)

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -184,7 +184,8 @@ impl<'a, 'tcx> CheckCrateVisitor<'a, 'tcx> {
         match self.tcx.hir().body_owner_kind(item_id) {
             hir::BodyOwnerKind::Closure |
             hir::BodyOwnerKind::Fn => self.in_fn = true,
-            hir::BodyOwnerKind::Static(_) => self.in_static = true,
+            hir::BodyOwnerKind::Static
+            | hir::BodyOwnerKind::StaticMut => self.in_static = true,
             _ => {}
         };
 
@@ -329,8 +330,8 @@ fn check_expr_kind<'a, 'tcx>(
                 // are inherently promotable with the exception
                 //  of "#[thread_local]" statics, which may not
                 // outlive the current function
-                Def::Static(did, _) => {
-
+                Def::Static(did)
+                | Def::StaticMut(did) => {
                     if v.in_static {
                         for attr in &v.tcx.get_attrs(did)[..] {
                             if attr.check_name("thread_local") {

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1388,8 +1388,9 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
             Fn(ref decl, .., ref ty_params, ref body) => {
                 self.process_fn(item, &decl, ty_params, &body)
             }
-            Static(ref typ, _, ref expr) => self.process_static_or_const_item(item, typ, expr),
-            Const(ref typ, ref expr) => self.process_static_or_const_item(item, &typ, &expr),
+            Const(ref typ, ref expr)
+            | Static(ref typ, ref expr)
+            | StaticMut(ref typ, ref expr) => self.process_static_or_const_item(item, typ, expr),
             Struct(ref def, ref ty_params) | Union(ref def, ref ty_params) => {
                 self.process_struct(item, def, ty_params)
             }
@@ -1664,7 +1665,8 @@ impl<'l, 'tcx: 'l, 'll, O: DumpOutput + 'll> Visitor<'l> for DumpVisitor<'l, 'tc
                     self.visit_ty(&ret_ty);
                 }
             }
-            ast::ForeignItemKind::Static(ref ty, _) => {
+            ast::ForeignItemKind::Static(ref ty)
+            | ast::ForeignItemKind::StaticMut(ref ty) => {
                 if let Some(var_data) = self.save_ctxt.get_extern_item_data(item) {
                     down_cast_data!(var_data, DefData, item.span);
                     self.dumper.dump_def(&access, var_data);

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -155,7 +155,8 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     attributes: lower_attributes(item.attrs.clone(), self),
                 }))
             }
-            ast::ForeignItemKind::Static(ref ty, _) => {
+            ast::ForeignItemKind::Static(ref ty)
+            | ast::ForeignItemKind::StaticMut(ref ty) => {
                 filter!(self.span_utils, item.ident.span);
 
                 let id = id_from_node_id(item.id, self);
@@ -203,7 +204,8 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                     attributes: lower_attributes(item.attrs.clone(), self),
                 }))
             }
-            ast::ItemKind::Static(ref typ, ..) => {
+            ast::ItemKind::Static(ref typ, _)
+            | ast::ItemKind::StaticMut(ref typ, _) => {
                 let qualname = format!("::{}",
                     self.tcx.def_path_str(self.tcx.hir().local_def_id(item.id)));
 
@@ -754,6 +756,7 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 })
             }
             HirDef::Static(..) |
+            HirDef::StaticMut(..) |
             HirDef::Const(..) |
             HirDef::AssociatedConst(..) |
             HirDef::Ctor(..) => {

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -325,9 +325,10 @@ impl Sig for ast::Item {
         let id = Some(self.id);
 
         match self.node {
-            ast::ItemKind::Static(ref ty, m, ref expr) => {
+            ast::ItemKind::Static(ref ty, ref expr)
+            | ast::ItemKind::StaticMut(ref ty, ref expr) => {
                 let mut text = "static ".to_owned();
-                if m == ast::Mutability::Mutable {
+                if let ast::ItemKind::StaticMut(..) = self.node {
                     text.push_str("mut ");
                 }
                 let name = self.ident.to_string();
@@ -796,9 +797,10 @@ impl Sig for ast::ForeignItem {
 
                 Ok(sig)
             }
-            ast::ForeignItemKind::Static(ref ty, m) => {
+            ast::ForeignItemKind::Static(ref ty)
+            | ast::ForeignItemKind::StaticMut(ref ty) => {
                 let mut text = "static ".to_owned();
-                if m {
+                if let ast::ForeignItemKind::StaticMut(_) = self.node {
                     text.push_str("mut ");
                 }
                 let name = self.ident.to_string();

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1646,7 +1646,8 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
             Def::Fn(def_id) |
             Def::Const(def_id) |
             Def::ConstParam(def_id) |
-            Def::Static(def_id, _) => {
+            Def::Static(def_id) |
+            Def::StaticMut(def_id) => {
                 path_segs.push(PathSeg(def_id, last));
             }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -753,8 +753,9 @@ fn primary_body_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     match tcx.hir().get_by_hir_id(id) {
         Node::Item(item) => {
             match item.node {
-                hir::ItemKind::Const(_, body) |
-                hir::ItemKind::Static(_, _, body) =>
+                hir::ItemKind::Const(_, body)
+                | hir::ItemKind::Static(_, body)
+                | hir::ItemKind::StaticMut(_, body) =>
                     Some((body, None)),
                 hir::ItemKind::Fn(ref decl, .., body) =>
                     Some((body, Some(decl))),
@@ -1323,7 +1324,8 @@ pub fn check_item_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, it: &'tcx hir::Ite
     let _indenter = indenter();
     match it.node {
         // Consts can play a role in type-checking, so they are included here.
-        hir::ItemKind::Static(..) => {
+        hir::ItemKind::Static(..)
+        | hir::ItemKind::StaticMut(..) => {
             let def_id = tcx.hir().local_def_id_from_hir_id(it.hir_id);
             tcx.typeck_tables_of(def_id);
             maybe_check_static_with_link_section(tcx, def_id, it.span);

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -108,15 +108,18 @@ pub fn check_item_well_formed<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: Def
         hir::ItemKind::Fn(..) => {
             check_item_fn(tcx, item);
         }
-        hir::ItemKind::Static(ref ty, ..) => {
-            check_item_type(tcx, item.hir_id, ty.span, false);
-        }
-        hir::ItemKind::Const(ref ty, ..) => {
+        hir::ItemKind::Const(ref ty, _)
+        | hir::ItemKind::Static(ref ty, _)
+        | hir::ItemKind::StaticMut(ref ty, _) => {
             check_item_type(tcx, item.hir_id, ty.span, false);
         }
         hir::ItemKind::ForeignMod(ref module) => for it in module.items.iter() {
-            if let hir::ForeignItemKind::Static(ref ty, ..) = it.node {
-                check_item_type(tcx, it.hir_id, ty.span, true);
+            match it.node {
+                hir::ForeignItemKind::Static(ref ty)
+                | hir::ForeignItemKind::StaticMut(ref ty) => {
+                    check_item_type(tcx, it.hir_id, ty.span, true);
+                }
+                _ => {}
             }
         },
         hir::ItemKind::Struct(ref struct_def, ref ast_generics) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -460,6 +460,7 @@ fn convert_item<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, item_id: hir::HirId) {
         hir::ItemKind::Existential(..)
         | hir::ItemKind::Ty(..)
         | hir::ItemKind::Static(..)
+        | hir::ItemKind::StaticMut(..)
         | hir::ItemKind::Const(..)
         | hir::ItemKind::Fn(..) => {
             tcx.generics_of(def_id);
@@ -957,9 +958,10 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
         }
 
         Node::ForeignItem(item) => match item.node {
-            ForeignItemKind::Static(..) => &no_generics,
+            ForeignItemKind::Static(..)
+            | ForeignItemKind::StaticMut(..)
+            | ForeignItemKind::Type => &no_generics,
             ForeignItemKind::Fn(_, _, ref generics) => generics,
-            ForeignItemKind::Type => &no_generics,
         },
 
         _ => &no_generics,
@@ -1205,8 +1207,9 @@ pub fn checked_type_of<'a, 'tcx>(
 
         Node::Item(item) => {
             match item.node {
-                ItemKind::Static(ref t, ..)
-                | ItemKind::Const(ref t, _)
+                ItemKind::Const(ref t, _)
+                | ItemKind::Static(ref t, _)
+                | ItemKind::StaticMut(ref t, _)
                 | ItemKind::Ty(ref t, _)
                 | ItemKind::Impl(.., ref t, _) => icx.to_ty(t),
                 ItemKind::Fn(..) => {
@@ -1269,7 +1272,8 @@ pub fn checked_type_of<'a, 'tcx>(
                 let substs = InternalSubsts::identity_for_item(tcx, def_id);
                 tcx.mk_fn_def(def_id, substs)
             }
-            ForeignItemKind::Static(ref t, _) => icx.to_ty(t),
+            ForeignItemKind::Static(ref t)
+            | ForeignItemKind::StaticMut(ref t) => icx.to_ty(t),
             ForeignItemKind::Type => tcx.mk_foreign(def_id),
         },
 
@@ -2014,9 +2018,10 @@ fn explicit_predicates_of<'a, 'tcx>(
         }
 
         Node::ForeignItem(item) => match item.node {
-            ForeignItemKind::Static(..) => &no_generics,
+            ForeignItemKind::Static(..)
+            | ForeignItemKind::StaticMut(..)
+            | ForeignItemKind::Type => &no_generics,
             ForeignItemKind::Fn(_, _, ref generics) => generics,
-            ForeignItemKind::Type => &no_generics,
         },
 
         _ => &no_generics,

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -93,9 +93,13 @@ pub fn try_inline(
             record_extern_fqn(cx, did, clean::TypeKind::Module);
             clean::ModuleItem(build_module(cx, did, visited))
         }
-        Def::Static(did, mtbl) => {
+        Def::Static(did) => {
             record_extern_fqn(cx, did, clean::TypeKind::Static);
-            clean::StaticItem(build_static(cx, did, mtbl))
+            clean::StaticItem(build_static(cx, did, false))
+        }
+        Def::StaticMut(did) => {
+            record_extern_fqn(cx, did, clean::TypeKind::Static);
+            clean::StaticItem(build_static(cx, did, true))
         }
         Def::Const(did) => {
             record_extern_fqn(cx, did, clean::TypeKind::Const);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -4052,10 +4052,17 @@ impl Clean<Item> for hir::ForeignItem {
                     ret_types,
                 })
             }
-            hir::ForeignItemKind::Static(ref ty, mutbl) => {
+            hir::ForeignItemKind::Static(ref ty) => {
                 ForeignStaticItem(Static {
                     type_: ty.clean(cx),
-                    mutability: if mutbl {Mutable} else {Immutable},
+                    mutability: Immutable,
+                    expr: String::new(),
+                })
+            }
+            hir::ForeignItemKind::StaticMut(ref ty) => {
+                ForeignStaticItem(Static {
+                    type_: ty.clean(cx),
+                    mutability: Mutable,
                     expr: String::new(),
                 })
             }
@@ -4204,7 +4211,8 @@ pub fn register_def(cx: &DocContext<'_>, def: Def) -> DefId {
         Def::Mod(i) => (i, TypeKind::Module),
         Def::ForeignTy(i) => (i, TypeKind::Foreign),
         Def::Const(i) => (i, TypeKind::Const),
-        Def::Static(i, _) => (i, TypeKind::Static),
+        Def::Static(i)
+        | Def::StaticMut(i) => (i, TypeKind::Static),
         Def::Variant(i) => (cx.tcx.parent(i).expect("cannot get parent def id"),
                             TypeKind::Enum),
         Def::Macro(i, mac_kind) => match mac_kind {

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -548,7 +548,8 @@ fn ambiguity_error(
                     _ => {
                         let type_ = match (def, ns) {
                             (Def::Const(..), _) => "const",
-                            (Def::Static(..), _) => "static",
+                            (Def::Static(..), _)
+                            | (Def::StaticMut(..), _) => "static",
                             (Def::Struct(..), _) => "struct",
                             (Def::Enum(..), _) => "enum",
                             (Def::Union(..), _) => "union",

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -501,10 +501,15 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 };
                 om.existentials.push(t);
             },
-            hir::ItemKind::Static(ref ty, ref mut_, ref exp) => {
+            hir::ItemKind::Static(ref ty, ref exp)
+            | hir::ItemKind::StaticMut(ref ty, ref exp) => {
                 let s = Static {
                     type_: ty.clone(),
-                    mutability: mut_.clone(),
+                    mutability: if let hir::ItemKind::StaticMut(..) = item.node {
+                        hir::MutMutable
+                    } else {
+                        hir::MutImmutable
+                    },
                     expr: exp.clone(),
                     id: item.hir_id,
                     name: ident.name,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2234,7 +2234,11 @@ pub enum ItemKind {
     /// A static item (`static` or `pub static`).
     ///
     /// E.g., `static FOO: i32 = 42;` or `static FOO: &'static str = "bar";`.
-    Static(P<Ty>, Mutability, P<Expr>),
+    Static(P<Ty>, P<Expr>),
+    /// A mutable static item (`static mut` or `pub static mut`).
+    ///
+    /// E.g., `pub static mut FOO: i32 = 42;`.
+    StaticMut(P<Ty>, P<Expr>),
     /// A constant item (`const` or `pub const`).
     ///
     /// E.g., `const FOO: i32 = 42;`.
@@ -2308,6 +2312,7 @@ impl ItemKind {
             ItemKind::ExternCrate(..) => "extern crate",
             ItemKind::Use(..) => "use",
             ItemKind::Static(..) => "static item",
+            ItemKind::StaticMut(..) => "mutable static item",
             ItemKind::Const(..) => "constant item",
             ItemKind::Fn(..) => "function",
             ItemKind::Mod(..) => "module",
@@ -2340,9 +2345,10 @@ pub struct ForeignItem {
 pub enum ForeignItemKind {
     /// A foreign function.
     Fn(P<FnDecl>, Generics),
-    /// A foreign static item (`static ext: u8`), with optional mutability.
-    /// (The boolean is `true` for mutable items).
-    Static(P<Ty>, bool),
+    /// A foreign static item (`static ext: u8`).
+    Static(P<Ty>),
+    /// A foreign mutable static item (`static mut ext: u8`).
+    StaticMut(P<Ty>),
     /// A foreign type.
     Ty,
     /// A macro invocation.
@@ -2354,6 +2360,7 @@ impl ForeignItemKind {
         match *self {
             ForeignItemKind::Fn(..) => "foreign function",
             ForeignItemKind::Static(..) => "foreign static item",
+            ForeignItemKind::StaticMut(..) => "foreign mutable static item",
             ForeignItemKind::Ty => "foreign type",
             ForeignItemKind::Macro(..) => "macro in foreign module",
         }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1122,7 +1122,10 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                    mutbl: ast::Mutability,
                    expr: P<ast::Expr>)
                    -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::Static(ty, mutbl, expr))
+        self.item(span, name, Vec::new(), match mutbl {
+            ast::Mutability::Immutable => ast::ItemKind::Static(ty, expr),
+            ast::Mutability::Mutable => ast::ItemKind::StaticMut(ty, expr),
+        })
     }
 
     fn item_const(&self,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1918,7 +1918,8 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_foreign_item(&mut self, i: &'a ast::ForeignItem) {
         match i.node {
             ast::ForeignItemKind::Fn(..) |
-            ast::ForeignItemKind::Static(..) => {
+            ast::ForeignItemKind::Static(..) |
+            ast::ForeignItemKind::StaticMut(..) => {
                 let link_name = attr::first_attr_value_str_by_name(&i.attrs, "link_name");
                 let links_to_llvm = match link_name {
                     Some(val) => val.as_str().starts_with("llvm."),

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -820,11 +820,9 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
     match kind {
         ItemKind::ExternCrate(_orig_name) => {}
         ItemKind::Use(use_tree) => vis.visit_use_tree(use_tree),
-        ItemKind::Static(ty, _mut, expr) => {
-            vis.visit_ty(ty);
-            vis.visit_expr(expr);
-        }
-        ItemKind::Const(ty, expr) => {
+        ItemKind::Const(ty, expr)
+        | ItemKind::Static(ty, expr)
+        | ItemKind::StaticMut(ty, expr) => {
             vis.visit_ty(ty);
             vis.visit_expr(expr);
         }
@@ -999,7 +997,8 @@ pub fn noop_flat_map_foreign_item<T: MutVisitor>(mut item: ForeignItem, visitor:
             visitor.visit_fn_decl(fdec);
             visitor.visit_generics(generics);
         }
-        ForeignItemKind::Static(t, _m) => visitor.visit_ty(t),
+        ForeignItemKind::Static(t)
+        | ForeignItemKind::StaticMut(t) => visitor.visit_ty(t),
         ForeignItemKind::Ty => {}
         ForeignItemKind::Macro(mac) => visitor.visit_mac(mac),
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -7337,7 +7337,8 @@ impl<'a> Parser<'a> {
         let e = self.parse_expr()?;
         self.expect(&token::Semi)?;
         let item = match m {
-            Some(m) => ItemKind::Static(ty, m, e),
+            Some(Mutability::Immutable) => ItemKind::Static(ty, e),
+            Some(Mutability::Mutable) => ItemKind::StaticMut(ty, e),
             None => ItemKind::Const(ty, e),
         };
         Ok((id, item, None))
@@ -7644,7 +7645,11 @@ impl<'a> Parser<'a> {
         Ok(ForeignItem {
             ident,
             attrs,
-            node: ForeignItemKind::Static(ty, mutbl),
+            node: if mutbl {
+                ForeignItemKind::StaticMut(ty)
+            } else {
+                ForeignItemKind::Static(ty)
+            },
             id: ast::DUMMY_NODE_ID,
             span: lo.to(hi),
             vis,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1140,11 +1140,18 @@ impl<'a> State<'a> {
                 self.s.word(";")?;
                 self.end() // end the outer fn box
             }
-            ast::ForeignItemKind::Static(ref t, m) => {
+            ast::ForeignItemKind::Static(ref t) => {
                 self.head(visibility_qualified(&item.vis, "static"))?;
-                if m {
-                    self.word_space("mut")?;
-                }
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(t)?;
+                self.s.word(";")?;
+                self.end()?; // end the head-ibox
+                self.end() // end the outer cbox
+            }
+            ast::ForeignItemKind::StaticMut(ref t) => {
+                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.word_space("mut")?;
                 self.print_ident(item.ident)?;
                 self.word_space(":")?;
                 self.print_type(t)?;
@@ -1234,11 +1241,22 @@ impl<'a> State<'a> {
                 self.end()?; // end inner head-block
                 self.end()?; // end outer head-block
             }
-            ast::ItemKind::Static(ref ty, m, ref expr) => {
+            ast::ItemKind::Static(ref ty, ref expr) => {
                 self.head(visibility_qualified(&item.vis, "static"))?;
-                if m == ast::Mutability::Mutable {
-                    self.word_space("mut")?;
-                }
+                self.print_ident(item.ident)?;
+                self.word_space(":")?;
+                self.print_type(ty)?;
+                self.s.space()?;
+                self.end()?; // end the head-ibox
+
+                self.word_space("=")?;
+                self.print_expr(expr)?;
+                self.s.word(";")?;
+                self.end()?; // end the outer cbox
+            }
+            ast::ItemKind::StaticMut(ref ty, ref expr) => {
+                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.word_space("mut")?;
                 self.print_ident(item.ident)?;
                 self.word_space(":")?;
                 self.print_type(ty)?;

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -223,8 +223,9 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
         ItemKind::Use(ref use_tree) => {
             visitor.visit_use_tree(use_tree, item.id, false)
         }
-        ItemKind::Static(ref typ, _, ref expr) |
-        ItemKind::Const(ref typ, ref expr) => {
+        ItemKind::Const(ref typ, ref expr)
+        | ItemKind::Static(ref typ, ref expr)
+        | ItemKind::StaticMut(ref typ, ref expr) => {
             visitor.visit_ty(typ);
             visitor.visit_expr(expr);
         }
@@ -465,7 +466,8 @@ pub fn walk_foreign_item<'a, V: Visitor<'a>>(visitor: &mut V, foreign_item: &'a 
             walk_fn_decl(visitor, function_declaration);
             visitor.visit_generics(generics)
         }
-        ForeignItemKind::Static(ref typ, _) => visitor.visit_ty(typ),
+        ForeignItemKind::Static(ref typ)
+        | ForeignItemKind::StaticMut(ref typ) => visitor.visit_ty(typ),
         ForeignItemKind::Ty => (),
         ForeignItemKind::Macro(ref mac) => visitor.visit_mac(mac),
     }

--- a/src/test/incremental/hashes/statics.rs
+++ b/src/test/incremental/hashes/statics.rs
@@ -26,16 +26,6 @@ static STATIC_VISIBILITY: u8 = 0;
 pub static STATIC_VISIBILITY: u8 = 0;
 
 
-// Change static mutability ---------------------------------------------------
-#[cfg(cfail1)]
-static STATIC_MUTABILITY: u8 = 0;
-
-#[cfg(not(cfail1))]
-#[rustc_clean(cfg="cfail2", except="Hir,HirBody")]
-#[rustc_clean(cfg="cfail3")]
-static mut STATIC_MUTABILITY: u8 = 0;
-
-
 // Add linkage attribute ------------------------------------------------------
 #[cfg(cfail1)]
 static STATIC_LINKAGE: u8 = 0;

--- a/src/test/ui/issues/issue-17718-patterns.rs
+++ b/src/test/ui/issues/issue-17718-patterns.rs
@@ -5,7 +5,7 @@ const A3: usize = 1;
 fn main() {
     match 1 {
         A1 => {} //~ ERROR: match bindings cannot shadow statics
-        A2 => {} //~ ERROR: match bindings cannot shadow statics
+        A2 => {} //~ ERROR: match bindings cannot shadow mutable statics
         A3 => {}
         _ => {}
     }

--- a/src/test/ui/issues/issue-17718-patterns.stderr
+++ b/src/test/ui/issues/issue-17718-patterns.stderr
@@ -7,14 +7,14 @@ LL | static A1: usize = 1;
 LL |         A1 => {}
    |         ^^ cannot be named the same as a static
 
-error[E0530]: match bindings cannot shadow statics
+error[E0530]: match bindings cannot shadow mutable statics
   --> $DIR/issue-17718-patterns.rs:8:9
    |
 LL | static mut A2: usize = 1;
-   | ------------------------- the static `A2` is defined here
+   | ------------------------- the mutable static `A2` is defined here
 ...
 LL |         A2 => {}
-   |         ^^ cannot be named the same as a static
+   |         ^^ cannot be named the same as a mutable static
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/lint-non-uppercase-statics.rs
+++ b/src/test/ui/lint/lint-non-uppercase-statics.rs
@@ -3,7 +3,7 @@
 
 static foo: isize = 1; //~ ERROR static variable `foo` should have an upper case name
 
-static mut bar: isize = 1; //~ ERROR static variable `bar` should have an upper case name
+static mut bar: isize = 1; //~ ERROR mutable static variable `bar` should have an upper case name
 
 #[no_mangle]
 pub static extern_foo: isize = 1; // OK, because #[no_mangle] supersedes the warning

--- a/src/test/ui/lint/lint-non-uppercase-statics.stderr
+++ b/src/test/ui/lint/lint-non-uppercase-statics.stderr
@@ -10,7 +10,7 @@ note: lint level defined here
 LL | #![forbid(non_upper_case_globals)]
    |           ^^^^^^^^^^^^^^^^^^^^^^
 
-error: static variable `bar` should have an upper case name
+error: mutable static variable `bar` should have an upper case name
   --> $DIR/lint-non-uppercase-statics.rs:6:12
    |
 LL | static mut bar: isize = 1;

--- a/src/test/ui/static/static-mut-not-pat.rs
+++ b/src/test/ui/static/static-mut-not-pat.rs
@@ -10,7 +10,7 @@ fn main() {
     // instead of spitting out a custom error about some identifier collisions
     // (we should allow shadowing)
     match 4 {
-        a => {} //~ ERROR match bindings cannot shadow statics
+        a => {} //~ ERROR match bindings cannot shadow mutable statics
         _ => {}
     }
 }
@@ -34,7 +34,7 @@ fn mutable_statics() {
     match (Foo { bar: Some(Direction::North), baz: NewBool(true) }) {
         Foo { bar: None, baz: NewBool(true) } => (),
         STATIC_MUT_FOO => (),
-        //~^ ERROR match bindings cannot shadow statics
+        //~^ ERROR match bindings cannot shadow mutable statics
         Foo { bar: Some(Direction::South), .. } => (),
         Foo { bar: Some(EAST), .. } => (),
         Foo { bar: Some(Direction::North), baz: NewBool(true) } => (),

--- a/src/test/ui/static/static-mut-not-pat.stderr
+++ b/src/test/ui/static/static-mut-not-pat.stderr
@@ -1,20 +1,20 @@
-error[E0530]: match bindings cannot shadow statics
+error[E0530]: match bindings cannot shadow mutable statics
   --> $DIR/static-mut-not-pat.rs:13:9
    |
 LL | static mut a: isize = 3;
-   | ------------------------ the static `a` is defined here
+   | ------------------------ the mutable static `a` is defined here
 ...
 LL |         a => {}
-   |         ^ cannot be named the same as a static
+   |         ^ cannot be named the same as a mutable static
 
-error[E0530]: match bindings cannot shadow statics
+error[E0530]: match bindings cannot shadow mutable statics
   --> $DIR/static-mut-not-pat.rs:36:9
    |
 LL | static mut STATIC_MUT_FOO: Foo = Foo { bar: Some(Direction::West), baz: NEW_FALSE };
-   | ------------------------------------------------------------------------------------ the static `STATIC_MUT_FOO` is defined here
+   | ------------------------------------------------------------------------------------ the mutable static `STATIC_MUT_FOO` is defined here
 ...
 LL |         STATIC_MUT_FOO => (),
-   |         ^^^^^^^^^^^^^^ cannot be named the same as a static
+   |         ^^^^^^^^^^^^^^ cannot be named the same as a mutable static
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
`Static` is currently the only variant of `Def` that describes an `Item` and contains more than the `DefId` of that item (i.e. it contains the mutability).
This lack of uniformity is making some refactors/cleanups a bit harder, or more annoying.

There are primarily two alternatives, AFAICT:
1. make `StaticMut` its own kind of item/def (this PR)
2. have everything that cares about the mutability, query it (like `is_const_fn`)
   * specifically, when working with a `DefId` and not `{ast,hir}::ItemKind::Static`

I was hoping 1. would be simpler than it turned out to be, but I did the work anyway, so I'm presenting this PR for people to judge which approach they prefer.
(e.g. all the changes to `Static | StaticMut`, in patterns, would be unnecessary for 2.)

cc @petrochenkov @oli-obk @nikomatsakis @michaelwoerister 