### PR TITLE
Hide type errors likely caused by incorrect struct literal

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -169,6 +169,9 @@ pub struct Session {
     /// Mapping from ident span to path span for paths that don't exist as written, but that
     /// exist under `std`. For example, wrote `str::from_utf8` instead of `std::str::from_utf8`.
     pub confused_type_with_std_module: Lock<FxHashMap<Span, Span>>,
+
+    /// This is a possible struct literal block.
+    pub possible_struct_literal: Lock<FxHashSet<Span>>,
 }
 
 pub struct PerfStats {
@@ -1253,6 +1256,7 @@ fn build_session_(
         driver_lint_caps,
         trait_methods_not_found: Lock::new(Default::default()),
         confused_type_with_std_module: Lock::new(Default::default()),
+        possible_struct_literal: Lock::new(Default::default()),
     };
 
     validate_commandline_args_with_session_available(&sess);

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -343,6 +343,7 @@ impl<'a> Resolver<'a> {
                             format!("({})", snippet),
                             Applicability::MaybeIncorrect,
                         );
+                        self.session.possible_struct_literal.borrow_mut().insert(sp);
                     } else {
                         err.span_label(
                             span,  // Note the parenthesis surrounding the suggestion below

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1933,6 +1933,7 @@ mod tests {
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
             buffered_lints: Lock::new(vec![]),
+            missing_ident_could_be_struct_literal: Lock::new(Default::default()),
         }
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1241,7 +1241,8 @@ impl<'a> StringReader<'a> {
 
                 return Ok(self.with_str_from(start, |string| {
                     // FIXME: perform NFKC normalization here. (Issue #2253)
-                    let ident = self.mk_ident(string);
+                    let mut ident = self.mk_ident(string);
+                    ident.span = self.mk_sp(start, self.pos);
 
                     if is_raw_ident {
                         let span = self.mk_sp(raw_start, self.pos);

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -47,6 +47,9 @@ pub struct ParseSess {
     included_mod_stack: Lock<Vec<PathBuf>>,
     source_map: Lrc<SourceMap>,
     pub buffered_lints: Lock<Vec<BufferedEarlyLint>>,
+    /// This ident comes from an abiguous parse that could belong to a struct literal in an invalid
+    /// context. We use it during type-checking to silence those errors.
+    pub missing_ident_could_be_struct_literal: Lock<FxHashSet<Span>>,
 }
 
 impl ParseSess {
@@ -70,6 +73,7 @@ impl ParseSess {
             included_mod_stack: Lock::new(vec![]),
             source_map,
             buffered_lints: Lock::new(vec![]),
+            missing_ident_could_be_struct_literal: Lock::new(Default::default()),
         }
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2922,13 +2922,22 @@ impl<'a> Parser<'a> {
             )
         );
         // could be a block but we won't know until type-checking
-        if self.look_ahead(1, |t| t.is_ident()) && (
-            // foo { bar }
-            self.look_ahead(2, |t| t == &token::CloseDelim(token::Brace)) ||
-            // foo { bar: baz }
-            self.look_ahead(2, |t| t == &token::Colon)
-        ) {
+        // foo { bar }
+        if self.look_ahead(1, |t| t.is_ident()) &&
+            self.look_ahead(2, |t| t == &token::CloseDelim(token::Brace))
+        {
             self.look_ahead(1, |t| {
+                if let token::Ident(ident, _) = t {
+                    self.sess.missing_ident_could_be_struct_literal.borrow_mut().insert(ident.span);
+                }
+            });
+        }
+        // foo { bar: baz }
+        if self.look_ahead(1, |t| t.is_ident()) &&
+            self.look_ahead(2, |t| t == &token::Colon) &&
+            self.look_ahead(3, |t| t.is_ident())
+        {
+            self.look_ahead(3, |t| {
                 if let token::Ident(ident, _) = t {
                     self.sess.missing_ident_could_be_struct_literal.borrow_mut().insert(ident.span);
                 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2921,6 +2921,19 @@ impl<'a> Parser<'a> {
                 self.look_ahead(3, |t| !t.can_begin_type())
             )
         );
+        // could be a block but we won't know until type-checking
+        if self.look_ahead(1, |t| t.is_ident()) && (
+            // foo { bar }
+            self.look_ahead(2, |t| t == &token::CloseDelim(token::Brace)) ||
+            // foo { bar: baz }
+            self.look_ahead(2, |t| t == &token::Colon)
+        ) {
+            self.look_ahead(1, |t| {
+                if let token::Ident(ident, _) = t {
+                    self.sess.missing_ident_could_be_struct_literal.borrow_mut().insert(ident.span);
+                }
+            });
+        }
 
         if struct_allowed || certainly_not_a_block() {
             // This is a struct literal, but we don't can't accept them here

--- a/src/test/ui/struct-literal-variant-in-if.rs
+++ b/src/test/ui/struct-literal-variant-in-if.rs
@@ -9,6 +9,8 @@ fn test_E(x: E) {
     let field = true;
     if x == E::V { field } {}
     //~^ ERROR expected value, found struct variant `E::V`
+    if x == E::V { field: field } {}
+    //~^ ERROR expected value, found struct variant `E::V`
     if x == E::I { field1: true, field2: 42 } {}
     //~^ ERROR struct literals are not allowed here
     if x == E::V { field: false } {}

--- a/src/test/ui/struct-literal-variant-in-if.rs
+++ b/src/test/ui/struct-literal-variant-in-if.rs
@@ -9,7 +9,6 @@ fn test_E(x: E) {
     let field = true;
     if x == E::V { field } {}
     //~^ ERROR expected value, found struct variant `E::V`
-    //~| ERROR mismatched types
     if x == E::I { field1: true, field2: 42 } {}
     //~^ ERROR struct literals are not allowed here
     if x == E::V { field: false } {}

--- a/src/test/ui/struct-literal-variant-in-if.stderr
+++ b/src/test/ui/struct-literal-variant-in-if.stderr
@@ -1,5 +1,5 @@
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:13:13
+  --> $DIR/struct-literal-variant-in-if.rs:12:13
    |
 LL |     if x == E::I { field1: true, field2: 42 } {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     if x == (E::I { field1: true, field2: 42 }) {}
    |             ^                                 ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:15:13
+  --> $DIR/struct-literal-variant-in-if.rs:14:13
    |
 LL |     if x == E::V { field: false } {}
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     if x == (E::V { field: false }) {}
    |             ^                     ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:17:13
+  --> $DIR/struct-literal-variant-in-if.rs:16:13
    |
 LL |     if x == E::J { field: -42 } {}
    |             ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     if x == (E::J { field: -42 }) {}
    |             ^                   ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:19:13
+  --> $DIR/struct-literal-variant-in-if.rs:18:13
    |
 LL |     if x == E::K { field: "" } {}
    |             ^^^^^^^^^^^^^^^^^^
@@ -47,19 +47,7 @@ LL |     if x == E::V { field } {}
    |             help: surround the struct literal with parenthesis: `(E::V { field })`
 
 error[E0308]: mismatched types
-  --> $DIR/struct-literal-variant-in-if.rs:10:20
-   |
-LL | fn test_E(x: E) {
-   |                 - help: try adding a return type: `-> bool`
-LL |     let field = true;
-LL |     if x == E::V { field } {}
-   |                    ^^^^^ expected (), found bool
-   |
-   = note: expected type `()`
-              found type `bool`
-
-error[E0308]: mismatched types
-  --> $DIR/struct-literal-variant-in-if.rs:21:20
+  --> $DIR/struct-literal-variant-in-if.rs:20:20
    |
 LL |     let y: usize = ();
    |                    ^^ expected usize, found ()
@@ -67,7 +55,7 @@ LL |     let y: usize = ();
    = note: expected type `usize`
               found type `()`
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0308, E0423.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/struct-literal-variant-in-if.stderr
+++ b/src/test/ui/struct-literal-variant-in-if.stderr
@@ -1,5 +1,5 @@
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:12:13
+  --> $DIR/struct-literal-variant-in-if.rs:14:13
    |
 LL |     if x == E::I { field1: true, field2: 42 } {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     if x == (E::I { field1: true, field2: 42 }) {}
    |             ^                                 ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:14:13
+  --> $DIR/struct-literal-variant-in-if.rs:16:13
    |
 LL |     if x == E::V { field: false } {}
    |             ^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     if x == (E::V { field: false }) {}
    |             ^                     ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:16:13
+  --> $DIR/struct-literal-variant-in-if.rs:18:13
    |
 LL |     if x == E::J { field: -42 } {}
    |             ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |     if x == (E::J { field: -42 }) {}
    |             ^                   ^
 
 error: struct literals are not allowed here
-  --> $DIR/struct-literal-variant-in-if.rs:18:13
+  --> $DIR/struct-literal-variant-in-if.rs:20:13
    |
 LL |     if x == E::K { field: "" } {}
    |             ^^^^^^^^^^^^^^^^^^
@@ -46,8 +46,16 @@ LL |     if x == E::V { field } {}
    |             |
    |             help: surround the struct literal with parenthesis: `(E::V { field })`
 
+error[E0423]: expected value, found struct variant `E::V`
+  --> $DIR/struct-literal-variant-in-if.rs:12:13
+   |
+LL |     if x == E::V { field: field } {}
+   |             ^^^^-----------------
+   |             |
+   |             help: surround the struct literal with parenthesis: `(E::V { field: field })`
+
 error[E0308]: mismatched types
-  --> $DIR/struct-literal-variant-in-if.rs:20:20
+  --> $DIR/struct-literal-variant-in-if.rs:22:20
    |
 LL |     let y: usize = ();
    |                    ^^ expected usize, found ()
@@ -55,7 +63,7 @@ LL |     let y: usize = ();
    = note: expected type `usize`
               found type `()`
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0308, E0423.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
When encountering a parse error that _could_ be a struct literal, but that we can't be certain, keep the found span around until we find a type error that confirms it, provide the appropriate suggestion to surround with braces and hide every type error and non-found ident error coming from within the likely struct literal's span.

r? @petrochenkov

_Follow up to #59981_