### PR TITLE
Don't stop evaluating due to errors before borrow checking

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -85,7 +85,7 @@ impl BoundRegion {
 /// N.B., if you change this, you'll probably want to change the corresponding
 /// AST structure in `libsyntax/ast.rs` as well.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
-         RustcEncodable, RustcDecodable, HashStable)]
+         RustcEncodable, RustcDecodable, HashStable, Debug)]
 pub enum TyKind<'tcx> {
     /// The primitive boolean type. Written as `bool`.
     Bool,

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -936,13 +936,6 @@ fn analysis<'tcx>(
         });
     });
 
-    // Abort so we don't try to construct MIR with liveness errors.
-    // We also won't want to continue with errors from rvalue promotion
-    // We only do so if the only error found so far *isn't* a missing `fn main()`
-    if !(entry_point.is_none() && sess.err_count() == 1) {
-        tcx.sess.abort_if_errors();
-    }
-
     time(sess, "borrow checking", || {
         if tcx.use_ast_borrowck() {
             borrowck::check_crate(tcx);

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -211,6 +211,7 @@ impl<'a, 'tcx> LiteralExpander<'a, 'tcx> {
         // the constant's pointee type
         crty: Ty<'tcx>,
     ) -> ConstValue<'tcx> {
+        debug!("fold_const_value_deref {:?} {:?} {:?}", val, rty, crty);
         match (val, &crty.sty, &rty.sty) {
             // the easy case, deref a reference
             (ConstValue::Scalar(Scalar::Ptr(p)), x, y) if x == y => ConstValue::ByRef(
@@ -238,6 +239,7 @@ impl<'a, 'tcx> LiteralExpander<'a, 'tcx> {
 
 impl<'a, 'tcx> PatternFolder<'tcx> for LiteralExpander<'a, 'tcx> {
     fn fold_pattern(&mut self, pat: &Pattern<'tcx>) -> Pattern<'tcx> {
+        debug!("fold_pattern {:?} {:?} {:?}", pat, pat.ty.sty, pat.kind);
         match (&pat.ty.sty, &*pat.kind) {
             (
                 &ty::Ref(_, rty, _),

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -603,7 +603,9 @@ fn check_legality_of_move_bindings(
             E0009,
             "cannot bind by-move and by-ref in the same pattern",
         );
-        err.span_label(by_ref_span.unwrap(), "both by-ref and by-move used");
+        if let Some(by_ref_span) = by_ref_span {
+            err.span_label(by_ref_span, "both by-ref and by-move used");
+        }
         for span in span_vec.iter(){
             err.span_label(*span, "by-move pattern here");
         }

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -974,10 +974,25 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                 PatternKind::Wild
             }
             ty::Adt(adt_def, _) if !self.tcx.has_attr(adt_def.did, "structural_match") => {
-                let msg = format!("to use a constant of type `{}` in a pattern, \
-                                    `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
-                                    self.tcx.def_path_str(adt_def.did),
-                                    self.tcx.def_path_str(adt_def.did));
+                let path = self.tcx.def_path_str(adt_def.did);
+                let msg = format!(
+                    "to use a constant of type `{}` in a pattern, \
+                     `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
+                    path,
+                    path,
+                );
+                self.tcx.sess.span_err(span, &msg);
+                PatternKind::Wild
+            }
+            ty::Ref(_, ty::TyS { sty: ty::Adt(adt_def, _), .. }, _)
+            if !self.tcx.has_attr(adt_def.did, "structural_match") => {
+                let path = self.tcx.def_path_str(adt_def.did);
+                let msg = format!(
+                    "to use a constant of type `{}` in a pattern, \
+                     `{}` must be annotated with `#[derive(PartialEq, Eq)]`",
+                    path,
+                    path,
+                );
                 self.tcx.sess.span_err(span, &msg);
                 PatternKind::Wild
             }

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -986,6 +986,8 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
             }
             ty::Ref(_, ty::TyS { sty: ty::Adt(adt_def, _), .. }, _)
             if !self.tcx.has_attr(adt_def.did, "structural_match") => {
+                // HACK(estebank): Side-step ICE #53708, but anything other than erroring here
+                // would be wrong. Returnging `PatternKind::Wild` is not technically correct.
                 let path = self.tcx.def_path_str(adt_def.did);
                 let msg = format!(
                     "to use a constant of type `{}` in a pattern, \

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1502,9 +1502,11 @@ impl MirPass for QualifyAndPromoteConstants {
                                 tcx.sess,
                                 span,
                                 E0723,
-                                "{} (see issue #57563)",
+                                "{}",
                                 err,
                             );
+                            diag.note("for more information, see issue \
+                                       https://github.com/rust-lang/rust/issues/57563");
                             diag.help(
                                 "add #![feature(const_fn)] to the crate attributes to enable",
                             );

--- a/src/test/ui/borrowck/borrowck-mutate-in-guard.rs
+++ b/src/test/ui/borrowck/borrowck-mutate-in-guard.rs
@@ -9,9 +9,15 @@ fn foo() -> isize {
     match x {
         Enum::A(_) if { x = Enum::B(false); false } => 1,
         //~^ ERROR cannot assign in a pattern guard
+        //~| WARN cannot assign `x` in match guard
+        //~| WARN this error has been downgraded to a warning for backwards compatibility
+        //~| WARN this represents potential undefined behavior in your code and this warning will
         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
         //~^ ERROR cannot mutably borrow in a pattern guard
-        //~^^ ERROR cannot assign in a pattern guard
+        //~| ERROR cannot assign in a pattern guard
+        //~| WARN cannot mutably borrow `x` in match guard
+        //~| WARN this error has been downgraded to a warning for backwards compatibility
+        //~| WARN this represents potential undefined behavior in your code and this warning will
         Enum::A(p) => *p,
         Enum::B(_) => 2,
     }

--- a/src/test/ui/borrowck/borrowck-mutate-in-guard.stderr
+++ b/src/test/ui/borrowck/borrowck-mutate-in-guard.stderr
@@ -5,7 +5,7 @@ LL |         Enum::A(_) if { x = Enum::B(false); false } => 1,
    |                         ^^^^^^^^^^^^^^^^^^ assignment in pattern guard
 
 error[E0301]: cannot mutably borrow in a pattern guard
-  --> $DIR/borrowck-mutate-in-guard.rs:12:38
+  --> $DIR/borrowck-mutate-in-guard.rs:15:38
    |
 LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
    |                                      ^ borrowed mutably in pattern guard
@@ -13,12 +13,35 @@ LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
    = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
 
 error[E0302]: cannot assign in a pattern guard
-  --> $DIR/borrowck-mutate-in-guard.rs:12:41
+  --> $DIR/borrowck-mutate-in-guard.rs:15:41
    |
 LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
    |                                         ^^^^^^^^^^^^^^^^^^^ assignment in pattern guard
 
+warning[E0510]: cannot assign `x` in match guard
+  --> $DIR/borrowck-mutate-in-guard.rs:10:25
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+LL |         Enum::A(_) if { x = Enum::B(false); false } => 1,
+   |                         ^^^^^^^^^^^^^^^^^^ cannot assign
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
+warning[E0510]: cannot mutably borrow `x` in match guard
+  --> $DIR/borrowck-mutate-in-guard.rs:15:33
+   |
+LL |     match x {
+   |           - value is immutable in match guard
+...
+LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
+   |                                 ^^^^^^ cannot mutably borrow
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0301, E0302.
+Some errors have detailed explanations: E0301, E0302, E0510.
 For more information about an error, try `rustc --explain E0301`.

--- a/src/test/ui/consts/const_let_refutable.rs
+++ b/src/test/ui/consts/const_let_refutable.rs
@@ -1,5 +1,11 @@
 fn main() {}
 
 const fn slice([a, b]: &[i32]) -> i32 { //~ ERROR refutable pattern in function argument
-    a + b
+    a + b //~ ERROR can only call other `const fn` within a `const fn`
+    //~^ WARN use of possibly uninitialized variable: `a`
+    //~| WARN this error has been downgraded to a warning for backwards compatibility
+    //~| WARN this represents potential undefined behavior in your code and this warning will
+    //~| WARN use of possibly uninitialized variable: `b`
+    //~| WARN this error has been downgraded to a warning for backwards compatibility
+    //~| WARN this represents potential undefined behavior in your code and this warning will
 }

--- a/src/test/ui/consts/const_let_refutable.stderr
+++ b/src/test/ui/consts/const_let_refutable.stderr
@@ -4,6 +4,34 @@ error[E0005]: refutable pattern in function argument: `&[]` not covered
 LL | const fn slice([a, b]: &[i32]) -> i32 {
    |                ^^^^^^ pattern `&[]` not covered
 
-error: aborting due to previous error
+error[E0723]: can only call other `const fn` within a `const fn`, but `const std::ops::Add::add` is not stable as `const fn`
+  --> $DIR/const_let_refutable.rs:4:5
+   |
+LL |     a + b
+   |     ^^^^^
+   |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
+   = help: add #![feature(const_fn)] to the crate attributes to enable
 
-For more information about this error, try `rustc --explain E0005`.
+warning[E0381]: use of possibly uninitialized variable: `a`
+  --> $DIR/const_let_refutable.rs:4:5
+   |
+LL |     a + b
+   |     ^ use of possibly uninitialized `a`
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
+warning[E0381]: use of possibly uninitialized variable: `b`
+  --> $DIR/const_let_refutable.rs:4:9
+   |
+LL |     a + b
+   |         ^ use of possibly uninitialized `b`
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0005, E0381, E0723.
+For more information about an error, try `rustc --explain E0005`.

--- a/src/test/ui/consts/match_ice.rs
+++ b/src/test/ui/consts/match_ice.rs
@@ -2,9 +2,17 @@
 
 struct S;
 
+#[derive(PartialEq, Eq)]
+struct T;
+
 fn main() {
     const C: &S = &S;
-    match C { //~ ERROR non-exhaustive
-        C => {} // this is a common bug around constants and references in patterns
+    match C {
+        C => {}
+        //~^ ERROR to use a constant of type `S` in a pattern, `S` must be annotated with
+    }
+    const K: &T = &T;
+    match K { //~ ERROR non-exhaustive patterns: `&T` not covered
+        K => {}
     }
 }

--- a/src/test/ui/consts/match_ice.stderr
+++ b/src/test/ui/consts/match_ice.stderr
@@ -1,11 +1,17 @@
 error[E0004]: non-exhaustive patterns: `&S` not covered
-  --> $DIR/match_ice.rs:7:11
+  --> $DIR/match_ice.rs:8:11
    |
 LL |     match C {
    |           ^ pattern `&S` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error: aborting due to previous error
+error[E0277]: can't compare `S` with `S`
+   |
+   = help: the trait `std::cmp::PartialEq` is not implemented for `S`
+   = note: required because of the requirements on the impl of `std::cmp::PartialEq` for `&S`
 
-For more information about this error, try `rustc --explain E0004`.
+error: aborting due to 2 previous errors
+
+Some errors occurred: E0004, E0277.
+For more information about an error, try `rustc --explain E0004`.

--- a/src/test/ui/consts/match_ice.stderr
+++ b/src/test/ui/consts/match_ice.stderr
@@ -1,17 +1,17 @@
-error[E0004]: non-exhaustive patterns: `&S` not covered
-  --> $DIR/match_ice.rs:8:11
+error: to use a constant of type `S` in a pattern, `S` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/match_ice.rs:11:9
    |
-LL |     match C {
-   |           ^ pattern `&S` not covered
+LL |         C => {}
+   |         ^
+
+error[E0004]: non-exhaustive patterns: `&T` not covered
+  --> $DIR/match_ice.rs:15:11
+   |
+LL |     match K {
+   |           ^ pattern `&T` not covered
    |
    = help: ensure that all possible cases are being handled, possibly by adding wildcards or more match arms
 
-error[E0277]: can't compare `S` with `S`
-   |
-   = help: the trait `std::cmp::PartialEq` is not implemented for `S`
-   = note: required because of the requirements on the impl of `std::cmp::PartialEq` for `&S`
-
 error: aborting due to 2 previous errors
 
-Some errors occurred: E0004, E0277.
-For more information about an error, try `rustc --explain E0004`.
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -1,9 +1,10 @@
-error[E0723]: heap allocations are not allowed in const fn (see issue #57563)
+error[E0723]: heap allocations are not allowed in const fn
   --> $DIR/bad_const_fn_body_ice.rs:2:5
    |
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/consts/min_const_fn/cast_errors.stderr
+++ b/src/test/ui/consts/min_const_fn/cast_errors.stderr
@@ -1,41 +1,46 @@
-error[E0723]: unsizing casts are not allowed in const fn (see issue #57563)
+error[E0723]: unsizing casts are not allowed in const fn
   --> $DIR/cast_errors.rs:3:41
    |
 LL | const fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                         ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:5:23
    |
 LL | const fn closure() -> fn() { || {} }
    |                       ^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:8:5
    |
 LL |     (|| {}) as fn();
    |     ^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:11:28
    |
 LL | const fn reify(f: fn()) -> unsafe fn() { f }
    |                            ^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:13:21
    |
 LL | const fn reify2() { main as unsafe fn(); }
    |                     ^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -1,9 +1,10 @@
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/cmp_fn_pointers.rs:1:14
    |
 LL | const fn cmp(x: fn(), y: fn()) -> bool {
    |              ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/loop_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/loop_ice.stderr
@@ -1,9 +1,10 @@
-error[E0723]: loops are not allowed in const fn (see issue #57563)
+error[E0723]: loops are not allowed in const fn
   --> $DIR/loop_ice.rs:2:5
    |
 LL |     loop {}
    |     ^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -4,12 +4,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner(self) -> T { self.0 }
    |                         ^^^^ constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:39:36
    |
 LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -18,12 +19,13 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_lt(self) -> T { self.0 }
    |                            ^^^^ constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:46:42
    |
 LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -32,228 +34,256 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const fn into_inner_s(self) -> T { self.0 }
    |                           ^^^^ constant functions cannot evaluate destructors
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:53:38
    |
 LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:58:39
    |
 LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:76:16
    |
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:78:18
    |
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
+error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:80:33
    |
 LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
+error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:82:35
    |
 LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int and `bool` operations are stable in const fn (see issue #57563)
+error[E0723]: only int and `bool` operations are stable in const fn
   --> $DIR/min_const_fn.rs:84:35
    |
 LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
+error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:86:43
    |
 LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: cannot access `static` items in const fn (see issue #57563)
+error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:90:27
    |
 LL | const fn foo25() -> u32 { BAR }
    |                           ^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: cannot access `static` items in const fn (see issue #57563)
+error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:91:36
    |
 LL | const fn foo26() -> &'static u32 { &BAR }
    |                                    ^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
+error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:92:42
    |
 LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
+error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:94:63
    |
 LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
+error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:96:42
    |
 LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: casting pointers to ints is unstable in const fn (see issue #57563)
+error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:98:63
    |
 LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } }
    |                                                               ^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn
   --> $DIR/min_const_fn.rs:100:38
    |
 LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn
   --> $DIR/min_const_fn.rs:102:29
    |
 LL | const fn foo30_5(b: bool) { while b { } }
    |                             ^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn
   --> $DIR/min_const_fn.rs:104:44
    |
 LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn
   --> $DIR/min_const_fn.rs:106:44
    |
 LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:108:14
    |
 LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:113:6
    |
 LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:118:6
    |
 LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:123:6
    |
 LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
+error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:129:24
    |
 LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:131:34
    |
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:133:22
    |
 LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: `impl Trait` in const fn is unstable (see issue #57563)
+error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:134:23
    |
 LL | const fn no_rpit() -> impl std::fmt::Debug {}
    |                       ^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:135:23
    |
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:136:32
    |
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0515]: cannot return reference to temporary value
@@ -268,28 +298,31 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:144:41
    |
 LL | const fn really_no_traits_i_mean_it() { (&() as &std::fmt::Debug, ()).1 }
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:147:21
    |
 LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:149:27
    |
 LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 36 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -1,17 +1,19 @@
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn_dyn.rs:9:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable (see issue #57563)
+error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn_dyn.rs:12:66
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 warning[E0716]: temporary value dropped while borrowed

--- a/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
@@ -1,17 +1,19 @@
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn_fn_ptr.rs:11:5
    |
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn_fn_ptr.rs:14:59
    |
 LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasPtr { field }) }
    |                                                           ^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -1,33 +1,37 @@
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn`
   --> $DIR/min_const_fn_libstd_stability.rs:15:25
    |
 LL | const fn bar() -> u32 { foo() }
    |                         ^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_fn_libstd_stability.rs:22:26
    |
 LL | const fn bar2() -> u32 { foo2() }
    |                          ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
+error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn_libstd_stability.rs:26:26
    |
 LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                          ^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_fn_libstd_stability.rs:34:32
    |
 LL | const fn bar2_gated() -> u32 { foo2_gated() }
    |                                ^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -1,33 +1,37 @@
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:15:41
    |
 LL | const unsafe fn bar() -> u32 { unsafe { foo() } }
    |                                         ^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:22:42
    |
 LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } }
    |                                          ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: only int, `bool` and `char` operations are stable in const fn (see issue #57563)
+error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:26:33
    |
 LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                                 ^^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:34:48
    |
 LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } }
    |                                                ^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -1,25 +1,28 @@
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:15:32
    |
 LL | const unsafe fn bar() -> u32 { foo() }
    |                                ^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:22:33
    |
 LL | const unsafe fn bar2() -> u32 { foo2() }
    |                                 ^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn` (see issue #57563)
+error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:30:39
    |
 LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() }
    |                                       ^^^^^^^^^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -1,17 +1,19 @@
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/mutable_borrow.rs:3:9
    |
 LL |     let b = &mut a;
    |         ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/mutable_borrow.rs:12:13
    |
 LL |         let b = &mut a;
    |             ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/single_variant_match_ice.stderr
+++ b/src/test/ui/consts/single_variant_match_ice.stderr
@@ -10,12 +10,13 @@ error[E0019]: constant contains unimplemented expression type
 LL |     x => 42,
    |     ^
 
-error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn (see issue #57563)
+error[E0723]: `if`, `match`, `&&` and `||` are not stable in const fn
   --> $DIR/single_variant_match_ice.rs:18:13
    |
 LL |             Prob => 0x1,
    |             ^^^^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/empty/empty-never-array.rs
+++ b/src/test/ui/empty/empty-never-array.rs
@@ -10,6 +10,9 @@ fn transmute<T, U>(t: T) -> U {
     let Helper::U(u) = Helper::T(t, []);
     //~^ ERROR refutable pattern in local binding: `T(_, _)` not covered
     u
+    //~^ WARN use of possibly uninitialized variable: `u`
+    //~| WARN this error has been downgraded to a warning for backwards compatibility
+    //~| WARN this represents potential undefined behavior in your code and this warning will
 }
 
 fn main() {

--- a/src/test/ui/empty/empty-never-array.stderr
+++ b/src/test/ui/empty/empty-never-array.stderr
@@ -11,6 +11,16 @@ LL | | }
 LL |       let Helper::U(u) = Helper::T(t, []);
    |           ^^^^^^^^^^^^ pattern `T(_, _)` not covered
 
+warning[E0381]: use of possibly uninitialized variable: `u`
+  --> $DIR/empty-never-array.rs:12:5
+   |
+LL |     u
+   |     ^ use of possibly uninitialized `u`
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0005`.
+Some errors have detailed explanations: E0005, E0381.
+For more information about an error, try `rustc --explain E0005`.

--- a/src/test/ui/error-codes/E0007.rs
+++ b/src/test/ui/error-codes/E0007.rs
@@ -4,6 +4,7 @@ fn main() {
         op_string @ Some(s) => {},
         //~^ ERROR E0007
         //~| ERROR E0303
+        //~| ERROR E0382
         None => {},
     }
 }

--- a/src/test/ui/error-codes/E0007.stderr
+++ b/src/test/ui/error-codes/E0007.stderr
@@ -10,7 +10,19 @@ error[E0303]: pattern bindings are not allowed after an `@`
 LL |         op_string @ Some(s) => {},
    |                          ^ not allowed after `@`
 
-error: aborting due to 2 previous errors
+error[E0382]: use of moved value
+  --> $DIR/E0007.rs:4:26
+   |
+LL |     let x = Some("s".to_string());
+   |         - move occurs because `x` has type `std::option::Option<std::string::String>`, which does not implement the `Copy` trait
+LL |     match x {
+LL |         op_string @ Some(s) => {},
+   |         -----------------^-
+   |         |                |
+   |         |                value used here after move
+   |         value moved here
 
-Some errors have detailed explanations: E0007, E0303.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0007, E0303, E0382.
 For more information about an error, try `rustc --explain E0007`.

--- a/src/test/ui/error-codes/E0030-teach.rs
+++ b/src/test/ui/error-codes/E0030-teach.rs
@@ -4,5 +4,6 @@ fn main() {
     match 5u32 {
         1000 ..= 5 => {}
         //~^ ERROR lower range bound must be less than or equal to upper
+        //~| ERROR lower range bound must be less than or equal to upper
     }
 }

--- a/src/test/ui/error-codes/E0030-teach.stderr
+++ b/src/test/ui/error-codes/E0030-teach.stderr
@@ -6,6 +6,12 @@ LL |         1000 ..= 5 => {}
    |
    = note: When matching against a range, the compiler verifies that the range is non-empty. Range patterns include both end-points, so this is equivalent to requiring the start of the range to be less than or equal to the end of the range.
 
-error: aborting due to previous error
+error[E0030]: lower range bound must be less than or equal to upper
+  --> $DIR/E0030-teach.rs:5:9
+   |
+LL |         1000 ..= 5 => {}
+   |         ^^^^ lower bound larger than upper bound
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0030`.

--- a/src/test/ui/error-codes/E0301.rs
+++ b/src/test/ui/error-codes/E0301.rs
@@ -2,6 +2,6 @@ fn main() {
     match Some(()) {
         None => { },
         option if option.take().is_none() => {}, //~ ERROR E0301
-        Some(_) => { }
+        Some(_) => { } //~^ ERROR E0596
     }
 }

--- a/src/test/ui/error-codes/E0301.stderr
+++ b/src/test/ui/error-codes/E0301.stderr
@@ -6,6 +6,15 @@ LL |         option if option.take().is_none() => {},
    |
    = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0596]: cannot borrow `option` as mutable, as it is immutable for the pattern guard
+  --> $DIR/E0301.rs:4:19
+   |
+LL |         option if option.take().is_none() => {},
+   |                   ^^^^^^ cannot borrow as mutable
+   |
+   = note: variables bound in patterns are immutable until the end of the pattern guard
 
-For more information about this error, try `rustc --explain E0301`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0301, E0596.
+For more information about an error, try `rustc --explain E0301`.

--- a/src/test/ui/error-codes/E0302.rs
+++ b/src/test/ui/error-codes/E0302.rs
@@ -2,6 +2,7 @@ fn main() {
     match Some(()) {
         None => { },
         option if { option = None; false } => { }, //~ ERROR E0302
+        //~^ ERROR cannot assign to `option`, as it is immutable for the pattern guard
         Some(_) => { }
     }
 }

--- a/src/test/ui/error-codes/E0302.stderr
+++ b/src/test/ui/error-codes/E0302.stderr
@@ -4,6 +4,14 @@ error[E0302]: cannot assign in a pattern guard
 LL |         option if { option = None; false } => { },
    |                     ^^^^^^^^^^^^^ assignment in pattern guard
 
-error: aborting due to previous error
+error[E0594]: cannot assign to `option`, as it is immutable for the pattern guard
+  --> $DIR/E0302.rs:4:21
+   |
+LL |         option if { option = None; false } => { },
+   |                     ^^^^^^^^^^^^^ cannot assign
+   |
+   = note: variables bound in patterns are immutable until the end of the pattern guard
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0302`.

--- a/src/test/ui/issues/issue-15381.rs
+++ b/src/test/ui/issues/issue-15381.rs
@@ -4,5 +4,8 @@ fn main() {
     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
         //~^ ERROR refutable pattern in `for` loop binding: `&[]` not covered
         println!("y={}", y);
+        //~^ WARN borrow of possibly uninitialized variable: `y`
+        //~| WARN this error has been downgraded to a warning for backwards compatibility
+        //~| WARN this represents potential undefined behavior in your code and this warning will
     }
 }

--- a/src/test/ui/issues/issue-15381.stderr
+++ b/src/test/ui/issues/issue-15381.stderr
@@ -4,6 +4,16 @@ error[E0005]: refutable pattern in `for` loop binding: `&[]` not covered
 LL |     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
    |         ^^^^^^^^ pattern `&[]` not covered
 
+warning[E0381]: borrow of possibly uninitialized variable: `y`
+  --> $DIR/issue-15381.rs:6:26
+   |
+LL |         println!("y={}", y);
+   |                          ^ use of possibly uninitialized `y`
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0005`.
+Some errors have detailed explanations: E0005, E0381.
+For more information about an error, try `rustc --explain E0005`.

--- a/src/test/ui/issues/issue-23302-3.rs
+++ b/src/test/ui/issues/issue-23302-3.rs
@@ -1,4 +1,5 @@
 const A: i32 = B; //~ ERROR cycle detected
+//~^ ERROR cycle detected
 
 const B: i32 = A;
 

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -10,18 +10,36 @@ note: ...which requires checking which parts of `A` are promotable to static...
 LL | const A: i32 = B;
    |                ^
 note: ...which requires const checking if rvalue is promotable to static `B`...
-  --> $DIR/issue-23302-3.rs:3:1
+  --> $DIR/issue-23302-3.rs:4:1
    |
 LL | const B: i32 = A;
    | ^^^^^^^^^^^^^^^^^
 note: ...which requires checking which parts of `B` are promotable to static...
-  --> $DIR/issue-23302-3.rs:3:16
+  --> $DIR/issue-23302-3.rs:4:16
    |
 LL | const B: i32 = A;
    |                ^
    = note: ...which again requires const checking if rvalue is promotable to static `A`, completing the cycle
    = note: cycle used when running analysis passes on this crate
 
-error: aborting due to previous error
+error[E0391]: cycle detected when processing `A`
+  --> $DIR/issue-23302-3.rs:1:16
+   |
+LL | const A: i32 = B;
+   |                ^
+   |
+note: ...which requires processing `B`...
+  --> $DIR/issue-23302-3.rs:4:16
+   |
+LL | const B: i32 = A;
+   |                ^
+   = note: ...which again requires processing `A`, completing the cycle
+note: cycle used when processing `A`
+  --> $DIR/issue-23302-3.rs:1:1
+   |
+LL | const A: i32 = B;
+   | ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/issues/issue-37550.stderr
+++ b/src/test/ui/issues/issue-37550.stderr
@@ -1,9 +1,10 @@
-error[E0723]: function pointers in const fn are unstable (see issue #57563)
+error[E0723]: function pointers in const fn are unstable
   --> $DIR/issue-37550.rs:3:9
    |
 LL |     let x = || t;
    |         ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-41255.rs
+++ b/src/test/ui/issues/issue-41255.rs
@@ -9,6 +9,8 @@ fn main() {
     match x {
         5.0 => {}, //~ ERROR floating-point types cannot be used in patterns
                    //~| WARNING hard error
+                   //~| ERROR floating-point types cannot be used in patterns
+                   //~| WARNING this was previously accepted by the compiler but is being
         5.0f32 => {}, //~ ERROR floating-point types cannot be used in patterns
                       //~| WARNING hard error
         -5.0 => {}, //~ ERROR floating-point types cannot be used in patterns

--- a/src/test/ui/issues/issue-41255.stderr
+++ b/src/test/ui/issues/issue-41255.stderr
@@ -13,7 +13,7 @@ LL | #![forbid(illegal_floating_point_literal_pattern)]
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:12:9
+  --> $DIR/issue-41255.rs:14:9
    |
 LL |         5.0f32 => {},
    |         ^^^^^^
@@ -22,7 +22,7 @@ LL |         5.0f32 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:14:10
+  --> $DIR/issue-41255.rs:16:10
    |
 LL |         -5.0 => {},
    |          ^^^
@@ -31,7 +31,7 @@ LL |         -5.0 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:16:9
+  --> $DIR/issue-41255.rs:18:9
    |
 LL |         1.0 .. 33.0 => {},
    |         ^^^
@@ -40,7 +40,7 @@ LL |         1.0 .. 33.0 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:16:16
+  --> $DIR/issue-41255.rs:18:16
    |
 LL |         1.0 .. 33.0 => {},
    |                ^^^^
@@ -49,7 +49,7 @@ LL |         1.0 .. 33.0 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:20:9
+  --> $DIR/issue-41255.rs:22:9
    |
 LL |         39.0 ..= 70.0 => {},
    |         ^^^^
@@ -58,7 +58,7 @@ LL |         39.0 ..= 70.0 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:20:18
+  --> $DIR/issue-41255.rs:22:18
    |
 LL |         39.0 ..= 70.0 => {},
    |                  ^^^^
@@ -67,7 +67,7 @@ LL |         39.0 ..= 70.0 => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:29:10
+  --> $DIR/issue-41255.rs:31:10
    |
 LL |         (3.14, 1) => {},
    |          ^^^^
@@ -76,7 +76,7 @@ LL |         (3.14, 1) => {},
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-41255.rs:36:18
+  --> $DIR/issue-41255.rs:38:18
    |
 LL |         Foo { x: 2.0 } => {},
    |                  ^^^
@@ -84,5 +84,14 @@ LL |         Foo { x: 2.0 } => {},
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-error: aborting due to 9 previous errors
+error: floating-point types cannot be used in patterns
+  --> $DIR/issue-41255.rs:10:9
+   |
+LL |         5.0 => {},
+   |         ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/issues/issue-6804.rs
+++ b/src/test/ui/issues/issue-6804.rs
@@ -10,6 +10,8 @@ fn main() {
     match x {
         NAN => {}, //~ ERROR floating-point types cannot be used
         //~^ WARN this was previously accepted by the compiler but is being phased out
+        //~| ERROR floating-point types cannot be used in patterns
+        //~| WARN this was previously accepted by the compiler but is being phased out
         _ => {},
     };
 

--- a/src/test/ui/issues/issue-6804.stderr
+++ b/src/test/ui/issues/issue-6804.stderr
@@ -13,7 +13,7 @@ LL | #![deny(illegal_floating_point_literal_pattern)]
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
 error: floating-point types cannot be used in patterns
-  --> $DIR/issue-6804.rs:17:10
+  --> $DIR/issue-6804.rs:19:10
    |
 LL |         [NAN, _] => {},
    |          ^^^
@@ -21,5 +21,14 @@ LL |         [NAN, _] => {},
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
-error: aborting due to 2 previous errors
+error: floating-point types cannot be used in patterns
+  --> $DIR/issue-6804.rs:11:9
+   |
+LL |         NAN => {},
+   |         ^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/match/match-range-fail-dominate.stderr
+++ b/src/test/ui/match/match-range-fail-dominate.stderr
@@ -62,5 +62,14 @@ error: unreachable pattern
 LL |       0.02f64 => {}
    |       ^^^^^^^
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-range-fail-dominate.rs:35:7
+   |
+LL |       0.01f64 ... 6.5f64 => {}
+   |       ^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/pattern/const-pat-ice.stderr
+++ b/src/test/ui/pattern/const-pat-ice.stderr
@@ -1,4 +1,4 @@
-thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', src/librustc_mir/hair/pattern/_match.rs:1069:5
+thread 'rustc' panicked at 'assertion failed: rows.iter().all(|r| r.len() == v.len())', src/librustc_mir/hair/pattern/_match.rs:1071:5
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/pattern/pattern-bindings-after-at.rs
+++ b/src/test/ui/pattern/pattern-bindings-after-at.rs
@@ -7,6 +7,9 @@ fn main() {
     match &mut Some(1) {
         ref mut z @ &mut Some(ref a) => {
         //~^ ERROR pattern bindings are not allowed after an `@`
+        //~| WARN cannot borrow `_` as immutable because it is also borrowed as mutable
+        //~| WARN this error has been downgraded to a warning for backwards compatibility
+        //~| WARN this represents potential undefined behavior in your code and this warning will
             **z = None;
             println!("{}", *a);
         }

--- a/src/test/ui/pattern/pattern-bindings-after-at.stderr
+++ b/src/test/ui/pattern/pattern-bindings-after-at.stderr
@@ -4,6 +4,22 @@ error[E0303]: pattern bindings are not allowed after an `@`
 LL |         ref mut z @ &mut Some(ref a) => {
    |                               ^^^^^ not allowed after `@`
 
+warning[E0502]: cannot borrow `_` as immutable because it is also borrowed as mutable
+  --> $DIR/pattern-bindings-after-at.rs:8:31
+   |
+LL |         ref mut z @ &mut Some(ref a) => {
+   |         ----------------------^^^^^-
+   |         |                     |
+   |         |                     immutable borrow occurs here
+   |         mutable borrow occurs here
+...
+LL |             **z = None;
+   |             ---------- mutable borrow later used here
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0303`.
+Some errors have detailed explanations: E0303, E0502.
+For more information about an error, try `rustc --explain E0303`.

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.rs
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.rs
@@ -6,6 +6,9 @@ fn foo(res: Result<u32, &R>) -> u32 {
     let Ok(x) = res;
     //~^ ERROR refutable pattern
     x
+    //~^ WARN use of possibly uninitialized variable: `x`
+    //~| WARN this error has been downgraded to a warning for backwards compatibility
+    //~| WARN this represents potential undefined behavior in your code and this warning will
 }
 
 fn main() {

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -4,6 +4,16 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
 LL |     let Ok(x) = res;
    |         ^^^^^ pattern `Err(_)` not covered
 
+warning[E0381]: use of possibly uninitialized variable: `x`
+  --> $DIR/recursive-types-are-not-uninhabited.rs:8:5
+   |
+LL |     x
+   |     ^ use of possibly uninitialized `x`
+   |
+   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
+   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
+
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0005`.
+Some errors have detailed explanations: E0005, E0381.
+For more information about an error, try `rustc --explain E0005`.

--- a/src/test/ui/rfc-2005-default-binding-mode/for.rs
+++ b/src/test/ui/rfc-2005-default-binding-mode/for.rs
@@ -5,5 +5,6 @@ pub fn main() {
     // The below desugars to &(ref n, mut m).
     for (n, mut m) in &tups {
         //~^ ERROR cannot bind by-move and by-ref in the same pattern
+        //~| ERROR cannot move out of borrowed content
     }
 }

--- a/src/test/ui/rfc-2005-default-binding-mode/for.stderr
+++ b/src/test/ui/rfc-2005-default-binding-mode/for.stderr
@@ -6,6 +6,21 @@ LL |     for (n, mut m) in &tups {
    |          |
    |          both by-ref and by-move used
 
-error: aborting due to previous error
+error[E0507]: cannot move out of borrowed content
+  --> $DIR/for.rs:6:23
+   |
+LL |     for (n, mut m) in &tups {
+   |             -----     ^^^^^ cannot move out of borrowed content
+   |             |
+   |             data moved here
+   |
+note: move occurs because `m` has type `Foo`, which does not implement the `Copy` trait
+  --> $DIR/for.rs:6:13
+   |
+LL |     for (n, mut m) in &tups {
+   |             ^^^^^
 
-For more information about this error, try `rustc --explain E0009`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0009, E0507.
+For more information about an error, try `rustc --explain E0009`.

--- a/src/test/ui/rfc1445/match-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/match-forbidden-without-eq.rs
@@ -20,6 +20,8 @@ fn main() {
         f32::INFINITY => { }
         //~^ WARNING floating-point types cannot be used in patterns
         //~| WARNING will become a hard error in a future release
+        //~| WARNING floating-point types cannot be used in patterns
+        //~| WARNING this was previously accepted by the compiler but is being phased out
         _ => { }
     }
 }

--- a/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/match-forbidden-without-eq.stderr
@@ -14,5 +14,14 @@ LL |         f32::INFINITY => { }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 
+warning: floating-point types cannot be used in patterns
+  --> $DIR/match-forbidden-without-eq.rs:20:9
+   |
+LL |         f32::INFINITY => { }
+   |         ^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
+
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -1,17 +1,19 @@
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/ranged_ints2_const.rs:11:9
    |
 LL |     let y = &mut x.0;
    |         ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
-error[E0723]: mutable references in const fn are unstable (see issue #57563)
+error[E0723]: mutable references in const fn are unstable
   --> $DIR/ranged_ints2_const.rs:18:9
    |
 LL |     let y = unsafe { &mut x.0 };
    |         ^
    |
+   = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add #![feature(const_fn)] to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block


### PR DESCRIPTION
r? @oli-obk 

Fix #60005. Follow up to #59903. Blocked on #53708, fixing the ICE in `src/test/ui/consts/match_ice.rs`.