### PR TITLE
Fix fn front matter parsing ICE from invalid code.

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6575,7 +6575,12 @@ impl<'a> Parser<'a> {
             };
             (respan(self.prev_span, Constness::NotConst), unsafety, abi)
         };
-        self.expect_keyword(keywords::Fn)?;
+        if !self.eat_keyword(keywords::Fn) {
+            // It is possible for `expect_one_of` to recover given the contents of
+            // `self.expected_tokens`, therefore, do not use `self.unexpected()` which doesn't
+            // account for this.
+            if !self.expect_one_of(&[], &[])? { unreachable!() }
+        }
         Ok((constness, unsafety, asyncness, abi))
     }
 

--- a/src/test/ui/issue-60075.rs
+++ b/src/test/ui/issue-60075.rs
@@ -1,0 +1,12 @@
+fn main() {}
+
+trait T {
+    fn qux() -> Option<usize> {
+        let _ = if true {
+        });
+//~^ ERROR expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
+//~^^ ERROR expected one of `.`, `;`, `?`, `else`, or an operator, found `}`
+//~^^^ ERROR 6:11: 6:12: expected identifier, found `;`
+//~^^^^ ERROR missing `fn`, `type`, or `const` for trait-item declaration
+        Some(4)
+    }

--- a/src/test/ui/issue-60075.stderr
+++ b/src/test/ui/issue-60075.stderr
@@ -1,0 +1,37 @@
+error: expected one of `.`, `;`, `?`, `else`, or an operator, found `}`
+  --> $DIR/issue-60075.rs:6:10
+   |
+LL |         });
+   |          ^ expected one of `.`, `;`, `?`, `else`, or an operator here
+
+error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
+  --> $DIR/issue-60075.rs:6:11
+   |
+LL |     fn qux() -> Option<usize> {
+   |                               - unclosed delimiter
+LL |         let _ = if true {
+LL |         });
+   |           ^
+   |           |
+   |           help: `}` may belong here
+
+error: expected identifier, found `;`
+  --> $DIR/issue-60075.rs:6:11
+   |
+LL |         });
+   |           ^ expected identifier
+
+error: missing `fn`, `type`, or `const` for trait-item declaration
+  --> $DIR/issue-60075.rs:6:12
+   |
+LL |           });
+   |  ____________^
+LL | |
+LL | |
+LL | |
+LL | |
+LL | |         Some(4)
+   | |________^ missing `fn`, `type`, or `const`
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #60075.

This PR fixes an "unreachable code" ICE that results from parsing
invalid code where the compiler is expecting the next trait item
declaration in the middle of the previous trait item due to extra
closing braces.

r? @estebank (thanks for the minimized test case)