### PR TITLE
Fix index-page generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,7 +1513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "minifier"
-version = "0.0.29"
+version = "0.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "macro-utils 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3018,7 +3018,7 @@ dependencies = [
 name = "rustdoc"
 version = "0.0.0"
 dependencies = [
- "minifier 0.0.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minifier 0.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4148,7 +4148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e2ffa2c986de11a9df78620c01eeaaf27d94d3ff02bf81bfcca953102dd0c6ff"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum minifier 0.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4950cb2617b1933e2da0446e864dfe0d6a22c22ff72297996c46e6a63b210b"
+"checksum minifier 0.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "4c909e78edf61f3aa0dd2086da168cdf304329044bbf248768ca3d20253ec8c0"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -10,6 +10,6 @@ path = "lib.rs"
 
 [dependencies]
 pulldown-cmark = { version = "0.4.1", default-features = false }
-minifier = "0.0.29"
+minifier = "0.0.30"
 tempfile = "3"
 parking_lot = "0.7"

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1319,8 +1319,11 @@ fn write_minify_replacer<W: Write>(
                             f,
                             "R",
                             Token::Char(ReservedChar::Backline),
-                            // This closure prevents crates' name to be aggregated. It allows to not
-                            // have to look for crate's name into the strings array.
+                            // This closure prevents crates' names from being aggregated.
+                            //
+                            // The point here is to check if the string is preceded by '[' and
+                            // "searchIndex". If so, it means this is a crate name and that it
+                            // shouldn't be aggregated.
                             |tokens, pos| {
                                 pos < 2 ||
                                 !tokens[pos - 1].is_char(ReservedChar::OpenBracket) ||

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1340,10 +1340,15 @@ fn write_minify_replacer<W: Write>(
                         .into();
                     tokens.apply(|f| {
                         // We add a backline after the newly created variables.
-                        minifier::js::aggregate_strings_into_array_with_separation(
+                        minifier::js::aggregate_strings_into_array_with_separation_filter(
                             f,
                             "R",
                             Token::Char(ReservedChar::Backline),
+                            |tokens, pos| {
+                                pos < 2 ||
+                                !tokens[pos - 1].is_char(ReservedChar::OpenBracket) ||
+                                tokens[pos - 2].get_other() != Some("searchIndex")
+                            }
                         )
                     })
                     .to_string()

--- a/src/test/rustdoc/index-page.rs
+++ b/src/test/rustdoc/index-page.rs
@@ -1,3 +1,5 @@
+// aux-build:all-item-types.rs
+// build-aux-docs
 // compile-flags: -Z unstable-options --enable-index-page
 
 #![crate_name = "foo"]
@@ -5,4 +7,5 @@
 // @has foo/../index.html
 // @has - '//span[@class="in-band"]' 'List of all crates'
 // @has - '//ul[@class="mod"]//a[@href="foo/index.html"]' 'foo'
+// @has - '//ul[@class="mod"]//a[@href="all_item_types/index.html"]' 'all_item_types'
 pub struct Foo;


### PR DESCRIPTION
Fixes #60096.

The minifier was minifying crates name in `searchIndex` key position, which was a bit problematic for multiple reasons.

r? @rust-lang/rustdoc 