### PR TITLE
std::net: Ipv4Addr and Ipv6Addr improvements

### DIFF
--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -512,7 +512,7 @@ impl Ipv4Addr {
     /// - addresses reserved for future protocols (see
     /// [`is_ietf_protocol_assignment()`](#method.is_ietf_protocol_assignment), except
     /// `192.0.0.9/32` and `192.0.0.10/32` which are globally routable
-    /// - addresses reserved for future use (see [`is_reserved()`](#method.is_reserved())
+    /// - addresses reserved for future use (see [`is_reserved()`](#method.is_reserved)
     /// - addresses reserved for networking devices benchmarking (see
     /// [`is_benchmarking`](#method.is_benchmarking))
     ///
@@ -1237,11 +1237,13 @@ impl Ipv6Addr {
     ///
     /// - [IETF RFC 4291 section 2.5.6]
     /// - [RFC 4291 errata 4406]
+    /// - [`is_unicast_link_local()`]
     ///
+    /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
     /// [IETF RFC 4291 section 2.5.6]: https://tools.ietf.org/html/rfc4291#section-2.5.6
     /// [`true`]: ../../std/primitive.bool.html
     /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
-    /// [`is_unicast_link_local()`](#method.is_unicast_link_local)
+    /// [`is_unicast_link_local()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local
     ///
     pub fn is_unicast_link_local_strict(&self) -> bool {
         (self.segments()[0] & 0xffff) == 0xfe80
@@ -1300,7 +1302,7 @@ impl Ipv6Addr {
     /// [IETF RFC 4291 section 2.4]: https://tools.ietf.org/html/rfc4291#section-2.4
     /// [`true`]: ../../std/primitive.bool.html
     /// [RFC 4291 errata 4406]: https://www.rfc-editor.org/errata/eid4406
-    /// [`is_unicast_link_local_strict()`](#method.is_unicast_link_local_strict)
+    /// [`is_unicast_link_local_strict()`]: ../../std/net/struct.Ipv6Addr.html#method.is_unicast_link_local_strict
     ///
     pub fn is_unicast_link_local(&self) -> bool {
         (self.segments()[0] & 0xffc0) == 0xfe80

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1104,12 +1104,20 @@ impl Ipv6Addr {
     ///
     /// - the loopback address
     /// - the link-local addresses
-    /// - the (deprecated) site-local addresses
     /// - unique local addresses
     /// - the unspecified address
     /// - the address range reserved for documentation
     ///
+    /// This method returns [`true`] for site-local addresses as per [RFC 4291 section 2.5.7]
+    ///
+    /// ```no_rust
+    /// The special behavior of [the site-local unicast] prefix defined in [RFC3513] must no longer
+    /// be supported in new implementations (i.e., new implementations must treat this prefix as
+    /// Global Unicast).
+    /// ```
+    ///
     /// [`true`]: ../../std/primitive.bool.html
+    /// [RFC 4291 section 2.5.7]: https://tools.ietf.org/html/rfc4291#section-2.5.7
     ///
     /// # Examples
     ///
@@ -1126,9 +1134,11 @@ impl Ipv6Addr {
     /// ```
     pub fn is_unicast_global(&self) -> bool {
         !self.is_multicast()
-            && !self.is_loopback() && !self.is_unicast_link_local()
-            && !self.is_unicast_site_local() && !self.is_unique_local()
-            && !self.is_unspecified() && !self.is_documentation()
+            && !self.is_loopback()
+            && !self.is_unicast_link_local()
+            && !self.is_unique_local()
+            && !self.is_unspecified()
+            && !self.is_documentation()
     }
 
     /// Returns the address's multicast scope if the address is multicast.

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1003,7 +1003,7 @@ impl Ipv6Addr {
         }
     }
 
-    /// Returns [`true`] if this is a unique local address (fc00::/7).
+    /// Returns [`true`] if this is a unique local address (`fc00::/7`).
     ///
     /// This property is defined in [IETF RFC 4193].
     ///

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -677,6 +677,13 @@ impl Ipv4Addr {
     /// [IETF RFC 1112]: https://tools.ietf.org/html/rfc1112
     /// [`true`]: ../../std/primitive.bool.html
     ///
+    /// # Warning
+    ///
+    /// As IANA assigns new addresses, this method will be
+    /// updated. This may result in non-reserved addresses being
+    /// treated as reserved in code that relies on an outdated version
+    /// of this method.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2008,8 +2008,8 @@ mod tests {
         let doc: u8 = 1 << 4;
 
         check!("0.0.0.0", unspec);
-        check!("0.0.0.1", global);
-        check!("0.1.0.0", global);
+        check!("0.0.0.1");
+        check!("0.1.0.0");
         check!("10.9.8.7");
         check!("127.1.2.3", loopback);
         check!("172.31.254.253");
@@ -2127,8 +2127,8 @@ mod tests {
         let documentation: u8 = 1 << 7;
 
         check!("0.0.0.0", unspec);
-        check!("0.0.0.1", global);
-        check!("0.1.0.0", global);
+        check!("0.0.0.1");
+        check!("0.1.0.0");
         check!("10.9.8.7", private);
         check!("127.1.2.3", loopback);
         check!("172.31.254.253", private);

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2164,16 +2164,17 @@ mod tests {
                 let unique_local: u16 = 1 << 2;
                 let global: u16 = 1 << 3;
                 let unicast_link_local: u16 = 1 << 4;
-                let unicast_site_local: u16 = 1 << 5;
-                let unicast_global: u16 = 1 << 6;
-                let documentation: u16 = 1 << 7;
-                let multicast_interface_local: u16 = 1 << 8;
-                let multicast_link_local: u16 = 1 << 9;
-                let multicast_realm_local: u16 = 1 << 10;
-                let multicast_admin_local: u16 = 1 << 11;
-                let multicast_site_local: u16 = 1 << 12;
-                let multicast_organization_local: u16 = 1 << 13;
-                let multicast_global: u16 = 1 << 14;
+                let unicast_link_local_strict: u16 = 1 << 5;
+                let unicast_site_local: u16 = 1 << 6;
+                let unicast_global: u16 = 1 << 7;
+                let documentation: u16 = 1 << 8;
+                let multicast_interface_local: u16 = 1 << 9;
+                let multicast_link_local: u16 = 1 << 10;
+                let multicast_realm_local: u16 = 1 << 11;
+                let multicast_admin_local: u16 = 1 << 12;
+                let multicast_site_local: u16 = 1 << 13;
+                let multicast_organization_local: u16 = 1 << 14;
+                let multicast_global: u16 = 1 << 15;
                 let multicast: u16 = multicast_interface_local
                     | multicast_admin_local
                     | multicast_global
@@ -2206,6 +2207,11 @@ mod tests {
                     assert!(ip!($s).is_unicast_link_local());
                 } else {
                     assert!(!ip!($s).is_unicast_link_local());
+                }
+                if ($mask & unicast_link_local_strict) == unicast_link_local_strict {
+                    assert!(ip!($s).is_unicast_link_local_strict());
+                } else {
+                    assert!(!ip!($s).is_unicast_link_local_strict());
                 }
                 if ($mask & unicast_site_local) == unicast_site_local {
                     assert!(ip!($s).is_unicast_site_local());
@@ -2265,16 +2271,17 @@ mod tests {
         let unique_local: u16 = 1 << 2;
         let global: u16 = 1 << 3;
         let unicast_link_local: u16 = 1 << 4;
-        let unicast_site_local: u16 = 1 << 5;
-        let unicast_global: u16 = 1 << 6;
-        let documentation: u16 = 1 << 7;
-        let multicast_interface_local: u16 = 1 << 8;
-        let multicast_link_local: u16 = 1 << 9;
-        let multicast_realm_local: u16 = 1 << 10;
-        let multicast_admin_local: u16 = 1 << 11;
-        let multicast_site_local: u16 = 1 << 12;
-        let multicast_organization_local: u16 = 1 << 13;
-        let multicast_global: u16 = 1 << 14;
+        let unicast_link_local_strict: u16 = 1 << 5;
+        let unicast_site_local: u16 = 1 << 6;
+        let unicast_global: u16 = 1 << 7;
+        let documentation: u16 = 1 << 8;
+        let multicast_interface_local: u16 = 1 << 9;
+        let multicast_link_local: u16 = 1 << 10;
+        let multicast_realm_local: u16 = 1 << 11;
+        let multicast_admin_local: u16 = 1 << 12;
+        let multicast_site_local: u16 = 1 << 13;
+        let multicast_organization_local: u16 = 1 << 14;
+        let multicast_global: u16 = 1 << 15;
 
         check!("::",
                &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -2304,8 +2311,30 @@ mod tests {
                &[0xfe, 0x80, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                unicast_link_local);
 
+        check!("fe80::",
+               &[0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+               unicast_link_local|unicast_link_local_strict);
+
         check!("febf:ffff::",
                &[0xfe, 0xbf, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+               unicast_link_local);
+
+        check!("febf::",
+               &[0xfe, 0xbf, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+               unicast_link_local);
+
+        check!("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+               &[0xfe, 0xbf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+               unicast_link_local);
+
+        check!("fe80::ffff:ffff:ffff:ffff",
+               &[0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+               unicast_link_local|unicast_link_local_strict);
+
+        check!("fe80:0:0:1::",
+               &[0xfe, 0x80, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0],
                unicast_link_local);
 
         check!("fec0::",

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -532,6 +532,31 @@ impl Ipv4Addr {
         !self.is_broadcast() && !self.is_documentation() && !self.is_unspecified()
     }
 
+    /// Returns [`true`] if this address part of the `198.18.0.0/15` range, which is reserved for
+    /// network devices benchmarking. This range is defined in [IETF RFC 2544] as `192.18.0.0`
+    /// through `198.19.255.255` but [errata 423] corrects it to `198.18.0.0/15`.
+    ///
+    /// [IETF RFC 1112]: https://tools.ietf.org/html/rfc1112
+    /// [errate 423]: https://www.rfc-editor.org/errata/eid423
+    /// [`true`]: ../../std/primitive.bool.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ip)]
+    /// use std::net::Ipv4Addr;
+    ///
+    /// fn main() {
+    ///     assert_eq!(Ipv4Addr::new(198, 17, 255, 255).is_benchmarking(), false);
+    ///     assert_eq!(Ipv4Addr::new(198, 18, 0, 0).is_benchmarking(), true);
+    ///     assert_eq!(Ipv4Addr::new(198, 19, 255, 255).is_benchmarking(), true);
+    ///     assert_eq!(Ipv4Addr::new(198, 20, 0, 0).is_benchmarking(), false);
+    /// }
+    /// ```
+    pub fn is_benchmarking(&self) -> bool {
+        self.octets()[0] == 198 && (self.octets()[1] & 0xfe) == 18
+    }
+
     /// Returns [`true`] if this address is reserved by IANA for future use. [IETF RFC 1112]
     /// defines the block of reserved addresses as `240.0.0.0/4`. This range normally includes the
     /// broadcast address `255.255.255.255`, but this implementation explicitely excludes it, since

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -532,6 +532,34 @@ impl Ipv4Addr {
         !self.is_broadcast() && !self.is_documentation() && !self.is_unspecified()
     }
 
+    /// Returns [`true`] if this address is reserved by IANA for future use. [IETF RFC 1112]
+    /// defines the block of reserved addresses as `240.0.0.0/4`. This range normally includes the
+    /// broadcast address `255.255.255.255`, but this implementation explicitely excludes it, since
+    /// it is obviously not reserved for future use.
+    ///
+    /// [IETF RFC 1112]: https://tools.ietf.org/html/rfc1112
+    /// [`true`]: ../../std/primitive.bool.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ip)]
+    /// use std::net::Ipv4Addr;
+    ///
+    /// fn main() {
+    ///     assert_eq!(Ipv4Addr::new(240, 0, 0, 0).is_reserved(), true);
+    ///     assert_eq!(Ipv4Addr::new(255, 255, 255, 254).is_reserved(), true);
+    ///
+    ///     assert_eq!(Ipv4Addr::new(239, 255, 255, 255).is_reserved(), false);
+    ///     // The broadcast address is not considered as reserved for future use by this
+    ///     // implementation
+    ///     assert_eq!(Ipv4Addr::new(255, 255, 255, 255).is_reserved(), false);
+    /// }
+    /// ```
+    pub fn is_reserved(&self) -> bool {
+        self.octets()[0] & 240 == 240 && !self.is_broadcast()
+    }
+
     /// Returns [`true`] if this is a multicast address (224.0.0.0/4).
     ///
     /// Multicast addresses have a most significant octet between 224 and 239,

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -532,6 +532,28 @@ impl Ipv4Addr {
         !self.is_broadcast() && !self.is_documentation() && !self.is_unspecified()
     }
 
+    /// Returns [`true`] if this address is part of the Shared Address Space defined in
+    /// [IETF RFC 6598] (`100.64.0.0/10`).
+    ///
+    /// [IETF RFC 6598]: https://tools.ietf.org/html/rfc6598
+    /// [`true`]: ../../std/primitive.bool.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ip)]
+    /// use std::net::Ipv4Addr;
+    ///
+    /// fn main() {
+    ///     assert_eq!(Ipv4Addr::new(100, 64, 0, 0).is_shared(), true);
+    ///     assert_eq!(Ipv4Addr::new(100, 127, 255, 255).is_shared(), true);
+    ///     assert_eq!(Ipv4Addr::new(100, 128, 0, 0).is_shared(), false);
+    /// }
+    /// ```
+    pub fn is_shared(&self) -> bool {
+        self.octets()[0] == 100 && (self.octets()[1] & 0b1100_0000 == 0b0100_0000)
+    }
+
     /// Returns [`true`] if this address is part of `192.0.0.0/24`, which is reserved to
     /// IANA for IETF protocol assignments, as documented in [IETF RFC 6890].
     ///

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2050,6 +2050,10 @@ mod tests {
         check!("240.0.0.0");
         check!("251.54.1.76");
         check!("254.255.255.255");
+        // make sure shared addresses are not global
+        check!("100.64.0.0");
+        check!("100.127.255.255");
+        check!("100.100.100.0");
 
         check!("::", unspec);
         check!("::1", loopback);
@@ -2096,6 +2100,7 @@ mod tests {
                 let benchmarking: u16 = 1 << 8;
                 let ietf_protocol_assignment: u16 = 1 << 9;
                 let reserved: u16 = 1 << 10;
+                let shared: u16 = 1 << 11;
 
                 if ($mask & unspec) == unspec {
                     assert!(ip!($s).is_unspecified());
@@ -2162,6 +2167,12 @@ mod tests {
                 } else {
                     assert!(!ip!($s).is_reserved());
                 }
+
+                if ($mask & shared) == shared {
+                    assert!(ip!($s).is_shared());
+                } else {
+                    assert!(!ip!($s).is_shared());
+                }
             }}
         }
 
@@ -2176,6 +2187,7 @@ mod tests {
         let benchmarking: u16 = 1 << 8;
         let ietf_protocol_assignment: u16 = 1 << 9;
         let reserved: u16 = 1 << 10;
+        let shared: u16 = 1 << 11;
 
         check!("0.0.0.0", unspec);
         check!("0.0.0.1");
@@ -2202,6 +2214,9 @@ mod tests {
         check!("240.0.0.0", reserved);
         check!("251.54.1.76", reserved);
         check!("254.255.255.255", reserved);
+        check!("100.64.0.0", shared);
+        check!("100.127.255.255", shared);
+        check!("100.100.100.0", shared);
     }
 
     #[test]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1335,6 +1335,14 @@ impl Ipv6Addr {
     ///     assert_eq!(Ipv6Addr::new(0xfec2, 0, 0, 0, 0, 0, 0, 0).is_unicast_site_local(), true);
     /// }
     /// ```
+    ///
+    /// # Warning
+    ///
+    /// As per [RFC 3879], the whole `FEC0::/10` prefix is
+    /// deprecated. New software must not support site-local
+    /// addresses.
+    ///
+    /// [RFC 3879]: https://tools.ietf.org/html/rfc3879
     pub fn is_unicast_site_local(&self) -> bool {
         (self.segments()[0] & 0xffc0) == 0xfec0
     }

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2032,7 +2032,7 @@ mod tests {
         check!("fdff:ffff::");
         check!("fe80:ffff::");
         check!("febf:ffff::");
-        check!("fec0::");
+        check!("fec0::", global);
         check!("ff01::", multicast);
         check!("ff02::", multicast);
         check!("ff03::", multicast);
@@ -2310,7 +2310,7 @@ mod tests {
 
         check!("fec0::",
                &[0xfe, 0xc0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-               unicast_site_local);
+               unicast_site_local|unicast_global|global);
 
         check!("ff01::",
                &[0xff, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -532,6 +532,40 @@ impl Ipv4Addr {
         !self.is_broadcast() && !self.is_documentation() && !self.is_unspecified()
     }
 
+    /// Returns [`true`] if this address is part of `192.0.0.0/24`, which is reserved to
+    /// IANA for IETF protocol assignments, as documented in [IETF RFC 6890].
+    ///
+    /// Note that parts of this block are in use:
+    ///
+    /// - `192.0.0.8/32` is the "IPv4 dummy address" (see [IETF RFC 7600])
+    /// - `192.0.0.9/32` is the "Port Control Protocol Anycast" (see [IETF RFC 7723])
+    /// - `192.0.0.10/32` is used for NAT traversal (see [IETF RFC 8155])
+    ///
+    /// [IETF RFC 6890]: https://tools.ietf.org/html/rfc6890
+    /// [IETF RFC 7600]: https://tools.ietf.org/html/rfc7600
+    /// [IETF RFC 7723]: https://tools.ietf.org/html/rfc7723
+    /// [IETF RFC 8155]: https://tools.ietf.org/html/rfc8155
+    /// [`true`]: ../../std/primitive.bool.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(ip)]
+    /// use std::net::Ipv4Addr;
+    ///
+    /// fn main() {
+    ///     assert_eq!(Ipv4Addr::new(192, 0, 0, 0).is_ietf_protocol_assignment(), true);
+    ///     assert_eq!(Ipv4Addr::new(192, 0, 0, 8).is_ietf_protocol_assignment(), true);
+    ///     assert_eq!(Ipv4Addr::new(192, 0, 0, 9).is_ietf_protocol_assignment(), true);
+    ///     assert_eq!(Ipv4Addr::new(192, 0, 0, 255).is_ietf_protocol_assignment(), true);
+    ///     assert_eq!(Ipv4Addr::new(192, 0, 1, 0).is_ietf_protocol_assignment(), false);
+    ///     assert_eq!(Ipv4Addr::new(191, 255, 255, 255).is_ietf_protocol_assignment(), false);
+    /// }
+    /// ```
+    pub fn is_ietf_protocol_assignment(&self) -> bool {
+        self.octets()[0] == 192 && self.octets()[1] == 0 && self.octets()[2] == 0
+    }
+
     /// Returns [`true`] if this address part of the `198.18.0.0/15` range, which is reserved for
     /// network devices benchmarking. This range is defined in [IETF RFC 2544] as `192.18.0.0`
     /// through `198.19.255.255` but [errata 423] corrects it to `198.18.0.0/15`.

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -1051,10 +1051,19 @@ impl Ipv6Addr {
         (self.segments()[0] & 0xffc0) == 0xfe80
     }
 
-    /// Returns [`true`] if this is a deprecated unicast site-local address
-    /// (fec0::/10).
+    /// Returns [`true`] if this is a deprecated unicast site-local address (fec0::/10). The
+    /// unicast site-local address format is defined in [RFC 4291 section 2.5.7] as:
+    ///
+    /// ```no_rust
+    /// |   10     |
+    /// |  bits    |         54 bits         |         64 bits            |
+    /// +----------+-------------------------+----------------------------+
+    /// |1111111011|        subnet ID        |       interface ID         |
+    /// +----------+-------------------------+----------------------------+
+    /// ```
     ///
     /// [`true`]: ../../std/primitive.bool.html
+    /// [RFC 4291 section 2.5.7]: https://tools.ietf.org/html/rfc4291#section-2.5.7
     ///
     /// # Examples
     ///

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2023,6 +2023,9 @@ mod tests {
         check!("224.0.0.0", global|multicast);
         check!("239.255.255.255", global|multicast);
         check!("255.255.255.255");
+        check!("198.18.0.0");
+        check!("198.18.54.2");
+        check!("198.19.255.255");
 
         check!("::", unspec);
         check!("::1", loopback);
@@ -2058,14 +2061,15 @@ mod tests {
             };
 
             ($s:expr, $mask:expr) => {{
-                let unspec: u8 = 1 << 0;
-                let loopback: u8 = 1 << 1;
-                let private: u8 = 1 << 2;
-                let link_local: u8 = 1 << 3;
-                let global: u8 = 1 << 4;
-                let multicast: u8 = 1 << 5;
-                let broadcast: u8 = 1 << 6;
-                let documentation: u8 = 1 << 7;
+                let unspec: u16 = 1 << 0;
+                let loopback: u16 = 1 << 1;
+                let private: u16 = 1 << 2;
+                let link_local: u16 = 1 << 3;
+                let global: u16 = 1 << 4;
+                let multicast: u16 = 1 << 5;
+                let broadcast: u16 = 1 << 6;
+                let documentation: u16 = 1 << 7;
+                let benchmarking: u16 = 1 << 8;
 
                 if ($mask & unspec) == unspec {
                     assert!(ip!($s).is_unspecified());
@@ -2114,17 +2118,24 @@ mod tests {
                 } else {
                     assert!(!ip!($s).is_documentation());
                 }
+
+                if ($mask & benchmarking) == benchmarking {
+                    assert!(ip!($s).is_benchmarking());
+                } else {
+                    assert!(!ip!($s).is_benchmarking());
+                }
             }}
         }
 
-        let unspec: u8 = 1 << 0;
-        let loopback: u8 = 1 << 1;
-        let private: u8 = 1 << 2;
-        let link_local: u8 = 1 << 3;
-        let global: u8 = 1 << 4;
-        let multicast: u8 = 1 << 5;
-        let broadcast: u8 = 1 << 6;
-        let documentation: u8 = 1 << 7;
+        let unspec: u16 = 1 << 0;
+        let loopback: u16 = 1 << 1;
+        let private: u16 = 1 << 2;
+        let link_local: u16 = 1 << 3;
+        let global: u16 = 1 << 4;
+        let multicast: u16 = 1 << 5;
+        let broadcast: u16 = 1 << 6;
+        let documentation: u16 = 1 << 7;
+        let benchmarking: u16 = 1 << 8;
 
         check!("0.0.0.0", unspec);
         check!("0.0.0.1");
@@ -2142,6 +2153,9 @@ mod tests {
         check!("224.0.0.0", global|multicast);
         check!("239.255.255.255", global|multicast);
         check!("255.255.255.255", broadcast);
+        check!("198.18.0.0", benchmarking);
+        check!("198.18.54.2", benchmarking);
+        check!("198.19.255.255", benchmarking);
     }
 
     #[test]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2031,6 +2031,10 @@ mod tests {
         check!("192.0.0.0");
         check!("192.0.0.255");
         check!("192.0.0.100");
+        // make sure reserved addresses are not global
+        check!("240.0.0.0");
+        check!("251.54.1.76");
+        check!("254.255.255.255");
 
         check!("::", unspec);
         check!("::1", loopback);
@@ -2076,6 +2080,7 @@ mod tests {
                 let documentation: u16 = 1 << 7;
                 let benchmarking: u16 = 1 << 8;
                 let ietf_protocol_assignment: u16 = 1 << 9;
+                let reserved: u16 = 1 << 10;
 
                 if ($mask & unspec) == unspec {
                     assert!(ip!($s).is_unspecified());
@@ -2136,6 +2141,12 @@ mod tests {
                 } else {
                     assert!(!ip!($s).is_ietf_protocol_assignment());
                 }
+
+                if ($mask & reserved) == reserved {
+                    assert!(ip!($s).is_reserved());
+                } else {
+                    assert!(!ip!($s).is_reserved());
+                }
             }}
         }
 
@@ -2149,6 +2160,7 @@ mod tests {
         let documentation: u16 = 1 << 7;
         let benchmarking: u16 = 1 << 8;
         let ietf_protocol_assignment: u16 = 1 << 9;
+        let reserved: u16 = 1 << 10;
 
         check!("0.0.0.0", unspec);
         check!("0.0.0.1");
@@ -2172,6 +2184,9 @@ mod tests {
         check!("192.0.0.0", ietf_protocol_assignment);
         check!("192.0.0.255", ietf_protocol_assignment);
         check!("192.0.0.100", ietf_protocol_assignment);
+        check!("240.0.0.0", reserved);
+        check!("251.54.1.76", reserved);
+        check!("254.255.255.255", reserved);
     }
 
     #[test]

--- a/src/libstd/net/ip.rs
+++ b/src/libstd/net/ip.rs
@@ -2023,9 +2023,14 @@ mod tests {
         check!("224.0.0.0", global|multicast);
         check!("239.255.255.255", global|multicast);
         check!("255.255.255.255");
+        // make sure benchmarking addresses are not global
         check!("198.18.0.0");
         check!("198.18.54.2");
         check!("198.19.255.255");
+        // make sure addresses reserved for protocol assignment are not global
+        check!("192.0.0.0");
+        check!("192.0.0.255");
+        check!("192.0.0.100");
 
         check!("::", unspec);
         check!("::1", loopback);
@@ -2070,6 +2075,7 @@ mod tests {
                 let broadcast: u16 = 1 << 6;
                 let documentation: u16 = 1 << 7;
                 let benchmarking: u16 = 1 << 8;
+                let ietf_protocol_assignment: u16 = 1 << 9;
 
                 if ($mask & unspec) == unspec {
                     assert!(ip!($s).is_unspecified());
@@ -2124,6 +2130,12 @@ mod tests {
                 } else {
                     assert!(!ip!($s).is_benchmarking());
                 }
+
+                if ($mask & ietf_protocol_assignment) == ietf_protocol_assignment {
+                    assert!(ip!($s).is_ietf_protocol_assignment());
+                } else {
+                    assert!(!ip!($s).is_ietf_protocol_assignment());
+                }
             }}
         }
 
@@ -2136,6 +2148,7 @@ mod tests {
         let broadcast: u16 = 1 << 6;
         let documentation: u16 = 1 << 7;
         let benchmarking: u16 = 1 << 8;
+        let ietf_protocol_assignment: u16 = 1 << 9;
 
         check!("0.0.0.0", unspec);
         check!("0.0.0.1");
@@ -2156,6 +2169,9 @@ mod tests {
         check!("198.18.0.0", benchmarking);
         check!("198.18.54.2", benchmarking);
         check!("198.19.255.255", benchmarking);
+        check!("192.0.0.0", ietf_protocol_assignment);
+        check!("192.0.0.255", ietf_protocol_assignment);
+        check!("192.0.0.100", ietf_protocol_assignment);
     }
 
     #[test]


### PR DESCRIPTION
Picking this up again from my previous PR: https://github.com/rust-lang/rust/pull/56050
Related to: https://github.com/rust-lang/rust/issues/27709
Fixes: https://github.com/rust-lang/rust/issues/57558

- add `add Ipv4Addr::is_reserved()`
  - [X] implementation
  - [X] tests
- add `Ipv6Addr::is_unicast_link_local_strict()` and update `Ipv6Addr::is_unicast_link_local()` documentation
  - [X] implementation
  - [X] test
- add `Ipv4Addr::is_benchmarking()`
  - [X] implementation
  - [X] test
- add `Ipv4Addr::is_ietf_protocol_assignment()`
  - [X] implementation
  - [X] test
- add `Ipv4Addr::is_shared()`
  - [X] implementation
  - [x] test
- fix `Ipv4Addr:is_global()`
  - [X] implementation
  - [x] test
- [X] refactor the tests for IP properties. This makes the tests more verbose, but using macros have two advantages:
    - it will now be easier to add tests for all the new methods
    - we get clear error messages when a test is failing. For instance:

```
---- net::ip::tests::ip_properties stdout ----
thread '<unnamed>' panicked at 'assertion failed: !ip!("fec0::").is_global()', src/libstd/net/ip.rs:2036:9

```

Whereas previously it was something like

```
thread '<unnamed>' panicked at 'assertion failed: `(left == right)`
   left: `true`,
  right: `false`', libstd/net/ip.rs:1948:13
```

-----------------------

# Ongoing discussions:

## Should `Ipv4Addr::is_global()` return `true` or `false` for reserved addresses? 

Reserved addresses are addresses that are matched by `Ipv4Addr::is_reserved()`.
@the8472 [pointed out](https://github.com/rust-lang/rust/pull/60145#issuecomment-485458319) that [RFC 4291](https://tools.ietf.org/html/rfc4291#section-2.4) says IPv6 reserved addresses should be considered global:

```
Future specifications may redefine one or more sub-ranges of the
Global Unicast space for other purposes, but unless and until that
happens, implementations must treat all addresses that do not start
with any of the above-listed prefixes as Global Unicast addresses.
```

We could extrapolate that this should also be the case for IPv4. However, it seems that [IANA considers them non global](https://www.iana.org/assignments/ipv4-address-space/ipv4-address-space.xhtml) (see [my comment](https://github.com/rust-lang/rust/pull/60145#issuecomment-485713270))

### Final decision

There seems to be a consensus that reserved addresses have a different meaning for IPv4 and IPv6 ([comment1](https://github.com/rust-lang/rust/pull/60145#issuecomment-485963789) [comment2](https://github.com/rust-lang/rust/pull/60145#issuecomment-485944582), so we can consider that RFC4291 does not apply to IPv4, and that reserved IPv4 addresses are _not_ global.

## Should `Ipv6Addr::is_unicast_site_local()` exist?

@pusateri [noted](https://github.com/rust-lang/rust/pull/60145#issuecomment-485507515) that site-local addresses have been deprecated for a while by [RFC 3879](https://tools.ietf.org/html/rfc3879) and new implementations _must not_ support them. However, since this method is stable, removing does not seem possible. This kind of situation is covered by the RFC which stated that existing implementation _may_ continue supporting site-local addresses.

### Final decision

Let's keep this method. It is stable already, and the RFC explicitly states that existing implementation may remain.

---------

Note: I'll be AFK from April 27th to May 11th. Anyone should feel free to pick this up if the PR hasn't been merged by then. Sorry for dragging that for so long already.