### PR TITLE
use SecRandomCopyBytes on macOS in Miri

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -262,6 +262,7 @@ fn main() {
             // The flags here should be kept in sync with `add_miri_default_args`
             // in miri's `src/lib.rs`.
             cmd.arg("-Zalways-encode-mir");
+            cmd.arg("--cfg=miri");
             // These options are preferred by miri, to be able to perform better validation,
             // but the bootstrap compiler might not understand them.
             if stage != "0" {

--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -13,6 +13,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
 
 #[cfg(all(unix,
           not(target_os = "ios"),
+          not(all(target_os = "macos", miri)),
           not(target_os = "openbsd"),
           not(target_os = "freebsd"),
           not(target_os = "fuchsia")))]
@@ -106,7 +107,9 @@ mod imp {
 // once per thread in `hashmap_random_keys`. Therefore `SecRandomCopyBytes` is
 // only used on iOS where direct access to `/dev/urandom` is blocked by the
 // sandbox.
-#[cfg(target_os = "ios")]
+// HACK: However, we do use this when running in Miri on macOS; intercepting this is much
+// easier than intercepting accesses to /dev/urandom.
+#[cfg(any(target_os = "ios", all(target_os = "macos", miri)))]
 mod imp {
     use crate::io;
     use crate::ptr;


### PR DESCRIPTION
This is a hack to fix https://github.com/rust-lang/miri/issues/686: on macOS, rustc will open `/dev/urandom` to initialize a `HashMap`. That's quite hard to emulate properly in Miri without a full-blown implementation of file descriptors.  However, Miri needs an implementation of `SecRandomCopyBytes` anyway to support [getrandom](https://crates.io/crates/getrandom), so using it here should work just as well.

This will only have an effect when libstd is compiled specifically for Miri, but that will generally be the case when people use `cargo miri`.

This is clearly a hack, so I am opening this to start a discussion about whether we are okay with such a hack or not.

Cc @oli-obk 