### PR TITLE
Fix #58270, fix off-by-one error in error diagnostics.

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -268,6 +268,7 @@ impl EmitterWriter {
                 // 6..7. This is degenerate input, but it's best to degrade
                 // gracefully -- and the parser likes to supply a span like
                 // that for EOF, in particular.
+
                 if lo.col_display == hi.col_display && lo.line == hi.line {
                     hi.col_display += 1;
                 }
@@ -547,6 +548,15 @@ impl EmitterWriter {
                     && j > i                      // multiline lines).
                     && p == 0  // We're currently on the first line, move the label one line down
                 {
+                    // If we're overlapping with an un-labelled annotation with the same span
+                    // we can just merge them in the output
+                    if next.start_col == annotation.start_col
+                    && next.end_col == annotation.end_col
+                    && !next.has_label()
+                    {
+                        continue;
+                    }
+
                     // This annotation needs a new line in the output.
                     p += 1;
                     break;

--- a/src/test/ui/issue-60075.stderr
+++ b/src/test/ui/issue-60075.stderr
@@ -11,9 +11,7 @@ LL |     fn qux() -> Option<usize> {
    |                               - unclosed delimiter
 LL |         let _ = if true {
 LL |         });
-   |           ^
-   |           |
-   |           help: `}` may belong here
+   |           ^ help: `}` may belong here
 
 error: expected identifier, found `;`
   --> $DIR/issue-60075.rs:6:11

--- a/src/test/ui/issues/issue-58856-1.stderr
+++ b/src/test/ui/issues/issue-58856-1.stderr
@@ -2,9 +2,8 @@ error: expected one of `)`, `,`, or `:`, found `>`
   --> $DIR/issue-58856-1.rs:2:14
    |
 LL |     fn b(self>
-   |         -    ^
-   |         |    |
-   |         |    help: `)` may belong here
+   |         -    ^ help: `)` may belong here
+   |         |
    |         unclosed delimiter
 
 error: aborting due to previous error

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-both-are-structs-3.stderr
@@ -2,9 +2,7 @@ error[E0623]: lifetime mismatch
   --> $DIR/ex3-both-anon-regions-both-are-structs-3.rs:7:11
    |
 LL | fn foo(mut x: Ref) {
-   |               ---
-   |               |
-   |               this type is declared with multiple lifetimes...
+   |               --- this type is declared with multiple lifetimes...
 LL |     x.a = x.b;
    |           ^^^ ...but data with one lifetime flows into the other here
 

--- a/src/test/ui/parser/issue-10636-2.stderr
+++ b/src/test/ui/parser/issue-10636-2.stderr
@@ -2,9 +2,8 @@ error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
   --> $DIR/issue-10636-2.rs:5:25
    |
 LL |     option.map(|some| 42;
-   |               -         ^
-   |               |         |
-   |               |         help: `)` may belong here
+   |               -         ^ help: `)` may belong here
+   |               |
    |               unclosed delimiter
 
 error: expected expression, found `)`

--- a/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
+++ b/src/test/ui/regions/regions-variance-contravariant-use-covariant-in-second-position.stderr
@@ -2,9 +2,7 @@ error[E0623]: lifetime mismatch
   --> $DIR/regions-variance-contravariant-use-covariant-in-second-position.rs:25:30
    |
 LL | fn use_<'short,'long>(c: S<'long, 'short>,
-   |                          ----------------
-   |                          |
-   |                          this type is declared with multiple lifetimes...
+   |                          ---------------- this type is declared with multiple lifetimes...
 ...
 LL |     let _: S<'long, 'long> = c;
    |                              ^ ...but data with one lifetime flows into the other here

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -2,9 +2,8 @@ error: expected one of `)`, `,`, `.`, `?`, or an operator, found `;`
   --> $DIR/token-error-correct-3.rs:15:35
    |
 LL |             callback(path.as_ref();
-   |                     -             ^
-   |                     |             |
-   |                     |             help: `)` may belong here
+   |                     -             ^ help: `)` may belong here
+   |                     |
    |                     unclosed delimiter
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`


### PR DESCRIPTION
This fixes #58270 by checking if two diagnostics overlap completely when we're calculating the line offset for each message.  