### PR TITLE
Add a tidy check for files with over 3,000 lines

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! A double-ended queue implemented with a growable ring buffer.
 //!
 //! This queue has `O(1)` amortized inserts and removals from both ends of the

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Numeric traits and functions for the built-in numeric types.
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/ptr.rs
+++ b/src/libcore/ptr.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Manually manage memory through raw pointers.
 //!
 //! *[See also the pointer primitive types](../../std/primitive.pointer.html).*

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Slice management and manipulation.
 //!
 //! For more details see [`std::slice`].

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! String manipulation.
 //!
 //! For more details, see the `std::str` module.

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Lowers the AST to the HIR.
 //!
 //! Since the AST and HIR are fairly similar, this is mostly a simple procedure,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! MIR datatypes and passes. See the [rustc guide] for more info.
 //!
 //! [rustc guide]: https://rust-lang.github.io/rustc-guide/mir/index.html

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Contains infrastructure for configuring the compiler, including parsing
 //! command line options.
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Candidate selection. See the [rustc guide] for more information on how this works.
 //!
 //! [rustc guide]: https://rust-lang.github.io/rustc-guide/traits/resolution.html#selection

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Type context book-keeping.
 
 use crate::arena::Arena;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 #![allow(usage_of_ty_tykind)]
 
 pub use self::Variance::*;

--- a/src/librustc_apfloat/tests/ieee.rs
+++ b/src/librustc_apfloat/tests/ieee.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use rustc_apfloat::{Category, ExpInt, IEK_INF, IEK_NAN, IEK_ZERO};
 use rustc_apfloat::{Float, FloatConvert, ParseError, Round, Status};
 use rustc_apfloat::ieee::{Half, Single, Double, Quad, X87DoubleExtended};

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(crate_visibility_modifier)]

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 /*!
 
 # typeck: check phase

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -1,4 +1,6 @@
 // ignore-tidy-linelength
+// ignore-tidy-filelength
+
 #![allow(non_snake_case)]
 
 register_long_diagnostics! {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! This module contains the "cleaned" pieces of the AST, and the functions
 //! that clean them.
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Rustdoc's HTML rendering module.
 //!
 //! This modules contains the bulk of the logic necessary for rendering a

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use self::Entry::*;
 
 use hashbrown::hash_map as base;

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Filesystem manipulation operations.
 //!
 //! This module contains basic methods to manipulate the contents of the local

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Cross-platform path manipulation.
 //!
 //! This module provides two types, [`PathBuf`] and [`Path`][`Path`] (akin to [`String`]

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 //! Multi-producer, single-consumer FIFO queue communication primitives.
 //!
 //! This module provides message-based communication over channels, concretely

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use crate::ast::{AngleBracketedArgs, AsyncArgument, ParenthesizedArgs, AttrStyle, BareFnTy};
 use crate::ast::{GenericBound, TraitBoundModifier};
 use crate::ast::Unsafety;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use crate::ast::{self, BlockCheckMode, PatKind, RangeEnd, RangeSyntax};
 use crate::ast::{SelfKind, GenericBound, TraitBoundModifier};
 use crate::ast::{Attribute, MacDelimiter, GenericArg};

--- a/src/test/run-pass/issues/issue-29466.rs
+++ b/src/test/run-pass/issues/issue-29466.rs
@@ -1,5 +1,9 @@
+// ignore-tidy-filelength
+//
 // run-pass
+
 #![allow(unused_variables)]
+
 macro_rules! m(
     ($e1:expr => $e2:expr) => ({ $e1 })
 );

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+
 use crate::common::CompareMode;
 use crate::common::{expected_output_path, UI_EXTENSIONS, UI_FIXED, UI_STDERR, UI_STDOUT};
 use crate::common::{output_base_dir, output_base_name, output_testname_unique};

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -3,6 +3,7 @@
 //! Example checks are:
 //!
 //! * No lines over 100 characters.
+//! * No files with over 3000 lines.
 //! * No tabs.
 //! * No trailing whitespace.
 //! * No CR characters.
@@ -17,6 +18,8 @@ use std::io::prelude::*;
 use std::path::Path;
 
 const COLS: usize = 100;
+
+const LINES: usize = 3000;
 
 const UNEXPLAINED_IGNORE_DOCTEST_INFO: &str = r#"unexplained "```ignore" doctest; try one:
 
@@ -139,11 +142,13 @@ pub fn check(path: &Path, bad: &mut bool) {
 
         let mut skip_cr = contains_ignore_directive(&contents, "cr");
         let mut skip_tab = contains_ignore_directive(&contents, "tab");
-        let mut skip_length = contains_ignore_directive(&contents, "linelength");
+        let mut skip_line_length = contains_ignore_directive(&contents, "linelength");
+        let mut skip_file_length = contains_ignore_directive(&contents, "filelength");
         let mut skip_end_whitespace = contains_ignore_directive(&contents, "end-whitespace");
         let mut skip_copyright = contains_ignore_directive(&contents, "copyright");
         let mut leading_new_lines = false;
         let mut trailing_new_lines = 0;
+        let mut lines = 0;
         for (i, line) in contents.split('\n').enumerate() {
             let mut err = |msg: &str| {
                 tidy_error!(bad, "{}:{}: {}", file.display(), i + 1, msg);
@@ -151,7 +156,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             if line.chars().count() > COLS && !long_line_is_ok(line) {
                 suppressible_tidy_err!(
                     err,
-                    skip_length,
+                    skip_line_length,
                     &format!("line longer than {} chars", COLS)
                 );
             }
@@ -197,6 +202,7 @@ pub fn check(path: &Path, bad: &mut bool) {
             } else {
                 trailing_new_lines = 0;
             }
+            lines = i;
         }
         if leading_new_lines {
             tidy_error!(bad, "{}: leading newline", file.display());
@@ -206,6 +212,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             1 => {}
             n => tidy_error!(bad, "{}: too many trailing newlines ({})", file.display(), n),
         };
+        if !skip_file_length && lines > LINES {
+            tidy_error!(bad, "{}: too many lines ({})", file.display(), lines);
+        }
 
         if let Directive::Ignore(false) = skip_cr {
             tidy_error!(bad, "{}: ignoring CR characters unnecessarily", file.display());
@@ -213,8 +222,11 @@ pub fn check(path: &Path, bad: &mut bool) {
         if let Directive::Ignore(false) = skip_tab {
             tidy_error!(bad, "{}: ignoring tab characters unnecessarily", file.display());
         }
-        if let Directive::Ignore(false) = skip_length {
+        if let Directive::Ignore(false) = skip_line_length {
             tidy_error!(bad, "{}: ignoring line length unnecessarily", file.display());
+        }
+        if let Directive::Ignore(false) = skip_file_length {
+            tidy_error!(bad, "{}: ignoring file length unnecessarily", file.display());
         }
         if let Directive::Ignore(false) = skip_end_whitespace {
             tidy_error!(bad, "{}: ignoring trailing whitespace unnecessarily", file.display());

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -212,14 +212,17 @@ pub fn check(path: &Path, bad: &mut bool) {
             1 => {}
             n => tidy_error!(bad, "{}: too many trailing newlines ({})", file.display(), n),
         };
-        if !skip_file_length && lines > LINES {
-            tidy_error!(
-                bad,
-                "{}: too many lines ({}) (add `// ignore-tidy-filelength` to the file to \
-                 suppress this error)",
-                file.display(),
-                lines
-            );
+        if lines > LINES {
+            let mut err = |_| {
+                tidy_error!(
+                    bad,
+                    "{}: too many lines ({}) (add `// \
+                     ignore-tidy-filelength` to the file to suppress this error)",
+                    file.display(),
+                    lines
+                );
+            };
+            suppressible_tidy_err!(err, skip_file_length, "");
         }
 
         if let Directive::Ignore(false) = skip_cr {

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -213,7 +213,13 @@ pub fn check(path: &Path, bad: &mut bool) {
             n => tidy_error!(bad, "{}: too many trailing newlines ({})", file.display(), n),
         };
         if !skip_file_length && lines > LINES {
-            tidy_error!(bad, "{}: too many lines ({})", file.display(), lines);
+            tidy_error!(
+                bad,
+                "{}: too many lines ({}) (add `// ignore-tidy-filelength` to the file to \
+                 suppress this error)",
+                file.display(),
+                lines
+            );
         }
 
         if let Directive::Ignore(false) = skip_cr {


### PR DESCRIPTION
Files with a large number of lines can cause issues in GitHub (e.g. https://github.com/rust-lang/rust/issues/60015) and also tend to be indicative of opportunities to refactor into less monolithic structures.

This adds a new check to tidy to warn against files that have more than 3,000 lines, as suggested in https://github.com/rust-lang/rust/issues/60015#issuecomment-483868594. (This number was chosen fairly arbitrarily as a reasonable indicator of size.) This check can be ignored with `// ignore-tidy-filelength`.

Existing files with greater than 3,000 lines currently ignore the check, but this helps us spot when files are getting too large. (We might try to split up all files larger than this in the future, as in https://github.com/rust-lang/rust/issues/60015).