### PR TITLE
Add a tidy check for leading newlines

### DIFF
--- a/src/rustc/rustc.rs
+++ b/src/rustc/rustc.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     // Pull in jemalloc when enabled.
     //

--- a/src/test/incremental/change_name_of_static_in_fn.rs
+++ b/src/test/incremental/change_name_of_static_in_fn.rs
@@ -1,4 +1,3 @@
-
 // revisions:rpass1 rpass2 rpass3
 
 // See issue #57692.

--- a/src/test/run-make-fulldeps/lto-dylib-dep/a_dylib.rs
+++ b/src/test/run-make-fulldeps/lto-dylib-dep/a_dylib.rs
@@ -1,4 +1,3 @@
-
 pub fn foo() {
     println!("bar");
 }

--- a/src/test/run-make-fulldeps/lto-dylib-dep/main.rs
+++ b/src/test/run-make-fulldeps/lto-dylib-dep/main.rs
@@ -1,4 +1,3 @@
-
 extern crate a_dylib;
 
 fn main() {

--- a/src/test/run-pass/coherence/auxiliary/re_rebalance_coherence_lib.rs
+++ b/src/test/run-pass/coherence/auxiliary/re_rebalance_coherence_lib.rs
@@ -1,5 +1,4 @@
-
-pub trait Backend{}
+pub trait Backend {}
 pub trait SupportsDefaultKeyword {}
 
 impl SupportsDefaultKeyword for Postgres {}

--- a/src/test/ui/coherence/auxiliary/re_rebalance_coherence_lib.rs
+++ b/src/test/ui/coherence/auxiliary/re_rebalance_coherence_lib.rs
@@ -1,5 +1,4 @@
-
-pub trait Backend{}
+pub trait Backend {}
 pub trait SupportsDefaultKeyword {}
 
 impl SupportsDefaultKeyword for Postgres {}

--- a/src/test/ui/e0119/conflict-with-std.rs
+++ b/src/test/ui/e0119/conflict-with-std.rs
@@ -1,4 +1,3 @@
-
 use std::marker::PhantomData;
 use std::convert::{TryFrom, AsRef};
 

--- a/src/test/ui/e0119/conflict-with-std.stderr
+++ b/src/test/ui/e0119/conflict-with-std.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `std::convert::AsRef<Q>` for type `std::boxed::Box<Q>`:
-  --> $DIR/conflict-with-std.rs:6:1
+  --> $DIR/conflict-with-std.rs:5:1
    |
 LL | impl AsRef<Q> for Box<Q> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | impl AsRef<Q> for Box<Q> {
              where T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::convert::From<S>` for type `S`:
-  --> $DIR/conflict-with-std.rs:13:1
+  --> $DIR/conflict-with-std.rs:12:1
    |
 LL | impl From<S> for S {
    | ^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | impl From<S> for S {
            - impl<T> std::convert::From<T> for T;
 
 error[E0119]: conflicting implementations of trait `std::convert::TryFrom<X>` for type `X`:
-  --> $DIR/conflict-with-std.rs:20:1
+  --> $DIR/conflict-with-std.rs:19:1
    |
 LL | impl TryFrom<X> for X {
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/auxiliary/re_rebalance_coherence_lib.rs
+++ b/src/test/ui/feature-gates/auxiliary/re_rebalance_coherence_lib.rs
@@ -1,5 +1,4 @@
-
-pub trait Backend{}
+pub trait Backend {}
 pub trait SupportsDefaultKeyword {}
 
 impl SupportsDefaultKeyword for Postgres {}

--- a/src/test/ui/mod-subitem-as-enum-variant.rs
+++ b/src/test/ui/mod-subitem-as-enum-variant.rs
@@ -1,4 +1,3 @@
-
 mod Mod {
     pub struct FakeVariant<T>(pub T);
 }

--- a/src/test/ui/mod-subitem-as-enum-variant.stderr
+++ b/src/test/ui/mod-subitem-as-enum-variant.stderr
@@ -1,5 +1,5 @@
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/mod-subitem-as-enum-variant.rs:8:11
+  --> $DIR/mod-subitem-as-enum-variant.rs:7:11
    |
 LL |     Mod::<i32>::FakeVariant(0);
    |           ^^^ type argument not allowed

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -112,6 +112,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         let skip_length = contents.contains("ignore-tidy-linelength");
         let skip_end_whitespace = contents.contains("ignore-tidy-end-whitespace");
         let skip_copyright = contents.contains("ignore-tidy-copyright");
+        let mut leading_new_lines = false;
         let mut trailing_new_lines = 0;
         for (i, line) in contents.split('\n').enumerate() {
             let mut err = |msg: &str| {
@@ -152,10 +153,16 @@ pub fn check(path: &Path, bad: &mut bool) {
                 err(LLVM_UNREACHABLE_INFO);
             }
             if line.is_empty() {
+                if i == 0 {
+                    leading_new_lines = true;
+                }
                 trailing_new_lines += 1;
             } else {
                 trailing_new_lines = 0;
             }
+        }
+        if leading_new_lines {
+            tidy_error!(bad, "{}: leading newline", file.display());
         }
         match trailing_new_lines {
             0 => tidy_error!(bad, "{}: missing trailing newline", file.display()),


### PR DESCRIPTION
This is fairly uncommon, but it can slip through when refactoring (as evidenced by the files with leading newlines here).