### PR TITLE
Generator optimization: Overlap locals that never have storage live at the same time

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -9,7 +9,7 @@ use crate::hir::def_id::DefId;
 use crate::hir::{self, InlineAsm as HirInlineAsm};
 use crate::mir::interpret::{ConstValue, InterpError, Scalar};
 use crate::mir::visit::MirVisitable;
-use rustc_data_structures::bit_set::BitSet;
+use rustc_data_structures::bit_set::BitMatrix;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::graph::dominators::{dominators, Dominators};
 use rustc_data_structures::graph::{self, GraphPredecessors, GraphSuccessors};
@@ -3008,7 +3008,7 @@ pub struct GeneratorLayout<'tcx> {
     /// Which saved locals are storage-live at the same time. Locals that do not
     /// have conflicts with each other are allowed to overlap in the computed
     /// layout.
-    pub storage_conflicts: IndexVec<GeneratorSavedLocal, BitSet<GeneratorSavedLocal>>,
+    pub storage_conflicts: BitMatrix<GeneratorSavedLocal, GeneratorSavedLocal>,
 
     /// Names and scopes of all the stored generator locals.
     /// NOTE(tmandry) This is *strictly* a temporary hack for codegen
@@ -3586,7 +3586,7 @@ impl<'tcx> TypeFoldable<'tcx> for GeneratorSavedLocal {
     }
 }
 
-impl<'tcx, T: Idx> TypeFoldable<'tcx> for BitSet<T> {
+impl<'tcx, R: Idx, C: Idx> TypeFoldable<'tcx> for BitMatrix<R, C> {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, _: &mut F) -> Self {
         self.clone()
     }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1501,13 +1501,6 @@ impl<'tcx> BasicBlockData<'tcx> {
         self.terminator.as_mut().expect("invalid terminator state")
     }
 
-    pub fn is_unreachable(&self) -> bool {
-        match self.terminator().kind {
-            TerminatorKind::Unreachable => true,
-            _ => false,
-        }
-    }
-
     pub fn retain_statements<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Statement<'_>) -> bool,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -9,6 +9,7 @@ use crate::hir::def_id::DefId;
 use crate::hir::{self, InlineAsm as HirInlineAsm};
 use crate::mir::interpret::{ConstValue, InterpError, Scalar};
 use crate::mir::visit::MirVisitable;
+use rustc_data_structures::bit_set::BitSet;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::graph::dominators::{dominators, Dominators};
 use rustc_data_structures::graph::{self, GraphPredecessors, GraphSuccessors};
@@ -1498,6 +1499,13 @@ impl<'tcx> BasicBlockData<'tcx> {
 
     pub fn terminator_mut(&mut self) -> &mut Terminator<'tcx> {
         self.terminator.as_mut().expect("invalid terminator state")
+    }
+
+    pub fn is_unreachable(&self) -> bool {
+        match self.terminator().kind {
+            TerminatorKind::Unreachable => true,
+            _ => false,
+        }
     }
 
     pub fn retain_statements<F>(&mut self, mut f: F)
@@ -2997,6 +3005,11 @@ pub struct GeneratorLayout<'tcx> {
     /// be stored in multiple variants.
     pub variant_fields: IndexVec<VariantIdx, IndexVec<Field, GeneratorSavedLocal>>,
 
+    /// Which saved locals are storage-live at the same time. Locals that do not
+    /// have conflicts with each other are allowed to overlap in the computed
+    /// layout.
+    pub storage_conflicts: IndexVec<GeneratorSavedLocal, BitSet<GeneratorSavedLocal>>,
+
     /// Names and scopes of all the stored generator locals.
     /// NOTE(tmandry) This is *strictly* a temporary hack for codegen
     /// debuginfo generation, and will be removed at some point.
@@ -3193,6 +3206,7 @@ BraceStructTypeFoldableImpl! {
     impl<'tcx> TypeFoldable<'tcx> for GeneratorLayout<'tcx> {
         field_tys,
         variant_fields,
+        storage_conflicts,
         __local_debuginfo_codegen_only_do_not_use,
     }
 }
@@ -3566,6 +3580,15 @@ impl<'tcx> TypeFoldable<'tcx> for Field {
 impl<'tcx> TypeFoldable<'tcx> for GeneratorSavedLocal {
     fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, _: &mut F) -> Self {
         *self
+    }
+    fn super_visit_with<V: TypeVisitor<'tcx>>(&self, _: &mut V) -> bool {
+        false
+    }
+}
+
+impl<'tcx, T: Idx> TypeFoldable<'tcx> for BitSet<T> {
+    fn super_fold_with<'gcx: 'tcx, F: TypeFolder<'gcx, 'tcx>>(&self, _: &mut F) -> Self {
+        self.clone()
     }
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, _: &mut V) -> bool {
         false

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -678,12 +678,13 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
 
                 // Next, check every pair of eligible locals to see if they
                 // conflict.
-                for (local_a, conflicts_a) in info.storage_conflicts.iter_enumerated() {
+                for local_a in info.storage_conflicts.rows() {
+                    let conflicts_a = info.storage_conflicts.count(local_a);
                     if ineligible_locals.contains(local_a) {
                         continue;
                     }
 
-                    for local_b in conflicts_a.iter() {
+                    for local_b in info.storage_conflicts.iter(local_a) {
                         // local_a and local_b are storage live at the same time, therefore they
                         // cannot overlap in the generator layout. The only way to guarantee
                         // this is if they are in the same variant, or one is ineligible
@@ -697,8 +698,8 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                         // If they conflict, we will choose one to make ineligible.
                         // This is not always optimal; it's just a greedy heuristic
                         // that seems to produce good results most of the time.
-                        let conflicts_b = &info.storage_conflicts[local_b];
-                        let (remove, other) = if conflicts_a.count() > conflicts_b.count() {
+                        let conflicts_b = info.storage_conflicts.count(local_b);
+                        let (remove, other) = if conflicts_a > conflicts_b {
                             (local_a, local_b)
                         } else {
                             (local_b, local_a)

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -503,6 +503,16 @@ impl<I: indexed_vec::Idx, CTX> HashStable<CTX> for bit_set::BitSet<I>
     }
 }
 
+impl<R: indexed_vec::Idx, C: indexed_vec::Idx, CTX> HashStable<CTX>
+for bit_set::BitMatrix<R, C>
+{
+    fn hash_stable<W: StableHasherResult>(&self,
+                                          ctx: &mut CTX,
+                                          hasher: &mut StableHasher<W>) {
+        self.words().hash_stable(ctx, hasher);
+    }
+}
+
 impl_stable_hash_via_hash!(::std::path::Path);
 impl_stable_hash_via_hash!(::std::path::PathBuf);
 

--- a/src/librustc_mir/dataflow/at_location.rs
+++ b/src/librustc_mir/dataflow/at_location.rs
@@ -131,6 +131,11 @@ where
         curr_state.subtract(&self.stmt_kill);
         f(curr_state.iter());
     }
+
+    /// Returns a bitset of the elements present in the current state.
+    pub fn as_dense(&self) -> &BitSet<BD::Idx> {
+        &self.curr_state
+    }
 }
 
 impl<'tcx, BD> FlowsAtLocation for FlowAtLocation<'tcx, BD>

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -431,7 +431,7 @@ fn for_each_block_location<'tcx, T: BitDenotation<'tcx>>(
         let term_loc = Location { block, statement_index: mir[block].statements.len() };
         analysis.before_terminator_effect(&mut sets, term_loc);
         f(sets.gen_set, term_loc);
-        analysis.before_statement_effect(&mut sets, term_loc);
+        analysis.terminator_effect(&mut sets, term_loc);
         f(sets.gen_set, term_loc);
     }
 }

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -380,6 +380,62 @@ pub fn state_for_location<'tcx, T: BitDenotation<'tcx>>(loc: Location,
     gen_set.to_dense()
 }
 
+/// Calls `f` with the dataflow state at every location in `mir`.
+/// Ignores blocks that terminate in `unreachable`.
+pub fn for_each_location<'tcx, T: BitDenotation<'tcx>>(
+    mir: &Body<'tcx>,
+    analysis: &T,
+    result: &DataflowResults<'tcx, T>,
+    mut f: impl FnMut(&HybridBitSet<T::Idx>, Location)
+) {
+    for (block, bb_data) in mir.basic_blocks().iter_enumerated() {
+        if bb_data.is_unreachable() {
+            continue;
+        }
+        for_each_block_location(mir, block, bb_data, analysis, result, &mut f);
+    }
+}
+
+fn for_each_block_location<'tcx, T: BitDenotation<'tcx>>(
+    mir: &Body<'tcx>,
+    block: BasicBlock,
+    bb_data: &BasicBlockData<'tcx>,
+    analysis: &T,
+    result: &DataflowResults<'tcx, T>,
+    f: &mut impl FnMut(&HybridBitSet<T::Idx>, Location)
+) {
+    let statements = &bb_data.statements;
+
+    let mut on_entry = result.sets().on_entry_set_for(block.index()).to_owned();
+    let mut kill_set = on_entry.to_hybrid();
+    let mut gen_set = kill_set.clone();
+
+    {
+        let mut sets = BlockSets {
+            on_entry: &mut on_entry,
+            kill_set: &mut kill_set,
+            gen_set: &mut gen_set,
+        };
+        // FIXME: This location is technically wrong, but there isn't a way to
+        // denote the start of a block.
+        f(sets.gen_set, Location { block, statement_index: 0 });
+
+        for statement_index in 0..statements.len() {
+            let loc = Location { block, statement_index };
+            analysis.before_statement_effect(&mut sets, loc);
+            f(sets.gen_set, loc);
+            analysis.statement_effect(&mut sets, loc);
+            f(sets.gen_set, loc);
+        }
+
+        let term_loc = Location { block, statement_index: mir[block].statements.len() };
+        analysis.before_terminator_effect(&mut sets, term_loc);
+        f(sets.gen_set, term_loc);
+        analysis.before_statement_effect(&mut sets, term_loc);
+        f(sets.gen_set, term_loc);
+    }
+}
+
 pub struct DataflowAnalysis<'a, 'tcx: 'a, O> where O: BitDenotation<'tcx>
 {
     flow_state: DataflowState<'tcx, O>,

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -380,62 +380,6 @@ pub fn state_for_location<'tcx, T: BitDenotation<'tcx>>(loc: Location,
     gen_set.to_dense()
 }
 
-/// Calls `f` with the dataflow state at every location in `mir`.
-/// Ignores blocks that terminate in `unreachable`.
-pub fn for_each_location<'tcx, T: BitDenotation<'tcx>>(
-    mir: &Body<'tcx>,
-    analysis: &T,
-    result: &DataflowResults<'tcx, T>,
-    mut f: impl FnMut(&HybridBitSet<T::Idx>, Location)
-) {
-    for (block, bb_data) in mir.basic_blocks().iter_enumerated() {
-        if bb_data.is_unreachable() {
-            continue;
-        }
-        for_each_block_location(mir, block, bb_data, analysis, result, &mut f);
-    }
-}
-
-fn for_each_block_location<'tcx, T: BitDenotation<'tcx>>(
-    mir: &Body<'tcx>,
-    block: BasicBlock,
-    bb_data: &BasicBlockData<'tcx>,
-    analysis: &T,
-    result: &DataflowResults<'tcx, T>,
-    f: &mut impl FnMut(&HybridBitSet<T::Idx>, Location)
-) {
-    let statements = &bb_data.statements;
-
-    let mut on_entry = result.sets().on_entry_set_for(block.index()).to_owned();
-    let mut kill_set = on_entry.to_hybrid();
-    let mut gen_set = kill_set.clone();
-
-    {
-        let mut sets = BlockSets {
-            on_entry: &mut on_entry,
-            kill_set: &mut kill_set,
-            gen_set: &mut gen_set,
-        };
-        // FIXME: This location is technically wrong, but there isn't a way to
-        // denote the start of a block.
-        f(sets.gen_set, Location { block, statement_index: 0 });
-
-        for statement_index in 0..statements.len() {
-            let loc = Location { block, statement_index };
-            analysis.before_statement_effect(&mut sets, loc);
-            f(sets.gen_set, loc);
-            analysis.statement_effect(&mut sets, loc);
-            f(sets.gen_set, loc);
-        }
-
-        let term_loc = Location { block, statement_index: mir[block].statements.len() };
-        analysis.before_terminator_effect(&mut sets, term_loc);
-        f(sets.gen_set, term_loc);
-        analysis.terminator_effect(&mut sets, term_loc);
-        f(sets.gen_set, term_loc);
-    }
-}
-
 pub struct DataflowAnalysis<'a, 'tcx: 'a, O> where O: BitDenotation<'tcx>
 {
     flow_state: DataflowState<'tcx, O>,

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -660,9 +660,10 @@ impl<'body, 'tcx: 'body, 's> StorageConflictVisitor<'body, 'tcx, 's> {
                    flow_state: &FlowAtLocation<'tcx, MaybeStorageLive<'body, 'tcx>>,
                    loc: Location) {
         // Ignore unreachable blocks.
-        if self.body.basic_blocks()[loc.block].is_unreachable() {
-            return;
-        }
+        match self.body.basic_blocks()[loc.block].terminator().kind {
+            TerminatorKind::Unreachable => return,
+            _ => (),
+        };
 
         let mut eligible_storage_live = flow_state.as_dense().clone();
         eligible_storage_live.intersect(&self.stored_locals);

--- a/src/test/run-pass/async-fn-size.rs
+++ b/src/test/run-pass/async-fn-size.rs
@@ -1,0 +1,106 @@
+// edition:2018
+// aux-build:arc_wake.rs
+
+#![feature(async_await, await_macro)]
+
+extern crate arc_wake;
+
+use std::pin::Pin;
+use std::future::Future;
+use std::sync::{
+    Arc,
+    atomic::{self, AtomicUsize},
+};
+use std::task::{Context, Poll};
+use arc_wake::ArcWake;
+
+struct Counter {
+    wakes: AtomicUsize,
+}
+
+impl ArcWake for Counter {
+    fn wake(self: Arc<Self>) {
+        Self::wake_by_ref(&self)
+    }
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.wakes.fetch_add(1, atomic::Ordering::SeqCst);
+    }
+}
+
+struct WakeOnceThenComplete(bool, u8);
+
+impl Future for WakeOnceThenComplete {
+    type Output = u8;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u8> {
+        if self.0 {
+            Poll::Ready(self.1)
+        } else {
+            cx.waker().wake_by_ref();
+            self.0 = true;
+            Poll::Pending
+        }
+    }
+}
+
+fn wait(fut: impl Future<Output = u8>) -> u8 {
+    let mut fut = Box::pin(fut);
+    let counter = Arc::new(Counter { wakes: AtomicUsize::new(0) });
+    let waker = ArcWake::into_waker(counter.clone());
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(out) => return out,
+            Poll::Pending => (),
+        }
+    }
+}
+
+fn base() -> WakeOnceThenComplete { WakeOnceThenComplete(false, 1) }
+
+async fn await1_level1() -> u8 {
+    await!(base())
+}
+
+async fn await2_level1() -> u8 {
+    await!(base()) + await!(base())
+}
+
+async fn await3_level1() -> u8 {
+    await!(base()) + await!(base()) + await!(base())
+}
+
+async fn await3_level2() -> u8 {
+    await!(await3_level1()) + await!(await3_level1()) + await!(await3_level1())
+}
+
+async fn await3_level3() -> u8 {
+    await!(await3_level2()) + await!(await3_level2()) + await!(await3_level2())
+}
+
+async fn await3_level4() -> u8 {
+    await!(await3_level3()) + await!(await3_level3()) + await!(await3_level3())
+}
+
+async fn await3_level5() -> u8 {
+    await!(await3_level4()) + await!(await3_level4()) + await!(await3_level4())
+}
+
+fn main() {
+    assert_eq!(2, std::mem::size_of_val(&base()));
+    assert_eq!(8, std::mem::size_of_val(&await1_level1()));
+    assert_eq!(12, std::mem::size_of_val(&await2_level1()));
+    assert_eq!(12, std::mem::size_of_val(&await3_level1()));
+    assert_eq!(20, std::mem::size_of_val(&await3_level2()));
+    assert_eq!(28, std::mem::size_of_val(&await3_level3()));
+    assert_eq!(36, std::mem::size_of_val(&await3_level4()));
+    assert_eq!(44, std::mem::size_of_val(&await3_level5()));
+
+    assert_eq!(1,   wait(base()));
+    assert_eq!(1,   wait(await1_level1()));
+    assert_eq!(2,   wait(await2_level1()));
+    assert_eq!(3,   wait(await3_level1()));
+    assert_eq!(9,   wait(await3_level2()));
+    assert_eq!(27,  wait(await3_level3()));
+    assert_eq!(81,  wait(await3_level4()));
+    assert_eq!(243, wait(await3_level5()));
+}

--- a/src/test/run-pass/generator/overlap-locals.rs
+++ b/src/test/run-pass/generator/overlap-locals.rs
@@ -1,0 +1,27 @@
+#![feature(generators)]
+
+fn main() {
+    let a = || {
+        {
+            let w: i32 = 4;
+            yield;
+            println!("{:?}", w);
+        }
+        {
+            let x: i32 = 5;
+            yield;
+            println!("{:?}", x);
+        }
+        {
+            let y: i32 = 6;
+            yield;
+            println!("{:?}", y);
+        }
+        {
+            let z: i32 = 7;
+            yield;
+            println!("{:?}", z);
+        }
+    };
+    assert_eq!(8, std::mem::size_of_val(&a));
+}


### PR DESCRIPTION
The specific goal of this optimization is to optimize async fns which use `await!`. Notably, `await!` has an enclosing scope around the futures it awaits ([definition](https://github.com/rust-lang/rust/blob/08bfe16129b0621bc90184f8704523d4929695ef/src/libstd/macros.rs#L365-L381)), which we rely on to implement the optimization.

More generally, the optimization allows overlapping the storage of some locals which are never storage-live at the same time. **We care about storage-liveness when computing the layout, because knowing a field is `StorageDead` is the only way to prove it will not be accessed, either directly or through a reference.**

To determine whether we can overlap two locals in the generator layout, we look at whether they might *both* be `StorageLive` at any point in the MIR. We use the `MaybeStorageLive` dataflow analysis for this. We iterate over every location in the MIR, and build a bitset for each local of the locals it might potentially conflict with.

Next, we assign every saved local to one or more variants. The variants correspond to suspension points, and we include the set of locals live across a given suspension point in the variant. (Note that we use liveness instead of storage-liveness here; this ensures that the local has actually been initialized in each variant it has been included in. If the local is not live across a suspension point, then it doesn't need to be included in that variant.). It's important to note that the variants are a "view" into our layout.

For the layout computation, we use a simplified approach.

1. Start with the set of locals assigned to only one variant. The rest are disqualified.
2. For each pair of locals which may conflict *and are not assigned to the same variant*, we pick one local to disqualify from overlapping.

Disqualified locals go into a non-overlapping "prefix" at the beginning of our layout. This means they always have space reserved for them. All the locals that are allowed to overlap in each variant are then laid out after this prefix, in the "overlap zone".

So, if A and B were disqualified, and X, Y, and Z were all eligible for overlap, our generator might look something like this:

You can think of a generator as an enum, where some fields are shared between variants. e.g.

```rust
enum Generator {
  Unresumed,
  Poisoned,
  Returned,
  Suspend0(A, B, X),
  Suspend1(B),
  Suspend2(A, Y, Z),
}
```

where every mention of `A` and `B` refer to the same field, which does not move when changing variants. Note that `A` and `B` would automatically be sent to the prefix in this example. Assuming that `X` is never `StorageLive` at the same time as either `Y` or `Z`, it would be allowed to overlap with them.

Note that if two locals (`Y` and `Z` in this case) are assigned to the same variant in our generator, their memory would never overlap in the layout. Thus they can both be eligible for the overlapping section, even if they are storage-live at the same time.

---

Depends on:
- [x] #59897 Multi-variant layouts for generators
- [x] #60840 Preserve local scopes in generator MIR
- [x] #61373 Emit StorageDead along unwind paths for generators

Before merging:

- [x] ~Wrap the types of all generator fields in `MaybeUninitialized` in layout::ty::field~ (opened #60889)
- [x] Make PR description more complete (e.g. explain why storage liveness is important and why we have to check every location)
- [x] Clean up TODO
- [x] Fix the layout code to enforce that the same field never moves around in the generator
- [x] Add tests for async/await
- [x] ~Reduce # bits we store by half, since the conflict relation is symmetric~ (note: decided not to do this, for simplicity)
- [x] Store liveness information for each yield point in our `GeneratorLayout`, that way we can emit more useful debuginfo AND tell miri which fields are definitely initialized for a given variant (see discussion at https://github.com/rust-lang/rust/pull/59897#issuecomment-489468627)