### PR TITLE
Identify when a stmt could have been parsed as an expr

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4177,17 +4177,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 if let Some(sp) = tcx.sess.parse_sess.abiguous_block_expr_parse
                                     .borrow().get(&sp)
                                 {
-                                    if let Ok(snippet) = tcx.sess.source_map()
-                                        .span_to_snippet(*sp)
-                                    {
-                                        err.span_suggestion(
-                                            *sp,
-                                            "parentheses are required to parse this \
-                                             as an expression",
-                                            format!("({})", snippet),
-                                            Applicability::MachineApplicable,
-                                        );
-                                    }
+                                    tcx.sess.parse_sess.expr_parentheses_needed(
+                                        &mut err,
+                                        *sp,
+                                        None,
+                                    );
                                 }
                                 err.emit();
                                 oprnd_t = tcx.types.err;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4174,7 +4174,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     oprnd_t,
                                 );
                                 let sp = tcx.sess.source_map().start_point(expr.span);
-                                if let Some(sp) = tcx.sess.parse_sess.abiguous_block_expr_parse
+                                if let Some(sp) = tcx.sess.parse_sess.ambiguous_block_expr_parse
                                     .borrow().get(&sp)
                                 {
                                     tcx.sess.parse_sess.expr_parentheses_needed(

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4182,7 +4182,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                     {
                                         err.span_suggestion(
                                             *sp,
-                                            "parenthesis are required to parse this \
+                                            "parentheses are required to parse this \
                                              as an expression",
                                             format!("({})", snippet),
                                             Applicability::MachineApplicable,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1899,7 +1899,7 @@ mod tests {
     use std::io;
     use std::path::PathBuf;
     use syntax_pos::{BytePos, Span, NO_EXPANSION};
-    use rustc_data_structures::fx::FxHashSet;
+    use rustc_data_structures::fx::{FxHashSet, FxHashMap};
     use rustc_data_structures::sync::Lock;
 
     fn mk_sess(sm: Lrc<SourceMap>) -> ParseSess {
@@ -1918,6 +1918,7 @@ mod tests {
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
             buffered_lints: Lock::new(vec![]),
+            abiguous_block_expr_parse: Lock::new(FxHashMap::default()),
         }
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1918,7 +1918,7 @@ mod tests {
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
             buffered_lints: Lock::new(vec![]),
-            abiguous_block_expr_parse: Lock::new(FxHashMap::default()),
+            ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
         }
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -11,7 +11,7 @@ use crate::tokenstream::{TokenStream, TokenTree};
 use crate::diagnostics::plugin::ErrorMap;
 use crate::print::pprust::token_to_string;
 
-use errors::{FatalError, Level, Handler, ColorConfig, Diagnostic, DiagnosticBuilder};
+use errors::{Applicability, FatalError, Level, Handler, ColorConfig, Diagnostic, DiagnosticBuilder};
 use rustc_data_structures::sync::{Lrc, Lock};
 use syntax_pos::{Span, SourceFile, FileName, MultiSpan};
 use log::debug;
@@ -47,6 +47,9 @@ pub struct ParseSess {
     included_mod_stack: Lock<Vec<PathBuf>>,
     source_map: Lrc<SourceMap>,
     pub buffered_lints: Lock<Vec<BufferedEarlyLint>>,
+    /// Contains the spans of block expressions that could have been incomplete based on the
+    /// operation token that followed it, but that the parser cannot identify without further
+    /// analysis.
     pub abiguous_block_expr_parse: Lock<FxHashMap<Span, Span>>,
 }
 
@@ -94,6 +97,24 @@ impl ParseSess {
                 lint_id,
             });
         });
+    }
+
+    /// Extend an error with a suggestion to wrap an expression with parentheses to allow the
+    /// parser to continue parsing the following operation as part of the same expression.
+    pub fn expr_parentheses_needed(
+        &self,
+        err: &mut DiagnosticBuilder<'_>,
+        span: Span,
+        alt_snippet: Option<String>,
+    ) {
+        if let Some(snippet) = self.source_map().span_to_snippet(span).ok().or(alt_snippet) {
+            err.span_suggestion(
+                span,
+                "parentheses are required to parse this as an expression",
+                format!("({})", snippet),
+                Applicability::MachineApplicable,
+            );
+        }
     }
 }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -50,7 +50,7 @@ pub struct ParseSess {
     /// Contains the spans of block expressions that could have been incomplete based on the
     /// operation token that followed it, but that the parser cannot identify without further
     /// analysis.
-    pub abiguous_block_expr_parse: Lock<FxHashMap<Span, Span>>,
+    pub ambiguous_block_expr_parse: Lock<FxHashMap<Span, Span>>,
 }
 
 impl ParseSess {
@@ -74,7 +74,7 @@ impl ParseSess {
             included_mod_stack: Lock::new(vec![]),
             source_map,
             buffered_lints: Lock::new(vec![]),
-            abiguous_block_expr_parse: Lock::new(FxHashMap::default()),
+            ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
         }
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -16,7 +16,7 @@ use rustc_data_structures::sync::{Lrc, Lock};
 use syntax_pos::{Span, SourceFile, FileName, MultiSpan};
 use log::debug;
 
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashSet, FxHashMap};
 use std::borrow::Cow;
 use std::iter;
 use std::path::{Path, PathBuf};
@@ -47,6 +47,7 @@ pub struct ParseSess {
     included_mod_stack: Lock<Vec<PathBuf>>,
     source_map: Lrc<SourceMap>,
     pub buffered_lints: Lock<Vec<BufferedEarlyLint>>,
+    pub abiguous_block_expr_parse: Lock<FxHashMap<Span, Span>>,
 }
 
 impl ParseSess {
@@ -70,6 +71,7 @@ impl ParseSess {
             included_mod_stack: Lock::new(vec![]),
             source_map,
             buffered_lints: Lock::new(vec![]),
+            abiguous_block_expr_parse: Lock::new(FxHashMap::default()),
         }
     }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3649,13 +3649,14 @@ impl<'a> Parser<'a> {
                 return Ok(lhs);
             }
             (true, Some(_)) => {
-                // #54186, #54482, #59975
                 // We've found an expression that would be parsed as a statement, but the next
                 // token implies this should be parsed as an expression.
-                let mut err = self.sess.span_diagnostic.struct_span_err(
-                    self.span,
-                    "ambiguous parse",
-                );
+                // For example: `if let Some(x) = x { x } else { 0 } / 2`
+                let mut err = self.sess.span_diagnostic.struct_span_err(self.span, &format!(
+                    "expected expression, found `{}`",
+                    pprust::token_to_string(&self.token),
+                ));
+                err.span_label(self.span, "expected expression");
                 let snippet = self.sess.source_map().span_to_snippet(lhs.span)
                     .unwrap_or_else(|_| pprust::expr_to_string(&lhs));
                 err.span_suggestion(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2931,14 +2931,7 @@ impl<'a> Parser<'a> {
                             if let Some(sp) = self.sess.abiguous_block_expr_parse.borrow()
                                 .get(&sp)
                             {
-                                if let Ok(snippet) = self.sess.source_map().span_to_snippet(*sp) {
-                                    err.span_suggestion(
-                                        *sp,
-                                        "parentheses are required to parse this as an expression",
-                                        format!("({})", snippet),
-                                        Applicability::MachineApplicable,
-                                    );
-                                }
+                                self.sess.expr_parentheses_needed(&mut err, *sp, None);
                             }
                             err.span_label(self.span, "expected expression");
                             return Err(err);
@@ -3657,14 +3650,11 @@ impl<'a> Parser<'a> {
                     pprust::token_to_string(&self.token),
                 ));
                 err.span_label(self.span, "expected expression");
-                let snippet = self.sess.source_map().span_to_snippet(lhs.span)
-                    .unwrap_or_else(|_| pprust::expr_to_string(&lhs));
-                err.span_suggestion(
+                self.sess.expr_parentheses_needed(
+                    &mut err,
                     lhs.span,
-                    "parentheses are required to parse this as an expression",
-                    format!("({})", snippet),
-                    Applicability::MachineApplicable,
-                );
+                    Some(pprust::expr_to_string(&lhs),
+                ));
                 err.emit();
             }
         }
@@ -4979,14 +4969,7 @@ impl<'a> Parser<'a> {
                         err.span_label(self.span, format!("expected {}", expected));
                         let sp = self.sess.source_map().start_point(self.span);
                         if let Some(sp) = self.sess.abiguous_block_expr_parse.borrow().get(&sp) {
-                            if let Ok(snippet) = self.sess.source_map().span_to_snippet(*sp) {
-                                err.span_suggestion(
-                                    *sp,
-                                    "parentheses are required to parse this as an expression",
-                                    format!("({})", snippet),
-                                    Applicability::MachineApplicable,
-                                );
-                            }
+                            self.sess.expr_parentheses_needed(&mut err, *sp, None);
                         }
                         return Err(err);
                     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2934,7 +2934,7 @@ impl<'a> Parser<'a> {
                                 if let Ok(snippet) = self.sess.source_map().span_to_snippet(*sp) {
                                     err.span_suggestion(
                                         *sp,
-                                        "parenthesis are required to parse this as an expression",
+                                        "parentheses are required to parse this as an expression",
                                         format!("({})", snippet),
                                         Applicability::MachineApplicable,
                                     );
@@ -2979,7 +2979,7 @@ impl<'a> Parser<'a> {
                     "struct literals are not allowed here",
                 );
                 err.multipart_suggestion(
-                    "surround the struct literal with parenthesis",
+                    "surround the struct literal with parentheses",
                     vec![
                         (lo.shrink_to_lo(), "(".to_string()),
                         (expr.span.shrink_to_hi(), ")".to_string()),
@@ -3661,7 +3661,7 @@ impl<'a> Parser<'a> {
                     .unwrap_or_else(|_| pprust::expr_to_string(&lhs));
                 err.span_suggestion(
                     lhs.span,
-                    "parenthesis are required to parse this as an expression",
+                    "parentheses are required to parse this as an expression",
                     format!("({})", snippet),
                     Applicability::MachineApplicable,
                 );
@@ -4982,7 +4982,7 @@ impl<'a> Parser<'a> {
                             if let Ok(snippet) = self.sess.source_map().span_to_snippet(*sp) {
                                 err.span_suggestion(
                                     *sp,
-                                    "parenthesis are required to parse this as an expression",
+                                    "parentheses are required to parse this as an expression",
                                     format!("({})", snippet),
                                     Applicability::MachineApplicable,
                                 );

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -207,6 +207,28 @@ impl AssocOp {
             ObsoleteInPlace | Assign | AssignOp(_) | As | DotDot | DotDotEq | Colon => None
         }
     }
+
+    pub fn can_continue_expr_unambiguously(&self) -> bool {
+        use AssocOp::*;
+        match self {
+            BitXor | // `{ 42 } ^ 3`
+            Assign | // `{ 42 } = { 42 }`
+            Divide | // `{ 42 } / 42`
+            Modulus | // `{ 42 } % 2`
+            ShiftRight | // `{ 42 } >> 2`
+            LessEqual | // `{ 42 } <= 3`
+            Greater | // `{ 42 } > 3`
+            GreaterEqual | // `{ 42 } >= 3`
+            AssignOp(_) | // `{ 42 } +=`
+            LAnd | // `{ 42 } &&foo`
+            As | // `{ 42 } as usize`
+            // Equal | // `{ 42 } == { 42 }`    Accepting these here would regress incorrect
+            // NotEqual | // `{ 42 } != { 42 }  struct literals parser recovery.
+            Colon => true, // `{ 42 }: usize`
+            _ => false,
+        }
+
+    }
 }
 
 pub const PREC_RESET: i8 = -100;

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -208,6 +208,10 @@ impl AssocOp {
         }
     }
 
+    /// This operator could be used to follow a block unambiguously.
+    ///
+    /// This is used for error recovery at the moment, providing a suggestion to wrap blocks with
+    /// parentheses while having a high degree of confidence on the correctness of the suggestion.
     pub fn can_continue_expr_unambiguously(&self) -> bool {
         use AssocOp::*;
         match self {
@@ -227,7 +231,6 @@ impl AssocOp {
             Colon => true, // `{ 42 }: usize`
             _ => false,
         }
-
     }
 }
 

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -3,7 +3,7 @@ error: struct literals are not allowed here
    |
 LL |     if let S { x: _x, y: 2 } = S { x: 1, y: 2 } { println!("Ok"); }
    |                                ^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if let S { x: _x, y: 2 } = (S { x: 1, y: 2 }) { println!("Ok"); }
    |                                ^                ^
@@ -19,7 +19,7 @@ error: struct literals are not allowed here
    |
 LL |     for _ in std::ops::Range { start: 0, end: 10 } {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     for _ in (std::ops::Range { start: 0, end: 10 }) {}
    |              ^                                     ^

--- a/src/test/ui/parser/expr-as-stmt.fixed
+++ b/src/test/ui/parser/expr-as-stmt.fixed
@@ -31,4 +31,10 @@ fn qux(a: Option<u32>, b: Option<u32>) -> bool {
     if let Some(y) = a { true } else { false }
 }
 
+fn moo(x: u32) -> bool {
+    (match x {
+        _ => 1,
+    }) > 0 //~ ERROR ambiguous parse
+}
+
 fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.fixed
+++ b/src/test/ui/parser/expr-as-stmt.fixed
@@ -1,0 +1,34 @@
+// run-rustfix
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![allow(unused_must_use)]
+
+fn foo() -> i32 {
+    ({2}) + {2} //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+}
+
+fn bar() -> i32 {
+    ({2}) + 2 //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+}
+
+fn zul() -> u32 {
+    let foo = 3;
+    ({ 42 }) + foo; //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+    32
+}
+
+fn baz() -> i32 {
+    ({ 3 }) * 3 //~ ERROR type `{integer}` cannot be dereferenced
+    //~^ ERROR mismatched types
+}
+
+fn qux(a: Option<u32>, b: Option<u32>) -> bool {
+    (if let Some(x) = a { true } else { false })
+    && //~ ERROR ambiguous parse
+    if let Some(y) = a { true } else { false }
+}
+
+fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.fixed
+++ b/src/test/ui/parser/expr-as-stmt.fixed
@@ -27,14 +27,14 @@ fn baz() -> i32 {
 
 fn qux(a: Option<u32>, b: Option<u32>) -> bool {
     (if let Some(x) = a { true } else { false })
-    && //~ ERROR ambiguous parse
+    && //~ ERROR expected expression
     if let Some(y) = a { true } else { false }
 }
 
 fn moo(x: u32) -> bool {
     (match x {
         _ => 1,
-    }) > 0 //~ ERROR ambiguous parse
+    }) > 0 //~ ERROR expected expression
 }
 
 fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.rs
+++ b/src/test/ui/parser/expr-as-stmt.rs
@@ -27,14 +27,14 @@ fn baz() -> i32 {
 
 fn qux(a: Option<u32>, b: Option<u32>) -> bool {
     if let Some(x) = a { true } else { false }
-    && //~ ERROR ambiguous parse
+    && //~ ERROR expected expression
     if let Some(y) = a { true } else { false }
 }
 
 fn moo(x: u32) -> bool {
     match x {
         _ => 1,
-    } > 0 //~ ERROR ambiguous parse
+    } > 0 //~ ERROR expected expression
 }
 
 fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.rs
+++ b/src/test/ui/parser/expr-as-stmt.rs
@@ -1,0 +1,34 @@
+// run-rustfix
+#![allow(unused_variables)]
+#![allow(dead_code)]
+#![allow(unused_must_use)]
+
+fn foo() -> i32 {
+    {2} + {2} //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+}
+
+fn bar() -> i32 {
+    {2} + 2 //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+}
+
+fn zul() -> u32 {
+    let foo = 3;
+    { 42 } + foo; //~ ERROR expected expression, found `+`
+    //~^ ERROR mismatched types
+    32
+}
+
+fn baz() -> i32 {
+    { 3 } * 3 //~ ERROR type `{integer}` cannot be dereferenced
+    //~^ ERROR mismatched types
+}
+
+fn qux(a: Option<u32>, b: Option<u32>) -> bool {
+    if let Some(x) = a { true } else { false }
+    && //~ ERROR ambiguous parse
+    if let Some(y) = a { true } else { false }
+}
+
+fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.rs
+++ b/src/test/ui/parser/expr-as-stmt.rs
@@ -31,4 +31,10 @@ fn qux(a: Option<u32>, b: Option<u32>) -> bool {
     if let Some(y) = a { true } else { false }
 }
 
+fn moo(x: u32) -> bool {
+    match x {
+        _ => 1,
+    } > 0 //~ ERROR ambiguous parse
+}
+
 fn main() {}

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -4,7 +4,7 @@ error: expected expression, found `+`
 LL |     {2} + {2}
    |     --- ^ expected expression
    |     |
-   |     help: parenthesis are required to parse this as an expression: `({2})`
+   |     help: parentheses are required to parse this as an expression: `({2})`
 
 error: expected expression, found `+`
   --> $DIR/expr-as-stmt.rs:12:9
@@ -12,7 +12,7 @@ error: expected expression, found `+`
 LL |     {2} + 2
    |     --- ^ expected expression
    |     |
-   |     help: parenthesis are required to parse this as an expression: `({2})`
+   |     help: parentheses are required to parse this as an expression: `({2})`
 
 error: expected expression, found `+`
   --> $DIR/expr-as-stmt.rs:18:12
@@ -20,13 +20,13 @@ error: expected expression, found `+`
 LL |     { 42 } + foo;
    |     ------ ^ expected expression
    |     |
-   |     help: parenthesis are required to parse this as an expression: `({ 42 })`
+   |     help: parentheses are required to parse this as an expression: `({ 42 })`
 
 error: expected expression, found `&&`
   --> $DIR/expr-as-stmt.rs:30:5
    |
 LL |     if let Some(x) = a { true } else { false }
-   |     ------------------------------------------ help: parenthesis are required to parse this as an expression: `(if let Some(x) = a { true } else { false })`
+   |     ------------------------------------------ help: parentheses are required to parse this as an expression: `(if let Some(x) = a { true } else { false })`
 LL |     &&
    |     ^^ expected expression
 
@@ -35,7 +35,7 @@ error: expected expression, found `>`
    |
 LL |     } > 0
    |       ^ expected expression
-help: parenthesis are required to parse this as an expression
+help: parentheses are required to parse this as an expression
    |
 LL |     (match x {
 LL |         _ => 1,
@@ -84,7 +84,7 @@ error[E0614]: type `{integer}` cannot be dereferenced
 LL |     { 3 } * 3
    |     ----- ^^^
    |     |
-   |     help: parenthesis are required to parse this as an expression: `({ 3 })`
+   |     help: parentheses are required to parse this as an expression: `({ 3 })`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -30,6 +30,18 @@ LL |     if let Some(x) = a { true } else { false }
 LL |     &&
    |     ^^
 
+error: ambiguous parse
+  --> $DIR/expr-as-stmt.rs:37:7
+   |
+LL |     } > 0
+   |       ^
+help: parenthesis are required to parse this as an expression
+   |
+LL |     (match x {
+LL |         _ => 1,
+LL |     }) > 0
+   |
+
 error[E0308]: mismatched types
   --> $DIR/expr-as-stmt.rs:7:6
    |
@@ -74,7 +86,7 @@ LL |     { 3 } * 3
    |     |
    |     help: parenthesis are required to parse this as an expression: `({ 3 })`
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0308, E0614.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -1,0 +1,80 @@
+error: expected expression, found `+`
+  --> $DIR/expr-as-stmt.rs:7:9
+   |
+LL |     {2} + {2}
+   |     --- ^ expected expression
+   |     |
+   |     help: parenthesis are required to parse this as an expression: `({2})`
+
+error: expected expression, found `+`
+  --> $DIR/expr-as-stmt.rs:12:9
+   |
+LL |     {2} + 2
+   |     --- ^ expected expression
+   |     |
+   |     help: parenthesis are required to parse this as an expression: `({2})`
+
+error: expected expression, found `+`
+  --> $DIR/expr-as-stmt.rs:18:12
+   |
+LL |     { 42 } + foo;
+   |     ------ ^ expected expression
+   |     |
+   |     help: parenthesis are required to parse this as an expression: `({ 42 })`
+
+error: ambiguous parse
+  --> $DIR/expr-as-stmt.rs:30:5
+   |
+LL |     if let Some(x) = a { true } else { false }
+   |     ------------------------------------------ help: parenthesis are required to parse this as an expression: `(if let Some(x) = a { true } else { false })`
+LL |     &&
+   |     ^^
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:7:6
+   |
+LL |     {2} + {2}
+   |      ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:12:6
+   |
+LL |     {2} + 2
+   |      ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:18:7
+   |
+LL |     { 42 } + foo;
+   |       ^^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/expr-as-stmt.rs:24:7
+   |
+LL |     { 3 } * 3
+   |       ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0614]: type `{integer}` cannot be dereferenced
+  --> $DIR/expr-as-stmt.rs:24:11
+   |
+LL |     { 3 } * 3
+   |     ----- ^^^
+   |     |
+   |     help: parenthesis are required to parse this as an expression: `({ 3 })`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0308, E0614.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -22,19 +22,19 @@ LL |     { 42 } + foo;
    |     |
    |     help: parenthesis are required to parse this as an expression: `({ 42 })`
 
-error: ambiguous parse
+error: expected expression, found `&&`
   --> $DIR/expr-as-stmt.rs:30:5
    |
 LL |     if let Some(x) = a { true } else { false }
    |     ------------------------------------------ help: parenthesis are required to parse this as an expression: `(if let Some(x) = a { true } else { false })`
 LL |     &&
-   |     ^^
+   |     ^^ expected expression
 
-error: ambiguous parse
+error: expected expression, found `>`
   --> $DIR/expr-as-stmt.rs:37:7
    |
 LL |     } > 0
-   |       ^
+   |       ^ expected expression
 help: parenthesis are required to parse this as an expression
    |
 LL |     (match x {

--- a/src/test/ui/parser/match-arrows-block-then-binop.rs
+++ b/src/test/ui/parser/match-arrows-block-then-binop.rs
@@ -1,7 +1,7 @@
 fn main() {
-
-    match 0 {
+    let _ = match 0 {
       0 => {
+        0
       } + 5 //~ ERROR expected pattern, found `+`
-    }
+    };
 }

--- a/src/test/ui/parser/match-arrows-block-then-binop.stderr
+++ b/src/test/ui/parser/match-arrows-block-then-binop.stderr
@@ -3,6 +3,12 @@ error: expected pattern, found `+`
    |
 LL |       } + 5
    |         ^ expected pattern
+help: parenthesis are required to parse this as an expression
+   |
+LL |       0 => ({
+LL |         0
+LL |       }) + 5
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/match-arrows-block-then-binop.stderr
+++ b/src/test/ui/parser/match-arrows-block-then-binop.stderr
@@ -3,7 +3,7 @@ error: expected pattern, found `+`
    |
 LL |       } + 5
    |         ^ expected pattern
-help: parenthesis are required to parse this as an expression
+help: parentheses are required to parse this as an expression
    |
 LL |       0 => ({
 LL |         0

--- a/src/test/ui/parser/struct-literal-in-for.stderr
+++ b/src/test/ui/parser/struct-literal-in-for.stderr
@@ -6,7 +6,7 @@ LL |       for x in Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     for x in (Foo {
 LL |         x: 3

--- a/src/test/ui/parser/struct-literal-in-if.stderr
+++ b/src/test/ui/parser/struct-literal-in-if.stderr
@@ -6,7 +6,7 @@ LL |       if Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if (Foo {
 LL |         x: 3

--- a/src/test/ui/parser/struct-literal-in-match-discriminant.stderr
+++ b/src/test/ui/parser/struct-literal-in-match-discriminant.stderr
@@ -6,7 +6,7 @@ LL |       match Foo {
 LL | |         x: 3
 LL | |     } {
    | |_____^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     match (Foo {
 LL |         x: 3

--- a/src/test/ui/parser/struct-literal-in-while.stderr
+++ b/src/test/ui/parser/struct-literal-in-while.stderr
@@ -6,7 +6,7 @@ LL |       while Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     while (Foo {
 LL |         x: 3

--- a/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
+++ b/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
@@ -6,7 +6,7 @@ LL |       while || Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     while || (Foo {
 LL |         x: 3

--- a/src/test/ui/struct-literal-variant-in-if.stderr
+++ b/src/test/ui/struct-literal-variant-in-if.stderr
@@ -3,7 +3,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::I { field1: true, field2: 42 } {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if x == (E::I { field1: true, field2: 42 }) {}
    |             ^                                 ^
@@ -13,7 +13,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::V { field: false } {}
    |             ^^^^^^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if x == (E::V { field: false }) {}
    |             ^                     ^
@@ -23,7 +23,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::J { field: -42 } {}
    |             ^^^^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if x == (E::J { field: -42 }) {}
    |             ^                   ^
@@ -33,7 +33,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::K { field: "" } {}
    |             ^^^^^^^^^^^^^^^^^^
-help: surround the struct literal with parenthesis
+help: surround the struct literal with parentheses
    |
 LL |     if x == (E::K { field: "" }) {}
    |             ^                  ^


### PR DESCRIPTION
There are some expressions that can be parsed as a statement without
a trailing semicolon depending on the context, which can lead to
confusing errors due to the same looking code being accepted in some
places and not others. Identify these cases and suggest enclosing in
parenthesis making the parse non-ambiguous without changing the
accepted grammar.

Fix #54186, cc #54482, fix #59975, fix #47287.