### PR TITLE
Add f16c target_feature

### DIFF
--- a/src/librustc_codegen_llvm/llvm_util.rs
+++ b/src/librustc_codegen_llvm/llvm_util.rs
@@ -145,6 +145,7 @@ const X86_WHITELIST: &[(&str, Option<&str>)] = &[
     ("bmi1", None),
     ("bmi2", None),
     ("cmpxchg16b", Some("cmpxchg16b_target_feature")),
+    ("f16c", Some("f16c_target_feature")),
     ("fma", None),
     ("fxsr", None),
     ("lzcnt", None),


### PR DESCRIPTION
This is requires for Intel 16-bit half-precision float intrinsics: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=fp16&expand=1769 - see companion stdsimd PR: https://github.com/rust-lang-nursery/stdsimd/pull/737. 

LLVM, Wikipedia CPUID page, and the Intel Dev Manual all call this CPUID feature "F16C", but the Intel intrinsics guide calls this "FP16C" - this is probably a bug in the intrinsics guide which we are tracking here: https://github.com/rust-lang-nursery/stdsimd/issues/738

r? @alexcrichton 