### PR TITLE
coretest: Downgrade deny to warn

### DIFF
--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -32,7 +32,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(copy_within)]
 #![feature(int_error_matching)]
-#![deny(rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 extern crate test;
 


### PR DESCRIPTION
The `deny` causes a build failure in https://github.com/RalfJung/miri-test-libstd. Since we use `-D warnings` for rustc builds, `warn` should be enough to lead to compile errors here, without impeding external builds.