### PR TITLE
Debug-print error when using rtunwrap

### DIFF
--- a/src/libstd/sys_common/mod.rs
+++ b/src/libstd/sys_common/mod.rs
@@ -30,10 +30,12 @@ macro_rules! rtassert {
 
 #[allow(unused_macros)] // not used on all platforms
 macro_rules! rtunwrap {
-    ($ok:ident, $e:expr) => (if let $ok(v) = $e {
-        v
-    } else {
-        rtabort!(concat!("unwrap failed: ", stringify!($e)));
+    ($ok:ident, $e:expr) => (match $e {
+        $ok(v) => v,
+        ref err => {
+            let err = err.as_ref().map(|_|()); // map Ok/Some which might not be Debug
+            rtabort!(concat!("unwrap failed: ", stringify!($e), " = {:?}"), err)
+        },
     })
 }
 


### PR DESCRIPTION
When I added this macro a while back I didn't have a way to make it print the failure for all types that you might want to unwrap. Now, I came up with a solution.