### PR TITLE
std: Derive `Default` for `io::Cursor`

### DIFF
--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -72,7 +72,7 @@ use core::convert::TryInto;
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Cursor<T> {
     inner: T,
     pos: u64,


### PR DESCRIPTION
I think this change is quite obvious, so made it insta-stable, but I won't insist on that.