### PR TITLE
Move pointee_info_at from rustc_codegen_llvm to rustc_target.

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1833,17 +1833,19 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
         })
     }
 
-    fn pointee_info_at(this: TyLayout<'tcx>, cx: &C, offset: Size
+    fn pointee_info_at(
+        this: TyLayout<'tcx>,
+        cx: &C,
+        offset: Size,
     ) -> Option<PointeeInfo> {
-        let mut result = None;
         match this.ty.sty {
             ty::RawPtr(mt) if offset.bytes() == 0 => {
-                result = cx.layout_of(mt.ty).ok()
+                cx.layout_of(mt.ty).ok()
                     .map(|layout| PointeeInfo {
                         size: layout.size,
                         align: layout.align.abi,
                         safe: None,
-                    });
+                    })
             }
 
             ty::Ref(_, ty, mt) if offset.bytes() == 0 => {
@@ -1877,12 +1879,12 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                     }
                 };
 
-                result = cx.layout_of(ty).ok()
+                cx.layout_of(ty).ok()
                     .map(|layout| PointeeInfo {
                         size: layout.size,
                         align: layout.align.abi,
                         safe: Some(kind),
-                    });
+                    })
             }
 
             _ => {
@@ -1915,6 +1917,8 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                     }
                 }
 
+                let mut result = None;
+
                 if let Some(variant) = data_variant {
                     let ptr_end = offset + Pointer.size(cx);
                     for i in 0..variant.fields.count() {
@@ -1945,10 +1949,10 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                         }
                     }
                 }
+
+                result
             }
         }
-
-        result
     }
 
 }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1961,6 +1961,14 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
         }
     }
 
+    fn is_freeze(
+        this: TyLayout<'tcx>,
+        cx: &C,
+        param_env: Self::ParamEnv,
+    )-> bool {
+        this.ty.is_freeze(cx.tcx(), param_env, DUMMY_SP)
+    }
+
 }
 
 struct Niche {

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1662,9 +1662,20 @@ impl ty::query::TyCtxtAt<'a, 'tcx, '_> {
     }
 }
 
+pub trait HasParamEnv<'tcx> {
+    fn param_env(&self) -> ty::ParamEnv<'tcx>;
+}
+
+impl<'tcx, C> HasParamEnv<'tcx> for LayoutCx<'tcx, C> {
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        self.param_env
+    }
+}
+
 impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
     where C: LayoutOf<Ty = Ty<'tcx>> + HasTyCtxt<'tcx>,
-          C::TyLayout: MaybeResult<TyLayout<'tcx>>
+          C::TyLayout: MaybeResult<TyLayout<'tcx>>,
+          C: HasParamEnv<'tcx>
 {
     type ParamEnv = ty::ParamEnv<'tcx>;
 
@@ -1960,15 +1971,6 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
             }
         }
     }
-
-    fn is_freeze(
-        this: TyLayout<'tcx>,
-        cx: &C,
-        param_env: Self::ParamEnv,
-    )-> bool {
-        this.ty.is_freeze(cx.tcx(), param_env, DUMMY_SP)
-    }
-
 }
 
 struct Niche {

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1720,10 +1720,9 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
         let tcx = cx.tcx();
         let discr_layout = |discr: &Scalar| -> C::TyLayout {
             let layout = LayoutDetails::scalar(cx, discr.clone());
-            MaybeResult::from_ok(TyLayout {
-                details: tcx.intern_layout(layout),
-                ty: discr.value.to_ty(tcx)
-            })
+            MaybeResult::from(Ok(
+                TyLayout {details: tcx.intern_layout(layout),ty: discr.value.to_ty(tcx)}
+            ))
         };
 
         cx.layout_of(match this.ty.sty {

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1888,7 +1888,7 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
             _ => {
                 let mut data_variant = match this.variants {
                     Variants::NicheFilling { dataful_variant, .. } => {
-                        // Only the niche itthis is always initialized,
+                        // Only the niche in this is always initialized,
                         // so only check for a pointer at its offset.
                         //
                         // If the niche is a pointer, it's either valid

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1931,8 +1931,9 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                             result = field.ok()
                                 .and_then(|field| {
                                     if ptr_end <= field_start + field.size {
+                                        let off = offset - field_start;
                                         // We found the right field, look inside it.
-                                        Self::pointee_info_at(field, cx, offset - field_start, param_env)
+                                        Self::pointee_info_at(field, cx, off, param_env)
                                     } else {
                                         None
                                     }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1666,6 +1666,8 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
     where C: LayoutOf<Ty = Ty<'tcx>> + HasTyCtxt<'tcx>,
           C::TyLayout: MaybeResult<TyLayout<'tcx>>
 {
+    type ParamEnv = ty::ParamEnv<'tcx>;
+
     fn for_variant(this: TyLayout<'tcx>, cx: &C, variant_index: VariantIdx) -> TyLayout<'tcx> {
         let details = match this.variants {
             Variants::Single { index } if index == variant_index => this.details,
@@ -1837,6 +1839,7 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
         this: TyLayout<'tcx>,
         cx: &C,
         offset: Size,
+        param_env: Self::ParamEnv,
     ) -> Option<PointeeInfo> {
         match this.ty.sty {
             ty::RawPtr(mt) if offset.bytes() == 0 => {
@@ -1850,7 +1853,7 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
 
             ty::Ref(_, ty, mt) if offset.bytes() == 0 => {
                 let tcx = cx.tcx();
-                let is_freeze = ty.is_freeze(tcx, ty::ParamEnv::reveal_all(), DUMMY_SP);
+                let is_freeze = ty.is_freeze(tcx, param_env, DUMMY_SP);
                 let kind = match mt {
                     hir::MutImmutable => if is_freeze {
                         PointerKind::Frozen
@@ -1929,7 +1932,7 @@ impl<'a, 'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
                                 .and_then(|field| {
                                     if ptr_end <= field_start + field.size {
                                         // We found the right field, look inside it.
-                                        Self::pointee_info_at(field, cx, offset - field_start)
+                                        Self::pointee_info_at(field, cx, offset - field_start, param_env)
                                     } else {
                                         None
                                     }

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -12,7 +12,7 @@ use rustc_target::abi::call::ArgType;
 use rustc_codegen_ssa::traits::*;
 
 use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TyLayout, Abi as LayoutAbi};
-use rustc::ty::{self, Ty, Instance, ParamEnv};
+use rustc::ty::{self, Ty, Instance};
 use rustc::ty::layout::{self, PointerKind};
 
 use libc::c_uint;
@@ -478,7 +478,7 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                 }
             }
 
-            if let Some(pointee) = layout.pointee_info_at(cx, offset, ParamEnv::reveal_all()) {
+            if let Some(pointee) = layout.pointee_info_at(cx, offset) {
                 if let Some(kind) = pointee.safe {
                     attrs.pointee_size = pointee.size;
                     attrs.pointee_align = Some(pointee.align);

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -2,17 +2,11 @@ use crate::llvm::{self, AttributePlace};
 use crate::builder::Builder;
 use crate::context::CodegenCx;
 use crate::type_::Type;
-use crate::type_of::{LayoutLlvmExt, PointerKind};
 use crate::value::Value;
+use crate::type_of::{LayoutLlvmExt};
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::mir::operand::OperandValue;
-<<<<<<< HEAD
-=======
-use type_::Type;
-use type_of::{LayoutLlvmExt};
-use value::Value;
->>>>>>> Remove old pointee_info_at body.
 use rustc_target::abi::call::ArgType;
 
 use rustc_codegen_ssa::traits::*;

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -7,13 +7,19 @@ use crate::value::Value;
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::mir::operand::OperandValue;
+<<<<<<< HEAD
+=======
+use type_::Type;
+use type_of::{LayoutLlvmExt};
+use value::Value;
+>>>>>>> Remove old pointee_info_at body.
 use rustc_target::abi::call::ArgType;
 
 use rustc_codegen_ssa::traits::*;
 
 use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TyLayout, Abi as LayoutAbi};
 use rustc::ty::{self, Ty, Instance};
-use rustc::ty::layout;
+use rustc::ty::layout::{self, PointerKind};
 
 use libc::c_uint;
 

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -18,7 +18,7 @@ use rustc_target::abi::call::ArgType;
 use rustc_codegen_ssa::traits::*;
 
 use rustc_target::abi::{HasDataLayout, LayoutOf, Size, TyLayout, Abi as LayoutAbi};
-use rustc::ty::{self, Ty, Instance};
+use rustc::ty::{self, Ty, Instance, ParamEnv};
 use rustc::ty::layout::{self, PointerKind};
 
 use libc::c_uint;
@@ -484,7 +484,7 @@ impl<'tcx> FnTypeExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                 }
             }
 
-            if let Some(pointee) = layout.pointee_info_at(cx, offset) {
+            if let Some(pointee) = layout.pointee_info_at(cx, offset, ParamEnv::reveal_all()) {
                 if let Some(kind) = pointee.safe {
                     attrs.pointee_size = pointee.size;
                     attrs.pointee_align = Some(pointee.align);

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -66,6 +66,12 @@ impl ty::layout::HasTyCtxt<'tcx> for Builder<'_, '_, 'tcx> {
     }
 }
 
+impl ty::layout::HasParamEnv<'tcx> for Builder<'_, '_, 'tcx> {
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        self.cx.param_env()
+    }
+}
+
 impl ty::layout::LayoutOf for Builder<'_, '_, 'tcx> {
     type Ty = Ty<'tcx>;
     type TyLayout = TyLayout<'tcx>;

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -15,7 +15,7 @@ use rustc_data_structures::small_c_str::SmallCStr;
 use rustc::mir::mono::Stats;
 use rustc::session::config::{self, DebugInfo};
 use rustc::session::Session;
-use rustc::ty::layout::{LayoutError, LayoutOf, PointeeInfo, Size, TyLayout, VariantIdx};
+use rustc::ty::layout::{LayoutError, LayoutOf, PointeeInfo, Size, TyLayout, VariantIdx, HasParamEnv};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::spec::{HasTargetSpec, Target};
@@ -859,5 +859,11 @@ impl LayoutOf for CodegenCx<'ll, 'tcx> {
             } else {
                 bug!("failed to get layout for `{}`: {}", ty, e)
             })
+    }
+}
+
+impl<'tcx, 'll> HasParamEnv<'tcx> for CodegenCx<'ll, 'tcx> {
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        panic!("asd")
     }
 }

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -16,7 +16,7 @@ use rustc_data_structures::small_c_str::SmallCStr;
 use rustc::mir::mono::Stats;
 use rustc::session::config::{self, DebugInfo};
 use rustc::session::Session;
-use rustc::ty::layout::{LayoutError, LayoutOf, Size, TyLayout, VariantIdx};
+use rustc::ty::layout::{LayoutError, LayoutOf, PointeeInfo, Size, TyLayout, VariantIdx};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::spec::{HasTargetSpec, Target};

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -8,7 +8,6 @@ use rustc::hir;
 
 use crate::monomorphize::partitioning::CodegenUnit;
 use crate::type_::Type;
-use crate::type_of::PointeeInfo;
 use rustc_codegen_ssa::traits::*;
 
 use rustc_data_structures::base_n;

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -15,7 +15,9 @@ use rustc_data_structures::small_c_str::SmallCStr;
 use rustc::mir::mono::Stats;
 use rustc::session::config::{self, DebugInfo};
 use rustc::session::Session;
-use rustc::ty::layout::{LayoutError, LayoutOf, PointeeInfo, Size, TyLayout, VariantIdx, HasParamEnv};
+use rustc::ty::layout::{
+    LayoutError, LayoutOf, PointeeInfo, Size, TyLayout, VariantIdx, HasParamEnv
+};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::util::nodemap::FxHashMap;
 use rustc_target::spec::{HasTargetSpec, Target};
@@ -864,6 +866,6 @@ impl LayoutOf for CodegenCx<'ll, 'tcx> {
 
 impl<'tcx, 'll> HasParamEnv<'tcx> for CodegenCx<'ll, 'tcx> {
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        panic!("asd")
+        ty::ParamEnv::reveal_all()
     }
 }

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -2,9 +2,11 @@ use crate::abi::{FnType, FnTypeExt};
 use crate::common::*;
 use crate::type_::Type;
 use rustc::hir;
+use abi::{FnType, FnTypeExt};
+use common::*;
 use rustc::ty::{self, Ty, TypeFoldable};
-use rustc::ty::layout::{self, Align, LayoutOf, Size, TyLayout};
-use rustc_target::abi::FloatTy;
+use rustc::ty::layout::{self, Align, LayoutOf, PointeeInfo, Size, TyLayout};
+use rustc_target::abi::{FloatTy, TyLayoutMethods};
 use rustc_mir::monomorphize::item::DefPathBasedNames;
 use rustc_codegen_ssa::traits::*;
 
@@ -172,28 +174,6 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
         let layout = self.layout_of(ty);
         (layout.size, layout.align.abi)
     }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum PointerKind {
-    /// Most general case, we know no restrictions to tell LLVM.
-    Shared,
-
-    /// `&T` where `T` contains no `UnsafeCell`, is `noalias` and `readonly`.
-    Frozen,
-
-    /// `&mut T`, when we know `noalias` is safe for LLVM.
-    UniqueBorrowed,
-
-    /// `Box<T>`, unlike `UniqueBorrowed`, it also has `noalias` on returns.
-    UniqueOwned
-}
-
-#[derive(Copy, Clone)]
-pub struct PointeeInfo {
-    pub size: Size,
-    pub align: Align,
-    pub safe: Option<PointerKind>,
 }
 
 pub trait LayoutLlvmExt<'tcx> {
@@ -406,112 +386,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             return pointee;
         }
 
-        let mut result = None;
-        match self.ty.sty {
-            ty::RawPtr(mt) if offset.bytes() == 0 => {
-                let (size, align) = cx.size_and_align_of(mt.ty);
-                result = Some(PointeeInfo {
-                    size,
-                    align,
-                    safe: None
-                });
-            }
-
-            ty::Ref(_, ty, mt) if offset.bytes() == 0 => {
-                let (size, align) = cx.size_and_align_of(ty);
-
-                let kind = match mt {
-                    hir::MutImmutable => if cx.type_is_freeze(ty) {
-                        PointerKind::Frozen
-                    } else {
-                        PointerKind::Shared
-                    },
-                    hir::MutMutable => {
-                        // Previously we would only emit noalias annotations for LLVM >= 6 or in
-                        // panic=abort mode. That was deemed right, as prior versions had many bugs
-                        // in conjunction with unwinding, but later versions didn’t seem to have
-                        // said issues. See issue #31681.
-                        //
-                        // Alas, later on we encountered a case where noalias would generate wrong
-                        // code altogether even with recent versions of LLVM in *safe* code with no
-                        // unwinding involved. See #54462.
-                        //
-                        // For now, do not enable mutable_noalias by default at all, while the
-                        // issue is being figured out.
-                        let mutable_noalias = cx.tcx.sess.opts.debugging_opts.mutable_noalias
-                            .unwrap_or(false);
-                        if mutable_noalias {
-                            PointerKind::UniqueBorrowed
-                        } else {
-                            PointerKind::Shared
-                        }
-                    }
-                };
-
-                result = Some(PointeeInfo {
-                    size,
-                    align,
-                    safe: Some(kind)
-                });
-            }
-
-            _ => {
-                let mut data_variant = match self.variants {
-                    // Within the discriminant field, only the niche itself is
-                    // always initialized, so we only check for a pointer at its
-                    // offset.
-                    //
-                    // If the niche is a pointer, it's either valid (according
-                    // to its type), or null (which the niche field's scalar
-                    // validity range encodes).  This allows using
-                    // `dereferenceable_or_null` for e.g., `Option<&T>`, and
-                    // this will continue to work as long as we don't start
-                    // using more niches than just null (e.g., the first page of
-                    // the address space, or unaligned pointers).
-                    layout::Variants::Multiple {
-                        discr_kind: layout::DiscriminantKind::Niche {
-                            dataful_variant,
-                            ..
-                        },
-                        discr_index,
-                        ..
-                    } if self.fields.offset(discr_index) == offset =>
-                        Some(self.for_variant(cx, dataful_variant)),
-                    _ => Some(*self),
-                };
-
-                if let Some(variant) = data_variant {
-                    // We're not interested in any unions.
-                    if let layout::FieldPlacement::Union(_) = variant.fields {
-                        data_variant = None;
-                    }
-                }
-
-                if let Some(variant) = data_variant {
-                    let ptr_end = offset + layout::Pointer.size(cx);
-                    for i in 0..variant.fields.count() {
-                        let field_start = variant.fields.offset(i);
-                        if field_start <= offset {
-                            let field = variant.field(cx, i);
-                            if ptr_end <= field_start + field.size {
-                                // We found the right field, look inside it.
-                                result = field.pointee_info_at(cx, offset - field_start);
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                // FIXME(eddyb) This should be for `ptr::Unique<T>`, not `Box<T>`.
-                if let Some(ref mut pointee) = result {
-                    if let ty::Adt(def, _) = self.ty.sty {
-                        if def.is_box() && offset.bytes() == 0 {
-                            pointee.safe = Some(PointerKind::UniqueOwned);
-                        }
-                    }
-                }
-            }
-        }
+        let result = Ty::pointee_info_at(*self, cx, offset);
 
         cx.pointee_infos.borrow_mut().insert((self.ty, offset), result);
         result

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -383,7 +383,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             return pointee;
         }
 
-        let result = Ty::pointee_info_at(*self, cx, offset, ty::ParamEnv::reveal_all());
+        let result = Ty::pointee_info_at(*self, cx, offset);
 
         cx.pointee_infos.borrow_mut().insert((self.ty, offset), result);
         result

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -1,9 +1,6 @@
 use crate::abi::{FnType, FnTypeExt};
 use crate::common::*;
 use crate::type_::Type;
-use rustc::hir;
-use abi::{FnType, FnTypeExt};
-use common::*;
 use rustc::ty::{self, Ty, TypeFoldable};
 use rustc::ty::layout::{self, Align, LayoutOf, PointeeInfo, Size, TyLayout};
 use rustc_target::abi::{FloatTy, TyLayoutMethods};

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -386,7 +386,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             return pointee;
         }
 
-        let result = Ty::pointee_info_at(*self, cx, offset);
+        let result = Ty::pointee_info_at(*self, cx, offset, ty::ParamEnv::reveal_all());
 
         cx.pointee_infos.borrow_mut().insert((self.ty, offset), result);
         result

--- a/src/librustc_codegen_ssa/traits/builder.rs
+++ b/src/librustc_codegen_ssa/traits/builder.rs
@@ -10,7 +10,7 @@ use crate::mir::operand::OperandRef;
 use crate::mir::place::PlaceRef;
 use crate::MemFlags;
 use rustc::ty::Ty;
-use rustc::ty::layout::{Align, Size};
+use rustc::ty::layout::{Align, Size, HasParamEnv};
 use std::ops::Range;
 use std::iter::TrustedLen;
 
@@ -29,6 +29,8 @@ pub trait BuilderMethods<'a, 'tcx: 'a>:
     + IntrinsicCallMethods<'tcx>
     + AsmBuilderMethods<'tcx>
     + StaticBuilderMethods<'tcx>
+    + HasParamEnv<'tcx>
+
 {
     fn new_block<'b>(cx: &'a Self::CodegenCx, llfn: Self::Value, name: &'b str) -> Self;
     fn with_cx(cx: &'a Self::CodegenCx) -> Self;

--- a/src/librustc_codegen_ssa/traits/mod.rs
+++ b/src/librustc_codegen_ssa/traits/mod.rs
@@ -41,6 +41,8 @@ pub use self::type_::{
     ArgTypeMethods, BaseTypeMethods, DerivedTypeMethods, LayoutTypeMethods, TypeMethods,
 };
 pub use self::write::{ModuleBufferMethods, ThinBufferMethods, WriteBackendMethods};
+use rustc::ty::layout::{HasParamEnv};
+
 
 use std::fmt;
 
@@ -58,6 +60,7 @@ pub trait CodegenMethods<'tcx>:
     + DeclareMethods<'tcx>
     + AsmMethods<'tcx>
     + PreDefineMethods<'tcx>
+    + HasParamEnv<'tcx>
 {
 }
 
@@ -72,6 +75,7 @@ impl<'tcx, T> CodegenMethods<'tcx> for T where
         + DeclareMethods<'tcx>
         + AsmMethods<'tcx>
         + PreDefineMethods<'tcx>
+        + HasParamEnv<'tcx>
 {
 }
 
@@ -85,5 +89,6 @@ pub trait HasCodegen<'tcx>:
             Type = Self::Type,
             Funclet = Self::Funclet,
             DIScope = Self::DIScope,
-        >;
+        >
+        + HasParamEnv<'tcx>;
 }

--- a/src/librustc_codegen_ssa/traits/mod.rs
+++ b/src/librustc_codegen_ssa/traits/mod.rs
@@ -89,6 +89,5 @@ pub trait HasCodegen<'tcx>:
             Type = Self::Type,
             Funclet = Self::Funclet,
             DIScope = Self::DIScope,
-        >
-        + HasParamEnv<'tcx>;
+        >;
 }

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -175,6 +175,14 @@ impl<'a, 'mir, 'tcx, M> layout::HasTyCtxt<'tcx> for InterpretCx<'a, 'mir, 'tcx, 
     }
 }
 
+impl<'a, 'mir, 'tcx, M> layout::HasParamEnv<'tcx> for InterpretCx<'a, 'mir, 'tcx, M>
+    where M: Machine<'a, 'mir, 'tcx>
+{
+    fn param_env(&self) -> ty::ParamEnv<'tcx> {
+        self.param_env
+    }
+}
+
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> LayoutOf
     for InterpretCx<'a, 'mir, 'tcx, M>
 {

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -7,6 +7,7 @@ use rustc::ty::layout::HasTyCtxt;
 use rustc::ty::layout::LayoutOf;
 use rustc::ty::layout::TargetDataLayout;
 use rustc::ty::layout::TyLayout;
+use rustc::ty::layout::HasParamEnv;
 use rustc::ty::ParamEnv;
 use rustc::ty::Ty;
 use rustc::ty::TyCtxt;
@@ -119,6 +120,12 @@ impl<'me, 'tcx> LayoutOf for UnwrapLayoutCx<'me, 'tcx> {
 impl<'me, 'tcx> HasTyCtxt<'tcx> for UnwrapLayoutCx<'me, 'tcx> {
     fn tcx<'a>(&'a self) -> TyCtxt<'a, 'tcx, 'tcx> {
         self.tcx
+    }
+}
+
+impl<'me, 'tcx> HasParamEnv<'tcx> for UnwrapLayoutCx<'me, 'tcx> {
+    fn param_env(&self) -> ParamEnv<'tcx> {
+        self.param_env
     }
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -933,6 +933,8 @@ pub struct PointeeInfo {
 }
 
 pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
+    type ParamEnv;
+
     fn for_variant(
         this: TyLayout<'a, Self>,
         cx: &C,
@@ -942,7 +944,8 @@ pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
     fn pointee_info_at(
         this: TyLayout<'a, Self>,
         cx: &C,
-        offset: Size
+        offset: Size,
+        param_env: Self::ParamEnv,
     ) -> Option<PointeeInfo>;
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -933,8 +933,6 @@ pub struct PointeeInfo {
 }
 
 pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
-    type ParamEnv;
-
     fn for_variant(
         this: TyLayout<'a, Self>,
         cx: &C,
@@ -945,7 +943,6 @@ pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
         this: TyLayout<'a, Self>,
         cx: &C,
         offset: Size,
-        param_env: Self::ParamEnv,
     ) -> Option<PointeeInfo>;
 }
 
@@ -958,11 +955,9 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::field(self, cx, i)
     }
-    pub fn pointee_info_at<C>(
-        self, cx: &C, offset: Size, param_env: Ty::ParamEnv
-    ) -> Option<PointeeInfo>
+    pub fn pointee_info_at<C>(self, cx: &C, offset: Size) -> Option<PointeeInfo>
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
-        Ty::pointee_info_at(self, cx, offset, param_env)
+        Ty::pointee_info_at(self, cx, offset)
     }
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -958,7 +958,9 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::field(self, cx, i)
     }
-    pub fn pointee_info_at<C>(self, cx: &C, offset: Size, param_env: Ty::ParamEnv) -> Option<PointeeInfo> 
+    pub fn pointee_info_at<C>(
+        self, cx: &C, offset: Size, param_env: Ty::ParamEnv
+    ) -> Option<PointeeInfo>
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::pointee_info_at(self, cx, offset, param_env)
     }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -910,6 +910,28 @@ pub trait LayoutOf {
     fn layout_of(&self, ty: Self::Ty) -> Self::TyLayout;
 }
 
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum PointerKind {
+    /// Most general case, we know no restrictions to tell LLVM.
+    Shared,
+
+    /// `&T` where `T` contains no `UnsafeCell`, is `noalias` and `readonly`.
+    Frozen,
+
+    /// `&mut T`, when we know `noalias` is safe for LLVM.
+    UniqueBorrowed,
+
+    /// `Box<T>`, unlike `UniqueBorrowed`, it also has `noalias` on returns.
+    UniqueOwned
+}
+
+#[derive(Copy, Clone)]
+pub struct PointeeInfo {
+    pub size: Size,
+    pub align: Align,
+    pub safe: Option<PointerKind>,
+}
+
 pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
     fn for_variant(
         this: TyLayout<'a, Self>,
@@ -917,6 +939,11 @@ pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
         variant_index: VariantIdx,
     ) -> TyLayout<'a, Self>;
     fn field(this: TyLayout<'a, Self>, cx: &C, i: usize) -> C::TyLayout;
+    fn pointee_info_at(
+        this: TyLayout<'a, Self>,
+        cx: &C,
+        offset: Size
+    ) -> Option<PointeeInfo>;
 }
 
 impl<'a, Ty> TyLayout<'a, Ty> {

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -958,6 +958,10 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::field(self, cx, i)
     }
+    pub fn pointee_info_at<C>(self, cx: &C, offset: Size, param_env: Ty::ParamEnv) -> Option<PointeeInfo> 
+    where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
+        Ty::pointee_info_at(self, cx, offset, param_env)
+    }
 }
 
 impl<'a, Ty> TyLayout<'a, Ty> {

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -947,11 +947,6 @@ pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
         offset: Size,
         param_env: Self::ParamEnv,
     ) -> Option<PointeeInfo>;
-    fn is_freeze(
-        this: TyLayout<'a, Self>,
-        cx: &C,
-        param_env: Self::ParamEnv,
-    )-> bool;
 }
 
 impl<'a, Ty> TyLayout<'a, Ty> {
@@ -968,10 +963,6 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     ) -> Option<PointeeInfo>
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::pointee_info_at(self, cx, offset, param_env)
-    }
-    pub fn is_freeze<C>(self, cx: &C, param_env: Ty::ParamEnv) -> bool
-    where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
-        Ty::is_freeze(self, cx, param_env)
     }
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -947,6 +947,11 @@ pub trait TyLayoutMethods<'a, C: LayoutOf<Ty = Self>>: Sized {
         offset: Size,
         param_env: Self::ParamEnv,
     ) -> Option<PointeeInfo>;
+    fn is_freeze(
+        this: TyLayout<'a, Self>,
+        cx: &C,
+        param_env: Self::ParamEnv,
+    )-> bool;
 }
 
 impl<'a, Ty> TyLayout<'a, Ty> {
@@ -963,6 +968,10 @@ impl<'a, Ty> TyLayout<'a, Ty> {
     ) -> Option<PointeeInfo>
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
         Ty::pointee_info_at(self, cx, offset, param_env)
+    }
+    pub fn is_freeze<C>(self, cx: &C, param_env: Ty::ParamEnv) -> bool
+    where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> {
+        Ty::is_freeze(self, cx, param_env)
     }
 }
 


### PR DESCRIPTION
Makes progress towards #56166.

This is a continuation of https://github.com/rust-lang/rust/pull/57150.

@oli-obk Should I close the older PR?