### PR TITLE
 Bootstrap x86_64 musl by itself 

### DIFF
--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -28,10 +28,17 @@ RUN CFLAGS="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none -Wl,--
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
+ENV HOSTS=x86_64-unknown-linux-musl
+
 ENV RUST_CONFIGURE_ARGS \
       --musl-root-x86_64=/usr/local/x86_64-linux-musl \
       --enable-extended \
-      --disable-docs
+      --disable-docs \
+      --set target.x86_64-unknown-linux-musl.crt-static=false \
+      --build $HOSTS \
+      --set target.x86_64-unknown-linux-musl.cc=x86_64-linux-musl-gcc \
+      --set target.x86_64-unknown-linux-musl.cxx=x86_64-linux-musl-g++ \
+      --set target.x86_64-unknown-linux-musl.linker=x86_64-linux-musl-gcc
 
 # Newer binutils broke things on some vms/distros (i.e., linking against
 # unknown relocs disabled by the following flag), so we need to go out of our
@@ -42,12 +49,4 @@ ENV RUST_CONFIGURE_ARGS \
 ENV CFLAGS_x86_64_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none \
     -Wl,--compress-debug-sections=none"
 
-ENV HOSTS=x86_64-unknown-linux-musl \
-    CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
-    CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
-
-# Musl defaults to static libs but we need them to be dynamic for host toolchain.
-# The toolchain will produce static libs by default.
-ENV RUSTFLAGS="-C target-feature=-crt-static"
-
-ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS
+ENV SCRIPT python2.7 ../x.py dist --build $HOSTS


### PR DESCRIPTION
It should slightly reduce build time and prepares ground for musl native tests.

NOTE: I haven't tested artifacts yet (only the build).

Can I have double try?

r? @alexcrichton 