### PR TITLE
Add guard for missing comma in macro call suggestion

### DIFF
--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -182,8 +182,10 @@ impl TokenStream {
                         (_, (TokenTree::Token(_, token::Token::Comma), _)) => continue,
                         ((TokenTree::Token(sp, token_left), NonJoint),
                          (TokenTree::Token(_, token_right), _))
-                        if (token_left.is_ident() || token_left.is_lit()) &&
-                            (token_right.is_ident() || token_right.is_lit()) => *sp,
+                        if ((token_left.is_ident() && !token_left.is_reserved_ident())
+                            || token_left.is_lit()) &&
+                            ((token_right.is_ident() && !token_right.is_reserved_ident())
+                            || token_right.is_lit()) => *sp,
                         ((TokenTree::Delimited(sp, ..), NonJoint), _) => sp.entire(),
                         _ => continue,
                     };

--- a/src/test/ui/macros/missing-comma.rs
+++ b/src/test/ui/macros/missing-comma.rs
@@ -10,6 +10,10 @@ macro_rules! bar {
     ($lvl:expr, $($arg:tt)+) => {}
 }
 
+macro_rules! check {
+    ($ty:ty, $expected:expr) => {};
+    ($ty_of:expr, $expected:expr) => {};
+}
 
 fn main() {
     println!("{}" a);
@@ -24,4 +28,7 @@ fn main() {
     //~^ ERROR no rules expected the token `d`
     bar!(Level::Error, );
     //~^ ERROR unexpected end of macro invocation
+    check!(<str as Debug>::fmt, "fmt");
+    check!(<str as Debug>::fmt, "fmt",);
+    //~^ ERROR no rules expected the token `,`
 }

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -1,11 +1,11 @@
 error: expected token: `,`
-  --> $DIR/missing-comma.rs:15:19
+  --> $DIR/missing-comma.rs:19:19
    |
 LL |     println!("{}" a);
    |                   ^
 
 error: no rules expected the token `b`
-  --> $DIR/missing-comma.rs:17:12
+  --> $DIR/missing-comma.rs:21:12
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -16,7 +16,7 @@ LL |     foo!(a b);
    |           help: missing comma here
 
 error: no rules expected the token `e`
-  --> $DIR/missing-comma.rs:19:21
+  --> $DIR/missing-comma.rs:23:21
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -27,7 +27,7 @@ LL |     foo!(a, b, c, d e);
    |                    help: missing comma here
 
 error: no rules expected the token `d`
-  --> $DIR/missing-comma.rs:21:18
+  --> $DIR/missing-comma.rs:25:18
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -38,7 +38,7 @@ LL |     foo!(a, b, c d, e);
    |                 help: missing comma here
 
 error: no rules expected the token `d`
-  --> $DIR/missing-comma.rs:23:18
+  --> $DIR/missing-comma.rs:27:18
    |
 LL | macro_rules! foo {
    | ---------------- when calling this macro
@@ -47,7 +47,7 @@ LL |     foo!(a, b, c d e);
    |                  ^ no rules expected this token in macro call
 
 error: unexpected end of macro invocation
-  --> $DIR/missing-comma.rs:25:23
+  --> $DIR/missing-comma.rs:29:23
    |
 LL | macro_rules! bar {
    | ---------------- when calling this macro
@@ -55,5 +55,14 @@ LL | macro_rules! bar {
 LL |     bar!(Level::Error, );
    |                       ^ missing tokens in macro arguments
 
-error: aborting due to 6 previous errors
+error: no rules expected the token `,`
+  --> $DIR/missing-comma.rs:32:38
+   |
+LL | macro_rules! check {
+   | ------------------ when calling this macro
+...
+LL |     check!(<str as Debug>::fmt, "fmt",);
+   |                                      ^ no rules expected this token in macro call
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
Fix #60233. Follow up to #58796.

r? @oli-obk 