### PR TITLE
Explicitly set height on rust logo <img> element in docs

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -183,13 +183,13 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
         if layout.logo.is_empty() {
             format!("<a href='{path}index.html'>\
                      <img src='{static_root_path}rust-logo{suffix}.png' \
-                          alt='logo' width='100' height='100'></a>",
+                          alt='logo' width='100'></a>",
                     path=p,
                     static_root_path=static_root_path,
                     suffix=page.resource_suffix)
         } else {
             format!("<a href='{}index.html'>\
-                     <img src='{}' alt='logo' width='100' height='100'></a>",
+                     <img src='{}' alt='logo' width='100'></a>",
                     p,
                     layout.logo)
         }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -183,13 +183,13 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
         if layout.logo.is_empty() {
             format!("<a href='{path}index.html'>\
                      <img src='{static_root_path}rust-logo{suffix}.png' \
-                          alt='logo' width='100'></a>",
+                          alt='logo' width='100' height='100'></a>",
                     path=p,
                     static_root_path=static_root_path,
                     suffix=page.resource_suffix)
         } else {
             format!("<a href='{}index.html'>\
-                     <img src='{}' alt='logo' width='100'></a>",
+                     <img src='{}' alt='logo' width='100' height='100'></a>",
                     p,
                     layout.logo)
         }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -182,14 +182,16 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
         let p = SlashChecker(&p);
         if layout.logo.is_empty() {
             format!("<a href='{path}index.html'>\
+                     <div class='logo-container'>\
                      <img src='{static_root_path}rust-logo{suffix}.png' \
-                          alt='logo' width='100'></a>",
+                          alt='logo' width='100'></div></a>",
                     path=p,
                     static_root_path=static_root_path,
                     suffix=page.resource_suffix)
         } else {
             format!("<a href='{}index.html'>\
-                     <img src='{}' alt='logo' width='100'></a>",
+                     <div class='logo-container'>\
+                     <img src='{}' alt='logo' width='100'></div></a>",
                     p,
                     layout.logo)
         }

--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -183,15 +183,13 @@ pub fn render<T: fmt::Display, S: fmt::Display>(
         if layout.logo.is_empty() {
             format!("<a href='{path}index.html'>\
                      <div class='logo-container'>\
-                     <img src='{static_root_path}rust-logo{suffix}.png' \
-                          alt='logo' width='100'></div></a>",
+                     <img src='{static_root_path}rust-logo{suffix}.png' alt='logo'></div></a>",
                     path=p,
                     static_root_path=static_root_path,
                     suffix=page.resource_suffix)
         } else {
             format!("<a href='{}index.html'>\
-                     <div class='logo-container'>\
-                     <img src='{}' alt='logo' width='100'></div></a>",
+                     <div class='logo-container'><img src='{}' alt='logo'></div></a>",
                     p,
                     layout.logo)
         }

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -183,14 +183,22 @@ nav.sub {
 }
 
 .logo-container {
-	height: 0;
-	padding-bottom: 50%;
-}
-
-.sidebar img {
+	height: 100px;
+	width: 100px;
+	position: relative;
 	margin: 20px auto;
 	display: block;
 	margin-top: 10px;
+}
+
+.logo-container > img {
+	max-width: 100px;
+	max-height: 100px;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	display: block;
 }
 
 .sidebar .location {
@@ -1035,12 +1043,18 @@ span.since {
 		padding: 0;
 	}
 
-	.sidebar img {
+	.sidebar .logo-container {
 		width: 35px;
+		height: 35px;
 		margin-top: 5px;
 		margin-bottom: 5px;
 		float: left;
 		margin-left: 50px;
+	}
+
+	.sidebar .logo-container > img {
+		max-width: 35px;
+		max-height: 35px;
 	}
 
 	.sidebar-menu {

--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -182,6 +182,11 @@ nav.sub {
 	display: none !important;
 }
 
+.logo-container {
+	height: 0;
+	padding-bottom: 50%;
+}
+
 .sidebar img {
 	margin: 20px auto;
 	display: block;


### PR DESCRIPTION
The layout of the left side menu in docs reflows when navigating between pages because of missing height on the <img> element of rust logo.

Setting height='100' tells the browser to reserve that vertical space, leading to a less janky experience.