### PR TITLE
[beta] bootstrap; remove redundant imports.

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1125,8 +1125,6 @@ impl Build {
     /// `rust.save-toolstates` in `config.toml`. If unspecified, nothing will be
     /// done. The file is updated immediately after this function completes.
     pub fn save_toolstate(&self, tool: &str, state: ToolState) {
-        use std::io::{Seek, SeekFrom};
-
         if let Some(ref path) = self.config.save_toolstates {
             let mut file = t!(fs::OpenOptions::new()
                 .create(true)


### PR DESCRIPTION
This is a backport of https://github.com/rust-lang/rust/pull/59974/commits/d6cc8551903e79bc3874e6d89f042f9691f95995 for fixing #60265 

r? @Centril 