### PR TITLE
Cleanup the MIR visitor

### DIFF
--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -151,7 +151,7 @@ impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
     fn visit_place(&mut self,
                    place: &mir::Place<'tcx>,
-                   context: PlaceContext<'tcx>,
+                   context: PlaceContext,
                    location: Location) {
         debug!("visit_place(place={:?}, context={:?})", place, context);
         let cx = self.fx.cx;
@@ -203,7 +203,7 @@ impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
     fn visit_local(&mut self,
                    &local: &mir::Local,
-                   context: PlaceContext<'tcx>,
+                   context: PlaceContext,
                    location: Location) {
         match context {
             PlaceContext::MutatingUse(MutatingUseContext::Call) => {
@@ -233,11 +233,11 @@ impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
             PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
             PlaceContext::MutatingUse(MutatingUseContext::Store) |
             PlaceContext::MutatingUse(MutatingUseContext::AsmOutput) |
-            PlaceContext::MutatingUse(MutatingUseContext::Borrow(..)) |
+            PlaceContext::MutatingUse(MutatingUseContext::Borrow) |
             PlaceContext::MutatingUse(MutatingUseContext::Projection) |
-            PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow(..)) |
-            PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow(..)) |
-            PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow(..)) |
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow) |
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow) |
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow) |
             PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection) => {
                 self.not_ssa(local);
             }

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -97,11 +97,10 @@ impl<Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
 impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
     for LocalAnalyzer<'mir, 'a, 'tcx, Bx> {
     fn visit_assign(&mut self,
-                    block: mir::BasicBlock,
                     place: &mir::Place<'tcx>,
                     rvalue: &mir::Rvalue<'tcx>,
                     location: Location) {
-        debug!("visit_assign(block={:?}, place={:?}, rvalue={:?})", block, place, rvalue);
+        debug!("visit_assign(place={:?}, rvalue={:?})", place, rvalue);
 
         if let mir::Place::Base(mir::PlaceBase::Local(index)) = *place {
             self.assign(index, location);
@@ -120,7 +119,6 @@ impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
     }
 
     fn visit_terminator_kind(&mut self,
-                             block: mir::BasicBlock,
                              kind: &mir::TerminatorKind<'tcx>,
                              location: Location) {
         let check = match *kind {
@@ -148,7 +146,7 @@ impl<'mir, 'a: 'mir, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
             }
         }
 
-        self.super_terminator_kind(block, kind, location);
+        self.super_terminator_kind(kind, location);
     }
 
     fn visit_place(&mut self,

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -95,7 +95,7 @@ impl LocalsStateAtExit {
         struct HasStorageDead(BitSet<Local>);
 
         impl<'tcx> Visitor<'tcx> for HasStorageDead {
-            fn visit_local(&mut self, local: &Local, ctx: PlaceContext<'tcx>, _: Location) {
+            fn visit_local(&mut self, local: &Local, ctx: PlaceContext, _: Location) {
                 if ctx == PlaceContext::NonUse(NonUseContext::StorageDead) {
                     self.0.insert(*local);
                 }
@@ -220,7 +220,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
     fn visit_local(
         &mut self,
         temp: &Local,
-        context: PlaceContext<'tcx>,
+        context: PlaceContext,
         location: Location,
     ) {
         if !context.is_use() {

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -184,7 +184,6 @@ struct GatherBorrows<'a, 'gcx: 'tcx, 'tcx: 'a> {
 impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
     fn visit_assign(
         &mut self,
-        block: mir::BasicBlock,
         assigned_place: &mir::Place<'tcx>,
         rvalue: &mir::Rvalue<'tcx>,
         location: mir::Location,
@@ -215,7 +214,7 @@ impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
             }
         }
 
-        self.super_assign(block, assigned_place, rvalue, location)
+        self.super_assign(assigned_place, rvalue, location)
     }
 
     fn visit_local(
@@ -286,15 +285,6 @@ impl<'a, 'gcx, 'tcx> Visitor<'tcx> for GatherBorrows<'a, 'gcx, 'tcx> {
         }
 
         return self.super_rvalue(rvalue, location);
-    }
-
-    fn visit_statement(
-        &mut self,
-        block: mir::BasicBlock,
-        statement: &mir::Statement<'tcx>,
-        location: Location,
-    ) {
-        return self.super_statement(block, statement, location);
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -100,7 +100,6 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
 
     fn visit_statement(
         &mut self,
-        block: BasicBlock,
         statement: &Statement<'tcx>,
         location: Location,
     ) {
@@ -117,12 +116,11 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
             ));
         }
 
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 
     fn visit_assign(
         &mut self,
-        block: BasicBlock,
         place: &Place<'tcx>,
         rvalue: &Rvalue<'tcx>,
         location: Location,
@@ -141,12 +139,11 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
             }
         }
 
-        self.super_assign(block, place, rvalue, location);
+        self.super_assign(place, rvalue, location);
     }
 
     fn visit_terminator(
         &mut self,
-        block: BasicBlock,
         terminator: &Terminator<'tcx>,
         location: Location,
     ) {
@@ -167,7 +164,7 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
             }
         }
 
-        self.super_terminator(block, terminator, location);
+        self.super_terminator(terminator, location);
     }
 
     fn visit_ascribe_user_ty(

--- a/src/librustc_mir/borrow_check/nll/explain_borrow/find_use.rs
+++ b/src/librustc_mir/borrow_check/nll/explain_borrow/find_use.rs
@@ -113,7 +113,7 @@ enum DefUseResult {
 }
 
 impl<'cx, 'gcx, 'tcx> Visitor<'tcx> for DefUseVisitor<'cx, 'gcx, 'tcx> {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, &local: &Local, context: PlaceContext, _: Location) {
         let local_ty = self.mir.local_decls[local].ty;
 
         let mut found_it = false;

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -58,7 +58,6 @@ struct InvalidationGenerator<'cx, 'tcx: 'cx, 'gcx: 'tcx> {
 impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
     fn visit_statement(
         &mut self,
-        block: BasicBlock,
         statement: &Statement<'tcx>,
         location: Location,
     ) {
@@ -134,13 +133,12 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
             }
         }
 
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 
     fn visit_terminator(
         &mut self,
-        block: BasicBlock,
-        terminator: &Terminator<'tcx>,
+        kind: &Terminator<'tcx>,
         location: Location
     ) {
         self.check_activations(location);
@@ -258,7 +256,7 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
             }
         }
 
-        self.super_terminator(block, terminator, location);
+        self.super_terminator(terminator, location);
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -14,7 +14,7 @@ use rustc::ty::TyCtxt;
 use rustc::mir::visit::Visitor;
 use rustc::mir::{BasicBlock, Location, Mir, Place, PlaceBase, Rvalue};
 use rustc::mir::{Statement, StatementKind};
-use rustc::mir::{Terminator, TerminatorKind};
+use rustc::mir::TerminatorKind;
 use rustc::mir::{Operand, BorrowKind};
 use rustc_data_structures::graph::dominators::Dominators;
 
@@ -136,14 +136,14 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
         self.super_statement(statement, location);
     }
 
-    fn visit_terminator(
+    fn visit_terminator_kind(
         &mut self,
-        kind: &Terminator<'tcx>,
+        kind: &TerminatorKind<'tcx>,
         location: Location
     ) {
         self.check_activations(location);
 
-        match terminator.kind {
+        match kind {
             TerminatorKind::SwitchInt {
                 ref discr,
                 switch_ty: _,
@@ -256,7 +256,7 @@ impl<'cx, 'tcx, 'gcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx, 'gcx> {
             }
         }
 
-        self.super_terminator(terminator, location);
+        self.super_terminator_kind(kind, location);
     }
 }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/local_use_map.rs
@@ -160,7 +160,7 @@ impl LocalUseMapBuild<'_> {
 }
 
 impl Visitor<'tcx> for LocalUseMapBuild<'_> {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext<'tcx>, location: Location) {
+    fn visit_local(&mut self, &local: &Local, context: PlaceContext, location: Location) {
         if self.locals_with_use_data[local] {
             match categorize(context) {
                 Some(DefUse::Def) => self.insert_def(local, location),

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -269,7 +269,7 @@ impl<'a, 'b, 'gcx, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'gcx, 'tcx> {
         }
     }
 
-    fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext<'_>, location: Location) {
+    fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         self.sanitize_place(place, location, context);
     }
 
@@ -447,7 +447,7 @@ impl<'a, 'b, 'gcx, 'tcx> TypeVerifier<'a, 'b, 'gcx, 'tcx> {
         &mut self,
         place: &Place<'tcx>,
         location: Location,
-        context: PlaceContext<'_>,
+        context: PlaceContext,
     ) -> PlaceTy<'tcx> {
         debug!("sanitize_place: {:?}", place);
         let place_ty = match place {

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -102,7 +102,7 @@ impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'c
     fn visit_local(
         &mut self,
         local: &Local,
-        place_context: PlaceContext<'tcx>,
+        place_context: PlaceContext,
         location: Location,
     ) {
         if place_context.is_place_assignment() && self.temporary_used_locals.contains(local) {

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -1,6 +1,6 @@
 use rustc::mir::visit::{PlaceContext, Visitor};
 use rustc::mir::{
-    BasicBlock, Local, Location, Place, PlaceBase, Statement, StatementKind, TerminatorKind
+    Local, Location, Place, PlaceBase, Statement, StatementKind, TerminatorKind
 };
 
 use rustc_data_structures::fx::FxHashSet;
@@ -55,7 +55,6 @@ struct GatherUsedMutsVisitor<'visit, 'cx: 'visit, 'gcx: 'tcx, 'tcx: 'cx> {
 impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'gcx, 'tcx> {
     fn visit_terminator_kind(
         &mut self,
-        _block: BasicBlock,
         kind: &TerminatorKind<'tcx>,
         _location: Location,
     ) {
@@ -77,7 +76,6 @@ impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'c
 
     fn visit_statement(
         &mut self,
-        _block: BasicBlock,
         statement: &Statement<'tcx>,
         _location: Location,
     ) {

--- a/src/librustc_mir/dataflow/impls/borrowed_locals.rs
+++ b/src/librustc_mir/dataflow/impls/borrowed_locals.rs
@@ -44,7 +44,7 @@ impl<'a, 'tcx> BitDenotation<'tcx> for HaveBeenBorrowedLocals<'a, 'tcx> {
 
         BorrowedLocalsVisitor {
             sets,
-        }.visit_statement(loc.block, stmt, loc);
+        }.visit_statement(stmt, loc);
 
         // StorageDead invalidates all borrows and raw pointers to a local
         match stmt.kind {
@@ -58,7 +58,7 @@ impl<'a, 'tcx> BitDenotation<'tcx> for HaveBeenBorrowedLocals<'a, 'tcx> {
                          loc: Location) {
         BorrowedLocalsVisitor {
             sets,
-        }.visit_terminator(loc.block, self.mir[loc.block].terminator(), loc);
+        }.visit_terminator(self.mir[loc.block].terminator(), loc);
     }
 
     fn propagate_call_return(

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -615,7 +615,6 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
     }
 
     fn visit_terminator_kind(&mut self,
-                             block: mir::BasicBlock,
                              kind: &mir::TerminatorKind<'tcx>,
                              location: Location) {
         debug!("visiting terminator {:?} @ {:?}", kind, location);
@@ -654,7 +653,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
             mir::TerminatorKind::FalseUnwind { .. } => bug!(),
         }
 
-        self.super_terminator_kind(block, kind, location);
+        self.super_terminator_kind(kind, location);
     }
 
     fn visit_place(&mut self,

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -658,7 +658,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
 
     fn visit_place(&mut self,
                     place: &mir::Place<'tcx>,
-                    context: mir::visit::PlaceContext<'tcx>,
+                    context: mir::visit::PlaceContext,
                     location: Location) {
         match place {
             Place::Base(

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -199,7 +199,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
 
     fn visit_place(&mut self,
                     place: &Place<'tcx>,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         match place {
             &Place::Projection(box Projection {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -65,7 +65,6 @@ impl<'a, 'gcx, 'tcx> UnsafetyChecker<'a, 'tcx> {
 
 impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
     fn visit_terminator(&mut self,
-                        block: BasicBlock,
                         terminator: &Terminator<'tcx>,
                         location: Location)
     {
@@ -97,11 +96,10 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                 }
             }
         }
-        self.super_terminator(block, terminator, location);
+        self.super_terminator(terminator, location);
     }
 
     fn visit_statement(&mut self,
-                       block: BasicBlock,
                        statement: &Statement<'tcx>,
                        location: Location)
     {
@@ -124,7 +122,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                     UnsafetyViolationKind::General)
             },
         }
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 
     fn visit_rvalue(&mut self,

--- a/src/librustc_mir/transform/cleanup_post_borrowck.rs
+++ b/src/librustc_mir/transform/cleanup_post_borrowck.rs
@@ -16,7 +16,7 @@
 //! [`FakeRead`]: rustc::mir::StatementKind::FakeRead
 //! [`Nop`]: rustc::mir::StatementKind::Nop
 
-use rustc::mir::{BasicBlock, BorrowKind, Rvalue, Location, Mir};
+use rustc::mir::{BorrowKind, Rvalue, Location, Mir};
 use rustc::mir::{Statement, StatementKind};
 use rustc::mir::visit::MutVisitor;
 use rustc::ty::TyCtxt;
@@ -38,7 +38,6 @@ impl MirPass for CleanupNonCodegenStatements {
 
 impl<'tcx> MutVisitor<'tcx> for DeleteNonCodegenStatements {
     fn visit_statement(&mut self,
-                       block: BasicBlock,
                        statement: &mut Statement<'tcx>,
                        location: Location) {
         match statement.kind {
@@ -47,6 +46,6 @@ impl<'tcx> MutVisitor<'tcx> for DeleteNonCodegenStatements {
             | StatementKind::FakeRead(..) => statement.make_nop(),
             _ => (),
         }
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 }

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -510,7 +510,7 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
     fn visit_local(
         &mut self,
         &local: &Local,
-        context: PlaceContext<'tcx>,
+        context: PlaceContext,
         _: Location,
     ) {
         use rustc::mir::visit::PlaceContext::*;

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -4,7 +4,7 @@
 
 use rustc::hir::def::Def;
 use rustc::mir::{Constant, Location, Place, PlaceBase, Mir, Operand, Rvalue, Local};
-use rustc::mir::{NullOp, UnOp, StatementKind, Statement, BasicBlock, LocalKind, Static, StaticKind};
+use rustc::mir::{NullOp, UnOp, StatementKind, Statement, LocalKind, Static, StaticKind};
 use rustc::mir::{TerminatorKind, ClearCrossCrate, SourceInfo, BinOp, ProjectionElem};
 use rustc::mir::visit::{Visitor, PlaceContext, MutatingUseContext, NonMutatingUseContext};
 use rustc::mir::interpret::{InterpError, Scalar, GlobalId, EvalResult};
@@ -549,7 +549,6 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for ConstPropagator<'b, 'a, 'tcx> {
 
     fn visit_statement(
         &mut self,
-        block: BasicBlock,
         statement: &Statement<'tcx>,
         location: Location,
     ) {
@@ -571,16 +570,15 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for ConstPropagator<'b, 'a, 'tcx> {
                 }
             }
         }
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 
     fn visit_terminator_kind(
         &mut self,
-        block: BasicBlock,
         kind: &TerminatorKind<'tcx>,
         location: Location,
     ) {
-        self.super_terminator_kind(block, kind, location);
+        self.super_terminator_kind(kind, location);
         let source_info = *self.mir.source_info(location);
         if let TerminatorKind::Assert { expected, msg, cond, .. } = kind {
             if let Some(value) = self.eval_operand(cond, source_info) {
@@ -601,7 +599,7 @@ impl<'b, 'a, 'tcx> Visitor<'tcx> for ConstPropagator<'b, 'a, 'tcx> {
                         },
                         Operand::Constant(_) => {}
                     }
-                    let span = self.mir[block]
+                    let span = self.mir[location.block]
                         .terminator
                         .as_ref()
                         .unwrap()

--- a/src/librustc_mir/transform/copy_prop.rs
+++ b/src/librustc_mir/transform/copy_prop.rs
@@ -134,9 +134,9 @@ impl MirPass for CopyPropagation {
     }
 }
 
-fn eliminate_self_assignments<'tcx>(
-    mir: &mut Mir<'tcx>,
-    def_use_analysis: &DefUseAnalysis<'tcx>,
+fn eliminate_self_assignments(
+    mir: &mut Mir<'_>,
+    def_use_analysis: &DefUseAnalysis,
 ) -> bool {
     let mut changed = false;
 
@@ -177,7 +177,7 @@ enum Action<'tcx> {
 }
 
 impl<'tcx> Action<'tcx> {
-    fn local_copy(mir: &Mir<'tcx>, def_use_analysis: &DefUseAnalysis<'_>, src_place: &Place<'tcx>)
+    fn local_copy(mir: &Mir<'tcx>, def_use_analysis: &DefUseAnalysis, src_place: &Place<'tcx>)
                   -> Option<Action<'tcx>> {
         // The source must be a local.
         let src_local = if let Place::Base(PlaceBase::Local(local)) = *src_place {
@@ -233,7 +233,7 @@ impl<'tcx> Action<'tcx> {
 
     fn perform(self,
                mir: &mut Mir<'tcx>,
-               def_use_analysis: &DefUseAnalysis<'tcx>,
+               def_use_analysis: &DefUseAnalysis,
                dest_local: Local,
                location: Location)
                -> bool {

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -41,10 +41,9 @@ impl<'a, 'tcx> MutVisitor<'tcx> for EraseRegionsVisitor<'a, 'tcx> {
     }
 
     fn visit_statement(&mut self,
-                       block: BasicBlock,
                        statement: &mut Statement<'tcx>,
                        location: Location) {
-        self.super_statement(block, statement, location);
+        self.super_statement(statement, location);
     }
 }
 

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -80,7 +80,7 @@ struct RenameLocalVisitor {
 impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: PlaceContext<'tcx>,
+                   _: PlaceContext,
                    _: Location) {
         if *local == self.from {
             *local = self.to;
@@ -93,14 +93,14 @@ struct DerefArgVisitor;
 impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: PlaceContext<'tcx>,
+                   _: PlaceContext,
                    _: Location) {
         assert_ne!(*local, self_arg());
     }
 
     fn visit_place(&mut self,
                     place: &mut Place<'tcx>,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         if *place == Place::Base(PlaceBase::Local(self_arg())) {
             *place = Place::Projection(Box::new(Projection {
@@ -120,14 +120,14 @@ struct PinArgVisitor<'tcx> {
 impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: PlaceContext<'tcx>,
+                   _: PlaceContext,
                    _: Location) {
         assert_ne!(*local, self_arg());
     }
 
     fn visit_place(&mut self,
                     place: &mut Place<'tcx>,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         if *place == Place::Base(PlaceBase::Local(self_arg())) {
             *place = Place::Projection(Box::new(Projection {
@@ -221,14 +221,14 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for TransformVisitor<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: PlaceContext<'tcx>,
+                   _: PlaceContext,
                    _: Location) {
         assert_eq!(self.remap.get(local), None);
     }
 
     fn visit_place(&mut self,
                     place: &mut Place<'tcx>,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         if let Place::Base(PlaceBase::Local(l)) = *place {
             // Replace an Local in the remap with a generator struct access

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -369,7 +369,6 @@ struct StorageIgnored(liveness::LiveVarSet);
 
 impl<'tcx> Visitor<'tcx> for StorageIgnored {
     fn visit_statement(&mut self,
-                       _block: BasicBlock,
                        statement: &Statement<'tcx>,
                        _location: Location) {
         match statement.kind {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -662,7 +662,7 @@ impl<'a, 'tcx> Integrator<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _ctxt: PlaceContext<'tcx>,
+                   _ctxt: PlaceContext,
                    _location: Location) {
         if *local == RETURN_PLACE {
             match self.destination {
@@ -683,7 +683,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
 
     fn visit_place(&mut self,
                     place: &mut Place<'tcx>,
-                    _ctxt: PlaceContext<'tcx>,
+                    _ctxt: PlaceContext,
                     _location: Location) {
 
         match place {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -723,9 +723,9 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
         }
     }
 
-    fn visit_terminator_kind(&mut self, block: BasicBlock,
+    fn visit_terminator_kind(&mut self,
                              kind: &mut TerminatorKind<'tcx>, loc: Location) {
-        self.super_terminator_kind(block, kind, loc);
+        self.super_terminator_kind(kind, loc);
 
         match *kind {
             TerminatorKind::GeneratorDrop |

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -24,12 +24,12 @@ pub fn no_landing_pads<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, mir: &mut Mir<'tcx
 }
 
 impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
-    fn visit_terminator(&mut self,
-                        terminator: &mut Terminator<'tcx>,
+    fn visit_terminator_kind(&mut self,
+                        kind: &mut TerminatorKind<'tcx>,
                         location: Location) {
-        if let Some(unwind) = terminator.kind.unwind_mut() {
+        if let Some(unwind) = kind.unwind_mut() {
             unwind.take();
         }
-        self.super_terminator(terminator, location);
+        self.super_terminator_kind(kind, location);
     }
 }

--- a/src/librustc_mir/transform/no_landing_pads.rs
+++ b/src/librustc_mir/transform/no_landing_pads.rs
@@ -25,12 +25,11 @@ pub fn no_landing_pads<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, mir: &mut Mir<'tcx
 
 impl<'tcx> MutVisitor<'tcx> for NoLandingPads {
     fn visit_terminator(&mut self,
-                        bb: BasicBlock,
                         terminator: &mut Terminator<'tcx>,
                         location: Location) {
         if let Some(unwind) = terminator.kind.unwind_mut() {
             unwind.take();
         }
-        self.super_terminator(bb, terminator, location);
+        self.super_terminator(terminator, location);
     }
 }

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -77,7 +77,7 @@ struct TempCollector<'tcx> {
 impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
     fn visit_local(&mut self,
                    &index: &Local,
-                   context: PlaceContext<'tcx>,
+                   context: PlaceContext,
                    location: Location) {
         debug!("visit_local: index={:?} context={:?} location={:?}", index, context, location);
         // We're only interested in temporaries and the return place
@@ -361,7 +361,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
 impl<'a, 'tcx> MutVisitor<'tcx> for Promoter<'a, 'tcx> {
     fn visit_local(&mut self,
                    local: &mut Local,
-                   _: PlaceContext<'tcx>,
+                   _: PlaceContext,
                    _: Location) {
         if self.source.local_kind(*local) == LocalKind::Temp {
             *local = self.promote_temp(*local);

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1182,10 +1182,9 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
     }
 
     fn visit_terminator_kind(&mut self,
-                             bb: BasicBlock,
                              kind: &TerminatorKind<'tcx>,
                              location: Location) {
-        debug!("visit_terminator_kind: bb={:?} kind={:?} location={:?}", bb, kind, location);
+        debug!("visit_terminator_kind: kind={:?} location={:?}", kind, location);
         if let TerminatorKind::Call { ref func, ref args, ref destination, .. } = *kind {
             if let Some((ref dest, _)) = *destination {
                 self.assign(dest, ValueSource::Call {
@@ -1313,7 +1312,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
                         continue;
                     }
 
-                    let candidate = Candidate::Argument { bb, index: i };
+                    let candidate = Candidate::Argument { bb: location.block, index: i };
                     // Since the argument is required to be constant,
                     // we care about constness, not promotability.
                     // If we checked for promotability, we'd miss out on
@@ -1346,7 +1345,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
                 self.visit_operand(arg, location);
             }
         } else if let TerminatorKind::Drop { location: ref place, .. } = *kind {
-            self.super_terminator_kind(bb, kind, location);
+            self.super_terminator_kind(kind, location);
 
             // Deny *any* live drops anywhere other than functions.
             if self.mode != Mode::Fn {
@@ -1377,12 +1376,11 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
             }
         } else {
             // Qualify any operands inside other terminators.
-            self.super_terminator_kind(bb, kind, location);
+            self.super_terminator_kind(kind, location);
         }
     }
 
     fn visit_assign(&mut self,
-                    _: BasicBlock,
                     dest: &Place<'tcx>,
                     rvalue: &Rvalue<'tcx>,
                     location: Location) {
@@ -1397,11 +1395,11 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
         self.span = source_info.span;
     }
 
-    fn visit_statement(&mut self, bb: BasicBlock, statement: &Statement<'tcx>, location: Location) {
-        debug!("visit_statement: bb={:?} statement={:?} location={:?}", bb, statement, location);
+    fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
+        debug!("visit_statement: statement={:?} location={:?}", statement, location);
         match statement.kind {
             StatementKind::Assign(..) => {
-                self.super_statement(bb, statement, location);
+                self.super_statement(statement, location);
             }
             // FIXME(eddyb) should these really do nothing?
             StatementKind::FakeRead(..) |
@@ -1413,14 +1411,6 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
             StatementKind::AscribeUserType(..) |
             StatementKind::Nop => {}
         }
-    }
-
-    fn visit_terminator(&mut self,
-                        bb: BasicBlock,
-                        terminator: &Terminator<'tcx>,
-                        location: Location) {
-        debug!("visit_terminator: bb={:?} terminator={:?} location={:?}", bb, terminator, location);
-        self.super_terminator(bb, terminator, location);
     }
 }
 

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -929,7 +929,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
 impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
     fn visit_place(&mut self,
                     place: &Place<'tcx>,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         debug!("visit_place: place={:?} context={:?} location={:?}", place, context, location);
         self.super_place(place, context, location);
@@ -1066,7 +1066,7 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
         debug!("visit_rvalue: rvalue={:?} location={:?}", rvalue, location);
 
         // Check nested operands and places.
-        if let Rvalue::Ref(region, kind, ref place) = *rvalue {
+        if let Rvalue::Ref(_, kind, ref place) = *rvalue {
             // Special-case reborrows.
             let mut is_reborrow = false;
             if let Place::Projection(ref proj) = *place {
@@ -1081,16 +1081,16 @@ impl<'a, 'tcx> Visitor<'tcx> for Checker<'a, 'tcx> {
             if is_reborrow {
                 let ctx = match kind {
                     BorrowKind::Shared => PlaceContext::NonMutatingUse(
-                        NonMutatingUseContext::SharedBorrow(region),
+                        NonMutatingUseContext::SharedBorrow,
                     ),
                     BorrowKind::Shallow => PlaceContext::NonMutatingUse(
-                        NonMutatingUseContext::ShallowBorrow(region),
+                        NonMutatingUseContext::ShallowBorrow,
                     ),
                     BorrowKind::Unique => PlaceContext::NonMutatingUse(
-                        NonMutatingUseContext::UniqueBorrow(region),
+                        NonMutatingUseContext::UniqueBorrow,
                     ),
                     BorrowKind::Mut { .. } => PlaceContext::MutatingUse(
-                        MutatingUseContext::Borrow(region),
+                        MutatingUseContext::Borrow,
                     ),
                 };
                 self.super_place(place, ctx, location);

--- a/src/librustc_mir/transform/simplify.rs
+++ b/src/librustc_mir/transform/simplify.rs
@@ -345,7 +345,7 @@ struct DeclMarker {
 }
 
 impl<'tcx> Visitor<'tcx> for DeclMarker {
-    fn visit_local(&mut self, local: &Local, ctx: PlaceContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, local: &Local, ctx: PlaceContext, _: Location) {
         // Ignore storage markers altogether, they get removed along with their otherwise unused
         // decls.
         // FIXME: Extend this to all non-uses.
@@ -372,7 +372,7 @@ impl<'tcx> MutVisitor<'tcx> for LocalUpdater {
         });
         self.super_basic_block_data(block, data);
     }
-    fn visit_local(&mut self, l: &mut Local, _: PlaceContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, l: &mut Local, _: PlaceContext, _: Location) {
         *l = self.map[*l].unwrap();
     }
 }

--- a/src/librustc_mir/transform/uniform_array_move_out.rs
+++ b/src/librustc_mir/transform/uniform_array_move_out.rs
@@ -304,7 +304,7 @@ impl<'tcx> Visitor<'tcx> for RestoreDataCollector {
 
     fn visit_local(&mut self,
                    local: &Local,
-                   context: PlaceContext<'tcx>,
+                   context: PlaceContext,
                    location: Location) {
         let local_use = &mut self.locals_use[*local];
         match context {

--- a/src/librustc_mir/transform/uniform_array_move_out.rs
+++ b/src/librustc_mir/transform/uniform_array_move_out.rs
@@ -58,7 +58,6 @@ struct UniformArrayMoveOutVisitor<'a, 'tcx: 'a> {
 
 impl<'a, 'tcx> Visitor<'tcx> for UniformArrayMoveOutVisitor<'a, 'tcx> {
     fn visit_assign(&mut self,
-                    block: BasicBlock,
                     dst_place: &Place<'tcx>,
                     rvalue: &Rvalue<'tcx>,
                     location: Location) {
@@ -82,7 +81,7 @@ impl<'a, 'tcx> Visitor<'tcx> for UniformArrayMoveOutVisitor<'a, 'tcx> {
                 }
             }
         }
-        self.super_assign(block, dst_place, rvalue, location)
+        self.super_assign(dst_place, rvalue, location)
     }
 }
 
@@ -294,14 +293,13 @@ struct RestoreDataCollector {
 
 impl<'tcx> Visitor<'tcx> for RestoreDataCollector {
     fn visit_assign(&mut self,
-                    block: BasicBlock,
                     place: &Place<'tcx>,
                     rvalue: &Rvalue<'tcx>,
                     location: Location) {
         if let Rvalue::Aggregate(box AggregateKind::Array(_), _) = *rvalue {
             self.candidates.push(location);
         }
-        self.super_assign(block, place, rvalue, location)
+        self.super_assign(place, rvalue, location)
     }
 
     fn visit_local(&mut self,

--- a/src/librustc_mir/util/collect_writes.rs
+++ b/src/librustc_mir/util/collect_writes.rs
@@ -27,7 +27,7 @@ struct FindLocalAssignmentVisitor {
 impl<'tcx> Visitor<'tcx> for FindLocalAssignmentVisitor {
     fn visit_local(&mut self,
                    local: &Local,
-                   place_context: PlaceContext<'tcx>,
+                   place_context: PlaceContext,
                    location: Location) {
         if self.needle != *local {
             return;

--- a/src/librustc_mir/util/def_use.rs
+++ b/src/librustc_mir/util/def_use.rs
@@ -3,34 +3,31 @@
 use rustc::mir::{Local, Location, Mir};
 use rustc::mir::visit::{PlaceContext, MutVisitor, Visitor};
 use rustc_data_structures::indexed_vec::IndexVec;
-use std::marker::PhantomData;
 use std::mem;
-use std::slice;
-use std::iter;
 
-pub struct DefUseAnalysis<'tcx> {
-    info: IndexVec<Local, Info<'tcx>>,
+pub struct DefUseAnalysis {
+    info: IndexVec<Local, Info>,
 }
 
 #[derive(Clone)]
-pub struct Info<'tcx> {
-    pub defs_and_uses: Vec<Use<'tcx>>,
+pub struct Info {
+    pub defs_and_uses: Vec<Use>,
 }
 
 #[derive(Clone)]
-pub struct Use<'tcx> {
-    pub context: PlaceContext<'tcx>,
+pub struct Use {
+    pub context: PlaceContext,
     pub location: Location,
 }
 
-impl<'tcx> DefUseAnalysis<'tcx> {
-    pub fn new(mir: &Mir<'tcx>) -> DefUseAnalysis<'tcx> {
+impl DefUseAnalysis {
+    pub fn new(mir: &Mir<'_>) -> DefUseAnalysis {
         DefUseAnalysis {
             info: IndexVec::from_elem_n(Info::new(), mir.local_decls.len()),
         }
     }
 
-    pub fn analyze(&mut self, mir: &Mir<'tcx>) {
+    pub fn analyze(&mut self, mir: &Mir<'_>) {
         self.clear();
 
         let mut finder = DefUseFinder {
@@ -46,13 +43,13 @@ impl<'tcx> DefUseAnalysis<'tcx> {
         }
     }
 
-    pub fn local_info(&self, local: Local) -> &Info<'tcx> {
+    pub fn local_info(&self, local: Local) -> &Info {
         &self.info[local]
     }
 
-    fn mutate_defs_and_uses<F>(&self, local: Local, mir: &mut Mir<'tcx>, mut callback: F)
+    fn mutate_defs_and_uses<F>(&self, local: Local, mir: &mut Mir<'_>, mut callback: F)
                                where F: for<'a> FnMut(&'a mut Local,
-                                                      PlaceContext<'tcx>,
+                                                      PlaceContext,
                                                       Location) {
         for place_use in &self.info[local].defs_and_uses {
             MutateUseVisitor::new(local,
@@ -64,20 +61,20 @@ impl<'tcx> DefUseAnalysis<'tcx> {
     // FIXME(pcwalton): this should update the def-use chains.
     pub fn replace_all_defs_and_uses_with(&self,
                                           local: Local,
-                                          mir: &mut Mir<'tcx>,
+                                          mir: &mut Mir<'_>,
                                           new_local: Local) {
         self.mutate_defs_and_uses(local, mir, |local, _, _| *local = new_local)
     }
 }
 
-struct DefUseFinder<'tcx> {
-    info: IndexVec<Local, Info<'tcx>>,
+struct DefUseFinder {
+    info: IndexVec<Local, Info>,
 }
 
-impl<'tcx> Visitor<'tcx> for DefUseFinder<'tcx> {
+impl Visitor<'_> for DefUseFinder {
     fn visit_local(&mut self,
                    &local: &Local,
-                   context: PlaceContext<'tcx>,
+                   context: PlaceContext,
                    location: Location) {
         self.info[local].defs_and_uses.push(Use {
             context,
@@ -86,8 +83,8 @@ impl<'tcx> Visitor<'tcx> for DefUseFinder<'tcx> {
     }
 }
 
-impl<'tcx> Info<'tcx> {
-    fn new() -> Info<'tcx> {
+impl Info {
+    fn new() -> Info {
         Info {
             defs_and_uses: vec![],
         }
@@ -107,7 +104,7 @@ impl<'tcx> Info<'tcx> {
 
     pub fn defs_not_including_drop(
         &self,
-    ) -> iter::Filter<slice::Iter<'_, Use<'tcx>>, fn(&&Use<'tcx>) -> bool> {
+    ) -> impl Iterator<Item=&Use> {
         self.defs_and_uses.iter().filter(|place_use| {
             place_use.context.is_mutating_use() && !place_use.context.is_drop()
         })
@@ -120,29 +117,27 @@ impl<'tcx> Info<'tcx> {
     }
 }
 
-struct MutateUseVisitor<'tcx, F> {
+struct MutateUseVisitor<F> {
     query: Local,
     callback: F,
-    phantom: PhantomData<&'tcx ()>,
 }
 
-impl<'tcx, F> MutateUseVisitor<'tcx, F> {
-    fn new(query: Local, callback: F, _: &Mir<'tcx>)
-           -> MutateUseVisitor<'tcx, F>
-           where F: for<'a> FnMut(&'a mut Local, PlaceContext<'tcx>, Location) {
+impl<F> MutateUseVisitor<F> {
+    fn new(query: Local, callback: F, _: &Mir<'_>)
+           -> MutateUseVisitor<F>
+           where F: for<'a> FnMut(&'a mut Local, PlaceContext, Location) {
         MutateUseVisitor {
             query,
             callback,
-            phantom: PhantomData,
         }
     }
 }
 
-impl<'tcx, F> MutVisitor<'tcx> for MutateUseVisitor<'tcx, F>
-              where F: for<'a> FnMut(&'a mut Local, PlaceContext<'tcx>, Location) {
+impl<F> MutVisitor<'_> for MutateUseVisitor<F>
+              where F: for<'a> FnMut(&'a mut Local, PlaceContext, Location) {
     fn visit_local(&mut self,
                     local: &mut Local,
-                    context: PlaceContext<'tcx>,
+                    context: PlaceContext,
                     location: Location) {
         if *local == self.query {
             (self.callback)(local, context, location)

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -110,7 +110,7 @@ pub enum DefUse {
     Drop,
 }
 
-pub fn categorize<'tcx>(context: PlaceContext<'tcx>) -> Option<DefUse> {
+pub fn categorize<'tcx>(context: PlaceContext) -> Option<DefUse> {
     match context {
         ///////////////////////////////////////////////////////////////////////////
         // DEFS
@@ -147,10 +147,10 @@ pub fn categorize<'tcx>(context: PlaceContext<'tcx>) -> Option<DefUse> {
         // This won't affect the results since we use this analysis for generators
         // and we only care about the result at suspension points. Borrows cannot
         // cross suspension points so this behavior is unproblematic.
-        PlaceContext::MutatingUse(MutatingUseContext::Borrow(..)) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow(..)) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow(..)) |
-        PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow(..)) |
+        PlaceContext::MutatingUse(MutatingUseContext::Borrow) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow) |
+        PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow) |
 
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
         PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy) |
@@ -220,7 +220,7 @@ impl DefsUses {
 
 impl<'tcx> Visitor<'tcx> for DefsUsesVisitor
 {
-    fn visit_local(&mut self, &local: &Local, context: PlaceContext<'tcx>, _: Location) {
+    fn visit_local(&mut self, &local: &Local, context: PlaceContext, _: Location) {
         match categorize(context) {
             Some(DefUse::Def) => self.defs_uses.add_def(local),
             Some(DefUse::Use) | Some(DefUse::Drop) => self.defs_uses.add_use(local),

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -247,9 +247,9 @@ fn block<'tcx>(
 
     // Visit the various parts of the basic block in reverse. If we go
     // forward, the logic in `add_def` and `add_use` would be wrong.
-    visitor.visit_terminator(BasicBlock::new(0), b.terminator(), dummy_location);
+    visitor.visit_terminator(b.terminator(), dummy_location);
     for statement in b.statements.iter().rev() {
-        visitor.visit_statement(BasicBlock::new(0), statement, dummy_location);
+        visitor.visit_statement(statement, dummy_location);
     }
 
     visitor.defs_uses

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -337,7 +337,7 @@ where
         )?;
 
         write_extra(tcx, w, |visitor| {
-            visitor.visit_statement(current_location.block, statement, current_location);
+            visitor.visit_statement(statement, current_location);
         })?;
 
         extra_data(PassWhere::AfterLocation(current_location), w)?;
@@ -358,7 +358,7 @@ where
     )?;
 
     write_extra(tcx, w, |visitor| {
-        visitor.visit_terminator(current_location.block, data.terminator(), current_location);
+        visitor.visit_terminator(data.terminator(), current_location);
     })?;
 
     extra_data(PassWhere::AfterLocation(current_location), w)?;


### PR DESCRIPTION
* Remove useless `BasicBlock` parameters on methods with `Location`s.
* Prefer `visit_terminator_kind` to `visit_terminator`.
* Remove `Region` from PlaceContexts. `visit_rvalue` should be used when the region is important.
* Remove unused visitor methods.