### PR TITLE
include rustc-std-workspace-alloc in rust-src

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -906,6 +906,7 @@ impl Step for Src {
             "src/stdsimd",
             "src/libproc_macro",
             "src/tools/rustc-std-workspace-core",
+            "src/tools/rustc-std-workspace-alloc",
             "src/librustc",
             "src/libsyntax",
         ];


### PR DESCRIPTION
This is needed to fix https://github.com/japaric/xargo/issues/240