### PR TITLE
bootstrap: use correct version numbers for llvm-tools and lldb

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1049,7 +1049,7 @@ impl Build {
     }
 
     fn llvm_tools_package_vers(&self) -> String {
-        self.package_vers(&self.rust_version())
+        self.package_vers(channel::CFG_RELEASE_NUM)
     }
 
     fn llvm_tools_vers(&self) -> String {
@@ -1057,7 +1057,7 @@ impl Build {
     }
 
     fn lldb_package_vers(&self) -> String {
-        self.package_vers(&self.rust_version())
+        self.package_vers(channel::CFG_RELEASE_NUM)
     }
 
     fn lldb_vers(&self) -> String {


### PR DESCRIPTION
The current URLs for the `llvm-tools` and `lldb` components are a bit broken right now:

```
https://static.rust-lang.org/dist/2019-04-25/llvm-tools-1.34.1 (fc50f328b 2019-04-24)-aarch64-unknown-linux-gnu.tar.gz
```

This PR uses proper version numbers for those. Tested a dist build locally and everything works.

r? @Mark-Simulacrum 