### PR TITLE
Internal lints: usage_of_qualified_ty & ty_pass_by_reference

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -690,7 +690,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         name: String,
         sub: ty::subst::SubstsRef<'tcx>,
         pos: usize,
-        other_ty: &Ty<'tcx>,
+        other_ty: Ty<'tcx>,
     ) {
         // `value` and `other_value` hold two incomplete type representation for display.
         // `name` is the path of both types being compared. `sub`
@@ -768,10 +768,10 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         path: String,
         sub: ty::subst::SubstsRef<'tcx>,
         other_path: String,
-        other_ty: &Ty<'tcx>,
+        other_ty: Ty<'tcx>,
     ) -> Option<()> {
         for (i, ta) in sub.types().enumerate() {
-            if &ta == other_ty {
+            if ta == other_ty {
                 self.highlight_outer(&mut t1_out, &mut t2_out, path, sub, i, &other_ty);
                 return Some(());
             }
@@ -839,7 +839,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// Compares two given types, eliding parts that are the same between them and highlighting
     /// relevant differences, and return two representation of those types for highlighted printing.
     fn cmp(&self, t1: Ty<'tcx>, t2: Ty<'tcx>) -> (DiagnosticStyledString, DiagnosticStyledString) {
-        fn equals<'tcx>(a: &Ty<'tcx>, b: &Ty<'tcx>) -> bool {
+        fn equals<'tcx>(a: Ty<'tcx>, b: Ty<'tcx>) -> bool {
             match (&a.sty, &b.sty) {
                 (a, b) if *a == *b => true,
                 (&ty::Int(_), &ty::Infer(ty::InferTy::IntVar(_)))
@@ -1099,7 +1099,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             }
         };
 
-        let span = cause.span(&self.tcx);
+        let span = cause.span(self.tcx);
 
         diag.span_label(span, terr.to_string());
         if let Some((sp, msg)) = secondary_span {
@@ -1233,7 +1233,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
             trace, terr
         );
 
-        let span = trace.cause.span(&self.tcx);
+        let span = trace.cause.span(self.tcx);
         let failure_code = trace.cause.as_failure_code(terr);
         let mut diag = match failure_code {
             FailureCode::Error0317(failure_str) => {

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -11,7 +11,7 @@ use errors::DiagnosticBuilder;
 
 struct FindLocalByTypeVisitor<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     infcx: &'a InferCtxt<'a, 'gcx, 'tcx>,
-    target_ty: &'a Ty<'tcx>,
+    target_ty: Ty<'tcx>,
     hir_map: &'a hir::map::Map<'gcx>,
     found_local_pattern: Option<&'gcx Pat>,
     found_arg_pattern: Option<&'gcx Pat>,
@@ -26,7 +26,7 @@ impl<'a, 'gcx, 'tcx> FindLocalByTypeVisitor<'a, 'gcx, 'tcx> {
             Some(ty) => {
                 let ty = self.infcx.resolve_type_vars_if_possible(&ty);
                 ty.walk().any(|inner_ty| {
-                    inner_ty == *self.target_ty || match (&inner_ty.sty, &self.target_ty.sty) {
+                    inner_ty == self.target_ty || match (&inner_ty.sty, &self.target_ty.sty) {
                         (&Infer(TyVar(a_vid)), &Infer(TyVar(b_vid))) => {
                             self.infcx
                                 .type_variables
@@ -68,10 +68,10 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for FindLocalByTypeVisitor<'a, 'gcx, 'tcx> {
 impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     pub fn extract_type_name(
         &self,
-        ty: &'a Ty<'tcx>,
+        ty: Ty<'tcx>,
         highlight: Option<ty::print::RegionHighlightMode>,
     ) -> String {
-        if let ty::Infer(ty::TyVar(ty_vid)) = (*ty).sty {
+        if let ty::Infer(ty::TyVar(ty_vid)) = ty.sty {
             let ty_vars = self.type_variables.borrow();
             if let TypeVariableOrigin::TypeParameterDefinition(_, name) =
                 *ty_vars.var_origin(ty_vid) {
@@ -102,7 +102,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
 
         let mut local_visitor = FindLocalByTypeVisitor {
             infcx: &self,
-            target_ty: &ty,
+            target_ty: ty,
             hir_map: &self.tcx.hir(),
             found_local_pattern: None,
             found_arg_pattern: None,

--- a/src/librustc/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -193,7 +193,7 @@ impl NiceRegionError<'me, 'gcx, 'tcx> {
         );
 
         let mut err = self.tcx().sess.struct_span_err(
-            cause.span(&self.tcx()),
+            cause.span(self.tcx()),
             &format!(
                 "implementation of `{}` is not general enough",
                 self.tcx().def_path_str(trait_def_id),

--- a/src/librustc/infer/nll_relate/mod.rs
+++ b/src/librustc/infer/nll_relate/mod.rs
@@ -267,7 +267,7 @@ where
     fn relate_projection_ty(
         &mut self,
         projection_ty: ty::ProjectionTy<'tcx>,
-        value_ty: ty::Ty<'tcx>,
+        value_ty: Ty<'tcx>,
     ) -> Ty<'tcx> {
         use crate::infer::type_variable::TypeVariableOrigin;
         use crate::traits::WhereClause;

--- a/src/librustc/middle/exported_symbols.rs
+++ b/src/librustc/middle/exported_symbols.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::stable_hasher::{StableHasher, HashStable,
                                            StableHasherResult};
 use std::cmp;
 use std::mem;
-use crate::ty;
+use crate::ty::{self, TyCtxt};
 use crate::ty::subst::SubstsRef;
 
 /// The SymbolExportLevel of a symbols specifies from which kinds of crates
@@ -39,7 +39,7 @@ pub enum ExportedSymbol<'tcx> {
 
 impl<'tcx> ExportedSymbol<'tcx> {
     pub fn symbol_name(&self,
-                       tcx: ty::TyCtxt<'_, 'tcx, '_>)
+                       tcx: TyCtxt<'_, 'tcx, '_>)
                        -> ty::SymbolName {
         match *self {
             ExportedSymbol::NonGeneric(def_id) => {
@@ -55,7 +55,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
     }
 
     pub fn compare_stable(&self,
-                          tcx: ty::TyCtxt<'_, 'tcx, '_>,
+                          tcx: TyCtxt<'_, 'tcx, '_>,
                           other: &ExportedSymbol<'tcx>)
                           -> cmp::Ordering {
         match *self {
@@ -92,7 +92,7 @@ impl<'tcx> ExportedSymbol<'tcx> {
     }
 }
 
-pub fn metadata_symbol_name(tcx: ty::TyCtxt<'_, '_, '_>) -> String {
+pub fn metadata_symbol_name(tcx: TyCtxt<'_, '_, '_>) -> String {
     format!("rust_metadata_{}_{}",
             tcx.original_crate_name(LOCAL_CRATE),
             tcx.crate_disambiguator(LOCAL_CRATE).to_fingerprint().to_hex())

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -18,7 +18,7 @@ pub enum MonoItem<'tcx> {
 }
 
 impl<'tcx> MonoItem<'tcx> {
-    pub fn size_estimate<'a>(&self, tcx: &TyCtxt<'a, 'tcx, 'tcx>) -> usize {
+    pub fn size_estimate<'a>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> usize {
         match *self {
             MonoItem::Fn(instance) => {
                 // Estimate the size of a function based on how many statements
@@ -144,7 +144,7 @@ impl<'tcx> CodegenUnit<'tcx> {
         base_n::encode(hash, base_n::CASE_INSENSITIVE)
     }
 
-    pub fn estimate_size<'a>(&mut self, tcx: &TyCtxt<'a, 'tcx, 'tcx>) {
+    pub fn estimate_size<'a>(&mut self, tcx: TyCtxt<'a, 'tcx, 'tcx>) {
         // Estimate the size of a codegen unit as (approximately) the number of MIR
         // statements it corresponds to.
         self.size_estimate = Some(self.items.keys().map(|mi| mi.size_estimate(tcx)).sum());

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -198,7 +198,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn visit_ty(&mut self,
-                        ty: & $($mutability)? Ty<'tcx>,
+                        ty: $(& $mutability)? Ty<'tcx>,
                         _: TyContext) {
                 self.super_ty(ty);
             }
@@ -864,7 +864,7 @@ macro_rules! make_mir_visitor {
                 self.visit_ty(& $($mutability)? ty.inferred_ty, TyContext::UserTy(ty.span));
             }
 
-            fn super_ty(&mut self, _ty: & $($mutability)? Ty<'tcx>) {
+            fn super_ty(&mut self, _ty: $(& $mutability)? Ty<'tcx>) {
             }
 
             fn super_region(&mut self, _region: & $($mutability)? ty::Region<'tcx>) {

--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -49,11 +49,11 @@ pub struct AutoTraitInfo<'cx> {
 }
 
 pub struct AutoTraitFinder<'a, 'tcx: 'a> {
-    tcx: &'a TyCtxt<'a, 'tcx, 'tcx>,
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
 }
 
 impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
-    pub fn new(tcx: &'a TyCtxt<'a, 'tcx, 'tcx>) -> Self {
+    pub fn new(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> Self {
         AutoTraitFinder { tcx }
     }
 
@@ -291,7 +291,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         infcx: &InferCtxt<'b, 'tcx, 'c>,
         ty_did: DefId,
         trait_did: DefId,
-        ty: ty::Ty<'c>,
+        ty: Ty<'c>,
         param_env: ty::ParamEnv<'c>,
         user_env: ty::ParamEnv<'c>,
         fresh_preds: &mut FxHashSet<ty::Predicate<'c>>,
@@ -661,7 +661,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         T: Iterator<Item = Obligation<'cx, ty::Predicate<'cx>>>,
     >(
         &self,
-        ty: ty::Ty<'_>,
+        ty: Ty<'_>,
         nested: T,
         computed_preds: &'b mut FxHashSet<ty::Predicate<'cx>>,
         fresh_preds: &'b mut FxHashSet<ty::Predicate<'cx>>,

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1242,7 +1242,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                            found: ty::PolyTraitRef<'tcx>)
         -> DiagnosticBuilder<'tcx>
     {
-        fn build_fn_sig_string<'a, 'gcx, 'tcx>(tcx: ty::TyCtxt<'a, 'gcx, 'tcx>,
+        fn build_fn_sig_string<'a, 'gcx, 'tcx>(tcx: TyCtxt<'a, 'gcx, 'tcx>,
                                                trait_ref: &ty::TraitRef<'tcx>) -> String {
             let inputs = trait_ref.substs.type_at(1);
             let sig = if let ty::Tuple(inputs) = inputs.sty {

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -138,7 +138,7 @@ pub struct ObligationCause<'tcx> {
 }
 
 impl<'tcx> ObligationCause<'tcx> {
-    pub fn span<'a, 'gcx>(&self, tcx: &TyCtxt<'a, 'gcx, 'tcx>) -> Span {
+    pub fn span<'a, 'gcx>(&self, tcx: TyCtxt<'a, 'gcx, 'tcx>) -> Span {
         match self.code {
             ObligationCauseCode::CompareImplMethodObligation { .. } |
             ObligationCauseCode::MainFunctionType |

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -3,7 +3,7 @@ use smallvec::SmallVec;
 use crate::traits;
 use crate::traits::project::Normalized;
 use crate::ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
-use crate::ty::{self, Lift, TyCtxt};
+use crate::ty::{self, Lift, Ty, TyCtxt};
 use syntax::symbol::InternedString;
 
 use std::fmt;
@@ -311,7 +311,7 @@ impl<'tcx> TypeVisitor<'tcx> for BoundNamesCollector {
         result
     }
 
-    fn visit_ty(&mut self, t: ty::Ty<'tcx>) -> bool {
+    fn visit_ty(&mut self, t: Ty<'tcx>) -> bool {
         use syntax::symbol::Symbol;
 
         match t.sty {

--- a/src/librustc/ty/fold.rs
+++ b/src/librustc/ty/fold.rs
@@ -421,7 +421,7 @@ struct BoundVarReplacer<'a, 'gcx: 'a + 'tcx, 'tcx: 'a> {
     current_index: ty::DebruijnIndex,
 
     fld_r: &'a mut (dyn FnMut(ty::BoundRegion) -> ty::Region<'tcx> + 'a),
-    fld_t: &'a mut (dyn FnMut(ty::BoundTy) -> ty::Ty<'tcx> + 'a),
+    fld_t: &'a mut (dyn FnMut(ty::BoundTy) -> Ty<'tcx> + 'a),
 }
 
 impl<'a, 'gcx, 'tcx> BoundVarReplacer<'a, 'gcx, 'tcx> {
@@ -431,7 +431,7 @@ impl<'a, 'gcx, 'tcx> BoundVarReplacer<'a, 'gcx, 'tcx> {
         fld_t: &'a mut G
     ) -> Self
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
-              G: FnMut(ty::BoundTy) -> ty::Ty<'tcx>
+              G: FnMut(ty::BoundTy) -> Ty<'tcx>
     {
         BoundVarReplacer {
             tcx,
@@ -533,7 +533,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         mut fld_t: G
     ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
-              G: FnMut(ty::BoundTy) -> ty::Ty<'tcx>,
+              G: FnMut(ty::BoundTy) -> Ty<'tcx>,
               T: TypeFoldable<'tcx>
     {
         use rustc_data_structures::fx::FxHashMap;
@@ -568,7 +568,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         fld_t: G
     ) -> (T, BTreeMap<ty::BoundRegion, ty::Region<'tcx>>)
         where F: FnMut(ty::BoundRegion) -> ty::Region<'tcx>,
-              G: FnMut(ty::BoundTy) -> ty::Ty<'tcx>,
+              G: FnMut(ty::BoundTy) -> Ty<'tcx>,
               T: TypeFoldable<'tcx>
     {
         self.replace_escaping_bound_vars(value.skip_binder(), fld_r, fld_t)
@@ -710,7 +710,7 @@ impl TypeFolder<'gcx, 'tcx> for Shifter<'a, 'gcx, 'tcx> {
         }
     }
 
-    fn fold_ty(&mut self, ty: ty::Ty<'tcx>) -> ty::Ty<'tcx> {
+    fn fold_ty(&mut self, ty: Ty<'tcx>) -> Ty<'tcx> {
         match ty.sty {
             ty::Bound(debruijn, bound_ty) => {
                 if self.amount == 0 || debruijn < self.current_index {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -212,7 +212,7 @@ impl AssociatedItem {
         }
     }
 
-    pub fn signature<'a, 'tcx>(&self, tcx: &TyCtxt<'a, 'tcx, 'tcx>) -> String {
+    pub fn signature<'a, 'tcx>(&self, tcx: TyCtxt<'a, 'tcx, 'tcx>) -> String {
         match self.kind {
             ty::AssociatedKind::Method => {
                 // We skip the binder here because the binder would deanonymize all

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -9,7 +9,7 @@ use crate::rustc_serialize::{Decodable, Decoder, Encodable, Encoder, opaque,
                       SpecializedDecoder, SpecializedEncoder,
                       UseSpecializedDecodable, UseSpecializedEncodable};
 use crate::session::{CrateDisambiguator, Session};
-use crate::ty;
+use crate::ty::{self, Ty};
 use crate::ty::codec::{self as ty_codec, TyDecoder, TyEncoder};
 use crate::ty::context::TyCtxt;
 use crate::util::common::{time, time_ext};
@@ -545,8 +545,8 @@ impl<'a, 'tcx: 'a, 'x> ty_codec::TyDecoder<'a, 'tcx> for CacheDecoder<'a, 'tcx, 
     fn cached_ty_for_shorthand<F>(&mut self,
                                   shorthand: usize,
                                   or_insert_with: F)
-                                  -> Result<ty::Ty<'tcx>, Self::Error>
-        where F: FnOnce(&mut Self) -> Result<ty::Ty<'tcx>, Self::Error>
+                                  -> Result<Ty<'tcx>, Self::Error>
+        where F: FnOnce(&mut Self) -> Result<Ty<'tcx>, Self::Error>
     {
         let tcx = self.tcx();
 
@@ -751,7 +751,7 @@ struct CacheEncoder<'enc, 'a, 'tcx, E>
 {
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     encoder: &'enc mut E,
-    type_shorthands: FxHashMap<ty::Ty<'tcx>, usize>,
+    type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::Predicate<'tcx>, usize>,
     expn_info_shorthands: FxHashMap<Mark, AbsoluteBytePos>,
     interpret_allocs: FxHashMap<interpret::AllocId, usize>,
@@ -881,11 +881,11 @@ impl<'enc, 'a, 'tcx, E> SpecializedEncoder<CrateNum> for CacheEncoder<'enc, 'a, 
     }
 }
 
-impl<'enc, 'a, 'tcx, E> SpecializedEncoder<ty::Ty<'tcx>> for CacheEncoder<'enc, 'a, 'tcx, E>
+impl<'enc, 'a, 'tcx, E> SpecializedEncoder<Ty<'tcx>> for CacheEncoder<'enc, 'a, 'tcx, E>
     where E: 'enc + ty_codec::TyEncoder
 {
     #[inline]
-    fn specialized_encode(&mut self, ty: &ty::Ty<'tcx>) -> Result<(), Self::Error> {
+    fn specialized_encode(&mut self, ty: &Ty<'tcx>) -> Result<(), Self::Error> {
         ty_codec::encode_with_shorthand(self, ty,
             |encoder| &mut encoder.type_shorthands)
     }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -495,7 +495,7 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
 
 pub fn register_internals(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_early_pass(sess, false, false, box DefaultHashTypes::new());
-    store.register_late_pass(sess, false, false, false, box TyKindUsage);
+    store.register_late_pass(sess, false, false, false, box TyTyKind);
     store.register_group(
         sess,
         false,
@@ -504,6 +504,8 @@ pub fn register_internals(store: &mut lint::LintStore, sess: Option<&Session>) {
         vec![
             LintId::of(DEFAULT_HASH_TYPES),
             LintId::of(USAGE_OF_TY_TYKIND),
+            LintId::of(TY_PASS_BY_REFERENCE),
+            LintId::of(USAGE_OF_QUALIFIED_TY),
         ],
     );
 }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -789,7 +789,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             ctor_vis = ty::Visibility::Restricted(DefId::local(CRATE_DEF_INDEX));
         }
 
-        let repr_options = get_repr_options(&tcx, adt_def_id);
+        let repr_options = get_repr_options(tcx, adt_def_id);
 
         Entry {
             kind: EntryKind::Struct(self.lazy(&data), repr_options),
@@ -1119,7 +1119,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             hir::ItemKind::GlobalAsm(..) => EntryKind::GlobalAsm,
             hir::ItemKind::Ty(..) => EntryKind::Type,
             hir::ItemKind::Existential(..) => EntryKind::Existential,
-            hir::ItemKind::Enum(..) => EntryKind::Enum(get_repr_options(&tcx, def_id)),
+            hir::ItemKind::Enum(..) => EntryKind::Enum(get_repr_options(tcx, def_id)),
             hir::ItemKind::Struct(ref struct_def, _) => {
                 let variant = tcx.adt_def(def_id).non_enum_variant();
 
@@ -1129,7 +1129,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
                 let ctor = struct_def.ctor_hir_id()
                     .map(|ctor_hir_id| tcx.hir().local_def_id_from_hir_id(ctor_hir_id).index);
 
-                let repr_options = get_repr_options(&tcx, def_id);
+                let repr_options = get_repr_options(tcx, def_id);
 
                 EntryKind::Struct(self.lazy(&VariantData {
                     ctor_kind: variant.ctor_kind,
@@ -1140,7 +1140,7 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
             }
             hir::ItemKind::Union(..) => {
                 let variant = tcx.adt_def(def_id).non_enum_variant();
-                let repr_options = get_repr_options(&tcx, def_id);
+                let repr_options = get_repr_options(tcx, def_id);
 
                 EntryKind::Union(self.lazy(&VariantData {
                     ctor_kind: variant.ctor_kind,
@@ -1938,7 +1938,7 @@ pub fn encode_metadata<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
     EncodedMetadata { raw_data: result }
 }
 
-pub fn get_repr_options<'a, 'tcx, 'gcx>(tcx: &TyCtxt<'a, 'tcx, 'gcx>, did: DefId) -> ReprOptions {
+pub fn get_repr_options<'a, 'tcx, 'gcx>(tcx: TyCtxt<'a, 'tcx, 'gcx>, did: DefId) -> ReprOptions {
     let ty = tcx.type_of(did);
     match ty.sty {
         ty::Adt(ref def, _) => return def.repr,

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -315,7 +315,7 @@ impl<'a, 'gcx, 'tcx> GatherBorrows<'a, 'gcx, 'tcx> {
             start_location, assigned_place, borrow_index,
         );
 
-        if !allow_two_phase_borrow(self.tcx, kind) {
+        if !allow_two_phase_borrow(kind) {
             debug!("  -> {:?}", start_location);
             return;
         }

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -315,7 +315,7 @@ impl<'a, 'gcx, 'tcx> GatherBorrows<'a, 'gcx, 'tcx> {
             start_location, assigned_place, borrow_index,
         );
 
-        if !allow_two_phase_borrow(&self.tcx, kind) {
+        if !allow_two_phase_borrow(self.tcx, kind) {
             debug!("  -> {:?}", start_location);
             return;
         }

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -12,7 +12,7 @@ use rustc::mir::{
     Place, PlaceBase, PlaceProjection, ProjectionElem, Rvalue, Statement, StatementKind,
     Static, StaticKind, TerminatorKind, VarBindingForm,
 };
-use rustc::ty::{self, DefIdTree};
+use rustc::ty::{self, DefIdTree, Ty};
 use rustc::ty::layout::VariantIdx;
 use rustc::ty::print::Print;
 use rustc_data_structures::fx::FxHashSet;
@@ -918,7 +918,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         borrow: &BorrowData<'tcx>,
         (place, drop_span): (&Place<'tcx>, Span),
         kind: Option<WriteKind>,
-        dropped_ty: ty::Ty<'tcx>,
+        dropped_ty: Ty<'tcx>,
     ) {
         debug!(
             "report_borrow_conflicts_with_destructor(\
@@ -1483,7 +1483,7 @@ pub(super) struct IncludingDowncast(bool);
 enum StorageDeadOrDrop<'tcx> {
     LocalStorageDead,
     BoxedStorageDead,
-    Destructor(ty::Ty<'tcx>),
+    Destructor(Ty<'tcx>),
 }
 
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
@@ -1787,7 +1787,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     /// End-user visible description of the `field_index`nth field of `ty`
     fn describe_field_from_ty(
         &self,
-        ty: &ty::Ty<'_>,
+        ty: Ty<'_>,
         field: Field,
         variant_index: Option<VariantIdx>
     ) -> String {
@@ -2258,18 +2258,18 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 #[derive(Debug)]
 enum AnnotatedBorrowFnSignature<'tcx> {
     NamedFunction {
-        arguments: Vec<(ty::Ty<'tcx>, Span)>,
-        return_ty: ty::Ty<'tcx>,
+        arguments: Vec<(Ty<'tcx>, Span)>,
+        return_ty: Ty<'tcx>,
         return_span: Span,
     },
     AnonymousFunction {
-        argument_ty: ty::Ty<'tcx>,
+        argument_ty: Ty<'tcx>,
         argument_span: Span,
-        return_ty: ty::Ty<'tcx>,
+        return_ty: Ty<'tcx>,
         return_span: Span,
     },
     Closure {
-        argument_ty: ty::Ty<'tcx>,
+        argument_ty: Ty<'tcx>,
         argument_span: Span,
     },
 }
@@ -2355,7 +2355,7 @@ impl<'tcx> AnnotatedBorrowFnSignature<'tcx> {
 impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
     /// Return the name of the provided `Ty` (that must be a reference) with a synthesized lifetime
     /// name where required.
-    fn get_name_for_ty(&self, ty: ty::Ty<'tcx>, counter: usize) -> String {
+    fn get_name_for_ty(&self, ty: Ty<'tcx>, counter: usize) -> String {
         let mut s = String::new();
         let mut printer = ty::print::FmtPrinter::new(self.infcx.tcx, &mut s, Namespace::TypeNS);
 
@@ -2378,7 +2378,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
 
     /// Returns the name of the provided `Ty` (that must be a reference)'s region with a
     /// synthesized lifetime name where required.
-    fn get_region_name_for_ty(&self, ty: ty::Ty<'tcx>, counter: usize) -> String {
+    fn get_region_name_for_ty(&self, ty: Ty<'tcx>, counter: usize) -> String {
         let mut s = String::new();
         let mut printer = ty::print::FmtPrinter::new(self.infcx.tcx, &mut s, Namespace::TypeNS);
 

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1076,7 +1076,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 (Read(kind), BorrowKind::Unique) | (Read(kind), BorrowKind::Mut { .. }) => {
                     // Reading from mere reservations of mutable-borrows is OK.
                     if !is_active(&this.dominators, borrow, context.loc) {
-                        assert!(allow_two_phase_borrow(&tcx, borrow.kind));
+                        assert!(allow_two_phase_borrow(tcx, borrow.kind));
                         return Control::Continue;
                     }
 
@@ -1233,7 +1233,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     BorrowKind::Shared => (Deep, Read(ReadKind::Borrow(bk))),
                     BorrowKind::Unique | BorrowKind::Mut { .. } => {
                         let wk = WriteKind::MutableBorrow(bk);
-                        if allow_two_phase_borrow(&self.infcx.tcx, bk) {
+                        if allow_two_phase_borrow(self.infcx.tcx, bk) {
                             (Deep, Reservation(wk))
                         } else {
                             (Deep, Write(wk))

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1076,7 +1076,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 (Read(kind), BorrowKind::Unique) | (Read(kind), BorrowKind::Mut { .. }) => {
                     // Reading from mere reservations of mutable-borrows is OK.
                     if !is_active(&this.dominators, borrow, context.loc) {
-                        assert!(allow_two_phase_borrow(tcx, borrow.kind));
+                        assert!(allow_two_phase_borrow(borrow.kind));
                         return Control::Continue;
                     }
 
@@ -1233,7 +1233,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                     BorrowKind::Shared => (Deep, Read(ReadKind::Borrow(bk))),
                     BorrowKind::Unique | BorrowKind::Mut { .. } => {
                         let wk = WriteKind::MutableBorrow(bk);
-                        if allow_two_phase_borrow(self.infcx.tcx, bk) {
+                        if allow_two_phase_borrow(bk) {
                             (Deep, Reservation(wk))
                         } else {
                             (Deep, Write(wk))

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -5,7 +5,7 @@ use rustc::mir::{
     Mutability, Operand, Place, PlaceBase, Projection, ProjectionElem, Static, StaticKind,
 };
 use rustc::mir::{Terminator, TerminatorKind};
-use rustc::ty::{self, Const, DefIdTree, TyS, TyCtxt};
+use rustc::ty::{self, Const, DefIdTree, Ty, TyS, TyCtxt};
 use rustc_data_structures::indexed_vec::Idx;
 use syntax_pos::Span;
 use syntax_pos::symbol::keywords;
@@ -613,7 +613,7 @@ fn suggest_ampmut<'cx, 'gcx, 'tcx>(
      })
 }
 
-fn is_closure_or_generator(ty: ty::Ty<'_>) -> bool {
+fn is_closure_or_generator(ty: Ty<'_>) -> bool {
     ty.is_closure() || ty.is_generator()
 }
 
@@ -626,7 +626,7 @@ fn is_closure_or_generator(ty: ty::Ty<'_>) -> bool {
 /// ```
 fn annotate_struct_field(
     tcx: TyCtxt<'cx, 'gcx, 'tcx>,
-    ty: ty::Ty<'tcx>,
+    ty: Ty<'tcx>,
     field: &mir::Field,
 ) -> Option<(Span, String)> {
     // Expect our local to be a reference to a struct of some kind.

--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -64,7 +64,7 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
 
     /// We sometimes have `ty` within an rvalue, or within a
     /// call. Make them live at the location where they appear.
-    fn visit_ty(&mut self, ty: &ty::Ty<'tcx>, ty_context: TyContext) {
+    fn visit_ty(&mut self, ty: ty::Ty<'tcx>, ty_context: TyContext) {
         match ty_context {
             TyContext::ReturnTy(SourceInfo { span, .. })
             | TyContext::YieldTy(SourceInfo { span, .. })
@@ -77,7 +77,7 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
                 );
             }
             TyContext::Location(location) => {
-                self.add_regular_live_constraint(*ty, location);
+                self.add_regular_live_constraint(ty, location);
             }
         }
 

--- a/src/librustc_mir/borrow_check/nll/constraint_generation.rs
+++ b/src/librustc_mir/borrow_check/nll/constraint_generation.rs
@@ -10,7 +10,7 @@ use rustc::mir::{BasicBlock, BasicBlockData, Location, Mir, Place, PlaceBase, Rv
 use rustc::mir::{SourceInfo, Statement, Terminator};
 use rustc::mir::UserTypeProjection;
 use rustc::ty::fold::TypeFoldable;
-use rustc::ty::{self, ClosureSubsts, GeneratorSubsts, RegionVid};
+use rustc::ty::{self, ClosureSubsts, GeneratorSubsts, RegionVid, Ty};
 use rustc::ty::subst::SubstsRef;
 
 pub(super) fn generate_constraints<'cx, 'gcx, 'tcx>(
@@ -64,7 +64,7 @@ impl<'cg, 'cx, 'gcx, 'tcx> Visitor<'tcx> for ConstraintGeneration<'cg, 'cx, 'gcx
 
     /// We sometimes have `ty` within an rvalue, or within a
     /// call. Make them live at the location where they appear.
-    fn visit_ty(&mut self, ty: ty::Ty<'tcx>, ty_context: TyContext) {
+    fn visit_ty(&mut self, ty: Ty<'tcx>, ty_context: TyContext) {
         match ty_context {
             TyContext::ReturnTy(SourceInfo { span, .. })
             | TyContext::YieldTy(SourceInfo { span, .. })

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -321,7 +321,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
                     BorrowKind::Shared => (Deep, Read(ReadKind::Borrow(bk))),
                     BorrowKind::Unique | BorrowKind::Mut { .. } => {
                         let wk = WriteKind::MutableBorrow(bk);
-                        if allow_two_phase_borrow(self.tcx, bk) {
+                        if allow_two_phase_borrow(bk) {
                             (Deep, Reservation(wk))
                         } else {
                             (Deep, Write(wk))
@@ -439,7 +439,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
                         // Reading from mere reservations of mutable-borrows is OK.
                         if !is_active(&this.dominators, borrow, context.loc) {
                             // If the borrow isn't active yet, reads don't invalidate it
-                            assert!(allow_two_phase_borrow(this.tcx, borrow.kind));
+                            assert!(allow_two_phase_borrow(borrow.kind));
                             return Control::Continue;
                         }
 

--- a/src/librustc_mir/borrow_check/nll/invalidation.rs
+++ b/src/librustc_mir/borrow_check/nll/invalidation.rs
@@ -321,7 +321,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
                     BorrowKind::Shared => (Deep, Read(ReadKind::Borrow(bk))),
                     BorrowKind::Unique | BorrowKind::Mut { .. } => {
                         let wk = WriteKind::MutableBorrow(bk);
-                        if allow_two_phase_borrow(&self.tcx, bk) {
+                        if allow_two_phase_borrow(self.tcx, bk) {
                             (Deep, Reservation(wk))
                         } else {
                             (Deep, Write(wk))
@@ -439,7 +439,7 @@ impl<'cg, 'cx, 'tcx, 'gcx> InvalidationGenerator<'cx, 'tcx, 'gcx> {
                         // Reading from mere reservations of mutable-borrows is OK.
                         if !is_active(&this.dominators, borrow, context.loc) {
                             // If the borrow isn't active yet, reads don't invalidate it
-                            assert!(allow_two_phase_borrow(&this.tcx, borrow.kind));
+                            assert!(allow_two_phase_borrow(this.tcx, borrow.kind));
                             return Control::Continue;
                         }
 

--- a/src/librustc_mir/borrow_check/path_utils.rs
+++ b/src/librustc_mir/borrow_check/path_utils.rs
@@ -11,10 +11,7 @@ use rustc_data_structures::graph::dominators::Dominators;
 /// Returns `true` if the borrow represented by `kind` is
 /// allowed to be split into separate Reservation and
 /// Activation phases.
-pub(super) fn allow_two_phase_borrow<'a, 'tcx, 'gcx: 'tcx>(
-    _tcx: TyCtxt<'a, 'gcx, 'tcx>,
-    kind: BorrowKind
-) -> bool {
+pub(super) fn allow_two_phase_borrow<'a, 'tcx, 'gcx: 'tcx>(kind: BorrowKind) -> bool {
     kind.allows_two_phase_borrow()
 }
 

--- a/src/librustc_mir/borrow_check/path_utils.rs
+++ b/src/librustc_mir/borrow_check/path_utils.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::graph::dominators::Dominators;
 /// allowed to be split into separate Reservation and
 /// Activation phases.
 pub(super) fn allow_two_phase_borrow<'a, 'tcx, 'gcx: 'tcx>(
-    _tcx: &TyCtxt<'a, 'gcx, 'tcx>,
+    _tcx: TyCtxt<'a, 'gcx, 'tcx>,
     kind: BorrowKind
 ) -> bool {
     kind.allows_two_phase_borrow()

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -440,7 +440,7 @@ impl<'a, 'mir, 'tcx> interpret::Machine<'a, 'mir, 'tcx>
 
         let span = ecx.frame().span;
         ecx.machine.loop_detector.observe_and_analyze(
-            &ecx.tcx,
+            *ecx.tcx,
             span,
             &ecx.memory,
             &ecx.stack[..],
@@ -513,7 +513,7 @@ pub fn error_to_const_error<'a, 'mir, 'tcx>(
 }
 
 fn validate_and_turn_into_const<'a, 'tcx>(
-    tcx: ty::TyCtxt<'a, 'tcx, 'tcx>,
+    tcx: TyCtxt<'a, 'tcx, 'tcx>,
     constant: RawConst<'tcx>,
     key: ty::ParamEnvAnd<'tcx, GlobalId<'tcx>>,
 ) -> ::rustc::mir::interpret::ConstEvalResult<'tcx> {

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -1,4 +1,4 @@
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{Ty, TyCtxt};
 use rustc::mir::*;
 use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
@@ -285,10 +285,10 @@ pub(crate) enum IllegalMoveOriginKind<'tcx> {
     /// implements `Drop`. Rust maintains invariant that all `Drop`
     /// ADT's remain fully-initialized so that user-defined destructor
     /// can safely read from all of the ADT's fields.
-    InteriorOfTypeWithDestructor { container_ty: ty::Ty<'tcx> },
+    InteriorOfTypeWithDestructor { container_ty: Ty<'tcx> },
 
     /// Illegal move due to attempt to move out of a slice or array.
-    InteriorOfSliceOrArray { ty: ty::Ty<'tcx>, is_index: bool, },
+    InteriorOfSliceOrArray { ty: Ty<'tcx>, is_index: bool, },
 }
 
 #[derive(Debug)]

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -47,7 +47,7 @@ impl<'a, 'mir, 'tcx> InfiniteLoopDetector<'a, 'mir, 'tcx>
 {
     pub fn observe_and_analyze<'b>(
         &mut self,
-        tcx: &TyCtxt<'b, 'tcx, 'tcx>,
+        tcx: TyCtxt<'b, 'tcx, 'tcx>,
         span: Span,
         memory: &Memory<'a, 'mir, 'tcx, CompileTimeInterpreter<'a, 'mir, 'tcx>>,
         stack: &[Frame<'mir, 'tcx>],

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -101,7 +101,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
     pub fn read_drop_type_from_vtable(
         &self,
         vtable: Pointer<M::PointerTag>,
-    ) -> EvalResult<'tcx, (ty::Instance<'tcx>, ty::Ty<'tcx>)> {
+    ) -> EvalResult<'tcx, (ty::Instance<'tcx>, Ty<'tcx>)> {
         // we don't care about the pointee type, we just want a pointer
         self.memory.check_align(vtable.into(), self.tcx.data_layout.pointer_align.abi)?;
         let drop_fn = self.memory

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -228,7 +228,7 @@ pub fn partition<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     // functions and statics defined in the local crate.
     let mut initial_partitioning = place_root_mono_items(tcx, mono_items);
 
-    initial_partitioning.codegen_units.iter_mut().for_each(|cgu| cgu.estimate_size(&tcx));
+    initial_partitioning.codegen_units.iter_mut().for_each(|cgu| cgu.estimate_size(tcx));
 
     debug_dump(tcx, "INITIAL PARTITIONING:", initial_partitioning.codegen_units.iter());
 
@@ -247,7 +247,7 @@ pub fn partition<'a, 'tcx, I>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
     let mut post_inlining = place_inlined_mono_items(initial_partitioning,
                                                             inlining_map);
 
-    post_inlining.codegen_units.iter_mut().for_each(|cgu| cgu.estimate_size(&tcx));
+    post_inlining.codegen_units.iter_mut().for_each(|cgu| cgu.estimate_size(tcx));
 
     debug_dump(tcx, "POST INLINING:", post_inlining.codegen_units.iter());
 

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -644,7 +644,7 @@ impl<'a, 'tcx> CloneShimBuilder<'a, 'tcx> {
 
     fn tuple_like_shim<I>(&mut self, dest: Place<'tcx>,
                           src: Place<'tcx>, tys: I)
-            where I: Iterator<Item = ty::Ty<'tcx>> {
+            where I: Iterator<Item = Ty<'tcx>> {
         let mut previous_field = None;
         for (i, ity) in tys.enumerate() {
             let field = Field::new(i);

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -1,7 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::hir;
 use rustc::mir::*;
-use rustc::ty::{self, Predicate, TyCtxt, adjustment::{PointerCast}};
+use rustc::ty::{self, Predicate, Ty, TyCtxt, adjustment::{PointerCast}};
 use rustc_target::spec::abi;
 use std::borrow::Cow;
 use syntax_pos::Span;
@@ -81,7 +81,7 @@ pub fn is_min_const_fn(
 
 fn check_ty(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
-    ty: ty::Ty<'tcx>,
+    ty: Ty<'tcx>,
     span: Span,
     fn_def_id: DefId,
 ) -> McfResult {

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -1,5 +1,5 @@
 use rustc::session::config::BorrowckMode;
-use rustc::ty::{self, TyCtxt};
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc_errors::{DiagnosticBuilder, DiagnosticId};
 use syntax_pos::{MultiSpan, Span};
 
@@ -437,7 +437,7 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     fn cannot_move_out_of_interior_noncopy(
         self,
         move_from_span: Span,
-        ty: ty::Ty<'_>,
+        ty: Ty<'_>,
         is_index: Option<bool>,
         o: Origin,
     ) -> DiagnosticBuilder<'cx> {
@@ -464,7 +464,7 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     fn cannot_move_out_of_interior_of_drop(
         self,
         move_from_span: Span,
-        container_ty: ty::Ty<'_>,
+        container_ty: Ty<'_>,
         o: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -1,5 +1,5 @@
 use core::unicode::property::Pattern_White_Space;
-use rustc::ty;
+use rustc::ty::TyCtxt;
 use syntax_pos::Span;
 
 pub mod borrowck_errors;
@@ -20,7 +20,7 @@ pub use self::graphviz::write_node_label as write_graphviz_node_label;
 
 /// If possible, suggest replacing `ref` with `ref mut`.
 pub fn suggest_ref_mut<'cx, 'gcx, 'tcx>(
-    tcx: ty::TyCtxt<'cx, 'gcx, 'tcx>,
+    tcx: TyCtxt<'cx, 'gcx, 'tcx>,
     binding_span: Span,
 ) -> Option<(String)> {
     let hi_src = tcx.sess.source_map().span_to_snippet(binding_span).unwrap();

--- a/src/librustc_traits/chalk_context/program_clauses/builtin.rs
+++ b/src/librustc_traits/chalk_context/program_clauses/builtin.rs
@@ -4,7 +4,7 @@ use rustc::traits::{
     ProgramClause,
     ProgramClauseCategory,
 };
-use rustc::ty;
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::{Kind, InternalSubsts, Subst};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
@@ -15,8 +15,8 @@ use crate::generic_types;
 /// `Implemented(ty: Trait) :- Implemented(nested: Trait)...`
 /// where `Trait` is specified by `trait_def_id`.
 fn builtin_impl_clause(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
-    ty: ty::Ty<'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
+    ty: Ty<'tcx>,
     nested: &[Kind<'tcx>],
     trait_def_id: DefId
 ) -> ProgramClause<'tcx> {
@@ -43,10 +43,10 @@ fn builtin_impl_clause(
 }
 
 crate fn assemble_builtin_unsize_impls<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     unsize_def_id: DefId,
-    source: ty::Ty<'tcx>,
-    target: ty::Ty<'tcx>,
+    source: Ty<'tcx>,
+    target: Ty<'tcx>,
     clauses: &mut Vec<Clause<'tcx>>
 ) {
     match (&source.sty, &target.sty) {
@@ -119,12 +119,12 @@ crate fn assemble_builtin_unsize_impls<'tcx>(
 }
 
 crate fn assemble_builtin_sized_impls<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     sized_def_id: DefId,
-    ty: ty::Ty<'tcx>,
+    ty: Ty<'tcx>,
     clauses: &mut Vec<Clause<'tcx>>
 ) {
-    let mut push_builtin_impl = |ty: ty::Ty<'tcx>, nested: &[Kind<'tcx>]| {
+    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[Kind<'tcx>]| {
         let clause = builtin_impl_clause(tcx, ty, nested, sized_def_id);
         // Bind innermost bound vars that may exist in `ty` and `nested`.
         clauses.push(Clause::ForAll(ty::Binder::bind(clause)));
@@ -223,12 +223,12 @@ crate fn assemble_builtin_sized_impls<'tcx>(
 }
 
 crate fn assemble_builtin_copy_clone_impls<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     trait_def_id: DefId,
-    ty: ty::Ty<'tcx>,
+    ty: Ty<'tcx>,
     clauses: &mut Vec<Clause<'tcx>>
 ) {
-    let mut push_builtin_impl = |ty: ty::Ty<'tcx>, nested: &[Kind<'tcx>]| {
+    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[Kind<'tcx>]| {
         let clause = builtin_impl_clause(tcx, ty, nested, trait_def_id);
         // Bind innermost bound vars that may exist in `ty` and `nested`.
         clauses.push(Clause::ForAll(ty::Binder::bind(clause)));

--- a/src/librustc_traits/chalk_context/program_clauses/mod.rs
+++ b/src/librustc_traits/chalk_context/program_clauses/mod.rs
@@ -10,7 +10,7 @@ use rustc::traits::{
     ProgramClauseCategory,
     Environment,
 };
-use rustc::ty;
+use rustc::ty::{self, TyCtxt};
 use rustc::hir::def_id::DefId;
 use super::ChalkInferenceContext;
 use std::iter;
@@ -19,7 +19,7 @@ use self::primitive::*;
 use self::builtin::*;
 
 fn assemble_clauses_from_impls<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     trait_def_id: DefId,
     clauses: &mut Vec<Clause<'tcx>>
 ) {
@@ -33,7 +33,7 @@ fn assemble_clauses_from_impls<'tcx>(
 }
 
 fn assemble_clauses_from_assoc_ty_values<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     trait_def_id: DefId,
     clauses: &mut Vec<Clause<'tcx>>
 ) {

--- a/src/librustc_traits/chalk_context/program_clauses/primitive.rs
+++ b/src/librustc_traits/chalk_context/program_clauses/primitive.rs
@@ -7,7 +7,7 @@ use rustc::traits::{
     ProgramClause,
     ProgramClauseCategory,
 };
-use rustc::ty;
+use rustc::ty::{self, TyCtxt};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc_target::spec::abi;
@@ -16,7 +16,7 @@ use crate::generic_types;
 use std::iter;
 
 crate fn wf_clause_for_raw_ptr<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     mutbl: hir::Mutability
 ) -> Clauses<'tcx> {
     let ptr_ty = generic_types::raw_ptr(tcx, mutbl);
@@ -33,7 +33,7 @@ crate fn wf_clause_for_raw_ptr<'tcx>(
 }
 
 crate fn wf_clause_for_fn_ptr<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     arity_and_output: usize,
     variadic: bool,
     unsafety: hir::Unsafety,
@@ -53,7 +53,7 @@ crate fn wf_clause_for_fn_ptr<'tcx>(
     tcx.mk_clauses(iter::once(wf_clause))
 }
 
-crate fn wf_clause_for_slice<'tcx>(tcx: ty::TyCtxt<'_, '_, 'tcx>) -> Clauses<'tcx> {
+crate fn wf_clause_for_slice<'tcx>(tcx: TyCtxt<'_, '_, 'tcx>) -> Clauses<'tcx> {
     let ty = generic_types::bound(tcx, 0);
     let slice_ty = tcx.mk_slice(ty);
 
@@ -83,7 +83,7 @@ crate fn wf_clause_for_slice<'tcx>(tcx: ty::TyCtxt<'_, '_, 'tcx>) -> Clauses<'tc
 }
 
 crate fn wf_clause_for_array<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     length: &'tcx ty::Const<'tcx>
 ) -> Clauses<'tcx> {
     let ty = generic_types::bound(tcx, 0);
@@ -115,7 +115,7 @@ crate fn wf_clause_for_array<'tcx>(
 }
 
 crate fn wf_clause_for_tuple<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     arity: usize
 ) -> Clauses<'tcx> {
     let type_list = generic_types::type_list(tcx, arity);
@@ -159,7 +159,7 @@ crate fn wf_clause_for_tuple<'tcx>(
 }
 
 crate fn wf_clause_for_ref<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     mutbl: hir::Mutability
 ) -> Clauses<'tcx> {
     let region = tcx.mk_region(
@@ -186,7 +186,7 @@ crate fn wf_clause_for_ref<'tcx>(
 }
 
 crate fn wf_clause_for_fn_def<'tcx>(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     def_id: DefId
 ) -> Clauses<'tcx> {
     let fn_def = generic_types::fn_def(tcx, def_id);

--- a/src/librustc_traits/chalk_context/resolvent_ops.rs
+++ b/src/librustc_traits/chalk_context/resolvent_ops.rs
@@ -16,7 +16,7 @@ use rustc::traits::{
     Environment,
     InEnvironment,
 };
-use rustc::ty::{self, Ty};
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc::ty::subst::Kind;
 use rustc::ty::relate::{Relate, RelateResult, TypeRelation};
 use syntax_pos::DUMMY_SP;
@@ -169,7 +169,7 @@ impl AnswerSubstitutor<'cx, 'gcx, 'tcx> {
 }
 
 impl TypeRelation<'cx, 'gcx, 'tcx> for AnswerSubstitutor<'cx, 'gcx, 'tcx> {
-    fn tcx(&self) -> ty::TyCtxt<'cx, 'gcx, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'cx, 'gcx, 'tcx> {
         self.infcx.tcx
     }
 

--- a/src/librustc_traits/generic_types.rs
+++ b/src/librustc_traits/generic_types.rs
@@ -6,7 +6,7 @@ use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc_target::spec::abi;
 
-crate fn bound(tcx: ty::TyCtxt<'_, '_, 'tcx>, index: u32) -> Ty<'tcx> {
+crate fn bound(tcx: TyCtxt<'_, '_, 'tcx>, index: u32) -> Ty<'tcx> {
     let ty = ty::Bound(
         ty::INNERMOST,
         ty::BoundVar::from_u32(index).into()
@@ -22,7 +22,7 @@ crate fn raw_ptr(tcx: TyCtxt<'_, '_, 'tcx>, mutbl: hir::Mutability) -> Ty<'tcx> 
 }
 
 crate fn fn_ptr(
-    tcx: ty::TyCtxt<'_, '_, 'tcx>,
+    tcx: TyCtxt<'_, '_, 'tcx>,
     arity_and_output: usize,
     c_variadic: bool,
     unsafety: hir::Unsafety,
@@ -44,7 +44,7 @@ crate fn fn_ptr(
     tcx.mk_fn_ptr(fn_sig)
 }
 
-crate fn type_list(tcx: ty::TyCtxt<'_, '_, 'tcx>, arity: usize) -> SubstsRef<'tcx> {
+crate fn type_list(tcx: TyCtxt<'_, '_, 'tcx>, arity: usize) -> SubstsRef<'tcx> {
     tcx.mk_substs(
         (0..arity).into_iter()
             .map(|i| ty::BoundVar::from(i))
@@ -53,7 +53,7 @@ crate fn type_list(tcx: ty::TyCtxt<'_, '_, 'tcx>, arity: usize) -> SubstsRef<'tc
     )
 }
 
-crate fn ref_ty(tcx: ty::TyCtxt<'_, '_, 'tcx>, mutbl: hir::Mutability) -> Ty<'tcx> {
+crate fn ref_ty(tcx: TyCtxt<'_, '_, 'tcx>, mutbl: hir::Mutability) -> Ty<'tcx> {
     let region = tcx.mk_region(
         ty::ReLateBound(ty::INNERMOST, ty::BoundRegion::BrAnon(0))
     );
@@ -64,17 +64,17 @@ crate fn ref_ty(tcx: ty::TyCtxt<'_, '_, 'tcx>, mutbl: hir::Mutability) -> Ty<'tc
     })
 }
 
-crate fn fn_def(tcx: ty::TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
+crate fn fn_def(tcx: TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
     tcx.mk_ty(ty::FnDef(def_id, InternalSubsts::bound_vars_for_item(tcx, def_id)))
 }
 
-crate fn closure(tcx: ty::TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
+crate fn closure(tcx: TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
     tcx.mk_closure(def_id, ty::ClosureSubsts {
         substs: InternalSubsts::bound_vars_for_item(tcx, def_id),
     })
 }
 
-crate fn generator(tcx: ty::TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
+crate fn generator(tcx: TyCtxt<'_, '_, 'tcx>, def_id: DefId) -> Ty<'tcx> {
     tcx.mk_generator(def_id, ty::GeneratorSubsts {
         substs: InternalSubsts::bound_vars_for_item(tcx, def_id),
     }, hir::GeneratorMovability::Movable)

--- a/src/librustc_typeck/check/compare_method.rs
+++ b/src/librustc_typeck/check/compare_method.rs
@@ -308,7 +308,7 @@ fn compare_predicate_entailment<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
             };
 
             let mut diag = struct_span_err!(tcx.sess,
-                                            cause.span(&tcx),
+                                            cause.span(tcx),
                                             E0053,
                                             "method `{}` has an incompatible type for trait",
                                             trait_m.ident);
@@ -448,9 +448,9 @@ fn extract_spans_for_error_reporting<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a
                 }).map(|(ref impl_arg, ref trait_arg)| {
                     (impl_arg.span, Some(trait_arg.span))
                 })
-                .unwrap_or_else(|| (cause.span(&tcx), tcx.hir().span_if_local(trait_m.def_id)))
+                .unwrap_or_else(|| (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id)))
             } else {
-                (cause.span(&tcx), tcx.hir().span_if_local(trait_m.def_id))
+                (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id))
             }
         }
         TypeError::Sorts(ExpectedFound { .. }) => {
@@ -483,14 +483,14 @@ fn extract_spans_for_error_reporting<'a, 'gcx, 'tcx>(infcx: &infer::InferCtxt<'a
                              {
                                  (impl_m_output.span(), Some(trait_m_output.span()))
                              } else {
-                                 (cause.span(&tcx), tcx.hir().span_if_local(trait_m.def_id))
+                                 (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id))
                              }
                          )
             } else {
-                (cause.span(&tcx), tcx.hir().span_if_local(trait_m.def_id))
+                (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id))
             }
         }
-        _ => (cause.span(&tcx), tcx.hir().span_if_local(trait_m.def_id)),
+        _ => (cause.span(tcx), tcx.hir().span_if_local(trait_m.def_id)),
     }
 }
 
@@ -549,7 +549,7 @@ fn compare_self_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 err.span_label(span, format!("trait method declared without `{}`", self_descr));
             } else {
                 err.note_trait_signature(trait_m.ident.to_string(),
-                                         trait_m.signature(&tcx));
+                                         trait_m.signature(tcx));
             }
             err.emit();
             return Err(ErrorReported);
@@ -569,7 +569,7 @@ fn compare_self_type<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 err.span_label(span, format!("`{}` used in trait", self_descr));
             } else {
                 err.note_trait_signature(trait_m.ident.to_string(),
-                                         trait_m.signature(&tcx));
+                                         trait_m.signature(tcx));
             }
             err.emit();
             return Err(ErrorReported);
@@ -726,7 +726,7 @@ fn compare_number_of_method_arguments<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 potentially_plural_count(trait_number_args, "parameter")));
         } else {
             err.note_trait_signature(trait_m.ident.to_string(),
-                                     trait_m.signature(&tcx));
+                                     trait_m.signature(tcx));
         }
         err.span_label(impl_span, format!("expected {}, found {}",
             potentially_plural_count(trait_number_args, "parameter"), impl_number_args));

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -26,7 +26,7 @@ use super::{MethodError, NoMatchData, CandidateSource};
 use super::probe::Mode;
 
 impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
-    fn is_fn_ty(&self, ty: &Ty<'tcx>, span: Span) -> bool {
+    fn is_fn_ty(&self, ty: Ty<'tcx>, span: Span) -> bool {
         let tcx = self.tcx;
         match ty.sty {
             // Not all of these (e.g., unsafe fns) implement `FnOnce`,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1026,10 +1026,10 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for GatherLocalsVisitor<'a, 'gcx, 'tcx> {
 /// points.
 struct GeneratorTypes<'tcx> {
     /// Type of value that is yielded.
-    yield_ty: ty::Ty<'tcx>,
+    yield_ty: Ty<'tcx>,
 
     /// Types that are captured (see `GeneratorInterior` for more).
-    interior: ty::Ty<'tcx>,
+    interior: Ty<'tcx>,
 
     /// Indicates if the generator is movable or static (immovable).
     movability: hir::GeneratorMovability,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1667,7 +1667,7 @@ fn check_impl_items_against_trait<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 err.span_label(span, format!("`{}` from trait", trait_item.ident));
             } else {
                 err.note_trait_signature(trait_item.ident.to_string(),
-                                         trait_item.signature(&tcx));
+                                         trait_item.signature(tcx));
             }
         }
         err.emit();

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -405,7 +405,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
                 c_ty
             } else {
                 span_bug!(
-                    hir_id.to_span(&self.fcx.tcx),
+                    hir_id.to_span(self.fcx.tcx),
                     "writeback: `{:?}` missing from the global type context",
                     c_ty
                 );
@@ -730,7 +730,7 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
             lifted
         } else {
             span_bug!(
-                span.to_span(&self.fcx.tcx),
+                span.to_span(self.fcx.tcx),
                 "writeback: `{:?}` missing from the global type context",
                 x
             );
@@ -739,24 +739,24 @@ impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {
 }
 
 trait Locatable {
-    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span;
+    fn to_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span;
 }
 
 impl Locatable for Span {
-    fn to_span(&self, _: &TyCtxt<'_, '_, '_>) -> Span {
+    fn to_span(&self, _: TyCtxt<'_, '_, '_>) -> Span {
         *self
     }
 }
 
 impl Locatable for DefIndex {
-    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span {
+    fn to_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         let hir_id = tcx.hir().def_index_to_hir_id(*self);
         tcx.hir().span_by_hir_id(hir_id)
     }
 }
 
 impl Locatable for hir::HirId {
-    fn to_span(&self, tcx: &TyCtxt<'_, '_, '_>) -> Span {
+    fn to_span(&self, tcx: TyCtxt<'_, '_, '_>) -> Span {
         tcx.hir().span_by_hir_id(*self)
     }
 }
@@ -789,7 +789,7 @@ impl<'cx, 'gcx, 'tcx> Resolver<'cx, 'gcx, 'tcx> {
     fn report_error(&self, t: Ty<'tcx>) {
         if !self.tcx.sess.has_errors() {
             self.infcx
-                .need_type_info_err(Some(self.body.id()), self.span.to_span(&self.tcx), t)
+                .need_type_info_err(Some(self.body.id()), self.span.to_span(self.tcx), t)
                 .emit();
         }
     }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1451,8 +1451,8 @@ pub fn checked_type_of<'a, 'tcx>(
 fn find_existential_constraints<'a, 'tcx>(
     tcx: TyCtxt<'a, 'tcx, 'tcx>,
     def_id: DefId,
-) -> ty::Ty<'tcx> {
-    use rustc::hir::*;
+) -> Ty<'tcx> {
+    use rustc::hir::{ImplItem, Item, TraitItem};
 
     struct ConstraintLocator<'a, 'tcx: 'a> {
         tcx: TyCtxt<'a, 'tcx, 'tcx>,
@@ -1463,7 +1463,7 @@ fn find_existential_constraints<'a, 'tcx>(
         // The mapping is an index for each use site of a generic parameter in the concrete type
         //
         // The indices index into the generic parameters on the existential type.
-        found: Option<(Span, ty::Ty<'tcx>, Vec<usize>)>,
+        found: Option<(Span, Ty<'tcx>, Vec<usize>)>,
     }
 
     impl<'a, 'tcx> ConstraintLocator<'a, 'tcx> {
@@ -1519,7 +1519,7 @@ fn find_existential_constraints<'a, 'tcx>(
                         ty::Param(p) => Some(*index_map.get(p).unwrap()),
                         _ => None,
                     }).collect();
-                let is_param = |ty: ty::Ty<'_>| match ty.sty {
+                let is_param = |ty: Ty<'_>| match ty.sty {
                     ty::Param(_) => true,
                     _ => false,
                 };

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -634,7 +634,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                                 // that we don't end up with duplicate bounds (e.g., for<'b, 'b>)
                                 for_generics.extend(p.generic_params.clone());
                                 p.generic_params = for_generics.into_iter().collect();
-                                self.is_fn_ty(&tcx, &p.trait_)
+                                self.is_fn_ty(tcx, &p.trait_)
                             }
                             _ => false,
                         };
@@ -681,7 +681,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                                 } => {
                                     let mut new_trait_path = trait_path.clone();
 
-                                    if self.is_fn_ty(&tcx, trait_) && left_name == FN_OUTPUT_NAME {
+                                    if self.is_fn_ty(tcx, trait_) && left_name == FN_OUTPUT_NAME {
                                         ty_to_fn
                                             .entry(*ty.clone())
                                             .and_modify(|e| *e = (e.0.clone(), Some(rhs.clone())))
@@ -850,7 +850,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
         vec.sort_by_cached_key(|x| format!("{:?}", x))
     }
 
-    fn is_fn_ty(&self, tcx: &TyCtxt<'_, '_, '_>, ty: &Type) -> bool {
+    fn is_fn_ty(&self, tcx: TyCtxt<'_, '_, '_>, ty: &Type) -> bool {
         match &ty {
             &&Type::ResolvedPath { ref did, .. } => {
                 *did == tcx.require_lang_item(lang_items::FnTraitLangItem)

--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -14,7 +14,7 @@ pub struct AutoTraitFinder<'a, 'tcx> {
 
 impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
     pub fn new(cx: &'a core::DocContext<'tcx>) -> Self {
-        let f = auto::AutoTraitFinder::new(&cx.tcx);
+        let f = auto::AutoTraitFinder::new(cx.tcx);
 
         AutoTraitFinder { cx, f }
     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -4399,7 +4399,7 @@ where
 
 // Start of code copied from rust-clippy
 
-pub fn path_to_def_local(tcx: &TyCtxt<'_, '_, '_>, path: &[&str]) -> Option<DefId> {
+pub fn path_to_def_local(tcx: TyCtxt<'_, '_, '_>, path: &[&str]) -> Option<DefId> {
     let krate = tcx.hir().krate();
     let mut items = krate.module.item_ids.clone();
     let mut path_it = path.iter().peekable();
@@ -4424,7 +4424,7 @@ pub fn path_to_def_local(tcx: &TyCtxt<'_, '_, '_>, path: &[&str]) -> Option<DefI
     }
 }
 
-pub fn path_to_def(tcx: &TyCtxt<'_, '_, '_>, path: &[&str]) -> Option<DefId> {
+pub fn path_to_def(tcx: TyCtxt<'_, '_, '_>, path: &[&str]) -> Option<DefId> {
     let crates = tcx.crates();
 
     let krate = crates

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -466,9 +466,9 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             };
 
             let send_trait = if crate_name == Some("core".to_string()) {
-                clean::path_to_def_local(&tcx, &["marker", "Send"])
+                clean::path_to_def_local(tcx, &["marker", "Send"])
             } else {
-                clean::path_to_def(&tcx, &["core", "marker", "Send"])
+                clean::path_to_def(tcx, &["core", "marker", "Send"])
             };
 
             let mut renderinfo = RenderInfo::default();

--- a/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.rs
+++ b/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.rs
@@ -1,0 +1,64 @@
+// compile-flags: -Z unstable-options
+
+#![feature(rustc_private)]
+#![deny(ty_pass_by_reference)]
+#![allow(unused)]
+
+extern crate rustc;
+
+use rustc::ty::{Ty, TyCtxt};
+
+fn ty_by_ref(
+    ty_val: Ty<'_>,
+    ty_ref: &Ty<'_>, //~ ERROR passing `Ty<'_>` by reference
+    ty_ctxt_val: TyCtxt<'_, '_, '_>,
+    ty_ctxt_ref: &TyCtxt<'_, '_, '_>, //~ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+) {
+}
+
+fn ty_multi_ref(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+//~^ ERROR passing `Ty<'_>` by reference
+//~^^ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+
+trait T {
+    fn ty_by_ref_in_trait(
+        ty_val: Ty<'_>,
+        ty_ref: &Ty<'_>, //~ ERROR passing `Ty<'_>` by reference
+        ty_ctxt_val: TyCtxt<'_, '_, '_>,
+        ty_ctxt_ref: &TyCtxt<'_, '_, '_>, //~ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+    );
+
+    fn ty_multi_ref_in_trait(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>);
+    //~^ ERROR passing `Ty<'_>` by reference
+    //~^^ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+}
+
+struct Foo;
+
+impl T for Foo {
+    fn ty_by_ref_in_trait(
+        ty_val: Ty<'_>,
+        ty_ref: &Ty<'_>,
+        ty_ctxt_val: TyCtxt<'_, '_, '_>,
+        ty_ctxt_ref: &TyCtxt<'_, '_, '_>,
+    ) {
+    }
+
+    fn ty_multi_ref_in_trait(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+}
+
+impl Foo {
+    fn ty_by_ref_assoc(
+        ty_val: Ty<'_>,
+        ty_ref: &Ty<'_>, //~ ERROR passing `Ty<'_>` by reference
+        ty_ctxt_val: TyCtxt<'_, '_, '_>,
+        ty_ctxt_ref: &TyCtxt<'_, '_, '_>, //~ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+    ) {
+    }
+
+    fn ty_multi_ref_assoc(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+    //~^ ERROR passing `Ty<'_>` by reference
+    //~^^ ERROR passing `TyCtxt<'_, '_, '_>` by reference
+}
+
+fn main() {}

--- a/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.stderr
+++ b/src/test/ui-fulldeps/internal-lints/pass_ty_by_ref.stderr
@@ -1,0 +1,80 @@
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:13:13
+   |
+LL |     ty_ref: &Ty<'_>,
+   |             ^^^^^^^ help: try passing by value: `Ty<'_>`
+   |
+note: lint level defined here
+  --> $DIR/pass_ty_by_ref.rs:4:9
+   |
+LL | #![deny(ty_pass_by_reference)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:15:18
+   |
+LL |     ty_ctxt_ref: &TyCtxt<'_, '_, '_>,
+   |                  ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:19:28
+   |
+LL | fn ty_multi_ref(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+   |                            ^^^^^^^ help: try passing by value: `Ty<'_>`
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:19:55
+   |
+LL | fn ty_multi_ref(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+   |                                                       ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:26:17
+   |
+LL |         ty_ref: &Ty<'_>,
+   |                 ^^^^^^^ help: try passing by value: `Ty<'_>`
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:28:22
+   |
+LL |         ty_ctxt_ref: &TyCtxt<'_, '_, '_>,
+   |                      ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:31:41
+   |
+LL |     fn ty_multi_ref_in_trait(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>);
+   |                                         ^^^^^^^ help: try passing by value: `Ty<'_>`
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:31:68
+   |
+LL |     fn ty_multi_ref_in_trait(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>);
+   |                                                                    ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:53:17
+   |
+LL |         ty_ref: &Ty<'_>,
+   |                 ^^^^^^^ help: try passing by value: `Ty<'_>`
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:55:22
+   |
+LL |         ty_ctxt_ref: &TyCtxt<'_, '_, '_>,
+   |                      ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: passing `Ty<'_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:59:38
+   |
+LL |     fn ty_multi_ref_assoc(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+   |                                      ^^^^^^^ help: try passing by value: `Ty<'_>`
+
+error: passing `TyCtxt<'_, '_, '_>` by reference
+  --> $DIR/pass_ty_by_ref.rs:59:65
+   |
+LL |     fn ty_multi_ref_assoc(ty_multi: &&Ty<'_>, ty_ctxt_multi: &&&&TyCtxt<'_, '_, '_>) {}
+   |                                                                 ^^^^^^^^^^^^^^^^^^^ help: try passing by value: `TyCtxt<'_, '_, '_>`
+
+error: aborting due to 12 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.rs
+++ b/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.rs
@@ -1,0 +1,35 @@
+// compile-flags: -Z unstable-options
+
+#![feature(rustc_private)]
+#![deny(usage_of_qualified_ty)]
+#![allow(unused)]
+
+extern crate rustc;
+
+use rustc::ty::{self, Ty, TyCtxt};
+
+macro_rules! qualified_macro {
+    ($a:ident) => {
+        fn ty_in_macro(
+            ty_q: ty::Ty<'_>,
+            ty: Ty<'_>,
+            ty_ctxt_q: ty::TyCtxt<'_, '_, '_>,
+            ty_ctxt: TyCtxt<'_, '_, '_>,
+        ) {
+            println!("{}", stringify!($a));
+        }
+    };
+}
+
+fn ty_qualified(
+    ty_q: ty::Ty<'_>, //~ ERROR usage of qualified `ty::Ty<'_>`
+    ty: Ty<'_>,
+    ty_ctxt_q: ty::TyCtxt<'_, '_, '_>, //~ ERROR usage of qualified `ty::TyCtxt<'_, '_, '_>`
+    ty_ctxt: TyCtxt<'_, '_, '_>,
+) {
+}
+
+
+fn main() {
+    qualified_macro!(a);
+}

--- a/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
+++ b/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
@@ -1,0 +1,20 @@
+error: usage of qualified `ty::Ty<'_>`
+  --> $DIR/qualified_ty_ty_ctxt.rs:25:11
+   |
+LL |     ty_q: ty::Ty<'_>,
+   |           ^^^^^^^^^^ help: try using it unqualified: `Ty<'_>`
+   |
+note: lint level defined here
+  --> $DIR/qualified_ty_ty_ctxt.rs:4:9
+   |
+LL | #![deny(usage_of_qualified_ty)]
+   |         ^^^^^^^^^^^^^^^^^^^^^
+
+error: usage of qualified `ty::TyCtxt<'_, '_, '_>`
+  --> $DIR/qualified_ty_ty_ctxt.rs:27:16
+   |
+LL |     ty_ctxt_q: ty::TyCtxt<'_, '_, '_>,
+   |                ^^^^^^^^^^^^^^^^^^^^^^ help: try using it unqualified: `TyCtxt<'_, '_, '_>`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
+++ b/src/test/ui-fulldeps/internal-lints/ty_tykind_usage.stderr
@@ -190,7 +190,7 @@ error: usage of `ty::TyKind`
 LL |     fn ty_kind(ty_bad: TyKind<'_>, ty_good: Ty<'_>) {}
    |                        ^^^^^^^^^^
    |
-   = help: try using `ty::Ty` instead
+   = help: try using `Ty` instead
 
 error: aborting due to 31 previous errors
 


### PR DESCRIPTION
Closes #59952 

Implements internal lints:

- `USAGE_OF_QUALIFIED_TY`
- `TY_PASS_BY_REFERENCE`

r? @oli-obk 