### PR TITLE
impl From<Infallible> for TryFromSliceError

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -11,7 +11,7 @@
 
 use crate::borrow::{Borrow, BorrowMut};
 use crate::cmp::Ordering;
-use crate::convert::TryFrom;
+use crate::convert::{Infallible, TryFrom};
 use crate::fmt;
 use crate::hash::{Hash, self};
 use crate::marker::Unsize;
@@ -69,6 +69,13 @@ impl TryFromSliceError {
     #[doc(hidden)]
     pub fn __description(&self) -> &str {
         "could not convert slice to array"
+    }
+}
+
+#[stable(feature = "try_from_slice_error", since = "1.36.0")]
+impl From<Infallible> for TryFromSliceError {
+    fn from(x: Infallible) -> TryFromSliceError {
+        match x {}
     }
 }
 


### PR DESCRIPTION
I believe this was missed when TryFrom was stabilized. I think `TryFromSliceError` and `TryFromIntError` are the only two `TryFrom` error types that appear in `std`. I think trait implementations have to be insta-stable, but I'm not sure.