### PR TITLE
Search for incompatible universes in borrow errors

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -674,8 +674,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         borrow_region: RegionVid,
         outlived_region: RegionVid,
     ) -> (ConstraintCategory, bool, Span, Option<RegionName>) {
-        let (category, from_closure, span) =
-            self.best_blame_constraint(mir, borrow_region, |r| r == outlived_region);
+        let (category, from_closure, span) = self.best_blame_constraint(
+            mir,
+            borrow_region,
+            |r| self.provides_universal_region(r, borrow_region, outlived_region)
+        );
         let outlived_fr_name =
             self.give_region_a_name(infcx, mir, upvars, mir_def_id, outlived_region, &mut 1);
         (category, from_closure, span, outlived_fr_name)

--- a/src/test/ui/nll/local-outlives-static-via-hrtb.rs
+++ b/src/test/ui/nll/local-outlives-static-via-hrtb.rs
@@ -1,0 +1,26 @@
+// Test that we handle the case when a local variable is borrowed for `'static`
+// due to an outlives constraint involving a region in an incompatible universe
+
+pub trait Outlives<'this> {}
+
+impl<'this, T> Outlives<'this> for T where T: 'this {}
+trait Reference {
+    type AssociatedType;
+}
+
+impl<'a, T: 'a> Reference for &'a T {
+    type AssociatedType = &'a ();
+}
+
+fn assert_static_via_hrtb<G>(_: G) where for<'a> G: Outlives<'a> {}
+
+fn assert_static_via_hrtb_with_assoc_type<T>(_: &'_ T)
+where
+    for<'a> &'a T: Reference<AssociatedType = &'a ()>,
+{}
+
+fn main() {
+    let local = 0;
+    assert_static_via_hrtb(&local); //~ ERROR `local` does not live long enough
+    assert_static_via_hrtb_with_assoc_type(&&local); //~ ERROR `local` does not live long enough
+}

--- a/src/test/ui/nll/local-outlives-static-via-hrtb.stderr
+++ b/src/test/ui/nll/local-outlives-static-via-hrtb.stderr
@@ -1,0 +1,26 @@
+error[E0597]: `local` does not live long enough
+  --> $DIR/local-outlives-static-via-hrtb.rs:24:28
+   |
+LL |     assert_static_via_hrtb(&local);
+   |     -----------------------^^^^^^-
+   |     |                      |
+   |     |                      borrowed value does not live long enough
+   |     argument requires that `local` is borrowed for `'static`
+LL |     assert_static_via_hrtb_with_assoc_type(&&local);
+LL | }
+   | - `local` dropped here while still borrowed
+
+error[E0597]: `local` does not live long enough
+  --> $DIR/local-outlives-static-via-hrtb.rs:25:45
+   |
+LL |     assert_static_via_hrtb_with_assoc_type(&&local);
+   |     ----------------------------------------^^^^^^-
+   |     |                                       |
+   |     |                                       borrowed value does not live long enough
+   |     argument requires that `local` is borrowed for `'static`
+LL | }
+   | - `local` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
If we have a borrow that has to live for `'static` we need to check for
any regions in incompatible universes when trying to find the cause.

closes #60274