### PR TITLE
Stabilized vectored IO

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -11,7 +11,7 @@
 
 use crate::fmt;
 use crate::ffi::OsString;
-use crate::io::{self, SeekFrom, Seek, Read, Initializer, Write, IoVec, IoVecMut};
+use crate::io::{self, SeekFrom, Seek, Read, Initializer, Write, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
 use crate::sys::fs as fs_imp;
 use crate::sys_common::{AsInnerMut, FromInner, AsInner, IntoInner};
@@ -617,7 +617,7 @@ impl Read for File {
         self.inner.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 
@@ -632,7 +632,7 @@ impl Write for File {
         self.inner.write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
 
@@ -650,7 +650,7 @@ impl Read for &File {
         self.inner.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 
@@ -665,7 +665,7 @@ impl Write for &File {
         self.inner.write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
 

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -5,7 +5,8 @@ use crate::io::prelude::*;
 use crate::cmp;
 use crate::error;
 use crate::fmt;
-use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoSlice, IoSliceMut};
+use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoSlice,
+        IoSliceMut};
 use crate::memchr;
 
 /// The `BufReader` struct adds buffering to any reader.

--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -5,7 +5,7 @@ use crate::io::prelude::*;
 use crate::cmp;
 use crate::error;
 use crate::fmt;
-use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, Initializer, DEFAULT_BUF_SIZE, Error, ErrorKind, SeekFrom, IoSlice, IoSliceMut};
 use crate::memchr;
 
 /// The `BufReader` struct adds buffering to any reader.
@@ -249,7 +249,7 @@ impl<R: Read> Read for BufReader<R> {
         Ok(nread)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let total_len = bufs.iter().map(|b| b.len()).sum::<usize>();
         if self.pos == self.cap && total_len >= self.buf.len() {
             self.discard_buffer();
@@ -609,7 +609,7 @@ impl<W: Write> Write for BufWriter<W> {
         }
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let total_len = bufs.iter().map(|b| b.len()).sum::<usize>();
         if self.buf.len() + total_len > self.buf.capacity() {
             self.flush_buf()?;

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -1,7 +1,7 @@
 use crate::io::prelude::*;
 
 use crate::cmp;
-use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoVec, IoVecMut};
+use crate::io::{self, Initializer, SeekFrom, Error, ErrorKind, IoSlice, IoSliceMut};
 
 use core::convert::TryInto;
 
@@ -230,7 +230,7 @@ impl<T> Read for Cursor<T> where T: AsRef<[u8]> {
         Ok(n)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let mut nread = 0;
         for buf in bufs {
             let n = self.read(buf)?;
@@ -275,7 +275,7 @@ fn slice_write(pos_mut: &mut u64, slice: &mut [u8], buf: &[u8]) -> io::Result<us
 fn slice_write_vectored(
     pos_mut: &mut u64,
     slice: &mut [u8],
-    bufs: &[IoVec<'_>],
+    bufs: &[IoSlice<'_>],
 ) -> io::Result<usize>
 {
     let mut nwritten = 0;
@@ -319,7 +319,7 @@ fn vec_write(pos_mut: &mut u64, vec: &mut Vec<u8>, buf: &[u8]) -> io::Result<usi
 fn vec_write_vectored(
     pos_mut: &mut u64,
     vec: &mut Vec<u8>,
-    bufs: &[IoVec<'_>],
+    bufs: &[IoSlice<'_>],
 ) -> io::Result<usize>
 {
     let mut nwritten = 0;
@@ -337,7 +337,7 @@ impl Write for Cursor<&mut [u8]> {
     }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         slice_write_vectored(&mut self.pos, self.inner, bufs)
     }
 
@@ -350,7 +350,7 @@ impl Write for Cursor<&mut Vec<u8>> {
         vec_write(&mut self.pos, self.inner, buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         vec_write_vectored(&mut self.pos, self.inner, bufs)
     }
 
@@ -363,7 +363,7 @@ impl Write for Cursor<Vec<u8>> {
         vec_write(&mut self.pos, &mut self.inner, buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         vec_write_vectored(&mut self.pos, &mut self.inner, bufs)
     }
 
@@ -378,7 +378,7 @@ impl Write for Cursor<Box<[u8]>> {
     }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         slice_write_vectored(&mut self.pos, &mut self.inner, bufs)
     }
 
@@ -388,7 +388,7 @@ impl Write for Cursor<Box<[u8]>> {
 #[cfg(test)]
 mod tests {
     use crate::io::prelude::*;
-    use crate::io::{Cursor, SeekFrom, IoVec, IoVecMut};
+    use crate::io::{Cursor, SeekFrom, IoSlice, IoSliceMut};
 
     #[test]
     fn test_vec_writer() {
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
         assert_eq!(writer.write_vectored(
-            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+            &[IoSlice::new(&[]), IoSlice::new(&[8, 9]), IoSlice::new(&[10])],
         ).unwrap(), 3);
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(writer, b);
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
         assert_eq!(writer.write_vectored(
-            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+            &[IoSlice::new(&[]), IoSlice::new(&[8, 9]), IoSlice::new(&[10])],
         ).unwrap(), 3);
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(&writer.get_ref()[..], b);
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(writer.write(&[1, 2, 3]).unwrap(), 3);
         assert_eq!(writer.write(&[4, 5, 6, 7]).unwrap(), 4);
         assert_eq!(writer.write_vectored(
-            &[IoVec::new(&[]), IoVec::new(&[8, 9]), IoVec::new(&[10])],
+            &[IoSlice::new(&[]), IoSlice::new(&[8, 9]), IoSlice::new(&[10])],
         ).unwrap(), 3);
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         assert_eq!(&writer.get_ref()[..], b);
@@ -452,18 +452,18 @@ mod tests {
     fn test_box_slice_writer_vectored() {
         let mut writer = Cursor::new(vec![0u8; 9].into_boxed_slice());
         assert_eq!(writer.position(), 0);
-        assert_eq!(writer.write_vectored(&[IoVec::new(&[0])]).unwrap(), 1);
+        assert_eq!(writer.write_vectored(&[IoSlice::new(&[0])]).unwrap(), 1);
         assert_eq!(writer.position(), 1);
         assert_eq!(
-            writer.write_vectored(&[IoVec::new(&[1, 2, 3]), IoVec::new(&[4, 5, 6, 7])]).unwrap(),
+            writer.write_vectored(&[IoSlice::new(&[1, 2, 3]), IoSlice::new(&[4, 5, 6, 7])]).unwrap(),
             7,
         );
         assert_eq!(writer.position(), 8);
         assert_eq!(writer.write_vectored(&[]).unwrap(), 0);
         assert_eq!(writer.position(), 8);
 
-        assert_eq!(writer.write_vectored(&[IoVec::new(&[8, 9])]).unwrap(), 1);
-        assert_eq!(writer.write_vectored(&[IoVec::new(&[10])]).unwrap(), 0);
+        assert_eq!(writer.write_vectored(&[IoSlice::new(&[8, 9])]).unwrap(), 1);
+        assert_eq!(writer.write_vectored(&[IoSlice::new(&[10])]).unwrap(), 0);
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
         assert_eq!(&**writer.get_ref(), b);
     }
@@ -495,11 +495,11 @@ mod tests {
         {
             let mut writer = Cursor::new(&mut buf[..]);
             assert_eq!(writer.position(), 0);
-            assert_eq!(writer.write_vectored(&[IoVec::new(&[0])]).unwrap(), 1);
+            assert_eq!(writer.write_vectored(&[IoSlice::new(&[0])]).unwrap(), 1);
             assert_eq!(writer.position(), 1);
             assert_eq!(
                 writer.write_vectored(
-                    &[IoVec::new(&[1, 2, 3]), IoVec::new(&[4, 5, 6, 7])],
+                    &[IoSlice::new(&[1, 2, 3]), IoSlice::new(&[4, 5, 6, 7])],
                 ).unwrap(),
                 7,
             );
@@ -507,8 +507,8 @@ mod tests {
             assert_eq!(writer.write_vectored(&[]).unwrap(), 0);
             assert_eq!(writer.position(), 8);
 
-            assert_eq!(writer.write_vectored(&[IoVec::new(&[8, 9])]).unwrap(), 1);
-            assert_eq!(writer.write_vectored(&[IoVec::new(&[10])]).unwrap(), 0);
+            assert_eq!(writer.write_vectored(&[IoSlice::new(&[8, 9])]).unwrap(), 1);
+            assert_eq!(writer.write_vectored(&[IoSlice::new(&[10])]).unwrap(), 0);
         }
         let b: &[_] = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
         assert_eq!(buf, b);
@@ -578,11 +578,11 @@ mod tests {
     fn test_mem_reader_vectored() {
         let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7]);
         let mut buf = [];
-        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        assert_eq!(reader.read_vectored(&mut [IoSliceMut::new(&mut buf)]).unwrap(), 0);
         assert_eq!(reader.position(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
             1,
         );
         assert_eq!(reader.position(), 1);
@@ -592,7 +592,7 @@ mod tests {
         let mut buf2 = [0; 4];
         assert_eq!(
             reader.read_vectored(
-                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+                &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)],
             ).unwrap(),
             7,
         );
@@ -629,11 +629,11 @@ mod tests {
     fn test_boxed_slice_reader_vectored() {
         let mut reader = Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7].into_boxed_slice());
         let mut buf = [];
-        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        assert_eq!(reader.read_vectored(&mut [IoSliceMut::new(&mut buf)]).unwrap(), 0);
         assert_eq!(reader.position(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
             1,
         );
         assert_eq!(reader.position(), 1);
@@ -643,7 +643,7 @@ mod tests {
         let mut buf2 = [0; 4];
         assert_eq!(
             reader.read_vectored(
-                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+                &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)],
             ).unwrap(),
             7,
         );
@@ -689,10 +689,10 @@ mod tests {
         let in_buf = vec![0, 1, 2, 3, 4, 5, 6, 7];
         let reader = &mut &in_buf[..];
         let mut buf = [];
-        assert_eq!(reader.read_vectored(&mut [IoVecMut::new(&mut buf)]).unwrap(), 0);
+        assert_eq!(reader.read_vectored(&mut [IoSliceMut::new(&mut buf)]).unwrap(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoVecMut::new(&mut []), IoVecMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
             1,
         );
         assert_eq!(reader.len(), 7);
@@ -702,7 +702,7 @@ mod tests {
         let mut buf2 = [0; 4];
         assert_eq!(
             reader.read_vectored(
-                &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+                &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)],
             ).unwrap(),
             7,
         );

--- a/src/libstd/io/cursor.rs
+++ b/src/libstd/io/cursor.rs
@@ -455,7 +455,10 @@ mod tests {
         assert_eq!(writer.write_vectored(&[IoSlice::new(&[0])]).unwrap(), 1);
         assert_eq!(writer.position(), 1);
         assert_eq!(
-            writer.write_vectored(&[IoSlice::new(&[1, 2, 3]), IoSlice::new(&[4, 5, 6, 7])]).unwrap(),
+            writer.write_vectored(&[
+                IoSlice::new(&[1, 2, 3]),
+                IoSlice::new(&[4, 5, 6, 7]),
+            ]).unwrap(),
             7,
         );
         assert_eq!(writer.position(), 8);
@@ -582,7 +585,10 @@ mod tests {
         assert_eq!(reader.position(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [
+                IoSliceMut::new(&mut []),
+                IoSliceMut::new(&mut buf),
+            ]).unwrap(),
             1,
         );
         assert_eq!(reader.position(), 1);
@@ -591,9 +597,10 @@ mod tests {
         let mut buf1 = [0; 4];
         let mut buf2 = [0; 4];
         assert_eq!(
-            reader.read_vectored(
-                &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)],
-            ).unwrap(),
+            reader.read_vectored(&mut [
+                IoSliceMut::new(&mut buf1),
+                IoSliceMut::new(&mut buf2),
+            ]).unwrap(),
             7,
         );
         let b1: &[_] = &[1, 2, 3, 4];
@@ -633,7 +640,10 @@ mod tests {
         assert_eq!(reader.position(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [
+                IoSliceMut::new(&mut []),
+                IoSliceMut::new(&mut buf),
+            ]).unwrap(),
             1,
         );
         assert_eq!(reader.position(), 1);
@@ -692,7 +702,10 @@ mod tests {
         assert_eq!(reader.read_vectored(&mut [IoSliceMut::new(&mut buf)]).unwrap(), 0);
         let mut buf = [0];
         assert_eq!(
-            reader.read_vectored(&mut [IoSliceMut::new(&mut []), IoSliceMut::new(&mut buf)]).unwrap(),
+            reader.read_vectored(&mut [
+                IoSliceMut::new(&mut []),
+                IoSliceMut::new(&mut buf),
+            ]).unwrap(),
             1,
         );
         assert_eq!(reader.len(), 7);

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -1,6 +1,6 @@
 use crate::cmp;
-use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoVecMut,
-         IoVec};
+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoSliceMut,
+         IoSlice};
 use crate::fmt;
 use crate::mem;
 
@@ -15,7 +15,7 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         (**self).read_vectored(bufs)
     }
 
@@ -45,7 +45,7 @@ impl<W: Write + ?Sized> Write for &mut W {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         (**self).write_vectored(bufs)
     }
 
@@ -94,7 +94,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         (**self).read_vectored(bufs)
     }
 
@@ -124,7 +124,7 @@ impl<W: Write + ?Sized> Write for Box<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { (**self).write(buf) }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         (**self).write_vectored(bufs)
     }
 
@@ -207,7 +207,7 @@ impl Read for &[u8] {
     }
 
     #[inline]
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let mut nread = 0;
         for buf in bufs {
             nread += self.read(buf)?;
@@ -280,7 +280,7 @@ impl Write for &mut [u8] {
     }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let mut nwritten = 0;
         for buf in bufs {
             nwritten += self.write(buf)?;
@@ -316,7 +316,7 @@ impl Write for Vec<u8> {
     }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let len = bufs.iter().map(|b| b.len()).sum();
         self.reserve(len);
         for buf in bufs {

--- a/src/libstd/io/impls.rs
+++ b/src/libstd/io/impls.rs
@@ -1,6 +1,6 @@
 use crate::cmp;
-use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind, IoSliceMut,
-         IoSlice};
+use crate::io::{self, SeekFrom, Read, Initializer, Write, Seek, BufRead, Error, ErrorKind,
+        IoSliceMut, IoSlice};
 use crate::fmt;
 use crate::mem;
 

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -390,7 +390,7 @@ fn read_to_end_with_reservation<R: Read + ?Sized>(r: &mut R,
     ret
 }
 
-pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoVecMut<'_>]) -> Result<usize>
+pub(crate) fn default_read_vectored<F>(read: F, bufs: &mut [IoSliceMut<'_>]) -> Result<usize>
 where
     F: FnOnce(&mut [u8]) -> Result<usize>
 {
@@ -401,7 +401,7 @@ where
     read(buf)
 }
 
-pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoVec<'_>]) -> Result<usize>
+pub(crate) fn default_write_vectored<F>(write: F, bufs: &[IoSlice<'_>]) -> Result<usize>
 where
     F: FnOnce(&[u8]) -> Result<usize>
 {
@@ -554,8 +554,8 @@ pub trait Read {
     ///
     /// The default implementation calls `read` with either the first nonempty
     /// buffer provided, or an empty one if none exists.
-    #[unstable(feature = "iovec", issue = "58452")]
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
+    #[stable(feature = "iovec", since = "1.36.0")]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
         default_read_vectored(|b| self.read(b), bufs)
     }
 
@@ -911,32 +911,32 @@ pub trait Read {
 /// It is semantically a wrapper around an `&mut [u8]`, but is guaranteed to be
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
-#[unstable(feature = "iovec", issue = "58452")]
+#[stable(feature = "iovec", since = "1.36.0")]
 #[repr(transparent)]
-pub struct IoVecMut<'a>(sys::io::IoVecMut<'a>);
+pub struct IoSliceMut<'a>(sys::io::IoSliceMut<'a>);
 
-#[unstable(feature = "iovec", issue = "58452")]
-impl<'a> fmt::Debug for IoVecMut<'a> {
+#[stable(feature = "iovec", since = "1.36.0")]
+impl<'a> fmt::Debug for IoSliceMut<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.0.as_slice(), fmt)
     }
 }
 
-impl<'a> IoVecMut<'a> {
-    /// Creates a new `IoVecMut` wrapping a byte slice.
+impl<'a> IoSliceMut<'a> {
+    /// Creates a new `IoSliceMut` wrapping a byte slice.
     ///
     /// # Panics
     ///
     /// Panics on Windows if the slice is larger than 4GB.
-    #[unstable(feature = "iovec", issue = "58452")]
+    #[stable(feature = "iovec", since = "1.36.0")]
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut(sys::io::IoVecMut::new(buf))
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(sys::io::IoSliceMut::new(buf))
     }
 }
 
-#[unstable(feature = "iovec", issue = "58452")]
-impl<'a> Deref for IoVecMut<'a> {
+#[stable(feature = "iovec", since = "1.36.0")]
+impl<'a> Deref for IoSliceMut<'a> {
     type Target = [u8];
 
     #[inline]
@@ -945,8 +945,8 @@ impl<'a> Deref for IoVecMut<'a> {
     }
 }
 
-#[unstable(feature = "iovec", issue = "58452")]
-impl<'a> DerefMut for IoVecMut<'a> {
+#[stable(feature = "iovec", since = "1.36.0")]
+impl<'a> DerefMut for IoSliceMut<'a> {
     #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         self.0.as_mut_slice()
@@ -958,32 +958,32 @@ impl<'a> DerefMut for IoVecMut<'a> {
 /// It is semantically a wrapper around an `&[u8]`, but is guaranteed to be
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
-#[unstable(feature = "iovec", issue = "58452")]
+#[stable(feature = "iovec", since = "1.36.0")]
 #[repr(transparent)]
-pub struct IoVec<'a>(sys::io::IoVec<'a>);
+pub struct IoSlice<'a>(sys::io::IoSlice<'a>);
 
-#[unstable(feature = "iovec", issue = "58452")]
-impl<'a> fmt::Debug for IoVec<'a> {
+#[stable(feature = "iovec", since = "1.36.0")]
+impl<'a> fmt::Debug for IoSlice<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.0.as_slice(), fmt)
     }
 }
 
-impl<'a> IoVec<'a> {
-    /// Creates a new `IoVec` wrapping a byte slice.
+impl<'a> IoSlice<'a> {
+    /// Creates a new `IoSlice` wrapping a byte slice.
     ///
     /// # Panics
     ///
     /// Panics on Windows if the slice is larger than 4GB.
-    #[unstable(feature = "iovec", issue = "58452")]
+    #[stable(feature = "iovec", since = "1.36.0")]
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec(sys::io::IoVec::new(buf))
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(sys::io::IoSlice::new(buf))
     }
 }
 
-#[unstable(feature = "iovec", issue = "58452")]
-impl<'a> Deref for IoVec<'a> {
+#[stable(feature = "iovec", since = "1.36.0")]
+impl<'a> Deref for IoSlice<'a> {
     type Target = [u8];
 
     #[inline]
@@ -1141,8 +1141,8 @@ pub trait Write {
     ///
     /// The default implementation calls `write` with either the first nonempty
     /// buffer provided, or an empty one if none exists.
-    #[unstable(feature = "iovec", issue = "58452")]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> Result<usize> {
+    #[stable(feature = "iovec", since = "1.36.0")]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> Result<usize> {
         default_write_vectored(|b| self.write(b), bufs)
     }
 
@@ -1926,7 +1926,7 @@ impl<T: Read, U: Read> Read for Chain<T, U> {
         self.second.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> Result<usize> {
         if !self.done_first {
             match self.first.read_vectored(bufs)? {
                 0 if bufs.iter().any(|b| !b.is_empty()) => self.done_first = true,

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -1,7 +1,7 @@
 #![allow(missing_copy_implementations)]
 
 use crate::fmt;
-use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoVec, IoVecMut};
+use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoSlice, IoSliceMut};
 use crate::mem;
 
 /// Copies the entire contents of a reader into a writer.
@@ -153,7 +153,7 @@ impl Read for Repeat {
     }
 
     #[inline]
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let mut nwritten = 0;
         for buf in bufs {
             nwritten += self.read(buf)?;
@@ -206,7 +206,7 @@ impl Write for Sink {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { Ok(buf.len()) }
 
     #[inline]
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let total_len = bufs.iter().map(|b| b.len()).sum();
         Ok(total_len)
     }

--- a/src/libstd/net/tcp.rs
+++ b/src/libstd/net/tcp.rs
@@ -1,7 +1,7 @@
 use crate::io::prelude::*;
 
 use crate::fmt;
-use crate::io::{self, Initializer, IoVec, IoVecMut};
+use crate::io::{self, Initializer, IoSlice, IoSliceMut};
 use crate::net::{ToSocketAddrs, SocketAddr, Shutdown};
 use crate::sys_common::net as net_imp;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -569,7 +569,7 @@ impl TcpStream {
 impl Read for TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -582,7 +582,7 @@ impl Read for TcpStream {
 impl Write for TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 
@@ -592,7 +592,7 @@ impl Write for TcpStream {
 impl Read for &TcpStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { self.0.read(buf) }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -605,7 +605,7 @@ impl Read for &TcpStream {
 impl Write for &TcpStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> { self.0.write(buf) }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 
@@ -930,7 +930,7 @@ impl fmt::Debug for TcpListener {
 #[cfg(all(test, not(any(target_os = "cloudabi", target_os = "emscripten"))))]
 mod tests {
     use crate::fmt;
-    use crate::io::{ErrorKind, IoVec, IoVecMut};
+    use crate::io::{ErrorKind, IoSlice, IoSliceMut};
     use crate::io::prelude::*;
     use crate::net::*;
     use crate::net::test::{next_test_ip4, next_test_ip6};
@@ -1216,7 +1216,7 @@ mod tests {
             let mut b = [0];
             let mut c = [0; 3];
             let len = t!(s2.read_vectored(
-                &mut [IoVecMut::new(&mut a), IoVecMut::new(&mut b), IoVecMut::new(&mut c)],
+                &mut [IoSliceMut::new(&mut a), IoSliceMut::new(&mut b), IoSliceMut::new(&mut c)],
             ));
             assert!(len > 0);
             assert_eq!(b, [10]);
@@ -1235,7 +1235,7 @@ mod tests {
             let a = [];
             let b = [10];
             let c = [11, 12];
-            t!(s1.write_vectored(&[IoVec::new(&a), IoVec::new(&b), IoVec::new(&c)]));
+            t!(s1.write_vectored(&[IoSlice::new(&a), IoSlice::new(&b), IoSlice::new(&c)]));
 
             let mut buf = [0; 4];
             let len = t!(s2.read(&mut buf));

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -111,7 +111,7 @@ use crate::io::prelude::*;
 use crate::ffi::OsStr;
 use crate::fmt;
 use crate::fs;
-use crate::io::{self, Initializer, IoVec, IoVecMut};
+use crate::io::{self, Initializer, IoSlice, IoSliceMut};
 use crate::path::Path;
 use crate::str;
 use crate::sys::pipe::{read2, AnonPipe};
@@ -225,7 +225,7 @@ impl Write for ChildStdin {
         self.inner.write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
 
@@ -276,7 +276,7 @@ impl Read for ChildStdout {
         self.inner.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 
@@ -328,7 +328,7 @@ impl Read for ChildStderr {
         self.inner.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 

--- a/src/libstd/sys/cloudabi/io.rs
+++ b/src/libstd/sys/cloudabi/io.rs
@@ -1,9 +1,9 @@
-pub struct IoVec<'a>(&'a [u8]);
+pub struct IoSlice<'a>(&'a [u8]);
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec(buf)
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
     }
 
     #[inline]
@@ -12,12 +12,12 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a>(&'a mut [u8]);
+pub struct IoSliceMut<'a>(&'a mut [u8]);
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut(buf)
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
     }
 
     #[inline]

--- a/src/libstd/sys/cloudabi/shims/fs.rs
+++ b/src/libstd/sys/cloudabi/shims/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};
@@ -198,7 +198,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -206,7 +206,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/net.rs
+++ b/src/libstd/sys/cloudabi/shims/net.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::time::Duration;
 use crate::sys::{unsupported, Void};
@@ -43,7 +43,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -51,7 +51,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/cloudabi/shims/pipe.rs
+++ b/src/libstd/sys/cloudabi/shims/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::Void;
 
 pub struct AnonPipe(Void);
@@ -8,7 +8,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -16,7 +16,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/redox/fs.rs
+++ b/src/libstd/sys/redox/fs.rs
@@ -2,7 +2,7 @@ use crate::os::unix::prelude::*;
 
 use crate::ffi::{OsString, OsStr};
 use crate::fmt;
-use crate::io::{self, Error, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, Error, SeekFrom, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
 use crate::sync::Arc;
 use crate::sys::fd::FileDesc;
@@ -278,7 +278,7 @@ impl File {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         crate::io::default_read_vectored(|buf| self.read(buf), bufs)
     }
 
@@ -286,7 +286,7 @@ impl File {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         crate::io::default_write_vectored(|buf| self.write(buf), bufs)
     }
 

--- a/src/libstd/sys/redox/io.rs
+++ b/src/libstd/sys/redox/io.rs
@@ -1,9 +1,9 @@
-pub struct IoVec<'a>(&'a [u8]);
+pub struct IoSlice<'a>(&'a [u8]);
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec(buf)
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
     }
 
     #[inline]
@@ -12,12 +12,12 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a>(&'a mut [u8]);
+pub struct IoSliceMut<'a>(&'a mut [u8]);
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut(buf)
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
     }
 
     #[inline]

--- a/src/libstd/sys/redox/net/tcp.rs
+++ b/src/libstd/sys/redox/net/tcp.rs
@@ -1,5 +1,5 @@
 use crate::cmp;
-use crate::io::{self, Error, ErrorKind, Result, IoVec, IoVecMut};
+use crate::io::{self, Error, ErrorKind, Result, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::net::{SocketAddr, Shutdown};
 use crate::path::Path;
@@ -34,7 +34,7 @@ impl TcpStream {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         io::default_read_vectored(|b| self.read(b), bufs)
     }
 
@@ -42,7 +42,7 @@ impl TcpStream {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         io::default_write_vectored(|b| self.write(b), bufs)
     }
 

--- a/src/libstd/sys/redox/pipe.rs
+++ b/src/libstd/sys/redox/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::{cvt, syscall};
 use crate::sys::fd::FileDesc;
 
@@ -24,7 +24,7 @@ impl AnonPipe {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         crate::io::default_read_vectored(|buf| self.read(buf), bufs)
     }
 
@@ -32,7 +32,7 @@ impl AnonPipe {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         crate::io::default_write_vectored(|buf| self.write(buf), bufs)
     }
 

--- a/src/libstd/sys/sgx/fs.rs
+++ b/src/libstd/sys/sgx/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};
@@ -200,7 +200,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -208,7 +208,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/sgx/io.rs
+++ b/src/libstd/sys/sgx/io.rs
@@ -1,9 +1,9 @@
-pub struct IoVec<'a>(&'a [u8]);
+pub struct IoSlice<'a>(&'a [u8]);
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec(buf)
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
     }
 
     #[inline]
@@ -12,12 +12,12 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a>(&'a mut [u8]);
+pub struct IoSliceMut<'a>(&'a mut [u8]);
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut(buf)
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
     }
 
     #[inline]

--- a/src/libstd/sys/sgx/net.rs
+++ b/src/libstd/sys/sgx/net.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 use crate::time::Duration;
 use crate::sys::{unsupported, Void, sgx_ineffective, AsInner, FromInner, IntoInner, TryIntoInner};
@@ -136,7 +136,7 @@ impl TcpStream {
         self.inner.inner.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         io::default_read_vectored(|b| self.read(b), bufs)
     }
 
@@ -144,7 +144,7 @@ impl TcpStream {
         self.inner.inner.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         io::default_write_vectored(|b| self.write(b), bufs)
     }
 

--- a/src/libstd/sys/sgx/pipe.rs
+++ b/src/libstd/sys/sgx/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::Void;
 
 pub struct AnonPipe(Void);
@@ -8,7 +8,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -16,7 +16,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/unix/ext/net.rs
+++ b/src/libstd/sys/unix/ext/net.rs
@@ -18,7 +18,7 @@ mod libc {
 use crate::ascii;
 use crate::ffi::OsStr;
 use crate::fmt;
-use crate::io::{self, Initializer, IoVec, IoVecMut};
+use crate::io::{self, Initializer, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::net::{self, Shutdown};
 use crate::os::unix::ffi::OsStrExt;
@@ -551,7 +551,7 @@ impl io::Read for UnixStream {
         io::Read::read(&mut &*self, buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         io::Read::read_vectored(&mut &*self, bufs)
     }
 
@@ -567,7 +567,7 @@ impl<'a> io::Read for &'a UnixStream {
         self.0.read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -583,7 +583,7 @@ impl io::Write for UnixStream {
         io::Write::write(&mut &*self, buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         io::Write::write_vectored(&mut &*self, bufs)
     }
 
@@ -598,7 +598,7 @@ impl<'a> io::Write for &'a UnixStream {
         self.0.write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 
@@ -1531,14 +1531,14 @@ mod test {
         let (mut s1, mut s2) = or_panic!(UnixStream::pair());
 
         let len = or_panic!(s1.write_vectored(
-            &[IoVec::new(b"hello"), IoVec::new(b" "), IoVec::new(b"world!")],
+            &[IoSlice::new(b"hello"), IoSlice::new(b" "), IoSlice::new(b"world!")],
         ));
         assert_eq!(len, 12);
 
         let mut buf1 = [0; 6];
         let mut buf2 = [0; 7];
         let len = or_panic!(s2.read_vectored(
-            &mut [IoVecMut::new(&mut buf1), IoVecMut::new(&mut buf2)],
+            &mut [IoSliceMut::new(&mut buf1), IoSliceMut::new(&mut buf2)],
         ));
         assert_eq!(len, 12);
         assert_eq!(&buf1, b"hello ");

--- a/src/libstd/sys/unix/fd.rs
+++ b/src/libstd/sys/unix/fd.rs
@@ -1,7 +1,7 @@
 #![unstable(reason = "not public", issue = "0", feature = "fd")]
 
 use crate::cmp;
-use crate::io::{self, Read, Initializer, IoVec, IoVecMut};
+use crate::io::{self, Read, Initializer, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::cvt;
@@ -53,7 +53,7 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         let ret = cvt(unsafe {
             libc::readv(self.fd,
                         bufs.as_ptr() as *const libc::iovec,
@@ -115,7 +115,7 @@ impl FileDesc {
         Ok(ret as usize)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let ret = cvt(unsafe {
             libc::writev(self.fd,
                          bufs.as_ptr() as *const libc::iovec,

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -2,7 +2,7 @@ use crate::os::unix::prelude::*;
 
 use crate::ffi::{CString, CStr, OsString, OsStr};
 use crate::fmt;
-use crate::io::{self, Error, ErrorKind, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, Error, ErrorKind, SeekFrom, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::path::{Path, PathBuf};
 use crate::ptr;
@@ -567,7 +567,7 @@ impl File {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -579,7 +579,7 @@ impl File {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 

--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -4,15 +4,15 @@ use crate::slice;
 use libc::{iovec, c_void};
 
 #[repr(transparent)]
-pub struct IoVec<'a> {
+pub struct IoSlice<'a> {
     vec: iovec,
     _p: PhantomData<&'a [u8]>,
 }
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec {
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice {
             vec: iovec {
                 iov_base: buf.as_ptr() as *mut u8 as *mut c_void,
                 iov_len: buf.len()
@@ -29,15 +29,15 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a> {
+pub struct IoSliceMut<'a> {
     vec: iovec,
     _p: PhantomData<&'a mut [u8]>,
 }
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut {
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut {
             vec: iovec {
                 iov_base: buf.as_mut_ptr() as *mut c_void,
                 iov_len: buf.len()

--- a/src/libstd/sys/unix/l4re.rs
+++ b/src/libstd/sys/unix/l4re.rs
@@ -5,7 +5,7 @@ macro_rules! unimpl {
 pub mod net {
     #![allow(warnings)]
     use crate::fmt;
-    use crate::io::{self, IoVec, IoVecMut};
+    use crate::io::{self, IoSlice, IoSliceMut};
     use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
     use crate::sys_common::{AsInner, FromInner, IntoInner};
     use crate::sys::fd::FileDesc;
@@ -46,7 +46,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 
@@ -66,7 +66,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
+        pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 
@@ -152,7 +152,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+        pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 
@@ -160,7 +160,7 @@ pub mod net {
             unimpl!();
         }
 
-        pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
+        pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
             unimpl!();
         }
 

--- a/src/libstd/sys/unix/net.rs
+++ b/src/libstd/sys/unix/net.rs
@@ -1,5 +1,5 @@
 use crate::ffi::CStr;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::net::{SocketAddr, Shutdown};
 use crate::str;
@@ -244,7 +244,7 @@ impl Socket {
         self.recv_with_flags(buf, MSG_PEEK)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -276,7 +276,7 @@ impl Socket {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 

--- a/src/libstd/sys/unix/pipe.rs
+++ b/src/libstd/sys/unix/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::fd::FileDesc;
@@ -60,7 +60,7 @@ impl AnonPipe {
         self.0.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
 
@@ -68,7 +68,7 @@ impl AnonPipe {
         self.0.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.0.write_vectored(bufs)
     }
 

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::fd::FileDesc;
 use crate::mem::ManuallyDrop;
 
@@ -15,7 +15,7 @@ impl io::Read for Stdin {
         ManuallyDrop::new(FileDesc::new(libc::STDIN_FILENO)).read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDIN_FILENO)).read_vectored(bufs)
     }
 }
@@ -29,7 +29,7 @@ impl io::Write for Stdout {
         ManuallyDrop::new(FileDesc::new(libc::STDOUT_FILENO)).write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDOUT_FILENO)).write_vectored(bufs)
     }
 
@@ -47,7 +47,7 @@ impl io::Write for Stderr {
         ManuallyDrop::new(FileDesc::new(libc::STDERR_FILENO)).write(buf)
     }
 
-    fn write_vectored(&mut self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(FileDesc::new(libc::STDERR_FILENO)).write_vectored(bufs)
     }
 

--- a/src/libstd/sys/wasi/ext/fs.rs
+++ b/src/libstd/sys/wasi/ext/fs.rs
@@ -3,7 +3,7 @@
 #![unstable(feature = "wasi_ext", issue = "0")]
 
 use crate::fs::{self, File, Metadata, OpenOptions};
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::os::wasi::ffi::OsStrExt;
 use crate::path::{Path, PathBuf};
 use crate::sys_common::{AsInner, AsInnerMut, FromInner};
@@ -25,7 +25,7 @@ pub trait FileExt {
     /// return with a short read.
     ///
     /// [`File::read`]: ../../../../std/fs/struct.File.html#method.read_vectored
-    fn read_at(&self, bufs: &mut [IoVecMut<'_>], offset: u64) -> io::Result<usize>;
+    fn read_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize>;
 
     /// Writes a number of bytes starting from a given offset.
     ///
@@ -43,7 +43,7 @@ pub trait FileExt {
     /// short write.
     ///
     /// [`File::write`]: ../../../../std/fs/struct.File.html#method.write_vectored
-    fn write_at(&self, bufs: &[IoVec<'_>], offset: u64) -> io::Result<usize>;
+    fn write_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize>;
 
     /// Returns the current position within the file.
     ///
@@ -105,11 +105,11 @@ pub trait FileExt {
 // FIXME: bind __wasi_random_get maybe? - on crates.io for unix
 
 impl FileExt for fs::File {
-    fn read_at(&self, bufs: &mut [IoVecMut<'_>], offset: u64) -> io::Result<usize> {
+    fn read_at(&self, bufs: &mut [IoSliceMut<'_>], offset: u64) -> io::Result<usize> {
         self.as_inner().fd().pread(bufs, offset)
     }
 
-    fn write_at(&self, bufs: &[IoVec<'_>], offset: u64) -> io::Result<usize> {
+    fn write_at(&self, bufs: &[IoSlice<'_>], offset: u64) -> io::Result<usize> {
         self.as_inner().fd().pwrite(bufs, offset)
     }
 

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -1,6 +1,6 @@
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
-use crate::io::{self, IoVec, IoVecMut, SeekFrom};
+use crate::io::{self, IoSlice, IoSliceMut, SeekFrom};
 use crate::iter;
 use crate::mem::{self, ManuallyDrop};
 use crate::os::wasi::ffi::{OsStrExt, OsStringExt};
@@ -414,18 +414,18 @@ impl File {
     }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.read_vectored(&mut [IoVecMut::new(buf)])
+        self.read_vectored(&mut [IoSliceMut::new(buf)])
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.fd.read(bufs)
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        self.write_vectored(&[IoVec::new(buf)])
+        self.write_vectored(&[IoSlice::new(buf)])
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.fd.write(bufs)
     }
 

--- a/src/libstd/sys/wasi/io.rs
+++ b/src/libstd/sys/wasi/io.rs
@@ -4,15 +4,15 @@ use crate::slice;
 use libc::{__wasi_ciovec_t, __wasi_iovec_t, c_void};
 
 #[repr(transparent)]
-pub struct IoVec<'a> {
+pub struct IoSlice<'a> {
     vec: __wasi_ciovec_t,
     _p: PhantomData<&'a [u8]>,
 }
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec {
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice {
             vec: __wasi_ciovec_t {
                 buf: buf.as_ptr() as *const c_void,
                 buf_len: buf.len(),
@@ -29,15 +29,15 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a> {
+pub struct IoSliceMut<'a> {
     vec: __wasi_iovec_t,
     _p: PhantomData<&'a mut [u8]>,
 }
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut {
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut {
             vec: __wasi_iovec_t {
                 buf: buf.as_mut_ptr() as *mut c_void,
                 buf_len: buf.len()

--- a/src/libstd/sys/wasi/net.rs
+++ b/src/libstd/sys/wasi/net.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
 use crate::time::Duration;
 use crate::sys::{unsupported, Void};
@@ -44,7 +44,7 @@ impl TcpStream {
         unsupported()
     }
 
-    pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         unsupported()
     }
 
@@ -52,7 +52,7 @@ impl TcpStream {
         unsupported()
     }
 
-    pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
         unsupported()
     }
 

--- a/src/libstd/sys/wasi/pipe.rs
+++ b/src/libstd/sys/wasi/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::Void;
 
 pub struct AnonPipe(Void);
@@ -8,7 +8,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -16,7 +16,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::libc;
 use crate::mem::ManuallyDrop;
 use crate::sys::fd::WasiFd;
@@ -13,10 +13,10 @@ impl Stdin {
     }
 
     pub fn read(&self, data: &mut [u8]) -> io::Result<usize> {
-        self.read_vectored(&mut [IoVecMut::new(data)])
+        self.read_vectored(&mut [IoSliceMut::new(data)])
     }
 
-    pub fn read_vectored(&self, data: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, data: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(libc::STDIN_FILENO as u32) })
             .read(data)
     }
@@ -28,10 +28,10 @@ impl Stdout {
     }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
-        self.write_vectored(&[IoVec::new(data)])
+        self.write_vectored(&[IoSlice::new(data)])
     }
 
-    pub fn write_vectored(&self, data: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(libc::STDOUT_FILENO as u32) })
             .write(data)
     }
@@ -47,10 +47,10 @@ impl Stderr {
     }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
-        self.write_vectored(&[IoVec::new(data)])
+        self.write_vectored(&[IoSlice::new(data)])
     }
 
-    pub fn write_vectored(&self, data: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, data: &[IoSlice<'_>]) -> io::Result<usize> {
         ManuallyDrop::new(unsafe { WasiFd::from_raw(libc::STDERR_FILENO as u32) })
             .write(data)
     }

--- a/src/libstd/sys/wasm/fs.rs
+++ b/src/libstd/sys/wasm/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, SeekFrom, IoSlice, IoSliceMut};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::{unsupported, Void};
@@ -200,7 +200,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -208,7 +208,7 @@ impl File {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/io.rs
+++ b/src/libstd/sys/wasm/io.rs
@@ -1,9 +1,9 @@
-pub struct IoVec<'a>(&'a [u8]);
+pub struct IoSlice<'a>(&'a [u8]);
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
-        IoVec(buf)
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
+        IoSlice(buf)
     }
 
     #[inline]
@@ -12,12 +12,12 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a>(&'a mut [u8]);
+pub struct IoSliceMut<'a>(&'a mut [u8]);
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
-        IoVecMut(buf)
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
+        IoSliceMut(buf)
     }
 
     #[inline]

--- a/src/libstd/sys/wasm/net.rs
+++ b/src/libstd/sys/wasm/net.rs
@@ -1,5 +1,5 @@
 use crate::fmt;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
 use crate::time::Duration;
 use crate::sys::{unsupported, Void};
@@ -40,7 +40,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -48,7 +48,7 @@ impl TcpStream {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/wasm/pipe.rs
+++ b/src/libstd/sys/wasm/pipe.rs
@@ -1,4 +1,4 @@
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::sys::Void;
 
 pub struct AnonPipe(Void);
@@ -8,7 +8,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn read_vectored(&self, _bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, _bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 
@@ -16,7 +16,7 @@ impl AnonPipe {
         match self.0 {}
     }
 
-    pub fn write_vectored(&self, _bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, _bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         match self.0 {}
     }
 

--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -2,7 +2,7 @@ use crate::os::windows::prelude::*;
 
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::io::{self, Error, SeekFrom, IoVec, IoVecMut};
+use crate::io::{self, Error, SeekFrom, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::path::{Path, PathBuf};
 use crate::ptr;
@@ -314,7 +314,7 @@ impl File {
         self.handle.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.handle.read_vectored(bufs)
     }
 
@@ -326,7 +326,7 @@ impl File {
         self.handle.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.handle.write_vectored(bufs)
     }
 

--- a/src/libstd/sys/windows/handle.rs
+++ b/src/libstd/sys/windows/handle.rs
@@ -1,7 +1,7 @@
 #![unstable(issue = "0", feature = "windows_handle")]
 
 use crate::cmp;
-use crate::io::{self, ErrorKind, Read, IoVec, IoVecMut};
+use crate::io::{self, ErrorKind, Read, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::ops::Deref;
 use crate::ptr;
@@ -89,7 +89,7 @@ impl RawHandle {
         }
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         crate::io::default_read_vectored(|buf| self.read(buf), bufs)
     }
 
@@ -173,7 +173,7 @@ impl RawHandle {
         Ok(amt as usize)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         crate::io::default_write_vectored(|buf| self.write(buf), bufs)
     }
 
@@ -208,7 +208,7 @@ impl<'a> Read for &'a RawHandle {
         (**self).read(buf)
     }
 
-    fn read_vectored(&mut self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         (**self).read_vectored(bufs)
     }
 }

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -3,16 +3,16 @@ use crate::slice;
 use crate::sys::c;
 
 #[repr(transparent)]
-pub struct IoVec<'a> {
+pub struct IoSlice<'a> {
     vec: c::WSABUF,
     _p: PhantomData<&'a [u8]>,
 }
 
-impl<'a> IoVec<'a> {
+impl<'a> IoSlice<'a> {
     #[inline]
-    pub fn new(buf: &'a [u8]) -> IoVec<'a> {
+    pub fn new(buf: &'a [u8]) -> IoSlice<'a> {
         assert!(buf.len() <= c::ULONG::max_value() as usize);
-        IoVec {
+        IoSlice {
             vec: c::WSABUF {
                 len: buf.len() as c::ULONG,
                 buf: buf.as_ptr() as *mut u8 as *mut c::CHAR,
@@ -29,16 +29,16 @@ impl<'a> IoVec<'a> {
     }
 }
 
-pub struct IoVecMut<'a> {
+pub struct IoSliceMut<'a> {
     vec: c::WSABUF,
     _p: PhantomData<&'a mut [u8]>,
 }
 
-impl<'a> IoVecMut<'a> {
+impl<'a> IoSliceMut<'a> {
     #[inline]
-    pub fn new(buf: &'a mut [u8]) -> IoVecMut<'a> {
+    pub fn new(buf: &'a mut [u8]) -> IoSliceMut<'a> {
         assert!(buf.len() <= c::ULONG::max_value() as usize);
-        IoVecMut {
+        IoSliceMut {
             vec: c::WSABUF {
                 len: buf.len() as c::ULONG,
                 buf: buf.as_mut_ptr() as *mut c::CHAR,

--- a/src/libstd/sys/windows/net.rs
+++ b/src/libstd/sys/windows/net.rs
@@ -1,7 +1,7 @@
 #![unstable(issue = "0", feature = "windows_net")]
 
 use crate::cmp;
-use crate::io::{self, Read, IoVec, IoVecMut};
+use crate::io::{self, Read, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::net::{SocketAddr, Shutdown};
 use crate::ptr;
@@ -208,7 +208,7 @@ impl Socket {
         self.recv_with_flags(buf, 0)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         // On unix when a socket is shut down all further reads return 0, so we
         // do the same on windows to map a shut down socket to returning EOF.
         let len = cmp::min(bufs.len(), c::DWORD::max_value() as usize) as c::DWORD;
@@ -268,7 +268,7 @@ impl Socket {
         self.recv_from_with_flags(buf, c::MSG_PEEK)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         let len = cmp::min(bufs.len(), c::DWORD::max_value() as usize) as c::DWORD;
         let mut nwritten = 0;
         unsafe {

--- a/src/libstd/sys/windows/pipe.rs
+++ b/src/libstd/sys/windows/pipe.rs
@@ -1,7 +1,7 @@
 use crate::os::windows::prelude::*;
 
 use crate::ffi::OsStr;
-use crate::io::{self, IoVec, IoVecMut};
+use crate::io::{self, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::path::Path;
 use crate::ptr;
@@ -166,7 +166,7 @@ impl AnonPipe {
         self.inner.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 
@@ -174,7 +174,7 @@ impl AnonPipe {
         self.inner.write(buf)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
 }

--- a/src/libstd/sys_common/net.rs
+++ b/src/libstd/sys_common/net.rs
@@ -1,7 +1,7 @@
 use crate::cmp;
 use crate::ffi::CString;
 use crate::fmt;
-use crate::io::{self, Error, ErrorKind, IoVec, IoVecMut};
+use crate::io::{self, Error, ErrorKind, IoSlice, IoSliceMut};
 use crate::mem;
 use crate::net::{SocketAddr, Shutdown, Ipv4Addr, Ipv6Addr};
 use crate::ptr;
@@ -256,7 +256,7 @@ impl TcpStream {
         self.inner.read(buf)
     }
 
-    pub fn read_vectored(&self, bufs: &mut [IoVecMut<'_>]) -> io::Result<usize> {
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.inner.read_vectored(bufs)
     }
 
@@ -271,7 +271,7 @@ impl TcpStream {
         Ok(ret as usize)
     }
 
-    pub fn write_vectored(&self, bufs: &[IoVec<'_>]) -> io::Result<usize> {
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
         self.inner.write_vectored(bufs)
     }
 

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -135,8 +135,8 @@ fn check(cache: &mut Cache,
        file.ends_with("ty/struct.Slice.html") ||
        file.ends_with("ty/enum.Attributes.html") ||
        file.ends_with("ty/struct.SymbolName.html") ||
-       file.ends_with("io/struct.IoVec.html") ||
-       file.ends_with("io/struct.IoVecMut.html") {
+       file.ends_with("io/struct.IoSlice.html") ||
+       file.ends_with("io/struct.IoSliceMut.html") {
         return None;
     }
     // FIXME(#32553)


### PR DESCRIPTION
This renames `std::io::IoVec` to `std::io::IoSlice` and
`std::io::IoVecMut` to `std::io::IoSliceMut`, and stabilizes
`std::io::IoSlice`, `std::io::IoSliceMut`,
`std::io::Read::read_vectored`, and `std::io::Write::write_vectored`.

Closes #58452

r? @alexcrichton 