### PR TITLE
tidy: Fix some more false positives for long URLs

### DIFF
--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -1,5 +1,3 @@
-# ignore-tidy-linelength
-
 set -ex
 
 curl -fo /usr/local/bin/sccache \

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 #![allow(non_snake_case)]
 
 // Error messages for EXXXX errors.

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-linelength
 // ignore-tidy-filelength
 
 #![allow(non_snake_case)]


### PR DESCRIPTION
A URL that's simply longer than 100 characters is ok regardless of context.

r? @varkor 