### PR TITLE
Don't try to render auto-trait bounds with any inference variables

### DIFF
--- a/src/librustc/traits/auto_trait.rs
+++ b/src/librustc/traits/auto_trait.rs
@@ -712,7 +712,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                     // Additionally, we check if we've seen this predicate before,
                     // to avoid rendering duplicate bounds to the user.
                     if self.is_param_no_infer(p.skip_binder().projection_ty.substs)
-                        && !p.ty().skip_binder().is_ty_infer()
+                        && !p.ty().skip_binder().has_infer_types()
                         && is_new_pred {
                             debug!("evaluate_nested_obligations: adding projection predicate\
                             to computed_preds: {:?}", predicate);

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2945,6 +2945,7 @@ impl Clean<Type> for hir::Ty {
 
 impl<'tcx> Clean<Type> for Ty<'tcx> {
     fn clean(&self, cx: &DocContext<'_>) -> Type {
+        debug!("cleaning type: {:?}", self);
         match self.sty {
             ty::Never => Never,
             ty::Bool => Primitive(PrimitiveType::Bool),


### PR DESCRIPTION
Previously, we checked if the target of a projection type was itself an
inference variable. However, for Rustdoc rendering purposes, there's no
distinction between an inference variable ('_') and a type containing
one (e.g. (MyStruct<u8, _>)) - we don't want to render either of them.

Fixes #60269

Due to the complexity of the original bug, which spans three different
crates (hyper, tower-hyper, and tower), I have been unable to create a
minimized reproduction for the issue.