### PR TITLE
Fix default value for setting "Auto-hide item methods' documentation"

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2105,7 +2105,7 @@ if (!DOMTokenList.prototype.remove) {
     }
 
     var toggle = createSimpleToggle(false);
-    var hideMethodDocs = getCurrentValue("rustdoc-method-docs") !== "false";
+    var hideMethodDocs = getCurrentValue("rustdoc-method-docs") === "true";
     var pageId = getPageId();
 
     var func = function(e) {


### PR DESCRIPTION
If I open any documentation page in incognito mode (for example [for `Option` enum](https://doc.rust-lang.org/nightly/std/option/enum.Option.html)), then methods will be collapsed, though [on the settings page](https://doc.rust-lang.org/nightly/settings.html) there will be displayed that "Auto-hide item methods' documentation" option is disabled. 

If I understand correctly, property "Auto-hide item methods' documentation" [should be disabled by default](https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/render.rs#L1969), so correct check would be `property === "true"`. This is consistent with other options:

Options which are enabled by default are compared to `"false"`

https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/render.rs#L1965-L1968

https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/static/main.js#L2238
https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/static/main.js#L2321
https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/static/main.js#L2070

Options which are disabled by default are compared to `"true"`

https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/render.rs#L1970-L1972

https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/static/main.js#L1389
https://github.com/rust-lang/rust/blob/938d4ffe16c4430e1dcede570b06227114cb73d5/src/librustdoc/html/static/main.js#L2334