### PR TITLE
Clarify the short explanation of E0207

### DIFF
--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -1943,9 +1943,11 @@ E0207: r##"
 Any type parameter or lifetime parameter of an `impl` must meet at least one of
 the following criteria:
 
- - it appears in the self type of the impl
- - for a trait impl, it appears in the trait reference
- - it is bound as an associated type
+ - it appears in the _implementing type_ of the impl, e.g. `impl<T> Foo<T>`
+ - for a trait impl, it appears in the _implemented trait_, e.g.
+   `impl<T> SomeTrait<T> for Foo`
+ - it is bound as an associated type, e.g. `impl<T, U> SomeTrait for T
+   where T: AnotherTrait<AssocType=U>`
 
 ### Error example 1
 
@@ -1964,9 +1966,9 @@ impl<T: Default> Foo {
 }
 ```
 
-The problem is that the parameter `T` does not appear in the self type (`Foo`)
-of the impl. In this case, we can fix the error by moving the type parameter
-from the `impl` to the method `get`:
+The problem is that the parameter `T` does not appear in the implementing type
+(`Foo`) of the impl. In this case, we can fix the error by moving the type
+parameter from the `impl` to the method `get`:
 
 
 ```


### PR DESCRIPTION
After being greatly improved in #33692, https://doc.rust-lang.org/error-index.html#E0207 uses terminology from the related RFC, which is different from the [reference](https://doc.rust-lang.org/reference/items/implementations.html), e.g. "self type" instead of "implementing type" and "trait reference" instead of "implemented trait".

It probably makes no difference to an experienced reader, but for a newbie like me it added to the confusion as you can't look up the definition of the terms being used and can't be sure you've guessed correctly...

I would also move the link to RFC to the top, as it seems to be the only doc that attempts to explain what the third criteria entails), but it seems to go against the accepted style.