### PR TITLE
resolve: Consider erroneous imports used to avoid duplicate diagnostics

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -627,6 +627,8 @@ impl<'a> Resolver<'a> {
             let dummy_binding = self.import(dummy_binding, directive);
             self.per_ns(|this, ns| {
                 let _ = this.try_define(directive.parent_scope.module, target, ns, dummy_binding);
+                // Consider erroneous imports used to avoid duplicate diagnostics.
+                this.record_use(target, ns, dummy_binding, false);
             });
         }
     }

--- a/src/test/ui/imports/unresolved-imports-used.rs
+++ b/src/test/ui/imports/unresolved-imports-used.rs
@@ -1,0 +1,12 @@
+// There should be *no* unused import errors.
+#![deny(unused_imports)]
+
+mod qux {
+   fn quz() {}
+}
+
+use qux::quz; //~ ERROR function `quz` is private
+use qux::bar; //~ ERROR unresolved import `qux::bar`
+use foo::bar; //~ ERROR unresolved import `foo`
+
+fn main() {}

--- a/src/test/ui/imports/unresolved-imports-used.stderr
+++ b/src/test/ui/imports/unresolved-imports-used.stderr
@@ -1,0 +1,22 @@
+error[E0432]: unresolved import `qux::bar`
+  --> $DIR/unresolved-imports-used.rs:9:5
+   |
+LL | use qux::bar;
+   |     ^^^^^^^^ no `bar` in `qux`
+
+error[E0432]: unresolved import `foo`
+  --> $DIR/unresolved-imports-used.rs:10:5
+   |
+LL | use foo::bar;
+   |     ^^^ maybe a missing `extern crate foo;`?
+
+error[E0603]: function `quz` is private
+  --> $DIR/unresolved-imports-used.rs:8:10
+   |
+LL | use qux::quz;
+   |          ^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0432, E0603.
+For more information about an error, try `rustc --explain E0432`.


### PR DESCRIPTION
Supersedes https://github.com/rust-lang/rust/pull/60295
Fixes https://github.com/rust-lang/rust/issues/48244
r? @estebank 