### PR TITLE
build-gcc: Create missing cc symlink

### DIFF
--- a/src/ci/docker/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-gcc.sh
@@ -32,6 +32,7 @@ hide_output ../gcc-$GCC/configure \
     --enable-languages=c,c++
 hide_output make -j10
 hide_output make install
+ln -s gcc /rustroot/bin/cc
 
 cd ..
 rm -rf gcc-build


### PR DESCRIPTION
This PR mostly fixes build error caused by using rustc docker images
to build [rustup][1] (with the error: ``linker `cc` not found``).

I don't know why gcc build script doesn't install cc hard link by default.
In build log, with `make SHELL='sh -x' install`, gcc build script installs c++ 
hard link but not `cc` one:

```bash
if test "" != "yes" ; then \
  rm -f /rustroot/bin/g++; \
  /usr/bin/install -c xg++ /rustroot/bin/g++; \
  chmod a+x /rustroot/bin/g++; \
  rm -f /rustroot/bin/c++; \
  ( cd /rustroot/bin && \
    ln g++ c++ ); \
  if [ -f cc1plus ] ; then \
    if [ ! -f g++-cross ] ; then \
      rm -f /rustroot/bin/x86_64-unknown-linux-gnu-g++; \
      ( cd /rustroot/bin && \
        ln g++ x86_64-unknown-linux-gnu-g++ ); \
      rm -f /rustroot/bin/x86_64-unknown-linux-gnu-c++; \
      ( cd /rustroot/bin && \
        ln c++ x86_64-unknown-linux-gnu-c++ ); \
    fi ; \
  fi; \
fi
```

This might be fixed downstream by manually creating cc hard link
or setting `RUSTFLAGS="-C linker=gcc"` as [suggested by @mati865][2].
But I find it better to fix it upstream in this PR.

[1]: https://github.com/rust-lang/rustup.rs/pull/1815
[2]: https://github.com/rust-lang/rustup.rs/pull/1815#discussion_r279192797
