### PR TITLE
Tidy: ensure lang features are sorted by since

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/libstd/sys/redox/ext/net.rs
+++ b/src/libstd/sys/redox/ext/net.rs
@@ -1,4 +1,4 @@
-#![stable(feature = "unix_socket_redox", since = "1.29")]
+#![stable(feature = "unix_socket_redox", since = "1.29.0")]
 
 //! Unix-specific networking functionality
 
@@ -27,7 +27,7 @@ use crate::sys::{cvt, fd::FileDesc, syscall};
 /// let addr = socket.local_addr().expect("Couldn't get local address");
 /// ```
 #[derive(Clone)]
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct SocketAddr(());
 
 impl SocketAddr {
@@ -55,7 +55,7 @@ impl SocketAddr {
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.as_pathname(), None);
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn as_pathname(&self) -> Option<&Path> {
         None
     }
@@ -83,12 +83,12 @@ impl SocketAddr {
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.is_unnamed(), true);
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn is_unnamed(&self) -> bool {
         false
     }
 }
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for SocketAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "SocketAddr")
@@ -109,10 +109,10 @@ impl fmt::Debug for SocketAddr {
 /// stream.read_to_string(&mut response).unwrap();
 /// println!("{}", response);
 /// ```
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct UnixStream(FileDesc);
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for UnixStream {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("UnixStream");
@@ -143,7 +143,7 @@ impl UnixStream {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         if let Some(s) = path.as_ref().to_str() {
             cvt(syscall::open(format!("chan:{}", s), syscall::O_CLOEXEC))
@@ -174,7 +174,7 @@ impl UnixStream {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn pair() -> io::Result<(UnixStream, UnixStream)> {
         let server = cvt(syscall::open("chan:", syscall::O_CREAT | syscall::O_CLOEXEC))
             .map(FileDesc::new)?;
@@ -198,7 +198,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let sock_copy = socket.try_clone().expect("Couldn't clone socket");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn try_clone(&self) -> io::Result<UnixStream> {
         self.0.duplicate().map(UnixStream)
     }
@@ -213,7 +213,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixStream::local_addr unimplemented on redox"))
     }
@@ -228,7 +228,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let addr = socket.peer_addr().expect("Couldn't get peer address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixStream::peer_addr unimplemented on redox"))
     }
@@ -267,7 +267,7 @@ impl UnixStream {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_read_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::set_read_timeout unimplemented on redox"))
     }
@@ -306,7 +306,7 @@ impl UnixStream {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_write_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::set_write_timeout unimplemented on redox"))
     }
@@ -323,7 +323,7 @@ impl UnixStream {
     /// socket.set_read_timeout(Some(Duration::new(1, 0))).expect("Couldn't set read timeout");
     /// assert_eq!(socket.read_timeout().unwrap(), Some(Duration::new(1, 0)));
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         Err(Error::new(ErrorKind::Other, "UnixStream::read_timeout unimplemented on redox"))
     }
@@ -340,7 +340,7 @@ impl UnixStream {
     /// socket.set_write_timeout(Some(Duration::new(1, 0))).expect("Couldn't set write timeout");
     /// assert_eq!(socket.write_timeout().unwrap(), Some(Duration::new(1, 0)));
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         Err(Error::new(ErrorKind::Other, "UnixStream::write_timeout unimplemented on redox"))
     }
@@ -355,7 +355,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// socket.set_nonblocking(true).expect("Couldn't set nonblocking");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
     }
@@ -375,7 +375,7 @@ impl UnixStream {
     ///
     /// # Platform specific
     /// On Redox this always returns `None`.
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         Ok(None)
     }
@@ -397,13 +397,13 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// socket.shutdown(Shutdown::Both).expect("shutdown function failed");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn shutdown(&self, _how: Shutdown) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::shutdown unimplemented on redox"))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl io::Read for UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         io::Read::read(&mut &*self, buf)
@@ -415,7 +415,7 @@ impl io::Read for UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> io::Read for &'a UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
@@ -427,7 +427,7 @@ impl<'a> io::Read for &'a UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl io::Write for UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         io::Write::write(&mut &*self, buf)
@@ -438,7 +438,7 @@ impl io::Write for UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> io::Write for &'a UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
@@ -449,21 +449,21 @@ impl<'a> io::Write for &'a UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl AsRawFd for UnixStream {
     fn as_raw_fd(&self) -> RawFd {
         self.0.raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl FromRawFd for UnixStream {
     unsafe fn from_raw_fd(fd: RawFd) -> UnixStream {
         UnixStream(FileDesc::new(fd))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl IntoRawFd for UnixStream {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw()
@@ -498,10 +498,10 @@ impl IntoRawFd for UnixStream {
 ///     }
 /// }
 /// ```
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct UnixListener(FileDesc);
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for UnixListener {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("UnixListener");
@@ -529,7 +529,7 @@ impl UnixListener {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         if let Some(s) = path.as_ref().to_str() {
             cvt(syscall::open(format!("chan:{}", s), syscall::O_CREAT | syscall::O_CLOEXEC))
@@ -563,7 +563,7 @@ impl UnixListener {
     ///     Err(e) => println!("accept function failed: {:?}", e),
     /// }
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         self.0.duplicate_path(b"listen").map(|fd| (UnixStream(fd), SocketAddr(())))
     }
@@ -583,7 +583,7 @@ impl UnixListener {
     ///
     /// let listener_copy = listener.try_clone().expect("try_clone failed");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn try_clone(&self) -> io::Result<UnixListener> {
         self.0.duplicate().map(UnixListener)
     }
@@ -599,7 +599,7 @@ impl UnixListener {
     ///
     /// let addr = listener.local_addr().expect("Couldn't get local address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixListener::local_addr unimplemented on redox"))
     }
@@ -615,7 +615,7 @@ impl UnixListener {
     ///
     /// listener.set_nonblocking(true).expect("Couldn't set non blocking");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
     }
@@ -636,7 +636,7 @@ impl UnixListener {
     ///
     /// # Platform specific
     /// On Redox this always returns `None`.
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         Ok(None)
     }
@@ -672,34 +672,34 @@ impl UnixListener {
     ///     }
     /// }
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn incoming<'a>(&'a self) -> Incoming<'a> {
         Incoming { listener: self }
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl AsRawFd for UnixListener {
     fn as_raw_fd(&self) -> RawFd {
         self.0.raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl FromRawFd for UnixListener {
     unsafe fn from_raw_fd(fd: RawFd) -> UnixListener {
         UnixListener(FileDesc::new(fd))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl IntoRawFd for UnixListener {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> IntoIterator for &'a UnixListener {
     type Item = io::Result<UnixStream>;
     type IntoIter = Incoming<'a>;
@@ -740,12 +740,12 @@ impl<'a> IntoIterator for &'a UnixListener {
 /// }
 /// ```
 #[derive(Debug)]
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct Incoming<'a> {
     listener: &'a UnixListener,
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> Iterator for Incoming<'a> {
     type Item = io::Result<UnixStream>;
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -109,15 +109,14 @@ macro_rules! declare_features {
 // stable (active).
 //
 // Note that the features should be grouped into internal/user-facing
-// and then sorted by version inside those groups.
-// FIXME(60361): Enforce ^-- with tidy.
+// and then sorted by version inside those groups. This is inforced with tidy.
 //
 // N.B., `tools/tidy/src/features.rs` parses this information directly out of the
 // source, so take care when modifying it.
 
 declare_features! (
     // -------------------------------------------------------------------------
-    // Internal feature gates.
+    // feature-group-start: internal feature gates
     // -------------------------------------------------------------------------
 
     // no tracking issue START
@@ -211,11 +210,11 @@ declare_features! (
 
     // no tracking issue END
 
-    // Allows using the `may_dangle` attribute (RFC 1327).
-    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
-
     // Allows using `#[structural_match]` which indicates that a type is structurally matchable.
     (active, structural_match, "1.8.0", Some(31434), None),
+
+    // Allows using the `may_dangle` attribute (RFC 1327).
+    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
 
     // Allows using the `#![panic_runtime]` attribute.
     (active, panic_runtime, "1.10.0", Some(32837), None),
@@ -252,7 +251,11 @@ declare_features! (
     (active, test_2018_feature, "1.31.0", Some(0), Some(Edition::Edition2018)),
 
     // -------------------------------------------------------------------------
-    // Actual feature gates (target features).
+    // feature-group-end: internal feature gates
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // feature-group-start: actual feature gates (target features)
     // -------------------------------------------------------------------------
 
     // FIXME: Document these and merge with the list below.
@@ -275,7 +278,11 @@ declare_features! (
     (active, f16c_target_feature, "1.36.0", Some(44839), None),
 
     // -------------------------------------------------------------------------
-    // Actual feature gates.
+    // feature-group-end: actual feature gates (target features)
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // feature-group-start: actual feature gates
     // -------------------------------------------------------------------------
 
     // Allows using `asm!` macro with which inline assembly can be embedded.
@@ -340,9 +347,6 @@ declare_features! (
     // Permits specifying whether a function should permit unwinding or abort on unwind.
     (active, unwind_attributes, "1.4.0", Some(58760), None),
 
-    // Allows using `#[naked]` on functions.
-    (active, naked_functions, "1.9.0", Some(32408), None),
-
     // Allows `#[no_debug]`.
     (active, no_debug, "1.5.0", Some(29721), None),
 
@@ -357,6 +361,9 @@ declare_features! (
 
     // Allows specialization of implementations (RFC 1210).
     (active, specialization, "1.7.0", Some(31844), None),
+
+    // Allows using `#[naked]` on functions.
+    (active, naked_functions, "1.9.0", Some(32408), None),
 
     // Allows `cfg(target_has_atomic = "...")`.
     (active, cfg_target_has_atomic, "1.9.0", Some(32976), None),
@@ -545,6 +552,10 @@ declare_features! (
 
     // Allows using C-variadics.
     (active, c_variadic, "1.34.0", Some(44930), None),
+
+    // -------------------------------------------------------------------------
+    // feature-group-end: actual feature gates
+    // -------------------------------------------------------------------------
 );
 
 // Some features are known to be incomplete and using them is likely to have

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 
 [dependencies]
+regex = "1"
 serde = "1.0.8"
 serde_derive = "1.0.8"
 serde_json = "1.0.2"

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -147,7 +147,7 @@ pub fn check(path: &Path, bad: &mut bool, quiet: bool) {
     }
 }
 
-fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator<Item=String> + 'a {
+fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator<Item = String> + 'a {
     features.iter().map(move |(name, feature)| {
         format!("{:<32} {:<8} {:<12} {:<8}",
                 name,

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -249,7 +249,7 @@ pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
                 Err(err) => {
                     tidy_error!(
                         bad,
-                        "libsyntax/feature_gate.rs:{}: failed to parse since: {} ({})",
+                        "libsyntax/feature_gate.rs:{}: failed to parse since: {} ({:?})",
                         line_number,
                         since_str,
                         err,

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -153,8 +153,8 @@ fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator
                 name,
                 family,
                 feature.level,
-                feature.since.as_ref().map_or("None".to_owned(),
-                                              |since| since.to_string()))
+                feature.since.map_or("None".to_owned(),
+                                     |since| since.to_string()))
     })
 }
 
@@ -265,7 +265,7 @@ pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
                         name,
                     );
                 }
-                prev_since = since.clone();
+                prev_since = since;
             }
 
             let issue_str = parts.next().unwrap().trim();

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -1,0 +1,66 @@
+use std::str::FromStr;
+use std::num::ParseIntError;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    parts: Vec<u32>,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let x = self.parts.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(".");
+        f.pad(&x)
+    }
+}
+
+impl FromStr for Version {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
+        Ok(Version { parts })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Version;
+
+    #[test]
+    fn test_try_from_invalid_version() {
+        assert!("".parse::<Version>().is_err());
+        assert!("hello".parse::<Version>().is_err());
+        assert!("1.32.hi".parse::<Version>().is_err());
+        assert!("1.32..1".parse::<Version>().is_err());
+    }
+
+    #[test]
+    fn test_try_from_single() {
+        assert_eq!("1.32.0".parse(), Ok(Version { parts: vec![1, 32, 0] }));
+        assert_eq!("1.0.0".parse(), Ok(Version { parts: vec![1, 0, 0] }));
+    }
+
+    #[test]
+    fn test_compare() {
+        let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
+        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
+        assert!(v_1_0_0 < v_1_32_1);
+        assert!(v_1_0_0 < v_1_32);
+        assert!(v_1_32 < v_1_32_1);
+    }
+
+    #[test]
+    fn test_to_string() {
+        let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
+        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
+
+        assert_eq!(v_1_0_0.to_string(), "1.0.0");
+        assert_eq!(v_1_32.to_string(), "1.32");
+        assert_eq!(v_1_32_1.to_string(), "1.32.1");
+        assert_eq!(format!("{:<8}", v_1_32_1), "1.32.1  ");
+        assert_eq!(format!("{:>8}", v_1_32_1), "  1.32.1");
+    }
+}

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::num::ParseIntError;
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
     parts: [u32; 3],
 }

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 use std::num::ParseIntError;
 use std::fmt;
+use std::convert::TryInto;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
-    parts: Vec<u32>,
+    parts: [u32; 3],
 }
 
 impl fmt::Display for Version {
@@ -14,12 +15,27 @@ impl fmt::Display for Version {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseVersionError {
+    ParseIntError(ParseIntError),
+    // core::array::TryFromSlice is not exported from std, so we invent our own variant
+    WrongNumberOfParts
+}
+
+impl From<ParseIntError> for ParseVersionError {
+    fn from(err: ParseIntError) -> Self {
+        ParseVersionError::ParseIntError(err)
+    }
+}
+
 impl FromStr for Version {
-    type Err = ParseIntError;
+    type Err = ParseVersionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
-        Ok(Version { parts })
+        let parts: Vec<_> = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
+        Ok(Self {
+            parts: parts.as_slice().try_into() .or(Err(ParseVersionError::WrongNumberOfParts))?,
+        })
     }
 }
 
@@ -33,32 +49,32 @@ mod test {
         assert!("hello".parse::<Version>().is_err());
         assert!("1.32.hi".parse::<Version>().is_err());
         assert!("1.32..1".parse::<Version>().is_err());
+        assert!("1.32".parse::<Version>().is_err());
+        assert!("1.32.0.1".parse::<Version>().is_err());
     }
 
     #[test]
     fn test_try_from_single() {
-        assert_eq!("1.32.0".parse(), Ok(Version { parts: vec![1, 32, 0] }));
-        assert_eq!("1.0.0".parse(), Ok(Version { parts: vec![1, 0, 0] }));
+        assert_eq!("1.32.0".parse(), Ok(Version { parts: [1, 32, 0] }));
+        assert_eq!("1.0.0".parse(), Ok(Version { parts: [1, 0, 0] }));
     }
 
     #[test]
     fn test_compare() {
         let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
-        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_0 = "1.32.0".parse::<Version>().unwrap();
         let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
         assert!(v_1_0_0 < v_1_32_1);
-        assert!(v_1_0_0 < v_1_32);
-        assert!(v_1_32 < v_1_32_1);
+        assert!(v_1_0_0 < v_1_32_0);
+        assert!(v_1_32_0 < v_1_32_1);
     }
 
     #[test]
     fn test_to_string() {
         let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
-        let v_1_32 = "1.32".parse::<Version>().unwrap();
         let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
 
         assert_eq!(v_1_0_0.to_string(), "1.0.0");
-        assert_eq!(v_1_32.to_string(), "1.32");
         assert_eq!(v_1_32_1.to_string(), "1.32.1");
         assert_eq!(format!("{:<8}", v_1_32_1), "1.32.1  ");
         assert_eq!(format!("{:>8}", v_1_32_1), "  1.32.1");

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(rust_2018_idioms)]
 
+extern crate regex;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
This is the tidy side of https://github.com/rust-lang/rust/issues/60361.

What is left is actually splitting features into groups and sorting by since.

This PR also likely to produce a small (a couple of lines) merge conflict with https://github.com/rust-lang/rust/pull/60362.

r? @Centril 