### PR TITLE
Fix line number display in source view

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1113,6 +1113,10 @@ span.since {
 	h1.fqn {
 		overflow: initial;
 	}
+
+	#main > .line-numbers {
+		margin-top: 0;
+	}
 }
 
 @media print {


### PR DESCRIPTION
Fixes #60310.

r? rust-lang/rustdoc

cc @Manishearth 

screenshot of the fix:

<img width="798" alt="Screenshot 2019-04-29 at 23 12 20" src="https://user-images.githubusercontent.com/3050060/56927541-b7286680-6ad4-11e9-9215-42dc4ef42691.png">
