### PR TITLE
Rename `RUST_LOG` to `RUSTC_LOG`

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -436,7 +436,7 @@ fn configure_cmake(builder: &Builder<'_>,
     }
 
     if env::var_os("SCCACHE_ERROR_LOG").is_some() {
-        cfg.env("RUST_LOG", "sccache=warn");
+        cfg.env("RUSTC_LOG", "sccache=warn");
     }
 }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -694,7 +694,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// potentially leaving "dangling type variables" behind.
     /// In such cases, an assertion will fail when attempting to
     /// register obligations, within a snapshot. Very useful, much
-    /// better than grovelling through megabytes of `RUST_LOG` output.
+    /// better than grovelling through megabytes of `RUSTC_LOG` output.
     ///
     /// HOWEVER, in some cases the flag is unhelpful. In particular, we
     /// sometimes create a "mini-fulfilment-cx" in which we enroll

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1163,7 +1163,7 @@ pub fn report_ices_to_stderr_if_any<F: FnOnce() -> R, R>(f: F) -> Result<R, Erro
 /// This allows tools to enable rust logging without having to magically match rustc's
 /// log crate version
 pub fn init_rustc_env_logger() {
-    env_logger::init();
+    env_logger::init_from_env("RUSTC_LOG");
 }
 
 pub fn main() {

--- a/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
+++ b/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
@@ -8,4 +8,4 @@ all:
 	mkdir -p $(TMPDIR)/outdir
 	$(RUSTC) foo.rs -o $(TMPDIR)/outdir/$(NAME)
 	ln -nsf outdir/$(NAME) $(TMPDIR)
-	RUST_LOG=rustc_metadata::loader $(RUSTC) bar.rs
+	RUSTC_LOG=rustc_metadata::loader $(RUSTC) bar.rs

--- a/src/test/run-pass/issues/issue-18075.rs
+++ b/src/test/run-pass/issues/issue-18075.rs
@@ -1,5 +1,5 @@
 // run-pass
-// exec-env:RUST_LOG=rustc::middle=debug
+// exec-env:RUSTC_LOG=rustc::middle=debug
 
 fn main() {
     let b = 1isize;

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -1,6 +1,6 @@
 // ignore-windows
 // ignore-emscripten no threads support
-// exec-env:RUST_LOG=debug
+// exec-env:RUSTC_LOG=debug
 
 use std::cell::Cell;
 use std::fmt;

--- a/src/test/run-pass/logging_before_rt_started.rs
+++ b/src/test/run-pass/logging_before_rt_started.rs
@@ -1,4 +1,4 @@
-// exec-env:RUST_LOG=std::ptr
+// exec-env:RUSTC_LOG=std::ptr
 
 // In issue #9487, it was realized that std::ptr was invoking the logging
 // infrastructure, and when std::ptr was used during runtime initialization,

--- a/src/test/run-pass/rustc-rust-log.rs
+++ b/src/test/run-pass/rustc-rust-log.rs
@@ -8,6 +8,6 @@
 // dont-check-compiler-stderr
 // compile-flags: --error-format human
 
-// rustc-env:RUST_LOG=debug
+// rustc-env:RUSTC_LOG=debug
 
 fn main() {}

--- a/src/test/run-pass/threads-sendsync/spawning-with-debug.rs
+++ b/src/test/run-pass/threads-sendsync/spawning-with-debug.rs
@@ -2,7 +2,7 @@
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
 // ignore-windows
-// exec-env:RUST_LOG=debug
+// exec-env:RUSTC_LOG=debug
 // ignore-emscripten no threads support
 
 // regression test for issue #10405, make sure we don't call println! too soon.


### PR DESCRIPTION
cc: #57985 

I think we should also change these submodules:

- rustc-guide
- Cargo (rename to `CARGO_LOG`, cc: https://github.com/rust-lang/cargo/pull/6605, https://github.com/rust-lang/cargo/issues/6189)
- miri
- rls
- rustfmt

r? @davidtwco 
