### PR TITLE
libprofiler_builtins: Set compilation flags more correctly for C code.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -158,9 +158,9 @@ install:
   # Note that the LLVM installer is an NSIS installer
   #
   # Original downloaded here came from
-  # http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
-  - if NOT defined MINGW_URL appveyor-retry appveyor DownloadFile https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/LLVM-7.0.0-win64.exe
-  - if NOT defined MINGW_URL .\LLVM-7.0.0-win64.exe /S /NCRC /D=C:\clang-rust
+  # http://releases.llvm.org/8.0.0/LLVM-8.0.0-win64.exe
+  - if NOT defined MINGW_URL appveyor-retry appveyor DownloadFile https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/LLVM-8.0.0-win64.exe
+  - if NOT defined MINGW_URL .\LLVM-8.0.0-win64.exe /S /NCRC /D=C:\clang-rust
   - if NOT defined MINGW_URL set RUST_CONFIGURE_ARGS=%RUST_CONFIGURE_ARGS% --set llvm.clang-cl=C:\clang-rust\bin\clang-cl.exe
 
   # Here we do a pretty heinous thing which is to mangle the MinGW installation

--- a/src/libprofiler_builtins/build.rs
+++ b/src/libprofiler_builtins/build.rs
@@ -44,6 +44,19 @@ fn main() {
         cfg.define("COMPILER_RT_HAS_UNAME", Some("1"));
     }
 
+    // Assume that the Unixes we are building this for have fnctl() available
+    if env::var_os("CARGO_CFG_UNIX").is_some() {
+        cfg.define("COMPILER_RT_HAS_FCNTL_LCK", Some("1"));
+    }
+
+    // This should be a pretty good heuristic for when to set
+    // COMPILER_RT_HAS_ATOMICS
+    if env::var_os("CARGO_CFG_TARGET_HAS_ATOMIC").map(|features| {
+        features.to_string_lossy().to_lowercase().contains("cas")
+    }).unwrap_or(false) {
+        cfg.define("COMPILER_RT_HAS_ATOMICS", Some("1"));
+    }
+
     // The source for `compiler-rt` comes from the `compiler-builtins` crate, so
     // load our env var set by cargo to find the source code.
     let root = env::var_os("DEP_COMPILER_RT_COMPILER_RT").unwrap();


### PR DESCRIPTION
In particular, set `COMPILER_RT_HAS_FCNTL_LCK` and `COMPILER_RT_HAS_ATOMICS` as appropriate. This should get rid of the various runtime warnings when executing instrumented binaries. 

The build script is using a heuristic here that hopefully is sufficient for the time being.

r? @alexcrichton 

Fixes #59531.