### PR TITLE
Account for paths in incorrect pub qualifier help

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -7276,7 +7276,9 @@ impl<'a> Parser<'a> {
             // `()` or a tuple might be allowed. For example, `struct Struct(pub (), pub (usize));`.
             // Because of this, we only `bump` the `(` if we're assured it is appropriate to do so
             // by the following tokens.
-            if self.look_ahead(1, |t| t.is_keyword(keywords::Crate)) {
+            if self.look_ahead(1, |t| t.is_keyword(keywords::Crate)) &&
+                self.look_ahead(2, |t| t != &token::ModSep) // account for `pub(crate::foo)`
+            {
                 // `pub(crate)`
                 self.bump(); // `(`
                 self.bump(); // `crate`
@@ -7319,7 +7321,7 @@ impl<'a> Parser<'a> {
 `pub(super)`: visible only in the current module's parent
 `pub(in path::to::module)`: visible only on the specified path"##;
                 let path = self.parse_path(PathStyle::Mod)?;
-                let sp = self.prev_span;
+                let sp = path.span;
                 let help_msg = format!("make this visible only to module `{}` with `in`", path);
                 self.expect(&token::CloseDelim(token::Paren))?;  // `)`
                 let mut err = struct_span_err!(self.sess.span_diagnostic, sp, E0704, "{}", msg);

--- a/src/test/ui/pub/pub-restricted.rs
+++ b/src/test/ui/pub/pub-restricted.rs
@@ -4,6 +4,8 @@ mod a {}
 
 pub (a) fn afn() {} //~ incorrect visibility restriction
 pub (b) fn bfn() {} //~ incorrect visibility restriction
+pub (crate::a) fn cfn() {} //~ incorrect visibility restriction
+
 pub fn privfn() {}
 mod x {
     mod y {

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -21,7 +21,18 @@ LL | pub (b) fn bfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:22:14
+  --> $DIR/pub-restricted.rs:7:6
+   |
+LL | pub (crate::a) fn cfn() {}
+   |      ^^^^^^^^ help: make this visible only to module `crate::a` with `in`: `in crate::a`
+   |
+   = help: some possible visibility restrictions are:
+           `pub(crate)`: visible only on the current crate
+           `pub(super)`: visible only in the current module's parent
+           `pub(in path::to::module)`: visible only on the specified path
+
+error[E0704]: incorrect visibility restriction
+  --> $DIR/pub-restricted.rs:24:14
    |
 LL |         pub (a) invalid: usize,
    |              ^ help: make this visible only to module `a` with `in`: `in a`
@@ -32,7 +43,7 @@ LL |         pub (a) invalid: usize,
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:31:6
+  --> $DIR/pub-restricted.rs:33:6
    |
 LL | pub (xyz) fn xyz() {}
    |      ^^^ help: make this visible only to module `xyz` with `in`: `in xyz`
@@ -43,10 +54,10 @@ LL | pub (xyz) fn xyz() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error: visibilities can only be restricted to ancestor modules
-  --> $DIR/pub-restricted.rs:23:17
+  --> $DIR/pub-restricted.rs:25:17
    |
 LL |         pub (in x) non_parent_invalid: usize,
    |                 ^
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Handle case where incorrect pub qualifier with a mod path is used and provide the same help given for all other incorrect qualifiers by making the `pub(crate)` parse check more specific.