### PR TITLE
doc: Warn about possible zombie apocalypse

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -134,6 +134,18 @@ use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
 /// the parent process wait until the child has actually exited before
 /// continuing.
 ///
+/// # Warning
+///
+/// On some system, calling [`wait`] or similar is necessary for the OS to
+/// release resources. A process that terminated but has not been waited on is
+/// still around as a "zombie". Leaving too many zombies around may exhaust
+/// global resources (for example process IDs).
+///
+/// The standard library does *not* automatically wait on child processes (not
+/// even if the `Child` is dropped), it is up to the application developer to do
+/// so. As a consequence, dropping `Child` handles without waiting on them first
+/// is not recommended in long-running applications.
+///
 /// # Examples
 ///
 /// ```should_panic


### PR DESCRIPTION
Extend the std::process::Child docs with warning about possible zombies.
The previous version mentioned that when dropping the Child, the
process is not killed. However, the wording gave the impression that
such behaviour is fine to do (leaving the reader believe low-level
details like reaping zombies of the dead processes is taken over by std
somehow; or simply leaving the reader unaware about the problem).