### PR TITLE
Make place projections concrete.

### DIFF
--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -152,7 +152,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn visit_projection(&mut self,
-                                place: & $($mutability)? PlaceProjection<'tcx>,
+                                place: & $($mutability)? Projection<'tcx>,
                                 context: PlaceContext,
                                 location: Location) {
                 self.super_projection(place, context, location);
@@ -689,7 +689,7 @@ macro_rules! make_mir_visitor {
             }
 
             fn super_projection(&mut self,
-                                proj: & $($mutability)? PlaceProjection<'tcx>,
+                                proj: & $($mutability)? Projection<'tcx>,
                                 context: PlaceContext,
                                 location: Location) {
                 let Projection { base, elem } = proj;

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -2,7 +2,7 @@ use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::mir::{
     self, AggregateKind, BindingForm, BorrowKind, ClearCrossCrate, ConstraintCategory, Local,
-    LocalDecl, LocalKind, Location, Operand, Place, PlaceBase, PlaceProjection,
+    LocalDecl, LocalKind, Location, Operand, Place, PlaceBase, Projection,
     ProjectionElem, Rvalue, Statement, StatementKind, TerminatorKind, VarBindingForm,
 };
 use rustc::ty::{self, Ty};
@@ -619,7 +619,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 // union being accessed and the field that was being accessed so we can check the
                 // second borrowed place for the same union and a access to a different field.
                 let mut current = first_borrowed_place;
-                while let Place::Projection(box PlaceProjection { base, elem }) = current {
+                while let Place::Projection(box Projection { base, elem }) = current {
                     match elem {
                         ProjectionElem::Field(field, _) if is_union(base) => {
                             return Some((base, field));
@@ -633,7 +633,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 // With the place of a union and a field access into it, we traverse the second
                 // borrowed place and look for a access to a different field of the same union.
                 let mut current = second_borrowed_place;
-                while let Place::Projection(box PlaceProjection { base, elem }) = current {
+                while let Place::Projection(box Projection { base, elem }) = current {
                     match elem {
                         ProjectionElem::Field(field, _) if {
                             is_union(base) && field != target_field && base == target_base
@@ -1495,7 +1495,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
             Place::Base(PlaceBase::Static(_)) => {
                 StorageDeadOrDrop::LocalStorageDead
             }
-            Place::Projection(box PlaceProjection { base, elem }) => {
+            Place::Projection(box Projection { base, elem }) => {
                 let base_access = self.classify_drop_access_kind(base);
                 match elem {
                     ProjectionElem::Deref => match base_access {

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -352,7 +352,7 @@ impl<'a, 'gcx, 'tcx> MirBorrowckCtxt<'a, 'gcx, 'tcx> {
                 ..
             } => {
                 let try_remove_deref = match move_from {
-                    Place::Projection(box PlaceProjection {
+                    Place::Projection(box Projection {
                         elem: ProjectionElem::Deref,
                         ..
                     }) => true,

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -2370,7 +2370,7 @@ impl<'a, 'gcx, 'tcx> TypeChecker<'a, 'gcx, 'tcx> {
             "add_reborrow_constraint({:?}, {:?}, {:?})",
             location, borrow_region, borrowed_place
         );
-        while let Place::Projection(box PlaceProjection { base, elem }) = borrowed_place {
+        while let Place::Projection(box Projection { base, elem }) = borrowed_place {
             debug!("add_reborrow_constraint - iteration {:?}", borrowed_place);
 
             match *elem {

--- a/src/librustc_mir/borrow_check/places_conflict.rs
+++ b/src/librustc_mir/borrow_check/places_conflict.rs
@@ -3,7 +3,7 @@ use crate::borrow_check::Overlap;
 use crate::borrow_check::{Deep, Shallow, AccessDepth};
 use rustc::hir;
 use rustc::mir::{
-    BorrowKind, Mir, Place, PlaceBase, PlaceProjection, ProjectionElem, PlaceProjectionsIter,
+    BorrowKind, Mir, Place, PlaceBase, Projection, ProjectionElem, ProjectionsIter,
     StaticKind
 };
 use rustc::ty::{self, TyCtxt};
@@ -86,9 +86,9 @@ pub(super) fn borrow_conflicts_with_place<'gcx, 'tcx>(
 fn place_components_conflict<'gcx, 'tcx>(
     tcx: TyCtxt<'_, 'gcx, 'tcx>,
     mir: &Mir<'tcx>,
-    borrow_projections: (&PlaceBase<'tcx>, PlaceProjectionsIter<'_, 'tcx>),
+    borrow_projections: (&PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>),
     borrow_kind: BorrowKind,
-    access_projections: (&PlaceBase<'tcx>, PlaceProjectionsIter<'_, 'tcx>),
+    access_projections: (&PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>),
     access: AccessDepth,
     bias: PlaceConflictBias,
 ) -> bool {
@@ -368,8 +368,8 @@ fn place_base_conflict<'a, 'gcx: 'tcx, 'tcx>(
 fn place_projection_conflict<'a, 'gcx: 'tcx, 'tcx>(
     tcx: TyCtxt<'a, 'gcx, 'tcx>,
     mir: &Mir<'tcx>,
-    pi1: &PlaceProjection<'tcx>,
-    pi2: &PlaceProjection<'tcx>,
+    pi1: &Projection<'tcx>,
+    pi2: &Projection<'tcx>,
     bias: PlaceConflictBias,
 ) -> Overlap {
     match (&pi1.elem, &pi2.elem) {

--- a/src/librustc_mir/dataflow/drop_flag_effects.rs
+++ b/src/librustc_mir/dataflow/drop_flag_effects.rs
@@ -10,7 +10,7 @@ pub fn move_path_children_matching<'tcx, F>(move_data: &MoveData<'tcx>,
                                         path: MovePathIndex,
                                         mut cond: F)
                                         -> Option<MovePathIndex>
-    where F: FnMut(&mir::PlaceProjection<'tcx>) -> bool
+    where F: FnMut(&mir::Projection<'tcx>) -> bool
 {
     let mut next_child = move_data.move_paths[path].first_child;
     while let Some(child_index) = next_child {

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -114,7 +114,7 @@ impl<'b, 'a, 'gcx, 'tcx> Gatherer<'b, 'a, 'gcx, 'tcx> {
 
     fn move_path_for_projection(&mut self,
                                 place: &Place<'tcx>,
-                                proj: &PlaceProjection<'tcx>)
+                                proj: &Projection<'tcx>)
                                 -> Result<MovePathIndex, MoveError<'tcx>>
     {
         let base = self.move_path_for(&proj.base)?;

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -161,7 +161,7 @@ trait Qualif {
 
     fn in_projection_structurally(
         cx: &ConstCx<'_, 'tcx>,
-        proj: &PlaceProjection<'tcx>,
+        proj: &Projection<'tcx>,
     ) -> bool {
         let base_qualif = Self::in_place(cx, &proj.base);
         let qualif = base_qualif && Self::mask_for_ty(
@@ -181,7 +181,7 @@ trait Qualif {
         }
     }
 
-    fn in_projection(cx: &ConstCx<'_, 'tcx>, proj: &PlaceProjection<'tcx>) -> bool {
+    fn in_projection(cx: &ConstCx<'_, 'tcx>, proj: &Projection<'tcx>) -> bool {
         Self::in_projection_structurally(cx, proj)
     }
 
@@ -387,7 +387,7 @@ impl Qualif for IsNotPromotable {
         }
     }
 
-    fn in_projection(cx: &ConstCx<'_, 'tcx>, proj: &PlaceProjection<'tcx>) -> bool {
+    fn in_projection(cx: &ConstCx<'_, 'tcx>, proj: &Projection<'tcx>) -> bool {
         match proj.elem {
             ProjectionElem::Deref |
             ProjectionElem::Downcast(..) => return true,

--- a/src/librustc_mir/transform/uniform_array_move_out.rs
+++ b/src/librustc_mir/transform/uniform_array_move_out.rs
@@ -89,7 +89,7 @@ impl<'a, 'tcx> UniformArrayMoveOutVisitor<'a, 'tcx> {
     fn uniform(&mut self,
                location: Location,
                dst_place: &Place<'tcx>,
-               proj: &PlaceProjection<'tcx>,
+               proj: &Projection<'tcx>,
                item_ty: &'tcx ty::TyS<'tcx>,
                size: u32) {
         match proj.elem {
@@ -103,7 +103,7 @@ impl<'a, 'tcx> UniformArrayMoveOutVisitor<'a, 'tcx> {
                                           Place::Base(PlaceBase::Local(temp)),
                                           Rvalue::Use(
                                               Operand::Move(
-                                                  Place::Projection(box PlaceProjection{
+                                                  Place::Projection(box Projection{
                                                       base: proj.base.clone(),
                                                       elem: ProjectionElem::ConstantIndex{
                                                           offset: i,
@@ -133,7 +133,7 @@ impl<'a, 'tcx> UniformArrayMoveOutVisitor<'a, 'tcx> {
                                       dst_place.clone(),
                                       Rvalue::Use(
                                           Operand::Move(
-                                              Place::Projection(box PlaceProjection{
+                                              Place::Projection(box Projection{
                                                   base: proj.base.clone(),
                                                   elem: ProjectionElem::ConstantIndex{
                                                       offset: size - offset,
@@ -246,7 +246,7 @@ impl RestoreSubsliceArrayMoveOut {
                              dst_place.clone(),
                              Rvalue::Use(
                                  Operand::Move(
-                                     Place::Projection(box PlaceProjection{
+                                     Place::Projection(box Projection{
                                          base: opt_src_place.unwrap().clone(),
                                          elem: ProjectionElem::Subslice{
                                              from: min, to: size - max - 1}}))));
@@ -261,7 +261,7 @@ impl RestoreSubsliceArrayMoveOut {
                 let statement = &block.statements[location.statement_index];
                 if let StatementKind::Assign(
                     Place::Base(PlaceBase::Local(_)),
-                    box Rvalue::Use(Operand::Move(Place::Projection(box PlaceProjection{
+                    box Rvalue::Use(Operand::Move(Place::Projection(box Projection{
                         ref base, elem: ProjectionElem::ConstantIndex{
                             offset, min_length: _, from_end: false}})))) = statement.kind {
                     return Some((offset, base))


### PR DESCRIPTION
**I'm not sure if we want this. I'm raising the PR  for discussion**

Whilst doing some work on our Rust fork, I noticed the following:

Once upon a time (commit 9bd35c07c26) there were two kinds of
projection: one for places, and one for constants. It therefore made
sense to share the `Projection` struct for both. Although the different
use-cases used different concrete types, sharing was made possible by
type-parameterisation of `Projection`.

Since then, however, the usage of projections in constants has
disappeared, meaning that (forgetting lifetimes for a moment) the
parameterised type is only every instantiated under one guise. So it may
as well be a concrete type. Right?

What do people think? This is entirely untested, although it does check.

If we *don't* want this, then we should at least update the incorrect comment against `Projection`.

Thanks