### PR TITLE
Const prop refactoring

### DIFF
--- a/src/test/ui/consts/const-err.rs
+++ b/src/test/ui/consts/const-err.rs
@@ -13,4 +13,5 @@ const FOO: u8 = [5u8][1];
 fn main() {
     black_box((FOO, FOO));
     //~^ ERROR erroneous constant used
+    //~| ERROR erroneous constant
 }

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -13,11 +13,17 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:14:15
+  --> $DIR/const-err.rs:14:16
    |
 LL |     black_box((FOO, FOO));
-   |               ^^^^^^^^^^ referenced constant has errors
+   |                ^^^ referenced constant has errors
 
-error: aborting due to previous error
+error[E0080]: erroneous constant used
+  --> $DIR/const-err.rs:14:21
+   |
+LL |     black_box((FOO, FOO));
+   |                     ^^^ referenced constant has errors
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This is rebased on top of #60428 so only the top commit is new. 

This is the refactoring to remove the `mir` field from `ConstPropagator` which is necessary before we can begin to actually propagate constants.

r? @oli-obk 