### PR TITLE
rustc: rename -Z emit-directives to -Z emit-artifact-notifications and simplify the output.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1462,8 +1462,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          the same values as the target option of the same name"),
     allow_features: Option<Vec<String>> = (None, parse_opt_comma_list, [TRACKED],
         "only allow the listed language features to be enabled in code (space separated)"),
-    emit_directives: bool = (false, parse_bool, [UNTRACKED],
-        "emit build directives if producing JSON output"),
+    emit_artifact_notifications: bool = (false, parse_bool, [UNTRACKED],
+        "emit notifications after each artifact has been output (only in the JSON format)"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -95,6 +95,9 @@ pub fn link_binary<'a, B: ArchiveBuilder<'a>>(sess: &'a Session,
                     );
                 }
             }
+            if sess.opts.debugging_opts.emit_artifact_notifications {
+                sess.parse_sess.span_diagnostic.emit_artifact_notification(&out_filename);
+            }
         }
 
         if sess.opts.cg.save_temps {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 use std::io::prelude::*;
 use std::io;
 use std::cmp::{min, Reverse};
+use std::path::Path;
 use termcolor::{StandardStream, ColorChoice, ColorSpec, BufferWriter, Ansi};
 use termcolor::{WriteColor, Color, Buffer};
 
@@ -52,9 +53,10 @@ pub trait Emitter {
     /// Emit a structured diagnostic.
     fn emit_diagnostic(&mut self, db: &DiagnosticBuilder<'_>);
 
-    /// Emit a JSON directive. The default is to do nothing; this should only
-    /// be emitted with --error-format=json.
-    fn maybe_emit_json_directive(&mut self, _directive: String) {}
+    /// Emit a notification that an artifact has been output.
+    /// This is currently only supported for the JSON format,
+    /// other formats can, and will, simply ignore it.
+    fn emit_artifact_notification(&mut self, _path: &Path) {}
 
     /// Checks if should show explanations about "rustc --explain"
     fn should_show_explain(&self) -> bool {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -26,6 +26,7 @@ use std::borrow::Cow;
 use std::cell::Cell;
 use std::{error, fmt};
 use std::panic;
+use std::path::Path;
 
 use termcolor::{ColorSpec, Color};
 
@@ -294,16 +295,9 @@ impl error::Error for ExplicitBug {
 pub use diagnostic::{Diagnostic, SubDiagnostic, DiagnosticStyledString, DiagnosticId};
 pub use diagnostic_builder::DiagnosticBuilder;
 
-/// A handler deals with two kinds of compiler output.
-/// - Errors: certain errors (fatal, bug, unimpl) may cause immediate exit,
-///   others log errors for later reporting.
-/// - Directives: with --error-format=json, the compiler produces directives
-///   that indicate when certain actions have completed, which are useful for
-///   Cargo. They may change at any time and should not be considered a public
-///   API.
-///
-/// This crate's name (rustc_errors) doesn't encompass the directives, because
-/// directives were added much later.
+/// A handler deals with errors and other compiler output.
+/// Certain errors (fatal, bug, unimpl) may cause immediate exit,
+/// others log errors for later reporting.
 pub struct Handler {
     pub flags: HandlerFlags,
 
@@ -775,8 +769,8 @@ impl Handler {
         }
     }
 
-    pub fn maybe_emit_json_directive(&self, directive: String) {
-        self.emitter.borrow_mut().maybe_emit_json_directive(directive);
+    pub fn emit_artifact_notification(&self, path: &Path) {
+        self.emitter.borrow_mut().emit_artifact_notification(path);
     }
 }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1048,14 +1048,11 @@ fn encode_and_write_metadata<'tcx>(
                 tcx.sess.fatal(&format!("couldn't create a temp dir: {}", err))
             });
         let metadata_filename = emit_metadata(tcx.sess, &metadata, &metadata_tmpdir);
-        match std::fs::rename(&metadata_filename, &out_filename) {
-            Ok(_) => {
-                if tcx.sess.opts.debugging_opts.emit_directives {
-                    tcx.sess.parse_sess.span_diagnostic.maybe_emit_json_directive(
-                        format!("metadata file written: {}", out_filename.display()));
-                }
-            }
-            Err(e) => tcx.sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e)),
+        if let Err(e) = fs::rename(&metadata_filename, &out_filename) {
+            tcx.sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e));
+        }
+        if tcx.sess.opts.debugging_opts.emit_artifact_notifications {
+            tcx.sess.parse_sess.span_diagnostic.emit_artifact_notification(&out_filename);
         }
     }
 

--- a/src/libserialize/serialize.rs
+++ b/src/libserialize/serialize.rs
@@ -764,9 +764,15 @@ macro_rules! tuple {
 
 tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
-impl Encodable for path::PathBuf {
+impl Encodable for path::Path {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
         self.to_str().unwrap().encode(e)
+    }
+}
+
+impl Encodable for path::PathBuf {
+    fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {
+        path::Path::encode(self, e)
     }
 }
 

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -19,6 +19,7 @@ use errors::emitter::{Emitter, HumanReadableErrorType};
 use syntax_pos::{MacroBacktrace, Span, SpanLabel, MultiSpan};
 use rustc_data_structures::sync::{self, Lrc};
 use std::io::{self, Write};
+use std::path::Path;
 use std::vec;
 use std::sync::{Arc, Mutex};
 
@@ -91,15 +92,15 @@ impl Emitter for JsonEmitter {
         }
     }
 
-    fn maybe_emit_json_directive(&mut self, directive: String) {
-        let data = Directive { directive };
+    fn emit_artifact_notification(&mut self, path: &Path) {
+        let data = ArtifactNotification { artifact: path };
         let result = if self.pretty {
             writeln!(&mut self.dst, "{}", as_pretty_json(&data))
         } else {
             writeln!(&mut self.dst, "{}", as_json(&data))
         };
         if let Err(e) = result {
-            panic!("failed to print message: {:?}", e);
+            panic!("failed to print notification: {:?}", e);
         }
     }
 }
@@ -181,9 +182,9 @@ struct DiagnosticCode {
 }
 
 #[derive(RustcEncodable)]
-struct Directive {
-    /// The directive itself.
-    directive: String,
+struct ArtifactNotification<'a> {
+    /// The path of the artifact.
+    artifact: &'a Path,
 }
 
 impl Diagnostic {

--- a/src/test/ui/consts/const-eval/unused-broken-const.stderr
+++ b/src/test/ui/consts/const-eval/unused-broken-const.stderr
@@ -1,5 +1,3 @@
-warning: due to multiple output types requested, the explicitly specified output file name will be adapted for each output type
-
 error: any use of this value will cause an error
   --> $DIR/unused-broken-const.rs:5:18
    |

--- a/src/test/ui/emit-artifact-notifications.nll.stderr
+++ b/src/test/ui/emit-artifact-notifications.nll.stderr
@@ -1,0 +1,1 @@
+{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications.nll/libemit_artifact_notifications.rmeta"}

--- a/src/test/ui/emit-artifact-notifications.rs
+++ b/src/test/ui/emit-artifact-notifications.rs
@@ -1,0 +1,6 @@
+// compile-flags:--emit=metadata --error-format=json -Z emit-artifact-notifications
+// compile-pass
+
+// A very basic test for the emission of artifact notifications in JSON output.
+
+fn main() {}

--- a/src/test/ui/emit-artifact-notifications.stderr
+++ b/src/test/ui/emit-artifact-notifications.stderr
@@ -1,0 +1,1 @@
+{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications/libemit_artifact_notifications.rmeta"}

--- a/src/test/ui/emit-directives.rs
+++ b/src/test/ui/emit-directives.rs
@@ -1,6 +1,0 @@
-// compile-flags:--emit=metadata --error-format=json -Z emit-directives
-// compile-pass
-
-// A very basic test for the emission of build directives in JSON output.
-
-fn main() {}

--- a/src/test/ui/emit-directives.rs
+++ b/src/test/ui/emit-directives.rs
@@ -1,11 +1,5 @@
-// ignore-tidy-linelength
 // compile-flags:--emit=metadata --error-format=json -Z emit-directives
 // compile-pass
-//
-// Normalization is required to eliminated minor path and filename differences
-// across platforms.
-// normalize-stderr-test: "metadata file written: .*/emit-directives" -> "metadata file written: .../emit-directives"
-// normalize-stderr-test: "emit-directives(\.\w*)?/a(\.\w*)?" -> "emit-directives/a"
 
 // A very basic test for the emission of build directives in JSON output.
 

--- a/src/test/ui/emit-directives.stderr
+++ b/src/test/ui/emit-directives.stderr
@@ -1,1 +1,1 @@
-{"directive":"metadata file written: .../emit-directives/a"}
+{"directive":"metadata file written: $TEST_BUILD_DIR/emit-directives/libemit_directives.rmeta"}

--- a/src/test/ui/emit-directives.stderr
+++ b/src/test/ui/emit-directives.stderr
@@ -1,1 +1,0 @@
-{"directive":"metadata file written: $TEST_BUILD_DIR/emit-directives/libemit_directives.rmeta"}

--- a/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
+++ b/src/test/ui/traits/trait-object-with-self-in-projection-output-repeated-supertrait.rs
@@ -1,5 +1,8 @@
 // compile-pass
 
+// FIXME(eddyb) shorten the name so windows doesn't choke on it.
+#![crate_name = "trait_test"]
+
 // Regression test related to #56288. Check that a supertrait projection (of
 // `Output`) that references `Self` is ok if there is another occurence of
 // the same supertrait that specifies the projection explicitly, even if

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -4,7 +4,7 @@
 use crate::errors::{Error, ErrorKind};
 use crate::runtest::ProcRes;
 use serde_json;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 #[derive(Deserialize)]
@@ -18,9 +18,9 @@ struct Diagnostic {
 }
 
 #[derive(Deserialize)]
-struct Directive {
+struct ArtifactNotification {
     #[allow(dead_code)]
-    directive: String,
+    artifact: PathBuf,
 }
 
 #[derive(Deserialize, Clone)]
@@ -75,8 +75,8 @@ pub fn extract_rendered(output: &str) -> String {
             if line.starts_with('{') {
                 if let Ok(diagnostic) = serde_json::from_str::<Diagnostic>(line) {
                     diagnostic.rendered
-                } else if let Ok(_directive) = serde_json::from_str::<Directive>(line) {
-                    // Swallow the directive.
+                } else if let Ok(_) = serde_json::from_str::<ArtifactNotification>(line) {
+                    // Ignore the notification.
                     None
                 } else {
                     print!(


### PR DESCRIPTION
This is my take on #60006 / #60419 (see https://github.com/rust-lang/rust/pull/60006#discussion_r275983732). 
I'm not too attached the "notifications" part, it's pretty much bikeshed material.
**EDIT**: for "artifact", @matklad pointed out Cargo already uses it (in https://github.com/rust-lang/rust/pull/60464#issuecomment-488576998)

The first two commits are fixes that could be landed independently, especially the `compiletest` one, which removes the need for any of the normalization added in #60006 to land the test.

The last commit enables the emission for all outputs, which was my main suggestion for #60006, mostly to show that it's minimal and not really a "scope creep" (as suggested in https://github.com/rust-lang/rust/pull/60006#discussion_r279964081).

cc @alexcrichton @nnethercote