### PR TITLE
fix building libstd with cfg(miri)

### DIFF
--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -30,6 +30,8 @@ fn main() {
         println!("cargo:rustc-link-lib=resolv");
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=System");
+        #[cfg(miri)]
+        println!("cargo:rustc-link-lib=framework=Security");
 
         // res_init and friends require -lresolv on macOS/iOS.
         // See #41582 and http://blog.achernya.com/2013/03/os-x-has-silly-libsystem.html

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -31,6 +31,8 @@ fn main() {
     } else if target.contains("apple-darwin") {
         println!("cargo:rustc-link-lib=System");
         #[cfg(miri)]
+        // With Miri, we use SecRandomCopyBytes got randomness, so we need to link
+        // with `framework=Security`.
         println!("cargo:rustc-link-lib=framework=Security");
 
         // res_init and friends require -lresolv on macOS/iOS.


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/60156 to fix the failure in https://github.com/rust-lang/miri/pull/721.

I *think* that build scripts get the same feature flags, but someone please correct me if I am wrong.

Also I wonder why this didn't cause https://github.com/rust-lang/rust/pull/60156 to fail...