### PR TITLE
test out experimental outlined hashmap design

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gankro/hashbrown?branch=singleton#99e5ba92e83a6ad40cbc5c9d79dd18a07592ebf1"
 dependencies = [
  "compiler_builtins 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-std-workspace-alloc 1.0.0",
@@ -3291,7 +3291,7 @@ dependencies = [
  "core 0.0.0",
  "dlmalloc 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fortanix-sgx-abi 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.3.0 (git+https://github.com/gankro/hashbrown?branch=singleton)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "panic_abort 0.0.0",
  "panic_unwind 0.0.0",
@@ -4134,7 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4743617a7464bbda3c8aec8558ff2f9429047e025771037df561d383337ff865"
 "checksum handlebars 0.32.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d89ec99d1594f285d4590fc32bac5f75cdab383f1123d504d27862c644a807dd"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
-"checksum hashbrown 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "570178d5e4952010d138b0f1d581271ff3a02406d990f887d1e87e3d6e43b0ac"
+"checksum hashbrown 0.3.0 (git+https://github.com/gankro/hashbrown?branch=singleton)" = "<none>"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum home 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "80dff82fb58cfbbc617fb9a9184b010be0529201553cda50ad04372bc2333aff"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.3.0"
-source = "git+https://github.com/gankro/hashbrown?branch=singleton#99e5ba92e83a6ad40cbc5c9d79dd18a07592ebf1"
+source = "git+https://github.com/gankro/hashbrown?branch=singleton#09ed47028875a10cb6ad9ffeceb61cc4a5c9d690"
 dependencies = [
  "compiler_builtins 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-std-workspace-alloc 1.0.0",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -22,7 +22,7 @@ libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of
 compiler_builtins = { version = "0.1.9" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
-hashbrown = { version = "0.3.0", features = ['rustc-dep-of-std'] }
+hashbrown = { version = "0.3.0", git = "https://github.com/gankro/hashbrown", branch = "singleton", features = ['rustc-dep-of-std'] }
 rustc-demangle = { version = "0.1.10", features = ['rustc-dep-of-std'] }
 backtrace-sys = { version = "0.1.24", features = ["rustc-dep-of-std"], optional = true }
 


### PR DESCRIPTION
sorry, need to do this to get try builds for https://github.com/rust-lang/hashbrown/pull/76

Can someone kick off whatever the perf/profiling/benchmark version of `try` is now? Want to see how this change affects rustc's perf and memory usage.

(Might also need to do this a few times to test out different versions of the patch)