### PR TITLE
 Make tests compatible with musl host 

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1870,6 +1870,10 @@ impl Step for CrateRustdoc {
         cargo.arg("--");
         cargo.args(&builder.config.cmd.test_args());
 
+        if self.host.contains("musl") {
+            cargo.arg("'-Ctarget-feature=-crt-static'");
+        }
+
         if !builder.config.verbose_tests {
             cargo.arg("--quiet");
         }

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -23,7 +23,7 @@ COPY scripts/musl-toolchain.sh /build/
 # We need to mitigate rust-lang/rust#34978 when compiling musl itself as well
 RUN CFLAGS="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
     CXXFLAGS="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none -Wl,--compress-debug-sections=none" \
-    bash musl-toolchain.sh x86_64 && rm -rf build
+    REPLACE_CC=1 bash musl-toolchain.sh x86_64 && rm -rf build
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/dist-x86_64-musl/Dockerfile
@@ -35,10 +35,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --disable-docs \
       --set target.x86_64-unknown-linux-musl.crt-static=false \
-      --build $HOSTS \
-      --set target.x86_64-unknown-linux-musl.cc=x86_64-linux-musl-gcc \
-      --set target.x86_64-unknown-linux-musl.cxx=x86_64-linux-musl-g++ \
-      --set target.x86_64-unknown-linux-musl.linker=x86_64-linux-musl-gcc
+      --build $HOSTS
 
 # Newer binutils broke things on some vms/distros (i.e., linking against
 # unknown relocs disabled by the following flag), so we need to go out of our
@@ -49,4 +46,5 @@ ENV RUST_CONFIGURE_ARGS \
 ENV CFLAGS_x86_64_unknown_linux_musl="-Wa,-mrelax-relocations=no -Wa,--compress-debug-sections=none \
     -Wl,--compress-debug-sections=none"
 
+# To run native tests replace `dist` below with `test`
 ENV SCRIPT python2.7 ../x.py dist --build $HOSTS

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -45,6 +45,13 @@ cd -
 ln -s $OUTPUT/$TARGET/lib/libc.so /lib/ld-musl-$ARCH.so.1
 echo $OUTPUT/$TARGET/lib >> /etc/ld-musl-$ARCH.path
 
+# Now when musl bootstraps itself create proper toolchain symlinks to make build and tests easier
+for exec in cc gcc; do
+    ln -s $TARGET-gcc /usr/local/bin/$exec
+done
+for exec in cpp c++ g++; do
+    ln -s $TARGET-g++ /usr/local/bin/$exec
+done
 
 export CC=$TARGET-gcc
 export CXX=$TARGET-g++

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -46,12 +46,14 @@ ln -s $OUTPUT/$TARGET/lib/libc.so /lib/ld-musl-$ARCH.so.1
 echo $OUTPUT/$TARGET/lib >> /etc/ld-musl-$ARCH.path
 
 # Now when musl bootstraps itself create proper toolchain symlinks to make build and tests easier
-for exec in cc gcc; do
-    ln -s $TARGET-gcc /usr/local/bin/$exec
-done
-for exec in cpp c++ g++; do
-    ln -s $TARGET-g++ /usr/local/bin/$exec
-done
+if [ "$REPLACE_CC" = "1" ]; then
+    for exec in cc gcc; do
+        ln -s $TARGET-gcc /usr/local/bin/$exec
+    done
+    for exec in cpp c++ g++; do
+        ln -s $TARGET-g++ /usr/local/bin/$exec
+    done
+fi
 
 export CC=$TARGET-gcc
 export CXX=$TARGET-g++

--- a/src/test/run-make-fulldeps/link-cfg/Makefile
+++ b/src/test/run-make-fulldeps/link-cfg/Makefile
@@ -2,7 +2,7 @@
 
 all: $(call DYLIB,return1) $(call DYLIB,return2) $(call NATIVE_STATICLIB,return3)
 	ls $(TMPDIR)
-	$(RUSTC) --print cfg --target x86_64-unknown-linux-musl | $(CGREP) crt-static
+	$(BARE_RUSTC) --print cfg --target x86_64-unknown-linux-musl | $(CGREP) crt-static
 
 	$(RUSTC) no-deps.rs --cfg foo
 	$(call RUN,no-deps)

--- a/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
+++ b/src/test/run-make-fulldeps/linker-output-non-utf8/Makefile
@@ -20,4 +20,4 @@ all:
 	$(RUSTC) library.rs
 	mkdir $(bad_dir)
 	mv $(TMPDIR)/liblibrary.a $(bad_dir)
-	LIBRARY_PATH=$(bad_dir) $(RUSTC) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined
+	$(RUSTC) -L $(bad_dir) exec.rs 2>&1 | $(CGREP) this_symbol_not_defined

--- a/src/test/run-make-fulldeps/reproducible-build/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build/Makefile
@@ -1,4 +1,8 @@
 -include ../tools.mk
+
+# ignore-musl
+# Objects are reproducible but their path is not.
+
 all:  \
 	smoke \
 	debug \

--- a/src/test/run-make/rustc-macro-dep-files/Makefile
+++ b/src/test/run-make/rustc-macro-dep-files/Makefile
@@ -2,7 +2,10 @@
 
 # FIXME(eddyb) provide `HOST_RUSTC` and `TARGET_RUSTC`
 # instead of hardcoding them everywhere they're needed.
+ifeq ($(IS_MUSL_HOST),1)
+ADDITIONAL_ARGS := $(RUSTFLAGS)
+endif
 all:
-	$(BARE_RUSTC) foo.rs --out-dir $(TMPDIR)
+	$(BARE_RUSTC) $(ADDITIONAL_ARGS) foo.rs --out-dir $(TMPDIR)
 	$(RUSTC) bar.rs --target $(TARGET) --emit dep-info
 	$(CGREP) -v "proc-macro source" < $(TMPDIR)/bar.d


### PR DESCRIPTION
As an alternative to passing explicit linker all over the place I could try linking `cc` to musl gcc since this bootstraps itself.

Assigning for discussion:
r? @alexcrichton 