### PR TITLE
build dist-aarch64-linux with --enable-profiler

### DIFF
--- a/src/ci/docker/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/dist-aarch64-linux/Dockerfile
@@ -32,5 +32,8 @@ ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-gcc \
 
 ENV HOSTS=aarch64-unknown-linux-gnu
 
-ENV RUST_CONFIGURE_ARGS --enable-extended --disable-docs
+ENV RUST_CONFIGURE_ARGS \
+      --enable-extended \
+      --enable-profiler \
+      --disable-docs
 ENV SCRIPT python2.7 ../x.py dist --host $HOSTS --target $HOSTS


### PR DESCRIPTION
This change should enable PGO to be used for aarch64-linux.

Fixes #57257.