### PR TITLE
Remove hamburger button from source code page

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -1052,6 +1052,10 @@ span.since {
 		height: 45px;
 	}
 
+	.rustdoc.source > .sidebar > .sidebar-menu {
+		display: none;
+	}
+
 	.sidebar-elems {
 		position: fixed;
 		z-index: 1;


### PR DESCRIPTION
Fixes #60483.

Screenshot:

<img width="575" alt="Screenshot 2019-05-03 at 00 12 51" src="https://user-images.githubusercontent.com/3050060/57110298-61ec8f00-6d38-11e9-85fd-d13be94b9c52.png">

cc @rust-lang/rustdoc 