### PR TITLE
Fix potential integer overflow in SGX memory range calculation.

### DIFF
--- a/src/libstd/sys/sgx/abi/mem.rs
+++ b/src/libstd/sys/sgx/abi/mem.rs
@@ -27,19 +27,23 @@ pub fn image_base() -> u64 {
 }
 
 /// Returns `true` if the specified memory range is in the enclave.
+///
+/// `p + len` must not overflow.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn is_enclave_range(p: *const u8, len: usize) -> bool {
-    let start=p as u64;
-    let end=start + (len as u64);
+    let start = p as u64;
+    let end = start + (len as u64);
     start >= image_base() &&
         end <= image_base() + (unsafe { ENCLAVE_SIZE } as u64) // unsafe ok: link-time constant
 }
 
 /// Returns `true` if the specified memory range is in userspace.
+///
+/// `p + len` must not overflow.
 #[unstable(feature = "sgx_platform", issue = "56975")]
 pub fn is_user_range(p: *const u8, len: usize) -> bool {
-    let start=p as u64;
-    let end=start + (len as u64);
+    let start = p as u64;
+    let end = start + (len as u64);
     end <= image_base() ||
         start >= image_base() + (unsafe { ENCLAVE_SIZE } as u64) // unsafe ok: link-time constant
 }


### PR DESCRIPTION
Thanks to Eduard Marin and David Oswald at the University of Burmingham, and Jo Van Bulck at KU Leuven for discovering this issue.