### PR TITLE
Rollup of 12 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,7 @@ dependencies = [
 name = "tidy"
 version = "0.1.0"
 dependencies = [
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.81 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -436,7 +436,7 @@ fn configure_cmake(builder: &Builder<'_>,
     }
 
     if env::var_os("SCCACHE_ERROR_LOG").is_some() {
-        cfg.env("RUST_LOG", "sccache=warn");
+        cfg.env("RUSTC_LOG", "sccache=warn");
     }
 }
 

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -362,10 +362,6 @@ struct Foo1 { x: &bool }
               // ^ expected lifetime parameter
 struct Foo2<'a> { x: &'a bool } // correct
 
-impl Foo2 {}
-  // ^^^^ expected lifetime parameter
-impl<'a> Foo2<'a> {} // correct
-
 struct Bar1 { x: Foo2 }
               // ^^^^ expected lifetime parameter
 struct Bar2<'a> { x: Foo2<'a> } // correct
@@ -2208,4 +2204,5 @@ register_diagnostics! {
     E0710, // an unknown tool name found in scoped lint
     E0711, // a feature has been declared with conflicting stability attributes
 //  E0702, // replaced with a generic attribute input check
+    E0726, // non-explicit (not `'_`) elided lifetime in unsupported position
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2110,15 +2110,49 @@ impl<'a> LoweringContext<'a> {
                         .expect("already checked that type args or bindings exist");
                     (false, first_generic_span.shrink_to_lo(), format!("{}, ", anon_lt_suggestion))
                 };
-                self.sess.buffer_lint_with_diagnostic(
-                    ELIDED_LIFETIMES_IN_PATHS,
-                    CRATE_NODE_ID,
-                    path_span,
-                    "hidden lifetime parameters in types are deprecated",
-                    builtin::BuiltinLintDiagnostics::ElidedLifetimesInPaths(
-                        expected_lifetimes, path_span, incl_angl_brckt, insertion_span, suggestion
-                    )
-                );
+                match self.anonymous_lifetime_mode {
+                    // In create-parameter mode we error here because we don't want to support
+                    // deprecated impl elision in new features like impl elision and `async fn`,
+                    // both of which work using the `CreateParameter` mode:
+                    //
+                    //     impl Foo for std::cell::Ref<u32> // note lack of '_
+                    //     async fn foo(_: std::cell::Ref<u32>) { ... }
+                    AnonymousLifetimeMode::CreateParameter => {
+                        let mut err = struct_span_err!(
+                            self.sess,
+                            path_span,
+                            E0726,
+                            "implicit elided lifetime not allowed here"
+                        );
+                        crate::lint::builtin::add_elided_lifetime_in_path_suggestion(
+                            &self.sess,
+                            &mut err,
+                            expected_lifetimes,
+                            path_span,
+                            incl_angl_brckt,
+                            insertion_span,
+                            suggestion,
+                        );
+                        err.emit();
+                    }
+                    AnonymousLifetimeMode::PassThrough |
+                    AnonymousLifetimeMode::ReportError |
+                    AnonymousLifetimeMode::Replace(_) => {
+                        self.sess.buffer_lint_with_diagnostic(
+                            ELIDED_LIFETIMES_IN_PATHS,
+                            CRATE_NODE_ID,
+                            path_span,
+                            "hidden lifetime parameters in types are deprecated",
+                            builtin::BuiltinLintDiagnostics::ElidedLifetimesInPaths(
+                                expected_lifetimes,
+                                path_span,
+                                incl_angl_brckt,
+                                insertion_span,
+                                suggestion,
+                            )
+                        );
+                    }
+                }
             }
         }
 
@@ -5298,13 +5332,15 @@ impl<'a> LoweringContext<'a> {
 
     fn elided_path_lifetime(&mut self, span: Span) -> hir::Lifetime {
         match self.anonymous_lifetime_mode {
-            // N.B., We intentionally ignore the create-parameter mode here
-            // and instead "pass through" to resolve-lifetimes, which will then
-            // report an error. This is because we don't want to support
-            // impl elision for deprecated forms like
-            //
-            //     impl Foo for std::cell::Ref<u32> // note lack of '_
-            AnonymousLifetimeMode::CreateParameter |
+            AnonymousLifetimeMode::CreateParameter => {
+                // We should have emitted E0726 when processing this path above
+                self.sess.delay_span_bug(
+                    span,
+                    "expected 'implicit elided lifetime not allowed' error",
+                );
+                let id = self.sess.next_node_id();
+                self.new_named_lifetime(id, span, hir::LifetimeName::Error)
+            }
             // This is the normal case.
             AnonymousLifetimeMode::PassThrough => self.new_implicit_lifetime(span),
 

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1927,6 +1927,9 @@ pub enum ArgSource {
 /// Represents the header (not the body) of a function declaration.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
 pub struct FnDecl {
+    /// The types of the function's arguments.
+    ///
+    /// Additional argument data is stored in the function's [body](Body::arguments).
     pub inputs: HirVec<Ty>,
     pub output: FunctionRetTy,
     pub c_variadic: bool,

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -644,7 +644,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                         for sp in prior_arms {
                             err.span_label(*sp, format!(
                                 "this is found to be of type `{}`",
-                                last_ty,
+                                self.resolve_type_vars_if_possible(&last_ty),
                             ));
                         }
                     } else if let Some(sp) = prior_arms.last() {

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -694,7 +694,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
     /// potentially leaving "dangling type variables" behind.
     /// In such cases, an assertion will fail when attempting to
     /// register obligations, within a snapshot. Very useful, much
-    /// better than grovelling through megabytes of `RUST_LOG` output.
+    /// better than grovelling through megabytes of `RUSTC_LOG` output.
     ///
     /// HOWEVER, in some cases the flag is unhelpful. In particular, we
     /// sometimes create a "mini-fulfilment-cx" in which we enroll

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -382,7 +382,7 @@ declare_lint! {
 
 declare_lint! {
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
-    Warn,
+    Deny,
     "ambiguous associated items"
 }
 

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -477,6 +477,48 @@ pub enum BuiltinLintDiagnostics {
     RedundantImport(Vec<(Span, bool)>, ast::Ident),
 }
 
+pub(crate) fn add_elided_lifetime_in_path_suggestion(
+    sess: &Session,
+    db: &mut DiagnosticBuilder<'_>,
+    n: usize,
+    path_span: Span,
+    incl_angl_brckt: bool,
+    insertion_span: Span,
+    anon_lts: String,
+) {
+    let (replace_span, suggestion) = if incl_angl_brckt {
+        (insertion_span, anon_lts)
+    } else {
+        // When possible, prefer a suggestion that replaces the whole
+        // `Path<T>` expression with `Path<'_, T>`, rather than inserting `'_, `
+        // at a point (which makes for an ugly/confusing label)
+        if let Ok(snippet) = sess.source_map().span_to_snippet(path_span) {
+            // But our spans can get out of whack due to macros; if the place we think
+            // we want to insert `'_` isn't even within the path expression's span, we
+            // should bail out of making any suggestion rather than panicking on a
+            // subtract-with-overflow or string-slice-out-out-bounds (!)
+            // FIXME: can we do better?
+            if insertion_span.lo().0 < path_span.lo().0 {
+                return;
+            }
+            let insertion_index = (insertion_span.lo().0 - path_span.lo().0) as usize;
+            if insertion_index > snippet.len() {
+                return;
+            }
+            let (before, after) = snippet.split_at(insertion_index);
+            (path_span, format!("{}{}{}", before, anon_lts, after))
+        } else {
+            (insertion_span, anon_lts)
+        }
+    };
+    db.span_suggestion(
+        replace_span,
+        &format!("indicate the anonymous lifetime{}", if n >= 2 { "s" } else { "" }),
+        suggestion,
+        Applicability::MachineApplicable
+    );
+}
+
 impl BuiltinLintDiagnostics {
     pub fn run(self, sess: &Session, db: &mut DiagnosticBuilder<'_>) {
         match self {
@@ -521,36 +563,14 @@ impl BuiltinLintDiagnostics {
             BuiltinLintDiagnostics::ElidedLifetimesInPaths(
                 n, path_span, incl_angl_brckt, insertion_span, anon_lts
             ) => {
-                let (replace_span, suggestion) = if incl_angl_brckt {
-                    (insertion_span, anon_lts)
-                } else {
-                    // When possible, prefer a suggestion that replaces the whole
-                    // `Path<T>` expression with `Path<'_, T>`, rather than inserting `'_, `
-                    // at a point (which makes for an ugly/confusing label)
-                    if let Ok(snippet) = sess.source_map().span_to_snippet(path_span) {
-                        // But our spans can get out of whack due to macros; if the place we think
-                        // we want to insert `'_` isn't even within the path expression's span, we
-                        // should bail out of making any suggestion rather than panicking on a
-                        // subtract-with-overflow or string-slice-out-out-bounds (!)
-                        // FIXME: can we do better?
-                        if insertion_span.lo().0 < path_span.lo().0 {
-                            return;
-                        }
-                        let insertion_index = (insertion_span.lo().0 - path_span.lo().0) as usize;
-                        if insertion_index > snippet.len() {
-                            return;
-                        }
-                        let (before, after) = snippet.split_at(insertion_index);
-                        (path_span, format!("{}{}{}", before, anon_lts, after))
-                    } else {
-                        (insertion_span, anon_lts)
-                    }
-                };
-                db.span_suggestion(
-                    replace_span,
-                    &format!("indicate the anonymous lifetime{}", if n >= 2 { "s" } else { "" }),
-                    suggestion,
-                    Applicability::MachineApplicable
+                add_elided_lifetime_in_path_suggestion(
+                    sess,
+                    db,
+                    n,
+                    path_span,
+                    incl_angl_brckt,
+                    insertion_span,
+                    anon_lts,
                 );
             }
             BuiltinLintDiagnostics::UnknownCrateTypes(span, note, sugg) => {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -757,12 +757,12 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     /// Check if a `DefId`'s path matches the given absolute type path usage.
     ///
     /// # Examples
-    /// ```rust,ignore (no `cx` or `def_id` available)
+    ///
+    /// ```rust,ignore (no context or def id available)
     /// if cx.match_def_path(def_id, &["core", "option", "Option"]) {
     ///     // The given `def_id` is that of an `Option` type
     /// }
     /// ```
-    // Uplifted from rust-lang/rust-clippy
     pub fn match_def_path(&self, def_id: DefId, path: &[&str]) -> bool {
         let names = self.get_def_path(def_id);
 
@@ -772,13 +772,13 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
     /// Gets the absolute path of `def_id` as a vector of `&str`.
     ///
     /// # Examples
-    /// ```rust,ignore (no `cx` or `def_id` available)
+    ///
+    /// ```rust,ignore (no context or def id available)
     /// let def_path = cx.get_def_path(def_id);
     /// if let &["core", "option", "Option"] = &def_path[..] {
     ///     // The given `def_id` is that of an `Option` type
     /// }
     /// ```
-    // Uplifted from rust-lang/rust-clippy
     pub fn get_def_path(&self, def_id: DefId) -> Vec<LocalInternedString> {
         pub struct AbsolutePathPrinter<'a, 'tcx> {
             pub tcx: TyCtxt<'a, 'tcx, 'tcx>,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -63,7 +63,7 @@ pub struct CrateDebugContext<'a, 'tcx> {
     llcontext: &'a llvm::Context,
     llmod: &'a llvm::Module,
     builder: &'a mut DIBuilder<'a>,
-    created_files: RefCell<FxHashMap<(Symbol, Symbol), &'a DIFile>>,
+    created_files: RefCell<FxHashMap<(Option<Symbol>, Option<Symbol>), &'a DIFile>>,
     created_enum_disr_types: RefCell<FxHashMap<(DefId, layout::Primitive), &'a DIType>>,
 
     type_map: RefCell<TypeMap<'a, 'tcx>>,

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -1163,7 +1163,7 @@ pub fn report_ices_to_stderr_if_any<F: FnOnce() -> R, R>(f: F) -> Result<R, Erro
 /// This allows tools to enable rust logging without having to magically match rustc's
 /// log crate version
 pub fn init_rustc_env_logger() {
-    env_logger::init();
+    env_logger::init_from_env("RUSTC_LOG");
 }
 
 pub fn main() {

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -20,7 +20,7 @@ use syntax::ptr::P;
 use syntax::visit::{self, Visitor};
 use syntax::{span_err, struct_span_err, walk_list};
 use syntax_ext::proc_macro_decls::is_proc_macro_attr;
-use syntax_pos::Span;
+use syntax_pos::{Span, MultiSpan};
 use errors::Applicability;
 use log::debug;
 
@@ -682,7 +682,9 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Existential(ref bounds, _) => {
                 if !bounds.iter()
                           .any(|b| if let GenericBound::Trait(..) = *b { true } else { false }) {
-                    self.err_handler().span_err(item.span, "at least one trait must be specified");
+                    let msp = MultiSpan::from_spans(bounds.iter()
+                        .map(|bound| bound.span()).collect());
+                    self.err_handler().span_err(msp, "at least one trait must be specified");
                 }
             }
             _ => {}

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -679,6 +679,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                                                 "unions cannot have zero fields");
                 }
             }
+            ItemKind::Existential(ref bounds, _) => {
+                if !bounds.iter()
+                          .any(|b| if let GenericBound::Trait(..) = *b { true } else { false }) {
+                    self.err_handler().span_err(item.span, "at least one trait must be specified");
+                }
+            }
             _ => {}
         }
 

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -1,8 +1,8 @@
 use crate::check::{FnCtxt, Expectation, Diverges, Needs};
 use crate::check::coercion::CoerceMany;
 use crate::util::nodemap::FxHashMap;
-use errors::Applicability;
-use rustc::hir::{self, PatKind};
+use errors::{Applicability, DiagnosticBuilder};
+use rustc::hir::{self, PatKind, Pat};
 use rustc::hir::def::{Def, CtorKind};
 use rustc::hir::pat_util::EnumerateAndAdjustIterator;
 use rustc::infer;
@@ -377,64 +377,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                             // Look for a case like `fn foo(&foo: u32)` and suggest
                             // `fn foo(foo: &u32)`
                             if let Some(mut err) = err {
-                                if let PatKind::Binding(..) = inner.node {
-                                    let parent_id = tcx.hir().get_parent_node_by_hir_id(pat.hir_id);
-                                    let parent = tcx.hir().get_by_hir_id(parent_id);
-                                    debug!("inner {:?} pat {:?} parent {:?}", inner, pat, parent);
-                                    match parent {
-                                        hir::Node::Item(hir::Item {
-                                            node: hir::ItemKind::Fn(..), ..
-                                        }) |
-                                        hir::Node::ForeignItem(hir::ForeignItem {
-                                            node: hir::ForeignItemKind::Fn(..), ..
-                                        }) |
-                                        hir::Node::TraitItem(hir::TraitItem {
-                                            node: hir::TraitItemKind::Method(..), ..
-                                        }) |
-                                        hir::Node::ImplItem(hir::ImplItem {
-                                            node: hir::ImplItemKind::Method(..), ..
-                                        }) => { // this pat is likely an argument
-                                            if let Ok(snippet) = tcx.sess.source_map()
-                                                .span_to_snippet(inner.span)
-                                            { // FIXME: turn into structured suggestion, will need
-                                              // a span that also includes the the arg's type.
-                                                err.help(&format!(
-                                                    "did you mean `{}: &{}`?",
-                                                    snippet,
-                                                    expected,
-                                                ));
-                                            }
-                                        }
-                                        hir::Node::Expr(hir::Expr {
-                                            node: hir::ExprKind::Match(..), ..
-                                        }) => { // rely on match ergonomics
-                                            if let Ok(snippet) = tcx.sess.source_map()
-                                                .span_to_snippet(inner.span)
-                                            {
-                                                err.span_suggestion(
-                                                    pat.span,
-                                                    "you can rely on match ergonomics and remove \
-                                                     the explicit borrow",
-                                                    snippet,
-                                                    Applicability::MaybeIncorrect,
-                                                );
-                                            }
-                                        }
-                                        hir::Node::Pat(_) => {  // nested `&&pat`
-                                            if let Ok(snippet) = tcx.sess.source_map()
-                                                .span_to_snippet(inner.span)
-                                            {
-                                                err.span_suggestion(
-                                                    pat.span,
-                                                    "you can probaly remove the explicit borrow",
-                                                    snippet,
-                                                    Applicability::MaybeIncorrect,
-                                                );
-                                            }
-                                        }
-                                        _ => {} // don't provide suggestions in other cases #55175
-                                    }
-                                }
+                                self.borrow_pat_suggestion(&mut err, &pat, &inner, &expected);
                                 err.emit();
                             }
                             (rptr_ty, inner_ty)
@@ -564,6 +507,59 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         // bound in a closure signature, and that detection gets thrown
         // off when we substitute fresh region variables here to enable
         // subtyping.
+    }
+
+    fn borrow_pat_suggestion(
+        &self,
+        err: &mut DiagnosticBuilder<'_>,
+        pat: &Pat,
+        inner: &Pat,
+        expected: &Ty<'tcx>,
+    ) {
+        let tcx = self.tcx;
+        if let PatKind::Binding(..) = inner.node {
+            let parent_id = tcx.hir().get_parent_node_by_hir_id(pat.hir_id);
+            let parent = tcx.hir().get_by_hir_id(parent_id);
+            debug!("inner {:?} pat {:?} parent {:?}", inner, pat, parent);
+            match parent {
+                hir::Node::Item(hir::Item { node: hir::ItemKind::Fn(..), .. }) |
+                hir::Node::ForeignItem(hir::ForeignItem {
+                    node: hir::ForeignItemKind::Fn(..), ..
+                }) |
+                hir::Node::TraitItem(hir::TraitItem { node: hir::TraitItemKind::Method(..), .. }) |
+                hir::Node::ImplItem(hir::ImplItem { node: hir::ImplItemKind::Method(..), .. }) => {
+                    // this pat is likely an argument
+                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
+                        // FIXME: turn into structured suggestion, will need a span that also
+                        // includes the the arg's type.
+                        err.help(&format!("did you mean `{}: &{}`?", snippet, expected));
+                    }
+                }
+                hir::Node::Expr(hir::Expr { node: hir::ExprKind::Match(..), .. }) => {
+                    // rely on match ergonomics
+                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
+                        err.span_suggestion(
+                            pat.span,
+                            "you can rely on match ergonomics and remove the explicit borrow",
+                            snippet,
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+                hir::Node::Pat(_) => {
+                    // nested `&&pat`
+                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
+                        err.span_suggestion(
+                            pat.span,
+                            "you can probably remove the explicit borrow",
+                            snippet,
+                            Applicability::MaybeIncorrect,
+                        );
+                    }
+                }
+                _ => {} // don't provide suggestions in other cases #55175
+            }
+        }
     }
 
     pub fn check_dereferencable(&self, span: Span, expected: Ty<'tcx>, inner: &hir::Pat) -> bool {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -535,19 +535,9 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                         err.help(&format!("did you mean `{}: &{}`?", snippet, expected));
                     }
                 }
-                hir::Node::Expr(hir::Expr { node: hir::ExprKind::Match(..), .. }) => {
-                    // rely on match ergonomics
-                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
-                        err.span_suggestion(
-                            pat.span,
-                            "you can rely on match ergonomics and remove the explicit borrow",
-                            snippet,
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
-                }
+                hir::Node::Expr(hir::Expr { node: hir::ExprKind::Match(..), .. }) |
                 hir::Node::Pat(_) => {
-                    // nested `&&pat`
+                    // rely on match ergonomics or it might be nested `&&pat`
                     if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
                         err.span_suggestion(
                             pat.span,

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -514,7 +514,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         pat: &Pat,
         inner: &Pat,
-        expected: &Ty<'tcx>,
+        expected: Ty<'tcx>,
     ) {
         let tcx = self.tcx;
         if let PatKind::Binding(..) = inner.node {

--- a/src/libstd/sys/redox/ext/net.rs
+++ b/src/libstd/sys/redox/ext/net.rs
@@ -1,4 +1,4 @@
-#![stable(feature = "unix_socket_redox", since = "1.29")]
+#![stable(feature = "unix_socket_redox", since = "1.29.0")]
 
 //! Unix-specific networking functionality
 
@@ -27,7 +27,7 @@ use crate::sys::{cvt, fd::FileDesc, syscall};
 /// let addr = socket.local_addr().expect("Couldn't get local address");
 /// ```
 #[derive(Clone)]
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct SocketAddr(());
 
 impl SocketAddr {
@@ -55,7 +55,7 @@ impl SocketAddr {
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.as_pathname(), None);
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn as_pathname(&self) -> Option<&Path> {
         None
     }
@@ -83,12 +83,12 @@ impl SocketAddr {
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// assert_eq!(addr.is_unnamed(), true);
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn is_unnamed(&self) -> bool {
         false
     }
 }
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for SocketAddr {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "SocketAddr")
@@ -109,10 +109,10 @@ impl fmt::Debug for SocketAddr {
 /// stream.read_to_string(&mut response).unwrap();
 /// println!("{}", response);
 /// ```
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct UnixStream(FileDesc);
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for UnixStream {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("UnixStream");
@@ -143,7 +143,7 @@ impl UnixStream {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn connect<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
         if let Some(s) = path.as_ref().to_str() {
             cvt(syscall::open(format!("chan:{}", s), syscall::O_CLOEXEC))
@@ -174,7 +174,7 @@ impl UnixStream {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn pair() -> io::Result<(UnixStream, UnixStream)> {
         let server = cvt(syscall::open("chan:", syscall::O_CREAT | syscall::O_CLOEXEC))
             .map(FileDesc::new)?;
@@ -198,7 +198,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let sock_copy = socket.try_clone().expect("Couldn't clone socket");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn try_clone(&self) -> io::Result<UnixStream> {
         self.0.duplicate().map(UnixStream)
     }
@@ -213,7 +213,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let addr = socket.local_addr().expect("Couldn't get local address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixStream::local_addr unimplemented on redox"))
     }
@@ -228,7 +228,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// let addr = socket.peer_addr().expect("Couldn't get peer address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixStream::peer_addr unimplemented on redox"))
     }
@@ -267,7 +267,7 @@ impl UnixStream {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_read_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::set_read_timeout unimplemented on redox"))
     }
@@ -306,7 +306,7 @@ impl UnixStream {
     /// let err = result.unwrap_err();
     /// assert_eq!(err.kind(), io::ErrorKind::InvalidInput)
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_write_timeout(&self, _timeout: Option<Duration>) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::set_write_timeout unimplemented on redox"))
     }
@@ -323,7 +323,7 @@ impl UnixStream {
     /// socket.set_read_timeout(Some(Duration::new(1, 0))).expect("Couldn't set read timeout");
     /// assert_eq!(socket.read_timeout().unwrap(), Some(Duration::new(1, 0)));
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
         Err(Error::new(ErrorKind::Other, "UnixStream::read_timeout unimplemented on redox"))
     }
@@ -340,7 +340,7 @@ impl UnixStream {
     /// socket.set_write_timeout(Some(Duration::new(1, 0))).expect("Couldn't set write timeout");
     /// assert_eq!(socket.write_timeout().unwrap(), Some(Duration::new(1, 0)));
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
         Err(Error::new(ErrorKind::Other, "UnixStream::write_timeout unimplemented on redox"))
     }
@@ -355,7 +355,7 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// socket.set_nonblocking(true).expect("Couldn't set nonblocking");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
     }
@@ -375,7 +375,7 @@ impl UnixStream {
     ///
     /// # Platform specific
     /// On Redox this always returns `None`.
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         Ok(None)
     }
@@ -397,13 +397,13 @@ impl UnixStream {
     /// let socket = UnixStream::connect("/tmp/sock").unwrap();
     /// socket.shutdown(Shutdown::Both).expect("shutdown function failed");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn shutdown(&self, _how: Shutdown) -> io::Result<()> {
         Err(Error::new(ErrorKind::Other, "UnixStream::shutdown unimplemented on redox"))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl io::Read for UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         io::Read::read(&mut &*self, buf)
@@ -415,7 +415,7 @@ impl io::Read for UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> io::Read for &'a UnixStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
@@ -427,7 +427,7 @@ impl<'a> io::Read for &'a UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl io::Write for UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         io::Write::write(&mut &*self, buf)
@@ -438,7 +438,7 @@ impl io::Write for UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> io::Write for &'a UnixStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
@@ -449,21 +449,21 @@ impl<'a> io::Write for &'a UnixStream {
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl AsRawFd for UnixStream {
     fn as_raw_fd(&self) -> RawFd {
         self.0.raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl FromRawFd for UnixStream {
     unsafe fn from_raw_fd(fd: RawFd) -> UnixStream {
         UnixStream(FileDesc::new(fd))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl IntoRawFd for UnixStream {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw()
@@ -498,10 +498,10 @@ impl IntoRawFd for UnixStream {
 ///     }
 /// }
 /// ```
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct UnixListener(FileDesc);
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl fmt::Debug for UnixListener {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = fmt.debug_struct("UnixListener");
@@ -529,7 +529,7 @@ impl UnixListener {
     ///     }
     /// };
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
         if let Some(s) = path.as_ref().to_str() {
             cvt(syscall::open(format!("chan:{}", s), syscall::O_CREAT | syscall::O_CLOEXEC))
@@ -563,7 +563,7 @@ impl UnixListener {
     ///     Err(e) => println!("accept function failed: {:?}", e),
     /// }
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         self.0.duplicate_path(b"listen").map(|fd| (UnixStream(fd), SocketAddr(())))
     }
@@ -583,7 +583,7 @@ impl UnixListener {
     ///
     /// let listener_copy = listener.try_clone().expect("try_clone failed");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn try_clone(&self) -> io::Result<UnixListener> {
         self.0.duplicate().map(UnixListener)
     }
@@ -599,7 +599,7 @@ impl UnixListener {
     ///
     /// let addr = listener.local_addr().expect("Couldn't get local address");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         Err(Error::new(ErrorKind::Other, "UnixListener::local_addr unimplemented on redox"))
     }
@@ -615,7 +615,7 @@ impl UnixListener {
     ///
     /// listener.set_nonblocking(true).expect("Couldn't set non blocking");
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
     }
@@ -636,7 +636,7 @@ impl UnixListener {
     ///
     /// # Platform specific
     /// On Redox this always returns `None`.
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         Ok(None)
     }
@@ -672,34 +672,34 @@ impl UnixListener {
     ///     }
     /// }
     /// ```
-    #[stable(feature = "unix_socket_redox", since = "1.29")]
+    #[stable(feature = "unix_socket_redox", since = "1.29.0")]
     pub fn incoming<'a>(&'a self) -> Incoming<'a> {
         Incoming { listener: self }
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl AsRawFd for UnixListener {
     fn as_raw_fd(&self) -> RawFd {
         self.0.raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl FromRawFd for UnixListener {
     unsafe fn from_raw_fd(fd: RawFd) -> UnixListener {
         UnixListener(FileDesc::new(fd))
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl IntoRawFd for UnixListener {
     fn into_raw_fd(self) -> RawFd {
         self.0.into_raw()
     }
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> IntoIterator for &'a UnixListener {
     type Item = io::Result<UnixStream>;
     type IntoIter = Incoming<'a>;
@@ -740,12 +740,12 @@ impl<'a> IntoIterator for &'a UnixListener {
 /// }
 /// ```
 #[derive(Debug)]
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 pub struct Incoming<'a> {
     listener: &'a UnixListener,
 }
 
-#[stable(feature = "unix_socket_redox", since = "1.29")]
+#[stable(feature = "unix_socket_redox", since = "1.29.0")]
 impl<'a> Iterator for Incoming<'a> {
     type Item = io::Result<UnixStream>;
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -109,15 +109,14 @@ macro_rules! declare_features {
 // stable (active).
 //
 // Note that the features should be grouped into internal/user-facing
-// and then sorted by version inside those groups.
-// FIXME(60361): Enforce ^-- with tidy.
+// and then sorted by version inside those groups. This is inforced with tidy.
 //
 // N.B., `tools/tidy/src/features.rs` parses this information directly out of the
 // source, so take care when modifying it.
 
 declare_features! (
     // -------------------------------------------------------------------------
-    // Internal feature gates.
+    // feature-group-start: internal feature gates
     // -------------------------------------------------------------------------
 
     // no tracking issue START
@@ -211,11 +210,11 @@ declare_features! (
 
     // no tracking issue END
 
-    // Allows using the `may_dangle` attribute (RFC 1327).
-    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
-
     // Allows using `#[structural_match]` which indicates that a type is structurally matchable.
     (active, structural_match, "1.8.0", Some(31434), None),
+
+    // Allows using the `may_dangle` attribute (RFC 1327).
+    (active, dropck_eyepatch, "1.10.0", Some(34761), None),
 
     // Allows using the `#![panic_runtime]` attribute.
     (active, panic_runtime, "1.10.0", Some(32837), None),
@@ -252,7 +251,11 @@ declare_features! (
     (active, test_2018_feature, "1.31.0", Some(0), Some(Edition::Edition2018)),
 
     // -------------------------------------------------------------------------
-    // Actual feature gates (target features).
+    // feature-group-end: internal feature gates
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // feature-group-start: actual feature gates (target features)
     // -------------------------------------------------------------------------
 
     // FIXME: Document these and merge with the list below.
@@ -275,7 +278,11 @@ declare_features! (
     (active, f16c_target_feature, "1.36.0", Some(44839), None),
 
     // -------------------------------------------------------------------------
-    // Actual feature gates.
+    // feature-group-end: actual feature gates (target features)
+    // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // feature-group-start: actual feature gates
     // -------------------------------------------------------------------------
 
     // Allows using `asm!` macro with which inline assembly can be embedded.
@@ -340,9 +347,6 @@ declare_features! (
     // Permits specifying whether a function should permit unwinding or abort on unwind.
     (active, unwind_attributes, "1.4.0", Some(58760), None),
 
-    // Allows using `#[naked]` on functions.
-    (active, naked_functions, "1.9.0", Some(32408), None),
-
     // Allows `#[no_debug]`.
     (active, no_debug, "1.5.0", Some(29721), None),
 
@@ -357,6 +361,9 @@ declare_features! (
 
     // Allows specialization of implementations (RFC 1210).
     (active, specialization, "1.7.0", Some(31844), None),
+
+    // Allows using `#[naked]` on functions.
+    (active, naked_functions, "1.9.0", Some(32408), None),
 
     // Allows `cfg(target_has_atomic = "...")`.
     (active, cfg_target_has_atomic, "1.9.0", Some(32976), None),
@@ -545,6 +552,10 @@ declare_features! (
 
     // Allows using C-variadics.
     (active, c_variadic, "1.34.0", Some(44930), None),
+
+    // -------------------------------------------------------------------------
+    // feature-group-end: actual feature gates
+    // -------------------------------------------------------------------------
 );
 
 // Some features are known to be incomplete and using them is likely to have

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -8725,9 +8725,9 @@ impl<'a> Parser<'a> {
                 // Check if this is a ident pattern, if so, we can optimize and avoid adding a
                 // `let <pat> = __argN;` statement, instead just adding a `let <pat> = <pat>;`
                 // statement.
-                let (ident, is_simple_pattern) = match input.pat.node {
-                    PatKind::Ident(_, ident, _) => (ident, true),
-                    _ => (ident, false),
+                let (binding_mode, ident, is_simple_pattern) = match input.pat.node {
+                    PatKind::Ident(binding_mode, ident, _) => (binding_mode, ident, true),
+                    _ => (BindingMode::ByValue(Mutability::Immutable), ident, false),
                 };
 
                 // Construct an argument representing `__argN: <ty>` to replace the argument of the
@@ -8755,9 +8755,7 @@ impl<'a> Parser<'a> {
                 let move_local = Local {
                     pat: P(Pat {
                         id,
-                        node: PatKind::Ident(
-                            BindingMode::ByValue(Mutability::Immutable), ident, None,
-                        ),
+                        node: PatKind::Ident(binding_mode, ident, None),
                         span,
                     }),
                     // We explicitly do not specify the type for this statement. When the user's

--- a/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
+++ b/src/test/run-make-fulldeps/libs-through-symlinks/Makefile
@@ -8,4 +8,4 @@ all:
 	mkdir -p $(TMPDIR)/outdir
 	$(RUSTC) foo.rs -o $(TMPDIR)/outdir/$(NAME)
 	ln -nsf outdir/$(NAME) $(TMPDIR)
-	RUST_LOG=rustc_metadata::loader $(RUSTC) bar.rs
+	RUSTC_LOG=rustc_metadata::loader $(RUSTC) bar.rs

--- a/src/test/run-pass/existential_type.rs
+++ b/src/test/run-pass/existential_type.rs
@@ -68,14 +68,14 @@ fn my_other_iter<U>(u: U) -> MyOtherIter<U> {
 }
 
 trait Trait {}
-existential type GenericBound<'a, T: Trait>: 'a;
+existential type GenericBound<'a, T: Trait>: Sized + 'a;
 
 fn generic_bound<'a, T: Trait + 'a>(t: T) -> GenericBound<'a, T> {
     t
 }
 
 mod pass_through {
-    pub existential type Passthrough<T>: 'static;
+    pub existential type Passthrough<T>: Sized + 'static;
 
     fn define_passthrough<T: 'static>(t: T) -> Passthrough<T> {
         t

--- a/src/test/run-pass/issues/issue-18075.rs
+++ b/src/test/run-pass/issues/issue-18075.rs
@@ -1,5 +1,5 @@
 // run-pass
-// exec-env:RUST_LOG=rustc::middle=debug
+// exec-env:RUSTC_LOG=rustc::middle=debug
 
 fn main() {
     let b = 1isize;

--- a/src/test/run-pass/logging-only-prints-once.rs
+++ b/src/test/run-pass/logging-only-prints-once.rs
@@ -1,6 +1,6 @@
 // ignore-windows
 // ignore-emscripten no threads support
-// exec-env:RUST_LOG=debug
+// exec-env:RUSTC_LOG=debug
 
 use std::cell::Cell;
 use std::fmt;

--- a/src/test/run-pass/logging_before_rt_started.rs
+++ b/src/test/run-pass/logging_before_rt_started.rs
@@ -1,4 +1,4 @@
-// exec-env:RUST_LOG=std::ptr
+// exec-env:RUSTC_LOG=std::ptr
 
 // In issue #9487, it was realized that std::ptr was invoking the logging
 // infrastructure, and when std::ptr was used during runtime initialization,

--- a/src/test/run-pass/rustc-rust-log.rs
+++ b/src/test/run-pass/rustc-rust-log.rs
@@ -8,6 +8,6 @@
 // dont-check-compiler-stderr
 // compile-flags: --error-format human
 
-// rustc-env:RUST_LOG=debug
+// rustc-env:RUSTC_LOG=debug
 
 fn main() {}

--- a/src/test/run-pass/threads-sendsync/spawning-with-debug.rs
+++ b/src/test/run-pass/threads-sendsync/spawning-with-debug.rs
@@ -2,7 +2,7 @@
 #![allow(unused_must_use)]
 #![allow(unused_mut)]
 // ignore-windows
-// exec-env:RUST_LOG=debug
+// exec-env:RUSTC_LOG=debug
 // ignore-emscripten no threads support
 
 // regression test for issue #10405, make sure we don't call println! too soon.

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -15,7 +15,7 @@ error[E0425]: cannot find value `no` in this scope
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:310:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -24,7 +24,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:332:17
+', src/librustdoc/test.rs:341:17
 
 
 failures:

--- a/src/test/rustdoc-ui/unparseable-doc-test.rs
+++ b/src/test/rustdoc-ui/unparseable-doc-test.rs
@@ -1,0 +1,10 @@
+// compile-flags: --test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// failure-status: 101
+// rustc-env: RUST_BACKTRACE=0
+
+/// ```rust
+/// let x = 7;
+/// "unterminated
+/// ```
+pub fn foo() {}

--- a/src/test/rustdoc-ui/unparseable-doc-test.stdout
+++ b/src/test/rustdoc-ui/unparseable-doc-test.stdout
@@ -1,0 +1,24 @@
+
+running 1 test
+test $DIR/unparseable-doc-test.rs - foo (line 6) ... FAILED
+
+failures:
+
+---- $DIR/unparseable-doc-test.rs - foo (line 6) stdout ----
+error: unterminated double quote string
+ --> $DIR/unparseable-doc-test.rs:8:1
+  |
+2 | "unterminated
+  | ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+thread '$DIR/unparseable-doc-test.rs - foo (line 6)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
+note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+
+
+failures:
+    $DIR/unparseable-doc-test.rs - foo (line 6)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+

--- a/src/test/ui/async-await/mutable-arguments.rs
+++ b/src/test/ui/async-await/mutable-arguments.rs
@@ -1,0 +1,10 @@
+// edition:2018
+// run-pass
+
+#![feature(async_await)]
+
+async fn foo(n: u32, mut vec: Vec<u32>) {
+    vec.push(n);
+}
+
+fn main() {}

--- a/src/test/ui/async-fn-path-elision.rs
+++ b/src/test/ui/async-fn-path-elision.rs
@@ -1,0 +1,16 @@
+// edition:2018
+
+#![feature(async_await, await_macro)]
+#![allow(dead_code)]
+
+struct HasLifetime<'a>(&'a bool);
+
+async fn error(lt: HasLifetime) { //~ ERROR implicit elided lifetime not allowed here
+    if *lt.0 {}
+}
+
+fn no_error(lt: HasLifetime) {
+    if *lt.0 {}
+}
+
+fn main() {}

--- a/src/test/ui/async-fn-path-elision.stderr
+++ b/src/test/ui/async-fn-path-elision.stderr
@@ -1,0 +1,8 @@
+error[E0726]: implicit elided lifetime not allowed here
+  --> $DIR/async-fn-path-elision.rs:8:20
+   |
+LL | async fn error(lt: HasLifetime) {
+   |                    ^^^^^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
+
+error: aborting due to previous error
+

--- a/src/test/ui/consts/const-err.rs
+++ b/src/test/ui/consts/const-err.rs
@@ -13,4 +13,5 @@ const FOO: u8 = [5u8][1];
 fn main() {
     black_box((FOO, FOO));
     //~^ ERROR erroneous constant used
+    //~| ERROR erroneous constant
 }

--- a/src/test/ui/consts/const-err.stderr
+++ b/src/test/ui/consts/const-err.stderr
@@ -13,11 +13,17 @@ LL | #![warn(const_err)]
    |         ^^^^^^^^^
 
 error[E0080]: erroneous constant used
-  --> $DIR/const-err.rs:14:15
+  --> $DIR/const-err.rs:14:16
    |
 LL |     black_box((FOO, FOO));
-   |               ^^^^^^^^^^ referenced constant has errors
+   |                ^^^ referenced constant has errors
 
-error: aborting due to previous error
+error[E0080]: erroneous constant used
+  --> $DIR/const-err.rs:14:21
+   |
+LL |     black_box((FOO, FOO));
+   |                     ^^^ referenced constant has errors
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -24,7 +24,6 @@ LL |     let &&x = &1isize as &T;
    |
    = note: expected type `dyn T`
               found type `&_`
-   = help: did you mean `x: &dyn T`?
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:36:11
@@ -34,7 +33,6 @@ LL |     let &&&x = &(&1isize as &T);
    |
    = note: expected type `dyn T`
               found type `&_`
-   = help: did you mean `x: &dyn T`?
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:41:13

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -23,7 +23,7 @@ LL |     let &&x = &1isize as &T;
    |          ^^
    |          |
    |          expected trait T, found reference
-   |          help: you can probaly remove the explicit borrow: `x`
+   |          help: you can probably remove the explicit borrow: `x`
    |
    = note: expected type `dyn T`
               found type `&_`
@@ -35,7 +35,7 @@ LL |     let &&&x = &(&1isize as &T);
    |           ^^
    |           |
    |           expected trait T, found reference
-   |           help: you can probaly remove the explicit borrow: `x`
+   |           help: you can probably remove the explicit borrow: `x`
    |
    = note: expected type `dyn T`
               found type `&_`

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -20,7 +20,10 @@ error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:31:10
    |
 LL |     let &&x = &1isize as &T;
-   |          ^^ expected trait T, found reference
+   |          ^^
+   |          |
+   |          expected trait T, found reference
+   |          help: you can probaly remove the explicit borrow: `x`
    |
    = note: expected type `dyn T`
               found type `&_`
@@ -29,7 +32,10 @@ error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:36:11
    |
 LL |     let &&&x = &(&1isize as &T);
-   |           ^^ expected trait T, found reference
+   |           ^^
+   |           |
+   |           expected trait T, found reference
+   |           help: you can probaly remove the explicit borrow: `x`
    |
    = note: expected type `dyn T`
               found type `&_`

--- a/src/test/ui/existential_types/existential-types-with-no-traits.rs
+++ b/src/test/ui/existential_types/existential-types-with-no-traits.rs
@@ -1,0 +1,14 @@
+#![feature(existential_type)]
+
+existential type Foo: 'static;
+//~^ ERROR: at least one trait must be specified
+
+fn foo() -> Foo {
+    "foo"
+}
+
+fn bar() -> impl 'static { //~ ERROR: at least one trait must be specified
+    "foo"
+}
+
+fn main() {}

--- a/src/test/ui/existential_types/existential-types-with-no-traits.stderr
+++ b/src/test/ui/existential_types/existential-types-with-no-traits.stderr
@@ -1,0 +1,14 @@
+error: at least one trait must be specified
+  --> $DIR/existential-types-with-no-traits.rs:3:1
+   |
+LL | existential type Foo: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: at least one trait must be specified
+  --> $DIR/existential-types-with-no-traits.rs:10:13
+   |
+LL | fn bar() -> impl 'static {
+   |             ^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/existential_types/existential-types-with-no-traits.stderr
+++ b/src/test/ui/existential_types/existential-types-with-no-traits.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/existential-types-with-no-traits.rs:3:1
+  --> $DIR/existential-types-with-no-traits.rs:3:23
    |
 LL | existential type Foo: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                       ^^^^^^^
 
 error: at least one trait must be specified
   --> $DIR/existential-types-with-no-traits.rs:10:13

--- a/src/test/ui/existential_types/generic_nondefining_use.rs
+++ b/src/test/ui/existential_types/generic_nondefining_use.rs
@@ -4,6 +4,8 @@ fn main() {}
 
 existential type Cmp<T>: 'static;
 //~^ ERROR could not find defining uses
+//~^^ ERROR: at least one trait must be specified
+
 
 // not a defining use, because it doesn't define *all* possible generics
 fn cmp() -> Cmp<u32> { //~ ERROR defining existential type use does not fully define

--- a/src/test/ui/existential_types/generic_nondefining_use.stderr
+++ b/src/test/ui/existential_types/generic_nondefining_use.stderr
@@ -1,5 +1,11 @@
+error: at least one trait must be specified
+  --> $DIR/generic_nondefining_use.rs:5:1
+   |
+LL | existential type Cmp<T>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: defining existential type use does not fully define existential type
-  --> $DIR/generic_nondefining_use.rs:9:1
+  --> $DIR/generic_nondefining_use.rs:11:1
    |
 LL | / fn cmp() -> Cmp<u32> {
 LL | |     5u32
@@ -12,5 +18,5 @@ error: could not find defining uses
 LL | existential type Cmp<T>: 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/existential_types/generic_nondefining_use.stderr
+++ b/src/test/ui/existential_types/generic_nondefining_use.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_nondefining_use.rs:5:1
+  --> $DIR/generic_nondefining_use.rs:5:26
    |
 LL | existential type Cmp<T>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          ^^^^^^^
 
 error: defining existential type use does not fully define existential type
   --> $DIR/generic_nondefining_use.rs:11:1

--- a/src/test/ui/existential_types/generic_not_used.rs
+++ b/src/test/ui/existential_types/generic_not_used.rs
@@ -3,6 +3,7 @@
 fn main() {}
 
 existential type WrongGeneric<T: 'static>: 'static;
+//~^ ERROR: at least one trait must be specified
 
 fn wrong_generic<U: 'static, V: 'static>(_: U, v: V) -> WrongGeneric<U> {
 //~^ ERROR type parameter `V` is part of concrete type but not used in parameter list

--- a/src/test/ui/existential_types/generic_not_used.stderr
+++ b/src/test/ui/existential_types/generic_not_used.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_not_used.rs:5:1
+  --> $DIR/generic_not_used.rs:5:44
    |
 LL | existential type WrongGeneric<T: 'static>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                            ^^^^^^^
 
 error: type parameter `V` is part of concrete type but not used in parameter list for existential type
   --> $DIR/generic_not_used.rs:8:73

--- a/src/test/ui/existential_types/generic_not_used.stderr
+++ b/src/test/ui/existential_types/generic_not_used.stderr
@@ -1,5 +1,11 @@
+error: at least one trait must be specified
+  --> $DIR/generic_not_used.rs:5:1
+   |
+LL | existential type WrongGeneric<T: 'static>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: type parameter `V` is part of concrete type but not used in parameter list for existential type
-  --> $DIR/generic_not_used.rs:7:73
+  --> $DIR/generic_not_used.rs:8:73
    |
 LL |   fn wrong_generic<U: 'static, V: 'static>(_: U, v: V) -> WrongGeneric<U> {
    |  _________________________________________________________________________^
@@ -8,5 +14,5 @@ LL | |     v
 LL | | }
    | |_^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/existential_types/generic_type_does_not_live_long_enough.rs
+++ b/src/test/ui/existential_types/generic_type_does_not_live_long_enough.rs
@@ -8,6 +8,7 @@ fn main() {
 
 existential type WrongGeneric<T>: 'static;
 //~^ ERROR the parameter type `T` may not live long enough
+//~^^ ERROR: at least one trait must be specified
 
 fn wrong_generic<T>(t: T) -> WrongGeneric<T> {
     t

--- a/src/test/ui/existential_types/generic_type_does_not_live_long_enough.stderr
+++ b/src/test/ui/existential_types/generic_type_does_not_live_long_enough.stderr
@@ -1,3 +1,9 @@
+error: at least one trait must be specified
+  --> $DIR/generic_type_does_not_live_long_enough.rs:9:1
+   |
+LL | existential type WrongGeneric<T>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0308]: mismatched types
   --> $DIR/generic_type_does_not_live_long_enough.rs:6:18
    |
@@ -22,7 +28,7 @@ note: ...so that the type `T` will meet its required lifetime bounds
 LL | existential type WrongGeneric<T>: 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0308, E0310.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/existential_types/generic_type_does_not_live_long_enough.stderr
+++ b/src/test/ui/existential_types/generic_type_does_not_live_long_enough.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:9:1
+  --> $DIR/generic_type_does_not_live_long_enough.rs:9:35
    |
 LL | existential type WrongGeneric<T>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/generic_type_does_not_live_long_enough.rs:6:18

--- a/src/test/ui/existential_types/generic_underconstrained.rs
+++ b/src/test/ui/existential_types/generic_underconstrained.rs
@@ -4,6 +4,7 @@ fn main() {}
 
 trait Trait {}
 existential type Underconstrained<T: Trait>: 'static; //~ ERROR the trait bound `T: Trait`
+//~^ ERROR: at least one trait must be specified
 
 // no `Trait` bound
 fn underconstrain<T>(_: T) -> Underconstrained<T> {

--- a/src/test/ui/existential_types/generic_underconstrained.stderr
+++ b/src/test/ui/existential_types/generic_underconstrained.stderr
@@ -1,8 +1,8 @@
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained.rs:6:1
+  --> $DIR/generic_underconstrained.rs:6:46
    |
 LL | existential type Underconstrained<T: Trait>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^
 
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/generic_underconstrained.rs:6:1

--- a/src/test/ui/existential_types/generic_underconstrained.stderr
+++ b/src/test/ui/existential_types/generic_underconstrained.stderr
@@ -1,3 +1,9 @@
+error: at least one trait must be specified
+  --> $DIR/generic_underconstrained.rs:6:1
+   |
+LL | existential type Underconstrained<T: Trait>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/generic_underconstrained.rs:6:1
    |
@@ -7,6 +13,6 @@ LL | existential type Underconstrained<T: Trait>: 'static;
    = help: consider adding a `where T: Trait` bound
    = note: the return type of a function must have a statically known size
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/existential_types/generic_underconstrained2.rs
+++ b/src/test/ui/existential_types/generic_underconstrained2.rs
@@ -4,6 +4,7 @@ fn main() {}
 
 existential type Underconstrained<T: std::fmt::Debug>: 'static;
 //~^ ERROR `U` doesn't implement `std::fmt::Debug`
+//~^^ ERROR: at least one trait must be specified
 
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained<U>(_: U) -> Underconstrained<U> {
@@ -12,6 +13,7 @@ fn underconstrained<U>(_: U) -> Underconstrained<U> {
 
 existential type Underconstrained2<T: std::fmt::Debug>: 'static;
 //~^ ERROR `V` doesn't implement `std::fmt::Debug`
+//~^^ ERROR: at least one trait must be specified
 
 // not a defining use, because it doesn't define *all* possible generics
 fn underconstrained2<U, V>(_: U, _: V) -> Underconstrained2<V> {

--- a/src/test/ui/existential_types/generic_underconstrained2.stderr
+++ b/src/test/ui/existential_types/generic_underconstrained2.stderr
@@ -1,3 +1,15 @@
+error: at least one trait must be specified
+  --> $DIR/generic_underconstrained2.rs:5:1
+   |
+LL | existential type Underconstrained<T: std::fmt::Debug>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: at least one trait must be specified
+  --> $DIR/generic_underconstrained2.rs:14:1
+   |
+LL | existential type Underconstrained2<T: std::fmt::Debug>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: `U` doesn't implement `std::fmt::Debug`
   --> $DIR/generic_underconstrained2.rs:5:1
    |
@@ -9,7 +21,7 @@ LL | existential type Underconstrained<T: std::fmt::Debug>: 'static;
    = note: the return type of a function must have a statically known size
 
 error[E0277]: `V` doesn't implement `std::fmt::Debug`
-  --> $DIR/generic_underconstrained2.rs:13:1
+  --> $DIR/generic_underconstrained2.rs:14:1
    |
 LL | existential type Underconstrained2<T: std::fmt::Debug>: 'static;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `V` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
@@ -18,6 +30,6 @@ LL | existential type Underconstrained2<T: std::fmt::Debug>: 'static;
    = help: consider adding a `where V: std::fmt::Debug` bound
    = note: the return type of a function must have a statically known size
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/existential_types/generic_underconstrained2.stderr
+++ b/src/test/ui/existential_types/generic_underconstrained2.stderr
@@ -1,14 +1,14 @@
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:5:1
+  --> $DIR/generic_underconstrained2.rs:5:56
    |
 LL | existential type Underconstrained<T: std::fmt::Debug>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                        ^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/generic_underconstrained2.rs:14:1
+  --> $DIR/generic_underconstrained2.rs:14:57
    |
 LL | existential type Underconstrained2<T: std::fmt::Debug>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^
 
 error[E0277]: `U` doesn't implement `std::fmt::Debug`
   --> $DIR/generic_underconstrained2.rs:5:1

--- a/src/test/ui/existential_types/unused_generic_param.rs
+++ b/src/test/ui/existential_types/unused_generic_param.rs
@@ -1,18 +1,17 @@
-// compile-pass
 #![feature(existential_type)]
 
 fn main() {
 }
 
-// test that unused generic parameters are ok
 existential type PartiallyDefined<T>: 'static;
+//~^ ERROR: at least one trait must be specified
 
 fn partially_defined<T: std::fmt::Debug>(_: T) -> PartiallyDefined<T> {
     4u32
 }
 
-// test that unused generic parameters are ok
 existential type PartiallyDefined2<T>: 'static;
+//~^ ERROR: at least one trait must be specified
 
 fn partially_defined2<T: std::fmt::Debug>(_: T) -> PartiallyDefined2<T> {
     4u32

--- a/src/test/ui/existential_types/unused_generic_param.stderr
+++ b/src/test/ui/existential_types/unused_generic_param.stderr
@@ -1,14 +1,14 @@
 error: at least one trait must be specified
-  --> $DIR/unused_generic_param.rs:6:1
+  --> $DIR/unused_generic_param.rs:6:39
    |
 LL | existential type PartiallyDefined<T>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                       ^^^^^^^
 
 error: at least one trait must be specified
-  --> $DIR/unused_generic_param.rs:13:1
+  --> $DIR/unused_generic_param.rs:13:40
    |
 LL | existential type PartiallyDefined2<T>: 'static;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                        ^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/existential_types/unused_generic_param.stderr
+++ b/src/test/ui/existential_types/unused_generic_param.stderr
@@ -1,0 +1,14 @@
+error: at least one trait must be specified
+  --> $DIR/unused_generic_param.rs:6:1
+   |
+LL | existential type PartiallyDefined<T>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: at least one trait must be specified
+  --> $DIR/unused_generic_param.rs:13:1
+   |
+LL | existential type PartiallyDefined2<T>: 'static;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/impl-header-lifetime-elision/path-elided.rs
+++ b/src/test/ui/impl-header-lifetime-elision/path-elided.rs
@@ -5,7 +5,7 @@ trait MyTrait { }
 struct Foo<'a> { x: &'a u32 }
 
 impl MyTrait for Foo {
-    //~^ ERROR missing lifetime specifier
+    //~^ ERROR implicit elided lifetime not allowed here
 }
 
 fn main() {}

--- a/src/test/ui/impl-header-lifetime-elision/path-elided.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/path-elided.stderr
@@ -1,9 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0726]: implicit elided lifetime not allowed here
   --> $DIR/path-elided.rs:7:18
    |
 LL | impl MyTrait for Foo {
-   |                  ^^^ expected lifetime parameter
+   |                  ^^^- help: indicate the anonymous lifetime: `<'_>`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/impl-header-lifetime-elision/trait-elided.rs
+++ b/src/test/ui/impl-header-lifetime-elision/trait-elided.rs
@@ -3,7 +3,7 @@
 trait MyTrait<'a> { }
 
 impl MyTrait for u32 {
-    //~^ ERROR missing lifetime specifier
+    //~^ ERROR implicit elided lifetime not allowed here
 }
 
 fn main() {}

--- a/src/test/ui/impl-header-lifetime-elision/trait-elided.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/trait-elided.stderr
@@ -1,9 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0726]: implicit elided lifetime not allowed here
   --> $DIR/trait-elided.rs:5:6
    |
 LL | impl MyTrait for u32 {
-   |      ^^^^^^^ expected lifetime parameter
+   |      ^^^^^^^- help: indicate the anonymous lifetime: `<'_>`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/issues/issue-10412.rs
+++ b/src/test/ui/issues/issue-10412.rs
@@ -5,7 +5,8 @@ trait Serializable<'self, T> { //~ ERROR lifetimes cannot use keyword names
 
 impl<'self> Serializable<str> for &'self str { //~ ERROR lifetimes cannot use keyword names
     //~^ ERROR lifetimes cannot use keyword names
-    //~| ERROR missing lifetime specifier
+    //~| ERROR implicit elided lifetime not allowed here
+    //~| ERROR the size for values of type `str` cannot be known at compilation time
     fn serialize(val : &'self str) -> Vec<u8> { //~ ERROR lifetimes cannot use keyword names
         vec![1]
     }

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -29,23 +29,32 @@ LL | impl<'self> Serializable<str> for &'self str {
    |                                    ^^^^^
 
 error: lifetimes cannot use keyword names
-  --> $DIR/issue-10412.rs:9:25
+  --> $DIR/issue-10412.rs:10:25
    |
 LL |     fn serialize(val : &'self str) -> Vec<u8> {
    |                         ^^^^^
 
 error: lifetimes cannot use keyword names
-  --> $DIR/issue-10412.rs:12:37
+  --> $DIR/issue-10412.rs:13:37
    |
 LL |     fn deserialize(repr: &[u8]) -> &'self str {
    |                                     ^^^^^
 
-error[E0106]: missing lifetime specifier
+error[E0726]: implicit elided lifetime not allowed here
   --> $DIR/issue-10412.rs:6:13
    |
 LL | impl<'self> Serializable<str> for &'self str {
-   |             ^^^^^^^^^^^^^^^^^ expected lifetime parameter
+   |             ^^^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `Serializable<'_, str>`
 
-error: aborting due to 8 previous errors
+error[E0277]: the size for values of type `str` cannot be known at compilation time
+  --> $DIR/issue-10412.rs:6:13
+   |
+LL | impl<'self> Serializable<str> for &'self str {
+   |             ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `str`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/match/match-type-err-first-arm.rs
+++ b/src/test/ui/match/match-type-err-first-arm.rs
@@ -3,8 +3,7 @@ fn main() {
     let _ = test_func2(1);
 }
 
-fn test_func1(n: i32) -> i32 {
-    //~^ NOTE expected `i32` because of return type
+fn test_func1(n: i32) -> i32 { //~ NOTE expected `i32` because of return type
     match n {
         12 => 'b',
         //~^ ERROR mismatched types
@@ -14,10 +13,8 @@ fn test_func1(n: i32) -> i32 {
 }
 
 fn test_func2(n: i32) -> i32 {
-    let x = match n {
-    //~^ NOTE `match` arms have incompatible types
-        12 => 'b',
-        //~^ NOTE this is found to be of type `char`
+    let x = match n { //~ NOTE `match` arms have incompatible types
+        12 => 'b', //~ NOTE this is found to be of type `char`
         _ => 42,
         //~^ ERROR match arms have incompatible types
         //~| NOTE expected char, found integer
@@ -27,8 +24,7 @@ fn test_func2(n: i32) -> i32 {
 }
 
 fn test_func3(n: i32) -> i32 {
-    let x = match n {
-    //~^ NOTE `match` arms have incompatible types
+    let x = match n { //~ NOTE `match` arms have incompatible types
         1 => 'b',
         2 => 'b',
         3 => 'b',
@@ -42,4 +38,16 @@ fn test_func3(n: i32) -> i32 {
         //~| NOTE expected type `char`
     };
     x
+}
+
+fn test_func4() {
+    match Some(0u32) { //~ NOTE `match` arms have incompatible types
+        Some(x) => {
+            x //~ NOTE this is found to be of type `u32`
+        },
+        None => {}
+        //~^ ERROR match arms have incompatible types
+        //~| NOTE expected u32, found ()
+        //~| NOTE expected type `u32`
+    };
 }

--- a/src/test/ui/match/match-type-err-first-arm.stderr
+++ b/src/test/ui/match/match-type-err-first-arm.stderr
@@ -1,24 +1,23 @@
 error[E0308]: mismatched types
-  --> $DIR/match-type-err-first-arm.rs:9:15
+  --> $DIR/match-type-err-first-arm.rs:8:15
    |
 LL | fn test_func1(n: i32) -> i32 {
    |                          --- expected `i32` because of return type
-...
+LL |     match n {
 LL |         12 => 'b',
    |               ^^^ expected i32, found char
 
 error[E0308]: match arms have incompatible types
-  --> $DIR/match-type-err-first-arm.rs:21:14
+  --> $DIR/match-type-err-first-arm.rs:18:14
    |
 LL |       let x = match n {
    |  _____________-
-LL | |
 LL | |         12 => 'b',
    | |               --- this is found to be of type `char`
-LL | |
 LL | |         _ => 42,
    | |              ^^ expected char, found integer
-...  |
+LL | |
+LL | |
 LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
@@ -27,13 +26,13 @@ LL | |     };
               found type `{integer}`
 
 error[E0308]: match arms have incompatible types
-  --> $DIR/match-type-err-first-arm.rs:39:14
+  --> $DIR/match-type-err-first-arm.rs:35:14
    |
 LL |       let x = match n {
    |  _____________-
-LL | |
 LL | |         1 => 'b',
 LL | |         2 => 'b',
+LL | |         3 => 'b',
 ...  |
 LL | |         6 => 'b',
    | |              --- this and all prior arms are found to be of type `char`
@@ -48,6 +47,24 @@ LL | |     };
    = note: expected type `char`
               found type `{integer}`
 
-error: aborting due to 3 previous errors
+error[E0308]: match arms have incompatible types
+  --> $DIR/match-type-err-first-arm.rs:48:17
+   |
+LL | /     match Some(0u32) {
+LL | |         Some(x) => {
+LL | |             x
+   | |             - this is found to be of type `u32`
+LL | |         },
+LL | |         None => {}
+   | |                 ^^ expected u32, found ()
+...  |
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected type `u32`
+              found type `()`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -16,7 +16,6 @@ LL | fn agh(&&bar: &u32) {
    |
    = note: expected type `u32`
               found type `&_`
-   = help: did you mean `bar: &u32`?
 
 error[E0308]: mismatched types
   --> $DIR/issue-38371.rs:21:8

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -12,7 +12,10 @@ error[E0308]: mismatched types
   --> $DIR/issue-38371.rs:18:9
    |
 LL | fn agh(&&bar: &u32) {
-   |         ^^^^ expected u32, found reference
+   |         ^^^^
+   |         |
+   |         expected u32, found reference
+   |         help: you can probaly remove the explicit borrow: `bar`
    |
    = note: expected type `u32`
               found type `&_`

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -15,7 +15,7 @@ LL | fn agh(&&bar: &u32) {
    |         ^^^^
    |         |
    |         expected u32, found reference
-   |         help: you can probaly remove the explicit borrow: `bar`
+   |         help: you can probably remove the explicit borrow: `bar`
    |
    = note: expected type `u32`
               found type `&_`

--- a/src/test/ui/suggestions/match-ergonomics.rs
+++ b/src/test/ui/suggestions/match-ergonomics.rs
@@ -37,4 +37,5 @@ fn main() {
         v => {},
         _ => {},
     }
+    if let [&v] = &x[..] {} //~ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/match-ergonomics.rs
+++ b/src/test/ui/suggestions/match-ergonomics.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let x = vec![1i32];
+    match &x[..] {
+        [&v] => {}, //~ ERROR mismatched types
+        _ => {},
+    }
+    match x {
+        [&v] => {}, //~ ERROR expected an array or slice
+        _ => {},
+    }
+    match &x[..] {
+        [v] => {},
+        _ => {},
+    }
+    match &x[..] {
+        &[v] => {},
+        _ => {},
+    }
+    match x {
+        [v] => {}, //~ ERROR expected an array or slice
+        _ => {},
+    }
+    let y = 1i32;
+    match &y {
+        &v => {},
+        _ => {},
+    }
+    match y {
+        &v => {}, //~ ERROR mismatched types
+        _ => {},
+    }
+    match &y {
+        v => {},
+        _ => {},
+    }
+    match y {
+        v => {},
+        _ => {},
+    }
+}

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -26,14 +26,13 @@ error[E0308]: mismatched types
   --> $DIR/match-ergonomics.rs:29:9
    |
 LL |         &v => {},
-   |         ^^ expected i32, found reference
+   |         ^^
+   |         |
+   |         expected i32, found reference
+   |         help: you can probably remove the explicit borrow: `v`
    |
    = note: expected type `i32`
               found type `&_`
-help: you can rely on match ergonomics and remove the explicit borrow
-   |
-LL |         v => {},
-   |         ^
 
 error[E0308]: mismatched types
   --> $DIR/match-ergonomics.rs:40:13

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -35,7 +35,19 @@ help: you can rely on match ergonomics and remove the explicit borrow
 LL |         v => {},
    |         ^
 
-error: aborting due to 4 previous errors
+error[E0308]: mismatched types
+  --> $DIR/match-ergonomics.rs:40:13
+   |
+LL |     if let [&v] = &x[..] {}
+   |             ^^
+   |             |
+   |             expected i32, found reference
+   |             help: you can probably remove the explicit borrow: `v`
+   |
+   = note: expected type `i32`
+              found type `&_`
+
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0308, E0529.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -5,7 +5,7 @@ LL |         [&v] => {},
    |          ^^
    |          |
    |          expected i32, found reference
-   |          help: you can probaly remove the explicit borrow: `v`
+   |          help: you can probably remove the explicit borrow: `v`
    |
    = note: expected type `i32`
               found type `&_`

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -1,0 +1,41 @@
+error[E0308]: mismatched types
+  --> $DIR/match-ergonomics.rs:4:10
+   |
+LL |         [&v] => {},
+   |          ^^
+   |          |
+   |          expected i32, found reference
+   |          help: you can probaly remove the explicit borrow: `v`
+   |
+   = note: expected type `i32`
+              found type `&_`
+
+error[E0529]: expected an array or slice, found `std::vec::Vec<i32>`
+  --> $DIR/match-ergonomics.rs:8:9
+   |
+LL |         [&v] => {},
+   |         ^^^^ pattern cannot match with input type `std::vec::Vec<i32>`
+
+error[E0529]: expected an array or slice, found `std::vec::Vec<i32>`
+  --> $DIR/match-ergonomics.rs:20:9
+   |
+LL |         [v] => {},
+   |         ^^^ pattern cannot match with input type `std::vec::Vec<i32>`
+
+error[E0308]: mismatched types
+  --> $DIR/match-ergonomics.rs:29:9
+   |
+LL |         &v => {},
+   |         ^^ expected i32, found reference
+   |
+   = note: expected type `i32`
+              found type `&_`
+help: you can rely on match ergonomics and remove the explicit borrow
+   |
+LL |         v => {},
+   |         ^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0308, E0529.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-enum-variants-priority.rs
+++ b/src/test/ui/type-alias-enum-variants-priority.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_enum_variants)]
-#![deny(ambiguous_associated_items)]
 
 enum E {
     V

--- a/src/test/ui/type-alias-enum-variants-priority.stderr
+++ b/src/test/ui/type-alias-enum-variants-priority.stderr
@@ -1,23 +1,19 @@
 error: ambiguous associated item
-  --> $DIR/type-alias-enum-variants-priority.rs:15:15
+  --> $DIR/type-alias-enum-variants-priority.rs:14:15
    |
 LL |     fn f() -> Self::V { 0 }
    |               ^^^^^^^ help: use fully-qualified syntax: `<E as Trait>::V`
    |
-note: lint level defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:2:9
-   |
-LL | #![deny(ambiguous_associated_items)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: #[deny(ambiguous_associated_items)] on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
 note: `V` could refer to variant defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:5:5
+  --> $DIR/type-alias-enum-variants-priority.rs:4:5
    |
 LL |     V
    |     ^
 note: `V` could also refer to associated type defined here
-  --> $DIR/type-alias-enum-variants-priority.rs:9:5
+  --> $DIR/type-alias-enum-variants-priority.rs:8:5
    |
 LL |     type V;
    |     ^^^^^^^

--- a/src/tools/tidy/Cargo.toml
+++ b/src/tools/tidy/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 
 [dependencies]
+regex = "1"
 serde = "1.0.8"
 serde_derive = "1.0.8"
 serde_json = "1.0.2"

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -147,7 +147,7 @@ pub fn check(path: &Path, bad: &mut bool, quiet: bool) {
     }
 }
 
-fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator<Item=String> + 'a {
+fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator<Item = String> + 'a {
     features.iter().map(move |(name, feature)| {
         format!("{:<32} {:<8} {:<12} {:<8}",
                 name,

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -249,7 +249,7 @@ pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
                 Err(err) => {
                     tidy_error!(
                         bad,
-                        "libsyntax/feature_gate.rs:{}: failed to parse since: {} ({})",
+                        "libsyntax/feature_gate.rs:{}: failed to parse since: {} ({:?})",
                         line_number,
                         since_str,
                         err,

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -153,8 +153,8 @@ fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator
                 name,
                 family,
                 feature.level,
-                feature.since.as_ref().map_or("None".to_owned(),
-                                              |since| since.to_string()))
+                feature.since.map_or("None".to_owned(),
+                                     |since| since.to_string()))
     })
 }
 
@@ -265,7 +265,7 @@ pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
                         name,
                     );
                 }
-                prev_since = since.clone();
+                prev_since = since;
             }
 
             let issue_str = parts.next().unwrap().trim();

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -1,0 +1,66 @@
+use std::str::FromStr;
+use std::num::ParseIntError;
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+    parts: Vec<u32>,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let x = self.parts.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(".");
+        f.pad(&x)
+    }
+}
+
+impl FromStr for Version {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
+        Ok(Version { parts })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Version;
+
+    #[test]
+    fn test_try_from_invalid_version() {
+        assert!("".parse::<Version>().is_err());
+        assert!("hello".parse::<Version>().is_err());
+        assert!("1.32.hi".parse::<Version>().is_err());
+        assert!("1.32..1".parse::<Version>().is_err());
+    }
+
+    #[test]
+    fn test_try_from_single() {
+        assert_eq!("1.32.0".parse(), Ok(Version { parts: vec![1, 32, 0] }));
+        assert_eq!("1.0.0".parse(), Ok(Version { parts: vec![1, 0, 0] }));
+    }
+
+    #[test]
+    fn test_compare() {
+        let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
+        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
+        assert!(v_1_0_0 < v_1_32_1);
+        assert!(v_1_0_0 < v_1_32);
+        assert!(v_1_32 < v_1_32_1);
+    }
+
+    #[test]
+    fn test_to_string() {
+        let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
+        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
+
+        assert_eq!(v_1_0_0.to_string(), "1.0.0");
+        assert_eq!(v_1_32.to_string(), "1.32");
+        assert_eq!(v_1_32_1.to_string(), "1.32.1");
+        assert_eq!(format!("{:<8}", v_1_32_1), "1.32.1  ");
+        assert_eq!(format!("{:>8}", v_1_32_1), "  1.32.1");
+    }
+}

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 use std::num::ParseIntError;
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
     parts: [u32; 3],
 }

--- a/src/tools/tidy/src/features/version.rs
+++ b/src/tools/tidy/src/features/version.rs
@@ -1,10 +1,11 @@
 use std::str::FromStr;
 use std::num::ParseIntError;
 use std::fmt;
+use std::convert::TryInto;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version {
-    parts: Vec<u32>,
+    parts: [u32; 3],
 }
 
 impl fmt::Display for Version {
@@ -14,12 +15,27 @@ impl fmt::Display for Version {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum ParseVersionError {
+    ParseIntError(ParseIntError),
+    // core::array::TryFromSlice is not exported from std, so we invent our own variant
+    WrongNumberOfParts
+}
+
+impl From<ParseIntError> for ParseVersionError {
+    fn from(err: ParseIntError) -> Self {
+        ParseVersionError::ParseIntError(err)
+    }
+}
+
 impl FromStr for Version {
-    type Err = ParseIntError;
+    type Err = ParseVersionError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
-        Ok(Version { parts })
+        let parts: Vec<_> = s.split('.').map(|part| part.parse()).collect::<Result<_, _>>()?;
+        Ok(Self {
+            parts: parts.as_slice().try_into() .or(Err(ParseVersionError::WrongNumberOfParts))?,
+        })
     }
 }
 
@@ -33,32 +49,32 @@ mod test {
         assert!("hello".parse::<Version>().is_err());
         assert!("1.32.hi".parse::<Version>().is_err());
         assert!("1.32..1".parse::<Version>().is_err());
+        assert!("1.32".parse::<Version>().is_err());
+        assert!("1.32.0.1".parse::<Version>().is_err());
     }
 
     #[test]
     fn test_try_from_single() {
-        assert_eq!("1.32.0".parse(), Ok(Version { parts: vec![1, 32, 0] }));
-        assert_eq!("1.0.0".parse(), Ok(Version { parts: vec![1, 0, 0] }));
+        assert_eq!("1.32.0".parse(), Ok(Version { parts: [1, 32, 0] }));
+        assert_eq!("1.0.0".parse(), Ok(Version { parts: [1, 0, 0] }));
     }
 
     #[test]
     fn test_compare() {
         let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
-        let v_1_32 = "1.32".parse::<Version>().unwrap();
+        let v_1_32_0 = "1.32.0".parse::<Version>().unwrap();
         let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
         assert!(v_1_0_0 < v_1_32_1);
-        assert!(v_1_0_0 < v_1_32);
-        assert!(v_1_32 < v_1_32_1);
+        assert!(v_1_0_0 < v_1_32_0);
+        assert!(v_1_32_0 < v_1_32_1);
     }
 
     #[test]
     fn test_to_string() {
         let v_1_0_0 = "1.0.0".parse::<Version>().unwrap();
-        let v_1_32 = "1.32".parse::<Version>().unwrap();
         let v_1_32_1 = "1.32.1".parse::<Version>().unwrap();
 
         assert_eq!(v_1_0_0.to_string(), "1.0.0");
-        assert_eq!(v_1_32.to_string(), "1.32");
         assert_eq!(v_1_32_1.to_string(), "1.32.1");
         assert_eq!(format!("{:<8}", v_1_32_1), "1.32.1  ");
         assert_eq!(format!("{:>8}", v_1_32_1), "  1.32.1");

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(rust_2018_idioms)]
 
+extern crate regex;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Successful merges:

 - #59928 (Make deprecation lint `ambiguous_associated_items` deny-by-default)
 - #60220 (report fatal errors during doctest parsing)
 - #60373 (Tidy: ensure lang features are sorted by since)
 - #60388 (Disallow non-explicit elided lifetimes in async fn)
 - #60393 ( Do not suggest incorrect syntax on pattern type error due to borrow)
 - #60401 (Rename `RUST_LOG` to `RUSTC_LOG`)
 - #60409 (Require a trait in the bounds of existential types)
 - #60455 (Resolve match arm ty when arms diverge)
 - #60457 (Const prop refactoring)
 - #60467 (Avoid repeated interning of static strings.)
 - #60478 (minor compiler doc tweaks)
 - #60501 (Propagate mutability from arguments to local bindings in async fn)

Failed merges:


r? @ghost