### PR TITLE
Add rustfmt toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+# Currently, most of the code in the compiler uses historical style.
+#
+# For new code, consider running rustfmt with this config (it should
+# be picked up automatically).
+version = "Two"
+use_small_heuristics = "Max"


### PR DESCRIPTION
This commit adds an rustfmt.toml for using for **new** code.
Old code should continut to use old style, until we put automated
style checks in place.

See
https://internals.rust-lang.org/t/running-rustfmt-on-rust-lang-rust-and-other-rust-lang-repositories/8732/81
for the reason why we deviate from the default formatting. The TL;DR
is that currently compiler uses a pretty condensed style of code, and
default settings both create a huge diff and inflate the number of
lines. use_small_heuristics=Max fixes that.

version=Two is required for bug-fixes, which technically can't be made
to the stable first version

cc @Centril: I guess adding config file with agreed-upon formatting doesn't hurt :-)

EDIT: Zullip discussion: https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/x.2Epy.20fmt