### PR TITLE
rustc: collapse relevant DefPathData variants into {Type,Value,Macro,Lifetime}Ns.

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -952,7 +952,7 @@ impl<'a> LoweringContext<'a> {
         self.resolver.definitions().create_def_with_parent(
             parent_index,
             node_id,
-            DefPathData::LifetimeParam(str_name),
+            DefPathData::LifetimeNs(str_name),
             DefIndexAddressSpace::High,
             Mark::root(),
             span,
@@ -1749,7 +1749,7 @@ impl<'a> LoweringContext<'a> {
                     self.context.resolver.definitions().create_def_with_parent(
                         self.parent,
                         def_node_id,
-                        DefPathData::LifetimeParam(name.ident().as_interned_str()),
+                        DefPathData::LifetimeNs(name.ident().as_interned_str()),
                         DefIndexAddressSpace::High,
                         Mark::root(),
                         lifetime.span,

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -226,7 +226,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             let name = field.ident.map(|ident| ident.name)
                 .unwrap_or_else(|| Symbol::intern(&index.to_string()));
             let def = self.create_def(field.id,
-                                      DefPathData::Field(name.as_interned_str()),
+                                      DefPathData::ValueNs(name.as_interned_str()),
                                       REGULAR_SPACE,
                                       field.span);
             self.with_parent(def, |this| this.visit_struct_field(field));
@@ -238,7 +238,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
         let def_path_data = match param.kind {
             GenericParamKind::Lifetime { .. } => DefPathData::LifetimeParam(name),
             GenericParamKind::Type { .. } => DefPathData::TypeNs(name),
-            GenericParamKind::Const { .. } => DefPathData::ConstParam(name),
+            GenericParamKind::Const { .. } => DefPathData::ValueNs(name),
         };
         self.create_def(param.id, def_path_data, REGULAR_SPACE, param.ident.span);
 

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -164,7 +164,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             }
             ItemKind::Static(..) | ItemKind::Const(..) | ItemKind::Fn(..) =>
                 DefPathData::ValueNs(i.ident.as_interned_str()),
-            ItemKind::MacroDef(..) => DefPathData::MacroDef(i.ident.as_interned_str()),
+            ItemKind::MacroDef(..) => DefPathData::MacroNs(i.ident.as_interned_str()),
             ItemKind::Mac(..) => return self.visit_macro_invoc(i.id),
             ItemKind::GlobalAsm(..) => DefPathData::Misc,
             ItemKind::Use(..) => {
@@ -236,7 +236,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_generic_param(&mut self, param: &'a GenericParam) {
         let name = param.ident.as_interned_str();
         let def_path_data = match param.kind {
-            GenericParamKind::Lifetime { .. } => DefPathData::LifetimeParam(name),
+            GenericParamKind::Lifetime { .. } => DefPathData::LifetimeNs(name),
             GenericParamKind::Type { .. } => DefPathData::TypeNs(name),
             GenericParamKind::Const { .. } => DefPathData::ValueNs(name),
         };

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -341,13 +341,13 @@ pub enum DefPathData {
     TypeNs(InternedString),
     /// Something in the value NS
     ValueNs(InternedString),
-    /// A macro rule
-    MacroDef(InternedString),
+    /// Something in the macro NS
+    MacroNs(InternedString),
+    /// Something in the lifetime NS
+    LifetimeNs(InternedString),
     /// A closure expression
     ClosureExpr,
     // Subportions of items
-    /// A lifetime (generic) parameter
-    LifetimeParam(InternedString),
     /// Implicit ctor for a unit or tuple-like struct or enum variant.
     Ctor,
     /// A constant expression (see {ast,hir}::AnonConst).
@@ -614,8 +614,8 @@ impl DefPathData {
         match *self {
             TypeNs(name) |
             ValueNs(name) |
-            MacroDef(name) |
-            LifetimeParam(name) |
+            MacroNs(name) |
+            LifetimeNs(name) |
             GlobalMetaData(name) => Some(name),
 
             Impl |
@@ -633,8 +633,8 @@ impl DefPathData {
         let s = match *self {
             TypeNs(name) |
             ValueNs(name) |
-            MacroDef(name) |
-            LifetimeParam(name) |
+            MacroNs(name) |
+            LifetimeNs(name) |
             GlobalMetaData(name) => {
                 return name
             }

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -337,33 +337,19 @@ pub enum DefPathData {
     // Different kinds of items and item-like things:
     /// An impl
     Impl,
-    /// A trait
-    Trait(InternedString),
-    /// An associated type **declaration** (i.e., in a trait)
-    AssocTypeInTrait(InternedString),
-    /// An associated type **value** (i.e., in an impl)
-    AssocTypeInImpl(InternedString),
-    /// An existential associated type **value** (i.e., in an impl)
-    AssocExistentialInImpl(InternedString),
     /// Something in the type NS
     TypeNs(InternedString),
     /// Something in the value NS
     ValueNs(InternedString),
-    /// A module declaration
-    Module(InternedString),
     /// A macro rule
     MacroDef(InternedString),
     /// A closure expression
     ClosureExpr,
     // Subportions of items
-    /// A type (generic) parameter
-    TypeParam(InternedString),
     /// A lifetime (generic) parameter
     LifetimeParam(InternedString),
     /// A const (generic) parameter
     ConstParam(InternedString),
-    /// A variant of a enum
-    EnumVariant(InternedString),
     /// A struct field
     Field(InternedString),
     /// Implicit ctor for a unit or tuple-like struct or enum variant.
@@ -376,8 +362,6 @@ pub enum DefPathData {
     /// a whole crate (as opposed to just one item). GlobalMetaData components
     /// are only supposed to show up right below the crate root.
     GlobalMetaData(InternedString),
-    /// A trait alias.
-    TraitAlias(InternedString),
 }
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug,
@@ -633,18 +617,10 @@ impl DefPathData {
         use self::DefPathData::*;
         match *self {
             TypeNs(name) |
-            Trait(name) |
-            TraitAlias(name) |
-            AssocTypeInTrait(name) |
-            AssocTypeInImpl(name) |
-            AssocExistentialInImpl(name) |
             ValueNs(name) |
-            Module(name) |
             MacroDef(name) |
-            TypeParam(name) |
             LifetimeParam(name) |
             ConstParam(name) |
-            EnumVariant(name) |
             Field(name) |
             GlobalMetaData(name) => Some(name),
 
@@ -662,18 +638,10 @@ impl DefPathData {
         use self::DefPathData::*;
         let s = match *self {
             TypeNs(name) |
-            Trait(name) |
-            TraitAlias(name) |
-            AssocTypeInTrait(name) |
-            AssocTypeInImpl(name) |
-            AssocExistentialInImpl(name) |
             ValueNs(name) |
-            Module(name) |
             MacroDef(name) |
-            TypeParam(name) |
             LifetimeParam(name) |
             ConstParam(name) |
-            EnumVariant(name) |
             Field(name) |
             GlobalMetaData(name) => {
                 return name

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -348,10 +348,6 @@ pub enum DefPathData {
     // Subportions of items
     /// A lifetime (generic) parameter
     LifetimeParam(InternedString),
-    /// A const (generic) parameter
-    ConstParam(InternedString),
-    /// A struct field
-    Field(InternedString),
     /// Implicit ctor for a unit or tuple-like struct or enum variant.
     Ctor,
     /// A constant expression (see {ast,hir}::AnonConst).
@@ -620,8 +616,6 @@ impl DefPathData {
             ValueNs(name) |
             MacroDef(name) |
             LifetimeParam(name) |
-            ConstParam(name) |
-            Field(name) |
             GlobalMetaData(name) => Some(name),
 
             Impl |
@@ -641,8 +635,6 @@ impl DefPathData {
             ValueNs(name) |
             MacroDef(name) |
             LifetimeParam(name) |
-            ConstParam(name) |
-            Field(name) |
             GlobalMetaData(name) => {
                 return name
             }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -355,7 +355,6 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
             // the children of the visible parent (as was done when computing
             // `visible_parent_map`), looking for the specific child we currently have and then
             // have access to the re-exported name.
-            DefPathData::Module(ref mut name) |
             DefPathData::TypeNs(ref mut name) if Some(visible_parent) != actual_parent => {
                 let reexport = self.tcx().item_children(visible_parent)
                     .iter()
@@ -367,7 +366,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
             }
             // Re-exported `extern crate` (#43189).
             DefPathData::CrateRoot => {
-                data = DefPathData::Module(
+                data = DefPathData::TypeNs(
                     self.tcx().original_crate_name(def_id.krate).as_interned_str(),
                 );
             }
@@ -860,7 +859,6 @@ impl TyCtxt<'_, '_, '_> {
     fn guess_def_namespace(self, def_id: DefId) -> Namespace {
         match self.def_key(def_id).disambiguated_data.data {
             DefPathData::ValueNs(..) |
-            DefPathData::EnumVariant(..) |
             DefPathData::Field(..) |
             DefPathData::AnonConst |
             DefPathData::ConstParam(..) |

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -858,12 +858,16 @@ impl TyCtxt<'_, '_, '_> {
     // (but also some things just print a `DefId` generally so maybe we need this?)
     fn guess_def_namespace(self, def_id: DefId) -> Namespace {
         match self.def_key(def_id).disambiguated_data.data {
-            DefPathData::ValueNs(..) |
-            DefPathData::AnonConst |
-            DefPathData::ClosureExpr |
-            DefPathData::Ctor => Namespace::ValueNS,
+            DefPathData::TypeNs(..)
+            | DefPathData::CrateRoot
+            | DefPathData::ImplTrait => Namespace::TypeNS,
 
-            DefPathData::MacroDef(..) => Namespace::MacroNS,
+            DefPathData::ValueNs(..)
+            | DefPathData::AnonConst
+            | DefPathData::ClosureExpr
+            | DefPathData::Ctor => Namespace::ValueNS,
+
+            DefPathData::MacroNs(..) => Namespace::MacroNS,
 
             _ => Namespace::TypeNS,
         }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -859,9 +859,7 @@ impl TyCtxt<'_, '_, '_> {
     fn guess_def_namespace(self, def_id: DefId) -> Namespace {
         match self.def_key(def_id).disambiguated_data.data {
             DefPathData::ValueNs(..) |
-            DefPathData::Field(..) |
             DefPathData::AnonConst |
-            DefPathData::ConstParam(..) |
             DefPathData::ClosureExpr |
             DefPathData::Ctor => Namespace::ValueNS,
 

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -1,6 +1,7 @@
 //! Miscellaneous type-system utilities that are too small to deserve their own modules.
 
 use crate::hir;
+use crate::hir::def::DefKind;
 use crate::hir::def_id::DefId;
 use crate::hir::map::DefPathData;
 use crate::mir::interpret::{sign_extend, truncate};
@@ -529,21 +530,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
 
     /// Returns `true` if `def_id` refers to a trait (i.e., `trait Foo { ... }`).
     pub fn is_trait(self, def_id: DefId) -> bool {
-        if let DefPathData::Trait(_) = self.def_key(def_id).disambiguated_data.data {
-            true
-        } else {
-            false
-        }
+        self.def_kind(def_id) == Some(DefKind::Trait)
     }
 
     /// Returns `true` if `def_id` refers to a trait alias (i.e., `trait Foo = ...;`),
     /// and `false` otherwise.
     pub fn is_trait_alias(self, def_id: DefId) -> bool {
-        if let DefPathData::TraitAlias(_) = self.def_key(def_id).disambiguated_data.data {
-            true
-        } else {
-            false
-        }
+        self.def_kind(def_id) == Some(DefKind::TraitAlias)
     }
 
     /// Returns `true` if this `DefId` refers to the implicit constructor for

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -459,7 +459,7 @@ crate fn proc_macro_def_path_table(crate_root: &CrateRoot,
         let def_index = definitions.create_def_with_parent(
             crate_root,
             ast::DUMMY_NODE_ID,
-            DefPathData::MacroDef(name.as_interned_str()),
+            DefPathData::MacroNs(name.as_interned_str()),
             DefIndexAddressSpace::High,
             Mark::root(),
             DUMMY_SP);

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -586,8 +586,13 @@ impl<'a, 'b: 'a, 'tcx: 'b> IsolatedEncoder<'a, 'b, 'tcx> {
         let data = VariantData {
             ctor_kind: variant.ctor_kind,
             discr: variant.discr,
+            // FIXME(eddyb) deduplicate these with `encode_enum_variant_ctor`.
             ctor: variant.ctor_def_id.map(|did| did.index),
-            ctor_sig: None,
+            ctor_sig: if variant.ctor_kind == CtorKind::Fn {
+                variant.ctor_def_id.map(|ctor_def_id| self.lazy(&tcx.fn_sig(ctor_def_id)))
+            } else {
+                None
+            },
         };
 
         let enum_id = tcx.hir().as_local_hir_id(enum_did).unwrap();

--- a/src/test/ui/symbol-names/basic.stderr
+++ b/src/test/ui/symbol-names/basic.stderr
@@ -1,4 +1,4 @@
-error: symbol-name(_ZN5basic4main17h08bcaf310214ed52E)
+error: symbol-name(_ZN5basic4main17hd72940ef9669d526E)
   --> $DIR/basic.rs:3:1
    |
 LL | #[rustc_symbol_name]

--- a/src/test/ui/symbol-names/impl1.stderr
+++ b/src/test/ui/symbol-names/impl1.stderr
@@ -1,4 +1,4 @@
-error: symbol-name(_ZN5impl13foo3Foo3bar17hc487d6ec13fe9124E)
+error: symbol-name(_ZN5impl13foo3Foo3bar17he53b9bee7600ed8dE)
   --> $DIR/impl1.rs:8:9
    |
 LL |         #[rustc_symbol_name]
@@ -10,7 +10,7 @@ error: def-path(foo::Foo::bar)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN5impl13bar33_$LT$impl$u20$impl1..foo..Foo$GT$3baz17h38577281258e1527E)
+error: symbol-name(_ZN5impl13bar33_$LT$impl$u20$impl1..foo..Foo$GT$3baz17h86c41f0462d901d4E)
   --> $DIR/impl1.rs:18:9
    |
 LL |         #[rustc_symbol_name]


### PR DESCRIPTION
`DefPathData` was meant to disambiguate within each namespace, but over the years, that purpose was overlooked, and it started to serve a double-role as a sort of `DefKind` (which #60462 properly adds).
Now, we can go back to *only* categorizing namespaces (at least for the variants with names in them).

r? @petrochenkov or @nikomatsakis cc @michaelwoerister 