### PR TITLE
Fix async fn lowering ICE with APIT.

### DIFF
--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -92,10 +92,12 @@ impl<'a> DefCollector<'a> {
             visit::walk_generics(this, generics);
 
             // Walk the generated arguments for the `async fn`.
-            for a in arguments {
+            for (i, a) in arguments.iter().enumerate() {
                 use visit::Visitor;
                 if let Some(arg) = &a.arg {
                     this.visit_ty(&arg.ty);
+                } else {
+                    this.visit_ty(&decl.inputs[i].ty);
                 }
             }
 

--- a/src/test/ui/async-await/issue-60518.rs
+++ b/src/test/ui/async-await/issue-60518.rs
@@ -1,0 +1,12 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await)]
+
+// This is a regression test to ensure that simple bindings (where replacement arguments aren't
+// created during async fn lowering) that have their DefId used during HIR lowering (such as impl
+// trait) are visited during def collection and thus have a DefId.
+
+async fn foo(ws: impl Iterator<Item = ()>) {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #60518.

This PR fixes an ICE where simple bindings (which aren't replaced with replacement arguments during async fn lowering) were not being visited in the def collector and thus caused an ICE during HIR lowering for types that use their `DefId` at that point - such as `impl Trait`.

r? @cramertj