### PR TITLE
rustc: rename all occurences of "freevar" to "upvar".

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -140,7 +140,7 @@ pub enum Res<Id = hir::HirId> {
     SelfCtor(DefId /* impl */),  // `DefId` refers to the impl
     Local(Id),
     Upvar(Id,           // `HirId` of closed over local
-          usize,        // index in the `freevars` list of the closure
+          usize,        // index in the `upvars` list of the closure
           ast::NodeId), // expr node that creates the closure
 
     // Macro namespace

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2476,19 +2476,19 @@ impl ForeignItemKind {
     }
 }
 
-/// A free variable referred to in a function.
+/// A variable captured by a closure.
 #[derive(Debug, Copy, Clone, RustcEncodable, RustcDecodable, HashStable)]
-pub struct Freevar<Id = HirId> {
-    /// The variable being accessed free.
+pub struct Upvar<Id = HirId> {
+    /// The variable being captured.
     pub res: Res<Id>,
 
     // First span where it is accessed (there can be multiple).
     pub span: Span
 }
 
-impl<Id: fmt::Debug + Copy> Freevar<Id> {
-    pub fn map_id<R>(self, map: impl FnMut(Id) -> R) -> Freevar<R> {
-        Freevar {
+impl<Id: fmt::Debug + Copy> Upvar<Id> {
+    pub fn map_id<R>(self, map: impl FnMut(Id) -> R) -> Upvar<R> {
+        Upvar {
             res: self.res.map_id(map),
             span: self.span,
         }
@@ -2497,12 +2497,12 @@ impl<Id: fmt::Debug + Copy> Freevar<Id> {
     pub fn var_id(&self) -> Id {
         match self.res {
             Res::Local(id) | Res::Upvar(id, ..) => id,
-            _ => bug!("Freevar::var_id: bad res ({:?})", self.res)
+            _ => bug!("Upvar::var_id: bad res ({:?})", self.res)
         }
     }
 }
 
-pub type FreevarMap = NodeMap<Vec<Freevar<ast::NodeId>>>;
+pub type UpvarMap = NodeMap<Vec<Upvar<ast::NodeId>>>;
 
 pub type CaptureModeMap = NodeMap<CaptureClause>;
 

--- a/src/librustc/infer/error_reporting/note.rs
+++ b/src/librustc/infer/error_reporting/note.rs
@@ -46,7 +46,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                 err.span_note(span,
                               "...so that pointer is not dereferenced outside its lifetime");
             }
-            infer::FreeVariable(span, id) => {
+            infer::ClosureCapture(span, id) => {
                 err.span_note(span,
                               &format!("...so that captured variable `{}` does not outlive the \
                                         enclosing closure",
@@ -214,7 +214,7 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                     "the reference is only valid for ", sup, "");
                 err
             }
-            infer::FreeVariable(span, id) => {
+            infer::ClosureCapture(span, id) => {
                 let mut err = struct_span_err!(self.tcx.sess,
                                                span,
                                                E0474,

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -264,8 +264,8 @@ pub enum SubregionOrigin<'tcx> {
     /// Dereference of reference must be within its lifetime
     DerefPointer(Span),
 
-    /// Closure bound must not outlive captured free variables
-    FreeVariable(Span, ast::NodeId),
+    /// Closure bound must not outlive captured variables
+    ClosureCapture(Span, ast::NodeId),
 
     /// Index into slice must be within its lifetime
     IndexSlice(Span),
@@ -1660,7 +1660,7 @@ impl<'tcx> SubregionOrigin<'tcx> {
             InfStackClosure(a) => a,
             InvokeClosure(a) => a,
             DerefPointer(a) => a,
-            FreeVariable(a, _) => a,
+            ClosureCapture(a, _) => a,
             IndexSlice(a) => a,
             RelateObjectBound(a) => a,
             RelateParamBound(a, _) => a,

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -931,8 +931,8 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         debug!("walk_captures({:?})", closure_expr);
 
         let closure_def_id = self.tcx().hir().local_def_id_from_hir_id(closure_expr.hir_id);
-        self.tcx().with_freevars(closure_expr.hir_id, |freevars| {
-            for freevar in freevars {
+        if let Some(freevars) = self.tcx().freevars(closure_def_id) {
+            for freevar in freevars.iter() {
                 let var_hir_id = freevar.var_id();
                 let upvar_id = ty::UpvarId {
                     var_path: ty::UpvarPath { hir_id: var_hir_id },
@@ -960,7 +960,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                     }
                 }
             }
-        });
+        }
     }
 
     fn cat_captured_var(&mut self,

--- a/src/librustc/middle/expr_use_visitor.rs
+++ b/src/librustc/middle/expr_use_visitor.rs
@@ -931,9 +931,9 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
         debug!("walk_captures({:?})", closure_expr);
 
         let closure_def_id = self.tcx().hir().local_def_id_from_hir_id(closure_expr.hir_id);
-        if let Some(freevars) = self.tcx().freevars(closure_def_id) {
-            for freevar in freevars.iter() {
-                let var_hir_id = freevar.var_id();
+        if let Some(upvars) = self.tcx().upvars(closure_def_id) {
+            for upvar in upvars.iter() {
+                let var_hir_id = upvar.var_id();
                 let upvar_id = ty::UpvarId {
                     var_path: ty::UpvarPath { hir_id: var_hir_id },
                     closure_expr_id: closure_def_id.to_local(),
@@ -941,14 +941,14 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                 let upvar_capture = self.mc.tables.upvar_capture(upvar_id);
                 let cmt_var = return_if_err!(self.cat_captured_var(closure_expr.hir_id,
                                                                    fn_decl_span,
-                                                                   freevar));
+                                                                   upvar));
                 match upvar_capture {
                     ty::UpvarCapture::ByValue => {
                         let mode = copy_or_move(&self.mc,
                                                 self.param_env,
                                                 &cmt_var,
                                                 CaptureMove);
-                        self.delegate.consume(closure_expr.hir_id, freevar.span, &cmt_var, mode);
+                        self.delegate.consume(closure_expr.hir_id, upvar.span, &cmt_var, mode);
                     }
                     ty::UpvarCapture::ByRef(upvar_borrow) => {
                         self.delegate.borrow(closure_expr.hir_id,
@@ -956,7 +956,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
                                              &cmt_var,
                                              upvar_borrow.region,
                                              upvar_borrow.kind,
-                                             ClosureCapture(freevar.span));
+                                             ClosureCapture(upvar.span));
                     }
                 }
             }
@@ -966,7 +966,7 @@ impl<'a, 'gcx, 'tcx> ExprUseVisitor<'a, 'gcx, 'tcx> {
     fn cat_captured_var(&mut self,
                         closure_hir_id: hir::HirId,
                         closure_span: Span,
-                        upvar: &hir::Freevar)
+                        upvar: &hir::Upvar)
                         -> mc::McResult<mc::cmt_<'tcx>> {
         // Create the cmt for the variable being borrowed, from the
         // caller's perspective

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -483,16 +483,17 @@ fn visit_expr<'a, 'tcx>(ir: &mut IrMaps<'a, 'tcx>, expr: &'tcx Expr) {
         // in better error messages than just pointing at the closure
         // construction site.
         let mut call_caps = Vec::new();
-        ir.tcx.with_freevars(expr.hir_id, |freevars| {
-            call_caps.extend(freevars.iter().filter_map(|fv| {
-                if let Res::Local(rv) = fv.res {
-                    let fv_ln = ir.add_live_node(FreeVarNode(fv.span));
-                    Some(CaptureInfo { ln: fv_ln, var_hid: rv })
+        let closure_def_id = ir.tcx.hir().local_def_id_from_hir_id(expr.hir_id);
+        if let Some(freevars) = ir.tcx.freevars(closure_def_id) {
+            call_caps.extend(freevars.iter().filter_map(|freevar| {
+                if let Res::Local(rv) = freevar.res {
+                    let freevar_ln = ir.add_live_node(FreeVarNode(freevar.span));
+                    Some(CaptureInfo { ln: freevar_ln, var_hid: rv })
                 } else {
                     None
                 }
             }));
-        });
+        }
         ir.set_captures(expr.hir_id, call_caps);
 
         intravisit::walk_expr(ir, expr);

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2572,12 +2572,12 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             };
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            tcx.with_freevars(hir_id, |freevars| {
+                            if let Some(freevars) = tcx.freevars(def_id) {
                                 for (freevar, place) in freevars.iter().zip(places) {
                                     let var_name = tcx.hir().name_by_hir_id(freevar.var_id());
                                     struct_fmt.field(&var_name.as_str(), place);
                                 }
-                            });
+                            }
 
                             struct_fmt.finish()
                         } else {
@@ -2591,12 +2591,12 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                                                tcx.hir().span_by_hir_id(hir_id));
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            tcx.with_freevars(hir_id, |freevars| {
+                            if let Some(freevars) = tcx.freevars(def_id) {
                                 for (freevar, place) in freevars.iter().zip(places) {
                                     let var_name = tcx.hir().name_by_hir_id(freevar.var_id());
                                     struct_fmt.field(&var_name.as_str(), place);
                                 }
-                            });
+                            }
 
                             struct_fmt.finish()
                         } else {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2572,9 +2572,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                             };
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            if let Some(freevars) = tcx.freevars(def_id) {
-                                for (freevar, place) in freevars.iter().zip(places) {
-                                    let var_name = tcx.hir().name_by_hir_id(freevar.var_id());
+                            if let Some(upvars) = tcx.upvars(def_id) {
+                                for (upvar, place) in upvars.iter().zip(places) {
+                                    let var_name = tcx.hir().name_by_hir_id(upvar.var_id());
                                     struct_fmt.field(&var_name.as_str(), place);
                                 }
                             }
@@ -2591,9 +2591,9 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                                                tcx.hir().span_by_hir_id(hir_id));
                             let mut struct_fmt = fmt.debug_struct(&name);
 
-                            if let Some(freevars) = tcx.freevars(def_id) {
-                                for (freevar, place) in freevars.iter().zip(places) {
-                                    let var_name = tcx.hir().name_by_hir_id(freevar.var_id());
+                            if let Some(upvars) = tcx.upvars(def_id) {
+                                for (upvar, place) in upvars.iter().zip(places) {
+                                    let var_name = tcx.hir().name_by_hir_id(upvar.var_id());
                                     struct_fmt.field(&var_name.as_str(), place);
                                 }
                             }

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -824,7 +824,7 @@ rustc_queries! {
             desc { "generating a postorder list of CrateNums" }
         }
 
-        query freevars(_: DefId) -> Option<Lrc<Vec<hir::Freevar>>> {
+        query upvars(_: DefId) -> Option<Lrc<Vec<hir::Upvar>>> {
             eval_always
         }
         query maybe_unused_trait_import(_: DefId) -> bool {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1071,10 +1071,10 @@ pub struct GlobalCtxt<'tcx> {
 
     pub queries: query::Queries<'tcx>,
 
-    // Records the free variables referenced by every closure
+    // Records the captured variables referenced by every closure
     // expression. Do not track deps for this, just recompute it from
     // scratch every time.
-    freevars: FxHashMap<DefId, Lrc<Vec<hir::Freevar>>>,
+    upvars: FxHashMap<DefId, Lrc<Vec<hir::Upvar>>>,
 
     maybe_unused_trait_imports: FxHashSet<DefId>,
     maybe_unused_extern_crates: Vec<(DefId, Span)>,
@@ -1317,7 +1317,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                 }).collect();
                 (k, Lrc::new(exports))
             }).collect(),
-            freevars: resolutions.freevars.into_iter().map(|(k, v)| {
+            upvars: resolutions.upvars.into_iter().map(|(k, v)| {
                 let vars: Vec<_> = v.into_iter().map(|e| {
                     e.map_id(|id| hir.node_to_hir_id(id))
                 }).collect();
@@ -3055,7 +3055,7 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
         assert_eq!(id, LOCAL_CRATE);
         Lrc::new(middle::lang_items::collect(tcx))
     };
-    providers.freevars = |tcx, id| tcx.gcx.freevars.get(&id).cloned();
+    providers.upvars = |tcx, id| tcx.gcx.upvars.get(&id).cloned();
     providers.maybe_unused_trait_import = |tcx, id| {
         tcx.maybe_unused_trait_imports.contains(&id)
     };

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -9,7 +9,7 @@ pub use self::IntVarValue::*;
 pub use self::fold::TypeFoldable;
 
 use crate::hir::{map as hir_map, FreevarMap, GlobMap, TraitMap};
-use crate::hir::{HirId, Node};
+use crate::hir::Node;
 use crate::hir::def::{Res, DefKind, CtorOf, CtorKind, ExportMap};
 use crate::hir::def_id::{CrateNum, DefId, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_data_structures::svh::Svh;
@@ -3117,18 +3117,6 @@ impl Iterator for AssociatedItemsIterator<'_, '_, '_> {
         let def_id = self.def_ids.get(self.next_index)?;
         self.next_index += 1;
         Some(self.tcx.associated_item(*def_id))
-    }
-}
-
-impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
-    pub fn with_freevars<T, F>(self, fid: HirId, f: F) -> T where
-        F: FnOnce(&[hir::Freevar]) -> T,
-    {
-        let def_id = self.hir().local_def_id_from_hir_id(fid);
-        match self.freevars(def_id) {
-            None => f(&[]),
-            Some(d) => f(&d),
-        }
     }
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -8,7 +8,7 @@ pub use self::BorrowKind::*;
 pub use self::IntVarValue::*;
 pub use self::fold::TypeFoldable;
 
-use crate::hir::{map as hir_map, FreevarMap, GlobMap, TraitMap};
+use crate::hir::{map as hir_map, UpvarMap, GlobMap, TraitMap};
 use crate::hir::Node;
 use crate::hir::def::{Res, DefKind, CtorOf, CtorKind, ExportMap};
 use crate::hir::def_id::{CrateNum, DefId, LocalDefId, CRATE_DEF_INDEX, LOCAL_CRATE};
@@ -122,7 +122,7 @@ mod sty;
 
 #[derive(Clone)]
 pub struct Resolutions {
-    pub freevars: FreevarMap,
+    pub upvars: UpvarMap,
     pub trait_map: TraitMap,
     pub maybe_unused_trait_imports: NodeSet,
     pub maybe_unused_extern_crates: Vec<(NodeId, Span)>,

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -582,7 +582,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                 if let Some(hir_id) = self.tcx().hir().as_local_hir_id(did) {
                     p!(write("@{:?}", self.tcx().hir().span_by_hir_id(hir_id)));
                     let mut sep = " ";
-                    for (freevar, upvar_ty) in self.tcx().freevars(did)
+                    for (upvar, upvar_ty) in self.tcx().upvars(did)
                         .as_ref()
                         .map_or(&[][..], |v| &v[..])
                         .iter()
@@ -591,7 +591,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                         p!(
                             write("{}{}:",
                                     sep,
-                                    self.tcx().hir().name_by_hir_id(freevar.var_id())),
+                                    self.tcx().hir().name_by_hir_id(upvar.var_id())),
                             print(upvar_ty));
                         sep = ", ";
                     }
@@ -625,7 +625,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                         p!(write("@{:?}", self.tcx().hir().span_by_hir_id(hir_id)));
                     }
                     let mut sep = " ";
-                    for (freevar, upvar_ty) in self.tcx().freevars(did)
+                    for (upvar, upvar_ty) in self.tcx().upvars(did)
                         .as_ref()
                         .map_or(&[][..], |v| &v[..])
                         .iter()
@@ -634,7 +634,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                         p!(
                             write("{}{}:",
                                     sep,
-                                    self.tcx().hir().name_by_hir_id(freevar.var_id())),
+                                    self.tcx().hir().name_by_hir_id(upvar.var_id())),
                             print(upvar_ty));
                         sep = ", ";
                     }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -584,7 +584,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                     let mut sep = " ";
                     for (freevar, upvar_ty) in self.tcx().freevars(did)
                         .as_ref()
-                        .map_or(&[][..], |fv| &fv[..])
+                        .map_or(&[][..], |v| &v[..])
                         .iter()
                         .zip(upvar_tys)
                     {
@@ -627,7 +627,7 @@ pub trait PrettyPrinter<'gcx: 'tcx, 'tcx>:
                     let mut sep = " ";
                     for (freevar, upvar_ty) in self.tcx().freevars(did)
                         .as_ref()
-                        .map_or(&[][..], |fv| &fv[..])
+                        .map_or(&[][..], |v| &v[..])
                         .iter()
                         .zip(upvar_tys)
                     {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -180,7 +180,7 @@ impl ExpansionResult {
         ExpansionResult {
             defs: Steal::new(resolver.definitions),
             resolutions: Steal::new(Resolutions {
-                freevars: resolver.freevars,
+                upvars: resolver.upvars,
                 export_map: resolver.export_map,
                 trait_map: resolver.trait_map,
                 glob_map: resolver.glob_map,
@@ -199,7 +199,7 @@ impl ExpansionResult {
         ExpansionResult {
             defs: Steal::new(resolver.definitions.clone()),
             resolutions: Steal::new(Resolutions {
-                freevars: resolver.freevars.clone(),
+                upvars: resolver.upvars.clone(),
                 export_map: resolver.export_map.clone(),
                 trait_map: resolver.trait_map.clone(),
                 glob_map: resolver.glob_map.clone(),

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -1814,14 +1814,10 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 ty::Array(ty, _) | ty::Slice(ty) =>
                     self.describe_field_from_ty(&ty, field, variant_index),
                 ty::Closure(def_id, _) | ty::Generator(def_id, _, _) => {
-                    // Convert the def-id into a node-id. node-ids are only valid for
-                    // the local code in the current crate, so this returns an `Option` in case
+                    // `tcx.freevars(def_id)` returns an `Option`, which is `None` in case
                     // the closure comes from another crate. But in that case we wouldn't
                     // be borrowck'ing it, so we can just unwrap:
-                    let hir_id = self.infcx.tcx.hir().as_local_hir_id(def_id).unwrap();
-                    let freevar = self.infcx
-                        .tcx
-                        .with_freevars(hir_id, |fv| fv[field.index()]);
+                    let freevar = self.infcx.tcx.freevars(def_id).unwrap()[field.index()];
 
                     self.infcx.tcx.hir().name_by_hir_id(freevar.var_id()).to_string()
                 }
@@ -2613,28 +2609,19 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if let hir::ExprKind::Closure(
             .., args_span, _
         ) = expr {
-            let var_span = self.infcx.tcx.with_freevars(
-                hir_id,
-                |freevars| {
-                    for (v, place) in freevars.iter().zip(places) {
-                        match place {
-                            Operand::Copy(place) |
-                            Operand::Move(place) if target_place == place => {
-                                debug!("closure_span: found captured local {:?}", place);
-                                return Some(v.span);
-                            },
-                            _ => {}
-                        }
-                    }
+            for (v, place) in self.infcx.tcx.freevars(def_id)?.iter().zip(places) {
+                match place {
+                    Operand::Copy(place) |
+                    Operand::Move(place) if target_place == place => {
+                        debug!("closure_span: found captured local {:?}", place);
+                        return Some((*args_span, v.span));
+                    },
+                    _ => {}
+                }
+            }
 
-                    None
-                },
-            )?;
-
-            Some((*args_span, var_span))
-        } else {
-            None
         }
+        None
     }
 
     /// Helper to retrieve span(s) of given borrow from the current MIR

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -1814,12 +1814,12 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
                 ty::Array(ty, _) | ty::Slice(ty) =>
                     self.describe_field_from_ty(&ty, field, variant_index),
                 ty::Closure(def_id, _) | ty::Generator(def_id, _, _) => {
-                    // `tcx.freevars(def_id)` returns an `Option`, which is `None` in case
+                    // `tcx.upvars(def_id)` returns an `Option`, which is `None` in case
                     // the closure comes from another crate. But in that case we wouldn't
                     // be borrowck'ing it, so we can just unwrap:
-                    let freevar = self.infcx.tcx.freevars(def_id).unwrap()[field.index()];
+                    let upvar = self.infcx.tcx.upvars(def_id).unwrap()[field.index()];
 
-                    self.infcx.tcx.hir().name_by_hir_id(freevar.var_id()).to_string()
+                    self.infcx.tcx.hir().name_by_hir_id(upvar.var_id()).to_string()
                 }
                 _ => {
                     // Might need a revision when the fields in trait RFC is implemented
@@ -2609,7 +2609,7 @@ impl<'cx, 'gcx, 'tcx> MirBorrowckCtxt<'cx, 'gcx, 'tcx> {
         if let hir::ExprKind::Closure(
             .., args_span, _
         ) = expr {
-            for (v, place) in self.infcx.tcx.freevars(def_id)?.iter().zip(places) {
+            for (v, place) in self.infcx.tcx.upvars(def_id)?.iter().zip(places) {
                 match place {
                     Operand::Copy(place) |
                     Operand::Move(place) if target_place == place => {

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -516,10 +516,10 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                     span_bug!(expr.span, "closure expr w/o closure type: {:?}", closure_ty);
                 }
             };
-            let upvars = cx.tcx.freevars(def_id).iter()
-                .flat_map(|freevars| freevars.iter())
+            let upvars = cx.tcx.upvars(def_id).iter()
+                .flat_map(|upvars| upvars.iter())
                 .zip(substs.upvar_tys(def_id, cx.tcx))
-                .map(|(freevar, ty)| capture_freevar(cx, expr, freevar, ty))
+                .map(|(upvar, ty)| capture_upvar(cx, expr, upvar, ty))
                 .collect();
             ExprKind::Closure {
                 closure_id: def_id,
@@ -1184,12 +1184,12 @@ fn overloaded_place<'a, 'gcx, 'tcx>(
     ExprKind::Deref { arg: ref_expr.to_ref() }
 }
 
-fn capture_freevar<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
+fn capture_upvar<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                                    closure_expr: &'tcx hir::Expr,
-                                   freevar: &hir::Freevar,
-                                   freevar_ty: Ty<'tcx>)
+                                   upvar: &hir::Upvar,
+                                   upvar_ty: Ty<'tcx>)
                                    -> ExprRef<'tcx> {
-    let var_hir_id = freevar.var_id();
+    let var_hir_id = upvar.var_id();
     let upvar_id = ty::UpvarId {
         var_path: ty::UpvarPath { hir_id: var_hir_id },
         closure_expr_id: cx.tcx.hir().local_def_id_from_hir_id(closure_expr.hir_id).to_local(),
@@ -1201,7 +1201,7 @@ fn capture_freevar<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
         temp_lifetime,
         ty: var_ty,
         span: closure_expr.span,
-        kind: convert_var(cx, closure_expr, freevar.res),
+        kind: convert_var(cx, closure_expr, upvar.res),
     };
     match upvar_capture {
         ty::UpvarCapture::ByValue => captured_var.to_ref(),
@@ -1213,7 +1213,7 @@ fn capture_freevar<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
             };
             Expr {
                 temp_lifetime,
-                ty: freevar_ty,
+                ty: upvar_ty,
                 span: closure_expr.span,
                 kind: ExprKind::Borrow {
                     borrow_kind,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -516,12 +516,11 @@ fn make_mirror_unadjusted<'a, 'gcx, 'tcx>(cx: &mut Cx<'a, 'gcx, 'tcx>,
                     span_bug!(expr.span, "closure expr w/o closure type: {:?}", closure_ty);
                 }
             };
-            let upvars = cx.tcx.with_freevars(expr.hir_id, |freevars| {
-                freevars.iter()
-                    .zip(substs.upvar_tys(def_id, cx.tcx))
-                    .map(|(fv, ty)| capture_freevar(cx, expr, fv, ty))
-                    .collect()
-            });
+            let upvars = cx.tcx.freevars(def_id).iter()
+                .flat_map(|freevars| freevars.iter())
+                .zip(substs.upvar_tys(def_id, cx.tcx))
+                .map(|(freevar, ty)| capture_freevar(cx, expr, freevar, ty))
+                .collect();
             ExprKind::Closure {
                 closure_id: def_id,
                 substs,

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -170,7 +170,7 @@ impl<'rt, 'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> ValidityVisitor<'rt, 'a, '
                 if def_id.is_local() {
                     let tables = self.ecx.tcx.typeck_tables_of(def_id);
                     if let Some(upvars) = tables.upvar_list.get(&def_id) {
-                        // Sometimes the index is beyond the number of freevars (seen
+                        // Sometimes the index is beyond the number of upvars (seen
                         // for a generator).
                         if let Some(upvar_id) = upvars.get(field) {
                             let var_hir_id = upvar_id.var_path.hir_id;

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -449,7 +449,8 @@ fn check_expr_kind<'a, 'tcx>(
             let nested_body_promotable = v.check_nested_body(body_id);
             // Paths in constant contexts cannot refer to local variables,
             // as there are none, and thus closures can't have upvars there.
-            if v.tcx.with_freevars(e.hir_id, |fv| !fv.is_empty()) {
+            let closure_def_id = v.tcx.hir().local_def_id_from_hir_id(e.hir_id);
+            if !v.tcx.freevars(closure_def_id).map_or(true, |v| v.is_empty()) {
                 NotPromotable
             } else {
                 nested_body_promotable

--- a/src/librustc_passes/rvalue_promotion.rs
+++ b/src/librustc_passes/rvalue_promotion.rs
@@ -450,7 +450,7 @@ fn check_expr_kind<'a, 'tcx>(
             // Paths in constant contexts cannot refer to local variables,
             // as there are none, and thus closures can't have upvars there.
             let closure_def_id = v.tcx.hir().local_def_id_from_hir_id(e.hir_id);
-            if !v.tcx.freevars(closure_def_id).map_or(true, |v| v.is_empty()) {
+            if !v.tcx.upvars(closure_def_id).map_or(true, |v| v.is_empty()) {
                 NotPromotable
             } else {
                 nested_body_promotable

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -721,9 +721,8 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
 
         let b = self.shallow_resolve(b);
 
-        let hir_id_a = self.tcx.hir().as_local_hir_id(def_id_a).unwrap();
         match b.sty {
-            ty::FnPtr(fn_ty) if self.tcx.with_freevars(hir_id_a, |v| v.is_empty()) => {
+            ty::FnPtr(fn_ty) if self.tcx.freevars(def_id_a).map_or(true, |v| v.is_empty()) => {
                 // We coerce the closure, which has fn type
                 //     `extern "rust-call" fn((arg0,arg1,...)) -> _`
                 // to

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -722,7 +722,7 @@ impl<'f, 'gcx, 'tcx> Coerce<'f, 'gcx, 'tcx> {
         let b = self.shallow_resolve(b);
 
         match b.sty {
-            ty::FnPtr(fn_ty) if self.tcx.freevars(def_id_a).map_or(true, |v| v.is_empty()) => {
+            ty::FnPtr(fn_ty) if self.tcx.upvars(def_id_a).map_or(true, |v| v.is_empty()) => {
                 // We coerce the closure, which has fn type
                 //     `extern "rust-call" fn((arg0,arg1,...)) -> _`
                 // to

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -121,28 +121,28 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             None
         };
 
-        if let Some(freevars) = self.tcx.freevars(closure_def_id) {
-            let mut freevar_list: Vec<ty::UpvarId> = Vec::with_capacity(freevars.len());
-            for freevar in freevars.iter() {
+        if let Some(upvars) = self.tcx.upvars(closure_def_id) {
+            let mut upvar_list: Vec<ty::UpvarId> = Vec::with_capacity(upvars.len());
+            for upvar in upvars.iter() {
                 let upvar_id = ty::UpvarId {
                     var_path: ty::UpvarPath {
-                        hir_id: freevar.var_id(),
+                        hir_id: upvar.var_id(),
                     },
                     closure_expr_id: LocalDefId::from_def_id(closure_def_id),
                 };
                 debug!("seed upvar_id {:?}", upvar_id);
                 // Adding the upvar Id to the list of Upvars, which will be added
                 // to the map for the closure at the end of the for loop.
-                freevar_list.push(upvar_id);
+                upvar_list.push(upvar_id);
 
                 let capture_kind = match capture_clause {
                     hir::CaptureByValue => ty::UpvarCapture::ByValue,
                     hir::CaptureByRef => {
                         let origin = UpvarRegion(upvar_id, span);
-                        let freevar_region = self.next_region_var(origin);
+                        let upvar_region = self.next_region_var(origin);
                         let upvar_borrow = ty::UpvarBorrow {
                             kind: ty::ImmBorrow,
-                            region: freevar_region,
+                            region: upvar_region,
                         };
                         ty::UpvarCapture::ByRef(upvar_borrow)
                     }
@@ -153,14 +153,14 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     .upvar_capture_map
                     .insert(upvar_id, capture_kind);
             }
-            // Add the vector of freevars to the map keyed with the closure id.
+            // Add the vector of upvars to the map keyed with the closure id.
             // This gives us an easier access to them without having to call
-            // tcx.freevars again..
-            if !freevar_list.is_empty() {
+            // tcx.upvars again..
+            if !upvar_list.is_empty() {
                 self.tables
                     .borrow_mut()
                     .upvar_list
-                    .insert(closure_def_id, freevar_list);
+                    .insert(closure_def_id, upvar_list);
             }
         }
 
@@ -246,12 +246,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let tcx = self.tcx;
         let closure_def_id = tcx.hir().local_def_id_from_hir_id(closure_id);
 
-        tcx.freevars(closure_def_id).iter().flat_map(|freevars| {
-            freevars
+        tcx.upvars(closure_def_id).iter().flat_map(|upvars| {
+            upvars
                 .iter()
-                .map(|freevar| {
-                    let var_hir_id = freevar.var_id();
-                    let freevar_ty = self.node_ty(var_hir_id);
+                .map(|upvar| {
+                    let var_hir_id = upvar.var_id();
+                    let upvar_ty = self.node_ty(var_hir_id);
                     let upvar_id = ty::UpvarId {
                         var_path: ty::UpvarPath { hir_id: var_hir_id },
                         closure_expr_id: LocalDefId::from_def_id(closure_def_id),
@@ -259,16 +259,16 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     let capture = self.tables.borrow().upvar_capture(upvar_id);
 
                     debug!(
-                        "var_id={:?} freevar_ty={:?} capture={:?}",
-                        var_hir_id, freevar_ty, capture
+                        "var_id={:?} upvar_ty={:?} capture={:?}",
+                        var_hir_id, upvar_ty, capture
                     );
 
                     match capture {
-                        ty::UpvarCapture::ByValue => freevar_ty,
+                        ty::UpvarCapture::ByValue => upvar_ty,
                         ty::UpvarCapture::ByRef(borrow) => tcx.mk_ref(
                             borrow.region,
                             ty::TypeAndMut {
-                                ty: freevar_ty,
+                                ty: upvar_ty,
                                 mutbl: borrow.kind.to_mutbl_lossy(),
                             },
                         ),

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1093,8 +1093,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
                 }),
         );
 
-        tcx.with_freevars(hir_id, |fv| {
-            params.extend(fv.iter().zip((dummy_args.len() as u32)..).map(|(_, i)| {
+        if let Some(freevars) = tcx.freevars(def_id) {
+            params.extend(freevars.iter().zip((dummy_args.len() as u32)..).map(|(_, i)| {
                 ty::GenericParamDef {
                     index: type_start + i,
                     name: Symbol::intern("<upvar>").as_interned_str(),
@@ -1107,7 +1107,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
                     },
                 }
             }));
-        });
+        }
     }
 
     let param_def_id_to_index = params

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1093,8 +1093,8 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
                 }),
         );
 
-        if let Some(freevars) = tcx.freevars(def_id) {
-            params.extend(freevars.iter().zip((dummy_args.len() as u32)..).map(|(_, i)| {
+        if let Some(upvars) = tcx.upvars(def_id) {
+            params.extend(upvars.iter().zip((dummy_args.len() as u32)..).map(|(_, i)| {
                 ty::GenericParamDef {
                     index: type_start + i,
                     name: Symbol::intern("<upvar>").as_interned_str(),


### PR DESCRIPTION
Most of the more recent code talks about "(closure) upvars", so I believe that's the name we want to use.
There's also the possibility of using "capture" which is more user-facing, but I'd rather not change *both* "freevar" and "upvar" to something else in this one PR.

cc @nikomatsakis @petrochenkov 