### PR TITLE
Correct code points to match their textual description

### DIFF
--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -279,7 +279,7 @@ mod prim_never { }
 ///
 /// As always, remember that a human intuition for 'character' may not map to
 /// Unicode's definitions. For example, despite looking similar, the 'é'
-/// character is one Unicode code point while 'é' is two Unicode code points:
+/// character is one Unicode code point while 'é' is two Unicode code points:
 ///
 /// ```
 /// let mut chars = "é".chars();


### PR DESCRIPTION
Probably due to a copy-paste error, in the sentence

> For example, despite looking similar, the 'é' character is one Unicode code point while 'é' is two Unicode code points:

the two `é`'s were actually the same character in the text (i.e. the same Unicode character U+00E9).
The code listing below instead had two different Unicode characters for the two `é`s, as it was supposed to.
The example shown wasn't clear at first so I started inspecting the text and found this out.
I simply copied the character from the code listing to the description surrounding the code.
It's a minor thing but I thought it would make things clearer for others, especially since the example is about how Rust handles `char`s.