### PR TITLE
Add tests for concrete const types

### DIFF
--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.rs
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.rs
@@ -1,0 +1,14 @@
+// Test that a concrete const type i.e. A<2>, can be used as an argument type in a function
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct A<const N: usize>; // ok
+
+fn with_concrete_const_arg(_: A<2>) -> u32 { 17 }
+
+fn main() {
+    let val: A<2> = A;
+    assert_eq!(with_concrete_const_arg(val), 17);
+}

--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
@@ -1,0 +1,6 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/concrete-const-as-fn-arg.rs:4:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+

--- a/src/test/ui/const-generics/concrete-const-impl-method.rs
+++ b/src/test/ui/const-generics/concrete-const-impl-method.rs
@@ -1,0 +1,24 @@
+// Test that a method/associated non-method within an impl block of a concrete const type i.e. A<2>,
+// is callable.
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+pub struct A<const N: u32>;
+
+impl A<2> {
+    fn impl_method(&self) -> u32 {
+        17
+    }
+
+    fn associated_non_method() -> u32 {
+        17
+    }
+}
+
+fn main() {
+    let val: A<2> = A;
+    assert_eq!(val.impl_method(), 17);
+    assert_eq!(A::<2>::associated_non_method(), 17);
+}

--- a/src/test/ui/const-generics/concrete-const-impl-method.stderr
+++ b/src/test/ui/const-generics/concrete-const-impl-method.stderr
@@ -1,0 +1,6 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/concrete-const-impl-method.rs:5:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+


### PR DESCRIPTION
In response to the request for help in https://github.com/rust-lang/rust/issues/44580#issuecomment-488819344, I have added several ui tests around the use of concrete const types, i.e. A<2>.

r? @varkor 