### PR TITLE
Add #[doc(hidden)] attribute on compiler generated module.

### DIFF
--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -324,6 +324,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 
 // Creates a new module which looks like:
 //
+//      #[doc(hidden)]
 //      mod $gensym {
 //          extern crate proc_macro;
 //
@@ -356,6 +357,10 @@ fn mk_decls(
         edition: hygiene::default_edition(),
     });
     let span = DUMMY_SP.apply_mark(mark);
+
+    let hidden = cx.meta_list_item_word(span, Symbol::intern("hidden"));
+    let doc = cx.meta_list(span, Symbol::intern("doc"), vec![hidden]);
+    let doc_hidden = cx.attribute(span, doc);
 
     let proc_macro = Ident::from_str("proc_macro");
     let krate = cx.item(span,
@@ -421,7 +426,7 @@ fn mk_decls(
         span,
         span,
         ast::Ident::with_empty_ctxt(Symbol::gensym("decls")),
-        vec![],
+        vec![doc_hidden],
         vec![krate, decls_static],
     ).map(|mut i| {
         i.vis = respan(span, ast::VisibilityKind::Public);

--- a/src/test/ui/proc-macro/no-missing-docs.rs
+++ b/src/test/ui/proc-macro/no-missing-docs.rs
@@ -1,0 +1,16 @@
+//! Verify that the `decls` module implicitly added by the compiler does not cause `missing_docs`
+//! warnings.
+
+// compile-pass
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![deny(missing_docs)]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+/// Foo1.
+#[proc_macro]
+pub fn foo1(input: TokenStream) -> TokenStream { input }


### PR DESCRIPTION
Resolves unavoidable `missing_docs` warning/error on proc-macro crates.
Resolves #42008.

Changes not yet tested locally, however I wanted to submit first since `rustc` takes forever to compile.