### PR TITLE
Rename the Alloc trait to AllocHandle

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -31,7 +31,7 @@ extern "Rust" {
 
 /// The global memory allocator.
 ///
-/// This type implements the [`Alloc`] trait by forwarding calls
+/// This type implements the [`AllocHandle`] trait by forwarding calls
 /// to the allocator registered with the `#[global_allocator]` attribute
 /// if there is one, or the `std` crate’s default.
 ///
@@ -48,7 +48,7 @@ pub struct Global;
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `alloc` method
-/// of the [`Global`] type when it and the [`Alloc`] trait become stable.
+/// of the [`Global`] type when it and the [`AllocHandle`] trait become stable.
 ///
 /// # Safety
 ///
@@ -82,7 +82,7 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `dealloc` method
-/// of the [`Global`] type when it and the [`Alloc`] trait become stable.
+/// of the [`Global`] type when it and the [`AllocHandle`] trait become stable.
 ///
 /// # Safety
 ///
@@ -100,7 +100,7 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `realloc` method
-/// of the [`Global`] type when it and the [`Alloc`] trait become stable.
+/// of the [`Global`] type when it and the [`AllocHandle`] trait become stable.
 ///
 /// # Safety
 ///
@@ -118,7 +118,7 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 /// if there is one, or the `std` crate’s default.
 ///
 /// This function is expected to be deprecated in favor of the `alloc_zeroed` method
-/// of the [`Global`] type when it and the [`Alloc`] trait become stable.
+/// of the [`Global`] type when it and the [`AllocHandle`] trait become stable.
 ///
 /// # Safety
 ///
@@ -145,7 +145,7 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 }
 
 #[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl Alloc for Global {
+unsafe impl AllocHandle for Global {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         NonNull::new(alloc(layout)).ok_or(AllocErr)
@@ -232,7 +232,7 @@ mod tests {
     extern crate test;
     use test::Bencher;
     use crate::boxed::Box;
-    use crate::alloc::{Global, Alloc, Layout, handle_alloc_error};
+    use crate::alloc::{Global, AllocHandle, Layout, handle_alloc_error};
 
     #[test]
     fn allocate_zeroed() {

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -36,7 +36,7 @@ use core::mem::{self, MaybeUninit};
 use core::ptr::{self, Unique, NonNull};
 use core::slice;
 
-use crate::alloc::{Global, Alloc, Layout};
+use crate::alloc::{Global, AllocHandle, Layout};
 use crate::boxed::Box;
 
 const B: usize = 6;

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -247,7 +247,7 @@ use core::slice::from_raw_parts_mut;
 use core::convert::From;
 use core::usize;
 
-use crate::alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
+use crate::alloc::{Global, AllocHandle, Layout, box_free, handle_alloc_error};
 use crate::string::String;
 use crate::vec::Vec;
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -23,7 +23,7 @@ use core::{isize, usize};
 use core::convert::From;
 use core::slice::from_raw_parts_mut;
 
-use crate::alloc::{Global, Alloc, Layout, box_free, handle_alloc_error};
+use crate::alloc::{Global, AllocHandle, Layout, box_free, handle_alloc_error};
 use crate::boxed::Box;
 use crate::rc::is_dangling;
 use crate::string::String;

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,4 +1,4 @@
-use std::alloc::{Global, Alloc, Layout, System};
+use std::alloc::{Global, AllocHandle, Layout, System};
 
 /// Issue #45955.
 #[test]
@@ -11,7 +11,7 @@ fn std_heap_overaligned_request() {
     check_overalign_requests(Global)
 }
 
-fn check_overalign_requests<T: Alloc>(mut allocator: T) {
+fn check_overalign_requests<T: AllocHandle>(mut allocator: T) {
     let size = 8;
     let align = 16; // greater than size
     let iterations = 100;

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -579,7 +579,7 @@ pub unsafe trait GlobalAlloc {
     }
 }
 
-/// An implementation of `Alloc` can allocate, reallocate, and
+/// A handle to a memory allocator that can allocate, reallocate, and
 /// deallocate arbitrary blocks of data described via `Layout`.
 ///
 /// Some of the methods require that a memory block be *currently
@@ -645,11 +645,11 @@ pub unsafe trait GlobalAlloc {
 ///
 /// # Safety
 ///
-/// The `Alloc` trait is an `unsafe` trait for a number of reasons, and
+/// The `AllocHandle` trait is an `unsafe` trait for a number of reasons, and
 /// implementors must ensure that they adhere to these contracts:
 ///
 /// * Pointers returned from allocation functions must point to valid memory and
-///   retain their validity until at least the instance of `Alloc` is dropped
+///   retain their validity until at least the instance of `AllocHandle` is dropped
 ///   itself.
 ///
 /// * `Layout` queries and calculations in general must be correct. Callers of
@@ -659,7 +659,7 @@ pub unsafe trait GlobalAlloc {
 /// Note that this list may get tweaked over time as clarifications are made in
 /// the future.
 #[unstable(feature = "allocator_api", issue = "32838")]
-pub unsafe trait Alloc {
+pub unsafe trait AllocHandle {
 
     // (Note: some existing allocators have unspecified but well-defined
     // behavior in response to a zero size allocation request ;
@@ -1046,7 +1046,7 @@ pub unsafe trait Alloc {
     /// must be considered "currently allocated" and must be
     /// acceptable input to methods such as `realloc` or `dealloc`,
     /// *even if* `T` is a zero-sized type. In other words, if your
-    /// `Alloc` implementation overrides this method in a manner
+    /// `AllocHandle` implementation overrides this method in a manner
     /// that can return a zero-sized `ptr`, then all reallocation and
     /// deallocation methods need to be similarly overridden to accept
     /// such values as input.
@@ -1112,7 +1112,7 @@ pub unsafe trait Alloc {
     /// must be considered "currently allocated" and must be
     /// acceptable input to methods such as `realloc` or `dealloc`,
     /// *even if* `T` is a zero-sized type. In other words, if your
-    /// `Alloc` implementation overrides this method in a manner
+    /// `AllocHandle` implementation overrides this method in a manner
     /// that can return a zero-sized `ptr`, then all reallocation and
     /// deallocation methods need to be similarly overridden to accept
     /// such values as input.

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -135,7 +135,7 @@ pub struct System;
 
 // The Alloc impl just forwards to the GlobalAlloc impl, which is in `std::sys::*::alloc`.
 #[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl Alloc for System {
+unsafe impl AllocHandle for System {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         NonNull::new(GlobalAlloc::alloc(self, layout)).ok_or(AllocErr)

--- a/src/test/run-pass/allocator-alloc-one.rs
+++ b/src/test/run-pass/allocator-alloc-one.rs
@@ -2,7 +2,7 @@
 
 #![feature(allocator_api, nonnull)]
 
-use std::alloc::{Alloc, Global, Layout, handle_alloc_error};
+use std::alloc::{AllocHandle, Global, Layout, handle_alloc_error};
 
 fn main() {
     unsafe {

--- a/src/test/run-pass/allocator/custom.rs
+++ b/src/test/run-pass/allocator/custom.rs
@@ -7,7 +7,7 @@
 
 extern crate helper;
 
-use std::alloc::{self, Global, Alloc, System, Layout};
+use std::alloc::{self, Global, AllocHandle, System, Layout};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);

--- a/src/test/run-pass/allocator/xcrate-use.rs
+++ b/src/test/run-pass/allocator/xcrate-use.rs
@@ -9,7 +9,7 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{Global, Alloc, System, Layout};
+use std::alloc::{Global, AllocHandle, System, Layout};
 use std::sync::atomic::{Ordering, AtomicUsize};
 
 #[global_allocator]

--- a/src/test/run-pass/realloc-16687.rs
+++ b/src/test/run-pass/realloc-16687.rs
@@ -5,7 +5,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Global, Alloc, Layout, handle_alloc_error};
+use std::alloc::{Global, AllocHandle, Layout, handle_alloc_error};
 use std::ptr::{self, NonNull};
 
 fn main() {

--- a/src/test/run-pass/regions/regions-mock-codegen.rs
+++ b/src/test/run-pass/regions/regions-mock-codegen.rs
@@ -6,7 +6,7 @@
 
 #![feature(allocator_api)]
 
-use std::alloc::{Alloc, Global, Layout, handle_alloc_error};
+use std::alloc::{AllocHandle, Global, Layout, handle_alloc_error};
 use std::ptr::NonNull;
 
 struct arena(());


### PR DESCRIPTION
This is a breaking change to an unstable API.
Fixes https://github.com/rust-lang/wg-allocators/issues/8

This change has some consensus in its issue. Landing it now will hopefully help clarify the vocabulary, including for discussion within the Allocators WG itself.