### PR TITLE
test for #50518

### DIFF
--- a/src/test/ui/issues/issue-50518.rs
+++ b/src/test/ui/issues/issue-50518.rs
@@ -1,0 +1,40 @@
+// compile-pass
+use std::marker::PhantomData;
+
+struct Meta<A> {
+    value: i32,
+    type_: PhantomData<A>
+}
+
+trait MetaTrait {
+    fn get_value(&self) -> i32;
+}
+
+impl<A> MetaTrait for Meta<A> {
+    fn get_value(&self) -> i32 { self.value }
+}
+
+trait Bar {
+    fn get_const(&self) -> &dyn MetaTrait;
+}
+
+struct Foo<A> {
+    _value: A
+}
+
+impl<A: 'static> Foo<A> {
+    const CONST: &'static dyn MetaTrait = &Meta::<Self> {
+        value: 10,
+        type_: PhantomData
+    };
+}
+
+impl<A: 'static> Bar for Foo<A> {
+    fn get_const(&self) -> &dyn MetaTrait { Self::CONST }
+}
+
+fn main() {
+    let foo = Foo::<i32> { _value: 10 };
+    let bar: &dyn Bar = &foo;
+    println!("const {}", bar.get_const().get_value());
+}


### PR DESCRIPTION
It was fixed somewhere between 1.28.0 and 1.31.1

closes #50518

r? @estebank 

Where's the best place to add this test? I *think* we want "compile-pass" for this test (no need to run a binary, and not running saves us a millisecond of process creation) , but there's no compile-pass anymore.

Should this be UI test with empty stdout, stderr and zero return code?