### PR TITLE
Skip codegen for one UI test with long file path

### DIFF
--- a/src/test/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
+++ b/src/test/ui/nll/closure-requirements/region-lbr1-does-outlive-lbr2-because-implied-bound.rs
@@ -3,8 +3,7 @@
 
 // compile-flags:-Zborrowck=mir -Zverbose
 // compile-pass
-
-#![allow(warnings)]
+// skip-codegen
 
 fn foo<'a, 'b>(x: &'a &'b u32) -> &'a u32 {
     &**x


### PR DESCRIPTION
The path to this test is so long that object files produced by it hit some path length limit on Windows and linker cannot find them.
The workaround here is to skip codegen and avoid producing object files, this test doesn't need them anyway.