### PR TITLE
Upgrade non-LTS Ubuntu images in CI

### DIFF
--- a/src/ci/docker/dist-various-2/Dockerfile
+++ b/src/ci/docker/dist-various-2/Dockerfile
@@ -1,9 +1,12 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh
 
-RUN apt-get build-dep -y clang llvm && apt-get install -y --no-install-recommends \
+# Enable source repositories, which are disabled by default on Ubuntu >= 18.04
+RUN sed -i 's/^# deb-src/deb-src/' /etc/apt/sources.list
+
+RUN apt-get update && apt-get build-dep -y clang llvm && apt-get install -y --no-install-recommends \
   build-essential \
   gcc-multilib \
   libedit-dev \
@@ -15,7 +18,10 @@ RUN apt-get build-dep -y clang llvm && apt-get install -y --no-install-recommend
   nodejs \
   python2.7-dev \
   software-properties-common \
-  unzip
+  unzip \
+  # Needed for apt-key to work:
+  dirmngr \
+  gpg-agent
 
 RUN apt-key adv --batch --yes --keyserver keyserver.ubuntu.com --recv-keys 74DA7924C5513486
 RUN add-apt-repository -y 'deb http://apt.dilos.org/dilos dilos2-testing main'

--- a/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-fuchsia-toolchain.sh
@@ -10,7 +10,7 @@ pushd zircon > /dev/null
 
 # Download sources
 git init
-git remote add origin https://fuchsia.googlesource.com/zircon
+git remote add origin https://github.com/rust-lang-nursery/mirror-google-fuchsia-zircon
 git fetch --depth=1 origin $ZIRCON
 git reset --hard FETCH_HEAD
 

--- a/src/ci/docker/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-debug/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \

--- a/src/ci/docker/x86_64-gnu/Dockerfile
+++ b/src/ci/docker/x86_64-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.10
+FROM ubuntu:19.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   g++ \


### PR DESCRIPTION
This PR bumps `dist-various-2` to 18.04 LTS and both `x86_64-gnu` and `x86_64-gnu-debug` to 19.04.

Another change is the switch to [rust-lang/mirror-google-fuchsia-zircon](https://github.com/rust-lang/mirror-google-fuchsia-zircon) as the Zircon repository, used during Fuchsia tests: the original repository ([fuchsia.googlesource.com/zircon](https://fuchsia.googlesource.com/zircon)) is now behind a login wall and it doesn't contain anything at all.

r? @alexcrichton 
cc @cramertj -- what's happening on the Fuchsia side?