### PR TITLE
Fix .natvis visualizers.

### DIFF
--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -7,11 +7,11 @@
       <Item Name="[capacity]" ExcludeView="simple">buf.cap</Item>
       <ArrayItems>
         <Size>len</Size>
-        <ValuePointer>buf.ptr.pointer.__0</ValuePointer>
+        <ValuePointer>buf.ptr.pointer</ValuePointer>
       </ArrayItems>
     </Expand>
   </Type>
-  <Type Name="alloc::vec_deque::VecDeque&lt;*&gt;">
+  <Type Name="alloc::collections::vec_deque::VecDeque&lt;*&gt;">
     <DisplayString>{{ size={tail &lt;= head ? head - tail : buf.cap - tail + head} }}</DisplayString>
     <Expand>
       <Item Name="[size]" ExcludeView="simple">tail &lt;= head ? head - tail : buf.cap - tail + head</Item>
@@ -24,19 +24,19 @@
           <If Condition="i == head">
             <Break/>
           </If>
-          <Item>buf.ptr.pointer.__0 + i</Item>
+          <Item>buf.ptr.pointer[i]</Item>
           <Exec>i = (i + 1 == buf.cap ? 0 : i + 1)</Exec>
         </Loop>
       </CustomListItems>
     </Expand>
   </Type>
-  <Type Name="alloc::linked_list::LinkedList&lt;*&gt;">
+  <Type Name="alloc::collections::linked_list::LinkedList&lt;*&gt;">
     <DisplayString>{{ size={len} }}</DisplayString>
     <Expand>
       <LinkedListItems>
         <Size>len</Size>
-        <HeadPointer>*(alloc::linked_list::Node&lt;$T1&gt; **)&amp;head</HeadPointer>
-        <NextPointer>*(alloc::linked_list::Node&lt;$T1&gt; **)&amp;next</NextPointer>
+        <HeadPointer>*(alloc::collections::linked_list::Node&lt;$T1&gt; **)&amp;head</HeadPointer>
+        <NextPointer>*(alloc::collections::linked_list::Node&lt;$T1&gt; **)&amp;next</NextPointer>
         <ValueNode>element</ValueNode>
       </LinkedListItems>
     </Expand>

--- a/src/etc/natvis/libcore.natvis
+++ b/src/etc/natvis/libcore.natvis
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="core::ptr::Unique&lt;*&gt;">
-    <DisplayString>{{ Unique {*pointer.__0} }}</DisplayString>
+    <DisplayString>{{ Unique {pointer} }}</DisplayString>
     <Expand>
-      <Item Name="[ptr]">pointer.__0</Item>
+      <Item Name="[ptr]">pointer</Item>
     </Expand>
   </Type>
   <Type Name="core::ptr::Shared&lt;*&gt;">
-    <DisplayString>{{ Shared {*pointer.__0} }}</DisplayString>
+    <DisplayString>{{ Shared {pointer} }}</DisplayString>
     <Expand>
-      <Item Name="[ptr]">pointer.__0</Item>
+      <Item Name="[ptr]">pointer</Item>
     </Expand>
   </Type>
   <Type Name="core::option::Option&lt;*&gt;">


### PR DESCRIPTION
### Updated to handle these changes:
  - `core::ptr::*` lost their `__0` elements and are just plain pointers
  - `core::ptr::*` probably shouldn't dereference in `DisplayString` s
  - `VecDeque` probably *should* dereference it's buf pointer to display individual items.
  - `VecDeque` and `Vec` use `core::ptr::*` s
  - `VecDeque` and `LinkedList` moved modules again.

### Retested - still working fine, left alone:
  - `String`, `&str`, `Option`

### Side Chatter
  - Props to Alex for pointing out this was broken in the `#ides-and-editors` Discord channel
  - It'd be nice if there was a sane way to automate unit testing these visualizers.
    (I assume COM automation of Visual Studio would be a no go on the build servers, and probably really incredibly painful to write too!  Suggestions welcome...)