### PR TITLE
Include expression to wait for to the span of Await

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2764,6 +2764,7 @@ impl<'a> Parser<'a> {
                     self.expect(&token::OpenDelim(token::Paren))?;
                     let expr = self.parse_expr()?;
                     self.expect(&token::CloseDelim(token::Paren))?;
+                    hi = self.prev_span;
                     ex = ExprKind::Await(ast::AwaitOrigin::MacroLike, expr);
                 } else if self.token.is_path_start() {
                     let path = self.parse_path(PathStyle::Expr)?;

--- a/src/test/ui/feature-gate/await-macro.stderr
+++ b/src/test/ui/feature-gate/await-macro.stderr
@@ -2,7 +2,7 @@ error[E0658]: `await!(<expr>)` macro syntax is unstable, and will soon be remove
   --> $DIR/await-macro.rs:9:5
    |
 LL |     await!(bar());
-   |     ^^^^^
+   |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
    = help: add #![feature(await_macro)] to the crate attributes to enable


### PR DESCRIPTION
Currently the span of `await!` only includes itself:

```rust
    await!(3);
//  ^^^^^
```

This PR changes it so that the span holds the whole `await!` expression:

```rust
    await!(3);
//  ^^^^^^^^^