### PR TITLE
Extend #60676 test for nested mut patterns.

### DIFF
--- a/src/test/ui/async-await/issue-60674.rs
+++ b/src/test/ui/async-await/issue-60674.rs
@@ -11,4 +11,10 @@ extern crate issue_60674;
 #[issue_60674::attr]
 async fn f(mut x: u8) {}
 
+#[issue_60674::attr]
+async fn g((mut x, y, mut z): (u8, u8, u8)) {}
+
+#[issue_60674::attr]
+async fn g(mut x: u8, (a, mut b, c): (u8, u8, u8), y: u8) {}
+
 fn main() {}

--- a/src/test/ui/async-await/issue-60674.stdout
+++ b/src/test/ui/async-await/issue-60674.stdout
@@ -1,1 +1,3 @@
 async fn f(mut x: u8) { }
+async fn g((mut x, y, mut z): (u8, u8, u8)) { }
+async fn g(mut x: u8, (a, mut b, c): (u8, u8, u8), y: u8) { }


### PR DESCRIPTION
At request of @centril, this commit extends the existing test added by #60676 to include nested `mut` patterns.

cc @Centril 