### PR TITLE
Add regression test for #60629

### DIFF
--- a/src/test/incremental/issue-60629.rs
+++ b/src/test/incremental/issue-60629.rs
@@ -1,0 +1,11 @@
+// revisions:rpass1 rpass2
+
+struct A;
+
+#[cfg(rpass2)]
+impl From<A> for () {
+    fn from(_: A) {}
+}
+
+fn main() {}
+


### PR DESCRIPTION
This bug was fixed, but I don't know which one. (I think it even doesn't matter at all).

Added a regression test.

```
op@OP ~/m/r/s/t/incremental> rustc --version
rustc 1.35.0-nightly (acd8dd6a5 2019-04-05)
op@OP ~/m/r/s/t/incremental> rustc -C incremental= --cfg rpass1 issue-60629.rs
warning: struct is never constructed: `A`
 --> issue-60629.rs:3:1
  |
3 | struct A;
  | ^^^^^^^^^
  |
  = note: #[warn(dead_code)] on by default

op@OP ~/m/r/s/t/incremental> rustc -C incremental= --cfg rpass2 issue-60629.rs
error: internal compiler error: src/librustc/ty/query/plumbing.rs:1195: Cannot force dep node: coherent_trait(core[c27c]::ops[0]::drop[0]::Drop[0])

thread 'rustc' panicked at 'Box<Any>', src/librustc_errors/lib.rs:635:9
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
error: aborting due to previous error


note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.35.0-nightly (acd8dd6a5 2019-04-05) running on x86_64-unknown-linux-gnu

note: compiler flags: -C incremental
```

with latest nightly it does not crash anymore, so nothing more to do.

Fixes #60629
