### PR TITLE
WIP: Allocator- and fallibility-polymorphic collections 

### DIFF
--- a/src/liballoc/abort_adapter.rs
+++ b/src/liballoc/abort_adapter.rs
@@ -48,7 +48,10 @@ unsafe impl<A: Alloc> Alloc for AbortAdapter<A> {
                       ptr: NonNull<u8>,
                       layout: Layout,
                       new_size: usize) -> Result<NonNull<u8>, Self::Err> {
-        self.0.realloc(ptr, layout, new_size).or_else(|_| handle_alloc_error(layout))
+        self.0.realloc(ptr, layout, new_size).or_else(|_| {
+            let layout = Layout::from_size_align_unchecked(new_size, layout.align());
+            handle_alloc_error(layout)
+        })
     }
 
     unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {

--- a/src/liballoc/abort_adapter.rs
+++ b/src/liballoc/abort_adapter.rs
@@ -1,0 +1,109 @@
+//! An allocator adapter that blows up by calling `handle_alloc_error` on all errors.
+//!
+//! On one hand, concrete allocator implementations should always be written
+//! without panicking on user error and OOM to give users maximum
+//! flexibility. On the other hand, code that depends on allocation succeeding
+//! should depend on `Alloc<Err=!>` to avoid repetitively handling errors from
+//! which it cannot recover.
+//!
+//! This adapter bridges the gap, effectively allowing `Alloc<Err=!>` to be
+//! implemented by any allocator.
+
+#![unstable(feature = "allocator_api",
+            reason = "the precise API and guarantees it provides may be tweaked \
+                      slightly, especially to possibly take into account the \
+                      types being stored to make room for a future \
+                      tracing garbage collector",
+            issue = "32838")]
+
+use core::usize;
+use core::ptr::NonNull;
+
+use crate::alloc::*;
+
+/// An allocator adapter that blows up by calling `handle_alloc_error` on all errors.
+///
+/// See the [module-level documentation](../../std/abort_adapter/index.html) for more.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct AbortAdapter<Alloc>(pub Alloc);
+
+impl<A: AllocHelper> AllocHelper for AbortAdapter<A> {
+    type Err = !;
+}
+
+unsafe impl<A: Alloc> Alloc for AbortAdapter<A> {
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {
+        self.0.alloc(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        self.0.dealloc(ptr, layout)
+    }
+
+    fn usable_size(&self, layout: &Layout) -> (usize, usize) {
+        self.0.usable_size(layout)
+    }
+
+    unsafe fn realloc(&mut self,
+                      ptr: NonNull<u8>,
+                      layout: Layout,
+                      new_size: usize) -> Result<NonNull<u8>, Self::Err> {
+        self.0.realloc(ptr, layout, new_size).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {
+        self.0.alloc_zeroed(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, Self::Err> {
+        self.0.alloc_excess(layout).or_else(|_| handle_alloc_error(layout))
+    }
+
+    unsafe fn grow_in_place(&mut self,
+                            ptr: NonNull<u8>,
+                            layout: Layout,
+                            new_size: usize) -> Result<(), CannotReallocInPlace> {
+        self.0.grow_in_place(ptr, layout, new_size)
+    }
+
+    unsafe fn shrink_in_place(&mut self,
+                              ptr: NonNull<u8>,
+                              layout: Layout,
+                              new_size: usize) -> Result<(), CannotReallocInPlace> {
+        self.0.shrink_in_place(ptr, layout, new_size)
+    }
+
+    fn alloc_one<T>(&mut self) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.alloc_one().or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn dealloc_one<T>(&mut self, ptr: NonNull<T>)
+        where Self: Sized
+    {
+        self.0.dealloc_one(ptr)
+    }
+
+    fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.alloc_array(n).or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn realloc_array<T>(&mut self,
+                               ptr: NonNull<T>,
+                               n_old: usize,
+                               n_new: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized
+    {
+        self.0.realloc_array(ptr, n_old, n_new)
+            .or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+
+    unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), Self::Err>
+        where Self: Sized
+    {
+        self.0.dealloc_array(ptr, n).or_else(|_| handle_alloc_error(Layout::new::<T>()))
+    }
+}

--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -169,6 +169,12 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 
 #[cfg(not(test))]
 #[unstable(feature = "allocator_api", issue = "32838")]
+impl AllocHelper for Global {
+    type Err = AllocErr;
+}
+
+#[cfg(not(test))]
+#[unstable(feature = "allocator_api", issue = "32838")]
 unsafe impl Alloc for Global {
     #[inline]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {

--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -222,9 +222,14 @@ unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
 #[cfg_attr(not(test), lang = "box_free")]
 #[inline]
 pub(crate) unsafe fn box_free<T: ?Sized, A: Alloc>(ptr: Unique<T>, mut a: A) {
+    box_free_worker(ptr, &mut a)
+}
+
+#[inline]
+pub(crate) unsafe fn box_free_worker<T: ?Sized, A: Alloc>(ptr: Unique<T>, a: &mut A) {
     let size = size_of_val(&*ptr.as_ptr());
     let align = min_align_of_val(&*ptr.as_ptr());
-    // We do not allocate for Box<T, A> when T is ZST, so deallocation is also not necessary.
+    // We do not allocate for Box<T> when T is ZST, so deallocation is also not necessary.
     if size != 0 {
         let layout = Layout::from_size_align_unchecked(size, align);
         a.dealloc(NonNull::from(ptr).cast(), layout);

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -88,6 +88,7 @@ use core::ops::{
 use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
+use crate::alloc::{Alloc, Global, Layout, handle_alloc_error};
 use crate::vec::Vec;
 use crate::raw_vec::RawVec;
 use crate::str::from_boxed_utf8_unchecked;
@@ -98,7 +99,7 @@ use crate::str::from_boxed_utf8_unchecked;
 #[lang = "owned_box"]
 #[fundamental]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Box<T: ?Sized>(Unique<T>);
+pub struct Box<T: ?Sized, A = Global>(Unique<T>, pub(crate) A);
 
 impl<T> Box<T> {
     /// Allocates memory on the heap and then places `x` into it.
@@ -122,6 +123,49 @@ impl<T> Box<T> {
     #[inline(always)]
     pub fn pin(x: T) -> Pin<Box<T>> {
         (box x).into()
+    }
+}
+
+impl<T, A: Alloc> Box<T, A> {
+    /// Allocates memory in the given allocator and then places `x` into it.
+    ///
+    /// This doesn't actually allocate if `T` is zero-sized.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let five = Box::new_in(5, Global);
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline(always)]
+    pub fn new_in(x: T, a: A) -> Box<T, A> {
+        let mut a = a;
+        let layout = Layout::for_value(&x);
+        let size = layout.size();
+        let ptr = if size == 0 {
+            Unique::empty()
+        } else {
+            unsafe {
+                let ptr = a.alloc(layout).unwrap_or_else(|_| handle_alloc_error(layout));
+                ptr.cast().into()
+            }
+        };
+        // Move x into the location allocated above. This needs to happen
+        // for any size so that x is not dropped in some cases.
+        unsafe {
+            ptr::write(ptr.as_ptr() as *mut T, x);
+        }
+        Box(ptr, a)
+    }
+
+    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
+    /// `x` will be pinned in memory and unable to be moved.
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline(always)]
+    pub fn pin_in(x: T, a: A) -> Pin<Box<T, A>> {
+        Box::new_in(x, a).into()
     }
 }
 
@@ -165,9 +209,48 @@ impl<T: ?Sized> Box<T> {
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
     pub unsafe fn from_raw(raw: *mut T) -> Self {
-        Box(Unique::new_unchecked(raw))
+        Box(Unique::new_unchecked(raw), Global)
+    }
+}
+
+impl<T: ?Sized, A: Alloc> Box<T, A> {
+    /// Constructs a box from a raw pointer in the given allocator.
+    ///
+    /// This is similar to the [`Box::from_raw`] function, but assumes
+    /// the pointer was allocated with the given allocator.
+    ///
+    /// This function is unsafe because improper use may lead to
+    /// memory problems. For example, specifying the wrong allocator
+    /// may corrupt the allocator state.
+    ///
+    /// [`Box::from_raw`]: struct.Box.html#method.from_raw
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![feature(allocator_api)]
+    /// use std::alloc::Global;
+    /// let x = Box::new_in(5, Global);
+    /// let ptr = Box::into_raw(x);
+    /// let x = unsafe { Box::from_raw_in(ptr, Global) };
+    /// ```
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub unsafe fn from_raw_in(raw: *mut T, a: A) -> Self {
+        Box(Unique::new_unchecked(raw), a)
     }
 
+    /// Maps a `Box<T, A>` to `Box<U, A>` by applying a function to the
+    /// raw pointer.
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    #[inline]
+    pub unsafe fn map_raw<U: ?Sized, F: FnOnce(*mut T) -> *mut U>(b: Box<T, A>, f: F) -> Box<U, A> {
+        let a = ptr::read(&b.1);
+        Box::from_raw_in(f(Box::into_raw(b)), a)
+    }
+}
+
+impl<T: ?Sized, A> Box<T, A> {
     /// Consumes the `Box`, returning a wrapped raw pointer.
     ///
     /// The pointer will be properly aligned and non-null.
@@ -210,7 +293,7 @@ impl<T: ?Sized> Box<T> {
     /// [`Box::from_raw`]: struct.Box.html#method.from_raw
     #[stable(feature = "box_raw", since = "1.4.0")]
     #[inline]
-    pub fn into_raw(b: Box<T>) -> *mut T {
+    pub fn into_raw(b: Box<T, A>) -> *mut T {
         Box::into_raw_non_null(b).as_ptr()
     }
 
@@ -246,14 +329,14 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[unstable(feature = "box_into_raw_non_null", issue = "47336")]
     #[inline]
-    pub fn into_raw_non_null(b: Box<T>) -> NonNull<T> {
+    pub fn into_raw_non_null(b: Box<T, A>) -> NonNull<T> {
         Box::into_unique(b).into()
     }
 
     #[unstable(feature = "ptr_internals", issue = "0", reason = "use into_raw_non_null instead")]
     #[inline]
     #[doc(hidden)]
-    pub fn into_unique(b: Box<T>) -> Unique<T> {
+    pub fn into_unique(b: Box<T, A>) -> Unique<T> {
         let mut unique = b.0;
         mem::forget(b);
         // Box is kind-of a library type, but recognized as a "unique pointer" by
@@ -308,7 +391,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     #[stable(feature = "box_leak", since = "1.26.0")]
     #[inline]
-    pub fn leak<'a>(b: Box<T>) -> &'a mut T
+    pub fn leak<'a>(b: Box<T, A>) -> &'a mut T
     where
         T: 'a // Technically not needed, but kept to be explicit.
     {
@@ -321,7 +404,7 @@ impl<T: ?Sized> Box<T> {
     ///
     /// This is also available via [`From`].
     #[unstable(feature = "box_into_pin", issue = "0")]
-    pub fn into_pin(boxed: Box<T>) -> Pin<Box<T>> {
+    pub fn into_pin(boxed: Box<T, A>) -> Pin<Box<T, A>> {
         // It's not possible to move or replace the insides of a `Pin<Box<T>>`
         // when `T: !Unpin`,  so it's safe to pin it directly without any
         // additional requirements.
@@ -330,36 +413,36 @@ impl<T: ?Sized> Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T: ?Sized> Drop for Box<T> {
+unsafe impl<#[may_dangle] T: ?Sized, A> Drop for Box<T, A> {
     fn drop(&mut self) {
         // FIXME: Do nothing, drop is currently performed by compiler.
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Default> Default for Box<T> {
-    /// Creates a `Box<T>`, with the `Default` value for T.
-    fn default() -> Box<T> {
-        box Default::default()
+impl<T: Default, A: Alloc + Default> Default for Box<T, A> {
+    /// Creates a `Box<T, A>`, with the `Default` value for T.
+    fn default() -> Box<T, A> {
+        Box::new_in(Default::default(), A::default())
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Default for Box<[T]> {
-    fn default() -> Box<[T]> {
-        Box::<[T; 0]>::new([])
+impl<T, A: Alloc + Default> Default for Box<[T], A> {
+    fn default() -> Box<[T], A> {
+        Box::<[T; 0], A>::new_in([], A::default())
     }
 }
 
 #[stable(feature = "default_box_extra", since = "1.17.0")]
-impl Default for Box<str> {
-    fn default() -> Box<str> {
+impl<A: Alloc + Default> Default for Box<str, A> {
+    fn default() -> Box<str, A> {
         unsafe { from_boxed_utf8_unchecked(Default::default()) }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone> Clone for Box<T> {
+impl<T: Clone, A: Alloc + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
     /// # Examples
@@ -370,8 +453,8 @@ impl<T: Clone> Clone for Box<T> {
     /// ```
     #[rustfmt::skip]
     #[inline]
-    fn clone(&self) -> Box<T> {
-        box { (**self).clone() }
+    fn clone(&self) -> Box<T, A> {
+        Box::new_in((**self).clone(), self.1.clone())
     }
     /// Copies `source`'s contents into `self` without creating a new allocation.
     ///
@@ -386,17 +469,17 @@ impl<T: Clone> Clone for Box<T> {
     /// assert_eq!(*y, 5);
     /// ```
     #[inline]
-    fn clone_from(&mut self, source: &Box<T>) {
+    fn clone_from(&mut self, source: &Box<T, A>) {
         (**self).clone_from(&(**source));
     }
 }
 
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl Clone for Box<str> {
+impl<A: Alloc + Clone> Clone for Box<str, A> {
     fn clone(&self) -> Self {
         // this makes a copy of the data
-        let buf: Box<[u8]> = self.as_bytes().into();
+        let buf = Box::<[u8], A>::from_slice_in(self.as_bytes(), self.1.clone());
         unsafe {
             from_boxed_utf8_unchecked(buf)
         }
@@ -404,58 +487,58 @@ impl Clone for Box<str> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialEq> PartialEq for Box<T> {
+impl<T: ?Sized + PartialEq, A> PartialEq for Box<T, A> {
     #[inline]
-    fn eq(&self, other: &Box<T>) -> bool {
+    fn eq(&self, other: &Box<T, A>) -> bool {
         PartialEq::eq(&**self, &**other)
     }
     #[inline]
-    fn ne(&self, other: &Box<T>) -> bool {
+    fn ne(&self, other: &Box<T, A>) -> bool {
         PartialEq::ne(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + PartialOrd> PartialOrd for Box<T> {
+impl<T: ?Sized + PartialOrd, A> PartialOrd for Box<T, A> {
     #[inline]
-    fn partial_cmp(&self, other: &Box<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Box<T, A>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&**self, &**other)
     }
     #[inline]
-    fn lt(&self, other: &Box<T>) -> bool {
+    fn lt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::lt(&**self, &**other)
     }
     #[inline]
-    fn le(&self, other: &Box<T>) -> bool {
+    fn le(&self, other: &Box<T, A>) -> bool {
         PartialOrd::le(&**self, &**other)
     }
     #[inline]
-    fn ge(&self, other: &Box<T>) -> bool {
+    fn ge(&self, other: &Box<T, A>) -> bool {
         PartialOrd::ge(&**self, &**other)
     }
     #[inline]
-    fn gt(&self, other: &Box<T>) -> bool {
+    fn gt(&self, other: &Box<T, A>) -> bool {
         PartialOrd::gt(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Ord> Ord for Box<T> {
+impl<T: ?Sized + Ord, A> Ord for Box<T, A> {
     #[inline]
-    fn cmp(&self, other: &Box<T>) -> Ordering {
+    fn cmp(&self, other: &Box<T, A>) -> Ordering {
         Ord::cmp(&**self, &**other)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Eq> Eq for Box<T> {}
+impl<T: ?Sized + Eq, A> Eq for Box<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized + Hash> Hash for Box<T> {
+impl<T: ?Sized + Hash, A> Hash for Box<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         (**self).hash(state);
     }
 }
 
 #[stable(feature = "indirect_hasher_impl", since = "1.22.0")]
-impl<T: ?Sized + Hasher> Hasher for Box<T> {
+impl<T: ?Sized + Hasher, A> Hasher for Box<T, A> {
     fn finish(&self) -> u64 {
         (**self).finish()
     }
@@ -501,7 +584,7 @@ impl<T: ?Sized + Hasher> Hasher for Box<T> {
 }
 
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
-impl<T> From<T> for Box<T> {
+impl<T, A: Alloc + Default> From<T> for Box<T, A> {
     /// Converts a generic type `T` into a `Box<T>`
     ///
     /// The conversion allocates on the heap and moves `t`
@@ -515,22 +598,33 @@ impl<T> From<T> for Box<T> {
     /// assert_eq!(Box::from(x), boxed);
     /// ```
     fn from(t: T) -> Self {
-        Box::new(t)
+        Box::new_in(t, A::default())
     }
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<T: ?Sized> From<Box<T>> for Pin<Box<T>> {
+impl<T: ?Sized, A> From<Box<T, A>> for Pin<Box<T, A>> {
     /// Converts a `Box<T>` into a `Pin<Box<T>>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
-    fn from(boxed: Box<T>) -> Self {
+    fn from(boxed: Box<T, A>) -> Self {
         Box::into_pin(boxed)
     }
 }
 
+impl<T: Copy, A: Alloc> Box<[T], A> {
+    fn from_slice_in(slice: &[T], a: A) -> Box<[T], A> {
+        let len = slice.len();
+        let buf = RawVec::with_capacity_in(len, a);
+        unsafe {
+            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
+            buf.into_box()
+        }
+    }
+}
+
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl<T: Copy> From<&[T]> for Box<[T]> {
+impl<T: Copy, A: Alloc + Default> From<&[T]> for Box<[T], A> {
     /// Converts a `&[T]` into a `Box<[T]>`
     ///
     /// This conversion allocates on the heap
@@ -544,18 +638,13 @@ impl<T: Copy> From<&[T]> for Box<[T]> {
     ///
     /// println!("{:?}", boxed_slice);
     /// ```
-    fn from(slice: &[T]) -> Box<[T]> {
-        let len = slice.len();
-        let buf = RawVec::with_capacity(len);
-        unsafe {
-            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
-            buf.into_box()
-        }
+    fn from(slice: &[T]) -> Box<[T], A> {
+        Box::<_, _>::from_slice_in(slice, A::default())
     }
 }
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl From<&str> for Box<str> {
+impl<A: Alloc + Default> From<&str> for Box<str, A> {
     /// Converts a `&str` into a `Box<str>`
     ///
     /// This conversion allocates on the heap
@@ -567,13 +656,13 @@ impl From<&str> for Box<str> {
     /// println!("{}", boxed);
     /// ```
     #[inline]
-    fn from(s: &str) -> Box<str> {
+    fn from(s: &str) -> Box<str, A> {
         unsafe { from_boxed_utf8_unchecked(Box::from(s.as_bytes())) }
     }
 }
 
 #[stable(feature = "boxed_str_conv", since = "1.19.0")]
-impl From<Box<str>> for Box<[u8]> {
+impl<A: Alloc> From<Box<str, A>> for Box<[u8], A> {
     /// Converts a `Box<str>>` into a `Box<[u8]>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
@@ -591,12 +680,12 @@ impl From<Box<str>> for Box<[u8]> {
     /// assert_eq!(boxed_slice, boxed_str);
     /// ```
     #[inline]
-    fn from(s: Box<str>) -> Self {
-        unsafe { Box::from_raw(Box::into_raw(s) as *mut [u8]) }
+    fn from(s: Box<str, A>) -> Self {
+        unsafe { Box::map_raw(s, |p| p as *mut [u8]) }
     }
 }
 
-impl Box<dyn Any> {
+impl<A: Alloc> Box<dyn Any, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -618,19 +707,16 @@ impl Box<dyn Any> {
     ///     print_if_string(Box::new(0i8));
     /// }
     /// ```
-    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<dyn Any>> {
+    pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Box<dyn Any, A>> {
         if self.is::<T>() {
-            unsafe {
-                let raw: *mut dyn Any = Box::into_raw(self);
-                Ok(Box::from_raw(raw as *mut T))
-            }
+            unsafe { Ok(Box::map_raw(self, |p| p as *mut T)) }
         } else {
             Err(self)
         }
     }
 }
 
-impl Box<dyn Any + Send> {
+impl<A: Alloc> Box<dyn Any + Send, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -652,30 +738,30 @@ impl Box<dyn Any + Send> {
     ///     print_if_string(Box::new(0i8));
     /// }
     /// ```
-    pub fn downcast<T: Any>(self) -> Result<Box<T>, Box<dyn Any + Send>> {
-        <Box<dyn Any>>::downcast(self).map_err(|s| unsafe {
+    pub fn downcast<T: Any>(self) -> Result<Box<T, A>, Box<dyn Any + Send, A>> {
+        <Box<dyn Any, A>>::downcast(self).map_err(|s| unsafe {
             // reapply the Send marker
-            Box::from_raw(Box::into_raw(s) as *mut (dyn Any + Send))
+            Box::map_raw(s, |p| p as *mut (dyn Any + Send))
         })
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Display + ?Sized> fmt::Display for Box<T> {
+impl<T: fmt::Display + ?Sized, A> fmt::Display for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Debug + ?Sized> fmt::Debug for Box<T> {
+impl<T: fmt::Debug + ?Sized, A> fmt::Debug for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> fmt::Pointer for Box<T> {
+impl<T: ?Sized, A> fmt::Pointer for Box<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // It's not possible to extract the inner Uniq directly from the Box,
         // instead we cast it to a *const which aliases the Unique
@@ -685,7 +771,7 @@ impl<T: ?Sized> fmt::Pointer for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> Deref for Box<T> {
+impl<T: ?Sized, A> Deref for Box<T, A> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -694,17 +780,17 @@ impl<T: ?Sized> Deref for Box<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: ?Sized> DerefMut for Box<T> {
+impl<T: ?Sized, A> DerefMut for Box<T, A> {
     fn deref_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[unstable(feature = "receiver_trait", issue = "0")]
-impl<T: ?Sized> Receiver for Box<T> {}
+impl<T: ?Sized, A> Receiver for Box<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: Iterator + ?Sized> Iterator for Box<I> {
+impl<I: Iterator + ?Sized, A> Iterator for Box<I, A> {
     type Item = I::Item;
     fn next(&mut self) -> Option<I::Item> {
         (**self).next()
@@ -717,7 +803,7 @@ impl<I: Iterator + ?Sized> Iterator for Box<I> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
+impl<I: DoubleEndedIterator + ?Sized, A> DoubleEndedIterator for Box<I, A> {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
@@ -726,7 +812,7 @@ impl<I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for Box<I> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
+impl<I: ExactSizeIterator + ?Sized, A> ExactSizeIterator for Box<I, A> {
     fn len(&self) -> usize {
         (**self).len()
     }
@@ -736,10 +822,10 @@ impl<I: ExactSizeIterator + ?Sized> ExactSizeIterator for Box<I> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<I: FusedIterator + ?Sized> FusedIterator for Box<I> {}
+impl<I: FusedIterator + ?Sized, A> FusedIterator for Box<I, A> {}
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
+impl<A, F: FnOnce<A> + ?Sized, Alloc> FnOnce<A> for Box<F, Alloc> {
     type Output = <F as FnOnce<A>>::Output;
 
     extern "rust-call" fn call_once(self, args: A) -> Self::Output {
@@ -748,14 +834,14 @@ impl<A, F: FnOnce<A> + ?Sized> FnOnce<A> for Box<F> {
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: FnMut<A> + ?Sized> FnMut<A> for Box<F> {
+impl<A, F: FnMut<A> + ?Sized, Alloc> FnMut<A> for Box<F, Alloc> {
     extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
         <F as FnMut<A>>::call_mut(self, args)
     }
 }
 
 #[stable(feature = "boxed_closure_impls", since = "1.35.0")]
-impl<A, F: Fn<A> + ?Sized> Fn<A> for Box<F> {
+impl<A, F: Fn<A> + ?Sized, Alloc> Fn<A> for Box<F, Alloc> {
     extern "rust-call" fn call(&self, args: A) -> Self::Output {
         <F as Fn<A>>::call(self, args)
     }
@@ -841,8 +927,9 @@ impl<A, F> FnBox<A> for F
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Box<U>> for Box<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized, A> CoerceUnsized<Box<U, A>> for Box<T, A> {}
 
+//FIXME: Make generic over A when the compiler supports it.
 #[unstable(feature = "dispatch_from_dyn", issue = "0")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U>> for Box<T> {}
 
@@ -854,10 +941,10 @@ impl<A> FromIterator<A> for Box<[A]> {
 }
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone> Clone for Box<[T]> {
+impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         let mut new = BoxBuilder {
-            data: RawVec::with_capacity(self.len()),
+            data: RawVec::with_capacity_in(self.len(), self.1.clone()),
             len: 0,
         };
 
@@ -875,20 +962,20 @@ impl<T: Clone> Clone for Box<[T]> {
         return unsafe { new.into_box() };
 
         // Helper type for responding to panics correctly.
-        struct BoxBuilder<T> {
-            data: RawVec<T>,
+        struct BoxBuilder<T, A: Alloc> {
+            data: RawVec<T, A>,
             len: usize,
         }
 
-        impl<T> BoxBuilder<T> {
-            unsafe fn into_box(self) -> Box<[T]> {
+        impl<T, A: Alloc> BoxBuilder<T, A> {
+            unsafe fn into_box(self) -> Box<[T], A> {
                 let raw = ptr::read(&self.data);
                 mem::forget(self);
                 raw.into_box()
             }
         }
 
-        impl<T> Drop for BoxBuilder<T> {
+        impl<T, A: Alloc> Drop for BoxBuilder<T, A> {
             fn drop(&mut self) {
                 let mut data = self.data.ptr();
                 let max = unsafe { data.add(self.len) };
@@ -905,28 +992,28 @@ impl<T: Clone> Clone for Box<[T]> {
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::Borrow<T> for Box<T> {
+impl<T: ?Sized, A> borrow::Borrow<T> for Box<T, A> {
     fn borrow(&self) -> &T {
         &**self
     }
 }
 
 #[stable(feature = "box_borrow", since = "1.1.0")]
-impl<T: ?Sized> borrow::BorrowMut<T> for Box<T> {
+impl<T: ?Sized, A> borrow::BorrowMut<T> for Box<T, A> {
     fn borrow_mut(&mut self) -> &mut T {
         &mut **self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsRef<T> for Box<T> {
+impl<T: ?Sized, A> AsRef<T> for Box<T, A> {
     fn as_ref(&self) -> &T {
         &**self
     }
 }
 
 #[stable(since = "1.5.0", feature = "smart_ptr_as_ref")]
-impl<T: ?Sized> AsMut<T> for Box<T> {
+impl<T: ?Sized, A> AsMut<T> for Box<T, A> {
     fn as_mut(&mut self) -> &mut T {
         &mut **self
     }
@@ -955,10 +1042,10 @@ impl<T: ?Sized> AsMut<T> for Box<T> {
  *  could have a method to project a Pin<T> from it.
  */
 #[stable(feature = "pin", since = "1.33.0")]
-impl<T: ?Sized> Unpin for Box<T> { }
+impl<T: ?Sized, A> Unpin for Box<T, A> { }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
+impl<G: ?Sized + Generator + Unpin, A> Generator for Box<G, A> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -968,7 +1055,7 @@ impl<G: ?Sized + Generator + Unpin> Generator for Box<G> {
 }
 
 #[unstable(feature = "generator_trait", issue = "43122")]
-impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
+impl<G: ?Sized + Generator, A> Generator for Pin<Box<G, A>> {
     type Yield = G::Yield;
     type Return = G::Return;
 
@@ -978,7 +1065,7 @@ impl<G: ?Sized + Generator> Generator for Pin<Box<G>> {
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]
-impl<F: ?Sized + Future + Unpin> Future for Box<F> {
+impl<F: ?Sized + Future + Unpin, A> Future for Box<F, A> {
     type Output = F::Output;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -88,7 +88,7 @@ use core::ops::{
 use core::ptr::{self, NonNull, Unique};
 use core::task::{Context, Poll};
 
-use crate::alloc::{Alloc, Global, Layout, handle_alloc_error};
+use crate::alloc::{Alloc, AllocErr, Global, Layout, handle_alloc_error};
 use crate::vec::Vec;
 use crate::raw_vec::RawVec;
 use crate::str::from_boxed_utf8_unchecked;
@@ -126,7 +126,7 @@ impl<T> Box<T> {
     }
 }
 
-impl<T, A: Alloc> Box<T, A> {
+impl<T, A: Alloc<Err = AllocErr>> Box<T, A> {
     /// Allocates memory in the given allocator and then places `x` into it.
     ///
     /// This doesn't actually allocate if `T` is zero-sized.
@@ -213,7 +213,7 @@ impl<T: ?Sized> Box<T> {
     }
 }
 
-impl<T: ?Sized, A: Alloc> Box<T, A> {
+impl<T: ?Sized, A> Box<T, A> {
     /// Constructs a box from a raw pointer in the given allocator.
     ///
     /// This is similar to the [`Box::from_raw`] function, but assumes
@@ -420,7 +420,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A> Drop for Box<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Default, A: Alloc + Default> Default for Box<T, A> {
+impl<T: Default, A: Alloc<Err = AllocErr> + Default> Default for Box<T, A> {
     /// Creates a `Box<T, A>`, with the `Default` value for T.
     fn default() -> Box<T, A> {
         Box::new_in(Default::default(), A::default())
@@ -428,21 +428,21 @@ impl<T: Default, A: Alloc + Default> Default for Box<T, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T, A: Alloc + Default> Default for Box<[T], A> {
+impl<T, A: Alloc<Err = AllocErr> + Default> Default for Box<[T], A> {
     fn default() -> Box<[T], A> {
         Box::<[T; 0], A>::new_in([], A::default())
     }
 }
 
 #[stable(feature = "default_box_extra", since = "1.17.0")]
-impl<A: Alloc + Default> Default for Box<str, A> {
+impl<A: Alloc<Err = AllocErr> + Default> Default for Box<str, A> {
     fn default() -> Box<str, A> {
         unsafe { from_boxed_utf8_unchecked(Default::default()) }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone, A: Alloc + Clone> Clone for Box<T, A> {
+impl<T: Clone, A: Alloc<Err = AllocErr> + Clone> Clone for Box<T, A> {
     /// Returns a new box with a `clone()` of this box's contents.
     ///
     /// # Examples
@@ -474,9 +474,8 @@ impl<T: Clone, A: Alloc + Clone> Clone for Box<T, A> {
     }
 }
 
-
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<A: Alloc + Clone> Clone for Box<str, A> {
+impl<A: Alloc<Err = AllocErr> + Clone> Clone for Box<str, A> {
     fn clone(&self) -> Self {
         // this makes a copy of the data
         let buf = Box::<[u8], A>::from_slice_in(self.as_bytes(), self.1.clone());
@@ -584,7 +583,7 @@ impl<T: ?Sized + Hasher, A> Hasher for Box<T, A> {
 }
 
 #[stable(feature = "from_for_ptrs", since = "1.6.0")]
-impl<T, A: Alloc + Default> From<T> for Box<T, A> {
+impl<T, A: Alloc<Err = AllocErr> + Default> From<T> for Box<T, A> {
     /// Converts a generic type `T` into a `Box<T>`
     ///
     /// The conversion allocates on the heap and moves `t`
@@ -612,7 +611,7 @@ impl<T: ?Sized, A> From<Box<T, A>> for Pin<Box<T, A>> {
     }
 }
 
-impl<T: Copy, A: Alloc> Box<[T], A> {
+impl<T: Copy, A: Alloc<Err = AllocErr>> Box<[T], A> {
     fn from_slice_in(slice: &[T], a: A) -> Box<[T], A> {
         let len = slice.len();
         let buf = RawVec::with_capacity_in(len, a);
@@ -624,7 +623,7 @@ impl<T: Copy, A: Alloc> Box<[T], A> {
 }
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl<T: Copy, A: Alloc + Default> From<&[T]> for Box<[T], A> {
+impl<T: Copy, A: Alloc<Err = AllocErr> + Default> From<&[T]> for Box<[T], A> {
     /// Converts a `&[T]` into a `Box<[T]>`
     ///
     /// This conversion allocates on the heap
@@ -644,7 +643,7 @@ impl<T: Copy, A: Alloc + Default> From<&[T]> for Box<[T], A> {
 }
 
 #[stable(feature = "box_from_slice", since = "1.17.0")]
-impl<A: Alloc + Default> From<&str> for Box<str, A> {
+impl<A: Alloc<Err = AllocErr> + Default> From<&str> for Box<str, A> {
     /// Converts a `&str` into a `Box<str>`
     ///
     /// This conversion allocates on the heap
@@ -662,7 +661,7 @@ impl<A: Alloc + Default> From<&str> for Box<str, A> {
 }
 
 #[stable(feature = "boxed_str_conv", since = "1.19.0")]
-impl<A: Alloc> From<Box<str, A>> for Box<[u8], A> {
+impl<A> From<Box<str, A>> for Box<[u8], A> {
     /// Converts a `Box<str>>` into a `Box<[u8]>`
     ///
     /// This conversion does not allocate on the heap and happens in place.
@@ -685,7 +684,7 @@ impl<A: Alloc> From<Box<str, A>> for Box<[u8], A> {
     }
 }
 
-impl<A: Alloc> Box<dyn Any, A> {
+impl<A> Box<dyn Any, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -716,7 +715,7 @@ impl<A: Alloc> Box<dyn Any, A> {
     }
 }
 
-impl<A: Alloc> Box<dyn Any + Send, A> {
+impl<A: Alloc<Err=AllocErr>> Box<dyn Any + Send, A> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     /// Attempt to downcast the box to a concrete type.
@@ -941,7 +940,7 @@ impl<A> FromIterator<A> for Box<[A]> {
 }
 
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
-impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
+impl<T: Clone, A: Alloc<Err = AllocErr> + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {
         let mut new = BoxBuilder {
             data: RawVec::with_capacity_in(self.len(), self.1.clone()),
@@ -962,12 +961,12 @@ impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
         return unsafe { new.into_box() };
 
         // Helper type for responding to panics correctly.
-        struct BoxBuilder<T, A: Alloc> {
+        struct BoxBuilder<T, A: Alloc<Err = AllocErr>> {
             data: RawVec<T, A>,
             len: usize,
         }
 
-        impl<T, A: Alloc> BoxBuilder<T, A> {
+        impl<T, A: Alloc<Err = AllocErr>> BoxBuilder<T, A> {
             unsafe fn into_box(self) -> Box<[T], A> {
                 let raw = ptr::read(&self.data);
                 mem::forget(self);
@@ -975,7 +974,7 @@ impl<T: Clone, A: Alloc + Clone> Clone for Box<[T], A> {
             }
         }
 
-        impl<T, A: Alloc> Drop for BoxBuilder<T, A> {
+        impl<T, A: Alloc<Err = AllocErr>> Drop for BoxBuilder<T, A> {
             fn drop(&mut self) {
                 let mut data = self.data.ptr();
                 let max = unsafe { data.add(self.len) };

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -20,6 +20,8 @@ use core::marker::PhantomData;
 use core::mem;
 use core::ptr::NonNull;
 
+use crate::abort_adapter::AbortAdapter;
+use crate::alloc::{Alloc, Global};
 use crate::boxed::Box;
 use super::SpecExtend;
 
@@ -32,17 +34,19 @@ use super::SpecExtend;
 /// `LinkedList`. In general, array-based containers are faster,
 /// more memory efficient and make better use of CPU cache.
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct LinkedList<T> {
-    head: Option<NonNull<Node<T>>>,
-    tail: Option<NonNull<Node<T>>>,
+pub struct LinkedList<T, A: Alloc + Clone = AbortAdapter<Global>> {
+    head: Option<NonNull<Node<T, A>>>,
+    tail: Option<NonNull<Node<T, A>>>,
     len: usize,
-    marker: PhantomData<Box<Node<T>>>,
+    alloc: A,
+    marker: PhantomData<Box<Node<T, A>, A>>,
 }
 
-struct Node<T> {
-    next: Option<NonNull<Node<T>>>,
-    prev: Option<NonNull<Node<T>>>,
+struct Node<T, A: Alloc> {
+    next: Option<NonNull<Node<T, A>>>,
+    prev: Option<NonNull<Node<T, A>>>,
     element: T,
+    marker: PhantomData<Box<Node<T, A>, A>>,
 }
 
 /// An iterator over the elements of a `LinkedList`.
@@ -53,15 +57,16 @@ struct Node<T> {
 /// [`iter`]: struct.LinkedList.html#method.iter
 /// [`LinkedList`]: struct.LinkedList.html
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Iter<'a, T: 'a> {
-    head: Option<NonNull<Node<T>>>,
-    tail: Option<NonNull<Node<T>>>,
+
+pub struct Iter<'a, T: 'a, A: 'a + Alloc = AbortAdapter<Global> > {
+    head: Option<NonNull<Node<T, A>>>,
+    tail: Option<NonNull<Node<T, A>>>,
     len: usize,
-    marker: PhantomData<&'a Node<T>>,
+    marker: PhantomData<&'a Node<T, A>>,
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
+impl<'a, T: fmt::Debug, A: 'a + Alloc> fmt::Debug for Iter<'a, T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Iter")
          .field(&self.len)
@@ -71,7 +76,7 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 
 // FIXME(#26925) Remove in favor of `#[derive(Clone)]`
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Clone for Iter<'_, T> {
+impl<T, A: Alloc> Clone for Iter<'_, T, A> {
     fn clone(&self) -> Self {
         Iter { ..*self }
     }
@@ -85,13 +90,13 @@ impl<T> Clone for Iter<'_, T> {
 /// [`iter_mut`]: struct.LinkedList.html#method.iter_mut
 /// [`LinkedList`]: struct.LinkedList.html
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct IterMut<'a, T: 'a> {
+pub struct IterMut<'a, T: 'a, A: Alloc + Clone + 'a = AbortAdapter<Global>> {
     // We do *not* exclusively own the entire list here, references to node's `element`
     // have been handed out by the iterator!  So be careful when using this; the methods
     // called must be aware that there can be aliasing pointers to `element`.
-    list: &'a mut LinkedList<T>,
-    head: Option<NonNull<Node<T>>>,
-    tail: Option<NonNull<Node<T>>>,
+    list: &'a mut LinkedList<T, A>,
+    head: Option<NonNull<Node<T, A>>>,
+    tail: Option<NonNull<Node<T, A>>>,
     len: usize,
 }
 
@@ -112,10 +117,16 @@ impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
 ///
 /// [`into_iter`]: struct.LinkedList.html#method.into_iter
 /// [`LinkedList`]: struct.LinkedList.html
-#[derive(Clone)]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct IntoIter<T> {
-    list: LinkedList<T>,
+pub struct IntoIter<T, A: Alloc + Clone = AbortAdapter<Global>> {
+    list: LinkedList<T, A>,
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Clone> Clone for IntoIter<T> {
+    fn clone(&self) -> Self {
+        IntoIter { list: self.list.clone() }
+    }
 }
 
 #[stable(feature = "collection_debug", since = "1.17.0")]
@@ -127,25 +138,26 @@ impl<T: fmt::Debug> fmt::Debug for IntoIter<T> {
     }
 }
 
-impl<T> Node<T> {
+impl<T, A: Alloc> Node<T, A> {
     fn new(element: T) -> Self {
         Node {
             next: None,
             prev: None,
             element,
+            marker: PhantomData
         }
     }
 
-    fn into_element(self: Box<Self>) -> T {
+    fn into_element(self: Box<Self, A>) -> T {
         self.element
     }
 }
 
 // private methods
-impl<T> LinkedList<T> {
+impl<T, A: Alloc + Clone> LinkedList<T, A> {
     /// Adds the given node to the front of the list.
     #[inline]
-    fn push_front_node(&mut self, mut node: Box<Node<T>>) {
+    fn push_front_node(&mut self, mut node: Box<Node<T, A>, A>) {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
         unsafe {
@@ -166,11 +178,11 @@ impl<T> LinkedList<T> {
 
     /// Removes and returns the node at the front of the list.
     #[inline]
-    fn pop_front_node(&mut self) -> Option<Box<Node<T>>> {
+    fn pop_front_node(&mut self) -> Option<Box<Node<T, A>, A>> {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
         self.head.map(|node| unsafe {
-            let node = Box::from_raw(node.as_ptr());
+            let node = Box::from_raw_in(node.as_ptr(), self.alloc.clone());
             self.head = node.next;
 
             match self.head {
@@ -186,7 +198,7 @@ impl<T> LinkedList<T> {
 
     /// Adds the given node to the back of the list.
     #[inline]
-    fn push_back_node(&mut self, mut node: Box<Node<T>>) {
+    fn push_back_node(&mut self, mut node: Box<Node<T, A>, A>) {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
         unsafe {
@@ -207,11 +219,11 @@ impl<T> LinkedList<T> {
 
     /// Removes and returns the node at the back of the list.
     #[inline]
-    fn pop_back_node(&mut self) -> Option<Box<Node<T>>> {
+    fn pop_back_node(&mut self) -> Option<Box<Node<T, A>, A>> {
         // This method takes care not to create mutable references to whole nodes,
         // to maintain validity of aliasing pointers into `element`.
         self.tail.map(|node| unsafe {
-            let node = Box::from_raw(node.as_ptr());
+            let node = Box::from_raw_in(node.as_ptr(), self.alloc.clone());
             self.tail = node.prev;
 
             match self.tail {
@@ -232,7 +244,7 @@ impl<T> LinkedList<T> {
     /// This method takes care not to create mutable references to `element`, to
     /// maintain validity of aliasing pointers.
     #[inline]
-    unsafe fn unlink_node(&mut self, mut node: NonNull<Node<T>>) {
+    unsafe fn unlink_node(&mut self, mut node: NonNull<Node<T, A>>) {
         let node = node.as_mut(); // this one is ours now, we can create an &mut.
 
         // Not creating new mutable (unique!) references overlapping `element`.
@@ -274,10 +286,60 @@ impl<T> LinkedList<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Self {
+        Self::new_in(Default::default())
+    }
+
+    /// Appends an element to the back of a list
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::LinkedList;
+    ///
+    /// let mut d = LinkedList::new();
+    /// d.push_back(1);
+    /// d.push_back(3);
+    /// assert_eq!(3, *d.back().unwrap());
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn push_back(&mut self, elt: T) {
+        let Ok(()) = self.push_back_alloc(elt);
+    }
+
+    /// Adds an element first in the list.
+    ///
+    /// This operation should compute in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::LinkedList;
+    ///
+    /// let mut dl = LinkedList::new();
+    ///
+    /// dl.push_front(2);
+    /// assert_eq!(dl.front().unwrap(), &2);
+    ///
+    /// dl.push_front(1);
+    /// assert_eq!(dl.front().unwrap(), &1);
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn push_front(&mut self, elt: T) {
+        let Ok(()) = self.push_front_alloc(elt);
+    }
+}
+
+impl<T, A: Alloc + Clone> LinkedList<T, A> {
+    /// like `Self::new` but with an explicit allocator rather than the default
+    /// global one.
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn new_in(a: A) -> Self {
         LinkedList {
             head: None,
             tail: None,
             len: 0,
+            alloc: a,
             marker: PhantomData,
         }
     }
@@ -352,7 +414,7 @@ impl<T> LinkedList<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<'_, T, A> {
         Iter {
             head: self.head,
             tail: self.tail,
@@ -386,7 +448,7 @@ impl<T> LinkedList<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, T, A> {
         IterMut {
             head: self.head,
             tail: self.tail,
@@ -465,7 +527,7 @@ impl<T> LinkedList<T> {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn clear(&mut self) {
-        *self = Self::new();
+        *self = Self::new_in(self.alloc.clone());
     }
 
     /// Returns `true` if the `LinkedList` contains an element equal to the
@@ -610,8 +672,10 @@ impl<T> LinkedList<T> {
     /// assert_eq!(dl.front().unwrap(), &1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn push_front(&mut self, elt: T) {
-        self.push_front_node(box Node::new(elt));
+    pub fn push_front_alloc(&mut self, elt: T) -> Result<(), A::Err> {
+        let alloc = self.alloc.clone();
+        self.push_front_node(Box::new_in(Node::new(elt), alloc)?);
+        Ok(())
     }
 
     /// Removes the first element and returns it, or `None` if the list is
@@ -653,8 +717,10 @@ impl<T> LinkedList<T> {
     /// assert_eq!(3, *d.back().unwrap());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn push_back(&mut self, elt: T) {
-        self.push_back_node(box Node::new(elt));
+    pub fn push_back_alloc(&mut self, elt: T) -> Result<(), A::Err> {
+        let alloc = self.alloc.clone();
+        self.push_back_node(Box::new_in(Node::new(elt), alloc)?);
+        Ok(())
     }
 
     /// Removes the last element from a list and returns it, or `None` if
@@ -704,13 +770,14 @@ impl<T> LinkedList<T> {
     /// assert_eq!(splitted.pop_front(), None);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn split_off(&mut self, at: usize) -> LinkedList<T> {
+    pub fn split_off(&mut self, at: usize) -> Self {
         let len = self.len();
         assert!(at <= len, "Cannot split off at a nonexistent index");
         if at == 0 {
-            return mem::replace(self, Self::new());
+            let alloc = self.alloc.clone();
+            return mem::replace(self, Self::new_in(alloc));
         } else if at == len {
-            return Self::new();
+            return Self::new_in(self.alloc.clone());
         }
 
         // Below, we iterate towards the `i-1`th node, either from the start or the end,
@@ -748,6 +815,7 @@ impl<T> LinkedList<T> {
             head: second_part_head,
             tail: self.tail,
             len: len - at,
+            alloc: self.alloc.clone(),
             marker: PhantomData,
         };
 
@@ -785,7 +853,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(odds.into_iter().collect::<Vec<_>>(), vec![1, 3, 5, 9, 11, 13, 15]);
     /// ```
     #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
-    pub fn drain_filter<F>(&mut self, filter: F) -> DrainFilter<'_, T, F>
+    pub fn drain_filter<F>(&mut self, filter: F) -> DrainFilter<'_, T, F, A>
         where F: FnMut(&mut T) -> bool
     {
         // avoid borrow issues.
@@ -803,14 +871,14 @@ impl<T> LinkedList<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<#[may_dangle] T> Drop for LinkedList<T> {
+unsafe impl<#[may_dangle] T, A: Alloc + Clone> Drop for LinkedList<T, A> {
     fn drop(&mut self) {
         while let Some(_) = self.pop_front_node() {}
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Iterator for Iter<'a, T> {
+impl<'a, T, A: Alloc> Iterator for Iter<'a, T, A> {
     type Item = &'a T;
 
     #[inline]
@@ -835,7 +903,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+impl<'a, T, A: Alloc> DoubleEndedIterator for Iter<'a, T, A> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a T> {
         if self.len == 0 {
@@ -853,13 +921,13 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Iter<'_, T> {}
+impl<T, A: Alloc + Clone> ExactSizeIterator for Iter<'_, T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T> FusedIterator for Iter<'_, T> {}
+impl<T, A: Alloc + Clone> FusedIterator for Iter<'_, T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> Iterator for IterMut<'a, T> {
+impl<'a, T, A: Alloc + Clone> Iterator for IterMut<'a, T, A> {
     type Item = &'a mut T;
 
     #[inline]
@@ -884,7 +952,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+impl<'a, T, A: Alloc + Clone> DoubleEndedIterator for IterMut<'a, T, A> {
     #[inline]
     fn next_back(&mut self) -> Option<&'a mut T> {
         if self.len == 0 {
@@ -902,10 +970,10 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IterMut<'_, T> {}
+impl<T, A: Alloc + Clone> ExactSizeIterator for IterMut<'_, T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T> FusedIterator for IterMut<'_, T> {}
+impl<T, A: Alloc + Clone> FusedIterator for IterMut<'_, T, A> {}
 
 impl<T> IterMut<'_, T> {
     /// Inserts the given element just after the element most recently returned by `.next()`.
@@ -936,21 +1004,32 @@ impl<T> IterMut<'_, T> {
                reason = "this is probably better handled by a cursor type -- we'll see",
                issue = "27794")]
     pub fn insert_next(&mut self, element: T) {
-        match self.head {
+        let Ok(()) = self.insert_next_alloc(element);
+    }
+}
+
+impl<'a, T, A: Alloc + Clone> IterMut<'a, T, A> {
+    /// Like `Self::insert_next` but allows non-standard allocators. Might need
+    /// to be separate for stability reasons.
+    #[inline]
+    #[unstable(feature = "allocator_api", issue = "32838")]
+    pub fn insert_next_alloc(&mut self, element: T) -> Result<(), A::Err> {
+        Ok(match self.head {
             // `push_back` is okay with aliasing `element` references
-            None => self.list.push_back(element),
+            None => self.list.push_back_alloc(element)?,
             Some(head) => unsafe {
+                // `push_front` is okay with aliasing nodes
                 let prev = match head.as_ref().prev {
-                    // `push_front` is okay with aliasing nodes
-                    None => return self.list.push_front(element),
+                    None => return self.list.push_front_alloc(element),
                     Some(prev) => prev,
                 };
 
-                let node = Some(Box::into_raw_non_null(box Node {
+                let node = Some(NonNull::from(Box::into_unique(Box::new_in(Node {
                     next: Some(head),
                     prev: Some(prev),
                     element,
-                }));
+                    marker: PhantomData,
+                }, self.list.alloc.clone())?)));
 
                 // Not creating references to entire nodes to not invalidate the
                 // reference to `element` we handed to the user.
@@ -959,7 +1038,7 @@ impl<T> IterMut<'_, T> {
 
                 self.list.len += 1;
             },
-        }
+        })
     }
 
     /// Provides a reference to the next element, without changing the iterator.
@@ -996,18 +1075,18 @@ impl<T> IterMut<'_, T> {
 
 /// An iterator produced by calling `drain_filter` on LinkedList.
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
-pub struct DrainFilter<'a, T: 'a, F: 'a>
-    where F: FnMut(&mut T) -> bool,
+pub struct DrainFilter<'a, T: 'a, F: 'a, A: 'a = AbortAdapter<Global>>
+    where A: Alloc + Clone, F: FnMut(&mut T) -> bool,
 {
-    list: &'a mut LinkedList<T>,
-    it: Option<NonNull<Node<T>>>,
+    list: &'a mut LinkedList<T, A>,
+    it: Option<NonNull<Node<T, A>>>,
     pred: F,
     idx: usize,
     old_len: usize,
 }
 
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
-impl<T, F> Iterator for DrainFilter<'_, T, F>
+impl<T, F, A: Alloc + Clone> Iterator for DrainFilter<'_, T, F, A>
     where F: FnMut(&mut T) -> bool,
 {
     type Item = T;
@@ -1035,7 +1114,7 @@ impl<T, F> Iterator for DrainFilter<'_, T, F>
 }
 
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
-impl<T, F> Drop for DrainFilter<'_, T, F>
+impl<T, F, A: Alloc + Clone> Drop for DrainFilter<'_, T, F, A>
     where F: FnMut(&mut T) -> bool,
 {
     fn drop(&mut self) {
@@ -1044,7 +1123,7 @@ impl<T, F> Drop for DrainFilter<'_, T, F>
 }
 
 #[unstable(feature = "drain_filter", reason = "recently added", issue = "43244")]
-impl<T: fmt::Debug, F> fmt::Debug for DrainFilter<'_, T, F>
+impl<T: fmt::Debug, F, A: Alloc + Clone> fmt::Debug for DrainFilter<'_, T, F, A>
     where F: FnMut(&mut T) -> bool
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1055,7 +1134,7 @@ impl<T: fmt::Debug, F> fmt::Debug for DrainFilter<'_, T, F>
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Iterator for IntoIter<T> {
+impl<T, A: Alloc + Clone> Iterator for IntoIter<T, A> {
     type Item = T;
 
     #[inline]
@@ -1070,7 +1149,7 @@ impl<T> Iterator for IntoIter<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> DoubleEndedIterator for IntoIter<T> {
+impl<T, A: Alloc + Clone> DoubleEndedIterator for IntoIter<T, A> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {
         self.list.pop_back()
@@ -1078,10 +1157,10 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IntoIter<T> {}
+impl<T, A: Alloc + Clone> ExactSizeIterator for IntoIter<T, A> {}
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T> FusedIterator for IntoIter<T> {}
+impl<T, A: Alloc + Clone> FusedIterator for IntoIter<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> FromIterator<T> for LinkedList<T> {
@@ -1093,65 +1172,67 @@ impl<T> FromIterator<T> for LinkedList<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> IntoIterator for LinkedList<T> {
+impl<T, A: Alloc + Clone> IntoIterator for LinkedList<T, A> {
     type Item = T;
-    type IntoIter = IntoIter<T>;
+    type IntoIter = IntoIter<T, A>;
 
     /// Consumes the list into an iterator yielding elements by value.
     #[inline]
-    fn into_iter(self) -> IntoIter<T> {
+    fn into_iter(self) -> IntoIter<T, A> {
         IntoIter { list: self }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> IntoIterator for &'a LinkedList<T> {
+impl<'a, T, A: Alloc + Clone> IntoIterator for &'a LinkedList<T, A> {
     type Item = &'a T;
-    type IntoIter = Iter<'a, T>;
+    type IntoIter = Iter<'a, T, A>;
 
-    fn into_iter(self) -> Iter<'a, T> {
+    fn into_iter(self) -> Iter<'a, T, A> {
         self.iter()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> IntoIterator for &'a mut LinkedList<T> {
+impl<'a, T, A: Alloc + Clone> IntoIterator for &'a mut LinkedList<T, A> {
     type Item = &'a mut T;
-    type IntoIter = IterMut<'a, T>;
+    type IntoIter = IterMut<'a, T, A>;
 
-    fn into_iter(self) -> IterMut<'a, T> {
+    fn into_iter(self) -> IterMut<'a, T, A> {
         self.iter_mut()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Extend<T> for LinkedList<T> {
+impl<T, A: Alloc<Err=!> + Clone> Extend<T> for LinkedList<T, A> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         <Self as SpecExtend<I>>::spec_extend(self, iter);
     }
 }
 
-impl<I: IntoIterator> SpecExtend<I> for LinkedList<I::Item> {
+impl<I: IntoIterator, A: Alloc<Err=!> + Clone> SpecExtend<I> for LinkedList<I::Item, A> {
     default fn spec_extend(&mut self, iter: I) {
-        iter.into_iter().for_each(move |elt| self.push_back(elt));
+        iter.into_iter().for_each(move |elt| {
+            let Ok(()) = self.push_back_alloc(elt);
+        });
     }
 }
 
-impl<T> SpecExtend<LinkedList<T>> for LinkedList<T> {
-    fn spec_extend(&mut self, ref mut other: LinkedList<T>) {
+impl<T, A: Alloc<Err=!> + Clone> SpecExtend<LinkedList<T, A>> for LinkedList<T, A> {
+    fn spec_extend(&mut self, ref mut other: LinkedList<T, A>) {
         self.append(other);
     }
 }
 
 #[stable(feature = "extend_ref", since = "1.2.0")]
-impl<'a, T: 'a + Copy> Extend<&'a T> for LinkedList<T> {
+impl<'a, T: 'a + Copy, A: Alloc<Err=!> + Clone> Extend<&'a T> for LinkedList<T, A> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: PartialEq> PartialEq for LinkedList<T> {
+impl<T: PartialEq, A: Alloc + Clone> PartialEq for LinkedList<T, A> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other)
     }
@@ -1162,17 +1243,17 @@ impl<T: PartialEq> PartialEq for LinkedList<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Eq> Eq for LinkedList<T> {}
+impl<T: Eq, A: Alloc + Clone> Eq for LinkedList<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: PartialOrd> PartialOrd for LinkedList<T> {
+impl<T: PartialOrd, A: Alloc + Clone> PartialOrd for LinkedList<T, A> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.iter().partial_cmp(other)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord> Ord for LinkedList<T> {
+impl<T: Ord, A: Alloc + Clone> Ord for LinkedList<T, A> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other)
@@ -1187,14 +1268,14 @@ impl<T: Clone> Clone for LinkedList<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: fmt::Debug> fmt::Debug for LinkedList<T> {
+impl<T: fmt::Debug, A: Alloc + Clone> fmt::Debug for LinkedList<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self).finish()
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Hash> Hash for LinkedList<T> {
+impl<T: Hash, A: Alloc + Clone> Hash for LinkedList<T, A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.len().hash(state);
         for elt in self {
@@ -1218,10 +1299,10 @@ fn assert_covariance() {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<T: Send> Send for LinkedList<T> {}
+unsafe impl<T: Send, A: Alloc + Clone + Send> Send for LinkedList<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-unsafe impl<T: Sync> Sync for LinkedList<T> {}
+unsafe impl<T: Sync, A: Alloc + Clone + Sync> Sync for LinkedList<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
@@ -1244,16 +1325,18 @@ mod tests {
 
     use super::{LinkedList, Node};
 
+    type GlobalNode<T> = Node<T, AbortAdapater<Global>>;
+
     #[cfg(test)]
-    fn list_from<T: Clone>(v: &[T]) -> LinkedList<T> {
+    fn list_from<T: Clone>(v: &[T]) -> LinkedList<T, A> {
         v.iter().cloned().collect()
     }
 
-    pub fn check_links<T>(list: &LinkedList<T>) {
+    pub fn check_links<T>(list: &LinkedList<T, A>) {
         unsafe {
             let mut len = 0;
-            let mut last_ptr: Option<&Node<T>> = None;
-            let mut node_ptr: &Node<T>;
+            let mut last_ptr: Option<&GlobalNode<T>> = None;
+            let mut node_ptr: &GlobalNode<T>;
             match list.head {
                 None => {
                     // tail node should also be None.
@@ -1268,7 +1351,9 @@ mod tests {
                     (None, None) => {}
                     (None, _) => panic!("prev link for head"),
                     (Some(p), Some(pptr)) => {
-                        assert_eq!(p as *const Node<T>, pptr.as_ptr() as *const Node<T>);
+                        assert_eq!(
+                            p as *const GlobalNode<T>,
+                            pptr.as_ptr() as *const GlobalNode<T>);
                     }
                     _ => panic!("prev link is none, not good"),
                 }
@@ -1287,7 +1372,7 @@ mod tests {
 
             // verify that the tail node points to the last node.
             let tail = list.tail.as_ref().expect("some tail node").as_ref();
-            assert_eq!(tail as *const Node<T>, node_ptr as *const Node<T>);
+            assert_eq!(tail as *const GlobalNode<T>, node_ptr as *const GlobalNode<T>);
             // check that len matches interior links.
             assert_eq!(len, list.len);
         }

--- a/src/liballoc/collections/mod.rs
+++ b/src/liballoc/collections/mod.rs
@@ -46,24 +46,24 @@ use crate::alloc::{AllocErr, LayoutErr};
 /// Augments `AllocErr` with a CapacityOverflow variant.
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-pub enum CollectionAllocErr {
+pub enum CollectionAllocErr<E> {
     /// Error due to the computed capacity exceeding the collection's maximum
     /// (usually `isize::MAX` bytes).
     CapacityOverflow,
     /// Error due to the allocator (see the `AllocErr` type's docs).
-    AllocErr,
+    AllocErr(E),
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-impl From<AllocErr> for CollectionAllocErr {
+impl From<AllocErr> for CollectionAllocErr<AllocErr> {
     #[inline]
     fn from(AllocErr: AllocErr) -> Self {
-        CollectionAllocErr::AllocErr
+        CollectionAllocErr::AllocErr(AllocErr)
     }
 }
 
 #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-impl From<LayoutErr> for CollectionAllocErr {
+impl<E> From<LayoutErr> for CollectionAllocErr<E> {
     #[inline]
     fn from(_: LayoutErr) -> Self {
         CollectionAllocErr::CapacityOverflow

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -112,6 +112,7 @@
 #![feature(maybe_uninit_extra, maybe_uninit_slice, maybe_uninit_array)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
+#![feature(never_type)]
 
 // Allow testing this library
 
@@ -128,6 +129,7 @@ mod macros;
 // Heaps provided for low-level allocation strategies
 
 pub mod alloc;
+pub mod abort_adapter;
 
 // Primitive types using the heaps above
 

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -113,6 +113,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(never_type)]
+#![feature(exhaustive_patterns)]
 
 // Allow testing this library
 

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -7,7 +7,8 @@ use core::ops::Drop;
 use core::ptr::{self, NonNull, Unique};
 use core::slice;
 
-use crate::alloc::{Alloc, AllocErr, Layout, Global, handle_alloc_error};
+use crate::abort_adapter::AbortAdapter;
+use crate::alloc::{Alloc, Layout, Global};
 use crate::collections::CollectionAllocErr;
 use crate::boxed::Box;
 
@@ -21,7 +22,6 @@ use crate::boxed::Box;
 /// * Catches all overflows in capacity computations (promotes them to "capacity overflow" panics)
 /// * Guards against 32-bit systems allocating more than isize::MAX bytes
 /// * Guards against overflowing your length
-/// * Aborts on OOM or calls handle_alloc_error as applicable
 /// * Avoids freeing Unique::empty()
 /// * Contains a ptr::Unique and thus endows the user with all related benefits
 ///
@@ -39,13 +39,13 @@ use crate::boxed::Box;
 /// field. This allows zero-sized types to not be special-cased by consumers of
 /// this type.
 #[allow(missing_debug_implementations)]
-pub struct RawVec<T, A: Alloc<Err = AllocErr> = Global> {
+pub struct RawVec<T, A: Alloc = AbortAdapter<Global>> {
     ptr: Unique<T>,
     cap: usize,
     a: A,
 }
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     /// Like `new` but parameterized over the choice of allocator for
     /// the returned RawVec.
     pub const fn new_in(a: A) -> Self {
@@ -65,23 +65,24 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// Like `with_capacity` but parameterized over the choice of
     /// allocator for the returned RawVec.
     #[inline]
-    pub fn with_capacity_in(cap: usize, a: A) -> Self {
-        RawVec::allocate_in(cap, false, a)
+    pub fn with_capacity_in(cap: usize, a: A) -> Result<Self, A::Err> {
+        RawVec::allocate_in(cap, false, a).map_err(handle_overflow_error)
     }
 
     /// Like `with_capacity_zeroed` but parameterized over the choice
     /// of allocator for the returned RawVec.
     #[inline]
-    pub fn with_capacity_zeroed_in(cap: usize, a: A) -> Self {
-        RawVec::allocate_in(cap, true, a)
+    pub fn with_capacity_zeroed_in(cap: usize, a: A) -> Result<Self, A::Err> {
+        RawVec::allocate_in(cap, true, a).map_err(handle_overflow_error)
     }
 
-    fn allocate_in(cap: usize, zeroed: bool, mut a: A) -> Self {
-        unsafe {
+    fn allocate_in(cap: usize, zeroed: bool, mut a: A) -> Result<Self, CollectionAllocErr<A::Err>> {
+       unsafe {
             let elem_size = mem::size_of::<T>();
 
-            let alloc_size = cap.checked_mul(elem_size).unwrap_or_else(|| capacity_overflow());
-            alloc_guard(alloc_size).unwrap_or_else(|_| capacity_overflow());
+            let alloc_size = cap.checked_mul(elem_size)
+                .ok_or(CollectionAllocErr::CapacityOverflow)?;
+            alloc_guard(alloc_size)?;
 
             // handles ZSTs and `cap = 0` alike
             let ptr = if alloc_size == 0 {
@@ -89,34 +90,31 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
             } else {
                 let align = mem::align_of::<T>();
                 let layout = Layout::from_size_align(alloc_size, align).unwrap();
-                let result = if zeroed {
+                if zeroed {
                     a.alloc_zeroed(layout)
                 } else {
                     a.alloc(layout)
-                };
-                match result {
-                    Ok(ptr) => ptr.cast(),
-                    Err(_) => handle_alloc_error(layout),
-                }
+                }.map_err(CollectionAllocErr::AllocErr)?.cast()
             };
 
-            RawVec {
+            Ok(RawVec {
                 ptr: ptr.into(),
                 cap,
                 a,
-            }
+            })
         }
     }
 }
 
-impl<T> RawVec<T, Global> {
+impl<T> RawVec<T> {
     /// Creates the biggest possible RawVec (on the system heap)
     /// without allocating. If T has positive size, then this makes a
     /// RawVec with capacity 0. If T has 0 size, then it makes a
     /// RawVec with capacity `usize::MAX`. Useful for implementing
     /// delayed allocation.
     pub const fn new() -> Self {
-        Self::new_in(Global)
+        // Cannot use `Default::default()` cause const fun.
+        Self::new_in(AbortAdapter(Global))
     }
 
     /// Creates a RawVec (on the system heap) with exactly the
@@ -130,23 +128,23 @@ impl<T> RawVec<T, Global> {
     /// * Panics if the requested capacity exceeds `usize::MAX` bytes.
     /// * Panics on 32-bit platforms if the requested capacity exceeds
     ///   `isize::MAX` bytes.
-    ///
-    /// # Aborts
-    ///
-    /// Aborts on OOM
     #[inline]
     pub fn with_capacity(cap: usize) -> Self {
-        RawVec::allocate_in(cap, false, Global)
+        let Ok(v) = RawVec::allocate_in(cap, false, Default::default())
+            .map_err(handle_overflow_error);
+        v
     }
 
     /// Like `with_capacity` but guarantees the buffer is zeroed.
     #[inline]
     pub fn with_capacity_zeroed(cap: usize) -> Self {
-        RawVec::allocate_in(cap, true, Global)
+        let Ok(v) = RawVec::allocate_in(cap, true, Default::default())
+            .map_err(handle_overflow_error);
+        v
     }
 }
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     /// Reconstitutes a RawVec from a pointer, capacity, and allocator.
     ///
     /// # Undefined Behavior
@@ -163,7 +161,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     }
 }
 
-impl<T> RawVec<T, Global> {
+impl<T> RawVec<T> {
     /// Reconstitutes a RawVec from a pointer, capacity.
     ///
     /// # Undefined Behavior
@@ -175,7 +173,7 @@ impl<T> RawVec<T, Global> {
         RawVec {
             ptr: Unique::new_unchecked(ptr),
             cap,
-            a: Global,
+            a: Default::default(),
         }
     }
 
@@ -189,7 +187,7 @@ impl<T> RawVec<T, Global> {
     }
 }
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     /// Gets a raw pointer to the start of the allocation. Note that this is
     /// Unique::empty() if `cap = 0` or T is zero-sized. In the former case, you must
     /// be careful.
@@ -249,10 +247,6 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// * Panics on 32-bit platforms if the requested capacity exceeds
     ///   `isize::MAX` bytes.
     ///
-    /// # Aborts
-    ///
-    /// Aborts on OOM
-    ///
     /// # Examples
     ///
     /// ```
@@ -283,7 +277,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// ```
     #[inline(never)]
     #[cold]
-    pub fn double(&mut self) {
+    pub fn double(&mut self) -> Result<(), A::Err> {
         unsafe {
             let elem_size = mem::size_of::<T>();
 
@@ -305,29 +299,23 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
                     // `from_size_align_unchecked`.
                     let new_cap = 2 * self.cap;
                     let new_size = new_cap * elem_size;
-                    alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
-                    let ptr_res = self.a.realloc(NonNull::from(self.ptr).cast(),
-                                                 cur,
-                                                 new_size);
-                    match ptr_res {
-                        Ok(ptr) => (new_cap, ptr.cast().into()),
-                        Err(_) => handle_alloc_error(
-                            Layout::from_size_align_unchecked(new_size, cur.align())
-                        ),
-                    }
+                    alloc_guard::<!>(new_size).unwrap_or_else(|_| capacity_overflow());
+                    let ptr = self.a.realloc(NonNull::from(self.ptr).cast(),
+                                             cur,
+                                             new_size)?;
+                    (new_cap, ptr.cast().into())
                 }
                 None => {
                     // skip to 4 because tiny Vec's are dumb; but not if that
                     // would cause overflow
                     let new_cap = if elem_size > (!0) / 8 { 1 } else { 4 };
-                    match self.a.alloc_array::<T>(new_cap) {
-                        Ok(ptr) => (new_cap, ptr.into()),
-                        Err(_) => handle_alloc_error(Layout::array::<T>(new_cap).unwrap()),
-                    }
+                    let ptr = self.a.alloc_array::<T>(new_cap)?;
+                    (new_cap, ptr.cast().into())
                 }
             };
             self.ptr = uniq;
             self.cap = new_cap;
+            Ok(())
         }
     }
 
@@ -366,7 +354,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
             // overflow and the alignment is sufficiently small.
             let new_cap = 2 * self.cap;
             let new_size = new_cap * elem_size;
-            alloc_guard(new_size).unwrap_or_else(|_| capacity_overflow());
+            alloc_guard::<!>(new_size).unwrap_or_else(|_| capacity_overflow());
             match self.a.grow_in_place(NonNull::from(self.ptr).cast(), old_layout, new_size) {
                 Ok(_) => {
                     // We can't directly divide `size`.
@@ -378,13 +366,6 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
                 }
             }
         }
-    }
-
-    /// The same as `reserve_exact`, but returns on errors instead of panicking or aborting.
-    pub fn try_reserve_exact(&mut self, used_cap: usize, needed_extra_cap: usize)
-           -> Result<(), CollectionAllocErr> {
-
-        self.reserve_internal(used_cap, needed_extra_cap, Fallible, Exact)
     }
 
     /// Ensures that the buffer contains at least enough space to hold
@@ -403,24 +384,18 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// * Panics if the requested capacity exceeds `usize::MAX` bytes.
     /// * Panics on 32-bit platforms if the requested capacity exceeds
     ///   `isize::MAX` bytes.
-    ///
-    /// # Aborts
-    ///
-    /// Aborts on OOM
-    pub fn reserve_exact(&mut self, used_cap: usize, needed_extra_cap: usize) {
-        match self.reserve_internal(used_cap, needed_extra_cap, Infallible, Exact) {
-            Err(CollectionAllocErr::CapacityOverflow) => capacity_overflow(),
-            Err(CollectionAllocErr::AllocErr) => unreachable!(),
-            Ok(()) => { /* yay */ }
-         }
-     }
+    pub fn reserve_exact(&mut self, used_cap: usize, needed_extra_cap: usize)
+        -> Result<(), A::Err>
+    {
+        self.reserve_internal_2(used_cap, needed_extra_cap, Exact)
+    }
 
     /// Calculates the buffer's new size given that it'll hold `used_cap +
     /// needed_extra_cap` elements. This logic is used in amortized reserve methods.
     /// Returns `(new_capacity, new_alloc_size)`.
     fn amortized_new_size(&self, used_cap: usize, needed_extra_cap: usize)
-        -> Result<usize, CollectionAllocErr> {
-
+        -> Result<usize, CollectionAllocErr<A::Err>>
+    {
         // Nothing we can really do about these checks :(
         let required_cap = used_cap.checked_add(needed_extra_cap)
             .ok_or(CollectionAllocErr::CapacityOverflow)?;
@@ -428,12 +403,6 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
         let double_cap = self.cap * 2;
         // `double_cap` guarantees exponential growth.
         Ok(cmp::max(double_cap, required_cap))
-    }
-
-    /// The same as `reserve`, but returns on errors instead of panicking or aborting.
-    pub fn try_reserve(&mut self, used_cap: usize, needed_extra_cap: usize)
-        -> Result<(), CollectionAllocErr> {
-        self.reserve_internal(used_cap, needed_extra_cap, Fallible, Amortized)
     }
 
     /// Ensures that the buffer contains at least enough space to hold
@@ -453,10 +422,6 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// * Panics if the requested capacity exceeds `usize::MAX` bytes.
     /// * Panics on 32-bit platforms if the requested capacity exceeds
     ///   `isize::MAX` bytes.
-    ///
-    /// # Aborts
-    ///
-    /// Aborts on OOM
     ///
     /// # Examples
     ///
@@ -488,12 +453,8 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// #   vector.push_all(&[1, 3, 5, 7, 9]);
     /// # }
     /// ```
-    pub fn reserve(&mut self, used_cap: usize, needed_extra_cap: usize) {
-        match self.reserve_internal(used_cap, needed_extra_cap, Infallible, Amortized) {
-            Err(CollectionAllocErr::CapacityOverflow) => capacity_overflow(),
-            Err(CollectionAllocErr::AllocErr) => unreachable!(),
-            Ok(()) => { /* yay */ }
-        }
+    pub fn reserve(&mut self, used_cap: usize, needed_extra_cap: usize) -> Result<(), A::Err> {
+        self.reserve_internal_2(used_cap, needed_extra_cap, Amortized)
     }
     /// Attempts to ensure that the buffer contains at least enough space to hold
     /// `used_cap + needed_extra_cap` elements. If it doesn't already have
@@ -539,7 +500,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
 
             let new_layout = Layout::new::<T>().repeat(new_cap).unwrap().0;
             // FIXME: may crash and burn on over-reserve
-            alloc_guard(new_layout.size()).unwrap_or_else(|_| capacity_overflow());
+            alloc_guard::<!>(new_layout.size()).unwrap_or_else(|_| capacity_overflow());
             match self.a.grow_in_place(
                 NonNull::from(self.ptr).cast(), old_layout, new_layout.size(),
             ) {
@@ -560,17 +521,13 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     /// # Panics
     ///
     /// Panics if the given amount is *larger* than the current capacity.
-    ///
-    /// # Aborts
-    ///
-    /// Aborts on OOM.
-    pub fn shrink_to_fit(&mut self, amount: usize) {
+    pub fn shrink_to_fit(&mut self, amount: usize) -> Result<(), A::Err> {
         let elem_size = mem::size_of::<T>();
 
         // Set the `cap` because they might be about to promote to a `Box<[T]>`
         if elem_size == 0 {
             self.cap = amount;
-            return;
+            return Ok(());
         }
 
         // This check is my waterloo; it's the only thing Vec wouldn't have to do.
@@ -602,26 +559,40 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
                 let new_size = elem_size * amount;
                 let align = mem::align_of::<T>();
                 let old_layout = Layout::from_size_align_unchecked(old_size, align);
-                match self.a.realloc(NonNull::from(self.ptr).cast(),
-                                     old_layout,
-                                     new_size) {
-                    Ok(p) => self.ptr = p.cast().into(),
-                    Err(_) => handle_alloc_error(
-                        Layout::from_size_align_unchecked(new_size, align)
-                    ),
-                }
+                let ptr = self.a.realloc(NonNull::from(self.ptr).cast(),
+                                         old_layout,
+                                         new_size)?;
+                self.ptr = ptr.cast().into();
             }
             self.cap = amount;
         }
+        Ok(())
+    }
+
+    // Reborrow a `RawVec` as one which does diverge on allocation failures.
+    pub fn as_infallible(&mut self) -> &mut RawVec<T, AbortAdapter<A>> {
+        unsafe { ::core::mem::transmute(self) }
     }
 }
 
-enum Fallibility {
-    Fallible,
-    Infallible,
-}
+impl<T, A: Alloc> RawVec<T, AbortAdapter<A>> {
+    // Reborrow a `RawVec` as one which doesn't diverge on allocation failures.
+    pub fn as_fallible(&mut self) -> &mut RawVec<T, A> {
+        unsafe { ::core::mem::transmute(self) }
+    }
 
-use Fallibility::*;
+    /// The same as `reserve_exact`, but returns on errors instead of panicking or aborting.
+    pub fn try_reserve_exact(&mut self, used_cap: usize, needed_extra_cap: usize)
+                             -> Result<(), CollectionAllocErr<A::Err>> {
+        self.as_fallible().reserve_internal(used_cap, needed_extra_cap, Exact)
+    }
+
+    /// The same as `reserve`, but returns on errors instead of panicking or aborting.
+    pub fn try_reserve(&mut self, used_cap: usize, needed_extra_cap: usize)
+                       -> Result<(), CollectionAllocErr<A::Err>> {
+        self.as_fallible().reserve_internal(used_cap, needed_extra_cap, Amortized)
+    }
+}
 
 enum ReserveStrategy {
     Exact,
@@ -630,14 +601,13 @@ enum ReserveStrategy {
 
 use ReserveStrategy::*;
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     fn reserve_internal(
         &mut self,
         used_cap: usize,
         needed_extra_cap: usize,
-        fallibility: Fallibility,
         strategy: ReserveStrategy,
-    ) -> Result<(), CollectionAllocErr> {
+    ) -> Result<(), CollectionAllocErr<A::Err>> {
         unsafe {
             // NOTE: we don't early branch on ZSTs here because we want this
             // to actually catch "asking for more than usize::MAX" in that case.
@@ -661,29 +631,37 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
 
             alloc_guard(new_layout.size())?;
 
-            let res = match self.current_layout() {
+            let ptr = match self.current_layout() {
                 Some(layout) => {
                     debug_assert!(new_layout.align() == layout.align());
                     self.a.realloc(NonNull::from(self.ptr).cast(), layout, new_layout.size())
                 }
                 None => self.a.alloc(new_layout),
-            };
+            }.map_err(CollectionAllocErr::AllocErr)?;
 
-            match (&res, fallibility) {
-                (Err(AllocErr), Infallible) => handle_alloc_error(new_layout),
-                _ => {}
-            }
-
-            self.ptr = res?.cast().into();
+            self.ptr = ptr.cast().into();
             self.cap = new_cap;
 
             Ok(())
         }
     }
 
+    /// Like the above, but throws away capacity overflow errors
+    fn reserve_internal_2(
+        &mut self,
+        used_cap: usize,
+        needed_extra_cap: usize,
+        strategy: ReserveStrategy,
+    ) -> Result<(), A::Err> {
+        match self.reserve_internal(used_cap, needed_extra_cap, strategy) {
+            Err(CollectionAllocErr::CapacityOverflow) => capacity_overflow(),
+            Err(CollectionAllocErr::AllocErr(e)) => Err(e),
+            Ok(()) => Ok(()),
+        }
+    }
 }
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     /// Converts the entire buffer into `Box<[T], A>`.
     ///
     /// Note that this will correctly reconstitute any `cap` changes
@@ -704,7 +682,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     }
 }
 
-impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
+impl<T, A: Alloc> RawVec<T, A> {
     /// Frees the memory owned by the RawVec *without* trying to Drop its contents.
     pub unsafe fn dealloc_buffer(&mut self) {
         let elem_size = mem::size_of::<T>();
@@ -716,7 +694,7 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
     }
 }
 
-unsafe impl<#[may_dangle] T, A: Alloc<Err = AllocErr>> Drop for RawVec<T, A> {
+unsafe impl<#[may_dangle] T, A: Alloc> Drop for RawVec<T, A> {
     /// Frees the memory owned by the RawVec *without* trying to Drop its contents.
     fn drop(&mut self) {
         unsafe { self.dealloc_buffer(); }
@@ -735,11 +713,20 @@ unsafe impl<#[may_dangle] T, A: Alloc<Err = AllocErr>> Drop for RawVec<T, A> {
 // all 4GB in user-space. e.g., PAE or x32
 
 #[inline]
-fn alloc_guard(alloc_size: usize) -> Result<(), CollectionAllocErr> {
-    if mem::size_of::<usize>() < 8 && alloc_size > core::isize::MAX as usize {
+fn alloc_guard<E>(alloc_size: usize) -> Result<(), CollectionAllocErr<E>> {
+    if mem::size_of::<usize>() < 8 && alloc_size > ::core::isize::MAX as usize {
         Err(CollectionAllocErr::CapacityOverflow)
     } else {
         Ok(())
+    }
+}
+
+/// Reduce error to just allocation error
+#[inline]
+fn handle_overflow_error<E>(err: CollectionAllocErr<E>) -> E {
+    match err {
+        CollectionAllocErr::AllocErr(e) => e,
+        CollectionAllocErr::CapacityOverflow => capacity_overflow(),
     }
 }
 

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -682,8 +682,8 @@ impl<T, A: Alloc> RawVec<T, A> {
 
 }
 
-impl<T> RawVec<T, Global> {
-    /// Converts the entire buffer into `Box<[T]>`.
+impl<T, A: Alloc> RawVec<T, A> {
+    /// Converts the entire buffer into `Box<[T], A>`.
     ///
     /// Note that this will correctly reconstitute any `cap` changes
     /// that may have been performed. (see description of type for details)
@@ -693,10 +693,11 @@ impl<T> RawVec<T, Global> {
     /// All elements of `RawVec<T, Global>` must be initialized. Notice that
     /// the rules around uninitialized boxed values are not finalized yet,
     /// but until they are, it is advisable to avoid them.
-    pub unsafe fn into_box(self) -> Box<[T]> {
+    pub unsafe fn into_box(self) -> Box<[T], A> {
         // NOTE: not calling `cap()` here, actually using the real `cap` field!
         let slice = slice::from_raw_parts_mut(self.ptr(), self.cap);
-        let output: Box<[T]> = Box::from_raw(slice);
+        let a = ptr::read(&self.a);
+        let output: Box<[T], A> = Box::from_raw_in(slice, a);
         mem::forget(self);
         output
     }

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -422,7 +422,8 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
         -> Result<usize, CollectionAllocErr> {
 
         // Nothing we can really do about these checks :(
-        let required_cap = used_cap.checked_add(needed_extra_cap).ok_or(CollectionAllocErr::CapacityOverflow)?;
+        let required_cap = used_cap.checked_add(needed_extra_cap)
+            .ok_or(CollectionAllocErr::CapacityOverflow)?;
         // Cannot overflow, because `cap <= isize::MAX`, and type of `cap` is `usize`.
         let double_cap = self.cap * 2;
         // `double_cap` guarantees exponential growth.
@@ -651,10 +652,12 @@ impl<T, A: Alloc<Err = AllocErr>> RawVec<T, A> {
 
             // Nothing we can really do about these checks :(
             let new_cap = match strategy {
-                Exact => used_cap.checked_add(needed_extra_cap).ok_or(CollectionAllocErr::CapacityOverflow)?,
+                Exact => used_cap.checked_add(needed_extra_cap)
+                    .ok_or(CollectionAllocErr::CapacityOverflow)?,
                 Amortized => self.amortized_new_size(used_cap, needed_extra_cap)?,
             };
-            let new_layout = Layout::array::<T>(new_cap).map_err(|_| CollectionAllocErr::CapacityOverflow)?;
+            let new_layout = Layout::array::<T>(new_cap)
+                .map_err(|_| CollectionAllocErr::CapacityOverflow)?;
 
             alloc_guard(new_layout.size())?;
 

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -729,7 +729,7 @@ impl<T: ?Sized> Rc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free::<_, Global>(box_unique, Global);
 
             Rc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -35,6 +35,7 @@ use core::ptr;
 use core::iter::FusedIterator;
 use core::unicode::conversions;
 
+use crate::alloc::Alloc;
 use crate::borrow::ToOwned;
 use crate::boxed::Box;
 use crate::slice::{SliceConcatExt, SliceIndex};
@@ -585,6 +586,6 @@ impl str {
 /// ```
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked(v: Box<[u8]>) -> Box<str> {
-    Box::from_raw(Box::into_raw(v) as *mut str)
+pub unsafe fn from_boxed_utf8_unchecked<A: Alloc>(v: Box<[u8], A>) -> Box<str, A> {
+    Box::map_raw(v, |p| p as *mut str)
 }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -586,6 +586,6 @@ impl str {
 /// ```
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked<A: Alloc<Err=AllocErr>>(v: Box<[u8], A>) -> Box<str, A> {
+pub unsafe fn from_boxed_utf8_unchecked<A: Alloc>(v: Box<[u8], A>) -> Box<str, A> {
     Box::map_raw(v, |p| p as *mut str)
 }

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -35,7 +35,7 @@ use core::ptr;
 use core::iter::FusedIterator;
 use core::unicode::conversions;
 
-use crate::alloc::Alloc;
+use crate::alloc::{Alloc, AllocErr};
 use crate::borrow::ToOwned;
 use crate::boxed::Box;
 use crate::slice::{SliceConcatExt, SliceIndex};
@@ -586,6 +586,6 @@ impl str {
 /// ```
 #[stable(feature = "str_box_extras", since = "1.20.0")]
 #[inline]
-pub unsafe fn from_boxed_utf8_unchecked<A: Alloc>(v: Box<[u8], A>) -> Box<str, A> {
+pub unsafe fn from_boxed_utf8_unchecked<A: Alloc<Err=AllocErr>>(v: Box<[u8], A>) -> Box<str, A> {
     Box::map_raw(v, |p| p as *mut str)
 }

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -55,6 +55,7 @@ use core::ops::Bound::{Excluded, Included, Unbounded};
 use core::ptr;
 use core::str::{pattern::Pattern, lossy};
 
+use crate::alloc::AllocErr;
 use crate::borrow::{Cow, ToOwned};
 use crate::collections::CollectionAllocErr;
 use crate::boxed::Box;
@@ -953,7 +954,7 @@ impl String {
     /// # process_data("rust").expect("why is the test harness OOMing on 4 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>> {
         self.vec.try_reserve(additional)
     }
 
@@ -991,7 +992,9 @@ impl String {
     /// # process_data("rust").expect("why is the test harness OOMing on 4 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve_exact(&mut self, additional: usize)
+        -> Result<(), CollectionAllocErr<AllocErr>>
+    {
         self.vec.try_reserve_exact(additional)
     }
 

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -991,7 +991,7 @@ impl String {
     /// # process_data("rust").expect("why is the test harness OOMing on 4 bytes?");
     /// ```
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr>  {
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
         self.vec.try_reserve_exact(additional)
     }
 

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -615,7 +615,7 @@ impl<T: ?Sized> Arc<T> {
                 value_size);
 
             // Free the allocation without dropping its contents
-            box_free(box_unique);
+            box_free::<_, Global>(box_unique, Global);
 
             Arc { ptr: NonNull::new_unchecked(ptr), phantom: PhantomData }
         }

--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -1,4 +1,4 @@
-use std::alloc::{Global, Alloc, Layout, System};
+use std::alloc::{GlobalAlloc, Layout, System};
 
 /// Issue #45955.
 #[test]
@@ -6,21 +6,16 @@ fn alloc_system_overaligned_request() {
     check_overalign_requests(System)
 }
 
-#[test]
-fn std_heap_overaligned_request() {
-    check_overalign_requests(Global)
-}
-
-fn check_overalign_requests<T: Alloc>(mut allocator: T) {
+fn check_overalign_requests<T: GlobalAlloc>(allocator: T) {
     let size = 8;
     let align = 16; // greater than size
     let iterations = 100;
     unsafe {
         let pointers: Vec<_> = (0..iterations).map(|_| {
-            allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
+            allocator.alloc(Layout::from_size_align(size, align).unwrap())
         }).collect();
         for &ptr in &pointers {
-            assert_eq!((ptr.as_ptr() as usize) % align, 0,
+            assert_eq!((ptr as usize) % align, 0,
                        "Got a pointer less aligned than requested")
         }
 

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -579,6 +579,17 @@ pub unsafe trait GlobalAlloc {
     }
 }
 
+/// A hack so the default impl can condition on the associated type. This `Err`
+/// type ought to just live in the `Alloc` trait.
+#[unstable(feature = "allocator_api", issue = "32838")]
+pub trait AllocHelper {
+
+    /// The type of any errors thrown by the allocator, customarily
+    /// either `AllocErr`, for when error recovery is allowed, or `!`
+    /// to signify that all errors will result in .
+    type Err = AllocErr;
+}
+
 /// An implementation of `Alloc` can allocate, reallocate, and
 /// deallocate arbitrary blocks of data described via `Layout`.
 ///
@@ -659,7 +670,7 @@ pub unsafe trait GlobalAlloc {
 /// Note that this list may get tweaked over time as clarifications are made in
 /// the future.
 #[unstable(feature = "allocator_api", issue = "32838")]
-pub unsafe trait Alloc {
+pub unsafe trait Alloc: AllocHelper {
 
     // (Note: some existing allocators have unspecified but well-defined
     // behavior in response to a zero size allocation request ;
@@ -707,7 +718,7 @@ pub unsafe trait Alloc {
     /// rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr>;
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err>;
 
     /// Deallocate the memory referenced by `ptr`.
     ///
@@ -820,7 +831,7 @@ pub unsafe trait Alloc {
     unsafe fn realloc(&mut self,
                       ptr: NonNull<u8>,
                       layout: Layout,
-                      new_size: usize) -> Result<NonNull<u8>, AllocErr> {
+                      new_size: usize) -> Result<NonNull<u8>, Self::Err> {
         let old_size = layout.size();
 
         if new_size >= old_size {
@@ -863,7 +874,7 @@ pub unsafe trait Alloc {
     /// rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, Self::Err> {
         let size = layout.size();
         let p = self.alloc(layout);
         if let Ok(p) = p {
@@ -891,7 +902,7 @@ pub unsafe trait Alloc {
     /// rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, AllocErr> {
+    unsafe fn alloc_excess(&mut self, layout: Layout) -> Result<Excess, Self::Err> {
         let usable_size = self.usable_size(&layout);
         self.alloc(layout).map(|p| Excess(p, usable_size.1))
     }
@@ -918,7 +929,7 @@ pub unsafe trait Alloc {
     unsafe fn realloc_excess(&mut self,
                              ptr: NonNull<u8>,
                              layout: Layout,
-                             new_size: usize) -> Result<Excess, AllocErr> {
+                             new_size: usize) -> Result<Excess, Self::Err> {
         let new_layout = Layout::from_size_align_unchecked(new_size, layout.align());
         let usable_size = self.usable_size(&new_layout);
         self.realloc(ptr, layout, new_size)
@@ -1064,16 +1075,8 @@ pub unsafe trait Alloc {
     /// rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    fn alloc_one<T>(&mut self) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
-    {
-        let k = Layout::new::<T>();
-        if k.size() > 0 {
-            unsafe { self.alloc(k).map(|p| p.cast()) }
-        } else {
-            Err(AllocErr)
-        }
-    }
+    fn alloc_one<T>(&mut self) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized;
 
     /// Deallocates a block suitable for holding an instance of `T`.
     ///
@@ -1133,18 +1136,8 @@ pub unsafe trait Alloc {
     /// rather than directly invoking `panic!` or similar.
     ///
     /// [`handle_alloc_error`]: ../../alloc/alloc/fn.handle_alloc_error.html
-    fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
-    {
-        match Layout::array::<T>(n) {
-            Ok(ref layout) if layout.size() > 0 => {
-                unsafe {
-                    self.alloc(layout.clone()).map(|p| p.cast())
-                }
-            }
-            _ => Err(AllocErr),
-        }
-    }
+    fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized;
 
     /// Reallocates a block previously suitable for holding `n_old`
     /// instances of `T`, returning a block suitable for holding
@@ -1183,19 +1176,8 @@ pub unsafe trait Alloc {
     unsafe fn realloc_array<T>(&mut self,
                                ptr: NonNull<T>,
                                n_old: usize,
-                               n_new: usize) -> Result<NonNull<T>, AllocErr>
-        where Self: Sized
-    {
-        match (Layout::array::<T>(n_old), Layout::array::<T>(n_new)) {
-            (Ok(ref k_old), Ok(ref k_new)) if k_old.size() > 0 && k_new.size() > 0 => {
-                debug_assert!(k_old.align() == k_new.align());
-                self.realloc(ptr.cast(), k_old.clone(), k_new.size()).map(NonNull::cast)
-            }
-            _ => {
-                Err(AllocErr)
-            }
-        }
-    }
+                               n_new: usize) -> Result<NonNull<T>, Self::Err>
+        where Self: Sized;
 
     /// Deallocates a block suitable for holding `n` instances of `T`.
     ///
@@ -1217,12 +1199,59 @@ pub unsafe trait Alloc {
     /// constraints.
     ///
     /// Always returns `Err` on arithmetic overflow.
-    unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), AllocErr>
-        where Self: Sized
+    unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), Self::Err>
+        where Self: Sized;
+}
+
+#[unstable(feature = "allocator_api", issue = "32838")]
+default unsafe impl<A: AllocHelper<Err = AllocErr>> Alloc for A {
+    fn alloc_one<T>(&mut self) -> Result<NonNull<T>, Self::Err>
+    where Self: Sized
+    {
+        let k = Layout::new::<T>();
+        if k.size() > 0 {
+            unsafe { self.alloc(k).map(|p| p.cast()) }
+        } else {
+            Err(AllocErr)
+        }
+    }
+
+    fn alloc_array<T>(&mut self, n: usize) -> Result<NonNull<T>, Self::Err>
+    where Self: Sized
+    {
+        match Layout::array::<T>(n) {
+            Ok(ref layout) if layout.size() > 0 => {
+                unsafe {
+                    self.alloc(layout.clone()).map(|p| p.cast())
+                }
+            }
+            _ => Err(AllocErr),
+        }
+    }
+
+    unsafe fn dealloc_array<T>(&mut self, ptr: NonNull<T>, n: usize) -> Result<(), Self::Err>
+    where Self: Sized
     {
         match Layout::array::<T>(n) {
             Ok(ref k) if k.size() > 0 => {
                 Ok(self.dealloc(ptr.cast(), k.clone()))
+            }
+            _ => {
+                Err(AllocErr)
+            }
+        }
+    }
+
+    unsafe fn realloc_array<T>(&mut self,
+                               ptr: NonNull<T>,
+                               n_old: usize,
+                               n_new: usize) -> Result<NonNull<T>, Self::Err>
+    where Self: Sized
+    {
+        match (Layout::array::<T>(n_old), Layout::array::<T>(n_new)) {
+            (Ok(ref k_old), Ok(ref k_new)) if k_old.size() > 0 && k_new.size() > 0 => {
+                debug_assert!(k_old.align() == k_new.align());
+                self.realloc(ptr.cast(), k_old.clone(), k_new.size()).map(NonNull::cast)
             }
             _ => {
                 Err(AllocErr)

--- a/src/libstd/alloc.rs
+++ b/src/libstd/alloc.rs
@@ -63,7 +63,6 @@
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 use core::{mem, ptr};
-use core::ptr::NonNull;
 
 use crate::sys_common::util::dumb_print;
 
@@ -132,33 +131,6 @@ pub use alloc_crate::alloc::*;
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct System;
-
-// The Alloc impl just forwards to the GlobalAlloc impl, which is in `std::sys::*::alloc`.
-#[unstable(feature = "allocator_api", issue = "32838")]
-unsafe impl Alloc for System {
-    #[inline]
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc(self, layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn alloc_zeroed(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::alloc_zeroed(self, layout)).ok_or(AllocErr)
-    }
-
-    #[inline]
-    unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        GlobalAlloc::dealloc(self, ptr.as_ptr(), layout)
-    }
-
-    #[inline]
-    unsafe fn realloc(&mut self,
-                      ptr: NonNull<u8>,
-                      layout: Layout,
-                      new_size: usize) -> Result<NonNull<u8>, AllocErr> {
-        NonNull::new(GlobalAlloc::realloc(self, ptr.as_ptr(), layout, new_size)).ok_or(AllocErr)
-    }
-}
 
 static HOOK: AtomicPtr<()> = AtomicPtr::new(ptr::null_mut());
 

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -4,6 +4,8 @@ use self::Entry::*;
 
 use hashbrown::hash_map as base;
 
+use alloc::alloc::AllocErr;
+
 use crate::borrow::Borrow;
 use crate::cell::Cell;
 use crate::collections::CollectionAllocErr;
@@ -588,7 +590,7 @@ where
     /// ```
     #[inline]
     #[unstable(feature = "try_reserve", reason = "new API", issue = "48043")]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>> {
         self.base
             .try_reserve(additional)
             .map_err(map_collection_alloc_err)
@@ -2542,10 +2544,10 @@ fn map_entry<'a, K: 'a, V: 'a>(raw: base::RustcEntry<'a, K, V>) -> Entry<'a, K, 
 }
 
 #[inline]
-fn map_collection_alloc_err(err: hashbrown::CollectionAllocErr) -> CollectionAllocErr {
+fn map_collection_alloc_err(err: hashbrown::CollectionAllocErr) -> CollectionAllocErr<AllocErr> {
     match err {
         hashbrown::CollectionAllocErr::CapacityOverflow => CollectionAllocErr::CapacityOverflow,
-        hashbrown::CollectionAllocErr::AllocErr => CollectionAllocErr::AllocErr,
+        hashbrown::CollectionAllocErr::AllocErr => CollectionAllocErr::AllocErr(AllocErr),
     }
 }
 

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1,3 +1,5 @@
+use alloc::alloc::AllocErr;
+
 use crate::borrow::Borrow;
 use crate::collections::CollectionAllocErr;
 use crate::fmt;
@@ -383,7 +385,7 @@ impl<T, S> HashSet<T, S>
     /// ```
     #[inline]
     #[unstable(feature = "try_reserve", reason = "new API", issue="48043")]
-    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr> {
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), CollectionAllocErr<AllocErr>> {
         self.map.try_reserve(additional)
     }
 

--- a/src/test/run-pass/allocator/custom.rs
+++ b/src/test/run-pass/allocator/custom.rs
@@ -7,14 +7,14 @@
 
 extern crate helper;
 
-use std::alloc::{self, Global, Alloc, System, Layout};
+use std::alloc::{Global, Alloc, GlobalAlloc, System, Layout};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static HITS: AtomicUsize = AtomicUsize::new(0);
 
 struct A;
 
-unsafe impl alloc::GlobalAlloc for A {
+unsafe impl GlobalAlloc for A {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         HITS.fetch_add(1, Ordering::SeqCst);
         System.alloc(layout)
@@ -49,7 +49,7 @@ fn main() {
         drop(s);
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
 
-        let ptr = System.alloc(layout.clone()).unwrap();
+        let ptr = System.alloc(layout.clone());
         assert_eq!(HITS.load(Ordering::SeqCst), n + 4);
         helper::work_with(&ptr);
         System.dealloc(ptr, layout);

--- a/src/test/run-pass/allocator/xcrate-use.rs
+++ b/src/test/run-pass/allocator/xcrate-use.rs
@@ -9,7 +9,7 @@
 extern crate custom;
 extern crate helper;
 
-use std::alloc::{Global, Alloc, System, Layout};
+use std::alloc::{Global, Alloc, GlobalAlloc, System, Layout};
 use std::sync::atomic::{Ordering, AtomicUsize};
 
 #[global_allocator]
@@ -26,7 +26,7 @@ fn main() {
         Global.dealloc(ptr, layout.clone());
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
 
-        let ptr = System.alloc(layout.clone()).unwrap();
+        let ptr = System.alloc(layout.clone());
         assert_eq!(GLOBAL.0.load(Ordering::SeqCst), n + 2);
         helper::work_with(&ptr);
         System.dealloc(ptr, layout);

--- a/src/test/ui/error-codes/e0119/conflict-with-std.stderr
+++ b/src/test/ui/error-codes/e0119/conflict-with-std.stderr
@@ -5,7 +5,7 @@ LL | impl AsRef<Q> for Box<Q> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::convert::AsRef<T> for std::boxed::Box<T>
+           - impl<T, A> std::convert::AsRef<T> for std::boxed::Box<T, A>
              where T: ?Sized;
 
 error[E0119]: conflicting implementations of trait `std::convert::From<S>` for type `S`:

--- a/src/test/ui/issues/issue-14092.rs
+++ b/src/test/ui/issues/issue-14092.rs
@@ -1,4 +1,4 @@
 fn fn1(0: Box) {}
-        //~^ ERROR wrong number of type arguments: expected 1, found 0 [E0107]
+        //~^ ERROR wrong number of type arguments: expected at least 1, found 0 [E0107]
 
 fn main() {}

--- a/src/test/ui/issues/issue-14092.stderr
+++ b/src/test/ui/issues/issue-14092.stderr
@@ -1,8 +1,8 @@
-error[E0107]: wrong number of type arguments: expected 1, found 0
+error[E0107]: wrong number of type arguments: expected at least 1, found 0
   --> $DIR/issue-14092.rs:1:11
    |
 LL | fn fn1(0: Box) {}
-   |           ^^^ expected 1 type argument
+   |           ^^^ expected at least 1 type argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -1,13 +1,13 @@
-error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_>`:
+error[E0119]: conflicting implementations of trait `std::ops::Drop` for type `std::boxed::Box<_, _>`:
   --> $DIR/issue-41974.rs:7:1
    |
 LL | impl<T> Drop for T where T: A {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: conflicting implementation in crate `alloc`:
-           - impl<T> std::ops::Drop for std::boxed::Box<T>
+           - impl<T, A> std::ops::Drop for std::boxed::Box<T, A>
              where T: ?Sized;
-   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_>`
+   = note: downstream crates may implement trait `A` for type `std::boxed::Box<_, _>`
 
 error[E0120]: the Drop trait may only be implemented on structures
   --> $DIR/issue-41974.rs:7:18


### PR DESCRIPTION
Reopened https://github.com/rust-lang/rust/pull/52420. Cannot be merged until WG approves design, but good to keep open so still have CI.

This picks up where #58457 will leave off, adding allocator parameters to the other collections. It also adds and associated error type for allocation, so as to enable fallibility-polymorphic code and support the few impls and other functions which require "infallible" allocation.

When done, should convert all the collections for #42774

Unfortunately, as documented in #52396, I had to make an AllocHelper trait in order to get my default impl to work.

Like #58457 which this continues, this blocked on some decision about stability and the new type parameters. See https://github.com/rust-lang/rust/pull/60703#issuecomment-491806115 for details.