### PR TITLE
Fix a bug preventing const parameters from being used in const generic impls

### DIFF
--- a/src/test/ui/const-generics/impl-const-generic-struct.rs
+++ b/src/test/ui/const-generics/impl-const-generic-struct.rs
@@ -1,0 +1,16 @@
+// run-pass
+
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct S<const X: u32>;
+
+impl<const X: u32> S<{X}> {
+    fn x() -> u32 {
+        X
+    }
+}
+
+fn main() {
+    assert_eq!(S::<19>::x(), 19);
+}

--- a/src/test/ui/const-generics/impl-const-generic-struct.stderr
+++ b/src/test/ui/const-generics/impl-const-generic-struct.stderr
@@ -1,0 +1,6 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/impl-const-generic-struct.rs:3:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/60712.