### PR TITLE
Allow subdirectories to be tested by x.py test

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1186,6 +1186,12 @@ impl Step for Compiletest {
             })
             .filter(|p| p.starts_with(suite_path) && (p.is_dir() || p.is_file()))
             .filter_map(|p| {
+                // Since test suite paths are themselves directories, if we don't
+                // specify a directory or file, we'll get an empty string here
+                // (the result of the test suite directory without its suite prefix).
+                // Therefore, we need to filter these out, as only the first --test-args
+                // flag is respected, so providing an empty --test-args conflicts with
+                // any following it.
                 match p.strip_prefix(suite_path).ok().and_then(|p| p.to_str()) {
                     Some(s) if s != "" => Some(s),
                     _ => None,

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1184,8 +1184,13 @@ impl Step for Compiletest {
                     Err(_) => p,
                 }
             })
-            .filter(|p| p.starts_with(suite_path) && p.is_file())
-            .map(|p| p.strip_prefix(suite_path).unwrap().to_str().unwrap())
+            .filter(|p| p.starts_with(suite_path) && (p.is_dir() || p.is_file()))
+            .filter_map(|p| {
+                match p.strip_prefix(suite_path).ok().and_then(|p| p.to_str()) {
+                    Some(s) if s != "" => Some(s),
+                    _ => None,
+                }
+            })
             .collect();
 
         test_args.append(&mut builder.config.cmd.test_args());


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/60718.

As far as I can tell, multiple `--test-args` flags are ignored (only the first is respected), so if you specify a subdirectory, you won't also be able to filter using `--test-args`. If you don't specify a subdirectory, `--test-args` will continue working as usual, so this is strictly an improvement on the current state of affairs.