### PR TITLE
Fix display of const generics in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3149,7 +3149,10 @@ impl<'tcx> Clean<Constant> for ty::Const<'tcx> {
     fn clean(&self, cx: &DocContext<'_>) -> Constant {
         Constant {
             type_: self.ty.clean(cx),
-            expr: format!("{:?}", self.val), // FIXME(const_generics)
+            expr: match self.val {
+                ConstValue::Param(ty::ParamConst { name, .. }) => format!("{}", name),
+                e => format!("{:?}", e), // FIXME generic consts with expressions
+            },
         }
     }
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -262,9 +262,7 @@ impl fmt::Display for clean::Lifetime {
 
 impl fmt::Display for clean::Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.expr, f)?;
-        f.write_str(": ")?;
-        fmt::Display::fmt(&self.type_, f)
+        fmt::Display::fmt(&self.expr, f)
     }
 }
 

--- a/src/test/rustdoc/generic-const.rs
+++ b/src/test/rustdoc/generic-const.rs
@@ -1,0 +1,30 @@
+#![feature(const_generics)]
+#![crate_name = "foo"]
+
+// ignore-tidy-linelength
+
+pub enum Order {
+    Sorted,
+    Unsorted,
+}
+
+// @has foo/struct.VSet.html '//pre[@class="rust struct"]' 'pub struct VSet<T, const ORDER: Order>'
+// @has foo/struct.VSet.html '//h3[@id="impl-Send"]/code' 'impl<const ORDER: Order, T> Send for VSet<T, ORDER>'
+// @has foo/struct.VSet.html '//h3[@id="impl-Sync"]/code' 'impl<const ORDER: Order, T> Sync for VSet<T, ORDER>'
+pub struct VSet<T, const ORDER: Order> {
+    inner: Vec<T>,
+}
+
+// @has foo/struct.VSet.html '//h3[@id="impl"]/code' 'impl<T> VSet<T, { Order::Sorted }>'
+impl <T> VSet<T, {Order::Sorted}> {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+}
+
+// @has foo/struct.VSet.html '//h3[@id="impl-1"]/code' 'impl<T> VSet<T, { Order::Unsorted }>'
+impl <T> VSet<T, {Order::Unsorted}> {
+    pub fn new() -> Self {
+        Self { inner: Vec::new() }
+    }
+}


### PR DESCRIPTION
<img width="745" alt="Screenshot 2019-05-18 at 15 45 22" src="https://user-images.githubusercontent.com/3050060/57970638-04854e80-7984-11e9-9f04-da6b51ec8bc7.png">

Part of #60737.

cc @varkor 

r? @badboy 