### PR TITLE
add impl_trait_in_bindings to INCOMPLETE_FEATURES

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -563,6 +563,7 @@ declare_features! (
 // unanticipated results, such as compiler crashes. We warn the user about these
 // to alert them.
 const INCOMPLETE_FEATURES: &[Symbol] = &[
+    sym::impl_trait_in_bindings,
     sym::generic_associated_types,
     sym::const_generics
 ];

--- a/src/test/run-pass/impl-trait-in-bindings.rs
+++ b/src/test/run-pass/impl-trait-in-bindings.rs
@@ -1,4 +1,5 @@
 #![feature(impl_trait_in_bindings)]
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
 
 use std::fmt::Debug;
 

--- a/src/test/run-pass/impl-trait-in-bindings.stderr
+++ b/src/test/run-pass/impl-trait-in-bindings.stderr
@@ -1,0 +1,6 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/impl-trait-in-bindings.rs:1:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/impl-trait/bindings-opaque.rs
+++ b/src/test/ui/impl-trait/bindings-opaque.rs
@@ -1,4 +1,5 @@
 #![feature(impl_trait_in_bindings)]
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
 
 const FOO: impl Copy = 42;
 

--- a/src/test/ui/impl-trait/bindings-opaque.stderr
+++ b/src/test/ui/impl-trait/bindings-opaque.stderr
@@ -1,17 +1,23 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/bindings-opaque.rs:1:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0599]: no method named `count_ones` found for type `impl std::marker::Copy` in the current scope
-  --> $DIR/bindings-opaque.rs:10:17
+  --> $DIR/bindings-opaque.rs:11:17
    |
 LL |     let _ = FOO.count_ones();
    |                 ^^^^^^^^^^
 
 error[E0599]: no method named `count_ones` found for type `impl std::marker::Copy` in the current scope
-  --> $DIR/bindings-opaque.rs:12:17
+  --> $DIR/bindings-opaque.rs:13:17
    |
 LL |     let _ = BAR.count_ones();
    |                 ^^^^^^^^^^
 
 error[E0599]: no method named `count_ones` found for type `impl std::marker::Copy` in the current scope
-  --> $DIR/bindings-opaque.rs:14:17
+  --> $DIR/bindings-opaque.rs:15:17
    |
 LL |     let _ = foo.count_ones();
    |                 ^^^^^^^^^^

--- a/src/test/ui/impl-trait/bindings.rs
+++ b/src/test/ui/impl-trait/bindings.rs
@@ -1,4 +1,5 @@
 #![feature(impl_trait_in_bindings)]
+//~^ WARN the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
 
 fn a<T: Clone>(x: T) {
     const foo: impl Clone = x;

--- a/src/test/ui/impl-trait/bindings.stderr
+++ b/src/test/ui/impl-trait/bindings.stderr
@@ -1,23 +1,29 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/bindings.rs:1:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/bindings.rs:4:29
+  --> $DIR/bindings.rs:5:29
    |
 LL |     const foo: impl Clone = x;
    |                             ^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/bindings.rs:10:33
+  --> $DIR/bindings.rs:11:33
    |
 LL |         const foo: impl Clone = x;
    |                                 ^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/bindings.rs:17:33
+  --> $DIR/bindings.rs:18:33
    |
 LL |         const foo: impl Clone = x;
    |                                 ^ non-constant value
 
 error[E0435]: attempt to use a non-constant value in a constant
-  --> $DIR/bindings.rs:24:33
+  --> $DIR/bindings.rs:25:33
    |
 LL |         const foo: impl Clone = x;
    |                                 ^ non-constant value


### PR DESCRIPTION
impl_trait_in_bindings is not yet complete and can lead to compiler crashes.

Fixes #60764.