### PR TITLE
[rustdoc] Add sub settings

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2067,7 +2067,7 @@ if (!DOMTokenList.prototype.remove) {
     function autoCollapse(pageId, collapse) {
         if (collapse) {
             toggleAllDocs(pageId, true);
-        } else if (getCurrentValue("rustdoc-trait-implementations") !== "false") {
+        } else if (getCurrentValue("rustdoc-auto-hide-trait-implementations") !== "false") {
             var impl_list = document.getElementById("implementations-list");
 
             if (impl_list !== null) {
@@ -2105,7 +2105,7 @@ if (!DOMTokenList.prototype.remove) {
     }
 
     var toggle = createSimpleToggle(false);
-    var hideMethodDocs = getCurrentValue("rustdoc-method-docs") === "true";
+    var hideMethodDocs = getCurrentValue("rustdoc-auto-hide-method-docs") === "true";
     var pageId = getPageId();
 
     var func = function(e) {
@@ -2235,7 +2235,25 @@ if (!DOMTokenList.prototype.remove) {
         return wrapper;
     }
 
-    var showItemDeclarations = getCurrentValue("rustdoc-item-declarations") === "false";
+    var currentType = document.getElementsByClassName("type-decl")[0];
+    var className = null;
+    if (currentType) {
+        currentType = currentType.getElementsByClassName("rust")[0];
+        if (currentType) {
+            currentType.classList.forEach(function(item) {
+                if (item !== "main") {
+                    className = item;
+                    return true;
+                }
+            });
+        }
+    }
+    var showItemDeclarations = getCurrentValue("rustdoc-auto-hide-" + className);
+    var globalItemDeclarations = getCurrentValue("rustdoc-auto-hide-declarations");
+    if (showItemDeclarations === null && globalItemDeclarations !== null) {
+        showItemDeclarations = globalItemDeclarations;
+    }
+    showItemDeclarations = showItemDeclarations === "false";
     function buildToggleWrapper(e) {
         if (hasClass(e, "autohide")) {
             var wrap = e.previousElementSibling;
@@ -2318,7 +2336,7 @@ if (!DOMTokenList.prototype.remove) {
 
     // To avoid checking on "rustdoc-item-attributes" value on every loop...
     var itemAttributesFunc = function() {};
-    if (getCurrentValue("rustdoc-item-attributes") !== "false") {
+    if (getCurrentValue("rustdoc-auto-hide-attributes") !== "false") {
         itemAttributesFunc = function(x) {
             collapseDocs(x.previousSibling.childNodes[0], "toggle");
         };

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2249,9 +2249,15 @@ if (!DOMTokenList.prototype.remove) {
         }
     }
     var showItemDeclarations = getCurrentValue("rustdoc-auto-hide-" + className);
-    var globalItemDeclarations = getCurrentValue("rustdoc-auto-hide-declarations");
-    if (showItemDeclarations === null && globalItemDeclarations !== null) {
-        showItemDeclarations = globalItemDeclarations;
+    if (showItemDeclarations === null) {
+        if (className === "enum" || className === "macro") {
+            showItemDeclarations = "false";
+        } else if (className === "struct" || className === "union" || className === "trait") {
+            showItemDeclarations = "true";
+        } else {
+            // In case we found an unknown type, we just use the "parent" value.
+            showItemDeclarations = getCurrentValue("rustdoc-auto-hide-declarations");
+        }
     }
     showItemDeclarations = showItemDeclarations === "false";
     function buildToggleWrapper(e) {

--- a/src/librustdoc/html/static/settings.css
+++ b/src/librustdoc/html/static/settings.css
@@ -59,3 +59,9 @@ input:checked + .slider:before {
 	-ms-transform: translateX(19px);
 	transform: translateX(19px);
 }
+
+.setting-line > .sub-setting {
+	padding-left: 42px;
+	width: 100%;
+	display: block;
+}

--- a/src/librustdoc/html/static/settings.js
+++ b/src/librustdoc/html/static/settings.js
@@ -3,6 +3,35 @@
         updateLocalStorage('rustdoc-' + settingName, isEnabled);
     }
 
+    function updateChildren(elem) {
+        var state = elem.checked;
+
+        var parentLabel = elem.parentElement;
+        if (!parentLabel) {
+            return;
+        }
+        var parentSettingLine = parentLabel.parentElement;
+        if (!parentSettingLine) {
+            return;
+        }
+        var elems = parentSettingLine.getElementsByClassName("sub-setting")[0];
+        if (!elems) {
+            return;
+        }
+
+        var toggles = elems.getElementsByTagName("input");
+        if (!toggles || toggles.length < 1) {
+            return;
+        }
+        var ev = new Event("change");
+        for (var x = 0; x < toggles.length; ++x) {
+            if (toggles[x].checked !== state) {
+                toggles[x].checked = state;
+                toggles[x].dispatchEvent(ev);
+            }
+        }
+    }
+
     function getSettingValue(settingName) {
         return getCurrentValue('rustdoc-' + settingName);
     }
@@ -21,6 +50,7 @@
             }
             toggle.onchange = function() {
                 changeSetting(this.id, this.checked);
+                updateChildren(this);
             };
         }
     }

--- a/src/librustdoc/html/static/settings.js
+++ b/src/librustdoc/html/static/settings.js
@@ -41,13 +41,16 @@
         if (!elems || elems.length === 0) {
             return;
         }
-        for (var i = 0; i < elems.length; ++i) {
+        var i;
+        for (i = 0; i < elems.length; ++i) {
             var toggle = elems[i].previousElementSibling;
             var settingId = toggle.id;
             var settingValue = getSettingValue(settingId);
             if (settingValue !== null) {
                 toggle.checked = settingValue === "true";
             }
+        }
+        for (i = 0; i < elems.length; ++i) {
             toggle.onchange = function() {
                 changeSetting(this.id, this.checked);
                 updateChildren(this);


### PR DESCRIPTION
I added a mechanism to have the possibility to add sub-settings (when clicking on the master, all the children take the same value) and I added it for types to get a more fine-tuned handling on which types you want to see their declaration or not by default.

A little screenshot of the setting page with the sub-settings:

<img width="734" alt="Screenshot 2019-05-13 at 09 07 54" src="https://user-images.githubusercontent.com/3050060/57606270-d7dacc80-7568-11e9-96e9-d5ad000da2ed.png">

r? @Manishearth 