### PR TITLE
[stable] Destabilize the `Error::type_id` function

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,11 @@
+Version 1.34.2 (2019-05-14)
+===========================
+
+* [Destabilize the `Error::type_id` function due to a security
+   vulnerability][60785]
+
+[60785]: https://github.com/rust-lang/rust/pull/60785
+
 Version 1.34.1 (2019-04-25)
 ===========================
 

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -14,7 +14,7 @@ use crate::Build;
 use crate::config::Config;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.34.1";
+pub const CFG_RELEASE_NUM: &str = "1.34.2";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -196,7 +196,10 @@ pub trait Error: Debug + Display {
     fn source(&self) -> Option<&(dyn Error + 'static)> { None }
 
     /// Gets the `TypeId` of `self`
-    #[stable(feature = "error_type_id", since = "1.34.0")]
+    #[doc(hidden)]
+    #[unstable(feature = "error_type_id",
+               reason = "this is memory unsafe to override in user code",
+               issue = "60784")]
     fn type_id(&self) -> TypeId where Self: 'static {
         TypeId::of::<Self>()
     }


### PR DESCRIPTION
This commit destabilizes the `Error::type_id` function in the standard library.
This does so by effectively reverting #58048, restoring the `#[unstable]`
attribute. The security mailing list has recently been notified of a
vulnerability relating to the stabilization of this function. First stabilized
in Rust 1.34.0, a stable function here allows users to implement a custom
return value for this function:

    struct MyType;

    impl Error for MyType {
	fn type_id(&self) -> TypeId {
	    // Enable safe casting to `String` by accident.
	    TypeId::of::<String>()
	}
    }

This, when combined with the `Error::downcast` family of functions, allows
safely casting a type to any other type, clearly a memory safety issue! A
formal announcement has been made to the [security mailing list](https://groups.google.com/forum/#!topic/rustlang-security-announcements/aZabeCMUv70) as well as [the blog](https://blog.rust-lang.org/2019/05/13/Security-advisory.html)

This commit simply destabilizes the `Error::type_id` which, although breaking
for users since Rust 1.34.0, is hoped to have little impact and has been deemed
sufficient to mitigate this issue for the stable channel. The long-term fate of
the `Error::type_id` API will be discussed at #60784.