### PR TITLE
default to $ARCH-apple-macosx10.7.0 LLVM triple for darwin targets

### DIFF
--- a/src/librustc_target/spec/apple_base.rs
+++ b/src/librustc_target/spec/apple_base.rs
@@ -14,7 +14,7 @@ pub fn opts() -> TargetOptions {
     //
     // Here we detect what version is being requested, defaulting to 10.7. ELF
     // TLS is flagged as enabled if it looks to be supported.
-    let version = macos_deployment_target().unwrap_or((10, 7));
+    let version = macos_deployment_target();
 
     TargetOptions {
         // macOS has -dead_strip, which doesn't rely on function_sections
@@ -35,7 +35,7 @@ pub fn opts() -> TargetOptions {
     }
 }
 
-fn macos_deployment_target() -> Option<(u32, u32)> {
+fn macos_deployment_target() -> (u32, u32) {
     let deployment_target = env::var("MACOSX_DEPLOYMENT_TARGET").ok();
     let version = deployment_target.as_ref().and_then(|s| {
         let mut i = s.splitn(2, '.');
@@ -44,17 +44,10 @@ fn macos_deployment_target() -> Option<(u32, u32)> {
         a.parse::<u32>().and_then(|a| b.parse::<u32>().map(|b| (a, b))).ok()
     });
 
-    version
+    version.unwrap_or((10, 7))
 }
 
 pub fn macos_llvm_target(arch: &str) -> String {
-    let version = macos_deployment_target();
-    let llvm_target = match version {
-        Some((major, minor)) => {
-            format!("{}-apple-macosx{}.{}.0", arch, major, minor)
-        },
-        None => format!("{}-apple-darwin", arch)
-    };
-
-    llvm_target
+    let (major, minor) = macos_deployment_target();
+    format!("{}-apple-macosx{}.{}.0", arch, major, minor)
 }

--- a/src/test/codegen/i686-no-macosx-deployment-target.rs
+++ b/src/test/codegen/i686-no-macosx-deployment-target.rs
@@ -19,7 +19,7 @@ pub struct Bool {
     b: bool,
 }
 
-// CHECK: target triple = "i686-apple-darwin"
+// CHECK: target triple = "i686-apple-macosx10.7.0"
 #[no_mangle]
 pub extern "C" fn structbool() -> Bool {
     Bool { b: true }

--- a/src/test/codegen/x86_64-no-macosx-deployment-target.rs
+++ b/src/test/codegen/x86_64-no-macosx-deployment-target.rs
@@ -19,7 +19,7 @@ pub struct Bool {
     b: bool,
 }
 
-// CHECK: target triple = "x86_64-apple-darwin"
+// CHECK: target triple = "x86_64-apple-macosx10.7.0"
 #[no_mangle]
 pub extern "C" fn structbool() -> Bool {
     Bool { b: true }


### PR DESCRIPTION
Over in #60378, we made `rustc` switch LLVM target triples dynamically
based on the `MACOSX_DEPLOYMENT_TARGET` environment variable.  This
change was made to align with `clang`'s behavior, and therefore make
cross-language LTO feasible on OS X.  Otherwise, `rustc` would produce
LLVM bitcode files with a target triple of `x86_64-apple-darwin`,
`clang` would produce LLVM bitcode files with a target triple of
`x86_64-apple-macosx$VERSION`, and the linker would complain.

This change worked fine, except for one corner case: if you didn't have
`MACOSX_DEPLOYMENT_TARGET` set, and you wanted to do LTO on just Rust
code, you'd get warning messages similar to:

```
warning: Linking two modules of different target triples: ' is 'x86_64-apple-macosx10.7.0' whereas 'main.7rcbfp3g-cgu.4' is 'x86_64-apple-darwin'
```

This message occurs because libstd is compiled with
`MACOSX_DEPLOYMENT_TARGET` set to 10.7.  The LLVM bitcode distributed in
libstd's rlibs, then, is tagged with the target triple of
`x86_64-apple-macosx10.7.0`, while the bitcode `rustc` produces for
"user" code is tagged with the target triple of `x86_64-apple-darwin`.

It's not good to have LTO on just Rust code (probably much more common
than cross-language LTO) warn by default.  These warnings also break
Cargo's testsuite.

This change defaults to acting as though `MACOSX_DEPLOYMENT_TARGET` was
set to 10.7.  "user" code will then be given a target triple that is
equivalent to the target triple libstd bitcode is already using.  The
above warning will therefore go away.

`rustc` already assumes that compiling without
`MACOSX_DEPLOYMENT_TARGET` means that we're compiling for a target
compatible with OS X 10.7 (e.g. that things like TLS work properly).  So
this change is really just making things conform more closely to the
status quo.

(It's also worth noting that before and after this patch, compiling with
`MACOSX_DEPLOYMENT_TARGET` set to, say, 10.9, works just fine: target
triples with an "apple" version ignore OS versions when checking
compatibility, so bitcode with a `x86_64-apple-macosx10.7.0` triple works just
fine with bitcode with a `x86_64-apple-macosx10.9.0` triple.)