### PR TITLE
lexer: Disallow bare CR in raw byte strings

### DIFF
--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1346,7 +1346,7 @@ impl<'a> StringReader<'a> {
 
     fn validate_raw_str_escape(&self, content_start: BytePos, content_end: BytePos) {
         self.with_str_from_to(content_start, content_end, |lit: &str| {
-            unescape::unescape_raw_str(lit, &mut |range, c| {
+            unescape::unescape_raw_str(lit, unescape::Mode::Str, &mut |range, c| {
                 if let Err(err) = c {
                     emit_unescape_error(
                         &self.sess.span_diagnostic,
@@ -1363,7 +1363,7 @@ impl<'a> StringReader<'a> {
 
     fn validate_raw_byte_str_escape(&self, content_start: BytePos, content_end: BytePos) {
         self.with_str_from_to(content_start, content_end, |lit: &str| {
-            unescape::unescape_raw_byte_str(lit, &mut |range, c| {
+            unescape::unescape_raw_str(lit, unescape::Mode::ByteStr, &mut |range, c| {
                 if let Err(err) = c {
                     emit_unescape_error(
                         &self.sess.span_diagnostic,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1348,7 +1348,7 @@ impl<'a> StringReader<'a> {
 
     fn validate_raw_str_escape(&self, content_start: BytePos, content_end: BytePos) {
         self.with_str_from_to(content_start, content_end, |lit: &str| {
-            unescape::unescape_raw_str(lit, unescape::Mode::Str, &mut |range, c| {
+            unescape::unescape_raw_str(lit, &mut |range, c| {
                 if let Err(err) = c {
                     emit_unescape_error(
                         &self.sess.span_diagnostic,
@@ -1365,7 +1365,7 @@ impl<'a> StringReader<'a> {
 
     fn validate_raw_byte_str_escape(&self, content_start: BytePos, content_end: BytePos) {
         self.with_str_from_to(content_start, content_end, |lit: &str| {
-            unescape::unescape_raw_str(lit, unescape::Mode::ByteStr, &mut |range, c| {
+            unescape::unescape_raw_byte_str(lit, &mut |range, c| {
                 if let Err(err) = c {
                     emit_unescape_error(
                         &self.sess.span_diagnostic,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1242,6 +1242,8 @@ impl<'a> StringReader<'a> {
         id
     }
 
+    /// Scans a raw (byte) string, returning byte position range for `"<literal>"`
+    /// (including quotes) along with `#` character count in `(b)r##..."<literal>"##...`;
     fn scan_raw_string(&mut self) -> (BytePos, BytePos, u16) {
         let start_bpos = self.pos;
         self.bump();

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -130,7 +130,7 @@ impl<'a> StringReader<'a> {
         self.ch.is_none()
     }
 
-    fn fail_unterminated_raw_string(&self, pos: BytePos, hash_count: u16) {
+    fn fail_unterminated_raw_string(&self, pos: BytePos, hash_count: u16) -> ! {
         let mut err = self.struct_span_fatal(pos, pos, "unterminated raw string");
         err.span_label(self.mk_sp(pos, pos), "unterminated raw string");
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1275,12 +1275,6 @@ impl<'a> StringReader<'a> {
         let mut content_end_bpos;
         let mut valid = true;
         'outer: loop {
-            // if self.ch_is('"') {
-            // content_end_bpos = self.pos;
-            // for _ in 0..hash_count {
-            // self.bump();
-            // if !self.ch_is('#') {
-            // continue 'outer;
             match self.ch {
                 None => {
                     self.fail_unterminated_raw_string(start_bpos, hash_count);

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -4,7 +4,7 @@ use crate::ast::{self, Lit, LitKind};
 use crate::parse::parser::Parser;
 use crate::parse::PResult;
 use crate::parse::token::{self, Token, TokenKind};
-use crate::parse::unescape::{unescape_str, unescape_byte_str, unescape_raw_str};
+use crate::parse::unescape::{self, unescape_str, unescape_byte_str, unescape_raw_str};
 use crate::parse::unescape::{unescape_char, unescape_byte};
 use crate::print::pprust;
 use crate::symbol::{kw, sym, Symbol};
@@ -144,7 +144,7 @@ impl LitKind {
                 let symbol = if s.contains('\r') {
                     let mut buf = String::with_capacity(s.len());
                     let mut error = Ok(());
-                    unescape_raw_str(&s, &mut |_, unescaped_char| {
+                    unescape_raw_str(&s, unescape::Mode::Str, &mut |_, unescaped_char| {
                         match unescaped_char {
                             Ok(c) => buf.push(c),
                             Err(_) => error = Err(LitError::LexerError),

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -4,7 +4,8 @@ use crate::ast::{self, Lit, LitKind};
 use crate::parse::parser::Parser;
 use crate::parse::PResult;
 use crate::parse::token::{self, Token, TokenKind};
-use crate::parse::unescape::{unescape_str, unescape_char, unescape_byte_str, unescape_byte};
+use crate::parse::unescape::{unescape_str, unescape_byte_str, unescape_raw_str};
+use crate::parse::unescape::{unescape_char, unescape_byte};
 use crate::print::pprust;
 use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{TokenStream, TokenTree};
@@ -141,7 +142,17 @@ impl LitKind {
                 // Ditto.
                 let s = symbol.as_str();
                 let symbol = if s.contains('\r') {
-                    Symbol::intern(&raw_str_lit(&s))
+                    let mut buf = String::with_capacity(s.len());
+                    let mut error = Ok(());
+                    unescape_raw_str(&s, &mut |_, unescaped_char| {
+                        match unescaped_char {
+                            Ok(c) => buf.push(c),
+                            Err(_) => error = Err(LitError::LexerError),
+                        }
+                    });
+                    error?;
+                    buf.shrink_to_fit();
+                    Symbol::intern(&buf)
                 } else {
                     symbol
                 };
@@ -348,29 +359,6 @@ crate fn expect_no_suffix(diag: &Handler, sp: Span, kind: &str, suffix: Option<S
         err.span_label(sp, format!("invalid suffix `{}`", suf));
         err.emit();
     }
-}
-
-/// Parses a string representing a raw string literal into its final form. The
-/// only operation this does is convert embedded CRLF into a single LF.
-fn raw_str_lit(lit: &str) -> String {
-    debug!("raw_str_lit: {:?}", lit);
-    let mut res = String::with_capacity(lit.len());
-
-    let mut chars = lit.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\r' {
-            if *chars.peek().unwrap() != '\n' {
-                panic!("lexer accepted bare CR");
-            }
-            chars.next();
-            res.push('\n');
-        } else {
-            res.push(c);
-        }
-    }
-
-    res.shrink_to_fit();
-    res
 }
 
 // Checks if `s` looks like i32 or u1234 etc.

--- a/src/libsyntax/parse/unescape.rs
+++ b/src/libsyntax/parse/unescape.rs
@@ -71,7 +71,7 @@ where
 /// sequence of characters or errors.
 /// NOTE: Raw strings do not perform any explicit character escaping, here we
 /// only translate CRLF to LF and produce errors on bare CR.
-pub(crate) fn unescape_raw_str<F>(literal_text: &str, callback: &mut F)
+pub(crate) fn unescape_raw_str<F>(literal_text: &str, mode: Mode, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<char, EscapeError>),
 {
@@ -79,36 +79,20 @@ where
 
     let mut chars = literal_text.chars().peekable();
     while let Some(curr) = chars.next() {
-        let result = match (curr, chars.peek()) {
-            ('\r', Some('\n')) => Ok(curr),
-            ('\r', _) => Err(EscapeError::BareCarriageReturn),
-            _ => Ok(curr),
+        let (result, scanned) = match (curr, chars.peek()) {
+            ('\r', Some('\n')) => {
+                chars.next();
+                (Ok('\n'), [Some('\r'), Some('\n')])
+            },
+            ('\r', _) =>
+                (Err(EscapeError::BareCarriageReturn), [Some('\r'), None]),
+            (c, _) if mode.is_bytes() && c > '\x7F' =>
+                (Err(EscapeError::NonAsciiCharInByteString), [Some(c), None]),
+            (c, _) => (Ok(c), [Some(c), None]),
         };
-        callback(byte_offset..(byte_offset + curr.len_utf8()), result);
-        byte_offset += curr.len_utf8();
-    }
-}
-
-/// Takes a contents of a string literal (without quotes) and produces a
-/// sequence of characters or errors.
-/// NOTE: Raw strings do not perform any explicit character escaping, here we
-/// only translate CRLF to LF and produce errors on bare CR.
-pub(crate) fn unescape_raw_byte_str<F>(literal_text: &str, callback: &mut F)
-where
-    F: FnMut(Range<usize>, Result<char, EscapeError>),
-{
-    let mut byte_offset: usize = 0;
-
-    let mut chars = literal_text.chars().peekable();
-    while let Some(curr) = chars.next() {
-        let result = match (curr, chars.peek()) {
-            ('\r', Some('\n')) => Ok(curr),
-            ('\r', _) => Err(EscapeError::BareCarriageReturn),
-            (c, _) if c > '\x7F' => Err(EscapeError::NonAsciiCharInByteString),
-            _ => Ok(curr),
-        };
-        callback(byte_offset..(byte_offset + curr.len_utf8()), result);
-        byte_offset += curr.len_utf8();
+        let len_utf8: usize = scanned.iter().filter_map(|&x| x).map(char::len_utf8).sum();
+        callback(byte_offset..(byte_offset + len_utf8), result);
+        byte_offset += len_utf8;
     }
 }
 

--- a/src/libsyntax/parse/unescape.rs
+++ b/src/libsyntax/parse/unescape.rs
@@ -12,6 +12,7 @@ pub(crate) enum EscapeError {
     LoneSlash,
     InvalidEscape,
     BareCarriageReturn,
+    BareCarriageReturnInRawString,
     EscapeOnlyChar,
 
     TooShortHexEscape,
@@ -299,7 +300,7 @@ where
                 chars.next();
                 Ok('\n')
             },
-            ('\r', _) => Err(EscapeError::BareCarriageReturn),
+            ('\r', _) => Err(EscapeError::BareCarriageReturnInRawString),
             (c, _) if mode.is_bytes() && !c.is_ascii() =>
                 Err(EscapeError::NonAsciiCharInByteString),
             (c, _) => Ok(c),

--- a/src/libsyntax/parse/unescape.rs
+++ b/src/libsyntax/parse/unescape.rs
@@ -1,4 +1,4 @@
-//! Utilities for validating  string and char literals and turning them into
+//! Utilities for validating string and char literals and turning them into
 //! values they represent.
 
 use std::str::Chars;

--- a/src/libsyntax/parse/unescape.rs
+++ b/src/libsyntax/parse/unescape.rs
@@ -66,6 +66,28 @@ where
     })
 }
 
+/// Takes a contents of a string literal (without quotes) and produces a
+/// sequence of characters or errors.
+/// NOTE: Raw strings do not perform any explicit character escaping, here we
+/// only translate CRLF to LF and produce errors on bare CR.
+pub(crate) fn unescape_raw_str<F>(literal_text: &str, callback: &mut F)
+where
+    F: FnMut(Range<usize>, Result<char, EscapeError>),
+{
+    let mut byte_offset: usize = 0;
+
+    let mut chars = literal_text.chars().peekable();
+    while let Some(curr) = chars.next() {
+        let result = match (curr, chars.peek()) {
+            ('\r', Some('\n')) => Ok(curr),
+            ('\r', _) => Err(EscapeError::BareCarriageReturn),
+            _ => Ok(curr),
+        };
+        callback(byte_offset..(byte_offset + curr.len_utf8()), result);
+        byte_offset += curr.len_utf8();
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Mode {
     Char,

--- a/src/libsyntax/parse/unescape_error_reporting.rs
+++ b/src/libsyntax/parse/unescape_error_reporting.rs
@@ -124,6 +124,11 @@ pub(crate) fn emit_unescape_error(
             handler.span_err(span, "byte constant must be ASCII. \
                                     Use a \\xHH escape for a non-ASCII byte")
         }
+        EscapeError::NonAsciiCharInByteString => {
+            assert!(mode.is_bytes());
+            let (_c, span) = last_char();
+            handler.span_err(span, "raw byte string must be ASCII")
+        }
         EscapeError::OutOfRangeHexEscape => {
             handler.span_err(span, "this form of character escape may only be used \
                                     with characters in the range [\\x00-\\x7f]")

--- a/src/libsyntax/parse/unescape_error_reporting.rs
+++ b/src/libsyntax/parse/unescape_error_reporting.rs
@@ -80,6 +80,11 @@ pub(crate) fn emit_unescape_error(
             };
             handler.span_err(span, msg);
         }
+        EscapeError::BareCarriageReturnInRawString => {
+            assert!(mode.in_double_quotes());
+            let msg = "bare CR not allowed in raw string";
+            handler.span_err(span, msg);
+        }
         EscapeError::InvalidEscape => {
             let (c, span) = last_char();
 

--- a/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/run-pass/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -30,6 +30,9 @@ literal";
     let s = r"string
 literal";
     assert_eq!(s, "string\nliteral");
+    let s = br"byte string
+literal";
+    assert_eq!(s, "byte string\nliteral".as_bytes());
 
     // validate that our source file has CRLF endings
     let source = include_str!("lexer-crlf-line-endings-string-literal-doc-comment.rs");

--- a/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.rs
@@ -21,7 +21,7 @@ fn main() {
     let _s = "foobar"; //~ ERROR: bare CR not allowed in string
 
     // the following string literal has a bare CR in it
-    let _s = r"barfoo"; //~ ERROR: bare CR not allowed in raw string
+    let _s = r"barfoo"; //~ ERROR: bare CR not allowed in string
 
     // the following string literal has a bare CR in it
     let _s = "foo\bar"; //~ ERROR: unknown character escape: \r

--- a/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.rs
+++ b/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.rs
@@ -21,7 +21,7 @@ fn main() {
     let _s = "foobar"; //~ ERROR: bare CR not allowed in string
 
     // the following string literal has a bare CR in it
-    let _s = r"barfoo"; //~ ERROR: bare CR not allowed in string
+    let _s = r"barfoo"; //~ ERROR: bare CR not allowed in raw string
 
     // the following string literal has a bare CR in it
     let _s = "foo\bar"; //~ ERROR: unknown character escape: \r

--- a/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.stderr
+++ b/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.stderr
@@ -28,7 +28,7 @@ error: bare CR not allowed in string, use \r instead
 LL |     let _s = "foobar";
    |                  ^
 
-error: bare CR not allowed in string, use \r instead
+error: bare CR not allowed in raw string
   --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:24:19
    |
 LL |     let _s = r"barfoo";

--- a/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.stderr
+++ b/src/test/ui/parser/lex-bare-cr-string-literal-doc-comment.stderr
@@ -28,11 +28,11 @@ error: bare CR not allowed in string, use \r instead
 LL |     let _s = "foobar";
    |                  ^
 
-error: bare CR not allowed in raw string, use \r instead
-  --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:24:14
+error: bare CR not allowed in string, use \r instead
+  --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:24:19
    |
 LL |     let _s = r"barfoo";
-   |              ^^^^^
+   |                   ^
 
 error: unknown character escape: \r
   --> $DIR/lex-bare-cr-string-literal-doc-comment.rs:27:19

--- a/src/test/ui/parser/raw-byte-string-literals.rs
+++ b/src/test/ui/parser/raw-byte-string-literals.rs
@@ -1,7 +1,7 @@
 // ignore-tidy-cr
 // compile-flags: -Z continue-parse-after-error
 pub fn main() {
-    br"a"; //~ ERROR bare CR not allowed in string
+    br"a"; //~ ERROR bare CR not allowed in raw string
     br"é";  //~ ERROR raw byte string must be ASCII
     br##~"a"~##;  //~ ERROR only `#` is allowed in raw string delimitation
 }

--- a/src/test/ui/parser/raw-byte-string-literals.rs
+++ b/src/test/ui/parser/raw-byte-string-literals.rs
@@ -1,4 +1,7 @@
+// ignore-tidy-cr
+// compile-flags: -Z continue-parse-after-error
 pub fn main() {
+    br"a"; //~ ERROR bare CR not allowed in string
     br"é";  //~ ERROR raw byte string must be ASCII
     br##~"a"~##;  //~ ERROR only `#` is allowed in raw string delimitation
 }

--- a/src/test/ui/parser/raw-byte-string-literals.stderr
+++ b/src/test/ui/parser/raw-byte-string-literals.stderr
@@ -1,4 +1,4 @@
-error: bare CR not allowed in string, use \r instead
+error: bare CR not allowed in raw string
   --> $DIR/raw-byte-string-literals.rs:4:9
    |
 LL |     br"a";

--- a/src/test/ui/parser/raw-byte-string-literals.stderr
+++ b/src/test/ui/parser/raw-byte-string-literals.stderr
@@ -1,14 +1,20 @@
-error: raw byte string must be ASCII: \u{e9}
-  --> $DIR/raw-byte-string-literals.rs:2:8
+error: bare CR not allowed in string, use \r instead
+  --> $DIR/raw-byte-string-literals.rs:4:9
+   |
+LL |     br"a";
+   |         ^
+
+error: raw byte string must be ASCII
+  --> $DIR/raw-byte-string-literals.rs:5:8
    |
 LL |     br"é";
    |        ^
 
 error: found invalid character; only `#` is allowed in raw string delimitation: ~
-  --> $DIR/raw-byte-string-literals.rs:3:6
+  --> $DIR/raw-byte-string-literals.rs:6:6
    |
 LL |     br##~"a"~##;
    |      ^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Handles bare CR ~but doesn't translate `\r\n` to `\n` yet in raw strings yet~ and translates CRLF to LF in raw strings.

As a side-note I think it'd be good to change the `unescape_` to return plain iterators to reduce some boilerplate (e.g. `has_error` could benefit from collecting `Result<T>` and aborting early on errors) but will do that separately, unless I missed something here that prevents it.

@matklad @petrochenkov thoughts?