### PR TITLE
[WIP] Use `Into::into` in operator `?`

### DIFF
--- a/src/libcore/ops/try.rs
+++ b/src/libcore/ops/try.rs
@@ -34,7 +34,7 @@ pub trait Try {
     ///
     /// If an `Err(e)` result is returned, the value `e` will be "wrapped"
     /// in the return type of the enclosing scope (which must itself implement
-    /// `Try`). Specifically, the value `X::from_error(From::from(e))`
+    /// `Try`). Specifically, the value `X::from_error(Into::into(e))`
     /// is returned, where `X` is the return type of the enclosing function.
     #[unstable(feature = "try_trait", issue = "42327")]
     fn into_result(self) -> Result<Self::Ok, Self::Error>;

--- a/src/libcore/tests/result.rs
+++ b/src/libcore/tests/result.rs
@@ -198,7 +198,7 @@ pub fn test_unwrap_or_default() {
 #[test]
 fn test_try() {
     fn try_result_some() -> Option<u8> {
-        let val = Ok(1)?;
+        let val = Ok::<_, NoneError>(1)?;
         Some(val)
     }
     assert_eq!(try_result_some(), Some(1));

--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -370,7 +370,7 @@ impl fmt::Debug for DepNode {
 
         write!(f, "(")?;
 
-        crate::ty::tls::with_opt(|opt_tcx| {
+        crate::ty::tls::with_opt(|opt_tcx| -> fmt::Result {
             if let Some(tcx) = opt_tcx {
                 if let Some(def_id) = self.extract_def_id(tcx) {
                     write!(f, "{}", tcx.def_path_debug_str(def_id))?;

--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -171,7 +171,7 @@ impl fmt::Debug for DefId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DefId({}:{}", self.krate, self.index.as_array_index())?;
 
-        ty::tls::with_opt(|opt_tcx| {
+        ty::tls::with_opt(|opt_tcx| -> fmt::Result {
             if let Some(tcx) = opt_tcx {
                 write!(f, " ~ {}", tcx.def_path_debug_str(*self))?;
             }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -4755,9 +4755,9 @@ impl<'a> LoweringContext<'a> {
                 //     Ok(val) => #[allow(unreachable_code)] val,
                 //     Err(err) => #[allow(unreachable_code)]
                 //                 // If there is an enclosing `catch {...}`
-                //                 break 'catch_target Try::from_error(From::from(err)),
+                //                 break 'catch_target Try::from_error(Into::into(err)),
                 //                 // Otherwise
-                //                 return Try::from_error(From::from(err)),
+                //                 return Try::from_error(Into::into(err)),
                 // }
 
                 let unstable_span = self.sess.source_map().mark_span_with_reason(
@@ -4818,17 +4818,17 @@ impl<'a> LoweringContext<'a> {
                 };
 
                 // `Err(err) => #[allow(unreachable_code)]
-                //              return Try::from_error(From::from(err)),`
+                //              return Try::from_error(Into::into(err)),`
                 let err_arm = {
                     let err_ident = self.str_to_ident("err");
                     let (err_local, err_local_nid) = self.pat_ident(try_span, err_ident);
-                    let from_expr = {
-                        let from_path = &[sym::convert, sym::From, sym::from];
+                    let into_expr = {
+                        let into_path = &[sym::convert, sym::Into, sym::into];
                         let err_expr = self.expr_ident(try_span, err_ident, err_local_nid);
-                        self.expr_call_std_path(try_span, from_path, hir_vec![err_expr])
+                        self.expr_call_std_path(try_span, into_path, hir_vec![err_expr])
                     };
                     let from_err_expr =
-                        self.wrap_in_try_constructor(sym::from_error, from_expr, unstable_span);
+                        self.wrap_in_try_constructor(sym::from_error, into_expr, unstable_span);
                     let thin_attrs = ThinVec::from(attrs);
                     let catch_scope = self.catch_scopes.last().map(|x| *x);
                     let ret_expr = if let Some(catch_node) = catch_scope {

--- a/src/librustc/infer/unify_key.rs
+++ b/src/librustc/infer/unify_key.rs
@@ -139,10 +139,10 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
 
             // If one side is known, prefer that one.
             (ConstVariableValue::Known { .. }, ConstVariableValue::Unknown { .. }) => {
-                Ok(value1.val)
+                value1.val
             }
             (ConstVariableValue::Unknown { .. }, ConstVariableValue::Known { .. }) => {
-                Ok(value2.val)
+                value2.val
             }
 
             // If both sides are *unknown*, it hardly matters, does it?
@@ -154,9 +154,9 @@ impl<'tcx> UnifyValue for ConstVarValue<'tcx> {
                 // universe is the minimum of the two universes, because that is
                 // the one which contains the fewest names in scope.
                 let universe = cmp::min(universe1, universe2);
-                Ok(ConstVariableValue::Unknown { universe })
+                ConstVariableValue::Unknown { universe }
             }
-        }?;
+        };
 
         Ok(ConstVarValue {
             origin: ConstVariableOrigin::ConstInference(DUMMY_SP),

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -159,7 +159,7 @@ impl<'s> AllocDecodingSession<'s> {
 
         // Decode the AllocDiscriminant now so that we know if we have to reserve an
         // AllocId.
-        let (alloc_kind, pos) = decoder.with_position(pos, |decoder| {
+        let (alloc_kind, pos) = decoder.with_position(pos, |decoder| -> Result<_, D::Error> {
             let alloc_kind = AllocDiscriminant::decode(decoder)?;
             Ok((alloc_kind, decoder.position()))
         })?;
@@ -217,7 +217,7 @@ impl<'s> AllocDecodingSession<'s> {
         };
 
         // Now decode the actual data
-        let alloc_id = decoder.with_position(pos, |decoder| {
+        let alloc_id = decoder.with_position(pos, |decoder| -> Result<_, D::Error> {
             match alloc_kind {
                 AllocDiscriminant::Alloc => {
                     let allocation = <&'tcx Allocation as Decodable>::decode(decoder)?;

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2543,7 +2543,7 @@ impl<'tcx> Debug for Rvalue<'tcx> {
                         let variant_def = &adt_def.variants[variant];
 
                         let f = &mut *fmt;
-                        ty::tls::with(|tcx| {
+                        ty::tls::with(|tcx| -> fmt::Result {
                             let substs = tcx.lift(&substs).expect("could not lift for printing");
                             FmtPrinter::new(tcx, f, Namespace::ValueNS)
                                 .print_def_path(variant_def.def_id, substs)?;

--- a/src/librustc/ty/codec.rs
+++ b/src/librustc/ty/codec.rs
@@ -201,7 +201,7 @@ pub fn decode_predicates<'a, 'tcx, D>(decoder: &mut D)
             }?;
             Ok((predicate, Decodable::decode(decoder)?))
         })
-        .collect::<Result<Vec<_>, _>>()?,
+        .collect::<Result<Vec<_>, D::Error>>()?,
     })
 }
 

--- a/src/librustc/ty/instance.rs
+++ b/src/librustc/ty/instance.rs
@@ -174,7 +174,7 @@ impl<'tcx> InstanceDef<'tcx> {
 
 impl<'tcx> fmt::Display for Instance<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        ty::tls::with(|tcx| {
+        ty::tls::with(|tcx| -> fmt::Result {
             let substs = tcx.lift(&self.substs).expect("could not lift for printing");
             FmtPrinter::new(tcx, &mut *f, Namespace::ValueNS)
                 .print_def_path(self.def_id(), substs)?;

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -202,7 +202,7 @@ impl<'sess> OnDiskCache<'sess> {
             // Encode query results
             let mut query_result_index = EncodedQueryResultIndex::new();
 
-            time(tcx.sess, "encode query results", || {
+            time(tcx.sess, "encode query results", || -> Result<_, E::Error> {
                 use crate::ty::query::queries::*;
                 let enc = &mut encoder;
                 let qri = &mut query_result_index;
@@ -260,7 +260,7 @@ impl<'sess> OnDiskCache<'sess> {
 
                 Ok((dep_node_index, pos))
             })
-            .collect::<Result<_, _>>()?;
+            .collect::<Result<_, E::Error>>()?;
 
             let interpret_alloc_index = {
                 let mut interpret_alloc_index = Vec::new();

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -253,7 +253,7 @@ pub fn run_compiler(
         if let Some((ppm, opt_uii)) = pretty_info {
             if ppm.needs_ast_map(&opt_uii) {
                 pretty::visit_crate(sess, &mut compiler.parse()?.peek_mut(), ppm);
-                compiler.global_ctxt()?.peek_mut().enter(|tcx| {
+                compiler.global_ctxt()?.peek_mut().enter(|tcx| -> interface::Result<_> {
                     let expanded_crate = compiler.expansion()?.take().0;
                     pretty::print_after_hir_lowering(
                         tcx,

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -3,6 +3,7 @@
 #![feature(box_patterns)]
 #![feature(drain_filter)]
 #![feature(libc)]
+#![feature(never_type)]
 #![feature(nll)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_quote)]

--- a/src/librustc_mir/hair/constant.rs
+++ b/src/librustc_mir/hair/constant.rs
@@ -17,7 +17,7 @@ crate fn lit_to_const<'a, 'gcx, 'tcx>(
 ) -> Result<ty::Const<'tcx>, LitToConstError> {
     use syntax::ast::*;
 
-    let trunc = |n| {
+    let trunc = |n| -> Result<_, LitToConstError> {
         let param_ty = ParamEnv::reveal_all().and(tcx.lift_to_global(&ty).unwrap());
         let width = tcx.layout_of(param_ty).map_err(|_| LitToConstError::Reported)?.size;
         trace!("trunc {} with size {} and shift {}", n, width.bits(), 128 - width.bits());

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -287,6 +287,8 @@ symbols! {
         infer_static_outlives_requirements,
         inline,
         intel,
+        into,
+        Into,
         into_iter,
         IntoIterator,
         into_result,

--- a/src/test/ui/issues/issue-32709.stderr
+++ b/src/test/ui/issues/issue-32709.stderr
@@ -4,7 +4,8 @@ error[E0277]: `?` couldn't convert the error to `()`
 LL |     Err(5)?;
    |           ^ the trait `std::convert::From<{integer}>` is not implemented for `()`
    |
-   = note: required by `std::convert::From::from`
+   = note: required because of the requirements on the impl of `std::convert::Into<()>` for `{integer}`
+   = note: required by `std::convert::Into::into`
 
 error: aborting due to previous error
 

--- a/src/test/ui/try-block/try-block-bad-type.stderr
+++ b/src/test/ui/try-block/try-block-bad-type.stderr
@@ -10,7 +10,8 @@ LL |         Err("")?;
              <i32 as std::convert::From<i8>>
              <i32 as std::convert::From<std::num::NonZeroI32>>
            and 2 others
-   = note: required by `std::convert::From::from`
+   = note: required because of the requirements on the impl of `std::convert::Into<i32>` for `&str`
+   = note: required by `std::convert::Into::into`
 
 error[E0271]: type mismatch resolving `<std::result::Result<i32, i32> as std::ops::Try>::Ok == &str`
   --> $DIR/try-block-bad-type.rs:12:9

--- a/src/test/ui/try-on-option.stderr
+++ b/src/test/ui/try-on-option.stderr
@@ -4,7 +4,8 @@ error[E0277]: `?` couldn't convert the error to `()`
 LL |     x?;
    |      ^ the trait `std::convert::From<std::option::NoneError>` is not implemented for `()`
    |
-   = note: required by `std::convert::From::from`
+   = note: required because of the requirements on the impl of `std::convert::Into<()>` for `std::option::NoneError`
+   = note: required by `std::convert::Into::into`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
   --> $DIR/try-on-option.rs:13:5


### PR DESCRIPTION
#38751 proposes using `into` for `?`, and while commenters suggested problems with inference, I couldn't find any evidence where this was actually attempted -- so here we go!