### PR TITLE
Remove `ObsoleteInPlace`

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -4062,10 +4062,6 @@ impl<'a> LoweringContext<'a> {
     fn lower_expr(&mut self, e: &Expr) -> hir::Expr {
         let kind = match e.node {
             ExprKind::Box(ref inner) => hir::ExprKind::Box(P(self.lower_expr(inner))),
-            ExprKind::ObsoleteInPlace(..) => {
-                self.sess.abort_if_errors();
-                span_bug!(e.span, "encountered ObsoleteInPlace expr during lowering");
-            }
             ExprKind::Array(ref exprs) => {
                 hir::ExprKind::Array(exprs.iter().map(|x| self.lower_expr(x)).collect())
             }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -454,29 +454,6 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ExprKind::InlineAsm(..) if !self.session.target.target.options.allow_asm => {
                 span_err!(self.session, expr.span, E0472, "asm! is unsupported on this target");
             }
-            ExprKind::ObsoleteInPlace(ref place, ref val) => {
-                let mut err = self.err_handler().struct_span_err(
-                    expr.span,
-                    "emplacement syntax is obsolete (for now, anyway)",
-                );
-                err.note(
-                    "for more information, see \
-                     <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>"
-                );
-                match val.node {
-                    ExprKind::Lit(ref v) if v.node.is_numeric() => {
-                        err.span_suggestion(
-                            place.span.between(val.span),
-                            "if you meant to write a comparison against a negative value, add a \
-                             space in between `<` and `-`",
-                            "< -".to_string(),
-                            Applicability::MaybeIncorrect
-                        );
-                    }
-                    _ => {}
-                }
-                err.emit();
-            }
             _ => {}
         }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1037,7 +1037,6 @@ impl Expr {
     pub fn precedence(&self) -> ExprPrecedence {
         match self.node {
             ExprKind::Box(_) => ExprPrecedence::Box,
-            ExprKind::ObsoleteInPlace(..) => ExprPrecedence::ObsoleteInPlace,
             ExprKind::Array(_) => ExprPrecedence::Array,
             ExprKind::Call(..) => ExprPrecedence::Call,
             ExprKind::MethodCall(..) => ExprPrecedence::MethodCall,
@@ -1099,8 +1098,6 @@ pub enum RangeLimits {
 pub enum ExprKind {
     /// A `box x` expression.
     Box(P<Expr>),
-    /// First expr is the place; second expr is the value.
-    ObsoleteInPlace(P<Expr>, P<Expr>),
     /// An array (`[a, b, c, d]`)
     Array(Vec<P<Expr>>),
     /// A function call

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2117,9 +2117,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                        "type ascription is experimental");
                 }
             }
-            ast::ExprKind::ObsoleteInPlace(..) => {
-                // these get a hard error in ast-validation
-            }
             ast::ExprKind::Yield(..) => {
                 gate_feature_post!(&self, generators,
                                   e.span,

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1099,10 +1099,6 @@ pub fn noop_visit_anon_const<T: MutVisitor>(AnonConst { id, value }: &mut AnonCo
 pub fn noop_visit_expr<T: MutVisitor>(Expr { node, id, span, attrs }: &mut Expr, vis: &mut T) {
     match node {
         ExprKind::Box(expr) => vis.visit_expr(expr),
-        ExprKind::ObsoleteInPlace(a, b) => {
-            vis.visit_expr(a);
-            vis.visit_expr(b);
-        }
         ExprKind::Array(exprs) => visit_exprs(exprs, vis),
         ExprKind::Repeat(expr, count) => {
             vis.visit_expr(expr);

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3252,17 +3252,6 @@ impl<'a> Parser<'a> {
                 let (span, e) = self.interpolated_or_expr_span(e)?;
                 (lo.to(span), ExprKind::AddrOf(m, e))
             }
-            token::Ident(..) if self.token.is_keyword(kw::In) => {
-                self.bump();
-                let place = self.parse_expr_res(
-                    Restrictions::NO_STRUCT_LITERAL,
-                    None,
-                )?;
-                let blk = self.parse_block()?;
-                let span = blk.span;
-                let blk_expr = self.mk_expr(span, ExprKind::Block(blk, None), ThinVec::new());
-                (lo.to(span), ExprKind::ObsoleteInPlace(place, blk_expr))
-            }
             token::Ident(..) if self.token.is_keyword(kw::Box) => {
                 self.bump();
                 let e = self.parse_prefix_expr(None);
@@ -3500,8 +3489,6 @@ impl<'a> Parser<'a> {
                     self.mk_expr(span, binary, ThinVec::new())
                 }
                 AssocOp::Assign => self.mk_expr(span, ExprKind::Assign(lhs, rhs), ThinVec::new()),
-                AssocOp::ObsoleteInPlace =>
-                    self.mk_expr(span, ExprKind::ObsoleteInPlace(lhs, rhs), ThinVec::new()),
                 AssocOp::AssignOp(k) => {
                     let aop = match k {
                         token::Plus =>    BinOpKind::Add,
@@ -3820,9 +3807,6 @@ impl<'a> Parser<'a> {
                 String::new(),
                 Applicability::MachineApplicable,
             );
-            err.note("if you meant to use emplacement syntax, it is obsolete (for now, anyway)");
-            err.note("for more information on the status of emplacement syntax, see <\
-                      https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>");
             err.emit();
         }
         let expr = self.parse_expr_res(Restrictions::NO_STRUCT_LITERAL, None)?;

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -2005,13 +2005,6 @@ impl<'a> State<'a> {
                 self.word_space("box")?;
                 self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)?;
             }
-            ast::ExprKind::ObsoleteInPlace(ref place, ref expr) => {
-                let prec = AssocOp::ObsoleteInPlace.precedence() as i8;
-                self.print_expr_maybe_paren(place, prec + 1)?;
-                self.s.space()?;
-                self.word_space("<-")?;
-                self.print_expr_maybe_paren(expr, prec)?;
-            }
             ast::ExprKind::Array(ref exprs) => {
                 self.print_expr_vec(&exprs[..], attrs)?;
             }

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -45,8 +45,6 @@ pub enum AssocOp {
     GreaterEqual,
     /// `=`
     Assign,
-    /// `<-`
-    ObsoleteInPlace,
     /// `?=` where ? is one of the BinOpToken
     AssignOp(BinOpToken),
     /// `as`
@@ -75,7 +73,6 @@ impl AssocOp {
         use AssocOp::*;
         match *t {
             Token::BinOpEq(k) => Some(AssignOp(k)),
-            Token::LArrow => Some(ObsoleteInPlace),
             Token::Eq => Some(Assign),
             Token::BinOp(BinOpToken::Star) => Some(Multiply),
             Token::BinOp(BinOpToken::Slash) => Some(Divide),
@@ -145,7 +142,6 @@ impl AssocOp {
             LAnd => 6,
             LOr => 5,
             DotDot | DotDotEq => 4,
-            ObsoleteInPlace => 3,
             Assign | AssignOp(_) => 2,
         }
     }
@@ -155,7 +151,7 @@ impl AssocOp {
         use AssocOp::*;
         // NOTE: it is a bug to have an operators that has same precedence but different fixities!
         match *self {
-            ObsoleteInPlace | Assign | AssignOp(_) => Fixity::Right,
+            Assign | AssignOp(_) => Fixity::Right,
             As | Multiply | Divide | Modulus | Add | Subtract | ShiftLeft | ShiftRight | BitAnd |
             BitXor | BitOr | Less | Greater | LessEqual | GreaterEqual | Equal | NotEqual |
             LAnd | LOr | Colon => Fixity::Left,
@@ -167,7 +163,7 @@ impl AssocOp {
         use AssocOp::*;
         match *self {
             Less | Greater | LessEqual | GreaterEqual | Equal | NotEqual => true,
-            ObsoleteInPlace | Assign | AssignOp(_) | As | Multiply | Divide | Modulus | Add |
+            Assign | AssignOp(_) | As | Multiply | Divide | Modulus | Add |
             Subtract | ShiftLeft | ShiftRight | BitAnd | BitXor | BitOr | LAnd | LOr |
             DotDot | DotDotEq | Colon => false
         }
@@ -176,7 +172,7 @@ impl AssocOp {
     pub fn is_assign_like(&self) -> bool {
         use AssocOp::*;
         match *self {
-            Assign | AssignOp(_) | ObsoleteInPlace => true,
+            Assign | AssignOp(_) => true,
             Less | Greater | LessEqual | GreaterEqual | Equal | NotEqual | As | Multiply | Divide |
             Modulus | Add | Subtract | ShiftLeft | ShiftRight | BitAnd | BitXor | BitOr | LAnd |
             LOr | DotDot | DotDotEq | Colon => false
@@ -204,7 +200,7 @@ impl AssocOp {
             BitOr => Some(BinOpKind::BitOr),
             LAnd => Some(BinOpKind::And),
             LOr => Some(BinOpKind::Or),
-            ObsoleteInPlace | Assign | AssignOp(_) | As | DotDot | DotDotEq | Colon => None
+            Assign | AssignOp(_) | As | DotDot | DotDotEq | Colon => None
         }
     }
 
@@ -256,7 +252,6 @@ pub enum ExprPrecedence {
 
     Binary(BinOpKind),
 
-    ObsoleteInPlace,
     Cast,
     Type,
 
@@ -314,7 +309,6 @@ impl ExprPrecedence {
 
             // Binop-like expr kinds, handled by `AssocOp`.
             ExprPrecedence::Binary(op) => AssocOp::from_ast_binop(op).precedence() as i8,
-            ExprPrecedence::ObsoleteInPlace => AssocOp::ObsoleteInPlace.precedence() as i8,
             ExprPrecedence::Cast => AssocOp::As.precedence() as i8,
             ExprPrecedence::Type => AssocOp::Colon.precedence() as i8,
 

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -676,10 +676,6 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
         ExprKind::Box(ref subexpression) => {
             visitor.visit_expr(subexpression)
         }
-        ExprKind::ObsoleteInPlace(ref place, ref subexpression) => {
-            visitor.visit_expr(place);
-            visitor.visit_expr(subexpression)
-        }
         ExprKind::Array(ref subexpressions) => {
             walk_list!(visitor, visit_expr, subexpressions);
         }

--- a/src/test/ui/obsolete-in-place/bad.bad.stderr
+++ b/src/test/ui/obsolete-in-place/bad.bad.stderr
@@ -1,18 +1,19 @@
-error: emplacement syntax is obsolete (for now, anyway)
-  --> $DIR/bad.rs:9:5
-   |
-LL |     x <- y;
-   |     ^^^^^^
-   |
-   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
-
-error: emplacement syntax is obsolete (for now, anyway)
+error: expected expression, found keyword `in`
   --> $DIR/bad.rs:10:5
    |
 LL |     in(foo) { bar };
-   |     ^^^^^^^^^^^^^^^
+   |     ^^ expected expression
+
+error[E0282]: type annotations needed
+  --> $DIR/bad.rs:9:8
    |
-   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
+LL |     let (x, y, foo, bar);
+   |         ---------------- consider giving the pattern a type
+LL |     x <- y;
+   |        ^^^ cannot infer type
+   |
+   = note: type must be known at this point
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/obsolete-in-place/bad.rs
+++ b/src/test/ui/obsolete-in-place/bad.rs
@@ -1,15 +1,12 @@
 // Check that `<-` and `in` syntax gets a hard error.
 
-// revisions: good bad
-//[good] run-pass
-
-#[cfg(bad)]
-fn main() {
-    let (x, y, foo, bar);
-    x <- y; //[bad]~ ERROR emplacement syntax is obsolete
-    in(foo) { bar }; //[bad]~ ERROR emplacement syntax is obsolete
+fn foo() {
+    let (x, y) = (0, 0);
+    x <- y; //~ ERROR expected one of
+    //~^ ERROR mismatched types
 }
 
-#[cfg(good)]
 fn main() {
+    let (foo, bar) = (0, 0);
+    in(foo) { bar }; //~ ERROR expected expression, found keyword `in`
 }

--- a/src/test/ui/obsolete-in-place/bad.stderr
+++ b/src/test/ui/obsolete-in-place/bad.stderr
@@ -1,0 +1,27 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `<-`
+  --> $DIR/bad.rs:5:7
+   |
+LL |     x <- y;
+   |       ^^ expected one of 8 possible tokens here
+
+error: expected expression, found keyword `in`
+  --> $DIR/bad.rs:11:5
+   |
+LL |     in(foo) { bar };
+   |     ^^ expected expression
+
+error[E0308]: mismatched types
+  --> $DIR/bad.rs:5:5
+   |
+LL | fn foo() {
+   |          - possibly return type missing here?
+LL |     let (x, y) = (0, 0);
+LL |     x <- y;
+   |     ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/if-in-in.stderr
+++ b/src/test/ui/parser/if-in-in.stderr
@@ -5,9 +5,6 @@ LL |     for i in in 1..2 {
    |           ---^^
    |           |
    |           help: remove the duplicated `in`
-   |
-   = note: if you meant to use emplacement syntax, it is obsolete (for now, anyway)
-   = note: for more information on the status of emplacement syntax, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
 
 error: aborting due to previous error
 

--- a/src/test/ui/placement-syntax.rs
+++ b/src/test/ui/placement-syntax.rs
@@ -1,7 +1,6 @@
 fn main() {
     let x = -5;
-    if x<-1 {
-    //~^ ERROR emplacement syntax is obsolete
+    if x<-1 { //~ ERROR expected `{`, found `<-`
         println!("ok");
     }
 }

--- a/src/test/ui/placement-syntax.stderr
+++ b/src/test/ui/placement-syntax.stderr
@@ -1,14 +1,10 @@
-error: emplacement syntax is obsolete (for now, anyway)
-  --> $DIR/placement-syntax.rs:3:8
+error: expected `{`, found `<-`
+  --> $DIR/placement-syntax.rs:3:9
    |
 LL |     if x<-1 {
-   |        ^^^^
-   |
-   = note: for more information, see <https://github.com/rust-lang/rust/issues/27779#issuecomment-378416911>
-help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
-   |
-LL |     if x< -1 {
-   |         ^^^
+   |     --  ^^ expected `{`
+   |     |
+   |     this `if` statement has a condition, but no block
 
 error: aborting due to previous error
 


### PR DESCRIPTION
The in place syntax has been deprecated for over a year. As it is, this is accumulated cruft: the error messages are unlikely to be helpful any more and it conflicts with some useful syntax (e.g. const generics in some instances).

It may be that removing `Token::LArrow` is backwards-incompatible. We should do a crater run to check.

cc @eddyb  

