### PR TITLE
Improve "must use" lint for `Future` to suggest await

### DIFF
--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -23,7 +23,7 @@ use crate::task::{Context, Poll};
 /// When using a future, you generally won't call `poll` directly, but instead
 /// `await!` the value.
 #[doc(spotlight)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "a future remains idle unless you `.await` it."]
 #[stable(feature = "futures_api", since = "1.36.0")]
 pub trait Future {
     /// The type of value produced on completion.


### PR DESCRIPTION
Replacing must_use warning note in futures.rs for clarity.  #60797