### PR TITLE
Make parser aware of await where macro calls are expected

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2628,7 +2628,8 @@ impl<'a> Parser<'a> {
                     db.span_label(self.span, "expected expression");
                     db.note("variable declaration using `let` is a statement");
                     return Err(db);
-                } else if self.span.rust_2018() && self.eat_keyword(keywords::Await) {
+                } else if self.span.rust_2018() && self.eat_keyword(keywords::Await)
+                          && self.check(&token::Not) {
                     // FIXME: remove this branch when `await!` is no longer supported
                     // https://github.com/rust-lang/rust/issues/60610
                     self.expect(&token::Not)?;

--- a/src/test/ui/await-keyword/2018-edition-error-in-non-macro-position.rs
+++ b/src/test/ui/await-keyword/2018-edition-error-in-non-macro-position.rs
@@ -23,5 +23,5 @@ macro_rules! await {
 }
 
 fn main() {
-    match await { await => () } //~ ERROR expected `!`, found `{`
+    match await { await => () } //~ ERROR expected expression, found `{`
 }

--- a/src/test/ui/await-keyword/2018-edition-error-in-non-macro-position.stderr
+++ b/src/test/ui/await-keyword/2018-edition-error-in-non-macro-position.stderr
@@ -68,11 +68,11 @@ help: you can escape reserved keywords to use them as identifiers
 LL | macro_rules! r#await {
    |              ^^^^^^^
 
-error: expected `!`, found `{`
+error: expected expression, found `{`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:26:17
    |
 LL |     match await { await => () }
-   |     -----       ^ expected `!`
+   |     -----       ^ expected expression
    |     |
    |     while parsing this match expression
 

--- a/src/test/ui/await-keyword/2018-edition-error.rs
+++ b/src/test/ui/await-keyword/2018-edition-error.rs
@@ -10,5 +10,5 @@ use self::outer_mod::await::await; //~ ERROR expected identifier
     //~^ ERROR expected identifier, found reserved keyword `await`
 
 fn main() {
-    match await { await => () } //~ ERROR expected `!`, found `{`
+    match await { await => () } //~ ERROR expected expression, found `{`
 }

--- a/src/test/ui/await-keyword/2018-edition-error.stderr
+++ b/src/test/ui/await-keyword/2018-edition-error.stderr
@@ -38,11 +38,11 @@ help: you can escape reserved keywords to use them as identifiers
 LL | use self::outer_mod::await::r#await;
    |                             ^^^^^^^
 
-error: expected `!`, found `{`
+error: expected expression, found `{`
   --> $DIR/2018-edition-error.rs:13:17
    |
 LL |     match await { await => () }
-   |     -----       ^ expected `!`
+   |     -----       ^ expected expression
    |     |
    |     while parsing this match expression
 


### PR DESCRIPTION
This makes the parser to first check for '!' and see if it exists or not before
parsing it as `await!`. This is done because a proposed new syntax for await is
`expression.await` and hence await keyword can be used without `!`.

It fixes #60653