### PR TITLE
Stabilize RefCell::try_borrow_unguarded

### DIFF
--- a/src/doc/unstable-book/src/library-features/borrow-state.md
+++ b/src/doc/unstable-book/src/library-features/borrow-state.md
@@ -1,7 +1,0 @@
-# `borrow_state`
-
-The tracking issue for this feature is: [#27733]
-
-[#27733]: https://github.com/rust-lang/rust/issues/27733
-
-------------------------

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -969,7 +969,6 @@ impl<T: ?Sized> RefCell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(borrow_state)]
     /// use std::cell::RefCell;
     ///
     /// let c = RefCell::new(5);
@@ -984,7 +983,7 @@ impl<T: ?Sized> RefCell<T> {
     ///     assert!(unsafe { c.try_borrow_unguarded() }.is_ok());
     /// }
     /// ```
-    #[unstable(feature = "borrow_state", issue = "27733")]
+    #[stable(feature = "borrow_state", since = "1.37.0")]
     #[inline]
     pub unsafe fn try_borrow_unguarded(&self) -> Result<&T, BorrowError> {
         if !is_writing(self.borrow.get()) {


### PR DESCRIPTION
Servo has been using this since https://github.com/servo/servo/pull/23196 to add a runtime check to some unsafe code, as discussed in PR https://github.com/rust-lang/rust/pull/59211. Stabilizing would help do more of the same in libraries that also have users on Stable.