### PR TITLE
Fix dead link in src/doc/rust.md

### DIFF
--- a/src/doc/rust.md
+++ b/src/doc/rust.md
@@ -1,3 +1,3 @@
 % The Rust Reference Manual
 
-The manual has moved, and is now called [the reference](reference/index.html).
+The manual has moved, and is now called [the reference](https://github.com/rust-lang-nursery/reference).


### PR DESCRIPTION
The reference was moved to a submodule in https://github.com/rust-lang/rust/pull/40213.