### PR TITLE
Allow claiming issues with triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -4,3 +4,5 @@ allow-unauthenticated = [
     # I-* without I-nominated
     "I-compilemem", "I-compiletime", "I-crash", "I-hang", "I-ICE", "I-slow",
 ]
+
+[assign]


### PR DESCRIPTION
Not sure if this was intentionally left out, but it can probably be enabled now that https://github.com/rust-lang/triagebot/issues/3 is fixed (assuming that the deployed commit is recent enough). People have tried to use it already (https://github.com/rust-lang/rust/issues/60622#issuecomment-493212465).

r? @Mark-Simulacrum 