### PR TITLE
Checking generic args after late bound region err.

### DIFF
--- a/src/test/ui/issue-60622.rs
+++ b/src/test/ui/issue-60622.rs
@@ -1,0 +1,18 @@
+// ignore-tidy-linelength
+
+#![deny(warnings)]
+
+struct Borked {}
+
+impl Borked {
+    fn a(&self) {}
+}
+
+fn run_wild<T>(b: &Borked) {
+    b.a::<'_, T>();
+    //~^ ERROR cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+    //~^^ ERROR wrong number of type arguments: expected 0, found 1
+    //~^^^ WARN this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+}
+
+fn main() {}

--- a/src/test/ui/issue-60622.stderr
+++ b/src/test/ui/issue-60622.stderr
@@ -1,0 +1,27 @@
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/issue-60622.rs:12:11
+   |
+LL |     fn a(&self) {}
+   |          - the late bound lifetime parameter is introduced here
+...
+LL |     b.a::<'_, T>();
+   |           ^^
+   |
+note: lint level defined here
+  --> $DIR/issue-60622.rs:3:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: #[deny(late_bound_lifetime_arguments)] implied by #[deny(warnings)]
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/issue-60622.rs:12:15
+   |
+LL |     b.a::<'_, T>();
+   |               ^ unexpected type argument
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0107`.


### PR DESCRIPTION
Fixes #60622.

This PR fixes an ICE that occurs when a late bound region error is
emitted and that resulted in the rest of the generic arguments of a
function not being checked.

For example, you could specify a generic type parameter `T` in a function
call `foo<'_, T>()` to a function that doesn't have a generic type
parameter.

Since an error wasn't emitted from the function, compilation
continued to parts of typeck that didn't expect a generic type argument
in a call for a function that didn't have any generic type arguments.