### PR TITLE
Add entry-like methods to HashSet

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -635,7 +635,7 @@ impl<T, S> HashSet<T, S>
     /// assert_eq!(set.len(), 4); // 100 was inserted
     /// ```
     #[inline]
-    #[unstable(feature = "hash_set_entry", issue = "0")]
+    #[unstable(feature = "hash_set_entry", issue = "60896")]
     pub fn get_or_insert(&mut self, value: T) -> &T {
         self.map.raw_entry_mut().from_key(&value).or_insert(value, ()).0
     }
@@ -661,7 +661,7 @@ impl<T, S> HashSet<T, S>
     /// assert_eq!(set.len(), 4); // a new "fish" was inserted
     /// ```
     #[inline]
-    #[unstable(feature = "hash_set_entry", issue = "0")]
+    #[unstable(feature = "hash_set_entry", issue = "60896")]
     pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
         where T: Borrow<Q>,
               Q: Hash + Eq,

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -618,6 +618,58 @@ impl<T, S> HashSet<T, S>
         self.map.get_key_value(value).map(|(k, _)| k)
     }
 
+    /// Inserts the given `value` into the set if it is not present, then
+    /// returns a reference to the value in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(hash_set_entry)]
+    ///
+    /// use std::collections::HashSet;
+    ///
+    /// let mut set: HashSet<_> = [1, 2, 3].iter().cloned().collect();
+    /// assert_eq!(set.len(), 3);
+    /// assert_eq!(set.get_or_insert(2), &2);
+    /// assert_eq!(set.get_or_insert(100), &100);
+    /// assert_eq!(set.len(), 4); // 100 was inserted
+    /// ```
+    #[inline]
+    #[unstable(feature = "hash_set_entry", issue = "0")]
+    pub fn get_or_insert(&mut self, value: T) -> &T {
+        self.map.raw_entry_mut().from_key(&value).or_insert(value, ()).0
+    }
+
+    /// Inserts a value computed from `f` into the set if the given `value` is
+    /// not present, then returns a reference to the value in the set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(hash_set_entry)]
+    ///
+    /// use std::collections::HashSet;
+    ///
+    /// let mut set: HashSet<String> = ["cat", "dog", "horse"]
+    ///     .iter().map(|&pet| pet.to_owned()).collect();
+    ///
+    /// assert_eq!(set.len(), 3);
+    /// for &pet in &["cat", "dog", "fish"] {
+    ///     let value = set.get_or_insert_with(pet, str::to_owned);
+    ///     assert_eq!(value, pet);
+    /// }
+    /// assert_eq!(set.len(), 4); // a new "fish" was inserted
+    /// ```
+    #[inline]
+    #[unstable(feature = "hash_set_entry", issue = "0")]
+    pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
+        where T: Borrow<Q>,
+              Q: Hash + Eq,
+              F: FnOnce(&Q) -> T
+    {
+        self.map.raw_entry_mut().from_key(value).or_insert_with(|| (f(value), ())).0
+    }
+
     /// Returns `true` if `self` has no elements in common with `other`.
     /// This is equivalent to checking for an empty intersection.
     ///

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -637,6 +637,8 @@ impl<T, S> HashSet<T, S>
     #[inline]
     #[unstable(feature = "hash_set_entry", issue = "60896")]
     pub fn get_or_insert(&mut self, value: T) -> &T {
+        // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
+        // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
         self.map.raw_entry_mut().from_key(&value).or_insert(value, ()).0
     }
 
@@ -667,6 +669,8 @@ impl<T, S> HashSet<T, S>
               Q: Hash + Eq,
               F: FnOnce(&Q) -> T
     {
+        // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
+        // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
         self.map.raw_entry_mut().from_key(value).or_insert_with(|| (f(value), ())).0
     }
 


### PR DESCRIPTION
* `HashSet::get_or_insert`
* `HashSet::get_or_insert_with`

These provide a simplification of the `Entry` API for `HashSet`, with
names chosen to match the similar methods on `Option`.