### PR TITLE
error: remove StringError from Debug output

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -300,7 +300,6 @@ impl From<String> for Box<dyn Error + Send + Sync> {
     ///     mem::size_of::<Box<dyn Error + Send + Sync>>() == mem::size_of_val(&a_boxed_error))
     /// ```
     fn from(err: String) -> Box<dyn Error + Send + Sync> {
-        #[derive(Debug)]
         struct StringError(String);
 
         impl Error for StringError {
@@ -310,6 +309,13 @@ impl From<String> for Box<dyn Error + Send + Sync> {
         impl Display for StringError {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 Display::fmt(&self.0, f)
+            }
+        }
+
+        // Purposefully skip printing "StringError(..)"
+        impl Debug for StringError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                Debug::fmt(&self.0, f)
             }
         }
 


### PR DESCRIPTION
Seeing `StringError("something something")` in debug output can cause
 someone to think there was an error dealing with `String`s, not that the
error type is just a string. So, remove that noise.

For example:

```
io error: Custom { kind: InvalidData, error: StringError("corrupt data") }
```

With this change:

```
io error: Custom { kind: InvalidData, error: "corrupt data" }
```