### PR TITLE
Prevent Error::type_id overrides

### DIFF
--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -207,7 +207,7 @@ pub trait Error: Debug + Display {
 }
 
 mod private {
-    // this is a hack to prevent type_id from being overridden by Error
+    // This is a hack to prevent `type_id` from being overridden by `Error`
     // implementations, since that can enable unsound downcasting.
     #[unstable(feature = "error_type_id", issue = "60784")]
     #[derive(Debug)]

--- a/src/libstd/error.rs
+++ b/src/libstd/error.rs
@@ -201,9 +201,17 @@ pub trait Error: Debug + Display {
     #[unstable(feature = "error_type_id",
                reason = "this is memory unsafe to override in user code",
                issue = "60784")]
-    fn type_id(&self) -> TypeId where Self: 'static {
+    fn type_id(&self, _: private::Internal) -> TypeId where Self: 'static {
         TypeId::of::<Self>()
     }
+}
+
+mod private {
+    // this is a hack to prevent type_id from being overridden by Error
+    // implementations, since that can enable unsound downcasting.
+    #[unstable(feature = "error_type_id", issue = "60784")]
+    #[derive(Debug)]
+    pub struct Internal;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -575,7 +583,7 @@ impl dyn Error + 'static {
         let t = TypeId::of::<T>();
 
         // Get TypeId of the type in the trait object
-        let boxed = self.type_id();
+        let boxed = self.type_id(private::Internal);
 
         // Compare both TypeIds on equality
         t == boxed


### PR DESCRIPTION
type_id now takes an argument that can't be named outside of the
std::error module, which prevents any implementations from overriding
it. It's a pretty grody solution, and there's no way we can stabilize
the method with this API, but it avoids the soudness issue!

Closes #60784

r? @alexcrichton 