### PR TITLE
libstd: use block buffering when stdout is not a TTY

### DIFF
--- a/src/libstd/sys/cloudabi/stdio.rs
+++ b/src/libstd/sys/cloudabi/stdio.rs
@@ -23,7 +23,7 @@ impl Stdout {
     }
 
     pub fn is_tty(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/libstd/sys/cloudabi/stdio.rs
+++ b/src/libstd/sys/cloudabi/stdio.rs
@@ -21,6 +21,10 @@ impl Stdout {
     pub fn new() -> io::Result<Stdout> {
         Ok(Stdout(()))
     }
+
+    pub fn is_tty(&self) -> bool {
+        false
+    }
 }
 
 impl io::Write for Stdout {
@@ -60,6 +64,7 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
+pub const STDOUT_BUF_SIZE: usize = 0;
 
 pub fn panic_output() -> Option<impl io::Write> {
     Stderr::new().ok()

--- a/src/libstd/sys/redox/stdio.rs
+++ b/src/libstd/sys/redox/stdio.rs
@@ -21,6 +21,15 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+
+    pub fn is_tty(&self) -> bool {
+        if let Ok(fd) = syscall::dup(1, b"termios") {
+            let _ = syscall::close(fd);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl io::Write for Stdout {
@@ -58,6 +67,7 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
+pub const STDOUT_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
     Stderr::new().ok()

--- a/src/libstd/sys/sgx/stdio.rs
+++ b/src/libstd/sys/sgx/stdio.rs
@@ -33,7 +33,7 @@ impl Stdout {
 
     // FIXME: implement
     pub fn is_tty(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/libstd/sys/sgx/stdio.rs
+++ b/src/libstd/sys/sgx/stdio.rs
@@ -30,6 +30,11 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+
+    // FIXME: implement
+    pub fn is_tty(&self) -> bool {
+        false
+    }
 }
 
 impl io::Write for Stdout {
@@ -57,6 +62,7 @@ impl io::Write for Stderr {
 }
 
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
+pub const STDOUT_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn is_ebadf(err: &io::Error) -> bool {
     // FIXME: Rust normally maps Unix EBADF to `Other`

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -22,6 +22,10 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+
+    pub fn is_tty(&self) -> bool {
+        unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
+    }
 }
 
 impl io::Write for Stdout {
@@ -61,6 +65,7 @@ pub fn is_ebadf(err: &io::Error) -> bool {
 }
 
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
+pub const STDOUT_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
 
 pub fn panic_output() -> Option<impl io::Write> {
     Stderr::new().ok()

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -27,6 +27,11 @@ impl Stdout {
         Ok(Stdout)
     }
 
+    // FIXME: implement?
+    pub fn is_tty(&self) -> bool {
+        false
+    }
+
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {
         self.write_vectored(&[IoSlice::new(data)])
     }
@@ -71,6 +76,7 @@ impl io::Write for Stderr {
 }
 
 pub const STDIN_BUF_SIZE: usize = crate::sys_common::io::DEFAULT_BUF_SIZE;
+pub const STDOUT_BUF_SIZE: usize = 0;
 
 pub fn is_ebadf(err: &io::Error) -> bool {
     err.raw_os_error() == Some(libc::__WASI_EBADF as i32)

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -29,7 +29,7 @@ impl Stdout {
 
     // FIXME: implement?
     pub fn is_tty(&self) -> bool {
-        false
+        true
     }
 
     pub fn write(&self, data: &[u8]) -> io::Result<usize> {

--- a/src/libstd/sys/wasm/stdio.rs
+++ b/src/libstd/sys/wasm/stdio.rs
@@ -23,7 +23,7 @@ impl Stdout {
     }
 
     pub fn is_tty(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/libstd/sys/wasm/stdio.rs
+++ b/src/libstd/sys/wasm/stdio.rs
@@ -21,6 +21,10 @@ impl Stdout {
     pub fn new() -> io::Result<Stdout> {
         Ok(Stdout)
     }
+
+    pub fn is_tty(&self) -> bool {
+        false
+    }
 }
 
 impl io::Write for Stdout {
@@ -52,6 +56,7 @@ impl io::Write for Stderr {
 }
 
 pub const STDIN_BUF_SIZE: usize = 0;
+pub const STDOUT_BUF_SIZE: usize = 0;
 
 pub fn is_ebadf(_err: &io::Error) -> bool {
     true

--- a/src/libstd/sys/windows/c.rs
+++ b/src/libstd/sys/windows/c.rs
@@ -124,7 +124,7 @@ pub struct WIN32_FIND_DATAW {
     pub nFileSizeLow: DWORD,
     pub dwReserved0: DWORD,
     pub dwReserved1: DWORD,
-    pub cFileName: [wchar_t; 260], // #define MAX_PATH 260
+    pub cFileName: [wchar_t; MAX_PATH],
     pub cAlternateFileName: [wchar_t; 14],
 }
 impl Clone for WIN32_FIND_DATAW {
@@ -167,6 +167,8 @@ pub const SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE: DWORD = 0x2;
 pub const STD_INPUT_HANDLE: DWORD = -10i32 as DWORD;
 pub const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
 pub const STD_ERROR_HANDLE: DWORD = -12i32 as DWORD;
+
+pub const MAX_PATH: usize = 260;
 
 pub const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
@@ -422,6 +424,12 @@ pub struct FILE_BASIC_INFO {
 #[repr(C)]
 pub struct FILE_END_OF_FILE_INFO {
     pub EndOfFile: LARGE_INTEGER,
+}
+
+#[repr(C)]
+pub struct FILE_NAME_INFO {
+    pub FileNameLength: DWORD,
+    pub FileName: [WCHAR; 1],
 }
 
 #[repr(C)]
@@ -1047,6 +1055,11 @@ extern "system" {
                               dwFileAttributes: DWORD) -> BOOL;
     pub fn GetFileInformationByHandle(hFile: HANDLE,
                             lpFileInformation: LPBY_HANDLE_FILE_INFORMATION)
+                            -> BOOL;
+    pub fn GetFileInformationByHandleEx(hFile: HANDLE,
+                            FileInformationClass: FILE_INFO_BY_HANDLE_CLASS,
+                            lpFileInformation: LPVOID,
+                            dwBufferSize: DWORD)
                             -> BOOL;
 
     pub fn SetLastError(dwErrCode: DWORD);


### PR DESCRIPTION
This PR is meant to resolve #60673.

At the moment, there are a couple issues.  I am unfamiliar with several of the platforms in `libstd::io::sys`, so I don't actually know if they have methods to determine if `stdout` is a TTY (or some equivalent).

Additionally, the original issue mentioned buffering for `stderr` in addition to `stdout`, which I have *not* implemented at the moment (although doing so is pretty straightforward).  I also have not added methods to manually switch between block buffering and line buffering.  If either of these are desired, let me know and I'll try to add them.

I noticed that `run-pass/command-pre-exec.rs` seems to fail with this change because (AFAICT) the `println!()` in `Command::pre_exec()` doesn't get flushed, so the contents of `stdout` are missing a `hello`.  I haven't modified the test yet because I am unsure if we should just tell users to flush `stdout` (in which case I'll change the test), or if we should special case functions that can exit in `libstd`, or something else.

`run-pass/issues/issue-30490.rs` fails for a similar reason (doesn't flush before `exec`).