### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1294,8 +1294,16 @@ impl<'a, 'gcx, 'tcx> MemCategorizationContext<'a, 'gcx, 'tcx> {
                         }
                     }
                     def => {
-                        span_bug!(pat.span, "tuple struct pattern didn't resolve \
-                                             to variant or struct {:?}", def);
+                        debug!(
+                            "tuple struct pattern didn't resolve to variant or struct {:?} at {:?}",
+                            def,
+                            pat.span,
+                        );
+                        self.tcx.sess.delay_span_bug(pat.span, &format!(
+                            "tuple struct pattern didn't resolve to variant or struct {:?}",
+                            def,
+                        ));
+                        return Err(());
                     }
                 };
 

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -1454,13 +1454,18 @@ fn confirm_param_env_candidate<'cx, 'gcx, 'tcx>(
             }
         }
         Err(e) => {
-            span_bug!(
-                obligation.cause.span,
-                "Failed to unify obligation `{:?}` \
-                 with poly_projection `{:?}`: {:?}",
+            let msg = format!(
+                "Failed to unify obligation `{:?}` with poly_projection `{:?}`: {:?}",
                 obligation,
                 poly_cache_entry,
-                e);
+                e,
+            );
+            debug!("confirm_param_env_candidate: {}", msg);
+            infcx.tcx.sess.delay_span_bug(obligation.cause.span, &msg);
+            Progress {
+                ty: infcx.tcx.types.err,
+                obligations: vec![],
+            }
         }
     }
 }

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -23,7 +23,6 @@ use rustc::middle::cstore::ExternCrate;
 use rustc::session::config::{CrateType, Input, OutputType};
 use rustc::ty::{self, DefIdTree, TyCtxt};
 use rustc::{bug, span_bug};
-use rustc_typeck::hir_ty_to_ty;
 use rustc_codegen_utils::link::{filename_for_metadata, out_filename};
 use rustc_data_structures::sync::Lrc;
 
@@ -658,23 +657,9 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 ..
             }) => HirDef::Local(self.tcx.hir().hir_to_node_id(canonical_id)),
 
-            Node::Ty(ty) => if let hir::Ty {
-                node: hir::TyKind::Path(ref qpath),
-                ..
-            } = *ty
-            {
-                match *qpath {
-                    hir::QPath::Resolved(_, ref path) => path.def,
-                    hir::QPath::TypeRelative(..) => {
-                        let ty = hir_ty_to_ty(self.tcx, ty);
-                        if let ty::Projection(proj) = ty.sty {
-                            return HirDef::AssociatedTy(proj.item_def_id);
-                        }
-                        HirDef::Err
-                    }
-                }
-            } else {
-                HirDef::Err
+            Node::Ty(&hir::Ty { node: hir::TyKind::Path(ref qpath), .. } ) => {
+                let hir_id = self.tcx.hir().node_to_hir_id(id);
+                self.tables.qpath_def(qpath, hir_id)
             },
 
             _ => HirDef::Err,

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -647,6 +647,10 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
             Node::Pat(&hir::Pat {
                 node: hir::PatKind::TupleStruct(ref qpath, ..),
                 ..
+            }) |
+            Node::Ty(&hir::Ty {
+                node: hir::TyKind::Path(ref qpath),
+                ..
             }) => {
                 let hir_id = self.tcx.hir().node_to_hir_id(id);
                 self.tables.qpath_def(qpath, hir_id)
@@ -656,11 +660,6 @@ impl<'l, 'tcx: 'l> SaveContext<'l, 'tcx> {
                 node: hir::PatKind::Binding(_, canonical_id, ..),
                 ..
             }) => HirDef::Local(self.tcx.hir().hir_to_node_id(canonical_id)),
-
-            Node::Ty(&hir::Ty { node: hir::TyKind::Path(ref qpath), .. } ) => {
-                let hir_id = self.tcx.hir().node_to_hir_id(id);
-                self.tables.qpath_def(qpath, hir_id)
-            },
 
             _ => HirDef::Err,
         }

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -379,7 +379,7 @@ pub fn check_crate<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>)
     }
 }
 
-/// A quasi-deprecated helper used in rustdoc and save-analysis to get
+/// A quasi-deprecated helper used in rustdoc and clippy to get
 /// the type from a HIR node.
 pub fn hir_ty_to_ty<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, hir_ty: &hir::Ty) -> Ty<'tcx> {
     // In case there are any projections etc, find the "environment"

--- a/src/test/ui/fn-in-pat.rs
+++ b/src/test/ui/fn-in-pat.rs
@@ -1,0 +1,16 @@
+struct A {}
+
+impl A {
+    fn new() {}
+}
+
+fn hof<F>(_: F) where F: FnMut(()) {}
+
+fn ice() {
+    hof(|c| match c {
+        A::new() => (), //~ ERROR expected tuple struct/variant, found method
+        _ => ()
+    })
+}
+
+fn main() {}

--- a/src/test/ui/fn-in-pat.stderr
+++ b/src/test/ui/fn-in-pat.stderr
@@ -1,0 +1,9 @@
+error[E0164]: expected tuple struct/variant, found method `<A>::new`
+  --> $DIR/fn-in-pat.rs:11:9
+   |
+LL |         A::new() => (),
+   |         ^^^^^^^^ not a tuple variant or struct
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0164`.

--- a/src/test/ui/issues/issue-60283.rs
+++ b/src/test/ui/issues/issue-60283.rs
@@ -1,0 +1,17 @@
+pub trait Trait<'a> {
+    type Item;
+}
+
+impl<'a> Trait<'a> for () {
+    type Item = ();
+}
+
+pub fn foo<T, F>(_: T, _: F)
+where T: for<'a> Trait<'a>,
+      F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
+
+fn main() {
+    foo((), drop)
+    //~^ ERROR type mismatch in function arguments
+    //~| ERROR type mismatch resolving
+}

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -1,0 +1,34 @@
+error[E0631]: type mismatch in function arguments
+  --> $DIR/issue-60283.rs:14:5
+   |
+LL |     foo((), drop)
+   |     ^^^
+   |     |
+   |     expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
+   |     found signature of `fn(_) -> _`
+   |
+note: required by `foo`
+  --> $DIR/issue-60283.rs:9:1
+   |
+LL | / pub fn foo<T, F>(_: T, _: F)
+LL | | where T: for<'a> Trait<'a>,
+LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
+   | |_________________________________________________^
+
+error[E0271]: type mismatch resolving `for<'a> <fn(_) {std::mem::drop::<_>} as std::ops::FnOnce<(<() as Trait<'a>>::Item,)>>::Output == ()`
+  --> $DIR/issue-60283.rs:14:5
+   |
+LL |     foo((), drop)
+   |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime
+   |
+note: required by `foo`
+  --> $DIR/issue-60283.rs:9:1
+   |
+LL | / pub fn foo<T, F>(_: T, _: F)
+LL | | where T: for<'a> Trait<'a>,
+LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
+   | |_________________________________________________^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -31,4 +31,5 @@ LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0271`.
+Some errors occurred: E0271, E0631.
+For more information about an error, try `rustc --explain E0271`.


### PR DESCRIPTION
Rolled up:

*  [beta] save-analysis: Pull associated type definition using `qpath_def` #60881 
*  [beta] Update clippy #60918 

Cherry-picked:

* Instead of ICEing on incorrect pattern, use delay_span_bug #60641 
* Use `delay_span_bug` for "Failed to unify obligation" #60644  

r? @ghost