### PR TITLE
Allow lifetime elision in arbitrary_self_types

### DIFF
--- a/src/test/ui/self/arbitrary_self_types_impl_trait_lifetime.rs
+++ b/src/test/ui/self/arbitrary_self_types_impl_trait_lifetime.rs
@@ -1,0 +1,28 @@
+// compile-fail
+
+#![feature(arbitrary_self_types)]
+
+use std::pin::Pin;
+
+#[derive(Debug)]
+struct Foo;
+#[derive(Debug)]
+struct Bar<'a>(&'a Foo);
+
+impl std::ops::Deref for Bar<'_> {
+    type Target = Foo;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Foo {
+    fn f(self: Bar<'_>) -> impl std::fmt::Debug {
+        self
+        //~^ ERROR cannot infer an appropriate lifetime
+    }
+}
+
+fn main() {
+    { Bar(&Foo).f() };
+}

--- a/src/test/ui/self/arbitrary_self_types_impl_trait_lifetime.stderr
+++ b/src/test/ui/self/arbitrary_self_types_impl_trait_lifetime.stderr
@@ -1,0 +1,23 @@
+error: cannot infer an appropriate lifetime
+  --> $DIR/arbitrary_self_types_impl_trait_lifetime.rs:21:9
+   |
+LL |     fn f(self: Bar<'_>) -> impl std::fmt::Debug {
+   |                            -------------------- this return type evaluates to the `'static` lifetime...
+LL |         self
+   |         ^^^^ ...but this borrow...
+   |
+note: ...can't outlive the anonymous lifetime #1 defined on the method body at 20:5
+  --> $DIR/arbitrary_self_types_impl_trait_lifetime.rs:20:5
+   |
+LL | /     fn f(self: Bar<'_>) -> impl std::fmt::Debug {
+LL | |         self
+LL | |
+LL | |     }
+   | |_____^
+help: you can add a constraint to the return type to make it last less than `'static` and match the anonymous lifetime #1 defined on the method body at 20:5
+   |
+LL |     fn f(self: Bar<'_>) -> impl std::fmt::Debug + '_ {
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/self/arbitrary_self_types_inexact_lifetime.rs
+++ b/src/test/ui/self/arbitrary_self_types_inexact_lifetime.rs
@@ -1,0 +1,27 @@
+#![feature(arbitrary_self_types)]
+
+#[derive(Debug)]
+struct Foo;
+#[derive(Debug)]
+struct Bar<'a>(&'a Foo);
+
+impl std::ops::Deref for Bar<'_> {
+    type Target = Foo;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Foo {
+    fn a(self: &Box<Foo>, f: &Foo) -> &Foo { f } //~ ERROR E0106
+
+    fn b(self: &Box<Foo>, f: &Foo) -> &Box<Foo> { self } //~ ERROR E0106
+
+    fn c(this: &Box<Foo>, f: &Foo) -> &Foo { f } //~ ERROR E0106
+}
+
+impl<'a> Bar<'a> {
+    fn d(self: Self, f: &Foo, g: &Foo) -> (Bar<'a>, &Foo) { (self, f) } //~ ERROR E0106
+}
+
+fn main() {}

--- a/src/test/ui/self/arbitrary_self_types_inexact_lifetime.stderr
+++ b/src/test/ui/self/arbitrary_self_types_inexact_lifetime.stderr
@@ -1,0 +1,35 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_inexact_lifetime.rs:16:39
+   |
+LL |     fn a(self: &Box<Foo>, f: &Foo) -> &Foo { f }
+   |                                       ^ expected lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `self` or `f`
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_inexact_lifetime.rs:18:39
+   |
+LL |     fn b(self: &Box<Foo>, f: &Foo) -> &Box<Foo> { self }
+   |                                       ^ expected lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `self` or `f`
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_inexact_lifetime.rs:20:39
+   |
+LL |     fn c(this: &Box<Foo>, f: &Foo) -> &Foo { f }
+   |                                       ^ expected lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `this` or `f`
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_inexact_lifetime.rs:24:53
+   |
+LL |     fn d(self: Self, f: &Foo, g: &Foo) -> (Bar<'a>, &Foo) { (self, f) }
+   |                                                     ^ expected lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `f` or `g`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/arbitrary_self_types_lifetime.rs
+++ b/src/test/ui/self/arbitrary_self_types_lifetime.rs
@@ -1,0 +1,76 @@
+// compile-pass
+
+#![feature(arbitrary_self_types)]
+
+use std::pin::Pin;
+
+#[derive(Debug)]
+struct Foo;
+#[derive(Debug)]
+struct Bar<'a>(&'a Foo);
+
+impl std::ops::Deref for Bar<'_> {
+    type Target = Foo;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Foo {
+    fn a(&self) -> Bar<'_> {
+        Bar(self)
+    }
+
+    fn b(c: &Self) -> Bar<'_> {
+        Bar(c)
+    }
+
+    fn c(self: Bar<'_>) -> Bar<'_> {
+        self
+    }
+
+    fn d(e: Bar<'_>) -> Bar<'_> {
+        e
+    }
+
+    fn e(self: &Self) -> Bar<'_> {
+        Bar(self)
+    }
+
+    fn f(self: Bar<'_>) -> impl std::fmt::Debug + '_ {
+        self
+    }
+}
+
+impl<'a> Bar<'a> {
+    fn a(self: Bar<'a>, f: &Foo) -> (Bar<'a>, &Foo) { (self, f) }
+    fn b(self: Self, f: &Foo) -> (Bar<'a>, &Foo) { (self, f) }
+    fn d(self: Bar<'a>, f: &Foo) -> (Self, &Foo) { (self, f) }
+}
+
+impl Bar<'_> {
+    fn e(self: Self, f: &Foo) -> (Self, &Foo) { (self, f) }
+}
+
+struct Baz<T: Unpin> {
+    field: T,
+}
+
+impl<T: Unpin> Baz<T> {
+    fn field(self: Pin<&mut Self>) -> Pin<&mut T> {
+        let this = Pin::get_mut(self);
+        Pin::new(&mut this.field)
+    }
+}
+
+fn main() {
+    let foo = Foo;
+    { foo.a() };
+    { Foo::b(&foo) };
+    { Bar(&foo).c() };
+    { Foo::d(Bar(&foo)) };
+    { foo.e() };
+    { Bar(&foo).f() };
+    let mut baz = Baz { field: 0u8 };
+    { Pin::new(&mut baz).field() };
+}


### PR DESCRIPTION
Currently, `self` except `&Self` and `&mut Self` is skipped. By this, other `self`s with lifetime is also ignored. 
This PR changes it to only skip `Self`, `&Self` and `&mut Self`, and to handle other `self`s like normal arguments.

Closes #52675