### PR TITLE
syntax: Continue refactoring literals

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1249,8 +1249,7 @@ impl<'a> State<'a> {
 
     fn print_literal(&mut self, lit: &hir::Lit) -> io::Result<()> {
         self.maybe_print_comment(lit.span.lo())?;
-        let (token, suffix) = lit.node.to_lit_token();
-        self.writer().word(pprust::literal_to_string(token, suffix))
+        self.writer().word(pprust::literal_to_string(lit.node.to_lit_token()))
     }
 
     pub fn print_expr(&mut self, expr: &hir::Expr) -> io::Result<()> {

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -165,7 +165,6 @@ impl_stable_hash_for!(enum ::syntax::ast::LitIntType {
 impl_stable_hash_for!(struct ::syntax::ast::Lit {
     node,
     token,
-    suffix,
     span
 });
 
@@ -288,17 +287,23 @@ for tokenstream::TokenStream {
     }
 }
 
-impl_stable_hash_for!(enum token::Lit {
-    Bool(val),
-    Byte(val),
-    Char(val),
-    Err(val),
-    Integer(val),
-    Float(val),
-    Str_(val),
-    ByteStr(val),
-    StrRaw(val, n),
-    ByteStrRaw(val, n)
+impl_stable_hash_for!(enum token::LitKind {
+    Bool,
+    Byte,
+    Char,
+    Integer,
+    Float,
+    Str,
+    ByteStr,
+    StrRaw(n),
+    ByteStrRaw(n),
+    Err
+});
+
+impl_stable_hash_for!(struct token::Lit {
+    kind,
+    symbol,
+    suffix
 });
 
 fn hash_token<'a, 'gcx, W: StableHasherResult>(
@@ -348,10 +353,7 @@ fn hash_token<'a, 'gcx, W: StableHasherResult>(
         token::Token::CloseDelim(delim_token) => {
             std_hash::Hash::hash(&delim_token, hasher);
         }
-        token::Token::Literal(lit, opt_name) => {
-            lit.hash_stable(hcx, hasher);
-            opt_name.hash_stable(hcx, hasher);
-        }
+        token::Token::Literal(lit) => lit.hash_stable(hcx, hasher),
 
         token::Token::Ident(ident, is_raw) => {
             ident.name.hash_stable(hcx, hasher);

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -310,17 +310,17 @@ impl<'a> Classifier<'a> {
                 }
             }
 
-            token::Literal(lit, _suf) => {
-                match lit {
+            token::Literal(lit) => {
+                match lit.kind {
                     // Text literals.
-                    token::Byte(..) | token::Char(..) | token::Err(..) |
-                        token::ByteStr(..) | token::ByteStrRaw(..) |
-                        token::Str_(..) | token::StrRaw(..) => Class::String,
+                    token::Byte | token::Char | token::Err |
+                    token::ByteStr | token::ByteStrRaw(..) |
+                    token::Str | token::StrRaw(..) => Class::String,
 
                     // Number literals.
-                    token::Integer(..) | token::Float(..) => Class::Number,
+                    token::Integer | token::Float => Class::Number,
 
-                    token::Bool(..) => panic!("literal token contains `Lit::Bool`"),
+                    token::Bool => panic!("literal token contains `Lit::Bool`"),
                 }
             }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1347,8 +1347,6 @@ pub enum StrStyle {
 pub struct Lit {
     /// The original literal token as written in source code.
     pub token: token::Lit,
-    /// The original literal suffix as written in source code.
-    pub suffix: Option<Symbol>,
     /// The "semantic" representation of the literal lowered from the original tokens.
     /// Strings are unescaped, hexadecimal forms are eliminated, etc.
     /// FIXME: Remove this and only create the semantic representation during lowering to HIR.

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -554,7 +554,7 @@ impl MetaItemKind {
             Some(TokenTree::Token(_, token::Eq)) => {
                 tokens.next();
                 return if let Some(TokenTree::Token(span, token)) = tokens.next() {
-                    Lit::from_token(&token, span, None).map(MetaItemKind::NameValue)
+                    Lit::from_token(&token, span).ok().map(MetaItemKind::NameValue)
                 } else {
                     None
                 };
@@ -599,7 +599,7 @@ impl NestedMetaItem {
         where I: Iterator<Item = TokenTree>,
     {
         if let Some(TokenTree::Token(span, token)) = tokens.peek().cloned() {
-            if let Some(lit) = Lit::from_token(&token, span, None) {
+            if let Ok(lit) = Lit::from_token(&token, span) {
                 tokens.next();
                 return Some(NestedMetaItem::Literal(lit));
             }

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -77,8 +77,8 @@ pub fn expand_register_diagnostic<'cx>(ecx: &'cx mut ExtCtxt<'_>,
         },
         (3, Some(&TokenTree::Token(_, token::Ident(ref code, _))),
             Some(&TokenTree::Token(_, token::Comma)),
-            Some(&TokenTree::Token(_, token::Literal(token::StrRaw(description, _), None)))) => {
-            (code, Some(description))
+            Some(&TokenTree::Token(_, token::Literal(token::Lit { symbol, .. })))) => {
+            (code, Some(symbol))
         }
         _ => unreachable!()
     };

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -42,7 +42,7 @@ impl LitError {
                         .help("valid widths are 8, 16, 32, 64 and 128")
                         .emit();
                 } else {
-                    let msg = format!("invalid suffix `{}` for numeric literal", suf);
+                    let msg = format!("invalid suffix `{}` for integer literal", suf);
                     diag.struct_span_err(span, &msg)
                         .span_label(span, format!("invalid suffix `{}`", suf))
                         .help("the suffix must be one of the integral types (`u32`, `isize`, etc)")
@@ -71,7 +71,7 @@ impl LitError {
                     .emit();
             }
             LitError::IntTooLarge => {
-                diag.struct_span_err(span, "int literal is too large")
+                diag.struct_span_err(span, "integer literal is too large")
                     .emit();
             }
         }

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -3,7 +3,7 @@
 use crate::ast::{self, Ident, Lit, LitKind};
 use crate::parse::parser::Parser;
 use crate::parse::PResult;
-use crate::parse::token::{self, Token};
+use crate::parse::token;
 use crate::parse::unescape::{unescape_str, unescape_char, unescape_byte_str, unescape_byte};
 use crate::print::pprust;
 use crate::symbol::{kw, Symbol};
@@ -117,9 +117,9 @@ impl LitKind {
 
             token::Str_(mut sym) => {
                 // If there are no characters requiring special treatment we can
-                // reuse the symbol from the Token. Otherwise, we must generate a
+                // reuse the symbol from the token. Otherwise, we must generate a
                 // new symbol because the string in the LitKind is different to the
-                // string in the Token.
+                // string in the token.
                 let mut error = None;
                 let s = &sym.as_str();
                 if s.as_bytes().iter().any(|&c| c == b'\\' || c == b'\r') {
@@ -262,8 +262,8 @@ impl Lit {
     /// Losslessly convert an AST literal into a token stream.
     crate fn tokens(&self) -> TokenStream {
         let token = match self.token {
-            token::Bool(symbol) => Token::Ident(Ident::with_empty_ctxt(symbol), false),
-            token => Token::Literal(token, self.suffix),
+            token::Bool(symbol) => token::Ident(Ident::new(symbol, self.span), false),
+            token => token::Literal(token, self.suffix),
         };
         TokenTree::Token(self.span, token).into()
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1054,7 +1054,7 @@ impl<'a> Parser<'a> {
     }
 
     fn expect_no_suffix(&self, sp: Span, kind: &str, suffix: Option<ast::Name>) {
-        literal::expect_no_suffix(sp, &self.sess.span_diagnostic, kind, suffix)
+        literal::expect_no_suffix(&self.sess.span_diagnostic, sp, kind, suffix)
     }
 
     /// Attempts to consume a `<`. If `<<` is seen, replaces it with a single

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -352,10 +352,12 @@ impl TokenCursor {
         let body = TokenTree::Delimited(
             delim_span,
             token::Bracket,
-            [TokenTree::Token(sp, token::Ident(ast::Ident::with_empty_ctxt(sym::doc), false)),
-             TokenTree::Token(sp, token::Eq),
-             TokenTree::Token(sp, token::Literal(
-                token::StrRaw(Symbol::intern(&stripped), num_of_hashes), None))
+            [
+                TokenTree::Token(sp, token::Ident(ast::Ident::with_empty_ctxt(sym::doc), false)),
+                TokenTree::Token(sp, token::Eq),
+                TokenTree::Token(sp, token::Token::lit(
+                    token::StrRaw(num_of_hashes), Symbol::intern(&stripped), None
+                )),
             ]
             .iter().cloned().collect::<TokenStream>().into(),
         );
@@ -2241,10 +2243,10 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_field_name(&mut self) -> PResult<'a, Ident> {
-        if let token::Literal(token::Integer(name), suffix) = self.token {
+        if let token::Literal(token::Lit { kind: token::Integer, symbol, suffix }) = self.token {
             self.expect_no_suffix(self.span, "a tuple index", suffix);
             self.bump();
-            Ok(Ident::new(name, self.prev_span))
+            Ok(Ident::new(symbol, self.prev_span))
         } else {
             self.parse_ident_common(false)
         }
@@ -3045,19 +3047,19 @@ impl<'a> Parser<'a> {
                     token::Ident(..) => {
                         e = self.parse_dot_suffix(e, lo)?;
                     }
-                    token::Literal(token::Integer(name), suffix) => {
+                    token::Literal(token::Lit { kind: token::Integer, symbol, suffix }) => {
                         let span = self.span;
                         self.bump();
-                        let field = ExprKind::Field(e, Ident::new(name, span));
+                        let field = ExprKind::Field(e, Ident::new(symbol, span));
                         e = self.mk_expr(lo.to(span), field, ThinVec::new());
 
                         self.expect_no_suffix(span, "a tuple index", suffix);
                     }
-                    token::Literal(token::Float(n), _suf) => {
+                    token::Literal(token::Lit { kind: token::Float, symbol, .. }) => {
                       self.bump();
-                      let fstr = n.as_str();
-                      let mut err = self.diagnostic()
-                          .struct_span_err(self.prev_span, &format!("unexpected token: `{}`", n));
+                      let fstr = symbol.as_str();
+                      let msg = format!("unexpected token: `{}`", symbol);
+                      let mut err = self.diagnostic().struct_span_err(self.prev_span, &msg);
                       err.span_label(self.prev_span, "unexpected token");
                       if fstr.chars().all(|x| "0123456789.".contains(x)) {
                           let float = match fstr.parse::<f64>().ok() {
@@ -7557,11 +7559,12 @@ impl<'a> Parser<'a> {
     /// the `extern` keyword, if one is found.
     fn parse_opt_abi(&mut self) -> PResult<'a, Option<Abi>> {
         match self.token {
-            token::Literal(token::Str_(s), suf) | token::Literal(token::StrRaw(s, _), suf) => {
+            token::Literal(token::Lit { kind: token::Str, symbol, suffix }) |
+            token::Literal(token::Lit { kind: token::StrRaw(..), symbol, suffix }) => {
                 let sp = self.span;
-                self.expect_no_suffix(sp, "an ABI spec", suf);
+                self.expect_no_suffix(sp, "an ABI spec", suffix);
                 self.bump();
-                match abi::lookup(&s.as_str()) {
+                match abi::lookup(&symbol.as_str()) {
                     Some(abi) => Ok(Some(abi)),
                     None => {
                         let prev_span = self.prev_span;
@@ -7570,7 +7573,7 @@ impl<'a> Parser<'a> {
                             prev_span,
                             E0703,
                             "invalid ABI: found `{}`",
-                            s);
+                            symbol);
                         err.span_label(prev_span, "invalid ABI");
                         err.help(&format!("valid ABIs: {}", abi::all_names().join(", ")));
                         err.emit();
@@ -8370,8 +8373,10 @@ impl<'a> Parser<'a> {
 
     pub fn parse_optional_str(&mut self) -> Option<(Symbol, ast::StrStyle, Option<ast::Name>)> {
         let ret = match self.token {
-            token::Literal(token::Str_(s), suf) => (s, ast::StrStyle::Cooked, suf),
-            token::Literal(token::StrRaw(s, n), suf) => (s, ast::StrStyle::Raw(n), suf),
+            token::Literal(token::Lit { kind: token::Str, symbol, suffix }) =>
+                (symbol, ast::StrStyle::Cooked, suffix),
+            token::Literal(token::Lit { kind: token::StrRaw(n), symbol, suffix }) =>
+                (symbol, ast::StrStyle::Raw(n), suffix),
             _ => return None
         };
         self.bump();

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -73,6 +73,7 @@ pub enum LitKind {
     Err,
 }
 
+/// A literal token.
 #[derive(Clone, Copy, PartialEq, RustcEncodable, RustcDecodable, Debug)]
 pub struct Lit {
     pub kind: LitKind,
@@ -81,6 +82,7 @@ pub struct Lit {
 }
 
 impl LitKind {
+    /// An English article for the literal token kind.
     crate fn article(self) -> &'static str {
         match self {
             Integer | Err => "an",
@@ -91,13 +93,13 @@ impl LitKind {
     crate fn descr(self) -> &'static str {
         match self {
             Bool => panic!("literal token contains `Lit::Bool`"),
-            Byte => "byte literal",
-            Char => "char literal",
-            Integer => "integer literal",
-            Float => "float literal",
-            Str | StrRaw(..) => "string literal",
-            ByteStr | ByteStrRaw(..) => "byte string literal",
-            Err => "invalid literal",
+            Byte => "byte",
+            Char => "char",
+            Integer => "integer",
+            Float => "float",
+            Str | StrRaw(..) => "string",
+            ByteStr | ByteStrRaw(..) => "byte string",
+            Err => "error",
         }
     }
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -1,7 +1,7 @@
 pub use BinOpToken::*;
 pub use Nonterminal::*;
 pub use DelimToken::*;
-pub use Lit::*;
+pub use LitKind::*;
 pub use Token::*;
 
 use crate::ast::{self};
@@ -59,56 +59,59 @@ impl DelimToken {
     }
 }
 
-#[derive(Clone, PartialEq, RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
-pub enum Lit {
-    Bool(ast::Name), // AST only, must never appear in a `Token`
-    Byte(ast::Name),
-    Char(ast::Name),
-    Err(ast::Name),
-    Integer(ast::Name),
-    Float(ast::Name),
-    Str_(ast::Name),
-    StrRaw(ast::Name, u16), /* raw str delimited by n hash symbols */
-    ByteStr(ast::Name),
-    ByteStrRaw(ast::Name, u16), /* raw byte str delimited by n hash symbols */
+#[derive(Clone, Copy, PartialEq, RustcEncodable, RustcDecodable, Debug)]
+pub enum LitKind {
+    Bool, // AST only, must never appear in a `Token`
+    Byte,
+    Char,
+    Integer,
+    Float,
+    Str,
+    StrRaw(u16), // raw string delimited by `n` hash symbols
+    ByteStr,
+    ByteStrRaw(u16), // raw byte string delimited by `n` hash symbols
+    Err,
 }
 
-#[cfg(target_arch = "x86_64")]
-static_assert_size!(Lit, 8);
+#[derive(Clone, Copy, PartialEq, RustcEncodable, RustcDecodable, Debug)]
+pub struct Lit {
+    pub kind: LitKind,
+    pub symbol: Symbol,
+    pub suffix: Option<Symbol>,
+}
 
-impl Lit {
-    crate fn symbol(&self) -> Symbol {
-        match *self {
-            Bool(s) | Byte(s) | Char(s) | Integer(s) | Float(s) | Err(s) |
-            Str_(s) | StrRaw(s, _) | ByteStr(s) | ByteStrRaw(s, _) => s
-        }
-    }
-
-    crate fn article(&self) -> &'static str {
-        match *self {
-            Integer(_) | Err(_) => "an",
+impl LitKind {
+    crate fn article(self) -> &'static str {
+        match self {
+            Integer | Err => "an",
             _ => "a",
         }
     }
 
-    crate fn descr(&self) -> &'static str {
-        match *self {
-            Bool(_) => panic!("literal token contains `Lit::Bool`"),
-            Byte(_) => "byte literal",
-            Char(_) => "char literal",
-            Err(_) => "invalid literal",
-            Integer(_) => "integer literal",
-            Float(_) => "float literal",
-            Str_(_) | StrRaw(..) => "string literal",
-            ByteStr(_) | ByteStrRaw(..) => "byte string literal"
+    crate fn descr(self) -> &'static str {
+        match self {
+            Bool => panic!("literal token contains `Lit::Bool`"),
+            Byte => "byte literal",
+            Char => "char literal",
+            Integer => "integer literal",
+            Float => "float literal",
+            Str | StrRaw(..) => "string literal",
+            ByteStr | ByteStrRaw(..) => "byte string literal",
+            Err => "invalid literal",
         }
     }
 
-    crate fn may_have_suffix(&self) -> bool {
-        match *self {
-            Integer(..) | Float(..) | Err(..) => true,
+    crate fn may_have_suffix(self) -> bool {
+        match self {
+            Integer | Float | Err => true,
             _ => false,
         }
+    }
+}
+
+impl Lit {
+    pub fn new(kind: LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Lit {
+        Lit { kind, symbol, suffix }
     }
 }
 
@@ -201,7 +204,7 @@ pub enum Token {
     CloseDelim(DelimToken),
 
     /* Literals */
-    Literal(Lit, Option<ast::Name>),
+    Literal(Lit),
 
     /* Name components */
     Ident(ast::Ident, /* is_raw */ bool),
@@ -318,6 +321,10 @@ impl Token {
         self == &Question || self == &OpenDelim(Paren)
     }
 
+    pub fn lit(kind: LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Token {
+        Literal(Lit::new(kind, symbol, suffix))
+    }
+
     /// Returns `true` if the token is any literal
     crate fn is_lit(&self) -> bool {
         match *self {
@@ -326,9 +333,9 @@ impl Token {
         }
     }
 
-    crate fn expect_lit(&self) -> (Lit, Option<Symbol>) {
+    crate fn expect_lit(&self) -> Lit {
         match *self {
-            Literal(lit, suf) => (lit, suf),
+            Literal(lit) => lit,
             _=> panic!("`expect_lit` called on non-literal"),
         }
     }
@@ -579,12 +586,12 @@ impl Token {
             (&DocComment(a), &DocComment(b)) |
             (&Shebang(a), &Shebang(b)) => a == b,
 
+            (&Literal(a), &Literal(b)) => a == b,
+
             (&Lifetime(a), &Lifetime(b)) => a.name == b.name,
             (&Ident(a, b), &Ident(c, d)) => b == d && (a.name == c.name ||
                                                        a.name == kw::DollarCrate ||
                                                        c.name == kw::DollarCrate),
-
-            (&Literal(a, b), &Literal(c, d)) => b == d && a == c,
 
             (&Interpolated(_), &Interpolated(_)) => false,
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -110,12 +110,6 @@ impl Lit {
             _ => false,
         }
     }
-
-    // See comments in `Nonterminal::to_tokenstream` for why we care about
-    // *probably* equal here rather than actual equality
-    fn probably_equal_for_proc_macro(&self, other: &Lit) -> bool {
-        mem::discriminant(self) == mem::discriminant(other)
-    }
 }
 
 pub(crate) fn ident_can_begin_expr(ident: ast::Ident, is_raw: bool) -> bool {
@@ -590,9 +584,7 @@ impl Token {
                                                        a.name == kw::DollarCrate ||
                                                        c.name == kw::DollarCrate),
 
-            (&Literal(ref a, b), &Literal(ref c, d)) => {
-                b == d && a.probably_equal_for_proc_macro(c)
-            }
+            (&Literal(a, b), &Literal(c, d)) => b == d && a == c,
 
             (&Interpolated(_), &Interpolated(_)) => false,
 

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -77,7 +77,21 @@ pub enum Lit {
 static_assert_size!(Lit, 8);
 
 impl Lit {
-    crate fn literal_name(&self) -> &'static str {
+    crate fn symbol(&self) -> Symbol {
+        match *self {
+            Bool(s) | Byte(s) | Char(s) | Integer(s) | Float(s) | Err(s) |
+            Str_(s) | StrRaw(s, _) | ByteStr(s) | ByteStrRaw(s, _) => s
+        }
+    }
+
+    crate fn article(&self) -> &'static str {
+        match *self {
+            Integer(_) | Err(_) => "an",
+            _ => "a",
+        }
+    }
+
+    crate fn descr(&self) -> &'static str {
         match *self {
             Bool(_) => panic!("literal token contains `Lit::Bool`"),
             Byte(_) => "byte literal",
@@ -92,7 +106,7 @@ impl Lit {
 
     crate fn may_have_suffix(&self) -> bool {
         match *self {
-            Integer(..) | Float(..) => true,
+            Integer(..) | Float(..) | Err(..) => true,
             _ => false,
         }
     }
@@ -315,6 +329,13 @@ impl Token {
         match *self {
             Literal(..) => true,
             _           => false,
+        }
+    }
+
+    crate fn expect_lit(&self) -> (Lit, Option<Symbol>) {
+        match *self {
+            Literal(lit, suf) => (lit, suf),
+            _=> panic!("`expect_lit` called on non-literal"),
         }
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -163,22 +163,22 @@ fn binop_to_string(op: BinOpToken) -> &'static str {
     }
 }
 
-pub fn literal_to_string(lit: token::Lit, suffix: Option<ast::Name>) -> String {
-    let mut out = match lit {
-        token::Byte(b)           => format!("b'{}'", b),
-        token::Char(c)           => format!("'{}'", c),
-        token::Err(c)            => format!("'{}'", c),
-        token::Bool(c)           |
-        token::Float(c)          |
-        token::Integer(c)        => c.to_string(),
-        token::Str_(s)           => format!("\"{}\"", s),
-        token::StrRaw(s, n)      => format!("r{delim}\"{string}\"{delim}",
-                                            delim="#".repeat(n as usize),
-                                            string=s),
-        token::ByteStr(v)        => format!("b\"{}\"", v),
-        token::ByteStrRaw(s, n)  => format!("br{delim}\"{string}\"{delim}",
-                                            delim="#".repeat(n as usize),
-                                            string=s),
+pub fn literal_to_string(token::Lit { kind, symbol, suffix }: token::Lit) -> String {
+    let mut out = match kind {
+        token::Byte          => format!("b'{}'", symbol),
+        token::Char          => format!("'{}'", symbol),
+        token::Bool          |
+        token::Float         |
+        token::Integer       => symbol.to_string(),
+        token::Str           => format!("\"{}\"", symbol),
+        token::StrRaw(n)     => format!("r{delim}\"{string}\"{delim}",
+                                        delim="#".repeat(n as usize),
+                                        string=symbol),
+        token::ByteStr       => format!("b\"{}\"", symbol),
+        token::ByteStrRaw(n) => format!("br{delim}\"{string}\"{delim}",
+                                        delim="#".repeat(n as usize),
+                                        string=symbol),
+        token::Err           => format!("'{}'", symbol),
     };
 
     if let Some(suffix) = suffix {
@@ -231,7 +231,7 @@ pub fn token_to_string(tok: &Token) -> String {
         token::SingleQuote          => "'".to_string(),
 
         /* Literals */
-        token::Literal(lit, suf) => literal_to_string(lit, suf),
+        token::Literal(lit) => literal_to_string(lit),
 
         /* Name components */
         token::Ident(s, false)      => s.to_string(),
@@ -571,7 +571,7 @@ pub trait PrintState<'a> {
 
     fn print_literal(&mut self, lit: &ast::Lit) -> io::Result<()> {
         self.maybe_print_comment(lit.span.lo())?;
-        self.writer().word(literal_to_string(lit.token, lit.suffix))
+        self.writer().word(literal_to_string(lit.token))
     }
 
     fn print_string(&mut self, st: &str,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -163,7 +163,8 @@ fn binop_to_string(op: BinOpToken) -> &'static str {
     }
 }
 
-pub fn literal_to_string(token::Lit { kind, symbol, suffix }: token::Lit) -> String {
+pub fn literal_to_string(lit: token::Lit) -> String {
+    let token::Lit { kind, symbol, suffix } = lit;
     let mut out = match kind {
         token::Byte          => format!("b'{}'", symbol),
         token::Char          => format!("'{}'", symbol),

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -4,7 +4,7 @@ use syntax::ast::{self, *};
 use syntax::source_map::Spanned;
 use syntax::ext::base::*;
 use syntax::ext::build::AstBuilder;
-use syntax::parse::token;
+use syntax::parse::token::{self, Token};
 use syntax::parse::parser::Parser;
 use syntax::print::pprust;
 use syntax::ptr::P;
@@ -31,13 +31,10 @@ pub fn expand_assert<'cx>(
         tts: custom_message.unwrap_or_else(|| {
             TokenStream::from(TokenTree::Token(
                 DUMMY_SP,
-                token::Literal(
-                    token::Lit::Str_(Name::intern(&format!(
-                        "assertion failed: {}",
-                        pprust::expr_to_string(&cond_expr).escape_debug()
-                    ))),
-                    None,
-                ),
+                Token::lit(token::Str, Symbol::intern(&format!(
+                    "assertion failed: {}",
+                    pprust::expr_to_string(&cond_expr).escape_debug()
+                )), None),
             ))
         }).into(),
         delim: MacDelimiter::Parenthesis,
@@ -106,7 +103,7 @@ fn parse_assert<'a>(
     //
     // Parse this as an actual message, and suggest inserting a comma. Eventually, this should be
     // turned into an error.
-    let custom_message = if let token::Literal(token::Lit::Str_(_), _) = parser.token {
+    let custom_message = if let token::Literal(token::Lit { kind: token::Str, .. }) = parser.token {
         let mut err = cx.struct_span_warn(parser.span, "unexpected string literal");
         let comma_span = cx.source_map().next_point(parser.prev_span);
         err.span_suggestion_short(

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -150,7 +150,7 @@ impl FromInternal<(TreeAndJoint, &'_ ParseSess, &'_ mut Vec<Self>)>
                 stack.push(tt!(Ident::new(ident.name, false)));
                 tt!(Punct::new('\'', true))
             }
-            Literal(lit, suffix) => tt!(Literal { lit, suffix }),
+            Literal(lit) => tt!(Literal { lit }),
             DocComment(c) => {
                 let style = comments::doc_comment_style(&c.as_str());
                 let stripped = comments::strip_doc_comment_decoration(&c.as_str());
@@ -161,7 +161,7 @@ impl FromInternal<(TreeAndJoint, &'_ ParseSess, &'_ mut Vec<Self>)>
                 let stream = vec![
                     Ident(ast::Ident::new(Symbol::intern("doc"), span), false),
                     Eq,
-                    Literal(Lit::Str_(Symbol::intern(&escaped)), None),
+                    Token::lit(token::Str, Symbol::intern(&escaped), None),
                 ]
                 .into_iter()
                 .map(|token| tokenstream::TokenTree::Token(span, token))
@@ -215,31 +215,29 @@ impl ToInternal<TokenStream> for TokenTree<Group, Punct, Ident, Literal> {
                 return tokenstream::TokenTree::Token(span, token).into();
             }
             TokenTree::Literal(self::Literal {
-                lit: Lit::Integer(ref a),
-                suffix,
+                lit: token::Lit { kind: token::Integer, symbol, suffix },
                 span,
-            }) if a.as_str().starts_with("-") => {
+            }) if symbol.as_str().starts_with("-") => {
                 let minus = BinOp(BinOpToken::Minus);
-                let integer = Symbol::intern(&a.as_str()[1..]);
-                let integer = Literal(Lit::Integer(integer), suffix);
+                let symbol = Symbol::intern(&symbol.as_str()[1..]);
+                let integer = Token::lit(token::Integer, symbol, suffix);
                 let a = tokenstream::TokenTree::Token(span, minus);
                 let b = tokenstream::TokenTree::Token(span, integer);
                 return vec![a, b].into_iter().collect();
             }
             TokenTree::Literal(self::Literal {
-                lit: Lit::Float(ref a),
-                suffix,
+                lit: token::Lit { kind: token::Float, symbol, suffix },
                 span,
-            }) if a.as_str().starts_with("-") => {
+            }) if symbol.as_str().starts_with("-") => {
                 let minus = BinOp(BinOpToken::Minus);
-                let float = Symbol::intern(&a.as_str()[1..]);
-                let float = Literal(Lit::Float(float), suffix);
+                let symbol = Symbol::intern(&symbol.as_str()[1..]);
+                let float = Token::lit(token::Float, symbol, suffix);
                 let a = tokenstream::TokenTree::Token(span, minus);
                 let b = tokenstream::TokenTree::Token(span, float);
                 return vec![a, b].into_iter().collect();
             }
-            TokenTree::Literal(self::Literal { lit, suffix, span }) => {
-                return tokenstream::TokenTree::Token(span, Literal(lit, suffix)).into()
+            TokenTree::Literal(self::Literal { lit, span }) => {
+                return tokenstream::TokenTree::Token(span, Literal(lit)).into()
             }
         };
 
@@ -355,7 +353,6 @@ impl Ident {
 #[derive(Clone, Debug)]
 pub struct Literal {
     lit: token::Lit,
-    suffix: Option<Symbol>,
     span: Span,
 }
 
@@ -379,6 +376,13 @@ impl<'a> Rustc<'a> {
             sess: cx.parse_sess,
             def_site: to_span(Transparency::Opaque),
             call_site: to_span(Transparency::Transparent),
+        }
+    }
+
+    pub fn lit(&mut self, kind: token::LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Literal {
+        Literal {
+            lit: token::Lit::new(kind, symbol, suffix),
+            span: server::Span::call_site(self),
         }
     }
 }
@@ -536,59 +540,31 @@ impl server::Literal for Rustc<'_> {
         format!("{:?}", literal)
     }
     fn integer(&mut self, n: &str) -> Self::Literal {
-        Literal {
-            lit: token::Lit::Integer(Symbol::intern(n)),
-            suffix: None,
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Integer, Symbol::intern(n), None)
     }
     fn typed_integer(&mut self, n: &str, kind: &str) -> Self::Literal {
-        Literal {
-            lit: token::Lit::Integer(Symbol::intern(n)),
-            suffix: Some(Symbol::intern(kind)),
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Integer, Symbol::intern(n), Some(Symbol::intern(kind)))
     }
     fn float(&mut self, n: &str) -> Self::Literal {
-        Literal {
-            lit: token::Lit::Float(Symbol::intern(n)),
-            suffix: None,
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Float, Symbol::intern(n), None)
     }
     fn f32(&mut self, n: &str) -> Self::Literal {
-        Literal {
-            lit: token::Lit::Float(Symbol::intern(n)),
-            suffix: Some(Symbol::intern("f32")),
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Float, Symbol::intern(n), Some(Symbol::intern("f32")))
     }
     fn f64(&mut self, n: &str) -> Self::Literal {
-        Literal {
-            lit: token::Lit::Float(Symbol::intern(n)),
-            suffix: Some(Symbol::intern("f64")),
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Float, Symbol::intern(n), Some(Symbol::intern("f64")))
     }
     fn string(&mut self, string: &str) -> Self::Literal {
         let mut escaped = String::new();
         for ch in string.chars() {
             escaped.extend(ch.escape_debug());
         }
-        Literal {
-            lit: token::Lit::Str_(Symbol::intern(&escaped)),
-            suffix: None,
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Str, Symbol::intern(&escaped), None)
     }
     fn character(&mut self, ch: char) -> Self::Literal {
         let mut escaped = String::new();
         escaped.extend(ch.escape_unicode());
-        Literal {
-            lit: token::Lit::Char(Symbol::intern(&escaped)),
-            suffix: None,
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::Char, Symbol::intern(&escaped), None)
     }
     fn byte_string(&mut self, bytes: &[u8]) -> Self::Literal {
         let string = bytes
@@ -597,11 +573,7 @@ impl server::Literal for Rustc<'_> {
             .flat_map(ascii::escape_default)
             .map(Into::<char>::into)
             .collect::<String>();
-        Literal {
-            lit: token::Lit::ByteStr(Symbol::intern(&string)),
-            suffix: None,
-            span: server::Span::call_site(self),
-        }
+        self.lit(token::ByteStr, Symbol::intern(&string), None)
     }
     fn span(&mut self, literal: &Self::Literal) -> Self::Span {
         literal.span

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -379,7 +379,7 @@ impl<'a> Rustc<'a> {
         }
     }
 
-    pub fn lit(&mut self, kind: token::LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Literal {
+    fn lit(&mut self, kind: token::LitKind, symbol: Symbol, suffix: Option<Symbol>) -> Literal {
         Literal {
             lit: token::Lit::new(kind, symbol, suffix),
             span: server::Span::call_site(self),

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -246,6 +246,8 @@ symbols! {
         extern_prelude,
         extern_types,
         f16c_target_feature,
+        f32,
+        f64,
         feature,
         ffi_returns_twice,
         field_init_shorthand,

--- a/src/test/ui/old-suffixes-are-really-forbidden.stderr
+++ b/src/test/ui/old-suffixes-are-really-forbidden.stderr
@@ -1,4 +1,4 @@
-error: invalid suffix `is` for numeric literal
+error: invalid suffix `is` for integer literal
   --> $DIR/old-suffixes-are-really-forbidden.rs:2:13
    |
 LL |     let a = 1_is;
@@ -6,7 +6,7 @@ LL |     let a = 1_is;
    |
    = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
 
-error: invalid suffix `us` for numeric literal
+error: invalid suffix `us` for integer literal
   --> $DIR/old-suffixes-are-really-forbidden.rs:3:13
    |
 LL |     let b = 2_us;

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -22,8 +22,8 @@ fn main() {
     1234f1024; //~ ERROR invalid width `1024` for float literal
     1234.5f1024; //~ ERROR invalid width `1024` for float literal
 
-    1234suffix; //~ ERROR invalid suffix `suffix` for numeric literal
-    0b101suffix; //~ ERROR invalid suffix `suffix` for numeric literal
+    1234suffix; //~ ERROR invalid suffix `suffix` for integer literal
+    0b101suffix; //~ ERROR invalid suffix `suffix` for integer literal
     1.0suffix; //~ ERROR invalid suffix `suffix` for float literal
     1.0e10suffix; //~ ERROR invalid suffix `suffix` for float literal
 }

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -78,7 +78,7 @@ LL |     1234.5f1024;
    |
    = help: valid widths are 32 and 64
 
-error: invalid suffix `suffix` for numeric literal
+error: invalid suffix `suffix` for integer literal
   --> $DIR/bad-lit-suffixes.rs:25:5
    |
 LL |     1234suffix;
@@ -86,7 +86,7 @@ LL |     1234suffix;
    |
    = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
 
-error: invalid suffix `suffix` for numeric literal
+error: invalid suffix `suffix` for integer literal
   --> $DIR/bad-lit-suffixes.rs:26:5
    |
 LL |     0b101suffix;

--- a/src/test/ui/parser/int-literal-too-large-span.rs
+++ b/src/test/ui/parser/int-literal-too-large-span.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999
-    //~^ ERROR int literal is too large
+    //~^ ERROR integer literal is too large
         ; // the span shouldn't point to this.
 }

--- a/src/test/ui/parser/int-literal-too-large-span.stderr
+++ b/src/test/ui/parser/int-literal-too-large-span.stderr
@@ -1,4 +1,4 @@
-error: int literal is too large
+error: integer literal is too large
   --> $DIR/int-literal-too-large-span.rs:4:5
    |
 LL |     9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999

--- a/src/test/ui/parser/issue-5544-a.rs
+++ b/src/test/ui/parser/issue-5544-a.rs
@@ -1,4 +1,4 @@
 fn main() {
     let __isize = 340282366920938463463374607431768211456; // 2^128
-    //~^ ERROR int literal is too large
+    //~^ ERROR integer literal is too large
 }

--- a/src/test/ui/parser/issue-5544-a.stderr
+++ b/src/test/ui/parser/issue-5544-a.stderr
@@ -1,4 +1,4 @@
-error: int literal is too large
+error: integer literal is too large
   --> $DIR/issue-5544-a.rs:2:19
    |
 LL |     let __isize = 340282366920938463463374607431768211456; // 2^128

--- a/src/test/ui/parser/issue-5544-b.rs
+++ b/src/test/ui/parser/issue-5544-b.rs
@@ -1,4 +1,4 @@
 fn main() {
     let __isize = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ff;
-    //~^ ERROR int literal is too large
+    //~^ ERROR integer literal is too large
 }

--- a/src/test/ui/parser/issue-5544-b.stderr
+++ b/src/test/ui/parser/issue-5544-b.stderr
@@ -1,4 +1,4 @@
-error: int literal is too large
+error: integer literal is too large
   --> $DIR/issue-5544-b.rs:2:19
    |
 LL |     let __isize = 0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ff;

--- a/src/test/ui/parser/lex-bad-numeric-literals.rs
+++ b/src/test/ui/parser/lex-bad-numeric-literals.rs
@@ -13,8 +13,8 @@ fn main() {
     0o; //~ ERROR: no valid digits
     1e+; //~ ERROR: expected at least one digit in exponent
     0x539.0; //~ ERROR: hexadecimal float literal is not supported
-    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: int literal is too large
-    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: int literal is too large
+    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: integer literal is too large
+    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: integer literal is too large
     0x; //~ ERROR: no valid digits
     0xu32; //~ ERROR: no valid digits
     0ou32; //~ ERROR: no valid digits

--- a/src/test/ui/parser/lex-bad-numeric-literals.rs
+++ b/src/test/ui/parser/lex-bad-numeric-literals.rs
@@ -13,8 +13,10 @@ fn main() {
     0o; //~ ERROR: no valid digits
     1e+; //~ ERROR: expected at least one digit in exponent
     0x539.0; //~ ERROR: hexadecimal float literal is not supported
-    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: integer literal is too large
-    9900000000000000000000000000999999999999999999999999999999; //~ ERROR: integer literal is too large
+    9900000000000000000000000000999999999999999999999999999999;
+    //~^ ERROR: integer literal is too large
+    9900000000000000000000000000999999999999999999999999999999;
+    //~^ ERROR: integer literal is too large
     0x; //~ ERROR: no valid digits
     0xu32; //~ ERROR: no valid digits
     0ou32; //~ ERROR: no valid digits

--- a/src/test/ui/parser/lex-bad-numeric-literals.stderr
+++ b/src/test/ui/parser/lex-bad-numeric-literals.stderr
@@ -65,43 +65,43 @@ LL |     0x539.0;
    |     ^^^^^^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:18:5
+  --> $DIR/lex-bad-numeric-literals.rs:20:5
    |
 LL |     0x;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:19:5
+  --> $DIR/lex-bad-numeric-literals.rs:21:5
    |
 LL |     0xu32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:20:5
+  --> $DIR/lex-bad-numeric-literals.rs:22:5
    |
 LL |     0ou32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:21:5
+  --> $DIR/lex-bad-numeric-literals.rs:23:5
    |
 LL |     0bu32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:22:5
+  --> $DIR/lex-bad-numeric-literals.rs:24:5
    |
 LL |     0b;
    |     ^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:24:5
+  --> $DIR/lex-bad-numeric-literals.rs:26:5
    |
 LL |     0o123.456;
    |     ^^^^^^^^^
 
 error: binary float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:26:5
+  --> $DIR/lex-bad-numeric-literals.rs:28:5
    |
 LL |     0b111.101;
    |     ^^^^^^^^^
@@ -119,19 +119,19 @@ LL |     9900000000000000000000000000999999999999999999999999999999;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: integer literal is too large
-  --> $DIR/lex-bad-numeric-literals.rs:17:5
+  --> $DIR/lex-bad-numeric-literals.rs:18:5
    |
 LL |     9900000000000000000000000000999999999999999999999999999999;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:23:5
+  --> $DIR/lex-bad-numeric-literals.rs:25:5
    |
 LL |     0o123f64;
    |     ^^^^^^^^ not supported
 
 error: binary float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:25:5
+  --> $DIR/lex-bad-numeric-literals.rs:27:5
    |
 LL |     0b101f64;
    |     ^^^^^^^^ not supported

--- a/src/test/ui/parser/lex-bad-numeric-literals.stderr
+++ b/src/test/ui/parser/lex-bad-numeric-literals.stderr
@@ -112,13 +112,13 @@ error: octal float literal is not supported
 LL |     0o2f32;
    |     ^^^^^^ not supported
 
-error: int literal is too large
+error: integer literal is too large
   --> $DIR/lex-bad-numeric-literals.rs:16:5
    |
 LL |     9900000000000000000000000000999999999999999999999999999999;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: int literal is too large
+error: integer literal is too large
   --> $DIR/lex-bad-numeric-literals.rs:17:5
    |
 LL |     9900000000000000000000000000999999999999999999999999999999;

--- a/src/test/ui/parser/no-binary-float-literal.rs
+++ b/src/test/ui/parser/no-binary-float-literal.rs
@@ -4,5 +4,5 @@ fn main() {
     0b101.010;
     //~^ ERROR binary float literal is not supported
     0b101p4f64;
-    //~^ ERROR invalid suffix `p4f64` for numeric literal
+    //~^ ERROR invalid suffix `p4f64` for integer literal
 }

--- a/src/test/ui/parser/no-binary-float-literal.stderr
+++ b/src/test/ui/parser/no-binary-float-literal.stderr
@@ -10,7 +10,7 @@ error: binary float literal is not supported
 LL |     0b101010f64;
    |     ^^^^^^^^^^^ not supported
 
-error: invalid suffix `p4f64` for numeric literal
+error: invalid suffix `p4f64` for integer literal
   --> $DIR/no-binary-float-literal.rs:6:5
    |
 LL |     0b101p4f64;

--- a/src/test/ui/parser/no-hex-float-literal.rs
+++ b/src/test/ui/parser/no-hex-float-literal.rs
@@ -4,6 +4,6 @@ fn main() {
     0x567.89;
     //~^ ERROR hexadecimal float literal is not supported
     0xDEAD.BEEFp-2f;
-    //~^ ERROR invalid suffix `f` for integer literal
+    //~^ ERROR invalid suffix `f` for float literal
     //~| ERROR `{integer}` is a primitive type and therefore doesn't have fields
 }

--- a/src/test/ui/parser/no-hex-float-literal.rs
+++ b/src/test/ui/parser/no-hex-float-literal.rs
@@ -4,6 +4,6 @@ fn main() {
     0x567.89;
     //~^ ERROR hexadecimal float literal is not supported
     0xDEAD.BEEFp-2f;
-    //~^ ERROR invalid suffix `f` for float literal
+    //~^ ERROR invalid suffix `f` for integer literal
     //~| ERROR `{integer}` is a primitive type and therefore doesn't have fields
 }

--- a/src/test/ui/parser/no-hex-float-literal.stderr
+++ b/src/test/ui/parser/no-hex-float-literal.stderr
@@ -4,13 +4,13 @@ error: hexadecimal float literal is not supported
 LL |     0x567.89;
    |     ^^^^^^^^
 
-error: invalid suffix `f` for integer literal
+error: invalid suffix `f` for float literal
   --> $DIR/no-hex-float-literal.rs:6:18
    |
 LL |     0xDEAD.BEEFp-2f;
    |                  ^^ invalid suffix `f`
    |
-   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
+   = help: valid suffixes are `f32` and `f64`
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/no-hex-float-literal.rs:2:11

--- a/src/test/ui/parser/no-hex-float-literal.stderr
+++ b/src/test/ui/parser/no-hex-float-literal.stderr
@@ -4,13 +4,13 @@ error: hexadecimal float literal is not supported
 LL |     0x567.89;
    |     ^^^^^^^^
 
-error: invalid suffix `f` for float literal
+error: invalid suffix `f` for integer literal
   --> $DIR/no-hex-float-literal.rs:6:18
    |
 LL |     0xDEAD.BEEFp-2f;
    |                  ^^ invalid suffix `f`
    |
-   = help: valid suffixes are `f32` and `f64`
+   = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
 
 error[E0610]: `{integer}` is a primitive type and therefore doesn't have fields
   --> $DIR/no-hex-float-literal.rs:2:11


### PR DESCRIPTION
A follow up to https://github.com/rust-lang/rust/pull/60679.

https://github.com/rust-lang/rust/commit/a2fd002bd5a91ba7997057724b72b9dac8fae550: Similarly to `EscapeError`, literal parsing now produces a `LitError`.
This way we can get rid of `diag: Option<(Span, &Handler)>` in interfaces while leaving attr/mod alone.

https://github.com/rust-lang/rust/commit/d9516d11208456d4a17fe68a34c1d0a00334e62c: Gathers all components of a literal token in a single struct.