### PR TITLE
Short circuit Send and Sync impls for TokenTree

### DIFF
--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -49,6 +49,28 @@ pub enum TokenTree {
     Delimited(DelimSpan, DelimToken, TokenStream),
 }
 
+// Ensure all fields of `TokenTree` is `Send` and `Sync`.
+#[cfg(parallel_compiler)]
+fn _dummy()
+where
+    Span: Send + Sync,
+    token::Token: Send + Sync,
+    DelimSpan: Send + Sync,
+    DelimToken: Send + Sync,
+    TokenStream: Send + Sync,
+{}
+
+// These are safe since we ensure that they hold for all fields in the `_dummy` function.
+//
+// These impls are only here because the compiler takes forever to compute the Send and Sync
+// bounds without them.
+// FIXME: Remove these impls when the compiler can compute the bounds quickly again.
+// See https://github.com/rust-lang/rust/issues/60846
+#[cfg(parallel_compiler)]
+unsafe impl Send for TokenTree {}
+#[cfg(parallel_compiler)]
+unsafe impl Sync for TokenTree {}
+
 impl TokenTree {
     /// Use this token tree as a matcher to parse given tts.
     pub fn parse(cx: &base::ExtCtxt<'_>, mtch: &[quoted::TokenTree], tts: TokenStream)


### PR DESCRIPTION
Workaround to make the parallel compiler build after https://github.com/rust-lang/rust/pull/60444.

r? @nikomatsakis 