### PR TITLE
[stable] Rust 1.35.0 stable release

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -43,7 +43,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 if [ "$DEPLOY$DEPLOY_ALT" != "" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1403,7 +1403,13 @@ pub fn checked_type_of<'a, 'tcx>(
                                     if !fail {
                                         return None;
                                     }
-                                    bug!("unexpected const parent path def {:?}", x);
+                                    tcx.sess.delay_span_bug(
+                                        DUMMY_SP,
+                                        &format!(
+                                            "unexpected const parent path def {:?}", x
+                                        ),
+                                    );
+                                    tcx.types.err
                                 }
                             }
                         }
@@ -1411,7 +1417,13 @@ pub fn checked_type_of<'a, 'tcx>(
                             if !fail {
                                 return None;
                             }
-                            bug!("unexpected const parent path {:?}", x);
+                            tcx.sess.delay_span_bug(
+                                DUMMY_SP,
+                                &format!(
+                                    "unexpected const parent path {:?}", x
+                                ),
+                            );
+                            tcx.types.err
                         }
                     }
                 }
@@ -1420,7 +1432,13 @@ pub fn checked_type_of<'a, 'tcx>(
                     if !fail {
                         return None;
                     }
-                    bug!("unexpected const parent in type_of_def_id(): {:?}", x);
+                    tcx.sess.delay_span_bug(
+                        DUMMY_SP,
+                        &format!(
+                            "unexpected const parent in type_of_def_id(): {:?}", x
+                        ),
+                    );
+                    tcx.types.err
                 }
             }
         }

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
@@ -1,0 +1,11 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+// We should probably be able to infer the types here. However, this test is checking that we don't
+// get an ICE in this case. It may be modified later to not be an error.
+
+struct Foo<const NUM_BYTES: usize>(pub [u8; NUM_BYTES]);
+
+fn main() {
+    let _ = Foo::<3>([1, 2, 3]); //~ ERROR type annotations needed
+}

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
@@ -1,3 +1,9 @@
+// The test is failing on 1.35.0 stable but that's not important since the ICE happens only with
+// the feature gate enabled, thus it doesn't affect stable.
+// https://github.com/rust-lang/rust/pull/60710#issuecomment-493662676
+//
+// ignore-test
+
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
@@ -1,0 +1,15 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/cannot-infer-type-for-const-param.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+
+error[E0282]: type annotations needed
+  --> $DIR/cannot-infer-type-for-const-param.rs:10:19
+   |
+LL |     let _ = Foo::<3>([1, 2, 3]);
+   |                   ^ cannot infer type for `{integer}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.rs
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.rs
@@ -1,0 +1,9 @@
+use std::convert::TryInto;
+
+struct S;
+
+fn main() {
+    let _: u32 = 5i32.try_into::<32>().unwrap(); //~ ERROR wrong number of const arguments
+    S.f::<0>(); //~ ERROR no method named `f`
+    S::<0>; //~ ERROR  wrong number of const arguments
+}

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -1,0 +1,25 @@
+error[E0107]: wrong number of const arguments: expected 0, found 1
+  --> $DIR/invalid-const-arg-for-type-param.rs:6:34
+   |
+LL |     let _: u32 = 5i32.try_into::<32>().unwrap();
+   |                                  ^^ unexpected const argument
+
+error[E0599]: no method named `f` found for type `S` in the current scope
+  --> $DIR/invalid-const-arg-for-type-param.rs:7:7
+   |
+LL | struct S;
+   | --------- method `f` not found for this
+...
+LL |     S.f::<0>();
+   |       ^
+
+error[E0107]: wrong number of const arguments: expected 0, found 1
+  --> $DIR/invalid-const-arg-for-type-param.rs:8:9
+   |
+LL |     S::<0>;
+   |         ^ unexpected const argument
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0107, E0599.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -21,5 +21,5 @@ LL |     S::<0>;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0107, E0599.
+Some errors occurred: E0107, E0599.
 For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
This also cherry-picks this beta backport:

* #60710: Use `delay_span_bug` for error cases when checking `AnonConst` parent

r? @ghost
cc @Mark-Simulacrum @rust-lang/release