### PR TITLE
Set -funwind-tables and -fno-exceptions unconditionally for LLVM's libunwind

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -67,13 +67,10 @@ mod llvm_libunwind {
             cfg.flag("-std=c99");
             cfg.flag("-std=c++11");
             cfg.flag("-nostdinc++");
-            if cfg.is_flag_supported("-funwind-tables").unwrap_or_default() &&
-               cfg.is_flag_supported("-fno-exceptions").unwrap_or_default() {
-                cfg.flag("-funwind-tables");
-                cfg.flag("-fno-exceptions");
-            }
+            cfg.flag("-fno-exceptions");
             cfg.flag("-fno-rtti");
             cfg.flag("-fstrict-aliasing");
+            cfg.flag("-funwind-tables");
         }
 
         let mut unwind_sources = vec![


### PR DESCRIPTION
These are required otherwise libunwind will end up with undefined
references to __gxx_personality_v0 which is provided by C++ ABI
library and that's undesirable.