### PR TITLE
adjust deprecation date of mem::uninitialized

### DIFF
--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -466,7 +466,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// [`MaybeUninit<T>`]: union.MaybeUninit.html
 /// [inv]: union.MaybeUninit.html#initialization-invariant
 #[inline]
-#[rustc_deprecated(since = "1.40.0", reason = "use `mem::MaybeUninit` instead")]
+#[rustc_deprecated(since = "1.38.0", reason = "use `mem::MaybeUninit` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn uninitialized<T>() -> T {
     intrinsics::panic_if_uninhabited::<T>();


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/60445 we [decided](https://github.com/rust-lang/rust/pull/60445#issuecomment-488626308) that we'd deprecate for 1.38 instead of 1.40, but I forgot to adjust for that.