### PR TITLE
librustc_data_structures: Improve union of sparse and dense hybrid set 

### DIFF
--- a/src/librustc_data_structures/bit_set.rs
+++ b/src/librustc_data_structures/bit_set.rs
@@ -5,6 +5,10 @@ use std::iter;
 use std::marker::PhantomData;
 use std::mem;
 use std::slice;
+#[cfg(test)]
+extern crate test;
+#[cfg(test)]
+use test::Bencher;
 
 pub type Word = u64;
 pub const WORD_BYTES: usize = mem::size_of::<Word>();
@@ -1131,4 +1135,18 @@ fn sparse_matrix_iter() {
         assert_eq!(i, j);
     }
     assert!(iter.next().is_none());
+}
+
+#[bench]
+fn union_hybrid_sparse_to_dense(b: &mut Bencher) {
+    let mut pre_dense: HybridBitSet<usize> = HybridBitSet::new_empty(256);
+    for i in 0..10 {
+        assert!(pre_dense.insert(i));
+    }
+    let pre_sparse: HybridBitSet<usize> = HybridBitSet::new_empty(256);
+    b.iter(|| {
+        let dense = pre_dense.clone();
+        let mut sparse = pre_sparse.clone();
+        sparse.union(&dense);
+    })
 }

--- a/src/librustc_data_structures/bit_set.rs
+++ b/src/librustc_data_structures/bit_set.rs
@@ -518,10 +518,12 @@ impl<T: Idx> HybridBitSet<T> {
                         changed
                     }
                     HybridBitSet::Dense(other_dense) => {
-                        // `self` is sparse and `other` is dense. Densify
-                        // `self` and then do the bitwise union.
-                        let mut new_dense = self_sparse.to_dense();
-                        let changed = new_dense.union(other_dense);
+                        // `self` is sparse and `other` is dense. Clone the
+                        // other set and do the bitwise union with sparse
+                        // `self`. This avoids traversing the dense
+                        // representation twice.
+                        let mut new_dense = other_dense.clone();
+                        let changed = new_dense.union(self_sparse);
                         *self = HybridBitSet::Dense(new_dense);
                         changed
                     }


### PR DESCRIPTION
This optimization speeds up the union of a hybrid bitset when that
switches it from a sparse representation to a dense bitset. It now
clones the dense bitset and integrate only the spare elements instead of
densifying the sparse bitset, initializing all elements, and then a
union on two dense bitset, touching all words a second time.

Provides a benchmark to validate the optimization. Times on my machine:
* Now: `bit_set::union_hybrid_sparse_to_dense ... bench:          75 ns/iter (+/- 6)`
* Previous: `bit_set::union_hybrid_sparse_to_dense ... bench:          94 ns/iter (+/- 9)`