### PR TITLE
Make -Zemit-artifact-notifications also emit the artifact type

### DIFF
--- a/src/librustc_codegen_ssa/back/link.rs
+++ b/src/librustc_codegen_ssa/back/link.rs
@@ -96,7 +96,7 @@ pub fn link_binary<'a, B: ArchiveBuilder<'a>>(sess: &'a Session,
                 }
             }
             if sess.opts.debugging_opts.emit_artifact_notifications {
-                sess.parse_sess.span_diagnostic.emit_artifact_notification(&out_filename);
+                sess.parse_sess.span_diagnostic.emit_artifact_notification(&out_filename, "link");
             }
         }
 

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -56,7 +56,7 @@ pub trait Emitter {
     /// Emit a notification that an artifact has been output.
     /// This is currently only supported for the JSON format,
     /// other formats can, and will, simply ignore it.
-    fn emit_artifact_notification(&mut self, _path: &Path) {}
+    fn emit_artifact_notification(&mut self, _path: &Path, _artifact_type: &str) {}
 
     /// Checks if should show explanations about "rustc --explain"
     fn should_show_explain(&self) -> bool {

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -769,8 +769,8 @@ impl Handler {
         }
     }
 
-    pub fn emit_artifact_notification(&self, path: &Path) {
-        self.emitter.borrow_mut().emit_artifact_notification(path);
+    pub fn emit_artifact_notification(&self, path: &Path, artifact_type: &str) {
+        self.emitter.borrow_mut().emit_artifact_notification(path, artifact_type);
     }
 }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -1052,7 +1052,8 @@ fn encode_and_write_metadata<'tcx>(
             tcx.sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e));
         }
         if tcx.sess.opts.debugging_opts.emit_artifact_notifications {
-            tcx.sess.parse_sess.span_diagnostic.emit_artifact_notification(&out_filename);
+            tcx.sess.parse_sess.span_diagnostic
+                .emit_artifact_notification(&out_filename, "metadata");
         }
     }
 

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -92,8 +92,8 @@ impl Emitter for JsonEmitter {
         }
     }
 
-    fn emit_artifact_notification(&mut self, path: &Path) {
-        let data = ArtifactNotification { artifact: path };
+    fn emit_artifact_notification(&mut self, path: &Path, artifact_type: &str) {
+        let data = ArtifactNotification { artifact: path, emit: artifact_type };
         let result = if self.pretty {
             writeln!(&mut self.dst, "{}", as_pretty_json(&data))
         } else {
@@ -185,6 +185,8 @@ struct DiagnosticCode {
 struct ArtifactNotification<'a> {
     /// The path of the artifact.
     artifact: &'a Path,
+    /// What kind of artifact we're emitting.
+    emit: &'a str,
 }
 
 impl Diagnostic {

--- a/src/test/ui/emit-artifact-notifications.nll.stderr
+++ b/src/test/ui/emit-artifact-notifications.nll.stderr
@@ -1,1 +1,1 @@
-{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications.nll/libemit_artifact_notifications.rmeta"}
+{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications.nll/libemit_artifact_notifications.rmeta","emit":"metadata"}

--- a/src/test/ui/emit-artifact-notifications.stderr
+++ b/src/test/ui/emit-artifact-notifications.stderr
@@ -1,1 +1,1 @@
-{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications/libemit_artifact_notifications.rmeta"}
+{"artifact":"$TEST_BUILD_DIR/emit-artifact-notifications/libemit_artifact_notifications.rmeta","emit":"metadata"}


### PR DESCRIPTION
This is easier for tooling to handle than trying to reverse-engineer the type from the filename extension. The field name and value is intended to reflect the `--emit` command-line option.

Related issues https://github.com/rust-lang/rust/issues/60988 https://github.com/rust-lang/rust/issues/58465
cc @alexcrichton 