### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -130,9 +130,9 @@ impl<T: ?Sized> Box<T> {
     /// the destructor of `T` and free the allocated memory. For this
     /// to be safe, the memory must have been allocated in the precise
     /// way that `Box` expects, namely, using the global allocator
-    /// with the correct [`Layout`] for holding a value of type `T`. In 
+    /// with the correct [`Layout`] for holding a value of type `T`. In
     /// particular, this will be satisfied for a pointer obtained
-    /// from a previously existing `Box` using [`Box::into_raw`]. 
+    /// from a previously existing `Box` using [`Box::into_raw`].
     ///
     /// # Safety
     ///
@@ -172,7 +172,7 @@ impl<T: ?Sized> Box<T> {
     /// After calling this function, the caller is responsible for the
     /// memory previously managed by the `Box`. In particular, the
     /// caller should properly destroy `T` and release the memory. The
-    /// easiest way to do so is to convert the raw pointer back into a `Box` 
+    /// easiest way to do so is to convert the raw pointer back into a `Box`
     /// with the [`Box::from_raw`] function.
     ///
     /// Note: this is an associated function, which means that you have
@@ -180,7 +180,7 @@ impl<T: ?Sized> Box<T> {
     /// is so that there is no conflict with a method on the inner type.
     ///
     /// # Examples
-    /// Converting the raw pointer back into a `Box` with [`Box::from_raw`] 
+    /// Converting the raw pointer back into a `Box` with [`Box::from_raw`]
     /// for automatic cleanup:
     /// ```
     /// let x = Box::new(String::from("Hello"));
@@ -191,7 +191,7 @@ impl<T: ?Sized> Box<T> {
     /// ```
     /// use std::alloc::{Layout, dealloc};
     /// use std::ptr;
-    /// 
+    ///
     /// let x = Box::new(String::from("Hello"));
     /// let p = Box::into_raw(x);
     /// unsafe{ ptr::drop_in_place(p); }

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -466,7 +466,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// [`MaybeUninit<T>`]: union.MaybeUninit.html
 /// [inv]: union.MaybeUninit.html#initialization-invariant
 #[inline]
-#[rustc_deprecated(since = "1.40.0", reason = "use `mem::MaybeUninit` instead")]
+#[rustc_deprecated(since = "1.38.0", reason = "use `mem::MaybeUninit` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn uninitialized<T>() -> T {
     intrinsics::panic_if_uninhabited::<T>();

--- a/src/librustc/middle/intrinsicck.rs
+++ b/src/librustc/middle/intrinsicck.rs
@@ -6,7 +6,7 @@ use crate::ty::query::Providers;
 
 use rustc_target::spec::abi::Abi::RustIntrinsic;
 use rustc_data_structures::indexed_vec::Idx;
-use syntax_pos::Span;
+use syntax_pos::{Span, sym};
 use crate::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use crate::hir;
 
@@ -69,7 +69,7 @@ fn unpack_option_like<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 impl<'a, 'tcx> ExprVisitor<'a, 'tcx> {
     fn def_id_is_transmute(&self, def_id: DefId) -> bool {
         self.tcx.fn_sig(def_id).abi() == RustIntrinsic &&
-        self.tcx.item_name(def_id) == "transmute"
+        self.tcx.item_name(def_id) == sym::transmute
     }
 
     fn check_transmute(&self, span: Span, from: Ty<'tcx>, to: Ty<'tcx>) {

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1853,7 +1853,7 @@ pub fn rustc_optgroups() -> Vec<RustcOptGroup> {
 
 // Convert strings provided as --cfg [cfgspec] into a crate_cfg
 pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String>)> {
-    syntax::with_globals(move || {
+    syntax::with_default_globals(move || {
         let cfg = cfgspecs.into_iter().map(|s| {
             let sess = parse::ParseSess::new(FilePathMapping::empty());
             let filename = FileName::cfg_spec_source_code(&s);
@@ -2735,7 +2735,7 @@ mod tests {
     // When the user supplies --test we should implicitly supply --cfg test
     #[test]
     fn test_switch_implies_cfg_test() {
-        syntax::with_globals(|| {
+        syntax::with_default_globals(|| {
             let matches = &match optgroups().parse(&["--test".to_string()]) {
                 Ok(m) => m,
                 Err(f) => panic!("test_switch_implies_cfg_test: {}", f),
@@ -2753,7 +2753,7 @@ mod tests {
     #[test]
     fn test_switch_implies_cfg_test_unless_cfg_test() {
         use syntax::symbol::sym;
-        syntax::with_globals(|| {
+        syntax::with_default_globals(|| {
             let matches = &match optgroups().parse(&["--test".to_string(),
                                                      "--cfg=test".to_string()]) {
                 Ok(m) => m,
@@ -2771,7 +2771,7 @@ mod tests {
 
     #[test]
     fn test_can_print_warnings() {
-        syntax::with_globals(|| {
+        syntax::with_default_globals(|| {
             let matches = optgroups().parse(&["-Awarnings".to_string()]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);
@@ -2779,7 +2779,7 @@ mod tests {
             assert!(!sess.diagnostic().flags.can_emit_warnings);
         });
 
-        syntax::with_globals(|| {
+        syntax::with_default_globals(|| {
             let matches = optgroups()
                 .parse(&["-Awarnings".to_string(), "-Dwarnings".to_string()])
                 .unwrap();
@@ -2789,7 +2789,7 @@ mod tests {
             assert!(sess.diagnostic().flags.can_emit_warnings);
         });
 
-        syntax::with_globals(|| {
+        syntax::with_default_globals(|| {
             let matches = optgroups().parse(&["-Adead_code".to_string()]).unwrap();
             let registry = errors::registry::Registry::new(&[]);
             let (sessopts, _) = build_session_options_and_crate_config(&matches);

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -243,15 +243,15 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                     // `{Self}` is allowed
                     Position::ArgumentNamed(s) if s == "Self" => (),
                     // `{ThisTraitsName}` is allowed
-                    Position::ArgumentNamed(s) if s == name => (),
+                    Position::ArgumentNamed(s) if s == name.as_str() => (),
                     // `{from_method}` is allowed
                     Position::ArgumentNamed(s) if s == "from_method" => (),
                     // `{from_desugaring}` is allowed
                     Position::ArgumentNamed(s) if s == "from_desugaring" => (),
                     // So is `{A}` if A is a type parameter
-                    Position::ArgumentNamed(s) => match generics.params.iter().find(|param|
-                        param.name == s
-                    ) {
+                    Position::ArgumentNamed(s) => match generics.params.iter().find(|param| {
+                        param.name.as_str() == s
+                    }) {
                         Some(_) => (),
                         None => {
                             span_err!(tcx.sess, span, E0230,
@@ -301,7 +301,7 @@ impl<'a, 'gcx, 'tcx> OnUnimplementedFormatString {
                 Piece::NextArgument(a) => match a.position {
                     Position::ArgumentNamed(s) => match generic_map.get(s) {
                         Some(val) => val,
-                        None if s == name => {
+                        None if s == name.as_str() => {
                             &trait_str
                         }
                         None => {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2981,9 +2981,9 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         }
     }
 
-    pub fn item_name(self, id: DefId) -> InternedString {
+    pub fn item_name(self, id: DefId) -> Symbol {
         if id.index == CRATE_DEF_INDEX {
-            self.original_crate_name(id.krate).as_interned_str()
+            self.original_crate_name(id.krate)
         } else {
             let def_key = self.def_key(id);
             match def_key.disambiguated_data.data {
@@ -2995,7 +2995,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     }),
                 _ => def_key.disambiguated_data.data.get_opt_name().unwrap_or_else(|| {
                     bug!("item_name: no name for {:?}", self.def_path(id));
-                }),
+                }).as_symbol(),
             }
         }
     }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -1140,14 +1140,16 @@ impl<F: fmt::Write> PrettyPrinter<'gcx, 'tcx> for FmtPrinter<'_, 'gcx, 'tcx, F> 
 
         match *region {
             ty::ReEarlyBound(ref data) => {
-                data.name != "" && data.name != "'_"
+                data.name.as_symbol() != keywords::Invalid.name() &&
+                data.name.as_symbol() != keywords::UnderscoreLifetime.name()
             }
 
             ty::ReLateBound(_, br) |
             ty::ReFree(ty::FreeRegion { bound_region: br, .. }) |
             ty::RePlaceholder(ty::Placeholder { name: br, .. }) => {
                 if let ty::BrNamed(_, name) = br {
-                    if name != "" && name != "'_" {
+                    if name.as_symbol() != keywords::Invalid.name() &&
+                       name.as_symbol() != keywords::UnderscoreLifetime.name() {
                         return true;
                     }
                 }
@@ -1203,7 +1205,7 @@ impl<F: fmt::Write> FmtPrinter<'_, '_, '_, F> {
         // `explain_region()` or `note_and_explain_region()`.
         match *region {
             ty::ReEarlyBound(ref data) => {
-                if data.name != "" {
+                if data.name.as_symbol() != keywords::Invalid.name() {
                     p!(write("{}", data.name));
                     return Ok(self);
                 }
@@ -1212,7 +1214,8 @@ impl<F: fmt::Write> FmtPrinter<'_, '_, '_, F> {
             ty::ReFree(ty::FreeRegion { bound_region: br, .. }) |
             ty::RePlaceholder(ty::Placeholder { name: br, .. }) => {
                 if let ty::BrNamed(_, name) = br {
-                    if name != "" && name != "'_" {
+                    if name.as_symbol() != keywords::Invalid.name() &&
+                       name.as_symbol() != keywords::UnderscoreLifetime.name() {
                         p!(write("{}", name));
                         return Ok(self);
                     }

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -14,7 +14,7 @@ use syntax::{
         base::{ExtCtxt, Resolver},
         build::AstBuilder,
         expand::ExpansionConfig,
-        hygiene::{self, Mark, SyntaxContext},
+        hygiene::{Mark, SyntaxContext},
     },
     mut_visit::{self, MutVisitor},
     parse::ParseSess,
@@ -96,7 +96,7 @@ impl MutVisitor for ExpandAllocatorDirectives<'_> {
             ].into()),
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: hygiene::default_edition(),
+            edition: self.sess.edition,
         });
 
         // Tie the span to the macro expansion info we just created

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -37,7 +37,7 @@ use std::ffi::CString;
 
 use syntax_pos::{self, Span, Pos};
 use syntax::ast;
-use syntax::symbol::{Symbol, InternedString};
+use syntax::symbol::InternedString;
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt};
 use rustc_codegen_ssa::traits::*;
 
@@ -63,7 +63,7 @@ pub struct CrateDebugContext<'a, 'tcx> {
     llcontext: &'a llvm::Context,
     llmod: &'a llvm::Module,
     builder: &'a mut DIBuilder<'a>,
-    created_files: RefCell<FxHashMap<(Option<Symbol>, Option<Symbol>), &'a DIFile>>,
+    created_files: RefCell<FxHashMap<(Option<String>, Option<String>), &'a DIFile>>,
     created_enum_disr_types: RefCell<FxHashMap<(DefId, layout::Primitive), &'a DIType>>,
 
     type_map: RefCell<TypeMap<'a, 'tcx>>,

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -264,7 +264,7 @@ fn compute_symbol_name(tcx: TyCtxt<'_, 'tcx, 'tcx>, instance: Instance<'tcx>) ->
             return name.as_interned_str();
         }
         // Don't mangle foreign items.
-        return tcx.item_name(def_id);
+        return tcx.item_name(def_id).as_interned_str();
     }
 
     if let Some(name) = &attrs.export_name {
@@ -274,7 +274,7 @@ fn compute_symbol_name(tcx: TyCtxt<'_, 'tcx, 'tcx>, instance: Instance<'tcx>) ->
 
     if attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE) {
         // Don't mangle
-        return tcx.item_name(def_id);
+        return tcx.item_name(def_id).as_interned_str();
     }
 
     // We want to compute the "type" of this item. Unfortunately, some

--- a/src/librustc_data_structures/macros.rs
+++ b/src/librustc_data_structures/macros.rs
@@ -1,13 +1,13 @@
 /// A simple static assertion macro. The first argument should be a unique
 /// ALL_CAPS identifier that describes the condition.
 #[macro_export]
-#[allow_internal_unstable(type_ascription)]
+#[allow_internal_unstable(type_ascription, underscore_const_names)]
 macro_rules! static_assert {
-    ($name:ident: $test:expr) => {
+    ($test:expr) => {
         // Use the bool to access an array such that if the bool is false, the access
         // is out-of-bounds.
         #[allow(dead_code)]
-        static $name: () = [()][!($test: bool) as usize];
+        const _: () = [()][!($test: bool) as usize];
     }
 }
 

--- a/src/librustc_data_structures/macros.rs
+++ b/src/librustc_data_structures/macros.rs
@@ -1,5 +1,4 @@
-/// A simple static assertion macro. The first argument should be a unique
-/// ALL_CAPS identifier that describes the condition.
+/// A simple static assertion macro.
 #[macro_export]
 #[allow_internal_unstable(type_ascription, underscore_const_names)]
 macro_rules! static_assert {

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -18,6 +18,7 @@ use std::result;
 use std::sync::{Arc, Mutex};
 use syntax;
 use syntax::source_map::{FileLoader, SourceMap};
+use syntax_pos::edition;
 
 pub type Result<T> = result::Result<T, ErrorReported>;
 
@@ -135,6 +136,7 @@ where
 {
     let stderr = config.stderr.take();
     util::spawn_thread_pool(
+        config.opts.edition,
         config.opts.debugging_opts.threads,
         &stderr,
         || run_compiler_in_existing_thread_pool(config, f),
@@ -146,5 +148,5 @@ where
     F: FnOnce() -> R + Send,
     R: Send,
 {
-    util::spawn_thread_pool(None, &None, f)
+    util::spawn_thread_pool(edition::DEFAULT_EDITION, None, &None, f)
 }

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -143,10 +143,10 @@ where
     )
 }
 
-pub fn default_thread_pool<F, R>(f: F) -> R
+pub fn default_thread_pool<F, R>(edition: edition::Edition, f: F) -> R
 where
     F: FnOnce() -> R + Send,
     R: Send,
 {
-    util::spawn_thread_pool(edition::DEFAULT_EDITION, None, &None, f)
+    util::spawn_thread_pool(edition, None, &None, f)
 }

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -48,7 +48,7 @@ use syntax::util::node_count::NodeCounter;
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax::symbol::Symbol;
 use syntax::feature_gate::AttributeType;
-use syntax_pos::{FileName, hygiene};
+use syntax_pos::{FileName, edition::Edition, hygiene};
 use syntax_ext;
 
 use serialize::json;
@@ -70,8 +70,6 @@ use std::ops::Generator;
 pub fn parse<'a>(sess: &'a Session, input: &Input) -> PResult<'a, ast::Crate> {
     sess.diagnostic()
         .set_continue_after_error(sess.opts.debugging_opts.continue_parse_after_error);
-    hygiene::set_default_edition(sess.edition());
-
     sess.profiler(|p| p.start_activity("parsing"));
     let krate = time(sess, "parsing", || match *input {
         Input::File(ref file) => parse::parse_crate_from_file(file, &sess.parse_sess),
@@ -375,7 +373,7 @@ fn configure_and_expand_inner<'a>(
         crate_loader,
         &resolver_arenas,
     );
-    syntax_ext::register_builtins(&mut resolver, plugin_info.syntax_exts);
+    syntax_ext::register_builtins(&mut resolver, plugin_info.syntax_exts, sess.edition());
 
     // Expand all macros
     sess.profiler(|p| p.start_activity("macro expansion"));

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -929,7 +929,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MutableTransmutes {
 
         fn def_id_is_transmute(cx: &LateContext<'_, '_>, def_id: DefId) -> bool {
             cx.tcx.fn_sig(def_id).abi() == RustIntrinsic &&
-            cx.tcx.item_name(def_id) == "transmute"
+            cx.tcx.item_name(def_id) == sym::transmute
         }
     }
 }

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -355,19 +355,19 @@ pub fn provide<'tcx>(providers: &mut Providers<'tcx>) {
                         return;
                     }
 
-                    let child = child.res.def_id();
-
-                    match visible_parent_map.entry(child) {
-                        Entry::Occupied(mut entry) => {
-                            // If `child` is defined in crate `cnum`, ensure
-                            // that it is mapped to a parent in `cnum`.
-                            if child.krate == cnum && entry.get().krate != cnum {
-                                entry.insert(parent);
+                    if let Some(child) = child.res.opt_def_id() {
+                        match visible_parent_map.entry(child) {
+                            Entry::Occupied(mut entry) => {
+                                // If `child` is defined in crate `cnum`, ensure
+                                // that it is mapped to a parent in `cnum`.
+                                if child.krate == cnum && entry.get().krate != cnum {
+                                    entry.insert(parent);
+                                }
                             }
-                        }
-                        Entry::Vacant(entry) => {
-                            entry.insert(parent);
-                            bfs_queue.push_back(child);
+                            Entry::Vacant(entry) => {
+                                entry.insert(parent);
+                                bfs_queue.push_back(child);
+                            }
                         }
                     }
                 };

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -432,7 +432,7 @@ impl cstore::CStore {
         let data = self.get_crate_data(id.krate);
         if let Some(ref proc_macros) = data.proc_macros {
             return LoadedMacro::ProcMacro(proc_macros[id.index.to_proc_macro_index()].1.clone());
-        } else if data.name == sym::proc_macro && data.item_name(id.index) == "quote" {
+        } else if data.name == sym::proc_macro && data.item_name(id.index) == sym::quote {
             use syntax::ext::base::SyntaxExtension;
             use syntax_ext::proc_macro_impl::BangProcMacro;
 

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -29,7 +29,7 @@ use rustc_serialize::{Decodable, Decoder, SpecializedDecoder, opaque};
 use syntax::attr;
 use syntax::ast::{self, Ident};
 use syntax::source_map;
-use syntax::symbol::{InternedString, sym};
+use syntax::symbol::{Symbol, sym};
 use syntax::ext::base::{MacroKind, SyntaxExtension};
 use syntax::ext::hygiene::Mark;
 use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, NO_EXPANSION};
@@ -497,12 +497,13 @@ impl<'a, 'tcx> CrateMetadata {
         }
     }
 
-    pub fn item_name(&self, item_index: DefIndex) -> InternedString {
+    pub fn item_name(&self, item_index: DefIndex) -> Symbol {
         self.def_key(item_index)
             .disambiguated_data
             .data
             .get_opt_name()
             .expect("no name in item_name")
+            .as_symbol()
     }
 
     pub fn def_kind(&self, index: DefIndex) -> Option<DefKind> {
@@ -568,7 +569,7 @@ impl<'a, 'tcx> CrateMetadata {
 
         ty::VariantDef::new(
             tcx,
-            Ident::from_interned_str(self.item_name(index)),
+            Ident::with_empty_ctxt(self.item_name(index)),
             variant_did,
             ctor_did,
             data.discr,
@@ -576,7 +577,7 @@ impl<'a, 'tcx> CrateMetadata {
                 let f = self.entry(index);
                 ty::FieldDef {
                     did: self.local_def_id(index),
-                    ident: Ident::from_interned_str(self.item_name(index)),
+                    ident: Ident::with_empty_ctxt(self.item_name(index)),
                     vis: f.visibility.decode(self)
                 }
             }).collect(),
@@ -787,7 +788,7 @@ impl<'a, 'tcx> CrateMetadata {
                             if let Some(kind) = self.def_kind(child_index) {
                                 callback(def::Export {
                                     res: Res::Def(kind, self.local_def_id(child_index)),
-                                    ident: Ident::from_interned_str(self.item_name(child_index)),
+                                    ident: Ident::with_empty_ctxt(self.item_name(child_index)),
                                     vis: self.get_visibility(child_index),
                                     span: self.entry(child_index).span.decode((self, sess)),
                                 });
@@ -982,7 +983,7 @@ impl<'a, 'tcx> CrateMetadata {
         self.entry(id)
             .children
             .decode(self)
-            .map(|index| self.item_name(index).as_symbol())
+            .map(|index| self.item_name(index))
             .collect()
     }
 

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -34,7 +34,7 @@ use syntax::ast;
 use syntax::attr;
 use syntax::source_map::Spanned;
 use syntax::symbol::{keywords, sym};
-use syntax_pos::{self, hygiene, FileName, SourceFile, Span};
+use syntax_pos::{self, FileName, SourceFile, Span};
 use log::{debug, trace};
 
 use rustc::hir::{self, PatKind};
@@ -480,7 +480,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             hash: tcx.crate_hash(LOCAL_CRATE),
             disambiguator: tcx.sess.local_crate_disambiguator(),
             panic_strategy: tcx.sess.panic_strategy(),
-            edition: hygiene::default_edition(),
+            edition: tcx.sess.edition(),
             has_global_allocator: has_global_allocator,
             has_panic_handler: has_panic_handler,
             has_default_lib_allocator: has_default_lib_allocator,

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -10,7 +10,7 @@ use rustc::ty::query::Providers;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
 
 use rustc_target::spec::abi::Abi;
-use syntax_pos::Span;
+use syntax_pos::{Span, sym};
 
 use std::fmt;
 use std::iter;
@@ -100,9 +100,9 @@ fn make_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
         }
         ty::InstanceDef::CloneShim(def_id, ty) => {
             let name = tcx.item_name(def_id);
-            if name == "clone" {
+            if name == sym::clone {
                 build_clone_shim(tcx, def_id, ty)
-            } else if name == "clone_from" {
+            } else if name == sym::clone_from {
                 debug!("make_shim({:?}: using default trait implementation", instance);
                 return tcx.optimized_mir(def_id);
             } else {

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -212,8 +212,8 @@ impl<'a, 'tcx> TransformVisitor<'a, 'tcx> {
     // Create a statement which reads the discriminant into a temporary
     fn get_discr(&self, mir: &mut Mir<'tcx>) -> (Statement<'tcx>, Place<'tcx>) {
         let temp_decl = LocalDecl::new_internal(self.tcx.types.isize, mir.span);
-        let temp = Place::Base(PlaceBase::Local(Local::new(mir.local_decls.len())));
-        mir.local_decls.push(temp_decl);
+        let local_decls_len = mir.local_decls.push(temp_decl);
+        let temp = Place::Base(PlaceBase::Local(local_decls_len));
 
         let self_place = Place::Base(PlaceBase::Local(self_arg()));
         let assign = Statement {

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -544,14 +544,14 @@ impl Qualif for IsNotImplicitlyPromotable {
 // Ensure the `IDX` values are sequential (`0..QUALIF_COUNT`).
 macro_rules! static_assert_seq_qualifs {
     ($i:expr => $first:ident $(, $rest:ident)*) => {
-        static_assert!(SEQ_QUALIFS: {
+        static_assert!({
             static_assert_seq_qualifs!($i + 1 => $($rest),*);
 
             $first::IDX == $i
         });
     };
     ($i:expr =>) => {
-        static_assert!(SEQ_QUALIFS: QUALIF_COUNT == $i);
+        static_assert!(QUALIF_COUNT == $i);
     };
 }
 static_assert_seq_qualifs!(

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -223,7 +223,7 @@ fn is_rustc_peek<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
                 if let ty::FnDef(def_id, _) = func.ty.sty {
                     let abi = tcx.fn_sig(def_id).abi();
                     let name = tcx.item_name(def_id);
-                    if abi == Abi::RustIntrinsic &&  name == "rustc_peek" {
+                    if abi == Abi::RustIntrinsic && name == sym::rustc_peek {
                         return Some((args, source_info.span));
                     }
                 }

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -6,7 +6,6 @@ use rustc::util::nodemap::FxHashMap;
 
 use syntax::ext::base::{SyntaxExtension, NamedSyntaxExtension, NormalTT, IdentTT};
 use syntax::ext::base::MacroExpanderFn;
-use syntax::ext::hygiene;
 use syntax::symbol::{Symbol, sym};
 use syntax::ast;
 use syntax::feature_gate::AttributeType;
@@ -130,7 +129,7 @@ impl<'a> Registry<'a> {
             allow_internal_unsafe: false,
             local_inner_macros: false,
             unstable_feature: None,
-            edition: hygiene::default_edition(),
+            edition: self.sess.edition(),
         });
     }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -17,7 +17,7 @@ use syntax::errors::DiagnosticBuilder;
 use syntax::ext::base::{self, Determinacy};
 use syntax::ext::base::{MacroKind, SyntaxExtension};
 use syntax::ext::expand::{AstFragment, Invocation, InvocationKind};
-use syntax::ext::hygiene::{self, Mark};
+use syntax::ext::hygiene::Mark;
 use syntax::ext::tt::macro_rules;
 use syntax::feature_gate::{
     feature_err, is_builtin_attr_name, AttributeGate, GateIssue, Stability, BUILTIN_ATTRIBUTES,
@@ -1100,7 +1100,7 @@ impl<'a> Resolver<'a> {
         let def_id = self.definitions.local_def_id(item.id);
         let ext = Lrc::new(macro_rules::compile(&self.session.parse_sess,
                                                &self.session.features_untracked(),
-                                               item, hygiene::default_edition()));
+                                               item, self.session.edition()));
         self.macro_map.insert(def_id, ext);
 
         let def = match item.node { ast::ItemKind::MacroDef(ref def) => def, _ => unreachable!() };

--- a/src/librustdoc/clean/cfg.rs
+++ b/src/librustdoc/clean/cfg.rs
@@ -418,7 +418,7 @@ mod test {
     use syntax::attr;
     use syntax::source_map::dummy_spanned;
     use syntax::symbol::Symbol;
-    use syntax::with_globals;
+    use syntax::with_default_globals;
 
     fn word_cfg(s: &str) -> Cfg {
         Cfg::Cfg(Symbol::intern(s), None)
@@ -466,7 +466,7 @@ mod test {
 
     #[test]
     fn test_cfg_not() {
-        with_globals(|| {
+        with_default_globals(|| {
             assert_eq!(!Cfg::False, Cfg::True);
             assert_eq!(!Cfg::True, Cfg::False);
             assert_eq!(!word_cfg("test"), Cfg::Not(Box::new(word_cfg("test"))));
@@ -484,7 +484,7 @@ mod test {
 
     #[test]
     fn test_cfg_and() {
-        with_globals(|| {
+        with_default_globals(|| {
             let mut x = Cfg::False;
             x &= Cfg::True;
             assert_eq!(x, Cfg::False);
@@ -536,7 +536,7 @@ mod test {
 
     #[test]
     fn test_cfg_or() {
-        with_globals(|| {
+        with_default_globals(|| {
             let mut x = Cfg::True;
             x |= Cfg::False;
             assert_eq!(x, Cfg::True);
@@ -588,7 +588,7 @@ mod test {
 
     #[test]
     fn test_parse_ok() {
-        with_globals(|| {
+        with_default_globals(|| {
             let mi = dummy_meta_item_word("all");
             assert_eq!(Cfg::parse(&mi), Ok(word_cfg("all")));
 
@@ -622,7 +622,7 @@ mod test {
 
     #[test]
     fn test_parse_err() {
-        with_globals(|| {
+        with_default_globals(|| {
             let mi = attr::mk_name_value_item(
                 DUMMY_SP,
                 Ident::from_str("foo"),
@@ -661,7 +661,7 @@ mod test {
 
     #[test]
     fn test_render_short_html() {
-        with_globals(|| {
+        with_default_globals(|| {
             assert_eq!(
                 word_cfg("unix").render_short_html(),
                 "Unix"
@@ -741,7 +741,7 @@ mod test {
 
     #[test]
     fn test_render_long_html() {
-        with_globals(|| {
+        with_default_globals(|| {
             assert_eq!(
                 word_cfg("unix").render_long_html(),
                 "This is supported on <strong>Unix</strong> only."

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1702,7 +1702,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics,
         let stripped_typarams = gens.params.iter().filter_map(|param| match param.kind {
             ty::GenericParamDefKind::Lifetime => None,
             ty::GenericParamDefKind::Type { .. } => {
-                if param.name == keywords::SelfUpper.name().as_str() {
+                if param.name.as_symbol() == keywords::SelfUpper.name() {
                     assert_eq!(param.index, 0);
                     return None;
                 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -94,9 +94,7 @@ pub fn main() {
     rustc_driver::set_sigpipe_handler();
     env_logger::init();
     let res = std::thread::Builder::new().stack_size(thread_stack_size).spawn(move || {
-        rustc_interface::interface::default_thread_pool(move || {
-            get_args().map(|args| main_args(&args)).unwrap_or(1)
-        })
+        get_args().map(|args| main_args(&args)).unwrap_or(1)
     }).unwrap().join().unwrap_or(rustc_driver::EXIT_FAILURE);
     process::exit(res);
 }
@@ -382,7 +380,12 @@ fn main_args(args: &[String]) -> i32 {
         Ok(opts) => opts,
         Err(code) => return code,
     };
+    rustc_interface::interface::default_thread_pool(options.edition, move || {
+        main_options(options)
+    })
+}
 
+fn main_options(options: config::Options) -> i32 {
     let diag = core::new_handler(options.error_format,
                                  None,
                                  options.debugging_options.treat_err_as_bug,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -8,6 +8,7 @@ use rustc::session::config::{OutputType, OutputTypes, Externs, CodegenOptions};
 use rustc::session::search_paths::SearchPath;
 use rustc::util::common::ErrorReported;
 use syntax::ast;
+use syntax::with_globals;
 use syntax::source_map::SourceMap;
 use syntax::edition::Edition;
 use syntax::feature_gate::UnstableFeatures;
@@ -386,12 +387,10 @@ pub fn make_test(s: &str,
 
     // Uses libsyntax to parse the doctest and find if there's a main fn and the extern
     // crate already is included.
-    let (already_has_main, already_has_extern_crate, found_macro) = crate::syntax::with_globals(|| {
+    let (already_has_main, already_has_extern_crate, found_macro) = with_globals(edition, || {
         use crate::syntax::{parse::{self, ParseSess}, source_map::FilePathMapping};
         use errors::emitter::EmitterWriter;
         use errors::Handler;
-
-        syntax::ext::hygiene::set_default_edition(edition);
 
         let filename = FileName::anon_source_code(s);
         let source = crates + &everything_else;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -5,7 +5,7 @@ use crate::attr::HasAttrs;
 use crate::source_map::{SourceMap, Spanned, respan};
 use crate::edition::Edition;
 use crate::ext::expand::{self, AstFragment, Invocation};
-use crate::ext::hygiene::{self, Mark, SyntaxContext, Transparency};
+use crate::ext::hygiene::{Mark, SyntaxContext, Transparency};
 use crate::mut_visit::{self, MutVisitor};
 use crate::parse::{self, parser, DirectoryOwnership};
 use crate::parse::token;
@@ -713,7 +713,7 @@ impl SyntaxExtension {
         }
     }
 
-    pub fn edition(&self) -> Edition {
+    pub fn edition(&self, default_edition: Edition) -> Edition {
         match *self {
             SyntaxExtension::NormalTT { edition, .. } |
             SyntaxExtension::DeclMacro { edition, .. } |
@@ -725,7 +725,7 @@ impl SyntaxExtension {
             SyntaxExtension::IdentTT { .. } |
             SyntaxExtension::MultiDecorator(..) |
             SyntaxExtension::MultiModifier(..) |
-            SyntaxExtension::BuiltinDerive(..) => hygiene::default_edition(),
+            SyntaxExtension::BuiltinDerive(..) => default_edition,
         }
     }
 }
@@ -734,6 +734,7 @@ pub type NamedSyntaxExtension = (Name, SyntaxExtension);
 
 pub trait Resolver {
     fn next_node_id(&mut self) -> ast::NodeId;
+
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark;
 
     fn resolve_dollar_crates(&mut self, fragment: &AstFragment);
@@ -768,6 +769,7 @@ pub struct DummyResolver;
 
 impl Resolver for DummyResolver {
     fn next_node_id(&mut self) -> ast::NodeId { ast::DUMMY_NODE_ID }
+
     fn get_module_scope(&mut self, _id: ast::NodeId) -> Mark { Mark::root() }
 
     fn resolve_dollar_crates(&mut self, _fragment: &AstFragment) {}

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -1,6 +1,6 @@
 use crate::attr::HasAttrs;
 use crate::ast;
-use crate::source_map::{hygiene, ExpnInfo, ExpnFormat};
+use crate::source_map::{ExpnInfo, ExpnFormat};
 use crate::ext::base::ExtCtxt;
 use crate::ext::build::AstBuilder;
 use crate::parse::parser::PathStyle;
@@ -64,7 +64,7 @@ pub fn add_derived_markers<T>(cx: &mut ExtCtxt<'_>, span: Span, traits: &[ast::P
         ].into()),
         allow_internal_unsafe: false,
         local_inner_macros: false,
-        edition: hygiene::default_edition(),
+        edition: cx.parse_sess.edition,
     });
 
     let span = span.with_ctxt(cx.backtrace());

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -5,7 +5,7 @@ use crate::source_map::{ExpnInfo, MacroBang, MacroAttribute, dummy_spanned, resp
 use crate::config::StripUnconfigured;
 use crate::ext::base::*;
 use crate::ext::derive::{add_derived_markers, collect_derives};
-use crate::ext::hygiene::{self, Mark, SyntaxContext};
+use crate::ext::hygiene::{Mark, SyntaxContext};
 use crate::ext::placeholders::{placeholder, PlaceholderExpander};
 use crate::feature_gate::{self, Features, GateIssue, is_builtin_attr, emit_feature_err};
 use crate::mut_visit::*;
@@ -560,7 +560,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             allow_internal_unstable: None,
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: ext.edition(),
+            edition: ext.edition(self.cx.parse_sess.edition),
         });
 
         match *ext {
@@ -805,7 +805,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         allow_internal_unstable: allow_internal_unstable.clone(),
                         allow_internal_unsafe: false,
                         local_inner_macros: false,
-                        edition: hygiene::default_edition(),
+                        edition: self.cx.parse_sess.edition,
                     });
 
                     let input: Vec<_> = mac.node.stream().into_trees().collect();
@@ -921,7 +921,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             allow_internal_unstable: None,
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: ext.edition(),
+            edition: ext.edition(self.cx.parse_sess.edition),
         };
 
         match *ext {

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -29,6 +29,7 @@ use rustc_data_structures::sync::Lock;
 use rustc_data_structures::bit_set::GrowableBitSet;
 pub use rustc_data_structures::thin_vec::ThinVec;
 use ast::AttrId;
+use syntax_pos::edition::Edition;
 
 // A variant of 'try!' that panics on an Err. This is used as a crutch on the
 // way towards a non-panic!-prone parser. It should be used for fatal parsing
@@ -82,24 +83,30 @@ pub struct Globals {
 }
 
 impl Globals {
-    fn new() -> Globals {
+    fn new(edition: Edition) -> Globals {
         Globals {
             // We have no idea how many attributes their will be, so just
             // initiate the vectors with 0 bits. We'll grow them as necessary.
             used_attrs: Lock::new(GrowableBitSet::new_empty()),
             known_attrs: Lock::new(GrowableBitSet::new_empty()),
-            syntax_pos_globals: syntax_pos::Globals::new(),
+            syntax_pos_globals: syntax_pos::Globals::new(edition),
         }
     }
 }
 
-pub fn with_globals<F, R>(f: F) -> R
+pub fn with_globals<F, R>(edition: Edition, f: F) -> R
     where F: FnOnce() -> R
 {
-    let globals = Globals::new();
+    let globals = Globals::new(edition);
     GLOBALS.set(&globals, || {
         syntax_pos::GLOBALS.set(&globals.syntax_pos_globals, f)
     })
+}
+
+pub fn with_default_globals<F, R>(f: F) -> R
+    where F: FnOnce() -> R
+{
+    with_globals(edition::DEFAULT_EDITION, f)
 }
 
 scoped_tls::scoped_thread_local!(pub static GLOBALS: Globals);

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1305,7 +1305,7 @@ mod tests {
     use crate::util::parser_testing::{string_to_crate, matches_codepattern};
     use crate::print::pprust;
     use crate::mut_visit;
-    use crate::with_globals;
+    use crate::with_default_globals;
     use super::*;
 
     // this version doesn't care about getting comments or docstrings in.
@@ -1343,7 +1343,7 @@ mod tests {
 
     // make sure idents get transformed everywhere
     #[test] fn ident_transformation () {
-        with_globals(|| {
+        with_default_globals(|| {
             let mut zz_visitor = ToZzIdentMutVisitor;
             let mut krate = string_to_crate(
                 "#[a] mod b {fn c (d : e, f : g) {h!(i,j,k);l;m}}".to_string());
@@ -1358,7 +1358,7 @@ mod tests {
 
     // even inside macro defs....
     #[test] fn ident_transformation_in_defs () {
-        with_globals(|| {
+        with_default_globals(|| {
             let mut zz_visitor = ToZzIdentMutVisitor;
             let mut krate = string_to_crate(
                 "macro_rules! a {(b $c:expr $(d $e:token)f+ => \

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1558,10 +1558,10 @@ mod tests {
     use crate::feature_gate::UnstableFeatures;
     use crate::parse::token;
     use crate::diagnostics::plugin::ErrorMap;
-    use crate::with_globals;
+    use crate::with_default_globals;
     use std::io;
     use std::path::PathBuf;
-    use syntax_pos::{BytePos, Span, NO_EXPANSION};
+    use syntax_pos::{BytePos, Span, NO_EXPANSION, edition::Edition};
     use rustc_data_structures::fx::{FxHashSet, FxHashMap};
     use rustc_data_structures::sync::Lock;
 
@@ -1581,6 +1581,7 @@ mod tests {
             raw_identifier_spans: Lock::new(Vec::new()),
             registered_diagnostics: Lock::new(ErrorMap::new()),
             buffered_lints: Lock::new(vec![]),
+            edition: Edition::from_session(),
             ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
         }
     }
@@ -1601,7 +1602,7 @@ mod tests {
 
     #[test]
     fn t1() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             let mut string_reader = setup(&sm,
@@ -1649,7 +1650,7 @@ mod tests {
 
     #[test]
     fn doublecolonparsing() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             check_tokenization(setup(&sm, &sh, "a b".to_string()),
@@ -1659,7 +1660,7 @@ mod tests {
 
     #[test]
     fn dcparsing_2() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             check_tokenization(setup(&sm, &sh, "a::b".to_string()),
@@ -1669,7 +1670,7 @@ mod tests {
 
     #[test]
     fn dcparsing_3() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             check_tokenization(setup(&sm, &sh, "a ::b".to_string()),
@@ -1679,7 +1680,7 @@ mod tests {
 
     #[test]
     fn dcparsing_4() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             check_tokenization(setup(&sm, &sh, "a:: b".to_string()),
@@ -1689,7 +1690,7 @@ mod tests {
 
     #[test]
     fn character_a() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             assert_eq!(setup(&sm, &sh, "'a'".to_string()).next_token().tok,
@@ -1699,7 +1700,7 @@ mod tests {
 
     #[test]
     fn character_space() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             assert_eq!(setup(&sm, &sh, "' '".to_string()).next_token().tok,
@@ -1709,7 +1710,7 @@ mod tests {
 
     #[test]
     fn character_escaped() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             assert_eq!(setup(&sm, &sh, "'\\n'".to_string()).next_token().tok,
@@ -1719,7 +1720,7 @@ mod tests {
 
     #[test]
     fn lifetime_name() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             assert_eq!(setup(&sm, &sh, "'abc".to_string()).next_token().tok,
@@ -1729,7 +1730,7 @@ mod tests {
 
     #[test]
     fn raw_string() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             assert_eq!(setup(&sm, &sh, "r###\"\"#a\\b\x00c\"\"###".to_string())
@@ -1741,7 +1742,7 @@ mod tests {
 
     #[test]
     fn literal_suffixes() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             macro_rules! test {
@@ -1787,7 +1788,7 @@ mod tests {
 
     #[test]
     fn nested_block_comments() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             let mut lexer = setup(&sm, &sh, "/* /* */ */'a'".to_string());
@@ -1802,7 +1803,7 @@ mod tests {
 
     #[test]
     fn crlf_comments() {
-        with_globals(|| {
+        with_default_globals(|| {
             let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
             let sh = mk_sess(sm.clone());
             let mut lexer = setup(&sm, &sh, "// test\r\n/// test\r\n".to_string());

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -330,6 +330,16 @@ pub fn stream_to_parser(sess: &ParseSess, stream: TokenStream) -> Parser<'_> {
 }
 
 /// Given stream, the `ParseSess` and the base directory, produces a parser.
+///
+/// Use this function when you are creating a parser from the token stream
+/// and also care about the current working directory of the parser (e.g.,
+/// you are trying to resolve modules defined inside a macro invocation).
+/// 
+/// # Note
+///
+/// The main usage of this function is outside of rustc, for those who uses
+/// libsyntax as a library. Please do not remove this function while refactoring
+/// just because it is not used in rustc codebase!
 pub fn stream_to_parser_with_base_dir<'a>(sess: &'a ParseSess,
                                           stream: TokenStream,
                                           base_dir: Directory<'a>) -> Parser<'a> {

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -329,6 +329,13 @@ pub fn stream_to_parser(sess: &ParseSess, stream: TokenStream) -> Parser<'_> {
     Parser::new(sess, stream, None, true, false)
 }
 
+/// Given stream, the `ParseSess` and the base directory, produces a parser.
+pub fn stream_to_parser_with_base_dir<'a>(sess: &'a ParseSess,
+                                          stream: TokenStream,
+                                          base_dir: Directory<'a>) -> Parser<'a> {
+    Parser::new(sess, stream, Some(base_dir), true, false)
+}
+
 /// A sequence separator.
 pub struct SeqSep {
     /// The seperator token.

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -334,7 +334,7 @@ pub fn stream_to_parser(sess: &ParseSess, stream: TokenStream) -> Parser<'_> {
 /// Use this function when you are creating a parser from the token stream
 /// and also care about the current working directory of the parser (e.g.,
 /// you are trying to resolve modules defined inside a macro invocation).
-/// 
+///
 /// # Note
 ///
 /// The main usage of this function is outside of rustc, for those who uses

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3147,12 +3147,12 @@ mod tests {
 
     use crate::ast;
     use crate::source_map;
-    use crate::with_globals;
+    use crate::with_default_globals;
     use syntax_pos;
 
     #[test]
     fn test_fun_to_string() {
-        with_globals(|| {
+        with_default_globals(|| {
             let abba_ident = ast::Ident::from_str("abba");
 
             let decl = ast::FnDecl {
@@ -3180,7 +3180,7 @@ mod tests {
 
     #[test]
     fn test_variant_to_string() {
-        with_globals(|| {
+        with_default_globals(|| {
             let ident = ast::Ident::from_str("principal_skinner");
 
             let var = source_map::respan(syntax_pos::DUMMY_SP, ast::Variant_ {

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -947,7 +947,7 @@ impl SourceMap {
             allow_internal_unstable,
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: hygiene::default_edition(),
+            edition: edition::Edition::from_session(),
         });
         span.with_ctxt(SyntaxContext::empty().apply_mark(mark))
     }

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -3,7 +3,7 @@ use crate::attr;
 use crate::edition::Edition;
 use crate::ext::hygiene::{Mark, SyntaxContext};
 use crate::symbol::{Ident, Symbol, keywords, sym};
-use crate::source_map::{ExpnInfo, MacroAttribute, dummy_spanned, hygiene, respan};
+use crate::source_map::{ExpnInfo, MacroAttribute, dummy_spanned, respan};
 use crate::ptr::P;
 use crate::tokenstream::TokenStream;
 
@@ -14,7 +14,7 @@ use syntax_pos::{DUMMY_SP, Span};
 /// Craft a span that will be ignored by the stability lint's
 /// call to source_map's `is_internal` check.
 /// The expanded code uses the unstable `#[prelude_import]` attribute.
-fn ignored_span(sp: Span) -> Span {
+fn ignored_span(sp: Span, edition: Edition) -> Span {
     let mark = Mark::fresh(Mark::root());
     mark.set_expn_info(ExpnInfo {
         call_site: DUMMY_SP,
@@ -25,7 +25,7 @@ fn ignored_span(sp: Span) -> Span {
         ].into()),
         allow_internal_unsafe: false,
         local_inner_macros: false,
-        edition: hygiene::default_edition(),
+        edition,
     });
     sp.with_ctxt(SyntaxContext::empty().apply_mark(mark))
 }
@@ -94,7 +94,7 @@ pub fn maybe_inject_crates_ref(
 
     INJECTED_CRATE_NAME.with(|opt_name| opt_name.set(Some(name)));
 
-    let span = ignored_span(DUMMY_SP);
+    let span = ignored_span(DUMMY_SP, edition);
     krate.module.items.insert(0, P(ast::Item {
         attrs: vec![ast::Attribute {
             style: ast::AttrStyle::Outer,

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -291,7 +291,7 @@ fn generate_test_harness(sess: &ParseSess,
         ].into()),
         allow_internal_unsafe: false,
         local_inner_macros: false,
-        edition: hygiene::default_edition(),
+        edition: sess.edition,
     });
 
     TestHarnessGenerator {

--- a/src/libsyntax/test_snippet.rs
+++ b/src/libsyntax/test_snippet.rs
@@ -1,5 +1,5 @@
 use crate::source_map::{SourceMap, FilePathMapping};
-use crate::with_globals;
+use crate::with_default_globals;
 
 use errors::Handler;
 use errors::emitter::EmitterWriter;
@@ -39,7 +39,7 @@ impl<T: Write> Write for Shared<T> {
 }
 
 fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &str) {
-    with_globals(|| {
+    with_default_globals(|| {
         let output = Arc::new(Mutex::new(Vec::new()));
 
         let source_map = Lrc::new(SourceMap::new(FilePathMapping::empty()));

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -557,7 +557,7 @@ impl DelimSpan {
 mod tests {
     use super::*;
     use crate::syntax::ast::Ident;
-    use crate::with_globals;
+    use crate::with_default_globals;
     use crate::parse::token::Token;
     use crate::util::parser_testing::string_to_stream;
     use syntax_pos::{Span, BytePos, NO_EXPANSION};
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn test_concat() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("foo::bar::baz");
             let test_fst = string_to_ts("foo::bar");
             let test_snd = string_to_ts("::baz");
@@ -585,7 +585,7 @@ mod tests {
 
     #[test]
     fn test_to_from_bijection() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_start = string_to_ts("foo::bar(baz)");
             let test_end = test_start.trees().collect();
             assert_eq!(test_start, test_end)
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_eq_0() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("foo");
             let test_eqs = string_to_ts("foo");
             assert_eq!(test_res, test_eqs)
@@ -603,7 +603,7 @@ mod tests {
 
     #[test]
     fn test_eq_1() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("::bar::baz");
             let test_eqs = string_to_ts("::bar::baz");
             assert_eq!(test_res, test_eqs)
@@ -612,7 +612,7 @@ mod tests {
 
     #[test]
     fn test_eq_3() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("");
             let test_eqs = string_to_ts("");
             assert_eq!(test_res, test_eqs)
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_diseq_0() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("::bar::baz");
             let test_eqs = string_to_ts("bar::baz");
             assert_eq!(test_res == test_eqs, false)
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_diseq_1() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test_res = string_to_ts("(bar,baz)");
             let test_eqs = string_to_ts("bar,baz");
             assert_eq!(test_res == test_eqs, false)
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_is_empty() {
-        with_globals(|| {
+        with_default_globals(|| {
             let test0: TokenStream = Vec::<TokenTree>::new().into_iter().collect();
             let test1: TokenStream =
                 TokenTree::Token(sp(0, 1), Token::Ident(Ident::from_str("a"), false)).into();
@@ -653,12 +653,14 @@ mod tests {
 
     #[test]
     fn test_dotdotdot() {
-        let mut builder = TokenStreamBuilder::new();
-        builder.push(TokenTree::Token(sp(0, 1), Token::Dot).joint());
-        builder.push(TokenTree::Token(sp(1, 2), Token::Dot).joint());
-        builder.push(TokenTree::Token(sp(2, 3), Token::Dot));
-        let stream = builder.build();
-        assert!(stream.eq_unspanned(&string_to_ts("...")));
-        assert_eq!(stream.trees().count(), 1);
+        with_default_globals(|| {
+            let mut builder = TokenStreamBuilder::new();
+            builder.push(TokenTree::Token(sp(0, 1), Token::Dot).joint());
+            builder.push(TokenTree::Token(sp(1, 2), Token::Dot).joint());
+            builder.push(TokenTree::Token(sp(2, 3), Token::Dot));
+            let stream = builder.build();
+            assert!(stream.eq_unspanned(&string_to_ts("...")));
+            assert_eq!(stream.trees().count(), 1);
+        })
     }
 }

--- a/src/libsyntax/util/lev_distance.rs
+++ b/src/libsyntax/util/lev_distance.rs
@@ -101,8 +101,8 @@ fn test_lev_distance() {
 
 #[test]
 fn test_find_best_match_for_name() {
-    use crate::with_globals;
-    with_globals(|| {
+    use crate::with_default_globals;
+    with_default_globals(|| {
         let input = vec![Symbol::intern("aaab"), Symbol::intern("aaabc")];
         assert_eq!(
             find_best_match_for_name(input.iter(), "aaaa", None),

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -42,17 +42,17 @@ pub mod proc_macro_impl;
 use rustc_data_structures::sync::Lrc;
 use syntax::ast;
 use syntax::ext::base::{MacroExpanderFn, NormalTT, NamedSyntaxExtension, MultiModifier};
-use syntax::ext::hygiene;
 use syntax::symbol::Symbol;
+use syntax::edition::Edition;
 
 pub fn register_builtins(resolver: &mut dyn syntax::ext::base::Resolver,
-                         user_exts: Vec<NamedSyntaxExtension>) {
+                         user_exts: Vec<NamedSyntaxExtension>,
+                         edition: Edition) {
     deriving::register_builtin_derives(resolver);
 
     let mut register = |name, ext| {
         resolver.add_builtin(ast::Ident::with_empty_ctxt(name), Lrc::new(ext));
     };
-
     macro_rules! register {
         ($( $name:ident: $f:expr, )*) => { $(
             register(Symbol::intern(stringify!($name)),
@@ -63,7 +63,7 @@ pub fn register_builtins(resolver: &mut dyn syntax::ext::base::Resolver,
                         allow_internal_unsafe: false,
                         local_inner_macros: false,
                         unstable_feature: None,
-                        edition: hygiene::default_edition(),
+                        edition,
                     });
         )* }
     }
@@ -108,7 +108,7 @@ pub fn register_builtins(resolver: &mut dyn syntax::ext::base::Resolver,
                 allow_internal_unsafe: false,
                 local_inner_macros: false,
                 unstable_feature: None,
-                edition: hygiene::default_edition(),
+                edition,
             });
     register(Symbol::intern("format_args_nl"),
              NormalTT {
@@ -120,7 +120,7 @@ pub fn register_builtins(resolver: &mut dyn syntax::ext::base::Resolver,
                  allow_internal_unsafe: false,
                  local_inner_macros: false,
                  unstable_feature: None,
-                 edition: hygiene::default_edition(),
+                 edition,
              });
 
     for (name, ext) in user_exts {

--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -4,7 +4,7 @@ use crate::deriving;
 
 use syntax::ast::{self, Ident};
 use syntax::attr;
-use syntax::source_map::{ExpnInfo, MacroAttribute, hygiene, respan};
+use syntax::source_map::{ExpnInfo, MacroAttribute, respan};
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
@@ -358,7 +358,7 @@ fn mk_decls(
         ].into()),
         allow_internal_unsafe: false,
         local_inner_macros: false,
-        edition: hygiene::default_edition(),
+        edition: cx.parse_sess.edition,
     });
     let span = DUMMY_SP.apply_mark(mark);
 

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -3,7 +3,7 @@
 
 use syntax::ext::base::*;
 use syntax::ext::build::AstBuilder;
-use syntax::ext::hygiene::{self, Mark, SyntaxContext};
+use syntax::ext::hygiene::{Mark, SyntaxContext};
 use syntax::attr;
 use syntax::ast;
 use syntax::print::pprust;
@@ -72,7 +72,7 @@ pub fn expand_test_or_bench(
             ].into()),
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: hygiene::default_edition(),
+            edition: cx.parse_sess.edition,
         });
         (item.span.with_ctxt(SyntaxContext::empty().apply_mark(mark)),
          attr_sp.with_ctxt(SyntaxContext::empty().apply_mark(mark)))

--- a/src/libsyntax_ext/test_case.rs
+++ b/src/libsyntax_ext/test_case.rs
@@ -11,7 +11,7 @@
 
 use syntax::ext::base::*;
 use syntax::ext::build::AstBuilder;
-use syntax::ext::hygiene::{self, Mark, SyntaxContext};
+use syntax::ext::hygiene::{Mark, SyntaxContext};
 use syntax::ast;
 use syntax::source_map::respan;
 use syntax::symbol::{Symbol, sym};
@@ -47,7 +47,7 @@ pub fn expand(
             ].into()),
             allow_internal_unsafe: false,
             local_inner_macros: false,
-            edition: hygiene::default_edition(),
+            edition: ecx.parse_sess.edition,
         });
         attr_sp.with_ctxt(SyntaxContext::empty().apply_mark(mark))
     };

--- a/src/libsyntax_pos/edition.rs
+++ b/src/libsyntax_pos/edition.rs
@@ -1,6 +1,7 @@
 use crate::symbol::{Symbol, sym};
 use std::fmt;
 use std::str::FromStr;
+use crate::GLOBALS;
 
 /// The edition of the compiler (RFC 2052)
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Debug, RustcEncodable, RustcDecodable, Eq)]
@@ -38,6 +39,10 @@ impl fmt::Display for Edition {
 }
 
 impl Edition {
+    pub fn from_session() -> Edition {
+        GLOBALS.with(|globals| globals.edition)
+    }
+
     pub fn lint_name(&self) -> &'static str {
         match *self {
             Edition::Edition2015 => "rust_2015_compatibility",

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -7,7 +7,7 @@
 
 use crate::GLOBALS;
 use crate::Span;
-use crate::edition::{Edition, DEFAULT_EDITION};
+use crate::edition::Edition;
 use crate::symbol::{keywords, Symbol};
 
 use serialize::{Encodable, Decodable, Encoder, Decoder};
@@ -174,7 +174,6 @@ crate struct HygieneData {
     marks: Vec<MarkData>,
     syntax_contexts: Vec<SyntaxContextData>,
     markings: FxHashMap<(SyntaxContext, Mark, Transparency), SyntaxContext>,
-    default_edition: Edition,
 }
 
 impl HygieneData {
@@ -196,21 +195,12 @@ impl HygieneData {
                 dollar_crate_name: keywords::DollarCrate.name(),
             }],
             markings: FxHashMap::default(),
-            default_edition: DEFAULT_EDITION,
         }
     }
 
     fn with<T, F: FnOnce(&mut HygieneData) -> T>(f: F) -> T {
         GLOBALS.with(|globals| f(&mut *globals.hygiene_data.borrow_mut()))
     }
-}
-
-pub fn default_edition() -> Edition {
-    HygieneData::with(|data| data.default_edition)
-}
-
-pub fn set_default_edition(edition: Edition) {
-    HygieneData::with(|data| data.default_edition = edition);
 }
 
 pub fn clear_markings() {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -1276,6 +1276,7 @@ impl Encodable for InternedString {
 mod tests {
     use super::*;
     use crate::Globals;
+    use crate::edition;
 
     #[test]
     fn interner_tests() {
@@ -1300,7 +1301,7 @@ mod tests {
 
     #[test]
     fn without_first_quote_test() {
-        GLOBALS.set(&Globals::new(), || {
+        GLOBALS.set(&Globals::new(edition::DEFAULT_EDITION), || {
             let i = Ident::from_str("'break");
             assert_eq!(i.without_first_quote().name, keywords::Break.name());
         });

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -1146,7 +1146,7 @@ impl Encodable for LocalInternedString {
 /// assert_ne!(Symbol::gensym("x"), Symbol::gensym("x"))
 /// assert_eq!(Symbol::gensym("x").as_interned_str(), Symbol::gensym("x").as_interned_str())
 /// ```
-#[derive(Clone, Copy, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct InternedString {
     symbol: Symbol,
 }
@@ -1208,42 +1208,6 @@ impl Ord for InternedString {
             return Ordering::Equal;
         }
         self.with2(other, |self_str, other_str| self_str.cmp(other_str))
-    }
-}
-
-impl<T: std::ops::Deref<Target = str>> PartialEq<T> for InternedString {
-    fn eq(&self, other: &T) -> bool {
-        self.with(|string| string == other.deref())
-    }
-}
-
-impl PartialEq<InternedString> for InternedString {
-    fn eq(&self, other: &InternedString) -> bool {
-        self.symbol == other.symbol
-    }
-}
-
-impl PartialEq<InternedString> for str {
-    fn eq(&self, other: &InternedString) -> bool {
-        other.with(|string| self == string)
-    }
-}
-
-impl<'a> PartialEq<InternedString> for &'a str {
-    fn eq(&self, other: &InternedString) -> bool {
-        other.with(|string| *self == string)
-    }
-}
-
-impl PartialEq<InternedString> for String {
-    fn eq(&self, other: &InternedString) -> bool {
-        other.with(|string| self == string)
-    }
-}
-
-impl<'a> PartialEq<InternedString> for &'a String {
-    fn eq(&self, other: &InternedString) -> bool {
-        other.with(|string| *self == string)
     }
 }
 

--- a/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
+++ b/src/test/run-pass-fulldeps/ast_stmt_expr_attr.rs
@@ -105,7 +105,7 @@ fn reject_stmt_parse(es: &str) {
 }
 
 fn main() {
-    syntax::with_globals(|| run());
+    syntax::with_default_globals(|| run());
 }
 
 fn run() {

--- a/src/test/run-pass-fulldeps/auxiliary/plugin-args.rs
+++ b/src/test/run-pass-fulldeps/auxiliary/plugin-args.rs
@@ -47,6 +47,6 @@ pub fn plugin_registrar(reg: &mut Registry) {
             allow_internal_unsafe: false,
             local_inner_macros: false,
             unstable_feature: None,
-            edition: hygiene::default_edition(),
+            edition: reg.sess.edition(),
         });
 }

--- a/src/test/run-pass-fulldeps/mod_dir_path_canonicalized.rs
+++ b/src/test/run-pass-fulldeps/mod_dir_path_canonicalized.rs
@@ -13,7 +13,7 @@ use syntax::parse::{self, ParseSess};
 mod gravy;
 
 pub fn main() {
-    syntax::with_globals(|| parse());
+    syntax::with_default_globals(|| parse());
 
     assert_eq!(gravy::foo(), 10);
 }

--- a/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/run-pass-fulldeps/pprust-expr-roundtrip.rs
@@ -189,7 +189,7 @@ impl MutVisitor for AddParens {
 }
 
 fn main() {
-    syntax::with_globals(|| run());
+    syntax::with_default_globals(|| run());
 }
 
 fn run() {

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -15,7 +15,7 @@ error[E0425]: cannot find value `no` in this scope
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
-thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
+thread '$DIR/failed-doctest-output.rs - OtherStruct (line 17)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:320:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 11) stdout ----
@@ -24,7 +24,7 @@ thread '$DIR/failed-doctest-output.rs - SomeStruct (line 11)' panicked at 'test 
 thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:3:1
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
-', src/librustdoc/test.rs:341:17
+', src/librustdoc/test.rs:342:17
 
 
 failures:

--- a/src/test/rustdoc-ui/unparseable-doc-test.stdout
+++ b/src/test/rustdoc-ui/unparseable-doc-test.stdout
@@ -13,7 +13,7 @@ error: unterminated double quote string
 
 error: aborting due to previous error
 
-thread '$DIR/unparseable-doc-test.rs - foo (line 6)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
+thread '$DIR/unparseable-doc-test.rs - foo (line 6)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:320:13
 note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -266,7 +266,7 @@ fn main() {
         *slot.borrow_mut() = Some((None, String::from("https://play.rust-lang.org/")));
     });
     let (format, dst) = parse_args();
-    let result = syntax::with_globals(move || {
+    let result = syntax::with_default_globals(move || {
         main_with_result(format, &dst)
     });
     if let Err(e) = result {


### PR DESCRIPTION
Successful merges:

 - #59742 (Move `edition` outside the hygiene lock and avoid accessing it)
 - #60581 (convert custom try macro to `?`)
 - #60963 (Update boxed::Box docs on memory layout)
 - #60973 (Avoid symbol interning in `file_metadata`.)
 - #60982 (Do not fail on child without DefId)
 - #60991 (LocalDecl push returns Local len)
 - #60995 (Add stream_to_parser_with_base_dir)
 - #60998 (static_assert: make use of anonymous constants)
 - #61003 (Remove impls for `InternedString`/string equality.)
 - #61006 (adjust deprecation date of mem::uninitialized)

Failed merges:


r? @ghost