### PR TITLE
Disable LLVM/debug assertions in gnu-full-bootstrap

### DIFF
--- a/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-full-bootstrap/Dockerfile
@@ -20,3 +20,9 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --enable-full-bootstrap
 ENV SCRIPT python2.7 ../x.py build
+
+# In general this just slows down the build and we're just a smoke test that
+# a full bootstrap works in general, so there's not much need to take this
+# penalty in build times.
+ENV NO_LLVM_ASSERTIONS 1
+ENV NO_DEBUG_ASSERTIONS 1


### PR DESCRIPTION
This builder already is very close to the 2 hour mark and the debug
assertions aren't really buying us anything over what all the other
containers are enabling, so let's disable them for this slow builder.