### PR TITLE
enable target thumbv7a-pc-windows-msvc in nightly build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ environment:
   - CI_JOB_NAME: dist-x86_64-msvc
     RUST_CONFIGURE_ARGS: >
       --build=x86_64-pc-windows-msvc
-      --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+      --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc,thumbv7a-pc-windows-msvc
       --enable-full-tools
       --enable-profiler
     SCRIPT: python x.py dist

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -100,6 +100,7 @@ static TARGETS: &[&str] = &[
     "sparc64-unknown-linux-gnu",
     "sparcv9-sun-solaris",
     "thumbv6m-none-eabi",
+    "thumbv7a-pc-windows-msvc",
     "thumbv7em-none-eabi",
     "thumbv7em-none-eabihf",
     "thumbv7m-none-eabi",


### PR DESCRIPTION
This change (hopefully) enables the target `thumbv7a-pc-windows-msvc` in nightly build, this is a follow up of this PR https://github.com/rust-lang/rust/pull/60895 which enables the build end to end, now it's time to enable this target in nightly build, so user can simply rustup to get this target and build their thumbv7a project for Windows.

**How can I verify this change?** I'm not very certain if I made enough changes here, I need some information regarding when and where the build happens in master, so I can check out the pipeline. Or do I have to wait a couple days, and  try add new target from nightly build, if I can successfully install the new target, it mean it worked? 

**Follow up question**
I also noticed aarch64-pc-windows-msvc are mentioned in another two repos, https://github.com/rust-lang/libc.git (https://github.com/chandde/libc/commit/fe67c762ac26292a6914432290bd1d8b1627ac49) and https://github.com/rust-lang/rust-forge.git (https://github.com/chandde/rust-forge/commit/5faa6d5ccd5ada866017638259f870324d90b8c2). I believe I'll need to add thumbv7a there as well, but only after this PR is merged and it's being built successfully in nightly build? 