### PR TITLE
Simplify CharIndices.next

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -663,16 +663,10 @@ impl<'a> Iterator for CharIndices<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<(usize, char)> {
-        let pre_len = self.iter.iter.len();
-        match self.iter.next() {
-            None => None,
-            Some(ch) => {
-                let index = self.front_offset;
-                let len = self.iter.iter.len();
-                self.front_offset += pre_len - len;
-                Some((index, ch))
-            }
-        }
+        let ch = self.iter.next()?;
+        let index = self.front_offset;
+        self.front_offset += ch.len_utf8();
+        Some((index, ch))
     }
 
     #[inline]


### PR DESCRIPTION
`Char.len_utf8` is stable since #49698, making this a little easier to follow.