### PR TITLE
librustc_errors: Remove unused annotation style `OldSchoolNoteText`

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1645,7 +1645,7 @@ impl<'a> WritableDst<'a> {
                 }
             }
             Style::Quotation => {}
-            Style::OldSchoolNoteText | Style::MainHeaderMsg => {
+            Style::MainHeaderMsg => {
                 spec.set_bold(true);
                 if cfg!(windows) {
                     spec.set_intense(true)

--- a/src/librustc_errors/snippet.rs
+++ b/src/librustc_errors/snippet.rs
@@ -188,7 +188,6 @@ pub enum Style {
     UnderlineSecondary,
     LabelPrimary,
     LabelSecondary,
-    OldSchoolNoteText,
     NoStyle,
     Level(Level),
     Highlight,


### PR DESCRIPTION
I could not find any references to it and the `snippet` module does not
seem to be exported publicly, so I think it can be safely removed.

This was originally removed in 17bd76a51 and I'm not sure why it is still there.