### PR TITLE
tidy: don't short-circuit on license error

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -241,7 +241,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         }
 
         let toml = dir.path().join("Cargo.toml");
-        *bad = *bad || !check_license(&toml);
+        *bad = !check_license(&toml) || *bad;
     }
     assert!(saw_dir, "no vendored source");
 }


### PR DESCRIPTION
If there is more than one license error, tidy would only print the first
error. This changes it so that all license errors are printed.