### PR TITLE
Fixed type-alias-bounds lint doc

### DIFF
--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -529,18 +529,21 @@ This lint detects bounds in type aliases. These are not currently enforced.
 Some example code that triggers this lint:
 
 ```rust
+#[allow(dead_code)]
 type SendVec<T: Send> = Vec<T>;
 ```
 
 This will produce:
 
 ```text
-warning: type alias is never used: `SendVec`
- --> src/main.rs:1:1
+warning: bounds on generic parameters are not enforced in type aliases
+ --> src/lib.rs:2:17
   |
-1 | type SendVec<T: Send> = Vec<T>;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+2 | type SendVec<T: Send> = Vec<T>;
+  |                 ^^^^
   |
+  = note: #[warn(type_alias_bounds)] on by default
+  = help: the bound will not be checked when the type alias is used, and should be removed
 ```
 
 ## tyvar-behind-raw-pointer


### PR DESCRIPTION
The example code under type-alias-bounds lint produced two warnings - one from the lint itself and another from the dead_code lint, and only the second one was in the doc. This looked like an error, so I've added `#[allow(dead_code)]` and replaced the example output with the expected one.

[Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=%23%5Ballow(dead_code)%5D%0Atype%20SendVec%3CT%3A%20Send%3E%20%3D%20Vec%3CT%3E%3B)

According to guidelines,
r? @steveklabnik