### PR TITLE
SliceConcatExt::connect defaults to calling join

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -582,7 +582,9 @@ pub trait SliceConcatExt<T: ?Sized> {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_deprecated(since = "1.3.0", reason = "renamed to join")]
-    fn connect(&self, sep: &T) -> Self::Output;
+    fn connect(&self, sep: &T) -> Self::Output {
+        self.join(sep)
+    }
 }
 
 #[unstable(feature = "slice_concat_ext",
@@ -615,10 +617,6 @@ impl<T: Clone, V: Borrow<[T]>> SliceConcatExt<T> for [V] {
             result.extend_from_slice(v.borrow())
         }
         result
-    }
-
-    fn connect(&self, sep: &T) -> Vec<T> {
-        self.join(sep)
     }
 }
 

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -86,10 +86,6 @@ impl<S: Borrow<str>> SliceConcatExt<str> for [S] {
             String::from_utf8_unchecked( join_generic_copy(self, sep.as_bytes()) )
         }
     }
-
-    fn connect(&self, sep: &str) -> String {
-        self.join(sep)
-    }
 }
 
 macro_rules! spezialize_for_lengths {


### PR DESCRIPTION
It makes sense to default a deprecated method to the new one.  Precedence example is `Error::cause` defaults to calling `Error::source`.