### PR TITLE
Improve the explicit_outlives_requirements lint 

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -773,7 +773,6 @@ pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Generi
 
 pub fn walk_generics<'v, V: Visitor<'v>>(visitor: &mut V, generics: &'v Generics) {
     walk_list!(visitor, visit_generic_param, &generics.params);
-    visitor.visit_id(generics.where_clause.hir_id);
     walk_list!(visitor, visit_where_predicate, &generics.where_clause.predicates);
 }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1727,8 +1727,8 @@ impl<'a> LoweringContext<'a> {
                 generics: hir::Generics {
                     params: lifetime_defs,
                     where_clause: hir::WhereClause {
-                        hir_id: lctx.next_id(),
                         predicates: hir_vec![],
+                        span,
                     },
                     span,
                 },
@@ -2619,8 +2619,8 @@ impl<'a> LoweringContext<'a> {
                 generics: hir::Generics {
                     params: generic_params,
                     where_clause: hir::WhereClause {
-                        hir_id: this.next_id(),
                         predicates: hir_vec![],
+                        span,
                     },
                     span,
                 },
@@ -2973,11 +2973,11 @@ impl<'a> LoweringContext<'a> {
             AnonymousLifetimeMode::ReportError,
             |this| {
                 hir::WhereClause {
-                    hir_id: this.lower_node_id(wc.id),
                     predicates: wc.predicates
                         .iter()
                         .map(|predicate| this.lower_where_predicate(predicate))
                         .collect(),
+                    span: wc.span,
                 }
             },
         )

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -592,8 +592,8 @@ impl Generics {
         Generics {
             params: HirVec::new(),
             where_clause: WhereClause {
-                hir_id: DUMMY_HIR_ID,
                 predicates: HirVec::new(),
+                span: DUMMY_SP,
             },
             span: DUMMY_SP,
         }
@@ -644,19 +644,18 @@ pub enum SyntheticTyParamKind {
 /// A where-clause in a definition.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
 pub struct WhereClause {
-    pub hir_id: HirId,
     pub predicates: HirVec<WherePredicate>,
+    // Only valid if predicates isn't empty.
+    span: Span,
 }
 
 impl WhereClause {
     pub fn span(&self) -> Option<Span> {
-        self.predicates.iter().map(|predicate| predicate.span())
-            .fold(None, |acc, i| match (acc, i) {
-                (None, i) => Some(i),
-                (Some(acc), i) => {
-                    Some(acc.to(i))
-                }
-            })
+        if self.predicates.is_empty() {
+            None
+        } else {
+            Some(self.span)
+        }
     }
 }
 

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -2202,8 +2202,8 @@ impl<'a> State<'a> {
         let generics = hir::Generics {
             params: hir::HirVec::new(),
             where_clause: hir::WhereClause {
-                hir_id: hir::DUMMY_HIR_ID,
                 predicates: hir::HirVec::new(),
+                span: syntax_pos::DUMMY_SP,
             },
             span: syntax_pos::DUMMY_SP,
         };

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1618,7 +1618,7 @@ impl ExplicitOutlivesRequirements {
             let mut from_start = true;
             for (i, bound_span) in bound_spans {
                 match last_merged_i {
-                    // If the first bound is inferable, our span should also eat the leading `+`
+                    // If the first bound is inferable, our span should also eat the leading `+`.
                     None if i == 0 => {
                         merged.push(bound_span.to(bounds[1].span().shrink_to_lo()));
                         last_merged_i = Some(0);
@@ -1732,15 +1732,17 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
                             hir::TyKind::Path(hir::QPath::Resolved(
                                 None,
                                 ref path,
-                            )) => if let Res::Def(DefKind::TyParam, def_id) = path.res {
-                                let index = ty_generics.param_def_id_to_index[&def_id];
-                                (
-                                    Self::lifetimes_outliving_type(inferred_outlives, index),
-                                    &predicate.bounds,
-                                    predicate.span,
-                                )
-                            } else {
-                                continue
+                            )) => {
+                                if let Res::Def(DefKind::TyParam, def_id) = path.res {
+                                    let index = ty_generics.param_def_id_to_index[&def_id];
+                                    (
+                                        Self::lifetimes_outliving_type(inferred_outlives, index),
+                                        &predicate.bounds,
+                                        predicate.span,
+                                    )
+                                } else {
+                                    continue;
+                                }
                             },
                             _ => { continue; }
                         }
@@ -1762,9 +1764,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
                 }
 
                 // If all the bounds on a predicate were inferable and there are
-                // further predicates, we want to eat the trailing comma
+                // further predicates, we want to eat the trailing comma.
                 if drop_predicate && i + 1 < num_predicates {
-                    let next_predicate_span = hir_generics.where_clause.predicates[i+1].span();
+                    let next_predicate_span = hir_generics.where_clause.predicates[i + 1].span();
                     where_lint_spans.push(
                         span.to(next_predicate_span.shrink_to_lo())
                     );
@@ -1787,13 +1789,12 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
                 // Extend the where clause back to the closing `>` of the
                 // generics, except for tuple struct, which have the `where`
                 // after the fields of the struct.
-                let full_where_span = match item.node {
-                    hir::ItemKind::Struct(hir::VariantData::Tuple(..), _) => {
-                        where_span
-                    }
-                    _ => {
-                        hir_generics.span.shrink_to_hi().to(where_span)
-                    }
+                let full_where_span = if let hir::ItemKind::Struct(hir::VariantData::Tuple(..), _)
+                        = item.node
+                {
+                    where_span
+                } else {
+                    hir_generics.span.shrink_to_hi().to(where_span)
                 };
                 lint_spans.push(
                     full_where_span

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -23,7 +23,7 @@
 
 use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
-use rustc::ty::{self, Ty};
+use rustc::ty::{self, Ty, TyCtxt};
 use rustc::{lint, util};
 use hir::Node;
 use util::nodemap::HirIdSet;
@@ -1494,58 +1494,107 @@ impl EarlyLintPass for KeywordIdents {
 declare_lint_pass!(ExplicitOutlivesRequirements => [EXPLICIT_OUTLIVES_REQUIREMENTS]);
 
 impl ExplicitOutlivesRequirements {
-    fn collect_outlives_bound_spans(
-        &self,
-        cx: &LateContext<'_, '_>,
-        item_def_id: DefId,
-        param_name: &str,
-        bounds: &hir::GenericBounds,
-        infer_static: bool
-    ) -> Vec<(usize, Span)> {
-        // For lack of a more elegant strategy for comparing the `ty::Predicate`s
-        // returned by this query with the params/bounds grabbed from the HIR—and
-        // with some regrets—we're going to covert the param/lifetime names to
-        // strings
-        let inferred_outlives = cx.tcx.inferred_outlives_of(item_def_id);
-
-        let ty_lt_names = inferred_outlives.iter().filter_map(|pred| {
-            let binder = match pred {
-                ty::Predicate::TypeOutlives(binder) => binder,
-                _ => { return None; }
-            };
-            let ty_outlives_pred = binder.skip_binder();
-            let ty_name = match ty_outlives_pred.0.sty {
-                ty::Param(param) => param.name.to_string(),
-                _ => { return None; }
-            };
-            let lt_name = match ty_outlives_pred.1 {
-                ty::RegionKind::ReEarlyBound(region) => {
-                    region.name.to_string()
-                },
-                _ => { return None; }
-            };
-            Some((ty_name, lt_name))
-        }).collect::<Vec<_>>();
-
-        let mut bound_spans = Vec::new();
-        for (i, bound) in bounds.iter().enumerate() {
-            if let hir::GenericBound::Outlives(lifetime) = bound {
-                let is_static = match lifetime.name {
-                    hir::LifetimeName::Static => true,
-                    _ => false
-                };
-                if is_static && !infer_static {
-                    // infer-outlives for 'static is still feature-gated (tracking issue #44493)
-                    continue;
+    fn lifetimes_outliving_lifetime<'tcx>(
+        inferred_outlives: &'tcx [ty::Predicate<'tcx>],
+        index: u32,
+    ) -> Vec<ty::Region<'tcx>> {
+        inferred_outlives.iter().filter_map(|pred| {
+            match pred {
+                ty::Predicate::RegionOutlives(outlives) => {
+                    let outlives = outlives.skip_binder();
+                    match outlives.0 {
+                        ty::ReEarlyBound(ebr) if ebr.index == index => {
+                            Some(outlives.1)
+                        }
+                        _ => None,
+                    }
                 }
-
-                let lt_name = &lifetime.name.ident().to_string();
-                if ty_lt_names.contains(&(param_name.to_owned(), lt_name.to_owned())) {
-                    bound_spans.push((i, bound.span()));
-                }
+                _ => None
             }
+        }).collect()
+    }
+
+    fn lifetimes_outliving_type<'tcx>(
+        inferred_outlives: &'tcx [ty::Predicate<'tcx>],
+        index: u32,
+    ) -> Vec<ty::Region<'tcx>> {
+        inferred_outlives.iter().filter_map(|pred| {
+            match pred {
+                ty::Predicate::TypeOutlives(outlives) => {
+                    let outlives = outlives.skip_binder();
+                    if outlives.0.is_param(index) {
+                        Some(outlives.1)
+                    } else {
+                        None
+                    }
+                }
+                _ => None
+            }
+        }).collect()
+    }
+
+    fn collect_outlived_lifetimes<'tcx>(
+        &self,
+        param: &'tcx hir::GenericParam,
+        tcx: TyCtxt<'tcx>,
+        inferred_outlives: &'tcx [ty::Predicate<'tcx>],
+        ty_generics: &'tcx ty::Generics,
+    ) -> Vec<ty::Region<'tcx>> {
+        let index = ty_generics.param_def_id_to_index[
+            &tcx.hir().local_def_id_from_hir_id(param.hir_id)];
+
+        match param.kind {
+            hir::GenericParamKind::Lifetime { .. } => {
+                Self::lifetimes_outliving_lifetime(inferred_outlives, index)
+            }
+            hir::GenericParamKind::Type { .. } => {
+                Self::lifetimes_outliving_type(inferred_outlives, index)
+            }
+            hir::GenericParamKind::Const { .. } => Vec::new(),
         }
-        bound_spans
+    }
+
+
+    fn collect_outlives_bound_spans<'tcx>(
+        &self,
+        tcx: TyCtxt<'tcx>,
+        bounds: &hir::GenericBounds,
+        inferred_outlives: &[ty::Region<'tcx>],
+        infer_static: bool,
+    ) -> Vec<(usize, Span)> {
+        use rustc::middle::resolve_lifetime::Region;
+
+        bounds
+            .iter()
+            .enumerate()
+            .filter_map(|(i, bound)| {
+                if let hir::GenericBound::Outlives(lifetime) = bound {
+                    let is_inferred = match tcx.named_region(lifetime.hir_id) {
+                        Some(Region::Static) if infer_static => {
+                            inferred_outlives.iter()
+                                .any(|r| if let ty::ReStatic = r { true } else { false })
+                        }
+                        Some(Region::EarlyBound(index, ..)) => inferred_outlives
+                            .iter()
+                            .any(|r| {
+                                if let ty::ReEarlyBound(ebr) = r {
+                                    ebr.index == index
+                                } else {
+                                    false
+                                }
+                            }),
+                        _ => false,
+                    };
+                    if is_inferred {
+                        Some((i, bound.span()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn consolidate_outlives_bound_spans(
@@ -1569,7 +1618,7 @@ impl ExplicitOutlivesRequirements {
             let mut from_start = true;
             for (i, bound_span) in bound_spans {
                 match last_merged_i {
-                    // If the first bound is inferable, our span should also eat the trailing `+`
+                    // If the first bound is inferable, our span should also eat the leading `+`
                     None if i == 0 => {
                         merged.push(bound_span.to(bounds[1].span().shrink_to_lo()));
                         last_merged_i = Some(0);
@@ -1607,26 +1656,48 @@ impl ExplicitOutlivesRequirements {
 
 impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
     fn check_item(&mut self, cx: &LateContext<'a, 'tcx>, item: &'tcx hir::Item) {
+        use rustc::middle::resolve_lifetime::Region;
+
         let infer_static = cx.tcx.features().infer_static_outlives_requirements;
         let def_id = cx.tcx.hir().local_def_id_from_hir_id(item.hir_id);
-        if let hir::ItemKind::Struct(_, ref generics) = item.node {
+        if let hir::ItemKind::Struct(_, ref hir_generics)
+            | hir::ItemKind::Enum(_, ref hir_generics)
+            | hir::ItemKind::Union(_, ref hir_generics) = item.node
+        {
+            let inferred_outlives = cx.tcx.inferred_outlives_of(def_id);
+            if inferred_outlives.is_empty() {
+                return;
+            }
+
+            let ty_generics = cx.tcx.generics_of(def_id);
+
             let mut bound_count = 0;
             let mut lint_spans = Vec::new();
 
-            for param in &generics.params {
-                let param_name = match param.kind {
-                    hir::GenericParamKind::Lifetime { .. } => continue,
-                    hir::GenericParamKind::Type { .. } => {
-                        match param.name {
-                            hir::ParamName::Fresh(_) => continue,
-                            hir::ParamName::Error => continue,
-                            hir::ParamName::Plain(name) => name.to_string(),
-                        }
+            for param in &hir_generics.params {
+                let has_lifetime_bounds = param.bounds.iter().any(|bound| {
+                    if let hir::GenericBound::Outlives(_) = bound {
+                        true
+                    } else {
+                        false
                     }
-                    hir::GenericParamKind::Const { .. } => continue,
-                };
+                });
+                if !has_lifetime_bounds {
+                    continue;
+                }
+
+                let relevant_lifetimes = self.collect_outlived_lifetimes(
+                    param,
+                    cx.tcx,
+                    inferred_outlives,
+                    ty_generics,
+                );
+                if relevant_lifetimes.is_empty() {
+                    continue;
+                }
+
                 let bound_spans = self.collect_outlives_bound_spans(
-                    cx, def_id, &param_name, &param.bounds, infer_static
+                    cx.tcx, &param.bounds, &relevant_lifetimes, infer_static,
                 );
                 bound_count += bound_spans.len();
                 lint_spans.extend(
@@ -1638,54 +1709,92 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ExplicitOutlivesRequirements {
 
             let mut where_lint_spans = Vec::new();
             let mut dropped_predicate_count = 0;
-            let num_predicates = generics.where_clause.predicates.len();
-            for (i, where_predicate) in generics.where_clause.predicates.iter().enumerate() {
-                if let hir::WherePredicate::BoundPredicate(predicate) = where_predicate {
-                    let param_name = match predicate.bounded_ty.node {
-                        hir::TyKind::Path(ref qpath) => {
-                            if let hir::QPath::Resolved(None, ty_param_path) = qpath {
-                                ty_param_path.segments[0].ident.to_string()
-                            } else {
-                                continue;
-                            }
-                        },
-                        _ => { continue; }
-                    };
-                    let bound_spans = self.collect_outlives_bound_spans(
-                        cx, def_id, &param_name, &predicate.bounds, infer_static
-                    );
-                    bound_count += bound_spans.len();
-
-                    let drop_predicate = bound_spans.len() == predicate.bounds.len();
-                    if drop_predicate {
-                        dropped_predicate_count += 1;
-                    }
-
-                    // If all the bounds on a predicate were inferable and there are
-                    // further predicates, we want to eat the trailing comma
-                    if drop_predicate && i + 1 < num_predicates {
-                        let next_predicate_span = generics.where_clause.predicates[i+1].span();
-                        where_lint_spans.push(
-                            predicate.span.to(next_predicate_span.shrink_to_lo())
-                        );
-                    } else {
-                        where_lint_spans.extend(
-                            self.consolidate_outlives_bound_spans(
-                                predicate.span.shrink_to_lo(),
+            let num_predicates = hir_generics.where_clause.predicates.len();
+            for (i, where_predicate) in hir_generics.where_clause.predicates.iter().enumerate() {
+                let (relevant_lifetimes, bounds, span) = match where_predicate {
+                    hir::WherePredicate::RegionPredicate(predicate) => {
+                        if let Some(Region::EarlyBound(index, ..))
+                            = cx.tcx.named_region(predicate.lifetime.hir_id)
+                        {
+                            (
+                                Self::lifetimes_outliving_lifetime(inferred_outlives, index),
                                 &predicate.bounds,
-                                bound_spans
+                                predicate.span,
                             )
-                        );
+                        } else {
+                            continue;
+                        }
                     }
+                    hir::WherePredicate::BoundPredicate(predicate) => {
+                        // FIXME we can also infer bounds on associated types,
+                        // and should check for them here.
+                        match predicate.bounded_ty.node {
+                            hir::TyKind::Path(hir::QPath::Resolved(
+                                None,
+                                ref path,
+                            )) => if let Res::Def(DefKind::TyParam, def_id) = path.res {
+                                let index = ty_generics.param_def_id_to_index[&def_id];
+                                (
+                                    Self::lifetimes_outliving_type(inferred_outlives, index),
+                                    &predicate.bounds,
+                                    predicate.span,
+                                )
+                            } else {
+                                continue
+                            },
+                            _ => { continue; }
+                        }
+                    }
+                    _ => continue,
+                };
+                if relevant_lifetimes.is_empty() {
+                    continue;
+                }
+
+                let bound_spans = self.collect_outlives_bound_spans(
+                    cx.tcx, bounds, &relevant_lifetimes, infer_static,
+                );
+                bound_count += bound_spans.len();
+
+                let drop_predicate = bound_spans.len() == bounds.len();
+                if drop_predicate {
+                    dropped_predicate_count += 1;
+                }
+
+                // If all the bounds on a predicate were inferable and there are
+                // further predicates, we want to eat the trailing comma
+                if drop_predicate && i + 1 < num_predicates {
+                    let next_predicate_span = hir_generics.where_clause.predicates[i+1].span();
+                    where_lint_spans.push(
+                        span.to(next_predicate_span.shrink_to_lo())
+                    );
+                } else {
+                    where_lint_spans.extend(
+                        self.consolidate_outlives_bound_spans(
+                            span.shrink_to_lo(),
+                            bounds,
+                            bound_spans
+                        )
+                    );
                 }
             }
 
             // If all predicates are inferable, drop the entire clause
             // (including the `where`)
             if num_predicates > 0 && dropped_predicate_count == num_predicates {
-                let full_where_span = generics.span.shrink_to_hi()
-                    .to(generics.where_clause.span()
-                    .expect("span of (nonempty) where clause should exist"));
+                let where_span = hir_generics.where_clause.span()
+                    .expect("span of (nonempty) where clause should exist");
+                // Extend the where clause back to the closing `>` of the
+                // generics, except for tuple struct, which have the `where`
+                // after the fields of the struct.
+                let full_where_span = match item.node {
+                    hir::ItemKind::Struct(hir::VariantData::Tuple(..), _) => {
+                        where_span
+                    }
+                    _ => {
+                        hir_generics.span.shrink_to_hi().to(where_span)
+                    }
+                };
                 lint_spans.push(
                     full_where_span
                 );

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2001,16 +2001,15 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let PathSeg(def_id, index) = path_segs.last().unwrap();
                 self.ast_path_to_ty(span, *def_id, &path.segments[*index])
             }
-            Res::Def(DefKind::TyParam, did) => {
+            Res::Def(DefKind::TyParam, def_id) => {
                 assert_eq!(opt_self_ty, None);
                 self.prohibit_generics(&path.segments);
 
-                let hir_id = tcx.hir().as_local_hir_id(did).unwrap();
+                let hir_id = tcx.hir().as_local_hir_id(def_id).unwrap();
                 let item_id = tcx.hir().get_parent_node_by_hir_id(hir_id);
                 let item_def_id = tcx.hir().local_def_id_from_hir_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
-                let index = generics.param_def_id_to_index[
-                    &tcx.hir().local_def_id_from_hir_id(hir_id)];
+                let index = generics.param_def_id_to_index[&def_id];
                 tcx.mk_ty_param(index, tcx.hir().name_by_hir_id(hir_id).as_interned_str())
             }
             Res::SelfTy(Some(_), None) => {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -362,7 +362,6 @@ impl Default for Generics {
         Generics {
             params: Vec::new(),
             where_clause: WhereClause {
-                id: DUMMY_NODE_ID,
                 predicates: Vec::new(),
                 span: DUMMY_SP,
             },
@@ -374,7 +373,6 @@ impl Default for Generics {
 /// A where-clause in a definition.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct WhereClause {
-    pub id: NodeId,
     pub predicates: Vec<WherePredicate>,
     pub span: Span,
 }

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -750,8 +750,7 @@ pub fn noop_visit_generics<T: MutVisitor>(generics: &mut Generics, vis: &mut T) 
 }
 
 pub fn noop_visit_where_clause<T: MutVisitor>(wc: &mut WhereClause, vis: &mut T) {
-    let WhereClause { id, predicates, span } = wc;
-    vis.visit_id(id);
+    let WhereClause { predicates, span } = wc;
     visit_vec(predicates, |predicate| vis.visit_where_predicate(predicate));
     vis.visit_span(span);
 }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -5075,7 +5075,6 @@ impl<'a> Parser<'a> {
         Ok(ast::Generics {
             params,
             where_clause: WhereClause {
-                id: ast::DUMMY_NODE_ID,
                 predicates: Vec::new(),
                 span: DUMMY_SP,
             },
@@ -5334,7 +5333,6 @@ impl<'a> Parser<'a> {
     /// ```
     fn parse_where_clause(&mut self) -> PResult<'a, WhereClause> {
         let mut where_clause = WhereClause {
-            id: ast::DUMMY_NODE_ID,
             predicates: Vec::new(),
             span: self.prev_span.to(self.prev_span),
         };

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -3042,7 +3042,6 @@ impl<'a> State<'a> {
         let generics = ast::Generics {
             params: Vec::new(),
             where_clause: ast::WhereClause {
-                id: ast::DUMMY_NODE_ID,
                 predicates: Vec::new(),
                 span: syntax_pos::DUMMY_SP,
             },

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -223,7 +223,6 @@ fn mk_generics(params: Vec<ast::GenericParam>, span: Span) -> Generics {
     Generics {
         params,
         where_clause: ast::WhereClause {
-            id: ast::DUMMY_NODE_ID,
             predicates: Vec::new(),
             span,
         },

--- a/src/test/ui/error-codes/E0646.stderr
+++ b/src/test/ui/error-codes/E0646.stderr
@@ -1,8 +1,8 @@
 error[E0646]: `main` function is not allowed to have a `where` clause
-  --> $DIR/E0646.rs:1:17
+  --> $DIR/E0646.rs:1:11
    |
 LL | fn main() where (): Copy {}
-   |                 ^^^^^^^^ `main` cannot have a `where` clause
+   |           ^^^^^^^^^^^^^^ `main` cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0647.stderr
+++ b/src/test/ui/error-codes/E0647.stderr
@@ -1,8 +1,8 @@
 error[E0647]: start function is not allowed to have a `where` clause
-  --> $DIR/E0647.rs:7:56
+  --> $DIR/E0647.rs:7:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where (): Copy {
-   |                                                        ^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^ start function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50714-1.stderr
+++ b/src/test/ui/issues/issue-50714-1.stderr
@@ -1,8 +1,8 @@
 error[E0647]: start function is not allowed to have a `where` clause
-  --> $DIR/issue-50714-1.rs:9:56
+  --> $DIR/issue-50714-1.rs:9:50
    |
 LL | fn start(_: isize, _: *const *const u8) -> isize where fn(&()): Eq {
-   |                                                        ^^^^^^^^^^^ start function cannot have a `where` clause
+   |                                                  ^^^^^^^^^^^^^^^^^ start function cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-50714.stderr
+++ b/src/test/ui/issues/issue-50714.stderr
@@ -1,8 +1,8 @@
 error[E0646]: `main` function is not allowed to have a `where` clause
-  --> $DIR/issue-50714.rs:3:17
+  --> $DIR/issue-50714.rs:3:11
    |
 LL | fn main() where fn(&()): Eq {}
-   |                 ^^^^^^^^^^^ `main` cannot have a `where` clause
+   |           ^^^^^^^^^^^^^^^^^ `main` cannot have a `where` clause
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.rs
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.rs
@@ -1,75 +1,368 @@
 #![allow(unused)]
 #![deny(explicit_outlives_requirements)]
 
-use std::fmt::{Debug, Display};
 
 // These examples should live in edition-lint-infer-outlives.rs, but are split
 // into this separate file because they can't be `rustfix`'d (and thus, can't
 // be part of a `run-rustfix` test file) until rust-lang-nursery/rustfix#141
 // is solved
 
-struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
+mod structs {
+    use std::fmt::Debug;
+
+    struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>
+        where U: 'a + Debug + 'b, 'b: 'a
+        //~^ ERROR outlives requirements can be inferred
+    {
+        tee: T,
+        yoo: &'a &'b U
+    }
 }
 
-struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+mod tuple_structs {
+    use std::fmt::Debug;
+
+    struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b>(&'a &'b T);
     //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
+
+    struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: 'a + Debug + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug>(&'a T, &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b>(&'a T, &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + Debug + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: Debug + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: 'b + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: Debug + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + Debug + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereAyTeeYooWhereAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U)
+        where U: 'a + Debug + 'b, 'b: 'a;
+    //~^ ERROR outlives requirements can be inferred
 }
 
-struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
+mod enums {
+    use std::fmt::Debug;
+
+    enum TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, },
+        W(&'a &'b U),
+    }
+
+    enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T, yoo: &'b U },
+        W,
+    }
+
+    enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T, &'b U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(&'b U),
+    }
+
+    enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T, &'b U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(&'b U)
+    }
+
+    enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T, yoo: &'b U },
+        W,
+    }
+
+    enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T, &'b U),
+        W,
+    }
+
+    enum BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W,
+    }
+
+    enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a &'b U),
+    }
+
+    enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+    }
 }
 
-struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+mod unions {
+    use std::fmt::Debug;
 
-struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+    union TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+    union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+    union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
 
-struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+    union TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
 
-struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
-}
+    union TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
 
-struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: &'b U
+    union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: &'b U
+    }
+
+    union BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 }
 
 fn main() {}

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
@@ -1,8 +1,8 @@
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:11:43
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:13:47
    |
-LL | struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
-   |                                           ^^^^^     ^^^^^
+LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+   |                                               ^^^^^     ^^^^^
    |
 note: lint level defined here
   --> $DIR/edition-lint-infer-outlives-multispan.rs:2:9
@@ -11,108 +11,678 @@ LL | #![deny(explicit_outlives_requirements)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   |                                          --   --
+LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                              --   --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:16:57
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:18:61
    |
-LL | struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
-   |                                                         ^^^^^     ^^^^^
+LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+   |                                                             ^^^^^     ^^^^^
 help: remove these bounds
    |
-LL | struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   |                                                        --   --
+LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                            --   --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:21:49
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:23:53
    |
-LL | struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
-   |                                                 ^^^^^     ^^^^^
+LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+   |                                                     ^^^^^     ^^^^^
 help: remove these bounds
    |
-LL | struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   |                                                --   --
+LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                    --   --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:27:44
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:29:48
    |
-LL | struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
-   |                                            ^^^^     ^^^^^
+LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+   |                                                ^^^^     ^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
-   |                                           --   --
+LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
+   |                                               --   --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:33:44
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:35:48
    |
-LL | struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
-   |                                            ^^^^          ^^^^^
+LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+   |                                                ^^^^          ^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
-   |                                           --        --
+LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                               --        --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:39:42
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:41:46
    |
-LL | struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
-   |                                          ^^^^    ^^^^^^^^^^^^
+LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+   |                                              ^^^^    ^^^^^^^^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
-   |                                         --  --
+LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
+   |                                             --  --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:45:63
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:47:67
    |
-LL | struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
-   |                                                               ^^^^^     ^^^^^
+LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+   |                                                                   ^^^^^     ^^^^^
 help: remove these bounds
    |
-LL | struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
-   |                                                              --   --
+LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                  --   --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:51:49
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:53:53
    |
-LL | struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
-   |                                                 ^^^^              ^^^^^
+LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+   |                                                     ^^^^              ^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   |                                                --            --
+LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                    --            --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:57:49
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:59:53
    |
-LL | struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
-   |                                                 ^^^^                   ^^^^^
+LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+   |                                                     ^^^^                   ^^^^^
 help: remove these bounds
    |
-LL | struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   |                                                --                 --
+LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                    --                 --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:63:65
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:65:69
    |
-LL | struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
-   |                                                                 ^^^^^^^   ^^^^^
+LL |     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+   |                                                                     ^^^^^^^   ^^^^^
 help: remove these bounds
    |
-LL | struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   |                                                                -- --
+LL |     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                                    -- --
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives-multispan.rs:69:65
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:71:69
    |
-LL | struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
-   |                                                                 ^^^^^^^        ^^^^^
+LL |     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+   |                                                                     ^^^^^^^        ^^^^^
 help: remove these bounds
    |
-LL | struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   |                                                                --      --
+LL |     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                    --      --
 
-error: aborting due to 11 previous errors
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:77:38
+   |
+LL |     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+   |                                      ^^^^   ^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeBee<'a, 'b, T> {
+   |                                     -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:82:40
+   |
+LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+   |                                        ^^^^   ^^^^^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b, T> {
+   |                                       -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:87:55
+   |
+LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+   |                                                       ^^^^     ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                                      --   --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:92:68
+   |
+LL |     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+   |                                                                    ^^^^^^^^   ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                                   -- --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:97:58
+   |
+LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+   |                                                          ^^^^        ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                         --      --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:104:18
+   |
+LL |         where U: 'a + Debug + 'b, 'b: 'a
+   |                  ^^^^^     ^^^^^  ^^^^^^
+help: remove these bounds
+   |
+LL |         where U: Debug, 
+   |                 --   ----
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:115:47
+   |
+LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b>(&'a &'b T);
+   |                                               ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
+   |                                              --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:118:72
+   |
+LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: 'a + Debug + 'b;
+   |                                                                        ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
+   |                                                                       --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:121:53
+   |
+LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b>(T, &'a &'b U);
+   |                                                     ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
+   |                                                    --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:124:48
+   |
+LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug>(&'a T, &'b U);
+   |                                                ^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug>(&'a T, &'b U);
+   |                                               --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:127:48
+   |
+LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b>(&'a T, &'b U);
+   |                                                ^^^^          ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug>(&'a T, &'b U);
+   |                                               --        --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:130:46
+   |
+LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b;
+   |                                              ^^^^                   ^^^^^^^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U>(&'a T, &'b U) ;
+   |                                             --                 --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:133:81
+   |
+LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + Debug + 'b;
+   |                                                                                 ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug;
+   |                                                                                --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:136:53
+   |
+LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b + Debug;
+   |                                                     ^^^^                            ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
+   |                                                    --                          --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:139:53
+   |
+LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: Debug + 'b;
+   |                                                     ^^^^                                 ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
+   |                                                    --                               --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:142:75
+   |
+LL |     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: 'b + Debug;
+   |                                                                           ^^^^^^^   ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
+   |                                                                          -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:145:75
+   |
+LL |     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: Debug + 'b;
+   |                                                                           ^^^^^^^        ^^^^^
+help: remove these bounds
+   |
+LL |     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
+   |                                                                          --      --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:148:38
+   |
+LL |     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b>(&'a &'b T);
+   |                                      ^^^^   ^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeBee<'a, 'b, T>(&'a &'b T);
+   |                                     -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:151:40
+   |
+LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b>(&'a &'b T);
+   |                                        ^^^^   ^^^^^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b, T>(&'a &'b T);
+   |                                       -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:154:55
+   |
+LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b>(&'a &'b T);
+   |                                                       ^^^^     ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
+   |                                                      --   --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:157:71
+   |
+LL |     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + Debug + 'b;
+   |                                                                       ^^^^^^^^   ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
+   |                                                                      -- --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:160:58
+   |
+LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b>(T, &'a &'b U);
+   |                                                          ^^^^        ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
+   |                                                         --      --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:164:18
+   |
+LL |         where U: 'a + Debug + 'b, 'b: 'a;
+   |                  ^^^^^     ^^^^^  ^^^^^^
+help: remove these bounds
+   |
+LL |         where U: Debug, ;
+   |                 --   ----
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:171:45
+   |
+LL |     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+   |                                             ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                            --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:176:59
+   |
+LL |     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+   |                                                           ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                          --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:181:51
+   |
+LL |     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+   |                                                   ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                  --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:187:46
+   |
+LL |     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+   |                                              ^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
+   |                                             --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:193:46
+   |
+LL |     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+   |                                              ^^^^          ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                             --        --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:199:44
+   |
+LL |     enum TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+   |                                            ^^^^    ^^^^^^^^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
+   |                                           --  --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:205:65
+   |
+LL |     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+   |                                                                 ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:211:51
+   |
+LL |     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+   |                                                   ^^^^              ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                  --            --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:217:51
+   |
+LL |     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+   |                                                   ^^^^                   ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                  --                 --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:223:67
+   |
+LL |     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+   |                                                                   ^^^^^^^   ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                                  -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:229:67
+   |
+LL |     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+   |                                                                   ^^^^^^^        ^^^^^
+help: remove these bounds
+   |
+LL |     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                  --      --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:235:36
+   |
+LL |     enum BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+   |                                    ^^^^   ^^^^
+help: remove these bounds
+   |
+LL |     enum BeeOutlivesAyTeeBee<'a, 'b, T> {
+   |                                   -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:240:38
+   |
+LL |     enum BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+   |                                      ^^^^   ^^^^^^^^^
+help: remove these bounds
+   |
+LL |     enum BeeOutlivesAyTeeAyBee<'a, 'b, T> {
+   |                                     -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:246:53
+   |
+LL |     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+   |                                                     ^^^^     ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                                    --   --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:251:66
+   |
+LL |     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+   |                                                                  ^^^^^^^^   ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                                 -- --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:256:56
+   |
+LL |     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+   |                                                        ^^^^        ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                       --      --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:262:75
+   |
+LL |     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
+   |                                                                           ^^^^^     ^^^^^  ^^^^^^
+help: remove these bounds
+   |
+LL |     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {
+   |                                                                          --   ----
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:271:46
+   |
+LL |     union TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
+   |                                              ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                             --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:276:60
+   |
+LL |     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
+   |                                                            ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                           --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:281:52
+   |
+LL |     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
+   |                                                    ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                   --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:287:47
+   |
+LL |     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
+   |                                               ^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
+   |                                              --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:293:47
+   |
+LL |     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
+   |                                               ^^^^          ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                              --        --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:299:45
+   |
+LL |     union TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
+   |                                             ^^^^    ^^^^^^^^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
+   |                                            --  --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:305:66
+   |
+LL |     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
+   |                                                                  ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                 --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:311:52
+   |
+LL |     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
+   |                                                    ^^^^              ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                   --            --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:317:52
+   |
+LL |     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
+   |                                                    ^^^^                   ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                   --                 --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:323:68
+   |
+LL |     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
+   |                                                                    ^^^^^^^   ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
+   |                                                                   -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:329:68
+   |
+LL |     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
+   |                                                                    ^^^^^^^        ^^^^^
+help: remove these bounds
+   |
+LL |     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
+   |                                                                   --      --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:335:37
+   |
+LL |     union BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
+   |                                     ^^^^   ^^^^
+help: remove these bounds
+   |
+LL |     union BeeOutlivesAyTeeBee<'a, 'b, T> {
+   |                                    -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:340:39
+   |
+LL |     union BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
+   |                                       ^^^^   ^^^^^^^^^
+help: remove these bounds
+   |
+LL |     union BeeOutlivesAyTeeAyBee<'a, 'b, T> {
+   |                                      -- --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:345:54
+   |
+LL |     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
+   |                                                      ^^^^     ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
+   |                                                     --   --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:350:67
+   |
+LL |     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
+   |                                                                   ^^^^^^^^   ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
+   |                                                                  -- --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:355:57
+   |
+LL |     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
+   |                                                         ^^^^        ^^^^^     ^^^^^
+help: remove these bounds
+   |
+LL |     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
+   |                                                        --      --   --
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-multispan.rs:361:76
+   |
+LL |     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
+   |                                                                            ^^^^^     ^^^^^  ^^^^^^
+help: remove these bounds
+   |
+LL |     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {
+   |                                                                           --   ----
+
+error: aborting due to 68 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives.fixed
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives.fixed
@@ -3,9 +3,6 @@
 #![allow(unused)]
 #![deny(explicit_outlives_requirements)]
 
-use std::fmt::{Debug, Display};
-
-
 // Programmatically generated examples!
 //
 // Exercise outlives bounds for each of the following parameter/position
@@ -17,177 +14,773 @@ use std::fmt::{Debug, Display};
 // • two parameters (T and U), one bound inline, one with a where clause
 // • two parameters (T and U), both with where clauses
 //
-// —and for every permutation of 0, 1, or 2 lifetimes to outlive and 0 or 1
-// trait bounds distributed among said parameters (subject to no where clause
-// being empty and the struct having at least one lifetime).
+// —and for every permutation of 1 or 2 lifetimes to outlive and 0 or 1 trait
+// bounds distributed among said parameters (subject to no where clause being
+// empty and the struct having at least one lifetime).
+//
+// —and for each of tuple structs, enums and unions.
 
+mod structs {
+    use std::fmt::Debug;
 
-struct TeeOutlivesAy<'a, T> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+    struct TeeOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeOutlivesAyIsDebug<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeIsDebugOutlivesAy<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereOutlivesAyIsDebug<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeYooOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooOutlivesAyIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeOutlivesAyYooIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeYooOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct TeeYooWhereOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct BeeOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    struct BeeWhereOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    struct BeeOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeOutlivesAyTeeDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
 }
 
-struct TeeOutlivesAyIsDebug<'a, T: Debug> {
+mod tuple_structs {
+    use std::fmt::Debug;
+
+    struct TeeOutlivesAy<'a, T>(&'a T);
     //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+
+    struct TeeOutlivesAyIsDebug<'a, T: Debug>(&'a T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeIsDebugOutlivesAy<'a, T: Debug>(&'a T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBee<'a, 'b, T>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: Debug>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAy<'a, T>(&'a T) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyIsDebug<'a, T>(&'a T) where T: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereIsDebugOutlivesAy<'a, T>(&'a T) where T: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyBee<'a, 'b, T>(&'a &'b T) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T>(&'a &'b T) where T: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T>(&'a &'b T) where T: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAy<'a, T, U>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyIsDebug<'a, T, U: Debug>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooIsDebug<'a, T, U: Debug>(&'a T, U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: Debug>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T, U: Debug>(&'a &'b T, U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAy<'a, T, U>(T, &'a U) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyIsDebug<'a, T, U>(T, &'a U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereIsDebugOutlivesAy<'a, T, U>(T, &'a U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooWhereIsDebug<'a, T, U>(&'a T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U>(T, &'a &'b U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U>(&'a &'b T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U>(&'a T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereAyBeeYooWhereIsDebug<'a, 'b, T, U>(&'a &'b T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAy<'a, 'b>(&'a &'b ());
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAy<'a, 'b>(&'a &'b ()) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTee<'a, 'b, T>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTee<'a, 'b, T>(&'a &'b T) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T>(&'a &'b T) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T>(&'a &'b T) ;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeDebug<'a, 'b, T: Debug>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T>(&'a &'b T) where T: Debug;
+    //~^ ERROR outlives requirements can be inferred
 }
 
-struct TeeIsDebugOutlivesAy<'a, T: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+mod enums {
+    use std::fmt::Debug;
+
+    enum TeeOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+    }
+
+    enum TeeOutlivesAyIsDebug<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T),
+    }
+
+    enum TeeIsDebugOutlivesAy<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W,
+    }
+
+    enum TeeOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum TeeOutlivesAyBeeIsDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum TeeWhereOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W,
+    }
+
+    enum TeeWhereOutlivesAyIsDebug<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T),
+        W,
+    }
+
+    enum TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+    }
+
+    enum TeeWhereOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W,
+    }
+
+    enum TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum TeeYooOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a U),
+    }
+
+    enum TeeYooOutlivesAyIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a U },
+        W,
+    }
+
+    enum TeeYooIsDebugOutlivesAy<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(U),
+    }
+
+    enum TeeYooOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a &'b U),
+        W,
+    }
+
+    enum TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeOutlivesAyBeeYooIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T, U),
+        W,
+    }
+
+    enum TeeYooWhereOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a U),
+    }
+
+    enum TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a U },
+        W,
+    }
+
+    enum TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(U),
+    }
+
+    enum TeeYooWhereOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a &'b U),
+        W,
+    }
+
+    enum TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a &'b U),
+    }
+
+    enum TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T, yoo: U },
+        W,
+    }
+
+    enum TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T, U),
+        W,
+    }
+
+    enum TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W(U),
+    }
+
+    enum BeeOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b () },
+    }
+
+    enum BeeWhereOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b ()),
+    }
+
+    enum BeeOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W,
+    }
+
+    enum BeeWhereOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum BeeOutlivesAyTeeDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
 }
 
-struct TeeOutlivesAyBee<'a, 'b, T> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+mod unions {
+    use std::fmt::Debug;
 
-struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeOutlivesAyIsDebug<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereOutlivesAy<'a, T> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeIsDebugOutlivesAy<'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereOutlivesAyIsDebug<'a, T> where T: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeOutlivesAyBeeIsDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereOutlivesAyBee<'a, 'b, T> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeWhereOutlivesAy<'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeWhereOutlivesAyIsDebug<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeYooOutlivesAy<'a, T, U> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeYooOutlivesAyIsDebug<'a, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereOutlivesAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeOutlivesAyYooIsDebug<'a, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeYooOutlivesAyBee<'a, 'b, T, U> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooOutlivesAyIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooIsDebugOutlivesAy<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
-}
+    union TeeOutlivesAyYooIsDebug<'a, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
 
-struct TeeYooWhereOutlivesAy<'a, T, U> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeOutlivesAyBeeYooIsDebug<'a, 'b, T, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
 
-struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereOutlivesAy<'a, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
-}
+    union TeeOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
 
-struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeYooWhereOutlivesAyBee<'a, 'b, T, U> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
+    union TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
+
+    union TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
+
+    union TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
+
+    union BeeOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    union BeeWhereOutlivesAy<'a, 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    union BeeOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeOutlivesAyTeeDebug<'a, 'b, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
 }
 
 

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives.rs
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives.rs
@@ -3,9 +3,6 @@
 #![allow(unused)]
 #![deny(explicit_outlives_requirements)]
 
-use std::fmt::{Debug, Display};
-
-
 // Programmatically generated examples!
 //
 // Exercise outlives bounds for each of the following parameter/position
@@ -17,177 +14,773 @@ use std::fmt::{Debug, Display};
 // • two parameters (T and U), one bound inline, one with a where clause
 // • two parameters (T and U), both with where clauses
 //
-// —and for every permutation of 0, 1, or 2 lifetimes to outlive and 0 or 1
-// trait bounds distributed among said parameters (subject to no where clause
-// being empty and the struct having at least one lifetime).
+// —and for every permutation of 1 or 2 lifetimes to outlive and 0 or 1 trait
+// bounds distributed among said parameters (subject to no where clause being
+// empty and the struct having at least one lifetime).
+//
+// —and for each of tuple structs, enums and unions.
 
+mod structs {
+    use std::fmt::Debug;
 
-struct TeeOutlivesAy<'a, T: 'a> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+    struct TeeOutlivesAy<'a, T: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereOutlivesAy<'a, T> where T: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
+
+    struct TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
+
+    struct TeeYooOutlivesAy<'a, T, U: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a U
+    }
+
+    struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: T,
+        yoo: &'a &'b U
+    }
+
+    struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: U
+    }
+
+    struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: U
+    }
+
+    struct BeeOutlivesAy<'a, 'b: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    struct BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    struct BeeOutlivesAyTee<'a, 'b: 'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
 }
 
-struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+mod tuple_structs {
+    use std::fmt::Debug;
+
+    struct TeeOutlivesAy<'a, T: 'a>(&'a T);
     //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+
+    struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug>(&'a T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a>(&'a T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAy<'a, T>(&'a T) where T: 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyIsDebug<'a, T>(&'a T) where T: 'a + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereIsDebugOutlivesAy<'a, T>(&'a T) where T: Debug + 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyBee<'a, 'b, T>(&'a &'b T) where T: 'a + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T>(&'a &'b T) where T: 'a + 'b + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T>(&'a &'b T) where T: Debug + 'a + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAy<'a, T, U: 'a>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a>(T, &'a U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug>(&'a T, U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b>(T, &'a &'b U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug>(&'a &'b T, U);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAy<'a, T, U>(T, &'a U) where U: 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyIsDebug<'a, T, U>(T, &'a U) where U: 'a + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereIsDebugOutlivesAy<'a, T, U>(T, &'a U) where U: Debug + 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U>(&'a T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + 'b + Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug + 'a + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U>(&'a &'b T, U) where U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U>(&'a T, U) where T: 'a, U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct TeeWhereAyBeeYooWhereIsDebug<'a, 'b, T, U>(&'a &'b T, U) where T: 'a + 'b, U: Debug;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAy<'a, 'b: 'a>(&'a &'b ());
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAy<'a, 'b>(&'a &'b ()) where 'b: 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTee<'a, 'b: 'a, T>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTee<'a, 'b, T>(&'a &'b T) where 'b: 'a;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + 'b;
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug>(&'a &'b T);
+    //~^ ERROR outlives requirements can be inferred
+
+    struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: Debug;
+    //~^ ERROR outlives requirements can be inferred
 }
 
-struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
+mod enums {
+    use std::fmt::Debug;
+
+    enum TeeOutlivesAy<'a, T: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+    }
+
+    enum TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T),
+    }
+
+    enum TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W,
+    }
+
+    enum TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum TeeWhereOutlivesAy<'a, T> where T: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W,
+    }
+
+    enum TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T),
+        W,
+    }
+
+    enum TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+    }
+
+    enum TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W,
+    }
+
+    enum TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum TeeYooOutlivesAy<'a, T, U: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a U),
+    }
+
+    enum TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a U },
+        W,
+    }
+
+    enum TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(U),
+    }
+
+    enum TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a &'b U),
+        W,
+    }
+
+    enum TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T, U),
+        W,
+    }
+
+    enum TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a U),
+    }
+
+    enum TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a U },
+        W,
+    }
+
+    enum TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a U),
+        W,
+    }
+
+    enum TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a T },
+        W(U),
+    }
+
+    enum TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T, yoo: &'a &'b U },
+        W,
+    }
+
+    enum TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(T, &'a &'b U),
+        W,
+    }
+
+    enum TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: T },
+        W(&'a &'b U),
+    }
+
+    enum TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T, yoo: U },
+        W,
+    }
+
+    enum TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a T, U),
+        W,
+    }
+
+    enum TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W(U),
+    }
+
+    enum BeeOutlivesAy<'a, 'b: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b () },
+    }
+
+    enum BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b ()),
+    }
+
+    enum BeeOutlivesAyTee<'a, 'b: 'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+        W,
+    }
+
+    enum BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+        W,
+    }
+
+    enum BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        V { tee: &'a &'b T },
+    }
+
+    enum BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        V(&'a &'b T),
+    }
 }
 
-struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+mod unions {
+    use std::fmt::Debug;
 
-struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeOutlivesAy<'a, T: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereOutlivesAy<'a, T> where T: 'a {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T
-}
+    union TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeWhereOutlivesAy<'a, T> where T: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T
-}
+    union TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeYooOutlivesAy<'a, T, U: 'a> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T
+    }
 
-struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T
+    }
 
-struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooOutlivesAy<'a, T, U: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
-}
+    union TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
 
-struct TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a U
-}
+    union TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
 
-struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
-    //~^ ERROR outlives requirements can be inferred
-    tee: T,
-    yoo: &'a &'b U
-}
+    union TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a U
+    }
 
-struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
-}
+    union TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
 
-struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a T,
-    yoo: U
-}
+    union TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
 
-struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
-    //~^ ERROR outlives requirements can be inferred
-    tee: &'a &'b T,
-    yoo: U
+    union TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: *const T,
+        yoo: &'a &'b U
+    }
+
+    union TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
+
+    union TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a T,
+        yoo: *const U
+    }
+
+    union TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+        yoo: *const U
+    }
+
+    union BeeOutlivesAy<'a, 'b: 'a> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    union BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b (),
+    }
+
+    union BeeOutlivesAyTee<'a, 'b: 'a, T> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
+
+    union BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+        //~^ ERROR outlives requirements can be inferred
+        tee: &'a &'b T,
+    }
 }
 
 

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives.stderr
@@ -1,8 +1,8 @@
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:25:27
+  --> $DIR/edition-lint-infer-outlives.rs:26:31
    |
-LL | struct TeeOutlivesAy<'a, T: 'a> {
-   |                           ^^^^ help: remove this bound
+LL |     struct TeeOutlivesAy<'a, T: 'a> {
+   |                               ^^^^ help: remove this bound
    |
 note: lint level defined here
   --> $DIR/edition-lint-infer-outlives.rs:4:9
@@ -11,178 +11,910 @@ LL | #![deny(explicit_outlives_requirements)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:30:36
+  --> $DIR/edition-lint-infer-outlives.rs:31:40
    |
-LL | struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
-   |                                    ^^^^^ help: remove this bound
+LL |     struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+   |                                        ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:35:41
+  --> $DIR/edition-lint-infer-outlives.rs:36:45
    |
-LL | struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
-   |                                         ^^^^^ help: remove this bound
+LL |     struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+   |                                             ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:40:34
+  --> $DIR/edition-lint-infer-outlives.rs:41:38
    |
-LL | struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
-   |                                  ^^^^^^^^^ help: remove these bounds
+LL |     struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+   |                                      ^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:45:43
+  --> $DIR/edition-lint-infer-outlives.rs:46:47
    |
-LL | struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
-   |                                           ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+   |                                               ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:50:48
+  --> $DIR/edition-lint-infer-outlives.rs:51:52
    |
-LL | struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
-   |                                                ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+   |                                                    ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:55:33
+  --> $DIR/edition-lint-infer-outlives.rs:56:37
    |
-LL | struct TeeWhereOutlivesAy<'a, T> where T: 'a {
-   |                                 ^^^^^^^^^^^^ help: remove this bound
+LL |     struct TeeWhereOutlivesAy<'a, T> where T: 'a {
+   |                                     ^^^^^^^^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:60:50
+  --> $DIR/edition-lint-infer-outlives.rs:61:54
    |
-LL | struct TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
-   |                                                  ^^^^^ help: remove this bound
+LL |     struct TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+   |                                                      ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:65:55
+  --> $DIR/edition-lint-infer-outlives.rs:66:59
    |
-LL | struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
-   |                                                       ^^^^^ help: remove this bound
+LL |     struct TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+   |                                                           ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:70:40
+  --> $DIR/edition-lint-infer-outlives.rs:71:44
    |
-LL | struct TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
-   |                                        ^^^^^^^^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+   |                                            ^^^^^^^^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:75:57
+  --> $DIR/edition-lint-infer-outlives.rs:76:61
    |
-LL | struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
-   |                                                         ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+   |                                                             ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:80:62
+  --> $DIR/edition-lint-infer-outlives.rs:81:66
    |
-LL | struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
-   |                                                              ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+   |                                                                  ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:85:33
+  --> $DIR/edition-lint-infer-outlives.rs:86:37
    |
-LL | struct TeeYooOutlivesAy<'a, T, U: 'a> {
-   |                                 ^^^^ help: remove this bound
-
-error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:91:42
-   |
-LL | struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
-   |                                          ^^^^^ help: remove this bound
-
-error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:97:47
-   |
-LL | struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
-   |                                               ^^^^^ help: remove this bound
-
-error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:103:37
-   |
-LL | struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+LL |     struct TeeYooOutlivesAy<'a, T, U: 'a> {
    |                                     ^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:109:40
+  --> $DIR/edition-lint-infer-outlives.rs:92:46
    |
-LL | struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
-   |                                        ^^^^^^^^^ help: remove these bounds
+LL |     struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+   |                                              ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:115:49
+  --> $DIR/edition-lint-infer-outlives.rs:98:51
    |
-LL | struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
-   |                                                 ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+   |                                                   ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:121:54
+  --> $DIR/edition-lint-infer-outlives.rs:104:41
    |
-LL | struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
-   |                                                      ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+   |                                         ^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:127:44
+  --> $DIR/edition-lint-infer-outlives.rs:110:44
    |
-LL | struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+LL |     struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
    |                                            ^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:133:39
+  --> $DIR/edition-lint-infer-outlives.rs:116:53
    |
-LL | struct TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
-   |                                       ^^^^^^^^^^^^ help: remove this bound
+LL |     struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+   |                                                     ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:139:56
+  --> $DIR/edition-lint-infer-outlives.rs:122:58
    |
-LL | struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
-   |                                                        ^^^^^ help: remove this bound
+LL |     struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+   |                                                          ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:145:61
+  --> $DIR/edition-lint-infer-outlives.rs:128:48
    |
-LL | struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+LL |     struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+   |                                                ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:134:43
+   |
+LL |     struct TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+   |                                           ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:140:60
+   |
+LL |     struct TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+   |                                                            ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:146:65
+   |
+LL |     struct TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+   |                                                                 ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:152:46
+   |
+LL |     struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+   |                                              ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:158:50
+   |
+LL |     struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+   |                                                  ^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:164:67
+   |
+LL |     struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+   |                                                                   ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:170:72
+   |
+LL |     struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+   |                                                                        ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:176:53
+   |
+LL |     struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+   |                                                     ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:182:62
+   |
+LL |     struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+   |                                                              ^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:188:69
+   |
+LL |     struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+   |                                                                     ^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:194:32
+   |
+LL |     struct BeeOutlivesAy<'a, 'b: 'a> {
+   |                                ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:199:38
+   |
+LL |     struct BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+   |                                      ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:204:35
+   |
+LL |     struct BeeOutlivesAyTee<'a, 'b: 'a, T> {
+   |                                   ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:209:44
+   |
+LL |     struct BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+   |                                            ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:214:52
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:219:54
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:224:40
+   |
+LL |     struct BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+   |                                        ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:229:61
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+   |                                                             ^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:238:31
+   |
+LL |     struct TeeOutlivesAy<'a, T: 'a>(&'a T);
+   |                               ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:241:40
+   |
+LL |     struct TeeOutlivesAyIsDebug<'a, T: 'a + Debug>(&'a T);
+   |                                        ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:244:45
+   |
+LL |     struct TeeIsDebugOutlivesAy<'a, T: Debug + 'a>(&'a T);
+   |                                             ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:247:38
+   |
+LL |     struct TeeOutlivesAyBee<'a, 'b, T: 'a + 'b>(&'a &'b T);
+   |                                      ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:250:47
+   |
+LL |     struct TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug>(&'a &'b T);
+   |                                               ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:253:52
+   |
+LL |     struct TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b>(&'a &'b T);
+   |                                                    ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:256:45
+   |
+LL |     struct TeeWhereOutlivesAy<'a, T>(&'a T) where T: 'a;
+   |                                             ^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:259:61
+   |
+LL |     struct TeeWhereOutlivesAyIsDebug<'a, T>(&'a T) where T: 'a + Debug;
    |                                                             ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:151:42
+  --> $DIR/edition-lint-infer-outlives.rs:262:66
    |
-LL | struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
-   |                                          ^^^^ help: remove this bound
+LL |     struct TeeWhereIsDebugOutlivesAy<'a, T>(&'a T) where T: Debug + 'a;
+   |                                                                  ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:157:46
+  --> $DIR/edition-lint-infer-outlives.rs:265:56
    |
-LL | struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
-   |                                              ^^^^^^^^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereOutlivesAyBee<'a, 'b, T>(&'a &'b T) where T: 'a + 'b;
+   |                                                        ^^^^^^^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:163:63
+  --> $DIR/edition-lint-infer-outlives.rs:268:72
    |
-LL | struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
-   |                                                               ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T>(&'a &'b T) where T: 'a + 'b + Debug;
+   |                                                                        ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:169:68
+  --> $DIR/edition-lint-infer-outlives.rs:271:77
    |
-LL | struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
-   |                                                                    ^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeWhereIsDebugOutlivesAyBee<'a, 'b, T>(&'a &'b T) where T: Debug + 'a + 'b;
+   |                                                                             ^^^^^^^^^^ help: remove these bounds
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:175:49
+  --> $DIR/edition-lint-infer-outlives.rs:274:37
    |
-LL | struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
-   |                                                 ^^^^^^^^^ help: remove these bounds
+LL |     struct TeeYooOutlivesAy<'a, T, U: 'a>(T, &'a U);
+   |                                     ^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:181:58
+  --> $DIR/edition-lint-infer-outlives.rs:277:46
    |
-LL | struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
-   |                                                          ^^^^^^^ help: remove this bound
+LL |     struct TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug>(T, &'a U);
+   |                                              ^^^^^ help: remove this bound
 
 error: outlives requirements can be inferred
-  --> $DIR/edition-lint-infer-outlives.rs:187:65
+  --> $DIR/edition-lint-infer-outlives.rs:280:51
    |
-LL | struct TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
-   |                                                                 ^^^^^^^^^^^^ help: remove these bounds
+LL |     struct TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a>(T, &'a U);
+   |                                                   ^^^^^ help: remove this bound
 
-error: aborting due to 30 previous errors
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:283:41
+   |
+LL |     struct TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug>(&'a T, U);
+   |                                         ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:286:44
+   |
+LL |     struct TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b>(T, &'a &'b U);
+   |                                            ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:289:53
+   |
+LL |     struct TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug>(T, &'a &'b U);
+   |                                                     ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:292:58
+   |
+LL |     struct TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b>(T, &'a &'b U);
+   |                                                          ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:295:48
+   |
+LL |     struct TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug>(&'a &'b T, U);
+   |                                                ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:298:54
+   |
+LL |     struct TeeYooWhereOutlivesAy<'a, T, U>(T, &'a U) where U: 'a;
+   |                                                      ^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:301:70
+   |
+LL |     struct TeeYooWhereOutlivesAyIsDebug<'a, T, U>(T, &'a U) where U: 'a + Debug;
+   |                                                                      ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:304:75
+   |
+LL |     struct TeeYooWhereIsDebugOutlivesAy<'a, T, U>(T, &'a U) where U: Debug + 'a;
+   |                                                                           ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:307:46
+   |
+LL |     struct TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U>(&'a T, U) where U: Debug;
+   |                                              ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:310:65
+   |
+LL |     struct TeeYooWhereOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + 'b;
+   |                                                                 ^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:313:81
+   |
+LL |     struct TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + 'b + Debug;
+   |                                                                                 ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:316:86
+   |
+LL |     struct TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug + 'a + 'b;
+   |                                                                                      ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:319:53
+   |
+LL |     struct TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U>(&'a &'b T, U) where U: Debug;
+   |                                                     ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:322:72
+   |
+LL |     struct TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U>(&'a T, U) where T: 'a, U: Debug;
+   |                                                                        ^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:325:75
+   |
+LL |     struct TeeWhereAyBeeYooWhereIsDebug<'a, 'b, T, U>(&'a &'b T, U) where T: 'a + 'b, U: Debug;
+   |                                                                           ^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:328:32
+   |
+LL |     struct BeeOutlivesAy<'a, 'b: 'a>(&'a &'b ());
+   |                                ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:331:51
+   |
+LL |     struct BeeWhereOutlivesAy<'a, 'b>(&'a &'b ()) where 'b: 'a;
+   |                                                   ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:334:35
+   |
+LL |     struct BeeOutlivesAyTee<'a, 'b: 'a, T>(&'a &'b T);
+   |                                   ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:337:56
+   |
+LL |     struct BeeWhereOutlivesAyTee<'a, 'b, T>(&'a &'b T) where 'b: 'a;
+   |                                                        ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:340:64
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'b;
+   |                                                                ^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:343:66
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + 'b;
+   |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:346:40
+   |
+LL |     struct BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug>(&'a &'b T);
+   |                                        ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:349:72
+   |
+LL |     struct BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: Debug;
+   |                                                                        ^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:356:29
+   |
+LL |     enum TeeOutlivesAy<'a, T: 'a> {
+   |                             ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:361:38
+   |
+LL |     enum TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+   |                                      ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:366:43
+   |
+LL |     enum TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+   |                                           ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:372:36
+   |
+LL |     enum TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+   |                                    ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:378:45
+   |
+LL |     enum TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+   |                                             ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:383:50
+   |
+LL |     enum TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+   |                                                  ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:388:35
+   |
+LL |     enum TeeWhereOutlivesAy<'a, T> where T: 'a {
+   |                                   ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:394:52
+   |
+LL |     enum TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+   |                                                    ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:400:57
+   |
+LL |     enum TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+   |                                                         ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:405:42
+   |
+LL |     enum TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+   |                                          ^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:410:59
+   |
+LL |     enum TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+   |                                                           ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:416:64
+   |
+LL |     enum TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+   |                                                                ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:422:35
+   |
+LL |     enum TeeYooOutlivesAy<'a, T, U: 'a> {
+   |                                   ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:428:44
+   |
+LL |     enum TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+   |                                            ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:434:49
+   |
+LL |     enum TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+   |                                                 ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:440:39
+   |
+LL |     enum TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+   |                                       ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:446:42
+   |
+LL |     enum TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
+   |                                          ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:452:51
+   |
+LL |     enum TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+   |                                                   ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:458:56
+   |
+LL |     enum TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+   |                                                        ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:464:46
+   |
+LL |     enum TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+   |                                              ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:470:41
+   |
+LL |     enum TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+   |                                         ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:476:58
+   |
+LL |     enum TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+   |                                                          ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:482:63
+   |
+LL |     enum TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+   |                                                               ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:488:44
+   |
+LL |     enum TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+   |                                            ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:494:48
+   |
+LL |     enum TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+   |                                                ^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:500:65
+   |
+LL |     enum TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+   |                                                                 ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:506:70
+   |
+LL |     enum TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+   |                                                                      ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:512:51
+   |
+LL |     enum TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+   |                                                   ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:518:60
+   |
+LL |     enum TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+   |                                                            ^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:524:67
+   |
+LL |     enum TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+   |                                                                   ^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:530:30
+   |
+LL |     enum BeeOutlivesAy<'a, 'b: 'a> {
+   |                              ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:535:36
+   |
+LL |     enum BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+   |                                    ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:540:33
+   |
+LL |     enum BeeOutlivesAyTee<'a, 'b: 'a, T> {
+   |                                 ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:546:42
+   |
+LL |     enum BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+   |                                          ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:552:50
+   |
+LL |     enum BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+   |                                                  ^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:557:52
+   |
+LL |     enum BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:563:38
+   |
+LL |     enum BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+   |                                      ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:568:59
+   |
+LL |     enum BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+   |                                                           ^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:577:30
+   |
+LL |     union TeeOutlivesAy<'a, T: 'a> {
+   |                              ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:582:39
+   |
+LL |     union TeeOutlivesAyIsDebug<'a, T: 'a + Debug> {
+   |                                       ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:587:44
+   |
+LL |     union TeeIsDebugOutlivesAy<'a, T: Debug + 'a> {
+   |                                            ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:592:37
+   |
+LL |     union TeeOutlivesAyBee<'a, 'b, T: 'a + 'b> {
+   |                                     ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:597:46
+   |
+LL |     union TeeOutlivesAyBeeIsDebug<'a, 'b, T: 'a + 'b + Debug> {
+   |                                              ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:602:51
+   |
+LL |     union TeeIsDebugOutlivesAyBee<'a, 'b, T: Debug + 'a + 'b> {
+   |                                                   ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:607:36
+   |
+LL |     union TeeWhereOutlivesAy<'a, T> where T: 'a {
+   |                                    ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:612:53
+   |
+LL |     union TeeWhereOutlivesAyIsDebug<'a, T> where T: 'a + Debug {
+   |                                                     ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:617:58
+   |
+LL |     union TeeWhereIsDebugOutlivesAy<'a, T> where T: Debug + 'a {
+   |                                                          ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:622:43
+   |
+LL |     union TeeWhereOutlivesAyBee<'a, 'b, T> where T: 'a + 'b {
+   |                                           ^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:627:60
+   |
+LL |     union TeeWhereOutlivesAyBeeIsDebug<'a, 'b, T> where T: 'a + 'b + Debug {
+   |                                                            ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:632:65
+   |
+LL |     union TeeWhereIsDebugOutlivesAyBee<'a, 'b, T> where T: Debug + 'a + 'b {
+   |                                                                 ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:637:36
+   |
+LL |     union TeeYooOutlivesAy<'a, T, U: 'a> {
+   |                                    ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:643:45
+   |
+LL |     union TeeYooOutlivesAyIsDebug<'a, T, U: 'a + Debug> {
+   |                                             ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:649:50
+   |
+LL |     union TeeYooIsDebugOutlivesAy<'a, T, U: Debug + 'a> {
+   |                                                  ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:655:40
+   |
+LL |     union TeeOutlivesAyYooIsDebug<'a, T: 'a, U: Debug> {
+   |                                        ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:661:43
+   |
+LL |     union TeeYooOutlivesAyBee<'a, 'b, T, U: 'a + 'b> {
+   |                                           ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:667:52
+   |
+LL |     union TeeYooOutlivesAyBeeIsDebug<'a, 'b, T, U: 'a + 'b + Debug> {
+   |                                                    ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:673:57
+   |
+LL |     union TeeYooIsDebugOutlivesAyBee<'a, 'b, T, U: Debug + 'a + 'b> {
+   |                                                         ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:679:47
+   |
+LL |     union TeeOutlivesAyBeeYooIsDebug<'a, 'b, T: 'a + 'b, U: Debug> {
+   |                                               ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:685:42
+   |
+LL |     union TeeYooWhereOutlivesAy<'a, T, U> where U: 'a {
+   |                                          ^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:691:59
+   |
+LL |     union TeeYooWhereOutlivesAyIsDebug<'a, T, U> where U: 'a + Debug {
+   |                                                           ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:697:64
+   |
+LL |     union TeeYooWhereIsDebugOutlivesAy<'a, T, U> where U: Debug + 'a {
+   |                                                                ^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:703:45
+   |
+LL |     union TeeOutlivesAyYooWhereIsDebug<'a, T: 'a, U> where U: Debug {
+   |                                             ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:709:49
+   |
+LL |     union TeeYooWhereOutlivesAyBee<'a, 'b, T, U> where U: 'a + 'b {
+   |                                                 ^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:715:66
+   |
+LL |     union TeeYooWhereOutlivesAyBeeIsDebug<'a, 'b, T, U> where U: 'a + 'b + Debug {
+   |                                                                  ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:721:71
+   |
+LL |     union TeeYooWhereIsDebugOutlivesAyBee<'a, 'b, T, U> where U: Debug + 'a + 'b {
+   |                                                                       ^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:727:52
+   |
+LL |     union TeeOutlivesAyBeeYooWhereIsDebug<'a, 'b, T: 'a + 'b, U> where U: Debug {
+   |                                                    ^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:733:61
+   |
+LL |     union TeeWhereOutlivesAyYooWhereIsDebug<'a, T, U> where T: 'a, U: Debug {
+   |                                                             ^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:739:68
+   |
+LL |     union TeeWhereOutlivesAyBeeYooWhereIsDebug<'a, 'b, T, U> where T: 'a + 'b, U: Debug {
+   |                                                                    ^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:745:31
+   |
+LL |     union BeeOutlivesAy<'a, 'b: 'a> {
+   |                               ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:750:37
+   |
+LL |     union BeeWhereOutlivesAy<'a, 'b> where 'b: 'a {
+   |                                     ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:755:34
+   |
+LL |     union BeeOutlivesAyTee<'a, 'b: 'a, T> {
+   |                                  ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:760:43
+   |
+LL |     union BeeWhereOutlivesAyTee<'a, 'b, T> where 'b: 'a {
+   |                                           ^^^^^^^^^^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:765:51
+   |
+LL |     union BeeWhereOutlivesAyTeeWhereBee<'a, 'b, T> where 'b: 'a, T: 'b {
+   |                                                   ^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:770:53
+   |
+LL |     union BeeWhereOutlivesAyTeeWhereAyBee<'a, 'b, T> where 'b: 'a, T: 'a + 'b {
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these bounds
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:775:39
+   |
+LL |     union BeeOutlivesAyTeeDebug<'a, 'b: 'a, T: Debug> {
+   |                                       ^^^^ help: remove this bound
+
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives.rs:780:60
+   |
+LL |     union BeeWhereOutlivesAyTeeWhereDebug<'a, 'b, T> where 'b: 'a, T: Debug {
+   |                                                            ^^^^^^^^ help: remove this bound
+
+error: aborting due to 152 previous errors
 


### PR DESCRIPTION
* Don't use Strings to compare parameters
* Extend the lint to lifetime bounds
* Extend the lint to enums and unions
* Use the correct span for where clauses in tuple structs
* Try to early-out where possible
* Remove unnecessary bounds in rustc crates