### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -157,7 +157,7 @@ Libraries
   produce a warning if their returning type is unused.
 - [The methods `checked_pow`, `saturating_pow`, `wrapping_pow`, and
   `overflowing_pow` are now available for all numeric types.][57873] These are
-  equivalvent to methods such as `wrapping_add` for the `pow` operation.
+  equivalent to methods such as `wrapping_add` for the `pow` operation.
 
 
 Stabilized APIs

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -982,7 +982,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 ///     out.write(vec![1, 2, 3]);
 /// }
 ///
-/// let mut v: MaybeUninit<Vec<i32>> = MaybeUninit::uninit();
+/// let mut v = MaybeUninit::uninit();
 /// unsafe { make_vec(v.as_mut_ptr()); }
 /// // Now we know `v` is initialized! This also makes sure the vector gets
 /// // properly dropped.
@@ -1071,7 +1071,7 @@ impl<T: ?Sized> DerefMut for ManuallyDrop<T> {
 /// optimizations, potentially resulting in a larger size:
 ///
 /// ```rust
-/// # use std::mem::{MaybeUninit, size_of, align_of};
+/// # use std::mem::{MaybeUninit, size_of};
 /// assert_eq!(size_of::<Option<bool>>(), 1);
 /// assert_eq!(size_of::<Option<MaybeUninit<bool>>>(), 2);
 /// ```

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -10,7 +10,6 @@ use crate::ich::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::indexed_vec::{IndexVec};
 use rustc_data_structures::stable_hasher::StableHasher;
-use serialize::{Encodable, Decodable, Encoder, Decoder};
 use crate::session::CrateDisambiguator;
 use std::borrow::Borrow;
 use std::fmt::Write;
@@ -25,14 +24,13 @@ use crate::util::nodemap::NodeMap;
 /// Internally the DefPathTable holds a tree of DefKeys, where each DefKey
 /// stores the DefIndex of its parent.
 /// There is one DefPathTable for each crate.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, RustcDecodable, RustcEncodable)]
 pub struct DefPathTable {
     index_to_key: Vec<DefKey>,
     def_path_hashes: Vec<DefPathHash>,
 }
 
 impl DefPathTable {
-
     fn allocate(&mut self,
                 key: DefKey,
                 def_path_hash: DefPathHash)
@@ -83,28 +81,6 @@ impl DefPathTable {
 
     pub fn size(&self) -> usize {
         self.index_to_key.len()
-    }
-}
-
-
-impl Encodable for DefPathTable {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        // Index to key
-        self.index_to_key.encode(s)?;
-
-        // DefPath hashes
-        self.def_path_hashes.encode(s)?;
-
-        Ok(())
-    }
-}
-
-impl Decodable for DefPathTable {
-    fn decode<D: Decoder>(d: &mut D) -> Result<DefPathTable, D::Error> {
-        Ok(DefPathTable {
-            index_to_key: Decodable::decode(d)?,
-            def_path_hashes : Decodable::decode(d)?,
-        })
     }
 }
 

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -475,6 +475,8 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
                 PlaceBase::Local(mir::RETURN_PLACE) => return err!(ReadFromReturnPointer),
                 PlaceBase::Local(local) => {
                     // FIXME use place_projection.is_empty() when is available
+                    // Do not use the layout passed in as argument if the base we are looking at
+                    // here is not the entire place.
                     let layout = if let Place::Base(_) = mir_place {
                         layout
                     } else {

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -295,6 +295,7 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
     }
 
     fn eval_place(&mut self, place: &Place<'tcx>, source_info: SourceInfo) -> Option<Const<'tcx>> {
+        trace!("eval_place(place={:?})", place);
         match *place {
             Place::Base(PlaceBase::Local(loc)) => self.places[loc].clone(),
             Place::Projection(ref proj) => match proj.elem {
@@ -515,6 +516,7 @@ impl<'a, 'mir, 'tcx> ConstPropagator<'a, 'mir, 'tcx> {
     }
 
     fn replace_with_const(&self, rval: &mut Rvalue<'tcx>, value: Const<'tcx>, span: Span) {
+        trace!("attepting to replace {:?} with {:?}", rval, value);
         self.ecx.validate_operand(
             value,
             vec![],
@@ -578,6 +580,10 @@ impl CanConstProp {
             // FIXME(oli-obk): lint variables until they are used in a condition
             // FIXME(oli-obk): lint if return value is constant
             *val = mir.local_kind(local) == LocalKind::Temp;
+
+            if !*val {
+                trace!("local {:?} can't be propagated because it's not a temporary", local);
+            }
         }
         cpv.visit_mir(mir);
         cpv.can_const_prop
@@ -597,6 +603,7 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
             // FIXME(oli-obk): we could be more powerful here, if the multiple writes
             // only occur in independent execution paths
             MutatingUse(MutatingUseContext::Store) => if self.found_assignment[local] {
+                trace!("local {:?} can't be propagated because of multiple assignments", local);
                 self.can_const_prop[local] = false;
             } else {
                 self.found_assignment[local] = true
@@ -608,7 +615,10 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
             NonMutatingUse(NonMutatingUseContext::Projection) |
             MutatingUse(MutatingUseContext::Projection) |
             NonUse(_) => {},
-            _ => self.can_const_prop[local] = false,
+            _ => {
+                trace!("local {:?} can't be propagaged because it's used: {:?}", local, context);
+                self.can_const_prop[local] = false;
+            },
         }
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5194,7 +5194,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         &self,
         res: Res,
         span: Span,
-    ) -> Result<(DefKind, DefId, Ty<'tcx>), ErrorReported> {
+    ) -> Result<Res, ErrorReported> {
         let tcx = self.tcx;
         if let Res::SelfCtor(impl_def_id) = res {
             let ty = self.impl_self_ty(span, impl_def_id).ty;
@@ -5204,11 +5204,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 Some(adt_def) if adt_def.has_ctor() => {
                     let variant = adt_def.non_enum_variant();
                     let ctor_def_id = variant.ctor_def_id.unwrap();
-                    Ok((
-                        DefKind::Ctor(CtorOf::Struct, variant.ctor_kind),
-                        ctor_def_id,
-                        tcx.type_of(ctor_def_id),
-                    ))
+                    Ok(Res::Def(DefKind::Ctor(CtorOf::Struct, variant.ctor_kind), ctor_def_id))
                 }
                 _ => {
                     let mut err = tcx.sess.struct_span_err(span,
@@ -5235,15 +5231,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 }
             }
         } else {
-            match res {
-                Res::Def(kind, def_id) => {
-                    // The things we are substituting into the type should not contain
-                    // escaping late-bound regions, and nor should the base type scheme.
-                    let ty = tcx.type_of(def_id);
-                    Ok((kind, def_id, ty))
-                }
-                _ => span_bug!(span, "unexpected res in rewrite_self_ctor: {:?}", res),
-            }
+            Ok(res)
         }
     }
 
@@ -5266,27 +5254,21 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
 
         let tcx = self.tcx;
 
-        match res {
-            Res::Local(hid) | Res::Upvar(hid, ..) => {
-                let ty = self.local_ty(span, hid).decl_ty;
-                let ty = self.normalize_associated_types_in(span, &ty);
-                self.write_ty(hir_id, ty);
-                return (ty, res);
-            }
-            _ => {}
-        }
-
-        let (kind, def_id, ty) = match self.rewrite_self_ctor(res, span) {
-            Ok(result) => result,
+        let res = match self.rewrite_self_ctor(res, span) {
+            Ok(res) => res,
             Err(ErrorReported) => return (tcx.types.err, res),
         };
-        let path_segs =
-            AstConv::def_ids_for_value_path_segments(self, segments, self_ty, kind, def_id);
+        let path_segs = match res {
+            Res::Local(_) | Res::Upvar(..) => Vec::new(),
+            Res::Def(kind, def_id) =>
+                AstConv::def_ids_for_value_path_segments(self, segments, self_ty, kind, def_id),
+            _ => bug!("instantiate_value_path on {:?}", res),
+        };
 
         let mut user_self_ty = None;
         let mut is_alias_variant_ctor = false;
-        match kind {
-            DefKind::Ctor(CtorOf::Variant, _) => {
+        match res {
+            Res::Def(DefKind::Ctor(CtorOf::Variant, _), _) => {
                 if let Some(self_ty) = self_ty {
                     let adt_def = self_ty.ty_adt_def().unwrap();
                     user_self_ty = Some(UserSelfTy {
@@ -5296,8 +5278,8 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                     is_alias_variant_ctor = true;
                 }
             }
-            DefKind::Method
-            | DefKind::AssociatedConst => {
+            Res::Def(DefKind::Method, def_id)
+            | Res::Def(DefKind::AssociatedConst, def_id) => {
                 let container = tcx.associated_item(def_id).container;
                 debug!("instantiate_value_path: def_id={:?} container={:?}", def_id, container);
                 match container {
@@ -5337,6 +5319,17 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                 None
             }
         }));
+
+        match res {
+            Res::Local(hid) | Res::Upvar(hid, ..) => {
+                let ty = self.local_ty(span, hid).decl_ty;
+                let ty = self.normalize_associated_types_in(span, &ty);
+                self.write_ty(hir_id, ty);
+                return (ty, res);
+            }
+            _ => {}
+        }
+
         if generics_has_err {
             // Don't try to infer type parameters when prohibited generic arguments were given.
             user_self_ty = None;
@@ -5373,6 +5366,12 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
         let has_self = path_segs.last().map(|PathSeg(def_id, _)| {
             tcx.generics_of(*def_id).has_self
         }).unwrap_or(false);
+
+        let def_id = res.def_id();
+
+        // The things we are substituting into the type should not contain
+        // escaping late-bound regions, and nor should the base type scheme.
+        let ty = tcx.type_of(def_id);
 
         let substs = AstConv::create_substs_for_generic_args(
             tcx,
@@ -5490,7 +5489,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                ty_substituted);
         self.write_substs(hir_id, substs);
 
-        (ty_substituted, Res::Def(kind, def_id))
+        (ty_substituted, res)
     }
 
     fn check_rustc_args_require_const(&self,

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -49,7 +49,7 @@ use crate::tokenstream::{self, DelimSpan, TokenTree, TokenStream, TreeAndJoint};
 use crate::symbol::{kw, sym, Symbol};
 use crate::parse::diagnostics::Error;
 
-use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId, FatalError};
 use rustc_target::spec::abi::{self, Abi};
 use syntax_pos::{Span, BytePos, DUMMY_SP, FileName, hygiene::CompilerDesugaringKind};
 use log::debug;
@@ -58,6 +58,7 @@ use std::borrow::Cow;
 use std::cmp;
 use std::mem;
 use std::path::{self, Path, PathBuf};
+use std::slice;
 
 #[derive(Debug)]
 /// Whether the type alias or associated type is a concrete type or an existential type
@@ -595,23 +596,6 @@ impl<'a> Parser<'a> {
         edible: &[token::Token],
         inedible: &[token::Token],
     ) -> PResult<'a, bool /* recovered */> {
-        fn tokens_to_string(tokens: &[TokenType]) -> String {
-            let mut i = tokens.iter();
-            // This might be a sign we need a connect method on Iterator.
-            let b = i.next()
-                     .map_or(String::new(), |t| t.to_string());
-            i.enumerate().fold(b, |mut b, (i, a)| {
-                if tokens.len() > 2 && i == tokens.len() - 2 {
-                    b.push_str(", or ");
-                } else if tokens.len() == 2 && i == tokens.len() - 2 {
-                    b.push_str(" or ");
-                } else {
-                    b.push_str(", ");
-                }
-                b.push_str(&a.to_string());
-                b
-            })
-        }
         if edible.contains(&self.token) {
             self.bump();
             Ok(false)
@@ -621,120 +605,7 @@ impl<'a> Parser<'a> {
         } else if self.last_unexpected_token_span == Some(self.span) {
             FatalError.raise();
         } else {
-            let mut expected = edible.iter()
-                .map(|x| TokenType::Token(x.clone()))
-                .chain(inedible.iter().map(|x| TokenType::Token(x.clone())))
-                .chain(self.expected_tokens.iter().cloned())
-                .collect::<Vec<_>>();
-            expected.sort_by_cached_key(|x| x.to_string());
-            expected.dedup();
-            let expect = tokens_to_string(&expected[..]);
-            let actual = self.this_token_to_string();
-            let (msg_exp, (label_sp, label_exp)) = if expected.len() > 1 {
-                let short_expect = if expected.len() > 6 {
-                    format!("{} possible tokens", expected.len())
-                } else {
-                    expect.clone()
-                };
-                (format!("expected one of {}, found `{}`", expect, actual),
-                 (self.sess.source_map().next_point(self.prev_span),
-                  format!("expected one of {} here", short_expect)))
-            } else if expected.is_empty() {
-                (format!("unexpected token: `{}`", actual),
-                 (self.prev_span, "unexpected token after this".to_string()))
-            } else {
-                (format!("expected {}, found `{}`", expect, actual),
-                 (self.sess.source_map().next_point(self.prev_span),
-                  format!("expected {} here", expect)))
-            };
-            self.last_unexpected_token_span = Some(self.span);
-            let mut err = self.fatal(&msg_exp);
-            if self.token.is_ident_named("and") {
-                err.span_suggestion_short(
-                    self.span,
-                    "use `&&` instead of `and` for the boolean operator",
-                    "&&".to_string(),
-                    Applicability::MaybeIncorrect,
-                );
-            }
-            if self.token.is_ident_named("or") {
-                err.span_suggestion_short(
-                    self.span,
-                    "use `||` instead of `or` for the boolean operator",
-                    "||".to_string(),
-                    Applicability::MaybeIncorrect,
-                );
-            }
-            let sp = if self.token == token::Token::Eof {
-                // This is EOF, don't want to point at the following char, but rather the last token
-                self.prev_span
-            } else {
-                label_sp
-            };
-            match self.recover_closing_delimiter(&expected.iter().filter_map(|tt| match tt {
-                TokenType::Token(t) => Some(t.clone()),
-                _ => None,
-            }).collect::<Vec<_>>(), err) {
-                Err(e) => err = e,
-                Ok(recovered) => {
-                    return Ok(recovered);
-                }
-            }
-
-            let is_semi_suggestable = expected.iter().any(|t| match t {
-                TokenType::Token(token::Semi) => true, // we expect a `;` here
-                _ => false,
-            }) && ( // a `;` would be expected before the current keyword
-                self.token.is_keyword(kw::Break) ||
-                self.token.is_keyword(kw::Continue) ||
-                self.token.is_keyword(kw::For) ||
-                self.token.is_keyword(kw::If) ||
-                self.token.is_keyword(kw::Let) ||
-                self.token.is_keyword(kw::Loop) ||
-                self.token.is_keyword(kw::Match) ||
-                self.token.is_keyword(kw::Return) ||
-                self.token.is_keyword(kw::While)
-            );
-            let cm = self.sess.source_map();
-            match (cm.lookup_line(self.span.lo()), cm.lookup_line(sp.lo())) {
-                (Ok(ref a), Ok(ref b)) if a.line != b.line && is_semi_suggestable => {
-                    // The spans are in different lines, expected `;` and found `let` or `return`.
-                    // High likelihood that it is only a missing `;`.
-                    err.span_suggestion_short(
-                        label_sp,
-                        "a semicolon may be missing here",
-                        ";".to_string(),
-                        Applicability::MaybeIncorrect,
-                    );
-                    err.emit();
-                    return Ok(true);
-                }
-                (Ok(ref a), Ok(ref b)) if a.line == b.line => {
-                    // When the spans are in the same line, it means that the only content between
-                    // them is whitespace, point at the found token in that case:
-                    //
-                    // X |     () => { syntax error };
-                    //   |                    ^^^^^ expected one of 8 possible tokens here
-                    //
-                    // instead of having:
-                    //
-                    // X |     () => { syntax error };
-                    //   |                   -^^^^^ unexpected token
-                    //   |                   |
-                    //   |                   expected one of 8 possible tokens here
-                    err.span_label(self.span, label_exp);
-                }
-                _ if self.prev_span == DUMMY_SP => {
-                    // Account for macro context where the previous span might not be
-                    // available to avoid incorrect output (#54841).
-                    err.span_label(self.span, "unexpected token");
-                }
-                _ => {
-                    err.span_label(sp, label_exp);
-                    err.span_label(self.span, "unexpected token");
-                }
-            }
-            Err(err)
+            self.expected_one_of_not_found(edible, inedible)
         }
     }
 
@@ -1186,6 +1057,34 @@ impl<'a> Parser<'a> {
         self.span = span;
         self.token = next;
         self.expected_tokens.clear();
+    }
+
+    pub fn look_ahead<R, F>(&self, dist: usize, f: F) -> R where
+        F: FnOnce(&token::Token) -> R,
+    {
+        if dist == 0 {
+            return f(&self.token)
+        }
+
+        f(&match self.token_cursor.frame.tree_cursor.look_ahead(dist - 1) {
+            Some(tree) => match tree {
+                TokenTree::Token(_, tok) => tok,
+                TokenTree::Delimited(_, delim, _) => token::OpenDelim(delim),
+            },
+            None => token::CloseDelim(self.token_cursor.frame.delim),
+        })
+    }
+
+    crate fn look_ahead_span(&self, dist: usize) -> Span {
+        if dist == 0 {
+            return self.span
+        }
+
+        match self.token_cursor.frame.tree_cursor.look_ahead(dist - 1) {
+            Some(TokenTree::Token(span, _)) => span,
+            Some(TokenTree::Delimited(span, ..)) => span.entire(),
+            None => self.look_ahead_span(dist - 1),
+        }
     }
 
     /// Is the current token one of the keywords that signals a bare function type?

--- a/src/test/ui/invalid-self-argument/bare-fn-start.rs
+++ b/src/test/ui/invalid-self-argument/bare-fn-start.rs
@@ -1,6 +1,6 @@
 fn a(&self) { }
-//~^ ERROR unexpected `self` argument in function
-//~| NOTE not valid as function argument
-//~| NOTE `self` is only valid as the first argument of an associated function
+//~^ ERROR unexpected `self` parameter in function
+//~| NOTE not valid as function parameter
+//~| NOTE `self` is only valid as the first parameter of an associated function
 
 fn main() { }

--- a/src/test/ui/invalid-self-argument/bare-fn-start.rs
+++ b/src/test/ui/invalid-self-argument/bare-fn-start.rs
@@ -1,5 +1,6 @@
 fn a(&self) { }
 //~^ ERROR unexpected `self` argument in function
+//~| NOTE not valid as function argument
 //~| NOTE `self` is only valid as the first argument of an associated function
 
 fn main() { }

--- a/src/test/ui/invalid-self-argument/bare-fn-start.stderr
+++ b/src/test/ui/invalid-self-argument/bare-fn-start.stderr
@@ -1,8 +1,10 @@
 error: unexpected `self` argument in function
-  --> $DIR/bare-fn-start.rs:1:7
+  --> $DIR/bare-fn-start.rs:1:6
    |
 LL | fn a(&self) { }
-   |       ^^^^ `self` is only valid as the first argument of an associated function
+   |      ^^^^^ not valid as function argument
+   |
+   = note: `self` is only valid as the first argument of an associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/invalid-self-argument/bare-fn-start.stderr
+++ b/src/test/ui/invalid-self-argument/bare-fn-start.stderr
@@ -1,10 +1,10 @@
-error: unexpected `self` argument in function
+error: unexpected `self` parameter in function
   --> $DIR/bare-fn-start.rs:1:6
    |
 LL | fn a(&self) { }
-   |      ^^^^^ not valid as function argument
+   |      ^^^^^ not valid as function parameter
    |
-   = note: `self` is only valid as the first argument of an associated function
+   = note: `self` is only valid as the first parameter of an associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/invalid-self-argument/bare-fn.rs
+++ b/src/test/ui/invalid-self-argument/bare-fn.rs
@@ -1,5 +1,6 @@
 fn b(foo: u32, &mut self) { }
 //~^ ERROR unexpected `self` argument in function
+//~| NOTE not valid as function argument
 //~| NOTE `self` is only valid as the first argument of an associated function
 
 fn main() { }

--- a/src/test/ui/invalid-self-argument/bare-fn.rs
+++ b/src/test/ui/invalid-self-argument/bare-fn.rs
@@ -1,6 +1,6 @@
 fn b(foo: u32, &mut self) { }
-//~^ ERROR unexpected `self` argument in function
-//~| NOTE not valid as function argument
-//~| NOTE `self` is only valid as the first argument of an associated function
+//~^ ERROR unexpected `self` parameter in function
+//~| NOTE not valid as function parameter
+//~| NOTE `self` is only valid as the first parameter of an associated function
 
 fn main() { }

--- a/src/test/ui/invalid-self-argument/bare-fn.stderr
+++ b/src/test/ui/invalid-self-argument/bare-fn.stderr
@@ -1,10 +1,10 @@
-error: unexpected `self` argument in function
+error: unexpected `self` parameter in function
   --> $DIR/bare-fn.rs:1:16
    |
 LL | fn b(foo: u32, &mut self) { }
-   |                ^^^^^^^^^ not valid as function argument
+   |                ^^^^^^^^^ not valid as function parameter
    |
-   = note: `self` is only valid as the first argument of an associated function
+   = note: `self` is only valid as the first parameter of an associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/invalid-self-argument/trait-fn.rs
+++ b/src/test/ui/invalid-self-argument/trait-fn.rs
@@ -2,8 +2,8 @@ struct Foo {}
 
 impl Foo {
     fn c(foo: u32, self) {}
-    //~^ ERROR unexpected `self` argument in function
-    //~| NOTE must be the first associated function argument
+    //~^ ERROR unexpected `self` parameter in function
+    //~| NOTE must be the first associated function parameter
 
     fn good(&mut self, foo: u32) {}
 }

--- a/src/test/ui/invalid-self-argument/trait-fn.rs
+++ b/src/test/ui/invalid-self-argument/trait-fn.rs
@@ -3,7 +3,7 @@ struct Foo {}
 impl Foo {
     fn c(foo: u32, self) {}
     //~^ ERROR unexpected `self` argument in function
-    //~| NOTE `self` is only valid as the first argument of an associated function
+    //~| NOTE must be the first associated function argument
 
     fn good(&mut self, foo: u32) {}
 }

--- a/src/test/ui/invalid-self-argument/trait-fn.stderr
+++ b/src/test/ui/invalid-self-argument/trait-fn.stderr
@@ -2,7 +2,7 @@ error: unexpected `self` argument in function
   --> $DIR/trait-fn.rs:4:20
    |
 LL |     fn c(foo: u32, self) {}
-   |                    ^^^^ `self` is only valid as the first argument of an associated function
+   |                    ^^^^ must be the first associated function argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/invalid-self-argument/trait-fn.stderr
+++ b/src/test/ui/invalid-self-argument/trait-fn.stderr
@@ -1,8 +1,8 @@
-error: unexpected `self` argument in function
+error: unexpected `self` parameter in function
   --> $DIR/trait-fn.rs:4:20
    |
 LL |     fn c(foo: u32, self) {}
-   |                    ^^^^ must be the first associated function argument
+   |                    ^^^^ must be the first associated function parameter
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-60989.rs
+++ b/src/test/ui/issues/issue-60989.rs
@@ -1,0 +1,18 @@
+struct A {}
+struct B {}
+
+impl From<A> for B {
+    fn from(a: A) -> B {
+        B{}
+    }
+}
+
+fn main() {
+    let c1 = ();
+    c1::<()>;
+    //~^ ERROR type arguments are not allowed for this type
+
+    let c1 = A {};
+    c1::<Into<B>>;
+    //~^ ERROR type arguments are not allowed for this type
+}

--- a/src/test/ui/issues/issue-60989.stderr
+++ b/src/test/ui/issues/issue-60989.stderr
@@ -1,0 +1,15 @@
+error[E0109]: type arguments are not allowed for this type
+  --> $DIR/issue-60989.rs:12:10
+   |
+LL |     c1::<()>;
+   |          ^^ type argument not allowed
+
+error[E0109]: type arguments are not allowed for this type
+  --> $DIR/issue-60989.rs:16:10
+   |
+LL |     c1::<Into<B>>;
+   |          ^^^^^^^ type argument not allowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/issues/issue-61108.rs
+++ b/src/test/ui/issues/issue-61108.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut bad_letters = vec!['e', 't', 'o', 'i'];
+    for l in bad_letters {
+        // something here
+    }
+    bad_letters.push('s'); //~ ERROR borrow of moved value: `bad_letters`
+}

--- a/src/test/ui/issues/issue-61108.stderr
+++ b/src/test/ui/issues/issue-61108.stderr
@@ -1,0 +1,17 @@
+error[E0382]: borrow of moved value: `bad_letters`
+  --> $DIR/issue-61108.rs:6:5
+   |
+LL |     let mut bad_letters = vec!['e', 't', 'o', 'i'];
+   |         --------------- move occurs because `bad_letters` has type `std::vec::Vec<char>`, which does not implement the `Copy` trait
+LL |     for l in bad_letters {
+   |              -----------
+   |              |
+   |              value moved here
+   |              help: consider borrowing to avoid moving into the for loop: `&bad_letters`
+...
+LL |     bad_letters.push('s');
+   |     ^^^^^^^^^^^ value borrowed here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/parser/self-in-function-arg.rs
+++ b/src/test/ui/parser/self-in-function-arg.rs
@@ -1,3 +1,3 @@
-fn foo(x:i32, self: i32) -> i32 { self } //~ ERROR unexpected `self` argument in function
+fn foo(x:i32, self: i32) -> i32 { self } //~ ERROR unexpected `self` parameter in function
 
 fn main() {}

--- a/src/test/ui/parser/self-in-function-arg.rs
+++ b/src/test/ui/parser/self-in-function-arg.rs
@@ -1,0 +1,3 @@
+fn foo(x:i32, self: i32) -> i32 { self } //~ ERROR unexpected `self` argument in function
+
+fn main() {}

--- a/src/test/ui/parser/self-in-function-arg.stderr
+++ b/src/test/ui/parser/self-in-function-arg.stderr
@@ -1,10 +1,10 @@
-error: unexpected `self` argument in function
+error: unexpected `self` parameter in function
   --> $DIR/self-in-function-arg.rs:1:15
    |
 LL | fn foo(x:i32, self: i32) -> i32 { self }
-   |               ^^^^ not valid as function argument
+   |               ^^^^ not valid as function parameter
    |
-   = note: `self` is only valid as the first argument of an associated function
+   = note: `self` is only valid as the first parameter of an associated function
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/self-in-function-arg.stderr
+++ b/src/test/ui/parser/self-in-function-arg.stderr
@@ -1,8 +1,8 @@
 error: unexpected `self` argument in function
-  --> $DIR/bare-fn.rs:1:16
+  --> $DIR/self-in-function-arg.rs:1:15
    |
-LL | fn b(foo: u32, &mut self) { }
-   |                ^^^^^^^^^ not valid as function argument
+LL | fn foo(x:i32, self: i32) -> i32 { self }
+   |               ^^^^ not valid as function argument
    |
    = note: `self` is only valid as the first argument of an associated function
 

--- a/src/test/ui/suggestions/borrow-for-loop-head.stderr
+++ b/src/test/ui/suggestions/borrow-for-loop-head.stderr
@@ -13,11 +13,10 @@ LL |     let a = vec![1, 2, 3];
    |         - move occurs because `a` has type `std::vec::Vec<i32>`, which does not implement the `Copy` trait
 LL |     for i in &a {
 LL |         for j in a {
-   |                  ^ value moved here, in previous iteration of loop
-help: consider borrowing this to avoid moving it into the for loop
-   |
-LL |         for j in &a {
-   |                  ^^
+   |                  ^
+   |                  |
+   |                  value moved here, in previous iteration of loop
+   |                  help: consider borrowing to avoid moving into the for loop: `&a`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #61087 (Tweak `self` arg not as first argument of a method diagnostic)
 - #61114 (Vec: avoid creating slices to the elements)
 - #61144 (Suggest borrowing for loop head on move error)
 - #61149 (Fix spelling in release notes)
 - #61161 (MaybeUninit doctest: remove unnecessary type ascription)
 - #61173 (Auto-derive Encode and Decode implementations of DefPathTable)
 - #61184 (Add additional trace statements to the const propagator)
 - #61189 (Turn turbo 🐟 🍨 into an error)
 - #61193 (Add comment to explain why we change the layout for Projection)

Failed merges:


r? @ghost