### PR TITLE
Print PermissionExt::mode() in octal in Documentation Examples

### DIFF
--- a/src/libstd/sys/redox/ext/fs.rs
+++ b/src/libstd/sys/redox/ext/fs.rs
@@ -27,7 +27,7 @@ pub trait PermissionsExt {
     ///     let metadata = f.metadata()?;
     ///     let permissions = metadata.permissions();
     ///
-    ///     println!("permissions: {}", permissions.mode());
+    ///     println!("permissions: {:o}", permissions.mode());
     ///     Ok(())
     /// }
     /// ```

--- a/src/libstd/sys/unix/ext/fs.rs
+++ b/src/libstd/sys/unix/ext/fs.rs
@@ -238,7 +238,7 @@ pub trait PermissionsExt {
     ///     let metadata = f.metadata()?;
     ///     let permissions = metadata.permissions();
     ///
-    ///     println!("permissions: {}", permissions.mode());
+    ///     println!("permissions: {:o}", permissions.mode());
     ///     Ok(()) }
     /// ```
     #[stable(feature = "fs_ext", since = "1.1.0")]


### PR DESCRIPTION
Printing the file permission mode on unix systems in decimal feels unintuitive. Printing it in octal gives the expected form of e.g. `664`.