### PR TITLE
Make tuple constructors real const fns

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1167,6 +1167,7 @@ impl<'a, 'tcx> CrateMetadata {
         let constness = match self.entry(id).kind {
             EntryKind::Method(data) => data.decode(self).fn_data.constness,
             EntryKind::Fn(data) => data.decode(self).constness,
+            EntryKind::Variant(..) | EntryKind::Struct(..) => hir::Constness::Const,
             _ => hir::Constness::NotConst,
         };
         constness == hir::Constness::Const

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -91,34 +91,6 @@ fn mir_borrowck<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> BorrowC
     let input_mir = tcx.mir_validated(def_id);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def_id));
 
-    // We are not borrow checking the automatically generated struct/variant constructors
-    // because we want to accept structs such as this (taken from the `linked-hash-map`
-    // crate):
-    // ```rust
-    // struct Qey<Q: ?Sized>(Q);
-    // ```
-    // MIR of this struct constructor looks something like this:
-    // ```rust
-    // fn Qey(_1: Q) -> Qey<Q>{
-    //     let mut _0: Qey<Q>;                  // return place
-    //
-    //     bb0: {
-    //         (_0.0: Q) = move _1;             // bb0[0]: scope 0 at src/main.rs:1:1: 1:26
-    //         return;                          // bb0[1]: scope 0 at src/main.rs:1:1: 1:26
-    //     }
-    // }
-    // ```
-    // The problem here is that `(_0.0: Q) = move _1;` is valid only if `Q` is
-    // of statically known size, which is not known to be true because of the
-    // `Q: ?Sized` constraint. However, it is true because the constructor can be
-    // called only when `Q` is of statically known size.
-    if tcx.is_constructor(def_id) {
-        return BorrowCheckResult {
-            closure_requirements: None,
-            used_mut_upvars: SmallVec::new(),
-        };
-    }
-
     let opt_closure_req = tcx.infer_ctxt().enter(|infcx| {
         let input_mir: &Body<'_> = &input_mir.borrow();
         do_mir_borrowck(&infcx, input_mir, def_id)

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -22,6 +22,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(unicode_internals)]
 #![feature(step_trait)]
 #![feature(slice_concat_ext)]
+#![feature(trusted_len)]
 #![feature(try_blocks)]
 
 #![recursion_limit="256"]

--- a/src/librustc_mir/util/aggregate.rs
+++ b/src/librustc_mir/util/aggregate.rs
@@ -1,0 +1,76 @@
+use rustc::mir::*;
+use rustc::ty::Ty;
+use rustc::ty::layout::VariantIdx;
+use rustc_data_structures::indexed_vec::Idx;
+
+use std::iter::TrustedLen;
+
+/// Expand `lhs = Rvalue::Aggregate(kind, operands)` into assignments to the fields.
+///
+/// Produces something like
+///
+/// (lhs as Variant).field0 = arg0;     // We only have a downcast if this is an enum
+/// (lhs as Variant).field1 = arg1;
+/// discriminant(lhs) = variant_index;  // If lhs is an enum or generator.
+pub fn expand_aggregate<'tcx>(
+    mut lhs: Place<'tcx>,
+    operands: impl Iterator<Item=(Operand<'tcx>, Ty<'tcx>)> + TrustedLen,
+    kind: AggregateKind<'tcx>,
+    source_info: SourceInfo,
+) -> impl Iterator<Item=Statement<'tcx>> + TrustedLen {
+    let mut set_discriminant = None;
+    let active_field_index = match kind {
+        AggregateKind::Adt(adt_def, variant_index, _, _, active_field_index) => {
+            if adt_def.is_enum() {
+                set_discriminant = Some(Statement {
+                    kind: StatementKind::SetDiscriminant {
+                        place: lhs.clone(),
+                        variant_index,
+                    },
+                    source_info,
+                });
+                lhs = lhs.downcast(adt_def, variant_index);
+            }
+            active_field_index
+        }
+        AggregateKind::Generator(..) => {
+            // Right now we only support initializing generators to
+            // variant 0 (Unresumed).
+            let variant_index = VariantIdx::new(0);
+            set_discriminant = Some(Statement {
+                kind: StatementKind::SetDiscriminant {
+                    place: lhs.clone(),
+                    variant_index,
+                },
+                source_info,
+            });
+
+            // Operands are upvars stored on the base place, so no
+            // downcast is necessary.
+
+            None
+        }
+        _ => None
+    };
+
+    operands.into_iter().enumerate().map(move |(i, (op, ty))| {
+        let lhs_field = if let AggregateKind::Array(_) = kind {
+            // FIXME(eddyb) `offset` should be u64.
+            let offset = i as u32;
+            assert_eq!(offset as usize, i);
+            lhs.clone().elem(ProjectionElem::ConstantIndex {
+                offset,
+                // FIXME(eddyb) `min_length` doesn't appear to be used.
+                min_length: offset + 1,
+                from_end: false
+            })
+        } else {
+            let field = Field::new(active_field_index.unwrap_or(i));
+            lhs.clone().field(field, ty)
+        };
+        Statement {
+            source_info,
+            kind: StatementKind::Assign(lhs_field, box Rvalue::Use(op)),
+        }
+    }).chain(set_discriminant)
+}

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -2,6 +2,7 @@ use core::unicode::property::Pattern_White_Space;
 use rustc::ty::TyCtxt;
 use syntax_pos::Span;
 
+pub mod aggregate;
 pub mod borrowck_errors;
 pub mod elaborate_drops;
 pub mod def_use;
@@ -13,6 +14,7 @@ pub(crate) mod pretty;
 pub mod liveness;
 pub mod collect_writes;
 
+pub use self::aggregate::expand_aggregate;
 pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
 pub use self::graphviz::{graphviz_safe_def_name, write_mir_graphviz};

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -560,6 +560,10 @@ declare_features! (
     // Allows the user of associated type bounds.
     (active, associated_type_bounds, "1.34.0", Some(52662), None),
 
+    // Allows calling constructor functions in `const fn`
+    // FIXME Create issue
+    (active, const_constructor, "1.37.0", Some(61456), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -185,6 +185,7 @@ symbols! {
         conservative_impl_trait,
         console,
         const_compare_raw_pointers,
+        const_constructor,
         const_fn,
         const_fn_union,
         const_generics,

--- a/src/test/mir-opt/unusual-item-types.rs
+++ b/src/test/mir-opt/unusual-item-types.rs
@@ -78,7 +78,8 @@ fn main() {
 //     let mut _0: Test;
 //
 //     bb0: {
-//         _0 = Test::X(move _1,);
+//         ((_0 as X).0: usize) = move _1;
+//         discriminant(_0) = 0;
 //         return;
 //     }
 // }

--- a/src/test/ui/consts/const_constructor/const-construct-call.rs
+++ b/src/test/ui/consts/const_constructor/const-construct-call.rs
@@ -1,0 +1,116 @@
+// Test that constructors are considered to be const fns with the required feature.
+
+// run-pass
+
+// revisions: min_const_fn const_fn
+
+#![cfg_attr(const_fn, feature(const_fn))]
+
+#![feature(const_constructor)]
+
+// Ctor(..) is transformed to Ctor { 0: ... } in HAIR lowering, so directly
+// calling constructors doesn't require them to be const.
+
+type ExternalType = std::panic::AssertUnwindSafe<(Option<i32>, Result<i32, bool>)>;
+
+const fn call_external_constructors_in_local_vars() -> ExternalType {
+    let f = Some;
+    let g = Err;
+    let h = std::panic::AssertUnwindSafe;
+    let x = f(5);
+    let y = g(false);
+    let z = h((x, y));
+    z
+}
+
+const CALL_EXTERNAL_CONSTRUCTORS_IN_LOCAL_VARS: ExternalType = {
+    let f = Some;
+    let g = Err;
+    let h = std::panic::AssertUnwindSafe;
+    let x = f(5);
+    let y = g(false);
+    let z = h((x, y));
+    z
+};
+
+const fn call_external_constructors_in_temps() -> ExternalType {
+    let x = { Some }(5);
+    let y = (*&Err)(false);
+    let z = [std::panic::AssertUnwindSafe][0]((x, y));
+    z
+}
+
+const CALL_EXTERNAL_CONSTRUCTORS_IN_TEMPS: ExternalType = {
+    let x = { Some }(5);
+    let y = (*&Err)(false);
+    let z = [std::panic::AssertUnwindSafe][0]((x, y));
+    z
+};
+
+#[derive(Debug, PartialEq)]
+enum LocalOption<T> {
+    Some(T),
+    _None,
+}
+
+#[derive(Debug, PartialEq)]
+enum LocalResult<T, E> {
+    _Ok(T),
+    Err(E),
+}
+
+#[derive(Debug, PartialEq)]
+struct LocalAssertUnwindSafe<T>(T);
+
+type LocalType = LocalAssertUnwindSafe<(LocalOption<i32>, LocalResult<i32, bool>)>;
+
+const fn call_local_constructors_in_local_vars() -> LocalType {
+    let f = LocalOption::Some;
+    let g = LocalResult::Err;
+    let h = LocalAssertUnwindSafe;
+    let x = f(5);
+    let y = g(false);
+    let z = h((x, y));
+    z
+}
+
+const CALL_LOCAL_CONSTRUCTORS_IN_LOCAL_VARS: LocalType = {
+    let f = LocalOption::Some;
+    let g = LocalResult::Err;
+    let h = LocalAssertUnwindSafe;
+    let x = f(5);
+    let y = g(false);
+    let z = h((x, y));
+    z
+};
+
+const fn call_local_constructors_in_temps() -> LocalType {
+    let x = { LocalOption::Some }(5);
+    let y = (*&LocalResult::Err)(false);
+    let z = [LocalAssertUnwindSafe][0]((x, y));
+    z
+}
+
+const CALL_LOCAL_CONSTRUCTORS_IN_TEMPS: LocalType = {
+    let x = { LocalOption::Some }(5);
+    let y = (*&LocalResult::Err)(false);
+    let z = [LocalAssertUnwindSafe][0]((x, y));
+    z
+};
+
+fn main() {
+    assert_eq!(
+        (
+            call_external_constructors_in_local_vars().0,
+            call_external_constructors_in_temps().0,
+            call_local_constructors_in_local_vars(),
+            call_local_constructors_in_temps(),
+        ),
+        (
+            CALL_EXTERNAL_CONSTRUCTORS_IN_LOCAL_VARS.0,
+            CALL_EXTERNAL_CONSTRUCTORS_IN_TEMPS.0,
+            CALL_LOCAL_CONSTRUCTORS_IN_LOCAL_VARS,
+            CALL_LOCAL_CONSTRUCTORS_IN_TEMPS,
+        )
+    );
+}

--- a/src/test/ui/consts/const_constructor/feature-gate-const_constructor.const_fn.stderr
+++ b/src/test/ui/consts/const_constructor/feature-gate-const_constructor.const_fn.stderr
@@ -1,0 +1,34 @@
+error: `std::prelude::v1::Some` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:9:37
+   |
+LL | const EXTERNAL_CONST: Option<i32> = {Some}(1);
+   |                                     ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `E::V` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:12:24
+   |
+LL | const LOCAL_CONST: E = {E::V}(1);
+   |                        ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `std::prelude::v1::Some` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:17:13
+   |
+LL |     let _ = {Some}(1);
+   |             ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `E::V` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:23:13
+   |
+LL |     let _ = {E::V}(1);
+   |             ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/consts/const_constructor/feature-gate-const_constructor.min_const_fn.stderr
+++ b/src/test/ui/consts/const_constructor/feature-gate-const_constructor.min_const_fn.stderr
@@ -1,0 +1,34 @@
+error: `std::prelude::v1::Some` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:9:37
+   |
+LL | const EXTERNAL_CONST: Option<i32> = {Some}(1);
+   |                                     ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `E::V` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:12:24
+   |
+LL | const LOCAL_CONST: E = {E::V}(1);
+   |                        ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `std::prelude::v1::Some` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:17:13
+   |
+LL |     let _ = {Some}(1);
+   |             ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: `E::V` is not yet stable as a const fn
+  --> $DIR/feature-gate-const_constructor.rs:23:13
+   |
+LL |     let _ = {E::V}(1);
+   |             ^^^^^^^^^
+   |
+   = help: add `#![feature(const_constructor)]` to the crate attributes to enable
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/consts/const_constructor/feature-gate-const_constructor.rs
+++ b/src/test/ui/consts/const_constructor/feature-gate-const_constructor.rs
@@ -1,0 +1,28 @@
+// revisions: min_const_fn const_fn
+
+#![cfg_attr(const_fn, feature(const_fn))]
+
+enum E {
+    V(i32),
+}
+
+const EXTERNAL_CONST: Option<i32> = {Some}(1);
+//[min_const_fn]~^ ERROR is not yet stable as a const fn
+//[const_fn]~^^ ERROR is not yet stable as a const fn
+const LOCAL_CONST: E = {E::V}(1);
+//[min_const_fn]~^ ERROR is not yet stable as a const fn
+//[const_fn]~^^ ERROR is not yet stable as a const fn
+
+const fn external_fn() {
+    let _ = {Some}(1);
+    //[min_const_fn]~^ ERROR is not yet stable as a const fn
+    //[const_fn]~^^ ERROR is not yet stable as a const fn
+}
+
+const fn local_fn() {
+    let _ = {E::V}(1);
+    //[min_const_fn]~^ ERROR is not yet stable as a const fn
+    //[const_fn]~^^ ERROR is not yet stable as a const fn
+}
+
+fn main() {}

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.rs
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.rs
@@ -1,0 +1,71 @@
+// Unit test for the "user substitutions" that are annotated on each
+// node.
+
+struct SomeStruct<T>(T);
+
+fn no_annot() {
+    let c = 66;
+    let f = SomeStruct;
+    f(&c);
+}
+
+fn annot_underscore() {
+    let c = 66;
+    let f = SomeStruct::<_>;
+    f(&c);
+}
+
+fn annot_reference_any_lifetime() {
+    let c = 66;
+    let f = SomeStruct::<&u32>;
+    f(&c);
+}
+
+fn annot_reference_static_lifetime() {
+    let c = 66;
+    let f = SomeStruct::<&'static u32>;
+    f(&c); //~ ERROR
+}
+
+fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+    let c = 66;
+    let f = SomeStruct::<&'a u32>;
+    f(&c); //~ ERROR
+}
+
+fn annot_reference_named_lifetime_ok<'a>(c: &'a u32) {
+    let f = SomeStruct::<&'a u32>;
+    f(c);
+}
+
+fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+    let _closure = || {
+        let c = 66;
+        let f = SomeStruct::<&'a u32>;
+        f(&c); //~ ERROR
+    };
+}
+
+fn annot_reference_named_lifetime_across_closure<'a>(_: &'a u32) {
+    let f = SomeStruct::<&'a u32>;
+    let _closure = || {
+        let c = 66;
+        f(&c); //~ ERROR
+    };
+}
+
+fn annot_reference_named_lifetime_in_closure_ok<'a>(c: &'a u32) {
+    let _closure = || {
+        let f = SomeStruct::<&'a u32>;
+        f(c);
+    };
+}
+
+fn annot_reference_named_lifetime_across_closure_ok<'a>(c: &'a u32) {
+    let f = SomeStruct::<&'a u32>;
+    let _closure = || {
+        f(c);
+    };
+}
+
+fn main() { }

--- a/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
+++ b/src/test/ui/nll/user-annotations/adt-tuple-struct-calls.stderr
@@ -1,0 +1,56 @@
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-tuple-struct-calls.rs:27:7
+   |
+LL |     f(&c);
+   |     --^^-
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'static`
+LL | }
+   | - `c` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-tuple-struct-calls.rs:33:7
+   |
+LL | fn annot_reference_named_lifetime<'a>(_d: &'a u32) {
+   |                                   -- lifetime `'a` defined here
+...
+LL |     f(&c);
+   |     --^^-
+   |     | |
+   |     | borrowed value does not live long enough
+   |     argument requires that `c` is borrowed for `'a`
+LL | }
+   | - `c` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-tuple-struct-calls.rs:45:11
+   |
+LL | fn annot_reference_named_lifetime_in_closure<'a>(_: &'a u32) {
+   |                                              -- lifetime `'a` defined here
+...
+LL |         f(&c);
+   |         --^^-
+   |         | |
+   |         | borrowed value does not live long enough
+   |         argument requires that `c` is borrowed for `'a`
+LL |     };
+   |     - `c` dropped here while still borrowed
+
+error[E0597]: `c` does not live long enough
+  --> $DIR/adt-tuple-struct-calls.rs:53:11
+   |
+LL |     let f = SomeStruct::<&'a u32>;
+   |         - lifetime `'1` appears in the type of `f`
+...
+LL |         f(&c);
+   |         --^^-
+   |         | |
+   |         | borrowed value does not live long enough
+   |         argument requires that `c` is borrowed for `'1`
+LL |     };
+   |     - `c` dropped here while still borrowed
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Mir construction special cases `Ctor(...)` to be lowered as `Ctor { 0: ... }`, which means this doesn't come up much in practice, but it seems inconsistent not to allow this.

Tracking issue: https://github.com/rust-lang/rust/issues/61456

r? @oli-obk 

