### PR TITLE
ci: Attempt to skip a full rustc compile on dist*

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1371,7 +1371,7 @@ mod __test {
 
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
-            &[dist::Docs { stage: 2, host: a },]
+            &[dist::Docs { host: a },]
         );
         assert_eq!(
             first(builder.cache.all::<dist::Mingw>()),
@@ -1405,8 +1405,8 @@ mod __test {
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
             &[
-                dist::Docs { stage: 2, host: a },
-                dist::Docs { stage: 2, host: b },
+                dist::Docs { host: a },
+                dist::Docs { host: b },
             ]
         );
         assert_eq!(
@@ -1447,8 +1447,8 @@ mod __test {
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
             &[
-                dist::Docs { stage: 2, host: a },
-                dist::Docs { stage: 2, host: b },
+                dist::Docs { host: a },
+                dist::Docs { host: b },
             ]
         );
         assert_eq!(
@@ -1488,6 +1488,7 @@ mod __test {
         let b = INTERNER.intern_str("B");
         let mut build = Build::new(configure(&["B"], &[]));
         build.config.docs = false;
+        build.config.extended = true;
         build.hosts = vec![b];
         let mut builder = Builder::new(&build);
         builder.run_step_descriptions(&Builder::get_step_descriptions(Kind::Dist), &[]);
@@ -1528,9 +1529,9 @@ mod __test {
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
             &[
-                dist::Docs { stage: 2, host: a },
-                dist::Docs { stage: 2, host: b },
-                dist::Docs { stage: 2, host: c },
+                dist::Docs { host: a },
+                dist::Docs { host: b },
+                dist::Docs { host: c },
             ]
         );
         assert_eq!(
@@ -1587,9 +1588,9 @@ mod __test {
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
             &[
-                dist::Docs { stage: 2, host: a },
-                dist::Docs { stage: 2, host: b },
-                dist::Docs { stage: 2, host: c },
+                dist::Docs { host: a },
+                dist::Docs { host: b },
+                dist::Docs { host: c },
             ]
         );
         assert_eq!(
@@ -1633,8 +1634,8 @@ mod __test {
         assert_eq!(
             first(builder.cache.all::<dist::Docs>()),
             &[
-                dist::Docs { stage: 2, host: a },
-                dist::Docs { stage: 2, host: b },
+                dist::Docs { host: a },
+                dist::Docs { host: b },
             ]
         );
         assert_eq!(

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -588,7 +588,12 @@ impl<'a> Builder<'a> {
     /// sysroot.
     ///
     /// See `force_use_stage1` for documentation on what each argument is.
-    pub fn compiler_for(&self, stage: u32, host: Interned<String>, target: Interned<String>) -> Compiler {
+    pub fn compiler_for(
+        &self,
+        stage: u32,
+        host: Interned<String>,
+        target: Interned<String>,
+    ) -> Compiler {
         if self.build.force_use_stage1(Compiler { stage, host }, target) {
             self.compiler(1, self.config.build)
         } else {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -70,20 +70,20 @@ impl Step for Std {
 
         builder.ensure(StartupObjects { compiler, target });
 
-        if builder.force_use_stage1(compiler, target) {
-            let from = builder.compiler(1, builder.config.build);
+        let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
+        if compiler_to_use != compiler {
             builder.ensure(Std {
-                compiler: from,
+                compiler: compiler_to_use,
                 target,
             });
-            builder.info(&format!("Uplifting stage1 std ({} -> {})", from.host, target));
+            builder.info(&format!("Uplifting stage1 std ({} -> {})", compiler_to_use.host, target));
 
             // Even if we're not building std this stage, the new sysroot must
             // still contain the third party objects needed by various targets.
             copy_third_party_objects(builder, &compiler, target);
 
             builder.ensure(StdLink {
-                compiler: from,
+                compiler: compiler_to_use,
                 target_compiler: compiler,
                 target,
             });
@@ -402,15 +402,16 @@ impl Step for Test {
             return;
         }
 
-        if builder.force_use_stage1(compiler, target) {
+        let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
+        if compiler_to_use != compiler {
             builder.ensure(Test {
-                compiler: builder.compiler(1, builder.config.build),
+                compiler: compiler_to_use,
                 target,
             });
             builder.info(
                 &format!("Uplifting stage1 test ({} -> {})", builder.config.build, target));
             builder.ensure(TestLink {
-                compiler: builder.compiler(1, builder.config.build),
+                compiler: compiler_to_use,
                 target_compiler: compiler,
                 target,
             });
@@ -527,15 +528,16 @@ impl Step for Rustc {
             return;
         }
 
-        if builder.force_use_stage1(compiler, target) {
+        let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
+        if compiler_to_use != compiler {
             builder.ensure(Rustc {
-                compiler: builder.compiler(1, builder.config.build),
+                compiler: compiler_to_use,
                 target,
             });
             builder.info(&format!("Uplifting stage1 rustc ({} -> {})",
                 builder.config.build, target));
             builder.ensure(RustcLink {
-                compiler: builder.compiler(1, builder.config.build),
+                compiler: compiler_to_use,
                 target_compiler: compiler,
                 target,
             });
@@ -691,9 +693,10 @@ impl Step for CodegenBackend {
             return;
         }
 
-        if builder.force_use_stage1(compiler, target) {
+        let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
+        if compiler_to_use != compiler {
             builder.ensure(CodegenBackend {
-                compiler: builder.compiler(1, builder.config.build),
+                compiler: compiler_to_use,
                 target,
                 backend,
             });

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -68,7 +68,6 @@ fn missing_tool(tool_name: &str, skip: bool) {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Docs {
-    pub stage: u32,
     pub host: Interned<String>,
 }
 
@@ -82,7 +81,6 @@ impl Step for Docs {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Docs {
-            stage: run.builder.top_stage,
             host: run.target,
         });
     }
@@ -130,7 +128,6 @@ impl Step for Docs {
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct RustcDocs {
-    pub stage: u32,
     pub host: Interned<String>,
 }
 
@@ -144,7 +141,6 @@ impl Step for RustcDocs {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(RustcDocs {
-            stage: run.builder.top_stage,
             host: run.target,
         });
     }
@@ -741,7 +737,14 @@ impl Step for Analysis {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Analysis {
-            compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
+            // Find the actual compiler (handling the full bootstrap option) which
+            // produced the save-analysis data because that data isn't copied
+            // through the sysroot uplifting.
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
@@ -760,11 +763,6 @@ impl Step for Analysis {
         }
 
         builder.ensure(Std { compiler, target });
-
-        // Find the actual compiler (handling the full bootstrap option) which
-        // produced the save-analysis data because that data isn't copied
-        // through the sysroot uplifting.
-        let compiler = builder.compiler_for(compiler.stage, compiler.host, target);
 
         let image = tmpdir(builder).join(format!("{}-{}-image", name, target));
 
@@ -1067,7 +1065,7 @@ pub fn sanitize_sh(path: &Path) -> String {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Cargo {
-    pub stage: u32,
+    pub compiler: Compiler,
     pub target: Interned<String>,
 }
 
@@ -1081,16 +1079,20 @@ impl Step for Cargo {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Cargo {
-            stage: run.builder.top_stage,
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> PathBuf {
-        let stage = self.stage;
+        let compiler = self.compiler;
         let target = self.target;
 
-        builder.info(&format!("Dist cargo stage{} ({})", stage, target));
+        builder.info(&format!("Dist cargo stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/cargo");
         let etc = src.join("src/etc");
         let release_num = builder.release_num("cargo");
@@ -1105,10 +1107,7 @@ impl Step for Cargo {
         // Prepare the image directory
         builder.create_dir(&image.join("share/zsh/site-functions"));
         builder.create_dir(&image.join("etc/bash_completion.d"));
-        let cargo = builder.ensure(tool::Cargo {
-            compiler: builder.compiler(stage, builder.config.build),
-            target
-        });
+        let cargo = builder.ensure(tool::Cargo { compiler, target });
         builder.install(&cargo, &image.join("bin"), 0o755);
         for man in t!(etc.join("man").read_dir()) {
             let man = t!(man);
@@ -1153,7 +1152,7 @@ impl Step for Cargo {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Rls {
-    pub stage: u32,
+    pub compiler: Compiler,
     pub target: Interned<String>,
 }
 
@@ -1167,17 +1166,21 @@ impl Step for Rls {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rls {
-            stage: run.builder.top_stage,
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
-        let stage = self.stage;
+        let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist RLS stage{} ({})", stage, target));
+        builder.info(&format!("Dist RLS stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/rls");
         let release_num = builder.release_num("rls");
         let name = pkgname(builder, "rls");
@@ -1192,8 +1195,9 @@ impl Step for Rls {
         // We expect RLS to build, because we've exited this step above if tool
         // state for RLS isn't testing.
         let rls = builder.ensure(tool::Rls {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new(),
         }).or_else(|| { missing_tool("RLS", builder.build.config.missing_tools); None })?;
 
         builder.install(&rls, &image.join("bin"), 0o755);
@@ -1232,7 +1236,7 @@ impl Step for Rls {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Clippy {
-    pub stage: u32,
+    pub compiler: Compiler,
     pub target: Interned<String>,
 }
 
@@ -1246,17 +1250,21 @@ impl Step for Clippy {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Clippy {
-            stage: run.builder.top_stage,
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
-        let stage = self.stage;
+        let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist clippy stage{} ({})", stage, target));
+        builder.info(&format!("Dist clippy stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/clippy");
         let release_num = builder.release_num("clippy");
         let name = pkgname(builder, "clippy");
@@ -1271,11 +1279,12 @@ impl Step for Clippy {
         // We expect clippy to build, because we've exited this step above if tool
         // state for clippy isn't testing.
         let clippy = builder.ensure(tool::Clippy {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new(),
         }).or_else(|| { missing_tool("clippy", builder.build.config.missing_tools); None })?;
         let cargoclippy = builder.ensure(tool::CargoClippy {
-            compiler: builder.compiler(stage, builder.config.build),
+            compiler,
             target, extra_features: Vec::new()
         }).or_else(|| { missing_tool("cargo clippy", builder.build.config.missing_tools); None })?;
 
@@ -1316,7 +1325,7 @@ impl Step for Clippy {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Miri {
-    pub stage: u32,
+    pub compiler: Compiler,
     pub target: Interned<String>,
 }
 
@@ -1330,17 +1339,21 @@ impl Step for Miri {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Miri {
-            stage: run.builder.top_stage,
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
-        let stage = self.stage;
+        let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist miri stage{} ({})", stage, target));
+        builder.info(&format!("Dist miri stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/miri");
         let release_num = builder.release_num("miri");
         let name = pkgname(builder, "miri");
@@ -1355,12 +1368,14 @@ impl Step for Miri {
         // We expect miri to build, because we've exited this step above if tool
         // state for miri isn't testing.
         let miri = builder.ensure(tool::Miri {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new(),
         }).or_else(|| { missing_tool("miri", builder.build.config.missing_tools); None })?;
         let cargomiri = builder.ensure(tool::CargoMiri {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new()
         }).or_else(|| { missing_tool("cargo miri", builder.build.config.missing_tools); None })?;
 
         builder.install(&miri, &image.join("bin"), 0o755);
@@ -1400,7 +1415,7 @@ impl Step for Miri {
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Rustfmt {
-    pub stage: u32,
+    pub compiler: Compiler,
     pub target: Interned<String>,
 }
 
@@ -1414,16 +1429,20 @@ impl Step for Rustfmt {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(Rustfmt {
-            stage: run.builder.top_stage,
+            compiler: run.builder.compiler_for(
+                run.builder.top_stage,
+                run.builder.config.build,
+                run.target,
+            ),
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
-        let stage = self.stage;
+        let compiler = self.compiler;
         let target = self.target;
 
-        builder.info(&format!("Dist Rustfmt stage{} ({})", stage, target));
+        builder.info(&format!("Dist Rustfmt stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/rustfmt");
         let release_num = builder.release_num("rustfmt");
         let name = pkgname(builder, "rustfmt");
@@ -1436,12 +1455,14 @@ impl Step for Rustfmt {
 
         // Prepare the image directory
         let rustfmt = builder.ensure(tool::Rustfmt {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new(),
         }).or_else(|| { missing_tool("Rustfmt", builder.build.config.missing_tools); None })?;
         let cargofmt = builder.ensure(tool::Cargofmt {
-            compiler: builder.compiler(stage, builder.config.build),
-            target, extra_features: Vec::new()
+            compiler,
+            target,
+            extra_features: Vec::new(),
         }).or_else(|| { missing_tool("Cargofmt", builder.build.config.missing_tools); None })?;
 
         builder.install(&rustfmt, &image.join("bin"), 0o755);
@@ -1506,30 +1527,28 @@ impl Step for Extended {
 
     /// Creates a combined installer for the specified target in the provided stage.
     fn run(self, builder: &Builder<'_>) {
-        let stage = self.stage;
         let target = self.target;
+        let stage = self.stage;
+        let compiler = builder.compiler_for(self.stage, self.host, self.target);
 
-        builder.info(&format!("Dist extended stage{} ({})", stage, target));
+        builder.info(&format!("Dist extended stage{} ({})", compiler.stage, target));
 
         let rustc_installer = builder.ensure(Rustc {
             compiler: builder.compiler(stage, target),
         });
-        let cargo_installer = builder.ensure(Cargo { stage, target });
-        let rustfmt_installer = builder.ensure(Rustfmt { stage, target });
-        let rls_installer = builder.ensure(Rls { stage, target });
-        let llvm_tools_installer = builder.ensure(LlvmTools { stage, target });
-        let clippy_installer = builder.ensure(Clippy { stage, target });
-        let miri_installer = builder.ensure(Miri { stage, target });
+        let cargo_installer = builder.ensure(Cargo { compiler, target });
+        let rustfmt_installer = builder.ensure(Rustfmt { compiler, target });
+        let rls_installer = builder.ensure(Rls { compiler, target });
+        let llvm_tools_installer = builder.ensure(LlvmTools { target });
+        let clippy_installer = builder.ensure(Clippy { compiler, target });
+        let miri_installer = builder.ensure(Miri { compiler, target });
         let lldb_installer = builder.ensure(Lldb { target });
         let mingw_installer = builder.ensure(Mingw { host: target });
-        let analysis_installer = builder.ensure(Analysis {
-            compiler: builder.compiler(stage, self.host),
-            target
-        });
+        let analysis_installer = builder.ensure(Analysis { compiler, target });
 
-        let docs_installer = builder.ensure(Docs { stage, host: target, });
+        let docs_installer = builder.ensure(Docs { host: target, });
         let std_installer = builder.ensure(Std {
-            compiler: builder.compiler(stage, self.host),
+            compiler: builder.compiler(stage, target),
             target,
         });
 
@@ -2077,7 +2096,6 @@ pub fn maybe_install_llvm_dylib(builder: &Builder<'_>,
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct LlvmTools {
-    pub stage: u32,
     pub target: Interned<String>,
 }
 
@@ -2091,26 +2109,24 @@ impl Step for LlvmTools {
 
     fn make_run(run: RunConfig<'_>) {
         run.builder.ensure(LlvmTools {
-            stage: run.builder.top_stage,
             target: run.target,
         });
     }
 
     fn run(self, builder: &Builder<'_>) -> Option<PathBuf> {
-        let stage = self.stage;
         let target = self.target;
         assert!(builder.config.extended);
 
         /* run only if llvm-config isn't used */
         if let Some(config) = builder.config.target_config.get(&target) {
             if let Some(ref _s) = config.llvm_config {
-                builder.info(&format!("Skipping LlvmTools stage{} ({}): external LLVM",
-                    stage, target));
+                builder.info(&format!("Skipping LlvmTools ({}): external LLVM",
+                    target));
                 return None;
             }
         }
 
-        builder.info(&format!("Dist LlvmTools stage{} ({})", stage, target));
+        builder.info(&format!("Dist LlvmTools ({})", target));
         let src = builder.src.join("src/llvm-project/llvm");
         let name = pkgname(builder, "llvm-tools");
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -475,12 +475,7 @@ impl Step for Std {
         builder.info(&format!("Documenting stage{} std ({})", stage, target));
         let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, builder.config.build);
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler
-        };
+        let compiler = builder.compiler_for(stage, builder.config.build, target);
 
         builder.ensure(compile::Std { compiler, target });
         let out_dir = builder.stage_out(compiler, Mode::Std)
@@ -563,12 +558,7 @@ impl Step for Test {
         builder.info(&format!("Documenting stage{} test ({})", stage, target));
         let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, builder.config.build);
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler
-        };
+        let compiler = builder.compiler_for(stage, builder.config.build, target);
 
         // Build libstd docs so that we generate relative links
         builder.ensure(Std { stage, target });
@@ -632,12 +622,7 @@ impl Step for WhitelistedRustc {
         builder.info(&format!("Documenting stage{} whitelisted compiler ({})", stage, target));
         let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
-        let compiler = builder.compiler(stage, builder.config.build);
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler
-        };
+        let compiler = builder.compiler_for(stage, builder.config.build, target);
 
         // Build libstd docs so that we generate relative links
         builder.ensure(Std { stage, target });
@@ -706,12 +691,7 @@ impl Step for Rustc {
         t!(fs::create_dir_all(&out));
 
         // Get the correct compiler for this stage.
-        let compiler = builder.compiler(stage, builder.config.build);
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler
-        };
+        let compiler = builder.compiler_for(stage, builder.config.build, target);
 
         if !builder.config.compiler_docs {
             builder.info("\tskipping - compiler/librustdoc docs disabled");
@@ -807,12 +787,7 @@ impl Step for Rustdoc {
         t!(fs::create_dir_all(&out));
 
         // Get the correct compiler for this stage.
-        let compiler = builder.compiler(stage, builder.config.build);
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler
-        };
+        let compiler = builder.compiler_for(stage, builder.config.build, target);
 
         if !builder.config.compiler_docs {
             builder.info("\tskipping - compiler/librustdoc docs disabled");

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -210,15 +210,21 @@ install!((self, builder, _config),
             Self::should_install(builder) {
             install_rls(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install RLS stage{} ({})", self.compiler.stage, self.target));
+            builder.info(
+                &format!("skipping Install RLS stage{} ({})", self.compiler.stage, self.target),
+            );
         }
     };
     Clippy, "clippy", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Clippy { compiler: self.compiler, target: self.target }).is_some() ||
-            Self::should_install(builder) {
+        if builder.ensure(dist::Clippy {
+            compiler: self.compiler,
+            target: self.target,
+        }).is_some() || Self::should_install(builder) {
             install_clippy(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install clippy stage{} ({})", self.compiler.stage, self.target));
+            builder.info(
+                &format!("skipping Install clippy stage{} ({})", self.compiler.stage, self.target),
+            );
         }
     };
     Miri, "miri", Self::should_build(_config), only_hosts: true, {
@@ -226,16 +232,21 @@ install!((self, builder, _config),
             Self::should_install(builder) {
             install_miri(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install miri stage{} ({})", self.compiler.stage, self.target));
+            builder.info(
+                &format!("skipping Install miri stage{} ({})", self.compiler.stage, self.target),
+            );
         }
     };
     Rustfmt, "rustfmt", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Rustfmt { compiler: self.compiler, target: self.target }).is_some() ||
-            Self::should_install(builder) {
+        if builder.ensure(dist::Rustfmt {
+            compiler: self.compiler,
+            target: self.target
+        }).is_some() || Self::should_install(builder) {
             install_rustfmt(builder, self.compiler.stage, self.target);
         } else {
             builder.info(
-                &format!("skipping Install Rustfmt stage{} ({})", self.compiler.stage, self.target));
+                &format!("skipping Install Rustfmt stage{} ({})", self.compiler.stage, self.target),
+            );
         }
     };
     Analysis, "analysis", Self::should_build(_config), only_hosts: false, {

--- a/src/bootstrap/install.rs
+++ b/src/bootstrap/install.rs
@@ -5,12 +5,13 @@
 
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf, Component};
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
 use build_helper::t;
 
 use crate::dist::{self, pkgname, sanitize_sh, tmpdir};
+use crate::Compiler;
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::cache::Interned;
@@ -58,7 +59,7 @@ fn install_sh(
     package: &str,
     name: &str,
     stage: u32,
-    host: Option<Interned<String>>
+    host: Option<Interned<String>>,
 ) {
     builder.info(&format!("Install {} stage{} ({:?})", package, stage, host));
 
@@ -144,9 +145,8 @@ macro_rules! install {
         $(
             #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct $name {
-            pub stage: u32,
+            pub compiler: Compiler,
             pub target: Interned<String>,
-            pub host: Interned<String>,
         }
 
         impl $name {
@@ -175,9 +175,8 @@ macro_rules! install {
 
             fn make_run(run: RunConfig<'_>) {
                 run.builder.ensure($name {
-                    stage: run.builder.top_stage,
+                    compiler: run.builder.compiler(run.builder.top_stage, run.builder.config.build),
                     target: run.target,
-                    host: run.builder.config.build,
                 });
             }
 
@@ -190,67 +189,67 @@ macro_rules! install {
 
 install!((self, builder, _config),
     Docs, "src/doc", _config.docs, only_hosts: false, {
-        builder.ensure(dist::Docs { stage: self.stage, host: self.target });
-        install_docs(builder, self.stage, self.target);
+        builder.ensure(dist::Docs { host: self.target });
+        install_docs(builder, self.compiler.stage, self.target);
     };
     Std, "src/libstd", true, only_hosts: true, {
         for target in &builder.targets {
             builder.ensure(dist::Std {
-                compiler: builder.compiler(self.stage, self.host),
+                compiler: self.compiler,
                 target: *target
             });
-            install_std(builder, self.stage, *target);
+            install_std(builder, self.compiler.stage, *target);
         }
     };
     Cargo, "cargo", Self::should_build(_config), only_hosts: true, {
-        builder.ensure(dist::Cargo { stage: self.stage, target: self.target });
-        install_cargo(builder, self.stage, self.target);
+        builder.ensure(dist::Cargo { compiler: self.compiler, target: self.target });
+        install_cargo(builder, self.compiler.stage, self.target);
     };
     Rls, "rls", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Rls { stage: self.stage, target: self.target }).is_some() ||
+        if builder.ensure(dist::Rls { compiler: self.compiler, target: self.target }).is_some() ||
             Self::should_install(builder) {
-            install_rls(builder, self.stage, self.target);
+            install_rls(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install RLS stage{} ({})", self.stage, self.target));
+            builder.info(&format!("skipping Install RLS stage{} ({})", self.compiler.stage, self.target));
         }
     };
     Clippy, "clippy", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Clippy { stage: self.stage, target: self.target }).is_some() ||
+        if builder.ensure(dist::Clippy { compiler: self.compiler, target: self.target }).is_some() ||
             Self::should_install(builder) {
-            install_clippy(builder, self.stage, self.target);
+            install_clippy(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install clippy stage{} ({})", self.stage, self.target));
+            builder.info(&format!("skipping Install clippy stage{} ({})", self.compiler.stage, self.target));
         }
     };
     Miri, "miri", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Miri { stage: self.stage, target: self.target }).is_some() ||
+        if builder.ensure(dist::Miri { compiler: self.compiler, target: self.target }).is_some() ||
             Self::should_install(builder) {
-            install_miri(builder, self.stage, self.target);
+            install_miri(builder, self.compiler.stage, self.target);
         } else {
-            builder.info(&format!("skipping Install miri stage{} ({})", self.stage, self.target));
+            builder.info(&format!("skipping Install miri stage{} ({})", self.compiler.stage, self.target));
         }
     };
     Rustfmt, "rustfmt", Self::should_build(_config), only_hosts: true, {
-        if builder.ensure(dist::Rustfmt { stage: self.stage, target: self.target }).is_some() ||
+        if builder.ensure(dist::Rustfmt { compiler: self.compiler, target: self.target }).is_some() ||
             Self::should_install(builder) {
-            install_rustfmt(builder, self.stage, self.target);
+            install_rustfmt(builder, self.compiler.stage, self.target);
         } else {
             builder.info(
-                &format!("skipping Install Rustfmt stage{} ({})", self.stage, self.target));
+                &format!("skipping Install Rustfmt stage{} ({})", self.compiler.stage, self.target));
         }
     };
     Analysis, "analysis", Self::should_build(_config), only_hosts: false, {
         builder.ensure(dist::Analysis {
-            compiler: builder.compiler(self.stage, self.host),
+            compiler: self.compiler,
             target: self.target
         });
-        install_analysis(builder, self.stage, self.target);
+        install_analysis(builder, self.compiler.stage, self.target);
     };
     Rustc, "src/librustc", true, only_hosts: true, {
         builder.ensure(dist::Rustc {
-            compiler: builder.compiler(self.stage, self.target),
+            compiler: self.compiler,
         });
-        install_rustc(builder, self.stage, self.target);
+        install_rustc(builder, self.compiler.stage, self.target);
     };
 );
 
@@ -266,15 +265,12 @@ impl Step for Src {
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         let config = &run.builder.config;
-        let cond = config.extended &&
-            config.tools.as_ref().map_or(true, |t| t.contains("src"));
+        let cond = config.extended && config.tools.as_ref().map_or(true, |t| t.contains("src"));
         run.path("src").default_condition(cond)
     }
 
     fn make_run(run: RunConfig<'_>) {
-        run.builder.ensure(Src {
-            stage: run.builder.top_stage,
-        });
+        run.builder.ensure(Src { stage: run.builder.top_stage });
     }
 
     fn run(self, builder: &Builder<'_>) {

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1707,15 +1707,11 @@ impl Step for Crate {
         builder.ensure(compile::Test { compiler, target });
         builder.ensure(RemoteCopyLibs { compiler, target });
 
-        // If we're not doing a full bootstrap but we're testing a stage2 version of
-        // libstd, then what we're actually testing is the libstd produced in
-        // stage1. Reflect that here by updating the compiler that we're working
-        // with automatically.
-        let compiler = if builder.force_use_stage1(compiler, target) {
-            builder.compiler(1, compiler.host)
-        } else {
-            compiler.clone()
-        };
+        // If we're not doing a full bootstrap but we're testing a stage2
+        // version of libstd, then what we're actually testing is the libstd
+        // produced in stage1. Reflect that here by updating the compiler that
+        // we're working with automatically.
+        let compiler = builder.compiler_for(compiler.stage, compiler.host, target);
 
         let mut cargo = builder.cargo(compiler, mode, target, test_kind.subcommand());
         match mode {

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -539,9 +539,9 @@ impl Step for Cargo {
     }
 
     fn run(self, builder: &Builder<'_>) -> PathBuf {
-        // Cargo depends on procedural macros, which requires a full host
-        // compiler to be available, so we need to depend on that.
-        builder.ensure(compile::Rustc {
+        // Cargo depends on procedural macros, so make sure the host
+        // libstd/libproc_macro is available.
+        builder.ensure(compile::Test {
             compiler: self.compiler,
             target: builder.config.build,
         });
@@ -613,26 +613,26 @@ macro_rules! tool_extended {
 tool_extended!((self, builder),
     Cargofmt, rustfmt, "src/tools/rustfmt", "cargo-fmt", {};
     CargoClippy, clippy, "src/tools/clippy", "cargo-clippy", {
-        // Clippy depends on procedural macros (serde), which requires a full host
-        // compiler to be available, so we need to depend on that.
-        builder.ensure(compile::Rustc {
+        // Clippy depends on procedural macros, so make sure that's built for
+        // the compiler itself.
+        builder.ensure(compile::Test {
             compiler: self.compiler,
             target: builder.config.build,
         });
     };
     Clippy, clippy, "src/tools/clippy", "clippy-driver", {
-        // Clippy depends on procedural macros (serde), which requires a full host
-        // compiler to be available, so we need to depend on that.
-        builder.ensure(compile::Rustc {
+        // Clippy depends on procedural macros, so make sure that's built for
+        // the compiler itself.
+        builder.ensure(compile::Test {
             compiler: self.compiler,
             target: builder.config.build,
         });
     };
     Miri, miri, "src/tools/miri", "miri", {};
     CargoMiri, miri, "src/tools/miri", "cargo-miri", {
-        // Miri depends on procedural macros (serde), which requires a full host
-        // compiler to be available, so we need to depend on that.
-        builder.ensure(compile::Rustc {
+        // Miri depends on procedural macros, so make sure that's built for
+        // the compiler itself.
+        builder.ensure(compile::Test {
             compiler: self.compiler,
             target: builder.config.build,
         });
@@ -646,9 +646,9 @@ tool_extended!((self, builder),
         if clippy.is_some() {
             self.extra_features.push("clippy".to_owned());
         }
-        // RLS depends on procedural macros, which requires a full host
-        // compiler to be available, so we need to depend on that.
-        builder.ensure(compile::Rustc {
+        // RLS depends on procedural macros, so make sure that's built for
+        // the compiler itself.
+        builder.ensure(compile::Test {
             compiler: self.compiler,
             target: builder.config.build,
         });


### PR DESCRIPTION
Currently when we're preparing cross-compiled compilers it can take
quite some time because we have to build the compiler itself three
different times. The first is the normal bootstrap, the second is a
second build for the build platform, and the third is the actual target
architecture compiler. The second compiler was historically built
exclusively for procedural macros, and long ago we didn't actually need
it.

This commit tries out avoiding that second compiled compiler, meaning we
only compile rustc for the build platform only once. Some local testing
shows that this is promising, but bors is of course the ultimate test!