### PR TITLE
azure: fix multiple checkouts on azure

### DIFF
--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -11,6 +11,7 @@ variables:
 
 jobs:
 - job: Linux
+  timeoutInMinutes: 600
   pool:
     vmImage: ubuntu-16.04
   steps:
@@ -150,6 +151,7 @@ jobs:
         IMAGE: mingw-check
 
 - job: macOS
+  timeoutInMinutes: 600
   pool:
     vmImage: macos-10.13
   steps:
@@ -212,6 +214,7 @@ jobs:
 
 
 - job: Windows
+  timeoutInMinutes: 600
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -153,8 +153,6 @@ jobs:
   pool:
     vmImage: macos-10.13
   steps:
-  - checkout: self
-    fetchDepth: 2
   - template: steps/run.yml
   strategy:
     matrix:


### PR DESCRIPTION
We were checking out the rustc repo multiple times on auto macOS, and
that was causing an error on the Azure side since multiple checkouts are
apparently not supported. This removes the extra checkout.

r? @alexcrichton 
fixes #61170