### PR TITLE
Box::into_vec: use Box::into_raw instead of mem::forget

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -137,17 +137,16 @@ pub use hack::to_vec;
 // `core::slice::SliceExt` - we need to supply these functions for the
 // `test_permutations` test
 mod hack {
-    use core::mem;
-
     use crate::boxed::Box;
     use crate::vec::Vec;
     #[cfg(test)]
     use crate::string::ToString;
 
-    pub fn into_vec<T>(mut b: Box<[T]>) -> Vec<T> {
+    pub fn into_vec<T>(b: Box<[T]>) -> Vec<T> {
         unsafe {
-            let xs = Vec::from_raw_parts(b.as_mut_ptr(), b.len(), b.len());
-            mem::forget(b);
+            let len = b.len();
+            let b = Box::into_raw(b);
+            let xs = Vec::from_raw_parts(b as *mut T, len, len);
             xs
         }
     }


### PR DESCRIPTION
`Box::into_raw` does, in one step, turn the `Box` into a raw ptr and avoid deallocation.  Seems cleaner than separating the two.

Also, `mem::forget` gets the `Box` with a `noalias` argument, but it is not actually correct that this is an exclusive pointer. So a stricter version of Stacked Borrows would complain here. (I can't actually make Stacked Borrows that strict yet though due to other issues.)