### PR TITLE
Remove special case for *ios* builds in run-make-fulldeps/print-target-list Makefile

### DIFF
--- a/src/test/run-make-fulldeps/print-target-list/Makefile
+++ b/src/test/run-make-fulldeps/print-target-list/Makefile
@@ -2,12 +2,9 @@
 
 # Checks that all the targets returned by `rustc --print target-list` are valid
 # target specifications
-# TODO remove the '*ios*' case when rust-lang/rust#29812 is fixed
 all:
 	for target in $(shell $(BARE_RUSTC) --print target-list); do \
 		case $$target in \
-			*ios*) \
-				;; \
 			*) \
 				$(BARE_RUSTC) --target $$target --print sysroot \
 				;; \

--- a/src/test/run-make-fulldeps/print-target-list/Makefile
+++ b/src/test/run-make-fulldeps/print-target-list/Makefile
@@ -4,9 +4,5 @@
 # target specifications
 all:
 	for target in $(shell $(BARE_RUSTC) --print target-list); do \
-		case $$target in \
-			*) \
-				$(BARE_RUSTC) --target $$target --print sysroot \
-				;; \
-			esac \
+		$(BARE_RUSTC) --target $$target --print sysroot \
 	done

--- a/src/test/run-make-fulldeps/print-target-list/Makefile
+++ b/src/test/run-make-fulldeps/print-target-list/Makefile
@@ -4,5 +4,5 @@
 # target specifications
 all:
 	for target in $(shell $(BARE_RUSTC) --print target-list); do \
-		$(BARE_RUSTC) --target $$target --print sysroot \
+		$(BARE_RUSTC) --target $$target --print sysroot; \
 	done


### PR DESCRIPTION
Previous `TODO` comment in this file mentions [an issue that was closed](https://github.com/rust-lang/rust/issues/29812), and I was able to confirm locally that provided code in that issue no longer produces an ICE. Discussion on that issue seems to indicate this code was no longer needed as of 1.12.0.

I removed the `*ios*` branch from this `case` statement as it may cause confusion, then removed the case statement entirely as it only had a wildcard branch.