### PR TITLE
Update musl to 1.1.22

### DIFF
--- a/src/ci/docker/scripts/musl.sh
+++ b/src/ci/docker/scripts/musl.sh
@@ -22,7 +22,7 @@ shift
 
 export CFLAGS="-fPIC $CFLAGS"
 
-MUSL=musl-1.1.20
+MUSL=musl-1.1.22
 
 # may have been downloaded in a previous run
 if [ ! -d $MUSL ]; then


### PR DESCRIPTION
This is the latest available version. I noticed Rust wasn't using the
latest version when I attempted to have Cargo link object files produced
outside of Cargo / Rust's toolchain and was getting missing symbol
errors. Those missing symbols were added in 1.1.21 and 1.1.22.

I'm not fully sure of the implications of this change or how
comprehensive the test coverage is. Upstream changes in 1.1.21 and
1.1.22 can be found at
https://git.musl-libc.org/cgit/musl/tree/WHATSNEW?h=v1.1.22&id=e97681d6f2c44bf5fa9ecdd30607cb63c780062e#n1989.