### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -395,6 +395,7 @@ impl<T: Clone> Clone for Box<T> {
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
 impl Clone for Box<str> {
     fn clone(&self) -> Self {
+        // this makes a copy of the data
         let buf: Box<[u8]> = self.as_bytes().into();
         unsafe {
             from_boxed_utf8_unchecked(buf)

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -395,11 +395,9 @@ impl<T: Clone> Clone for Box<T> {
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
 impl Clone for Box<str> {
     fn clone(&self) -> Self {
-        let len = self.len();
-        let buf = RawVec::with_capacity(len);
+        let buf: Box<[u8]> = self.as_bytes().into();
         unsafe {
-            ptr::copy_nonoverlapping(self.as_ptr(), buf.ptr(), len);
-            from_boxed_utf8_unchecked(buf.into_box())
+            from_boxed_utf8_unchecked(buf)
         }
     }
 }

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -546,9 +546,12 @@ impl<T: Copy> From<&[T]> for Box<[T]> {
     /// println!("{:?}", boxed_slice);
     /// ```
     fn from(slice: &[T]) -> Box<[T]> {
-        let mut boxed = unsafe { RawVec::with_capacity(slice.len()).into_box() };
-        boxed.copy_from_slice(slice);
-        boxed
+        let len = slice.len();
+        let buf = RawVec::with_capacity(len);
+        unsafe {
+            ptr::copy_nonoverlapping(slice.as_ptr(), buf.ptr(), len);
+            buf.into_box()
+        }
     }
 }
 

--- a/src/liballoc/raw_vec.rs
+++ b/src/liballoc/raw_vec.rs
@@ -685,12 +685,14 @@ impl<T, A: Alloc> RawVec<T, A> {
 impl<T> RawVec<T, Global> {
     /// Converts the entire buffer into `Box<[T]>`.
     ///
-    /// While it is not *strictly* Undefined Behavior to call
-    /// this procedure while some of the RawVec is uninitialized,
-    /// it certainly makes it trivial to trigger it.
-    ///
     /// Note that this will correctly reconstitute any `cap` changes
     /// that may have been performed. (see description of type for details)
+    ///
+    /// # Undefined Behavior
+    ///
+    /// All elements of `RawVec<T, Global>` must be initialized. Notice that
+    /// the rules around uninitialized boxed values are not finalized yet,
+    /// but until they are, it is advisable to avoid them.
     pub unsafe fn into_box(self) -> Box<[T]> {
         // NOTE: not calling `cap()` here, actually using the real `cap` field!
         let slice = slice::from_raw_parts_mut(self.ptr(), self.cap);

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -21,7 +21,7 @@ use crate::task::{Context, Poll};
 /// task.
 ///
 /// When using a future, you generally won't call `poll` directly, but instead
-/// `await!` the value.
+/// `.await` the value.
 #[doc(spotlight)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[stable(feature = "futures_api", since = "1.36.0")]

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -140,6 +140,11 @@
 //! call `next()` on your iterator, until it reaches `None`. Let's go over that
 //! next.
 //!
+//! Also note that `Iterator` provides a default implementation of methods such as `nth` and `fold`
+//! which call `next` internally. However, it is also possible to write a custom implementation of
+//! methods like `nth` and `fold` if an iterator can compute them more efficiently without calling
+//! `next`.
+//!
 //! # for Loops and IntoIterator
 //!
 //! Rust's `for` loop syntax is actually sugar for iterators. Here's a basic

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -964,6 +964,7 @@ pub trait Iterator {
     /// Creates an iterator that skips the first `n` elements.
     ///
     /// After they have been consumed, the rest of the elements are yielded.
+    /// Rather than overriding this method directly, instead override the `nth` method.
     ///
     /// # Examples
     ///

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -445,9 +445,10 @@ macro_rules! writeln {
 /// * Iterators that dynamically terminate.
 ///
 /// If the determination that the code is unreachable proves incorrect, the
-/// program immediately terminates with a [`panic!`]. The function [`unreachable_unchecked`],
-/// which belongs to the [`std::hint`] module, informs the compiler to
-/// optimize the code out of the release version entirely.
+/// program immediately terminates with a [`panic!`].
+///
+/// The unsafe counterpart of this macro is the [`unreachable_unchecked`] function, which
+/// instead of a [`panic!`] will cause undefined behavior if the code is reached.
 ///
 /// [`panic!`]:  ../std/macro.panic.html
 /// [`unreachable_unchecked`]: ../std/hint/fn.unreachable_unchecked.html

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -448,7 +448,7 @@ macro_rules! writeln {
 /// program immediately terminates with a [`panic!`].
 ///
 /// The unsafe counterpart of this macro is the [`unreachable_unchecked`] function, which
-/// instead of a [`panic!`] will cause undefined behavior if the code is reached.
+/// will cause undefined behavior if the code is reached.
 ///
 /// [`panic!`]:  ../std/macro.panic.html
 /// [`unreachable_unchecked`]: ../std/hint/fn.unreachable_unchecked.html

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1217,7 +1217,7 @@ For example:
 ```compile_fail,E0284
 fn foo() -> Result<bool, ()> {
     let results = [Ok(true), Ok(false), Err(())].iter().cloned();
-    let v : Vec<bool> = results.collect()?;
+    let v: Vec<bool> = results.collect()?;
     // Do things with v...
     Ok(true)
 }
@@ -1228,7 +1228,7 @@ Hence, `results.collect()` can return any type implementing
 `FromIterator<Result<bool, ()>>`. On the other hand, the
 `?` operator can accept any type implementing `Try`.
 
-The user of this code probably wants `collect()` to return a
+The author of this code probably wants `collect()` to return a
 `Result<Vec<bool>, ()>`, but the compiler can't be sure
 that there isn't another type `T` implementing both `Try` and
 `FromIterator<Result<bool, ()>>` in scope such that
@@ -1241,16 +1241,15 @@ To resolve this error, use a concrete type for the intermediate expression:
 fn foo() -> Result<bool, ()> {
     let results = [Ok(true), Ok(false), Err(())].iter().cloned();
     let v = {
-        let temp : Result<Vec<bool>, ()> = results.collect();
+        let temp: Result<Vec<bool>, ()> = results.collect();
         temp?
     };
     // Do things with v...
     Ok(true)
 }
 ```
-Note that the type of `v` can now be inferred from the type of `temp`
 
-
+Note that the type of `v` can now be inferred from the type of `temp`.
 "##,
 
 E0308: r##"

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1207,6 +1207,52 @@ fn main() {
 ```
 "##,
 
+E0284: r##"
+This error occurs when the compiler is unable to unambiguously infer the
+return type of a function or method which is generic on return type, such
+as the `collect` method for `Iterator`s.
+
+For example:
+
+```compile_fail,E0284
+fn foo() -> Result<bool, ()> {
+    let results = [Ok(true), Ok(false), Err(())].iter().cloned();
+    let v : Vec<bool> = results.collect()?;
+    // Do things with v...
+    Ok(true)
+}
+```
+
+Here we have an iterator `results` over `Result<bool, ()>`.
+Hence, `results.collect()` can return any type implementing
+`FromIterator<Result<bool, ()>>`. On the other hand, the
+`?` operator can accept any type implementing `Try`.
+
+The user of this code probably wants `collect()` to return a
+`Result<Vec<bool>, ()>`, but the compiler can't be sure
+that there isn't another type `T` implementing both `Try` and
+`FromIterator<Result<bool, ()>>` in scope such that
+`T::Ok == Vec<bool>`. Hence, this code is ambiguous and an error
+is returned.
+
+To resolve this error, use a concrete type for the intermediate expression:
+
+```
+fn foo() -> Result<bool, ()> {
+    let results = [Ok(true), Ok(false), Err(())].iter().cloned();
+    let v = {
+        let temp : Result<Vec<bool>, ()> = results.collect();
+        temp?
+    };
+    // Do things with v...
+    Ok(true)
+}
+```
+Note that the type of `v` can now be inferred from the type of `temp`
+
+
+"##,
+
 E0308: r##"
 This error occurs when the compiler was unable to infer the concrete type of a
 variable. It can occur for several cases, the most common of which is a
@@ -2158,7 +2204,6 @@ register_diagnostics! {
     E0278, // requirement is not satisfied
     E0279, // requirement is not satisfied
     E0280, // requirement is not satisfied
-    E0284, // cannot resolve type
 //  E0285, // overflow evaluation builtin bounds
 //  E0296, // replaced with a generic attribute input check
 //  E0300, // unexpanded macro

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -528,13 +528,9 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             }) => {
                 // Not projected from the implicit `self` in a closure.
                 debug_assert!(
-                    match *base {
-                        Place::Base(PlaceBase::Local(local)) => local == Local::new(1),
-                        Place::Projection(box Projection {
-                            ref base,
-                            elem: ProjectionElem::Deref,
-                        }) => *base == Place::Base(PlaceBase::Local(Local::new(1))),
-                        _ => false,
+                    match base.local() {
+                        Some(local) => local == Local::new(1),
+                        None => false,
                     },
                     "Unexpected capture place"
                 );

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -12,3 +12,4 @@ LL | trait Foo: Iterator<Item = i32> {}
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/associated-types/associated-types-unconstrained.stderr
+++ b/src/test/ui/associated-types/associated-types-unconstrained.stderr
@@ -6,3 +6,4 @@ LL |     let x: isize = Foo::bar();
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/issues/issue-12028.stderr
+++ b/src/test/ui/issues/issue-12028.stderr
@@ -6,3 +6,4 @@ LL |         self.input_stream(&mut stream);
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/question-mark-type-infer.stderr
+++ b/src/test/ui/question-mark-type-infer.stderr
@@ -6,3 +6,4 @@ LL |     l.iter().map(f).collect()?
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0284`.


### PR DESCRIPTION
Successful merges:

 - #61084 (Clarify docs for unreachable! macro)
 - #61220 (Added error message for E0284)
 - #61227 (Use .await syntax instead of await!)
 - #61230 (avoid creating Boxes of uninitalized values in RawVec)
 - #61237 (Updated the Iterator docs with information about overriding methods.)
 - #61241 (Check place iterative)
 - #61242 (Make dest_needs_borrow iterate instead of recurse)
 - #61247 (Make eval_place iterate instead of recurse)
 - #61248 (Use Place::local)

Failed merges:


r? @ghost