### PR TITLE
Mailmap fixes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,8 +5,8 @@
 # email addresses.
 #
 
-Aaron Todd <github@opprobrio.us>
 Aaron Power <theaaronepower@gmail.com> Erin Power <xampprocky@gmail.com>
+Aaron Todd <github@opprobrio.us>
 Abhishek Chanda <abhishek.becs@gmail.com> Abhishek Chanda <abhishek@cloudscaling.com>
 Adolfo Ochagavía <aochagavia92@gmail.com>
 Adrien Tétar <adri-from-59@hotmail.fr>
@@ -29,8 +29,8 @@ Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> Ariel Ben-Yehuda <ariel.byd@gmail.com>
 Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> arielb1 <arielb1@mail.tau.ac.il>
 Austin Seipp <mad.one@gmail.com> <as@hacks.yi.org>
 Aydin Kim <ladinjin@hanmail.net> aydin.kim <aydin.kim@samsung.com>
-Bastian Kauschke <bastian_kauschke@hotmail.de>
 Barosl Lee <vcs@barosl.com> Barosl LEE <github@barosl.com>
+Bastian Kauschke <bastian_kauschke@hotmail.de>
 Ben Alpert <ben@benalpert.com> <spicyjalapeno@gmail.com>
 Ben Sago <ogham@users.noreply.github.com> Ben S <ogham@bsago.me>
 Ben Sago <ogham@users.noreply.github.com> Ben S <ogham@users.noreply.github.com>
@@ -54,15 +54,15 @@ Chris C Cerami <chrisccerami@users.noreply.github.com> Chris C Cerami <chrisccer
 Chris Pressey <cpressey@gmail.com>
 Chris Thorn <chris@thorn.co> Chris Thorn <thorn@thoughtbot.com>
 Chris Vittal <christopher.vittal@gmail.com> Christopher Vittal <christopher.vittal@gmail.com>
-Christian Poveda <christianpoveda@protonmail.com> <z1mvader@protonmail.com>
 Christian Poveda <christianpoveda@protonmail.com> <cn.poveda.ruiz@gmail.com>
+Christian Poveda <christianpoveda@protonmail.com> <z1mvader@protonmail.com>
 Clark Gaebel <cg.wowus.cg@gmail.com> <cgaebel@mozilla.com>
 Clinton Ryan <clint.ryan3@gmail.com>
 Corey Richardson <corey@octayn.net> Elaine "See More" Nemo <corey@octayn.net>
 Cyryl Płotnicki <cyplo@cyplo.net>
 Damien Schoof <damien.schoof@gmail.com>
-Daniel Ramos <dan@daramos.com>
 Daniel J Rollins <drollins@financialforce.com>
+Daniel Ramos <dan@daramos.com>
 David Klein <david.klein@baesystemsdetica.com>
 David Manescu <david.manescu@gmail.com> <dman2626@uni.sydney.edu.au>
 David Ross <daboross@daboross.net>
@@ -71,9 +71,9 @@ Diggory Hardy <diggory.hardy@gmail.com> Diggory Hardy <github@dhardy.name>
 Dylan Braithwaite <dylanbraithwaite1@gmail.com> <mail@dylanb.me>
 Dzmitry Malyshau <kvarkus@gmail.com>
 E. Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>
+Eduard-Mihai Burtescu <edy.burt@gmail.com>
 Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
-Eduard-Mihai Burtescu <edy.burt@gmail.com>
 Elliott Slaughter <elliottslaughter@gmail.com> <eslaughter@mozilla.com>
 Elly Fong-Jones <elly@leptoquark.net>
 Eric Holk <eric.holk@gmail.com> <eholk@cs.indiana.edu>
@@ -81,8 +81,8 @@ Eric Holk <eric.holk@gmail.com> <eholk@mozilla.com>
 Eric Holmes <eric@ejholmes.net>
 Eric Reed <ecreed@cs.washington.edu> <ereed@mozilla.com>
 Erick Tryzelaar <erick.tryzelaar@gmail.com> <etryzelaar@iqt.org>
-Esteban Küber <esteban@kuber.com.ar> <estebank@users.noreply.github.com>
 Esteban Küber <esteban@kuber.com.ar> <esteban@commure.com>
+Esteban Küber <esteban@kuber.com.ar> <estebank@users.noreply.github.com>
 Esteban Küber <esteban@kuber.com.ar> <github@kuber.com.ar>
 Evgeny Sologubov
 Falco Hirschenberger <falco.hirschenberger@gmail.com> <hirschen@itwm.fhg.de>
@@ -103,9 +103,9 @@ Herman J. Radtke III <herman@hermanradtke.com> Herman J. Radtke III <hermanradtk
 Ilyong Cho <ilyoan@gmail.com>
 Ivan Ivaschenko <defuz.net@gmail.com>
 J. J. Weber <jjweber@gmail.com>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub@jakub.cc>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakubw@jakubw.net>
-Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 James Deng <cnjamesdeng@gmail.com> <cnJamesDeng@gmail.com>
 James Miller <bladeon@gmail.com> <james@aatch.net>
 James Perry <james.austin.perry@gmail.com>
@@ -120,6 +120,7 @@ Jethro Beekman <github@jbeekman.nl>
 Jihyun Yu <j.yu@navercorp.com> <yjh0502@gmail.com>
 Jihyun Yu <j.yu@navercorp.com> jihyun <jihyun@nablecomm.com>
 Jihyun Yu <j.yu@navercorp.com> Jihyun Yu <jihyun@nclab.kaist.ac.kr>
+João Oliveira <hello@jxs.pt> joaoxsouls <joaoxsouls@gmail.com>
 Johann Hofmann <git@johann-hofmann.com> Johann <git@johann-hofmann.com>
 John Clements <clements@racket-lang.org> <clements@brinckerhoff.org>
 John Hodge <acessdev@gmail.com> John Hodge <tpg@mutabah.net>
@@ -130,7 +131,6 @@ Jonathan S <gereeter@gmail.com> Jonathan S <gereeter+code@gmail.com>
 Jonathan Turner <probata@hotmail.com>
 Jorge Aparicio <japaric@linux.com> <japaricious@gmail.com>
 Joseph Martin <pythoner6@gmail.com>
-João Oliveira <hello@jxs.pt> joaoxsouls <joaoxsouls@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com> <josephtlyons@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
@@ -148,8 +148,6 @@ Lindsey Kuper <lindsey@composition.al> <lkuper@mozilla.com>
 Luke Metz <luke.metz@students.olin.edu>
 Luqman Aden <me@luqman.ca> <laden@csclub.uwaterloo.ca>
 Luqman Aden <me@luqman.ca> <laden@mozilla.com>
-NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
-NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
 Marcell Pardavi <marcell.pardavi@gmail.com>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Mark Rousskov <mark.simulacrum@gmail.com>
@@ -170,12 +168,14 @@ Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
 Mickaël Raybaud-Roig <raybaudroigm@gmail.com> m-r-r <raybaudroigm@gmail.com>
 Ms2ger <ms2ger@gmail.com> <Ms2ger@gmail.com>
 Mukilan Thiagarajan <mukilanthiagarajan@gmail.com>
+NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
+NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
 Nathan West <Lucretiel@gmail.com> <lucretiel@gmail.com>
 Nathan Wilson <wilnathan@gmail.com>
 Nathaniel Herman <nherman@post.harvard.edu> Nathaniel Herman <nherman@college.harvard.edu>
 Neil Pankey <npankey@gmail.com> <neil@wire.im>
-Nicole Mazzuca <npmazzuca@gmail.com>
 Nick Platt <platt.nicholas@gmail.com>
+Nicole Mazzuca <npmazzuca@gmail.com>
 Nif Ward <nif.ward@gmail.com>
 Oliver Schneider <oliver.schneider@kit.edu> oli-obk <github6541940@oli-obk.de>
 Oliver Schneider <oliver.schneider@kit.edu> Oliver 'ker' Schneider <rust19446194516@oli-obk.de>
@@ -233,8 +233,8 @@ Tim JIANG <p90eri@gmail.com>
 Tim Joseph Dumol <tim@timdumol.com>
 Torsten Weber <TorstenWeber12@gmail.com> <torstenweber12@gmail.com>
 Ty Overby <ty@pre-alpha.com>
-Ulrik Sverdrup <bluss@users.noreply.github.com> bluss <bluss>
 Ulrik Sverdrup <bluss@users.noreply.github.com> bluss <bluss@users.noreply.github.com>
+Ulrik Sverdrup <bluss@users.noreply.github.com> bluss <bluss>
 Ulrik Sverdrup <bluss@users.noreply.github.com> Ulrik Sverdrup <root@localhost>
 Vadim Petrochenkov <vadim.petrochenkov@gmail.com>
 Vadim Petrochenkov <vadim.petrochenkov@gmail.com> petrochenkov <vadim.petrochenkov@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -131,6 +131,8 @@ Jonathan Turner <probata@hotmail.com>
 Jorge Aparicio <japaric@linux.com> <japaricious@gmail.com>
 Joseph Martin <pythoner6@gmail.com>
 João Oliveira <hello@jxs.pt> joaoxsouls <joaoxsouls@gmail.com>
+Joseph T. Lyons <JosephTLyons@gmail.com> <josephtlyons@gmail.com>
+Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
 Jyun-Yan You <jyyou.tw@gmail.com> <jyyou@cs.nctu.edu.tw>
 Kang Seonghoon <kang.seonghoon@mearie.org> <public+git@mearie.org>

--- a/.mailmap
+++ b/.mailmap
@@ -46,8 +46,9 @@ Brian Anderson <banderson@mozilla.com> <banderson@mozilla.org>
 Brian Dawn <brian.t.dawn@gmail.com>
 Brian Leibig <brian@brianleibig.com> Brian Leibig <brian.leibig@gmail.com>
 Carl-Anton Ingmarsson <mail@carlanton.se> <ca.ingmarsson@gmail.com>
+Carol (Nichols || Goulding) <carol.nichols@gmail.com> <193874+carols10cents@users.noreply.github.com>
+Carol (Nichols || Goulding) <carol.nichols@gmail.com> <carol.nichols@gmail.com>
 Carol (Nichols || Goulding) <carol.nichols@gmail.com> <cnichols@thinkthroughmath.com>
-Carol (Nichols || Goulding) <carol.nichols@gmail.com> Carol Nichols <carol.nichols@gmail.com>
 Carol Willing <carolcode@willingconsulting.com>
 Chris C Cerami <chrisccerami@users.noreply.github.com> Chris C Cerami <chrisccerami@gmail.com>
 Chris Pressey <cpressey@gmail.com>


### PR DESCRIPTION
I've made a few fixes and additions to the .mailmap file.

- I've added my information to it, as I noticed it was popping up twice at the [Thanks](https://thanks.rust-lang.org/rust/all-time/) website (I've made contributions to the Rust Book).
- I noticed that @carols10cents‘ information was popping up in multiple places at the [Thanks](https://thanks.rust-lang.org/rust/all-time/) website and when running `git shortlog -s -e > out.txt`, and fixed her information
- I alphabetized the list using Atom's [Sort Lines package](https://github.com/atom/sort-lines)

The output from before and after running `git shortlog -s -e > out.txt` for Carol:
<img width="708" alt="Carol Before" src="https://user-images.githubusercontent.com/19867440/58472843-2d8ca880-8115-11e9-9624-d31ed23ae9b5.png">
<img width="523" alt="Carol After" src="https://user-images.githubusercontent.com/19867440/58472844-2d8ca880-8115-11e9-95c6-80b17cc04790.png">

The output from before and after running `git shortlog -s -e > out.txt` for myself:

<img width="489" alt="Joseph After" src="https://user-images.githubusercontent.com/19867440/58472941-6e84bd00-8115-11e9-8266-1d7fcd53d0bc.png">
<img width="421" alt="Joseph Before" src="https://user-images.githubusercontent.com/19867440/58472943-6e84bd00-8115-11e9-9fd2-d7ace7e3d636.png">

