### PR TITLE
Don't generate div inside header (h4/h3/h...) elements

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3804,7 +3804,7 @@ fn render_attributes(w: &mut dyn fmt::Write, it: &clean::Item, top: bool) -> fmt
         }
     }
     if attrs.len() > 0 {
-        write!(w, "<div class=\"docblock attributes{}\">{}</div>",
+        write!(w, "<span class=\"docblock attributes{}\">{}</span>",
                if top { " top-attr" } else { "" }, &attrs)?;
     }
     Ok(())

--- a/src/test/rustdoc/trait-attributes.rs
+++ b/src/test/rustdoc/trait-attributes.rs
@@ -3,7 +3,7 @@
 // ignore-tidy-linelength
 
 pub trait Foo {
-    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     fn foo();
 }
@@ -12,11 +12,11 @@ pub trait Foo {
 pub struct Bar;
 
 impl Bar {
-    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     pub fn bar() {}
 
-    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     pub fn bar2() {}
 }


### PR DESCRIPTION
Fixes #60865.

According to the HTML spec, we're not supposed to put `div` elements inside heading elements (h4/h3/h...). It doesn't change the display as far as I could tell.

r? @QuietMisdreavus 