### PR TITLE
[beta] Rollup backports

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1035,11 +1035,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a T> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1095,11 +1090,6 @@ impl<T> Iterator for IntoIter<T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<T> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1145,11 +1135,6 @@ impl<T> Iterator for Drain<'_, T> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<T> {
-        self.next_back()
     }
 }
 

--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -1193,11 +1193,6 @@ impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
     }
-
-    #[inline]
-    fn last(mut self) -> Option<(&'a K, &'a V)> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
@@ -1257,11 +1252,6 @@ impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<(&'a K, &'a mut V)> {
-        self.next_back()
     }
 }
 
@@ -1369,11 +1359,6 @@ impl<K, V> Iterator for IntoIter<K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.length, Some(self.length))
     }
-
-    #[inline]
-    fn last(mut self) -> Option<(K, V)> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1436,11 +1421,6 @@ impl<'a, K, V> Iterator for Keys<'a, K, V> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a K> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1477,11 +1457,6 @@ impl<'a, K, V> Iterator for Values<'a, K, V> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a V> {
-        self.next_back()
     }
 }
 
@@ -1520,11 +1495,6 @@ impl<'a, K, V> Iterator for Range<'a, K, V> {
             unsafe { Some(self.next_unchecked()) }
         }
     }
-
-    #[inline]
-    fn last(mut self) -> Option<(&'a K, &'a V)> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "map_values_mut", since = "1.10.0")]
@@ -1537,11 +1507,6 @@ impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a mut V> {
-        self.next_back()
     }
 }
 
@@ -1660,11 +1625,6 @@ impl<'a, K, V> Iterator for RangeMut<'a, K, V> {
         } else {
             unsafe { Some(self.next_unchecked()) }
         }
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<(&'a K, &'a mut V)> {
-        self.next_back()
     }
 }
 

--- a/src/liballoc/collections/btree/set.rs
+++ b/src/liballoc/collections/btree/set.rs
@@ -1019,11 +1019,6 @@ impl<'a, T> Iterator for Iter<'a, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a T> {
-        self.next_back()
-    }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
@@ -1048,11 +1043,6 @@ impl<T> Iterator for IntoIter<T> {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<T> {
-        self.next_back()
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1082,11 +1072,6 @@ impl<'a, T> Iterator for Range<'a, T> {
 
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next().map(|(k, _)| k)
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a T> {
-        self.next_back()
     }
 }
 

--- a/src/liballoc/string.rs
+++ b/src/liballoc/string.rs
@@ -2385,10 +2385,6 @@ impl Iterator for Drain<'_> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-    #[inline]
-    fn last(mut self) -> Option<char> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "drain", since = "1.6.0")]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -2395,11 +2395,6 @@ impl<T> Iterator for IntoIter<T> {
     fn count(self) -> usize {
         self.len()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<T> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -2519,11 +2514,6 @@ impl<T> Iterator for Drain<'_, T> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<T> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "drain", since = "1.6.0")]
@@ -2592,10 +2582,6 @@ impl<I: Iterator> Iterator for Splice<'_, I> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.drain.size_hint()
-    }
-
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
     }
 }
 

--- a/src/libcore/ascii.rs
+++ b/src/libcore/ascii.rs
@@ -117,8 +117,6 @@ impl Iterator for EscapeDefault {
     type Item = u8;
     fn next(&mut self) -> Option<u8> { self.range.next().map(|i| self.data[i]) }
     fn size_hint(&self) -> (usize, Option<usize>) { self.range.size_hint() }
-    #[inline]
-    fn last(mut self) -> Option<u8> { self.next_back() }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl DoubleEndedIterator for EscapeDefault {

--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -73,11 +73,6 @@ impl<I> Iterator for Rev<I> where I: DoubleEndedIterator {
     {
         self.iter.position(predicate)
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/mem.rs
+++ b/src/libcore/mem.rs
@@ -466,7 +466,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// [`MaybeUninit<T>`]: union.MaybeUninit.html
 /// [inv]: union.MaybeUninit.html#initialization-invariant
 #[inline]
-#[rustc_deprecated(since = "1.40.0", reason = "use `mem::MaybeUninit` instead")]
+#[rustc_deprecated(since = "1.38.0", reason = "use `mem::MaybeUninit` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn uninitialized<T>() -> T {
     intrinsics::panic_if_uninhabited::<T>();

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3547,11 +3547,6 @@ impl<'a, T, P> Iterator for Split<'a, T, P> where P: FnMut(&T) -> bool {
             (1, Some(self.v.len() + 1))
         }
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -3650,11 +3645,6 @@ impl<'a, T, P> Iterator for SplitMut<'a, T, P> where P: FnMut(&T) -> bool {
             (1, Some(self.v.len() + 1))
         }
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -3720,11 +3710,6 @@ impl<'a, T, P> Iterator for RSplit<'a, T, P> where P: FnMut(&T) -> bool {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
@@ -3788,11 +3773,6 @@ impl<'a, T, P> Iterator for RSplitMut<'a, T, P> where P: FnMut(&T) -> bool {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
     }
 }
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -1333,11 +1333,6 @@ impl<'a> Iterator for Lines<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1383,11 +1378,6 @@ impl<'a> Iterator for LinesAny<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
     }
 }
 
@@ -4231,11 +4221,6 @@ impl<'a> Iterator for SplitWhitespace<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "split_whitespace", since = "1.1.0")]
@@ -4261,11 +4246,6 @@ impl<'a> Iterator for SplitAsciiWhitespace<'a> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
     }
 }
 

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -746,10 +746,6 @@ impl Iterator for Args {
         self.inner.next().map(|s| s.into_string().unwrap())
     }
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
-    #[inline]
-    fn last(mut self) -> Option<String> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "env", since = "1.0.0")]
@@ -785,8 +781,6 @@ impl Iterator for ArgsOs {
     type Item = OsString;
     fn next(&mut self) -> Option<OsString> { self.inner.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.inner.size_hint() }
-    #[inline]
-    fn last(mut self) -> Option<OsString> { self.next_back() }
 }
 
 #[stable(feature = "env", since = "1.0.0")]

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -888,11 +888,6 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<&'a OsStr> {
         self.inner.next().map(Component::as_os_str)
     }
-
-    #[inline]
-    fn last(mut self) -> Option<&'a OsStr> {
-        self.next_back()
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -955,11 +950,6 @@ impl<'a> Iterator for Components<'a> {
             }
         }
         None
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item> {
-        self.next_back()
     }
 }
 

--- a/src/libstd/sys/unix/args.rs
+++ b/src/libstd/sys/unix/args.rs
@@ -35,8 +35,6 @@ impl Iterator for Args {
     type Item = OsString;
     fn next(&mut self) -> Option<OsString> { self.iter.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.iter.size_hint() }
-    #[inline]
-    fn last(mut self) -> Option<OsString> { self.next_back() }
 }
 
 impl ExactSizeIterator for Args {

--- a/src/libstd/sys/wasm/args.rs
+++ b/src/libstd/sys/wasm/args.rs
@@ -37,10 +37,6 @@ impl Iterator for Args {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
-    #[inline]
-    fn last(mut self) -> Option<OsString> {
-        self.next_back()
-    }
 }
 
 impl ExactSizeIterator for Args {

--- a/src/libstd/sys/windows/args.rs
+++ b/src/libstd/sys/windows/args.rs
@@ -181,8 +181,6 @@ impl Iterator for Args {
     type Item = OsString;
     fn next(&mut self) -> Option<OsString> { self.parsed_args_list.next() }
     fn size_hint(&self) -> (usize, Option<usize>) { self.parsed_args_list.size_hint() }
-    #[inline]
-    fn last(mut self) -> Option<OsString> { self.next_back() }
 }
 
 impl DoubleEndedIterator for Args {

--- a/src/test/ui/macros/issue-61033-1.rs
+++ b/src/test/ui/macros/issue-61033-1.rs
@@ -1,0 +1,9 @@
+// Regression test for issue #61033.
+
+macro_rules! test1 {
+    ($x:ident, $($tt:tt)*) => { $($tt)+ } //~ERROR this must repeat at least once
+}
+
+fn main() {
+    test1!(x,);
+}

--- a/src/test/ui/macros/issue-61033-1.stderr
+++ b/src/test/ui/macros/issue-61033-1.stderr
@@ -1,0 +1,8 @@
+error: this must repeat at least once
+  --> $DIR/issue-61033-1.rs:4:34
+   |
+LL |     ($x:ident, $($tt:tt)*) => { $($tt)+ }
+   |                                  ^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/macros/issue-61033-2.rs
+++ b/src/test/ui/macros/issue-61033-2.rs
@@ -1,0 +1,19 @@
+// Regression test for issue #61033.
+
+macro_rules! test2 {
+    (
+        $(* $id1:ident)*
+        $(+ $id2:ident)*
+    ) => {
+        $( //~ERROR meta-variable `id1` repeats 2 times
+            $id1 + $id2 // $id1 and $id2 may repeat different numbers of times
+        )*
+    }
+}
+
+fn main() {
+    test2! {
+        * a * b
+        + a + b + c
+    }
+}

--- a/src/test/ui/macros/issue-61033-2.stderr
+++ b/src/test/ui/macros/issue-61033-2.stderr
@@ -1,0 +1,11 @@
+error: meta-variable `id1` repeats 2 times, but `id2` repeats 3 times
+  --> $DIR/issue-61033-2.rs:8:10
+   |
+LL |           $(
+   |  __________^
+LL | |             $id1 + $id2 // $id1 and $id2 may repeat different numbers of times
+LL | |         )*
+   | |_________^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Rolled up:

* [beta] adjust deprecation date of mem::uninitialized #61160 

Cherry-picked:

* Fix ICE with inconsistent macro matchers #61046 
* Revert "Add implementations of last in terms of next_back on a bunch of DoubleEndedIterators." #61057 
* debuginfo: Revert to old/more verbose behavior for -Cdebuginfo=1 #61007 

r? @ghost