### PR TITLE
Print const generics properly in rustdoc

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3145,10 +3145,7 @@ impl<'tcx> Clean<Constant> for ty::Const<'tcx> {
     fn clean(&self, cx: &DocContext<'_>) -> Constant {
         Constant {
             type_: self.ty.clean(cx),
-            expr: match self.val {
-                ConstValue::Param(ty::ParamConst { name, .. }) => format!("{}", name),
-                e => format!("{:?}", e), // FIXME generic consts with expressions
-            },
+            expr: format!("{}", self),
         }
     }
 }

--- a/src/test/rustdoc/const-generics/add-impl.rs
+++ b/src/test/rustdoc/const-generics/add-impl.rs
@@ -1,0 +1,21 @@
+// ignore-tidy-linelength
+
+#![feature(const_generics)]
+
+#![crate_name = "foo"]
+
+use std::ops::Add;
+
+// @has foo/struct.Simd.html '//pre[@class="rust struct"]' 'pub struct Simd<T, const WIDTH: usize>'
+pub struct Simd<T, const WIDTH: usize> {
+    inner: T,
+}
+
+// @has foo/struct.Simd.html '//div[@id="implementations-list"]/h3/code' 'impl Add<Simd<u8, 16>> for Simd<u8, 16>'
+impl Add for Simd<u8, 16> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self { inner: 0 }
+    }
+}

--- a/src/test/rustdoc/const-generics/const-impl.rs
+++ b/src/test/rustdoc/const-generics/const-impl.rs
@@ -1,7 +1,8 @@
-#![feature(const_generics)]
-#![crate_name = "foo"]
-
 // ignore-tidy-linelength
+
+#![feature(const_generics)]
+
+#![crate_name = "foo"]
 
 pub enum Order {
     Sorted,


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/59276 is merged, we can print consts properly in rustdoc.

Fixes https://github.com/rust-lang/rust/issues/60737.
Fixes https://github.com/rust-lang/rust/issues/61257.

r? @GuillaumeGomez 	