### PR TITLE
Update musl-cross-make to 0.9.8

### DIFF
--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -3,7 +3,7 @@
 #
 # Versions of the toolchain components are configurable in `musl-cross-make/Makefile` and
 # musl unlike GLIBC is forward compatible so upgrading it shouldn't break old distributions.
-# Right now we have: Binutils 2.27, GCC 6.3.0, musl 1.1.18
+# Right now we have: Binutils 2.27, GCC 6.4.0, musl 1.1.22.
 set -ex
 
 hide_output() {
@@ -33,7 +33,7 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
-git clone https://github.com/richfelker/musl-cross-make -b v0.9.7
+git clone https://github.com/richfelker/musl-cross-make -b v0.9.8
 cd musl-cross-make
 
 hide_output make -j$(nproc) TARGET=$TARGET


### PR DESCRIPTION
This version uses musl 1.1.22 and GCC 6.4.0 by default. It also
contains support for newer binutils and GCC versions, should we
want to bump those as well. But I'm purposefully limiting this
patch in order to reduce the surface area for controversy.