### PR TITLE
Add env! instead of env::var and remove unwrap()

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -12,16 +12,13 @@ fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
     let rustdoc = env::var_os("RUSTDOC_REAL").expect("RUSTDOC_REAL was not set");
     let libdir = env::var_os("RUSTDOC_LIBDIR").expect("RUSTDOC_LIBDIR was not set");
-    let stage = env::var("RUSTC_STAGE").expect("RUSTC_STAGE was not set");
+    let stage = env!("RUSTC_STAGE","RUSTC_STAGE was not set");
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
     let mut has_unstable = false;
 
     use std::str::FromStr;
 
-    let verbose = match env::var("RUSTC_VERBOSE") {
-        Ok(s) => usize::from_str(&s).expect("RUSTC_VERBOSE should be an integer"),
-        Err(_) => 0,
-    };
+    let verbose = env!("RUSTC_VERBOSE","RUSTC_VERBOSE should be an integer");
 
     let mut dylib_path = bootstrap::util::dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -12,7 +12,7 @@ fn main() {
     let args = env::args_os().skip(1).collect::<Vec<_>>();
     let rustdoc = env::var_os("RUSTDOC_REAL").expect("RUSTDOC_REAL was not set");
     let libdir = env::var_os("RUSTDOC_LIBDIR").expect("RUSTDOC_LIBDIR was not set");
-    let stage = env!("RUSTC_STAGE","RUSTC_STAGE was not set");
+    let stage = env!("RUSTC_STAGE","RUSTC_STAGE was not set").to_String();
     let sysroot = env::var_os("RUSTC_SYSROOT").expect("RUSTC_SYSROOT was not set");
     let mut has_unstable = false;
 

--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -17,8 +17,11 @@ fn main() {
     let mut has_unstable = false;
 
     use std::str::FromStr;
-
-    let verbose = env!("RUSTC_VERBOSE","RUSTC_VERBOSE should be an integer");
+    
+    let verbose = match env::var("RUSTC_VERBOSE") {
+        Ok(s) => usize::from_str(&s).expect("RUSTC_VERBOSE should be an integer"),
+        Err(_) => 0,
+    };
 
     let mut dylib_path = bootstrap::util::dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -172,7 +172,8 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
         }
 
         if infcx.tcx.sess.opts.debugging_opts.polonius {
-            let algorithm = env!("POLONIUS_ALGORITHM","Hybrid");
+            let algorithm = env::var("POLONIUS_ALGORITHM")
+                .unwrap_or_else(|_| String::from("Hybrid"));
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
             debug!("compute_regions: using polonius algorithm {:?}", algorithm);
             Some(Rc::new(Output::compute(

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -172,8 +172,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'gcx, 'tcx>(
         }
 
         if infcx.tcx.sess.opts.debugging_opts.polonius {
-            let algorithm = env::var("POLONIUS_ALGORITHM")
-                .unwrap_or_else(|_| String::from("Hybrid"));
+            let algorithm = env!("POLONIUS_ALGORITHM","Hybrid");
             let algorithm = Algorithm::from_str(&algorithm).unwrap();
             debug!("compute_regions: using polonius algorithm {:?}", algorithm);
             Some(Rc::new(Output::compute(

--- a/src/libstd/build.rs
+++ b/src/libstd/build.rs
@@ -1,9 +1,7 @@
 #![deny(warnings)]
 
-use std::env;
-
 fn main() {
-    let target = env::var("TARGET").expect("TARGET was not set");
+    let target = env!("TARGET","TARGET was not set");
     if target.contains("linux") {
         if target.contains("android") {
             println!("cargo:rustc-link-lib=dl");

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let target = env!("TARGET","TARGET was not set");
+    let target = env!("TARGET","TARGET was not set").to_String();
 
     if cfg!(feature = "llvm-libunwind") &&
         (target.contains("linux") ||
@@ -51,8 +51,8 @@ mod llvm_libunwind {
 
     /// Compile the libunwind C/C++ source code.
     pub fn compile() {
-        let target_env = env!("CARGO_CFG_TARGET_ENV","CARGO_CFG_TARGET_ENV not found");
-        let target_vendor = env!("CARGO_CFG_TARGET_VENDOR","CARGO_CFG_TARGET_VENDOR not found");
+        let target_env = env!("CARGO_CFG_TARGET_ENV","CARGO_CFG_TARGET_ENV not found").to_String();
+        let target_vendor = env!("CARGO_CFG_TARGET_VENDOR","CARGO_CFG_TARGET_VENDOR not found").to_String();
         let cfg = &mut cc::Build::new();
 
         cfg.cpp(true);

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let target = env::var("TARGET").expect("TARGET was not set");
+    let target = env!("TARGET","TARGET was not set");
 
     if cfg!(feature = "llvm-libunwind") &&
         (target.contains("linux") ||
@@ -51,8 +51,8 @@ mod llvm_libunwind {
 
     /// Compile the libunwind C/C++ source code.
     pub fn compile() {
-        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
-        let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
+        let target_env = env!("CARGO_CFG_TARGET_ENV","CARGO_CFG_TARGET_ENV not found");
+        let target_vendor = env!("CARGO_CFG_TARGET_VENDOR","CARGO_CFG_TARGET_VENDOR not found");
         let cfg = &mut cc::Build::new();
 
         cfg.cpp(true);

--- a/src/test/run-pass/command-exec.rs
+++ b/src/test/run-pass/command-exec.rs
@@ -41,7 +41,7 @@ fn main() {
             "exec-test5" => {
                 env::set_var("VARIABLE", "ABC");
                 Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
-                assert_eq!(env::var("VARIABLE").unwrap(), "ABC");
+                assert_eq!(env!("VARIABLE","VARIABLE not found"), "ABC");
                 println!("passed");
             }
 

--- a/src/test/run-pass/command-pre-exec.rs
+++ b/src/test/run-pass/command-pre-exec.rs
@@ -17,7 +17,7 @@ fn main() {
     if let Some(arg) = env::args().nth(1) {
         match &arg[..] {
             "test1" => println!("hello2"),
-            "test2" => assert_eq!(env::var("FOO").unwrap(), "BAR"),
+            "test2" => assert_eq!(env!("FOO","FOO not found"), "BAR"),
             "test3" => assert_eq!(env::current_dir().unwrap().to_str().unwrap(), "/"),
             "empty" => {}
             _ => panic!("unknown argument: {}", arg),

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -230,7 +230,7 @@ fn render_error_page<T: Formatter>(err_map: &ErrorMetadataMap, output_path: &Pat
 }
 
 fn main_with_result(format: OutputFormat, dst: &Path) -> Result<(), Box<dyn Error>> {
-    let build_arch = env!("CFG_BUILD","CFG BUILD not found");
+    let build_arch = env!("CFG_BUILD","CFG BUILD not found").to_String();
     let metadata_dir = get_metadata_dir(&build_arch);
     let err_map = load_all_errors(&metadata_dir)?;
     match format {

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -230,7 +230,7 @@ fn render_error_page<T: Formatter>(err_map: &ErrorMetadataMap, output_path: &Pat
 }
 
 fn main_with_result(format: OutputFormat, dst: &Path) -> Result<(), Box<dyn Error>> {
-    let build_arch = env::var("CFG_BUILD")?;
+    let build_arch = env!("CFG_BUILD","CFG BUILD not found");
     let metadata_dir = get_metadata_dir(&build_arch);
     let err_map = load_all_errors(&metadata_dir)?;
     match format {


### PR DESCRIPTION
When we use env:: var, the code panics when the environment variables are not available.
But since we have env! macro, it helps us to give an error message instead of panicking the code.
Thanks