### PR TITLE
Swap order of `unsafe async fn` to `async unsafe fn`

### DIFF
--- a/src/test/ui/async-await/async-await.rs
+++ b/src/test/ui/async-await/async-await.rs
@@ -122,7 +122,7 @@ fn async_fn_with_internal_borrow(y: u8) -> impl Future<Output = u8> {
     }
 }
 
-unsafe async fn unsafe_async_fn(x: u8) -> u8 {
+async unsafe fn unsafe_async_fn(x: u8) -> u8 {
     wake_and_yield_once().await;
     x
 }

--- a/src/test/ui/async-await/await-macro.rs
+++ b/src/test/ui/async-await/await-macro.rs
@@ -122,7 +122,7 @@ fn async_fn_with_internal_borrow(y: u8) -> impl Future<Output = u8> {
     }
 }
 
-unsafe async fn unsafe_async_fn(x: u8) -> u8 {
+async unsafe fn unsafe_async_fn(x: u8) -> u8 {
     await!(wake_and_yield_once());
     x
 }


### PR DESCRIPTION
Change the order of `unsafe async fn` to `async unsafe fn`.

I had intended to do this a while back but didn't get around to it...

This should be done because:
- It is the order used by `const unsafe fn` so therefore it is consistent.
- This keeps all the "effect/restriction" modifiers to the left of `unsafe` (which according to some is not an effect) instead of mixing them such that we are more forward compatible with some sort of effect system.

r? @cramertj 