### PR TITLE
ci: display more debug information in the init_repo script

### DIFF
--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# FIXME(61301): we need to debug spurious failures with this on Windows on
+# Azure, so let's print more information in the logs.
+set -x
+
 set -o errexit
 set -o pipefail
 set -o nounset


### PR DESCRIPTION
I'm *really* confused about the error message [while cloning submodules on Windows on Azure](https://dev.azure.com/rust-lang/e71b0ddf-dd27-435a-873c-e30f86eea377/_apis/build/builds/295/logs/506):

```
/usr/bin/tar: You must specify one of the '-Acdtrux', '--delete' or '--test-label' options
Try '/usr/bin/tar --help' or '/usr/bin/tar --usage' for more information.
```

It doesn't make sense for it to execute a command without any of those flags since they're clearly added:

https://github.com/rust-lang/rust/blob/81970852e172c04322cbf8ba23effabeb491c83c/src/ci/init_repo.sh#L45

So this adds `set -x` to the script to hopefully catch what command it's executing.

r? @alexcrichton 
cc https://github.com/rust-lang/rust/issues/61301