### PR TITLE
ci: Favor SCRIPT instead of RUST_CHECK_TARGET

### DIFF
--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -165,7 +165,7 @@ jobs:
       # Note that the compiler is compiled to target 10.8 here because the Xcode
       # version that we're using, 8.2, cannot compile LLVM for OSX 10.7.
       x86_64-apple:
-        RUST_CHECK_TARGET: check
+        SCRIPT: ./x.py test
         RUST_CONFIGURE_ARGS: --build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
         MACOSX_DEPLOYMENT_TARGET: 10.8
@@ -174,7 +174,7 @@ jobs:
         NO_DEBUG_ASSERTIONS: 1
 
       dist-x86_64-apple:
-        RUST_CHECK_TARGET: dist
+        SCRIPT: ./x.py dist
         RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
         DEPLOY: 1
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
@@ -184,7 +184,7 @@ jobs:
         DIST_REQUIRE_ALL_TOOLS: 1
 
       dist-x86_64-apple-alt:
-        RUST_CHECK_TARGET: dist
+        SCRIPT: ./x.py dist
         RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
         DEPLOY_ALT: 1
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
@@ -193,7 +193,7 @@ jobs:
         NO_DEBUG_ASSERTIONS: 1
 
       i686-apple:
-        RUST_CHECK_TARGET: check
+        SCRIPT: ./x.py test
         RUST_CONFIGURE_ARGS: --build=i686-apple-darwin --set rust.jemalloc
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
         MACOSX_DEPLOYMENT_TARGET: 10.8
@@ -202,7 +202,7 @@ jobs:
         NO_DEBUG_ASSERTIONS: 1
 
       dist-i686-apple:
-        RUST_CHECK_TARGET: dist
+        SCRIPT: ./x.py dist
         RUST_CONFIGURE_ARGS: --build=i686-apple-darwin --enable-full-tools --enable-profiler --enable-lldb --set rust.jemalloc
         DEPLOY: 1
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1

--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -33,7 +33,7 @@ steps:
     brew install xz
     brew install swig
   displayName: Install build dependencies (OSX)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['RUST_CHECK_TARGET'],'dist'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['SCRIPT'],'./x.py dist'))
 
 # Switch to XCode 9.3 on OSX since it seems to be the last version that supports
 # i686-apple-darwin. We'll eventually want to upgrade this and it will probably

--- a/.azure-pipelines/try.yml
+++ b/.azure-pipelines/try.yml
@@ -35,7 +35,7 @@ jobs:
   strategy:
     matrix:
       dist-x86_64-apple:
-        RUST_CHECK_TARGET: dist
+        SCRIPT: ./x.py dist
         RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
         DEPLOY: 1
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
@@ -45,7 +45,7 @@ jobs:
         DIST_REQUIRE_ALL_TOOLS: 1
 
       dist-x86_64-apple-alt:
-        RUST_CHECK_TARGET: dist
+        SCRIPT: ./x.py dist
         RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
         DEPLOY_ALT: 1
         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       if: branch = try OR branch = auto
 
     - env: >
-        RUST_CHECK_TARGET=dist
+        SCRIPT="./x.py dist"
         RUST_CONFIGURE_ARGS="--enable-extended --enable-profiler --enable-lldb --set rust.jemalloc"
         SRC=.
         DEPLOY_ALT=1
@@ -59,7 +59,7 @@ matrix:
     # Note that the compiler is compiled to target 10.8 here because the Xcode
     # version that we're using, 8.2, cannot compile LLVM for OSX 10.7.
     - env: >
-        RUST_CHECK_TARGET=check
+        SCRIPT="./x.py test"
         RUST_CONFIGURE_ARGS="--build=x86_64-apple-darwin --enable-sanitizers --enable-profiler --set rust.jemalloc"
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
@@ -73,7 +73,7 @@ matrix:
       if: branch = auto
 
     - env: >
-        RUST_CHECK_TARGET=check
+        SCRIPT="./x.py test"
         RUST_CONFIGURE_ARGS="--build=i686-apple-darwin --set rust.jemalloc"
         SRC=.
         RUSTC_RETRY_LINKER_ON_SEGFAULT=1
@@ -93,7 +93,7 @@ matrix:
     # `xcode8.2` image as above. That's because we want to build releases for
     # OSX 10.7 and `xcode7` is the latest Xcode able to compile LLVM for 10.7.
     - env: >
-        RUST_CHECK_TARGET=dist
+        SCRIPT="./x.py dist"
         RUST_CONFIGURE_ARGS="--build=i686-apple-darwin --enable-full-tools --enable-profiler --enable-lldb --set rust.jemalloc"
         SRC=.
         DEPLOY=1
@@ -108,7 +108,7 @@ matrix:
       if: branch = auto
 
     - env: >
-        RUST_CHECK_TARGET=dist
+        SCRIPT="./x.py dist"
         RUST_CONFIGURE_ARGS="--target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc"
         SRC=.
         DEPLOY=1
@@ -260,7 +260,7 @@ install:
             export PATH=$PATH:$HOME
           ;;
         osx)
-          if [[ "$RUST_CHECK_TARGET" == dist ]]; then
+          if [[ "$SCRIPT" == "./x.py dist" ]]; then
             travis_retry brew update &&
             travis_retry brew install xz &&
             travis_retry brew install swig;

--- a/src/ci/docker/i686-gnu-nopt/Dockerfile
+++ b/src/ci/docker/i686-gnu-nopt/Dockerfile
@@ -18,4 +18,4 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=i686-unknown-linux-gnu --disable-optimize-tests
-ENV RUST_CHECK_TARGET check
+ENV SCRIPT python2.7 ../x.py test

--- a/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
@@ -24,4 +24,4 @@ ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-6.0 \
       --enable-llvm-link-shared
-ENV RUST_CHECK_TARGET check
+ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test

--- a/src/ci/docker/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-nopt/Dockerfile
@@ -19,4 +19,4 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
   --disable-optimize-tests \
   --set rust.test-compare-mode
-ENV RUST_CHECK_TARGET check
+ENV SCRIPT python2.7 ../x.py test

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -137,8 +137,6 @@ else
     return $retval
   }
 
-  do_make tidy
-  do_make all
   do_make "$RUST_CHECK_TARGET"
 fi
 


### PR DESCRIPTION
Since #61212 we've been timing out on OSX, and this looks to be because
we're building tools like Cargo and the RLS twice instead of once. This
turns out to be a slight bug in our configuration. CI builders using the
`RUST_CHECK_TARGET` directive actually execute `make all` just before
their acual target. In `make all` we're building a stage2 cargo, and
then in `make dist` we're building a stage1 cargo.

Other builders use `SCRIPT` which provides explicit control over what
`x.py` script, for example, is used to execute the build. This moves
almost all targets to using `SCRIPT` to ensure that we're explicitly
specifying what's being built where. Additionally this updates the logic
of `RUST_CHECK_TARGET` to remove the pre-flight tidy as well as the
pre-flight `make all`. The system LLVM builder (run on PRs) now
explicitly runs tidy first and then runs the rest of the test suite.