### PR TITLE
Fix links in Deref documentation

### DIFF
--- a/src/libcore/ops/deref.rs
+++ b/src/libcore/ops/deref.rs
@@ -23,9 +23,9 @@
 /// * Values of type `&T` are coerced to values of type `&U`
 /// * `T` implicitly implements all the (immutable) methods of the type `U`.
 ///
-/// For more details, visit [the chapter in *The Rust Programming Language*]
-/// [book] as well as the reference sections on [the dereference operator]
-/// [ref-deref-op], [method resolution] and [type coercions].
+/// For more details, visit [the chapter in *The Rust Programming Language*][book]
+/// as well as the reference sections on [the dereference operator][ref-deref-op],
+/// [method resolution] and [type coercions].
 ///
 /// [book]: ../../book/ch15-02-deref.html
 /// [`DerefMut`]: trait.DerefMut.html
@@ -113,9 +113,9 @@ impl<T: ?Sized> Deref for &mut T {
 /// * Values of type `&mut T` are coerced to values of type `&mut U`
 /// * `T` implicitly implements all the (mutable) methods of the type `U`.
 ///
-/// For more details, visit [the chapter in *The Rust Programming Language*]
-/// [book] as well as the reference sections on [the dereference operator]
-/// [ref-deref-op], [method resolution] and [type coercions].
+/// For more details, visit [the chapter in *The Rust Programming Language*][book]
+/// as well as the reference sections on [the dereference operator][ref-deref-op],
+/// [method resolution] and [type coercions].
 ///
 /// [book]: ../../book/ch15-02-deref.html
 /// [`Deref`]: trait.Deref.html


### PR DESCRIPTION
Fixes #61358.

In commonmark, the "link alias" has to be right after the link. Screenshot:

<img width="970" alt="Screenshot 2019-05-30 at 19 01 58" src="https://user-images.githubusercontent.com/3050060/58650155-3b594e00-830e-11e9-956c-4dadefa40ff0.png">

r? @Manishearth 