### PR TITLE
Implement Termination for Option<()>

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1626,6 +1626,16 @@ impl<E: fmt::Debug> Termination for Result<(), E> {
 }
 
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
+impl<T: Termination> Termination for Option<T> {
+    fn report(self) -> i32 {
+        match self {
+            Some(v) => v.report(),
+            None => 1,
+        }
+    }
+}
+
+#[unstable(feature = "termination_trait_lib", issue = "43301")]
 impl Termination for ! {
     fn report(self) -> i32 { self }
 }


### PR DESCRIPTION
After a question about this [here](https://github.com/rust-lang/rust/pull/61279#issuecomment-497374545), I decided to open this PR. However, is this how we should implement it? Should we consider `None` as a failure (because that's how I implemented it)?

Anyway, I think having this PR open is a good place to discuss about it (and closing it if we don't want it of course).

cc @ollie27 @rust-lang/compiler 