### PR TITLE
Add more detail to type inference error

### DIFF
--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -152,6 +152,11 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         //   |         the type parameter `E` is specified
         // ```
         let (ty_msg, suffix) = match &local_visitor.found_ty {
+            Some(ty) if &ty.to_string() != "_" && name == "_" => {
+                let ty = ty_to_string(ty);
+                (format!(" for `{}`", ty),
+                 format!("the explicit type `{}`, with the type parameters specified", ty))
+            }
             Some(ty) if &ty.to_string() != "_" && ty.to_string() != name => {
                 let ty = ty_to_string(ty);
                 (format!(" for `{}`", ty),

--- a/src/librustc/infer/error_reporting/need_type_info.rs
+++ b/src/librustc/infer/error_reporting/need_type_info.rs
@@ -142,24 +142,28 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
         // trying to infer. In the following example, `ty_msg` contains
         // " in `std::result::Result<i32, E>`":
         // ```
-        // error[E0282]: type annotations needed in `std::result::Result<i32, E>`
+        // error[E0282]: type annotations needed for `std::result::Result<i32, E>`
         //  --> file.rs:L:CC
         //   |
         // L |     let b = Ok(4);
         //   |         -   ^^ cannot infer type for `E` in `std::result::Result<i32, E>`
         //   |         |
-        //   |         consider giving `b` the type `std::result::Result<i32, E>` with the type
-        //   |         parameter `E` specified
+        //   |         consider giving `b` the explicit type `std::result::Result<i32, E>`, where
+        //   |         the type parameter `E` is specified
         // ```
         let (ty_msg, suffix) = match &local_visitor.found_ty {
             Some(ty) if &ty.to_string() != "_" && ty.to_string() != name => {
                 let ty = ty_to_string(ty);
-                (format!(" in `{}`", ty),
-                 format!( "the type `{}` with the type parameter `{}` specified", ty, name))
+                (format!(" for `{}`", ty),
+                 format!(
+                     "the explicit type `{}`, where the type parameter `{}` is specified",
+                    ty,
+                    name,
+                 ))
             }
             _ => (String::new(), "a type".to_owned()),
         };
-        let mut labels = vec![(span, InferCtxt::missing_type_msg(&name, &ty_msg))];
+        let mut labels = vec![(span, InferCtxt::missing_type_msg(&name))];
 
         if let Some(pattern) = local_visitor.found_arg_pattern {
             err_span = pattern.span;
@@ -229,15 +233,15 @@ impl<'a, 'gcx, 'tcx> InferCtxt<'a, 'gcx, 'tcx> {
                        span,
                        E0698,
                        "type inside generator must be known in this context");
-        err.span_label(span, InferCtxt::missing_type_msg(&name, ""));
+        err.span_label(span, InferCtxt::missing_type_msg(&name));
         err
     }
 
-    fn missing_type_msg(type_name: &str, postfix: &str) -> String {
+    fn missing_type_msg(type_name: &str) -> String {
         if type_name == "_" {
             "cannot infer type".to_owned()
         } else {
-            format!("cannot infer type for `{}`{}", type_name, postfix)
+            format!("cannot infer type for `{}`", type_name)
         }
     }
 }

--- a/src/test/ui/issues/issue-12187-1.rs
+++ b/src/test/ui/issues/issue-12187-1.rs
@@ -4,5 +4,5 @@ fn new<T>() -> &'static T {
 
 fn main() {
     let &v = new();
-    //~^ ERROR type annotations needed [E0282]
+    //~^ ERROR type annotations needed
 }

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `&_`
   --> $DIR/issue-12187-1.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed in `&_`
+error[E0282]: type annotations needed in `&T`
   --> $DIR/issue-12187-1.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `&_`
+error[E0282]: type annotations needed in `&_`
   --> $DIR/issue-12187-1.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -5,7 +5,7 @@ LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving this pattern the explicit type `&T`, where the type parameter `_` is specified
+   |         consider giving this pattern the explicit type `&T`, with the type parameters specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -1,11 +1,11 @@
-error[E0282]: type annotations needed in `&T`
+error[E0282]: type annotations needed for `&T`
   --> $DIR/issue-12187-1.rs:6:10
    |
 LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving this pattern the type `&T` with the type parameter `_` specified
+   |         consider giving this pattern the explicit type `&T`, where the type parameter `_` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-1.stderr
+++ b/src/test/ui/issues/issue-12187-1.stderr
@@ -5,7 +5,7 @@ LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving the pattern a type
+   |         consider giving this pattern the type `&T` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-2.rs
+++ b/src/test/ui/issues/issue-12187-2.rs
@@ -4,5 +4,5 @@ fn new<'r, T>() -> &'r T {
 
 fn main() {
     let &v = new();
-    //~^ ERROR type annotations needed [E0282]
+    //~^ ERROR type annotations needed
 }

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `&_`
+error[E0282]: type annotations needed in `&_`
   --> $DIR/issue-12187-2.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -5,7 +5,7 @@ LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving this pattern the explicit type `&T`, where the type parameter `_` is specified
+   |         consider giving this pattern the explicit type `&T`, with the type parameters specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -1,11 +1,11 @@
-error[E0282]: type annotations needed in `&T`
+error[E0282]: type annotations needed for `&T`
   --> $DIR/issue-12187-2.rs:6:10
    |
 LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving this pattern the type `&T` with the type parameter `_` specified
+   |         consider giving this pattern the explicit type `&T`, where the type parameter `_` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed in `&_`
+error[E0282]: type annotations needed in `&T`
   --> $DIR/issue-12187-2.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -5,7 +5,7 @@ LL |     let &v = new();
    |         -^
    |         ||
    |         |cannot infer type
-   |         consider giving the pattern a type
+   |         consider giving this pattern the type `&T` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12187-2.stderr
+++ b/src/test/ui/issues/issue-12187-2.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `&_`
   --> $DIR/issue-12187-2.rs:6:10
    |
 LL |     let &v = new();

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `B<_>`
+error[E0282]: type annotations needed in `B<T>`
   --> $DIR/issue-17551.rs:6:15
    |
 LL |     let foo = B(marker::PhantomData);
-   |         ---   ^ cannot infer type for `T` in `B<_>`
+   |         ---   ^ cannot infer type for `T` in `B<T>`
    |         |
    |         consider giving `foo` a type
 

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `B<T>`
 LL |     let foo = B(marker::PhantomData);
    |         ---   ^ cannot infer type for `T` in `B<T>`
    |         |
-   |         consider giving `foo` a type
+   |         consider giving `foo` the type `B<T>` with the type parameter `T` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `B<_>`
   --> $DIR/issue-17551.rs:6:15
    |
 LL |     let foo = B(marker::PhantomData);
    |         ---   ^ cannot infer type for `T`
    |         |
-   |         consider giving `foo` a type
+   |         consider giving `foo` the type `B<_>` with the type parameter `T` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `B<_>`
+error[E0282]: type annotations needed in `B<_>`
   --> $DIR/issue-17551.rs:6:15
    |
 LL |     let foo = B(marker::PhantomData);
-   |         ---   ^ cannot infer type for `T`
+   |         ---   ^ cannot infer type for `T` in `B<_>`
    |         |
-   |         consider giving `foo` the type `B<_>` with the type parameter `T` specified
+   |         consider giving `foo` a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `B<T>`
+error[E0282]: type annotations needed for `B<T>`
   --> $DIR/issue-17551.rs:6:15
    |
 LL |     let foo = B(marker::PhantomData);
-   |         ---   ^ cannot infer type for `T` in `B<T>`
+   |         ---   ^ cannot infer type for `T`
    |         |
-   |         consider giving `foo` the type `B<T>` with the type parameter `T` specified
+   |         consider giving `foo` the explicit type `B<T>`, where the type parameter `T` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20261.stderr
+++ b/src/test/ui/issues/issue-20261.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `&(_,)`
   --> $DIR/issue-20261.rs:4:11
    |
 LL |     for (ref i,) in [].iter() {

--- a/src/test/ui/issues/issue-20261.stderr
+++ b/src/test/ui/issues/issue-20261.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `&(_,)`
+error[E0282]: type annotations needed in `&(_,)`
   --> $DIR/issue-20261.rs:4:11
    |
 LL |     for (ref i,) in [].iter() {

--- a/src/test/ui/issues/issue-20261.stderr
+++ b/src/test/ui/issues/issue-20261.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed in `&(_,)`
+error[E0282]: type annotations needed for `&(_,)`
   --> $DIR/issue-20261.rs:4:11
    |
 LL |     for (ref i,) in [].iter() {

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `Expr<'_, VAR>`
+error[E0282]: type annotations needed for `Expr<'_, VAR>`
   --> $DIR/issue-23046.rs:17:15
    |
 LL |     let ex = |x| {
-   |               ^ consider giving this closure parameter the type `Expr<'_, VAR>` with the type parameter `VAR` specified
+   |               ^ consider giving this closure parameter the explicit type `Expr<'_, VAR>`, where the type parameter `VAR` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed for `Expr<'_, _>`
+error[E0282]: type annotations needed in `Expr<'_, _>`
   --> $DIR/issue-23046.rs:17:15
    |
 LL |     let ex = |x| {

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `Expr<'_, _>`
+error[E0282]: type annotations needed in `Expr<'_, VAR>`
   --> $DIR/issue-23046.rs:17:15
    |
 LL |     let ex = |x| {
-   |               ^ consider giving this closure parameter the type `Expr<'_, _>` with the type parameter `VAR` specified
+   |               ^ consider giving this closure parameter the type `Expr<'_, VAR>` with the type parameter `VAR` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23046.stderr
+++ b/src/test/ui/issues/issue-23046.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `Expr<'_, _>`
   --> $DIR/issue-23046.rs:17:15
    |
 LL |     let ex = |x| {
-   |               ^ consider giving this closure parameter a type
+   |               ^ consider giving this closure parameter the type `Expr<'_, _>` with the type parameter `VAR` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -1,11 +1,11 @@
-error[E0282]: type annotations needed in `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`
+error[E0282]: type annotations needed for `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`
   --> $DIR/issue-25368.rs:11:17
    |
 LL |     let (tx, rx) = channel();
-   |         -------- consider giving this pattern the type `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)` with the type parameter `T` specified
+   |         -------- consider giving this pattern the explicit type `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`, where the type parameter `T` is specified
 ...
 LL |         tx.send(Foo{ foo: PhantomData });
-   |                 ^^^ cannot infer type for `T` in `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`
+   |                 ^^^ cannot infer type for `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed in `(std::sync::mpsc::Sender<Foo<T>>, std:
   --> $DIR/issue-25368.rs:11:17
    |
 LL |     let (tx, rx) = channel();
-   |         -------- consider giving the pattern a type
+   |         -------- consider giving this pattern the type `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)` with the type parameter `T` specified
 ...
 LL |         tx.send(Foo{ foo: PhantomData });
    |                 ^^^ cannot infer type for `T` in `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -1,11 +1,11 @@
-error[E0282]: type annotations needed for `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
+error[E0282]: type annotations needed in `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
   --> $DIR/issue-25368.rs:11:17
    |
 LL |     let (tx, rx) = channel();
    |         -------- consider giving the pattern a type
 ...
 LL |         tx.send(Foo{ foo: PhantomData });
-   |                 ^^^ cannot infer type for `T`
+   |                 ^^^ cannot infer type for `T` in `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
   --> $DIR/issue-25368.rs:11:17
    |
 LL |     let (tx, rx) = channel();

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -1,11 +1,11 @@
-error[E0282]: type annotations needed in `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
+error[E0282]: type annotations needed in `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`
   --> $DIR/issue-25368.rs:11:17
    |
 LL |     let (tx, rx) = channel();
    |         -------- consider giving the pattern a type
 ...
 LL |         tx.send(Foo{ foo: PhantomData });
-   |                 ^^^ cannot infer type for `T` in `(std::sync::mpsc::Sender<Foo<_>>, std::sync::mpsc::Receiver<Foo<_>>)`
+   |                 ^^^ cannot infer type for `T` in `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `&[_; 0]`
+error[E0282]: type annotations needed in `&[_; 0]`
   --> $DIR/issue-7813.rs:2:13
    |
 LL |     let v = &[];
    |         -   ^^^ cannot infer type
    |         |
-   |         consider giving `v` the type `&[_; 0]` with the type parameter `_` specified
+   |         consider giving `v` a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `&[_; 0]`
 LL |     let v = &[];
    |         -   ^^^ cannot infer type
    |         |
-   |         consider giving `v` the explicit type `&[_; 0]`, where the type parameter `_` is specified
+   |         consider giving `v` the explicit type `&[_; 0]`, with the type parameters specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `&[_; 0]`
   --> $DIR/issue-7813.rs:2:13
    |
 LL |     let v = &[];
    |         -   ^^^ cannot infer type
    |         |
-   |         consider giving `v` a type
+   |         consider giving `v` the type `&[_; 0]` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `&[_; 0]`
 LL |     let v = &[];
    |         -   ^^^ cannot infer type
    |         |
-   |         consider giving `v` a type
+   |         consider giving `v` the type `&[_; 0]` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `&[_; 0]`
+error[E0282]: type annotations needed for `&[_; 0]`
   --> $DIR/issue-7813.rs:2:13
    |
 LL |     let v = &[];
    |         -   ^^^ cannot infer type
    |         |
-   |         consider giving `v` the type `&[_; 0]` with the type parameter `_` specified
+   |         consider giving `v` the explicit type `&[_; 0]`, where the type parameter `_` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.rs
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.rs
@@ -22,7 +22,7 @@ impl Foo for Vec<isize> {
 fn m1() {
     // we couldn't infer the type of the vector just based on calling foo()...
     let mut x = Vec::new();
-    //~^ ERROR type annotations needed [E0282]
+    //~^ ERROR type annotations needed
     x.foo();
 }
 

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `std::vec::Vec<T>`
 LL |     let mut x = Vec::new();
    |         -----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `std::vec::Vec<T>` with the type parameter `T` specified
 
 error[E0308]: mismatched types
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:33:20

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `std::vec::Vec<T>`
+error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:24:17
    |
 LL |     let mut x = Vec::new();
-   |         -----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
+   |         -----   ^^^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `x` the type `std::vec::Vec<T>` with the type parameter `T` specified
+   |         consider giving `x` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
 
 error[E0308]: mismatched types
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:33:20

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<T>`
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:24:17
    |
 LL |     let mut x = Vec::new();
-   |         -----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
+   |         -----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
    |         consider giving `x` a type
 

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `std::vec::Vec<_>`
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:24:17
    |
 LL |     let mut x = Vec::new();
    |         -----   ^^^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `std::vec::Vec<_>` with the type parameter `T` specified
 
 error[E0308]: mismatched types
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:33:20

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<_>`
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:24:17
    |
 LL |     let mut x = Vec::new();
-   |         -----   ^^^^^^^^ cannot infer type for `T`
+   |         -----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
    |         |
-   |         consider giving `x` the type `std::vec::Vec<_>` with the type parameter `T` specified
+   |         consider giving `x` a type
 
 error[E0308]: mismatched types
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:33:20

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed in `std::option::Option<_>`
   --> $DIR/issue-42234-unknown-receiver-type.rs:7:5
    |
 LL |     let x: Option<_> = None;
-   |         - consider giving `x` a type
+   |         - consider giving `x` the type `std::option::Option<_>` with the type parameter `T` specified
 LL |     x.unwrap().method_that_could_exist_on_some_type();
    |     ^^^^^^^^^^ cannot infer type for `T` in `std::option::Option<_>`
    |

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `std::option::Option<_>`
   --> $DIR/issue-42234-unknown-receiver-type.rs:7:5
    |
 LL |     let x: Option<_> = None;
-   |         - consider giving `x` a type
+   |         - consider giving `x` the type `std::option::Option<_>` with the type parameter `T` specified
 LL |     x.unwrap().method_that_could_exist_on_some_type();
    |     ^^^^^^^^^^ cannot infer type for `T`
    |

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `std::option::Option<_>`
+error[E0282]: type annotations needed for `std::option::Option<_>`
   --> $DIR/issue-42234-unknown-receiver-type.rs:7:5
    |
 LL |     let x: Option<_> = None;
-   |         - consider giving `x` the type `std::option::Option<_>` with the type parameter `T` specified
+   |         - consider giving `x` the explicit type `std::option::Option<_>`, where the type parameter `T` is specified
 LL |     x.unwrap().method_that_could_exist_on_some_type();
-   |     ^^^^^^^^^^ cannot infer type for `T` in `std::option::Option<_>`
+   |     ^^^^^^^^^^ cannot infer type for `T`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `std::option::Option<_>`
+error[E0282]: type annotations needed in `std::option::Option<_>`
   --> $DIR/issue-42234-unknown-receiver-type.rs:7:5
    |
 LL |     let x: Option<_> = None;
-   |         - consider giving `x` the type `std::option::Option<_>` with the type parameter `T` specified
+   |         - consider giving `x` a type
 LL |     x.unwrap().method_that_could_exist_on_some_type();
-   |     ^^^^^^^^^^ cannot infer type for `T`
+   |     ^^^^^^^^^^ cannot infer type for `T` in `std::option::Option<_>`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `[_; 0]`
+error[E0282]: type annotations needed in `[_; 0]`
   --> $DIR/cannot_infer_local_or_array.rs:2:13
    |
 LL |     let x = [];
    |         -   ^^ cannot infer type
    |         |
-   |         consider giving `x` the type `[_; 0]` with the type parameter `_` specified
+   |         consider giving `x` a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/cannot_infer_local_or_array.rs:2:13
    |
 LL |     let x = [];
    |         -   ^^ cannot infer type
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `[_; 0]` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `[_; 0]`
 LL |     let x = [];
    |         -   ^^ cannot infer type
    |         |
-   |         consider giving `x` the explicit type `[_; 0]`, where the type parameter `_` is specified
+   |         consider giving `x` the explicit type `[_; 0]`, with the type parameters specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `[_; 0]`
 LL |     let x = [];
    |         -   ^^ cannot infer type
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `[_; 0]` with the type parameter `_` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `[_; 0]`
+error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/cannot_infer_local_or_array.rs:2:13
    |
 LL |     let x = [];
    |         -   ^^ cannot infer type
    |         |
-   |         consider giving `x` the type `[_; 0]` with the type parameter `_` specified
+   |         consider giving `x` the explicit type `[_; 0]`, where the type parameter `_` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<_>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:13
    |
 LL |     let x = vec![];
-   |         -   ^^^^^^ cannot infer type for `T`
+   |         -   ^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
    |         |
-   |         consider giving `x` the type `std::vec::Vec<_>` with the type parameter `T` specified
+   |         consider giving `x` a type
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<T>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:13
    |
 LL |     let x = vec![];
-   |         -   ^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
+   |         -   ^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
    |         consider giving `x` a type
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `std::vec::Vec<T>`
 LL |     let x = vec![];
    |         -   ^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `std::vec::Vec<T>` with the type parameter `T` specified
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `std::vec::Vec<_>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:13
    |
 LL |     let x = vec![];
    |         -   ^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `x` a type
+   |         consider giving `x` the type `std::vec::Vec<_>` with the type parameter `T` specified
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `std::vec::Vec<T>`
+error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:13
    |
 LL |     let x = vec![];
-   |         -   ^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
+   |         -   ^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `x` the type `std::vec::Vec<T>` with the type parameter `T` specified
+   |         consider giving `x` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `(std::vec::Vec<_>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:18
    |
 LL |     let (x, ) = (vec![], );

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `(std::vec::Vec<_>,)`
+error[E0282]: type annotations needed in `(std::vec::Vec<T>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:18
    |
 LL |     let (x, ) = (vec![], );
-   |         -----    ^^^^^^ cannot infer type for `T` in `(std::vec::Vec<_>,)`
+   |         -----    ^^^^^^ cannot infer type for `T` in `(std::vec::Vec<T>,)`
    |         |
    |         consider giving the pattern a type
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed for `(std::vec::Vec<_>,)`
+error[E0282]: type annotations needed in `(std::vec::Vec<_>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:18
    |
 LL |     let (x, ) = (vec![], );
-   |         -----    ^^^^^^ cannot infer type for `T`
+   |         -----    ^^^^^^ cannot infer type for `T` in `(std::vec::Vec<_>,)`
    |         |
    |         consider giving the pattern a type
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `(std::vec::Vec<T>,)`
 LL |     let (x, ) = (vec![], );
    |         -----    ^^^^^^ cannot infer type for `T` in `(std::vec::Vec<T>,)`
    |         |
-   |         consider giving the pattern a type
+   |         consider giving this pattern the type `(std::vec::Vec<T>,)` with the type parameter `T` specified
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `(std::vec::Vec<T>,)`
+error[E0282]: type annotations needed for `(std::vec::Vec<T>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:18
    |
 LL |     let (x, ) = (vec![], );
-   |         -----    ^^^^^^ cannot infer type for `T` in `(std::vec::Vec<T>,)`
+   |         -----    ^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving this pattern the type `(std::vec::Vec<T>,)` with the type parameter `T` specified
+   |         consider giving this pattern the explicit type `(std::vec::Vec<T>,)`, where the type parameter `T` is specified
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed in `std::option::Option<T>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;
-   |         ------------ consider giving `closure0` a type
+   |         ------------ consider giving `closure0` the type `std::option::Option<T>` with the type parameter `_` specified
 ...
 LL |                         return c();
    |                                ^^^ cannot infer type

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `std::option::Option<T>`
+error[E0282]: type annotations needed for `std::option::Option<T>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;
-   |         ------------ consider giving `closure0` the type `std::option::Option<T>` with the type parameter `_` specified
+   |         ------------ consider giving `closure0` the explicit type `std::option::Option<T>`, where the type parameter `_` is specified
 ...
 LL |                         return c();
    |                                ^^^ cannot infer type

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `std::option::Option<T>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;
-   |         ------------ consider giving `closure0` the explicit type `std::option::Option<T>`, where the type parameter `_` is specified
+   |         ------------ consider giving `closure0` the explicit type `std::option::Option<T>`, with the type parameters specified
 ...
 LL |                         return c();
    |                                ^^^ cannot infer type

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed for `std::option::Option<_>`
+error[E0282]: type annotations needed in `std::option::Option<_>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;
-   |         ------------ consider giving `closure0` the type `std::option::Option<_>` with the type parameter `_` specified
+   |         ------------ consider giving `closure0` a type
 ...
 LL |                         return c();
    |                                ^^^ cannot infer type

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -1,4 +1,4 @@
-error[E0282]: type annotations needed in `std::option::Option<_>`
+error[E0282]: type annotations needed in `std::option::Option<T>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `std::option::Option<_>`
   --> $DIR/unboxed-closures-failed-recursive-fn-2.rs:16:32
    |
 LL |     let mut closure0 = None;
-   |         ------------ consider giving `closure0` a type
+   |         ------------ consider giving `closure0` the type `std::option::Option<_>` with the type parameter `_` specified
 ...
 LL |                         return c();
    |                                ^^^ cannot infer type

--- a/src/test/ui/vector-no-ann.rs
+++ b/src/test/ui/vector-no-ann.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _foo = Vec::new();
-    //~^ ERROR type annotations needed [E0282]
+    //~^ ERROR type annotations needed
 }

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -1,8 +1,8 @@
-error[E0282]: type annotations needed in `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<T>`
   --> $DIR/vector-no-ann.rs:2:16
    |
 LL |     let _foo = Vec::new();
-   |         ----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
+   |         ----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
    |         consider giving `_foo` a type
 

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed in `std::vec::Vec<T>`
+error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/vector-no-ann.rs:2:16
    |
 LL |     let _foo = Vec::new();
-   |         ----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
+   |         ----   ^^^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `_foo` the type `std::vec::Vec<T>` with the type parameter `T` specified
+   |         consider giving `_foo` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed for `std::vec::Vec<_>`
+error[E0282]: type annotations needed in `std::vec::Vec<_>`
   --> $DIR/vector-no-ann.rs:2:16
    |
 LL |     let _foo = Vec::new();
-   |         ----   ^^^^^^^^ cannot infer type for `T`
+   |         ----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<_>`
    |         |
-   |         consider giving `_foo` the type `std::vec::Vec<_>` with the type parameter `T` specified
+   |         consider giving `_foo` a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed in `std::vec::Vec<T>`
 LL |     let _foo = Vec::new();
    |         ----   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
    |         |
-   |         consider giving `_foo` a type
+   |         consider giving `_foo` the type `std::vec::Vec<T>` with the type parameter `T` specified
 
 error: aborting due to previous error
 

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -1,10 +1,10 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `std::vec::Vec<_>`
   --> $DIR/vector-no-ann.rs:2:16
    |
 LL |     let _foo = Vec::new();
    |         ----   ^^^^^^^^ cannot infer type for `T`
    |         |
-   |         consider giving `_foo` a type
+   |         consider giving `_foo` the type `std::vec::Vec<_>` with the type parameter `T` specified
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When encountering code where type inference fails, add more actionable
information:

```
fn main() {
    let foo = Vec::new();
}
```

```
error[E0282]: type annotations needed in `std::vec::Vec<T>`
  --> $DIR/vector-no-ann.rs:2:16
   |
LL |     let foo = Vec::new();
   |         ---   ^^^^^^^^ cannot infer type for `T` in `std::vec::Vec<T>`
   |         |
   |         consider giving `foo` a type
```

Fix #25633.