### PR TITLE
azure: split slow linux builders

### DIFF
--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -127,17 +127,29 @@ jobs:
       asmjs:
         IMAGE: asmjs
 
-      i686-gnu:
+      i686-gnu-1:
         IMAGE: i686-gnu
+        SCRIPT: make ci-subset-1
+      i686-gnu-2:
+        IMAGE: i686-gnu
+        SCRIPT: make ci-subset-2
 
-      i686-gnu-nopt:
+      i686-gnu-nopt-1:
         IMAGE: i686-gnu-nopt
+        SCRIPT: make ci-subset-1
+      i686-gnu-nopt-2:
+        IMAGE: i686-gnu-nopt
+        SCRIPT: make ci-subset-2
 
       test-various:
         IMAGE: test-various
 
-      x86_64-gnu:
+      x86_64-gnu-1:
         IMAGE: x86_64-gnu
+        SCRIPT: make ci-subset-1
+      x86_64-gnu-2:
+        IMAGE: x86_64-gnu
+        SCRIPT: make ci-subset-2
 
       x86_64-gnu-full-bootstrap:
         IMAGE: x86_64-gnu-full-bootstrap

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -171,8 +171,12 @@ jobs:
       x86_64-gnu-nopt:
         IMAGE: x86_64-gnu-nopt
 
-      x86_64-gnu-distcheck:
+      x86_64-gnu-distcheck-1:
         IMAGE: x86_64-gnu-distcheck
+        SCRIPT: ./x.py test distcheck --distcheck-make ci-subset-1
+      x86_64-gnu-distcheck-2:
+        IMAGE: x86_64-gnu-distcheck
+        SCRIPT: ./x.py test distcheck --distcheck-make ci-subset-2
 
       mingw-check:
         IMAGE: mingw-check

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -248,139 +248,139 @@ jobs:
 
 
 
-- job: Windows
-  timeoutInMinutes: 600
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - template: steps/run.yml
-  strategy:
-    matrix:
-      # 32/64 bit MSVC tests
-      x86_64-msvc-1:
-        MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
-        SCRIPT: make ci-subset-1
-        # FIXME(#59637)
-        NO_DEBUG_ASSERTIONS: 1
-        NO_LLVM_ASSERTIONS: 1
-      x86_64-msvc-2:
-        MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
-        SCRIPT: make ci-subset-2
-      i686-msvc-1:
-        MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-        SCRIPT: make ci-subset-1
-      i686-msvc-2:
-        MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
-        SCRIPT: make ci-subset-2
-      # MSVC aux tests
-      x86_64-msvc-aux:
-        MSYS_BITS: 64
-        RUST_CHECK_TARGET: check-aux EXCLUDE_CARGO=1
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
-      x86_64-msvc-cargo:
-        MSYS_BITS: 64
-        SCRIPT: python x.py test src/tools/cargotest src/tools/cargo
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
-        VCVARS_BAT: vcvars64.bat
-      # MSVC tools tests
-      x86_64-msvc-tools:
-        MSYS_BITS: 64
-        SCRIPT: src/ci/docker/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstates.json windows
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstates.json --enable-test-miri
-
-      # 32/64-bit MinGW builds.
-      #
-      # We are using MinGW with posix threads since LLVM does not compile with
-      # the win32 threads version due to missing support for C++'s std::thread.
-      #
-      # Instead of relying on the MinGW version installed on appveryor we download
-      # and install one ourselves so we won't be surprised by changes to appveyor's
-      # build image.
-      #
-      # Finally, note that the downloads below are all in the `rust-lang-ci` S3
-      # bucket, but they cleraly didn't originate there! The downloads originally
-      # came from the mingw-w64 SourceForge download site. Unfortunately
-      # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
-      i686-mingw-1:
-        MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-        SCRIPT: make ci-subset-1
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-        MINGW_DIR: mingw32
-        # FIXME(#59637)
-        NO_DEBUG_ASSERTIONS: 1
-        NO_LLVM_ASSERTIONS: 1
-      i686-mingw-2:
-        MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
-        SCRIPT: make ci-subset-2
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-        MINGW_DIR: mingw32
-      x86_64-mingw-1:
-        MSYS_BITS: 64
-        SCRIPT: make ci-subset-1
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
-        MINGW_DIR: mingw64
-        # FIXME(#59637)
-        NO_DEBUG_ASSERTIONS: 1
-        NO_LLVM_ASSERTIONS: 1
-      x86_64-mingw-2:
-        MSYS_BITS: 64
-        SCRIPT: make ci-subset-2
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
-        MINGW_DIR: mingw64
-
-      # 32/64 bit MSVC and GNU deployment
-      dist-x86_64-msvc:
-        RUST_CONFIGURE_ARGS: >
-          --build=x86_64-pc-windows-msvc
-          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
-          --enable-full-tools
-          --enable-profiler
-        SCRIPT: python x.py dist
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-      dist-i686-msvc:
-        RUST_CONFIGURE_ARGS: >
-          --build=i686-pc-windows-msvc
-          --target=i586-pc-windows-msvc
-          --enable-full-tools
-          --enable-profiler
-        SCRIPT: python x.py dist
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-      dist-i686-mingw:
-        MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools
-        SCRIPT: python x.py dist
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-        MINGW_DIR: mingw32
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-      dist-x86_64-mingw:
-        MSYS_BITS: 64
-        SCRIPT: python x.py dist
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
-        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
-        MINGW_DIR: mingw64
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-
-      # "alternate" deployment, see .travis.yml for more info
-      dist-x86_64-msvc-alt:
-        MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-        SCRIPT: python x.py dist
-        DEPLOY_ALT: 1
+#- job: Windows
+#  timeoutInMinutes: 600
+#  pool:
+#    vmImage: 'vs2017-win2016'
+#  steps:
+#  - template: steps/run.yml
+#  strategy:
+#    matrix:
+#      # 32/64 bit MSVC tests
+#      x86_64-msvc-1:
+#        MSYS_BITS: 64
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+#        SCRIPT: make ci-subset-1
+#        # FIXME(#59637)
+#        NO_DEBUG_ASSERTIONS: 1
+#        NO_LLVM_ASSERTIONS: 1
+#      x86_64-msvc-2:
+#        MSYS_BITS: 64
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-profiler
+#        SCRIPT: make ci-subset-2
+#      i686-msvc-1:
+#        MSYS_BITS: 32
+#        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+#        SCRIPT: make ci-subset-1
+#      i686-msvc-2:
+#        MSYS_BITS: 32
+#        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-msvc
+#        SCRIPT: make ci-subset-2
+#      # MSVC aux tests
+#      x86_64-msvc-aux:
+#        MSYS_BITS: 64
+#        RUST_CHECK_TARGET: check-aux EXCLUDE_CARGO=1
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+#      x86_64-msvc-cargo:
+#        MSYS_BITS: 64
+#        SCRIPT: python x.py test src/tools/cargotest src/tools/cargo
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc
+#        VCVARS_BAT: vcvars64.bat
+#      # MSVC tools tests
+#      x86_64-msvc-tools:
+#        MSYS_BITS: 64
+#        SCRIPT: src/ci/docker/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstates.json windows
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --save-toolstates=/tmp/toolstates.json --enable-test-miri
+#
+#      # 32/64-bit MinGW builds.
+#      #
+#      # We are using MinGW with posix threads since LLVM does not compile with
+#      # the win32 threads version due to missing support for C++'s std::thread.
+#      #
+#      # Instead of relying on the MinGW version installed on appveryor we download
+#      # and install one ourselves so we won't be surprised by changes to appveyor's
+#      # build image.
+#      #
+#      # Finally, note that the downloads below are all in the `rust-lang-ci` S3
+#      # bucket, but they cleraly didn't originate there! The downloads originally
+#      # came from the mingw-w64 SourceForge download site. Unfortunately
+#      # SourceForge is notoriously flaky, so we mirror it on our own infrastructure.
+#      i686-mingw-1:
+#        MSYS_BITS: 32
+#        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+#        SCRIPT: make ci-subset-1
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+#        MINGW_DIR: mingw32
+#        # FIXME(#59637)
+#        NO_DEBUG_ASSERTIONS: 1
+#        NO_LLVM_ASSERTIONS: 1
+#      i686-mingw-2:
+#        MSYS_BITS: 32
+#        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
+#        SCRIPT: make ci-subset-2
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+#        MINGW_DIR: mingw32
+#      x86_64-mingw-1:
+#        MSYS_BITS: 64
+#        SCRIPT: make ci-subset-1
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+#        MINGW_DIR: mingw64
+#        # FIXME(#59637)
+#        NO_DEBUG_ASSERTIONS: 1
+#        NO_LLVM_ASSERTIONS: 1
+#      x86_64-mingw-2:
+#        MSYS_BITS: 64
+#        SCRIPT: make ci-subset-2
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+#        MINGW_DIR: mingw64
+#
+#      # 32/64 bit MSVC and GNU deployment
+#      dist-x86_64-msvc:
+#        RUST_CONFIGURE_ARGS: >
+#          --build=x86_64-pc-windows-msvc
+#          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+#          --enable-full-tools
+#          --enable-profiler
+#        SCRIPT: python x.py dist
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#        DEPLOY: 1
+#      dist-i686-msvc:
+#        RUST_CONFIGURE_ARGS: >
+#          --build=i686-pc-windows-msvc
+#          --target=i586-pc-windows-msvc
+#          --enable-full-tools
+#          --enable-profiler
+#        SCRIPT: python x.py dist
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#        DEPLOY: 1
+#      dist-i686-mingw:
+#        MSYS_BITS: 32
+#        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools
+#        SCRIPT: python x.py dist
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+#        MINGW_DIR: mingw32
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#        DEPLOY: 1
+#      dist-x86_64-mingw:
+#        MSYS_BITS: 64
+#        SCRIPT: python x.py dist
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools
+#        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+#        MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
+#        MINGW_DIR: mingw64
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#        DEPLOY: 1
+#
+#      # "alternate" deployment, see .travis.yml for more info
+#      dist-x86_64-msvc-alt:
+#        MSYS_BITS: 64
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
+#        SCRIPT: python x.py dist
+#        DEPLOY_ALT: 1

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -126,26 +126,37 @@ jobs:
 
       asmjs:
         IMAGE: asmjs
+
       i686-gnu:
         IMAGE: i686-gnu
+
       i686-gnu-nopt:
         IMAGE: i686-gnu-nopt
+
       test-various:
         IMAGE: test-various
+
       x86_64-gnu:
         IMAGE: x86_64-gnu
+
       x86_64-gnu-full-bootstrap:
         IMAGE: x86_64-gnu-full-bootstrap
+
       x86_64-gnu-aux:
         IMAGE: x86_64-gnu-aux
+
       x86_64-gnu-tools:
         IMAGE: x86_64-gnu-tools
+
       x86_64-gnu-debug:
         IMAGE: x86_64-gnu-debug
+
       x86_64-gnu-nopt:
         IMAGE: x86_64-gnu-nopt
+
       x86_64-gnu-distcheck:
         IMAGE: x86_64-gnu-distcheck
+
       mingw-check:
         IMAGE: mingw-check
 

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -168,8 +168,12 @@ jobs:
       x86_64-gnu-debug:
         IMAGE: x86_64-gnu-debug
 
-      x86_64-gnu-nopt:
+      x86_64-gnu-nopt-1:
         IMAGE: x86_64-gnu-nopt
+        SCRIPT: make ci-subset-1
+      x86_64-gnu-nopt-2:
+        IMAGE: x86_64-gnu-nopt
+        SCRIPT: make ci-subset-2
 
       x86_64-gnu-distcheck-1:
         IMAGE: x86_64-gnu-distcheck

--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -156,6 +156,11 @@ jobs:
 
       x86_64-gnu-aux:
         IMAGE: x86_64-gnu-aux
+        SCRIPT: make check-aux EXCLUDE_CARGO=1
+
+      x86_64-gnu-cargo:
+        IMAGE: x86_64-gnu-aux
+        SCRIPT: ./x.py test src/tools/cargotest src/tools/cargo
 
       x86_64-gnu-tools:
         IMAGE: x86_64-gnu-tools

--- a/.azure-pipelines/try.yml
+++ b/.azure-pipelines/try.yml
@@ -26,53 +26,53 @@ jobs:
         IMAGE: dist-x86_64-linux
         DEPLOY_ALT: 1
 
-- job: macOS
-  timeoutInMinutes: 600
-  pool:
-    vmImage: macos-10.13
-  steps:
-  - template: steps/run.yml
-  strategy:
-    matrix:
-      dist-x86_64-apple:
-        SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
-        DEPLOY: 1
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-        DIST_REQUIRE_ALL_TOOLS: 1
-
-      dist-x86_64-apple-alt:
-        SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
-        DEPLOY_ALT: 1
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-
-- job: Windows
-  timeoutInMinutes: 600
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - template: steps/run.yml
-  strategy:
-    matrix:
-      dist-x86_64-msvc:
-        RUST_CONFIGURE_ARGS: >
-          --build=x86_64-pc-windows-msvc
-          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
-          --enable-full-tools
-          --enable-profiler
-        SCRIPT: python x.py dist
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-
-      dist-x86_64-msvc-alt:
-        MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-        SCRIPT: python x.py dist
-        DEPLOY_ALT: 1
+#- job: macOS
+#  timeoutInMinutes: 600
+#  pool:
+#    vmImage: macos-10.13
+#  steps:
+#  - template: steps/run.yml
+#  strategy:
+#    matrix:
+#      dist-x86_64-apple:
+#        SCRIPT: ./x.py dist
+#        RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
+#        DEPLOY: 1
+#        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+#        MACOSX_DEPLOYMENT_TARGET: 10.7
+#        NO_LLVM_ASSERTIONS: 1
+#        NO_DEBUG_ASSERTIONS: 1
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#
+#      dist-x86_64-apple-alt:
+#        SCRIPT: ./x.py dist
+#        RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
+#        DEPLOY_ALT: 1
+#        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+#        MACOSX_DEPLOYMENT_TARGET: 10.7
+#        NO_LLVM_ASSERTIONS: 1
+#        NO_DEBUG_ASSERTIONS: 1
+#
+#- job: Windows
+#  timeoutInMinutes: 600
+#  pool:
+#    vmImage: 'vs2017-win2016'
+#  steps:
+#  - template: steps/run.yml
+#  strategy:
+#    matrix:
+#      dist-x86_64-msvc:
+#        RUST_CONFIGURE_ARGS: >
+#          --build=x86_64-pc-windows-msvc
+#          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+#          --enable-full-tools
+#          --enable-profiler
+#        SCRIPT: python x.py dist
+#        DIST_REQUIRE_ALL_TOOLS: 1
+#        DEPLOY: 1
+#
+#      dist-x86_64-msvc-alt:
+#        MSYS_BITS: 64
+#        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
+#        SCRIPT: python x.py dist
+#        DEPLOY_ALT: 1

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -598,6 +598,7 @@ fn test_with_no_doc_stage0() {
         bless: false,
         compare_mode: None,
         rustfix_coverage: false,
+        distcheck_make: None,
     };
 
     let build = Build::new(config);
@@ -640,6 +641,7 @@ fn test_exclude() {
         bless: false,
         compare_mode: None,
         rustfix_coverage: false,
+        distcheck_make: None,
     };
 
     let build = Build::new(config);

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -63,6 +63,7 @@ pub enum Subcommand {
         fail_fast: bool,
         doc_tests: DocTests,
         rustfix_coverage: bool,
+        distcheck_make: Option<String>,
     },
     Bench {
         paths: Vec<PathBuf>,
@@ -204,6 +205,12 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`"
                     "rustfix-coverage",
                     "enable this to generate a Rustfix coverage file, which is saved in \
                         `/<build_base>/rustfix_missing_coverage.txt`",
+                );
+                opts.optopt(
+                    "",
+                    "distcheck-make",
+                    "the Makefile target to use for distcheck (default: check)",
+                    "MAKEFILE TARGET",
                 );
             }
             "bench" => {
@@ -412,6 +419,7 @@ Arguments:
                 } else {
                     DocTests::Yes
                 },
+                distcheck_make: matches.opt_str("distcheck-make"),
             },
             "bench" => Subcommand::Bench {
                 paths,
@@ -521,6 +529,15 @@ impl Subcommand {
             Subcommand::Test {
                 ref compare_mode, ..
             } => compare_mode.as_ref().map(|s| &s[..]),
+            _ => None,
+        }
+    }
+
+    pub fn distcheck_make(&self) -> Option<&str> {
+        match *self {
+            Subcommand::Test {
+                ref distcheck_make, ..
+            } => distcheck_make.as_ref().map(|s| s.as_str()),
             _ => None,
         }
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1987,7 +1987,7 @@ impl Step for Distcheck {
         );
         builder.run(
             Command::new(build_helper::make(&builder.config.build))
-                .arg("check")
+                .arg(builder.config.cmd.distcheck_make().unwrap_or("check"))
                 .current_dir(&dir),
         );
 


### PR DESCRIPTION
This PR splits into two the 6 Linux builders that regularly approach or go over the 3 hours mark on Azure, using the `make ci-subset-{1,2}` already used by other builders on Windows.

r? @alexcrichton 
cc https://github.com/rust-lang/rust/issues/61185