### PR TITLE
Emit StorageDead along unwind paths for generators

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -666,7 +666,7 @@ impl<'a, 'tcx> LayoutCx<'tcx, TyCtxt<'a, 'tcx, 'tcx>> {
                     size,
                     align,
                 });
-                debug!("generator layout: {:#?}", layout);
+                debug!("generator layout ({:?}): {:#?}", ty, layout);
                 layout
             }
 

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -1,7 +1,7 @@
 //! See docs in build/expr/mod.rs
 
 use crate::build::{BlockAnd, BlockAndExtension, Builder};
-use crate::build::scope::{CachedBlock, DropKind};
+use crate::build::scope::DropKind;
 use crate::hair::*;
 use rustc::middle::region;
 use rustc::mir::*;
@@ -103,9 +103,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
                 temp_lifetime,
                 temp_place,
                 expr_ty,
-                DropKind::Value {
-                    cached_block: CachedBlock::default(),
-                },
+                DropKind::Value,
             );
         }
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -544,7 +544,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let place = Place::Base(PlaceBase::Local(local_id));
         let var_ty = self.local_decls[local_id].ty;
         let region_scope = self.hir.region_scope_tree.var_scope(var.local_id);
-        self.schedule_drop(span, region_scope, &place, var_ty, DropKind::Storage);
+        self.schedule_drop(span, region_scope, &place, var_ty, DropKind::Storage { cached_block: CachedBlock::default() });
         place
     }
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -5,7 +5,7 @@
 //! This also includes code for pattern bindings in `let` statements and
 //! function parameters.
 
-use crate::build::scope::{CachedBlock, DropKind};
+use crate::build::scope::DropKind;
 use crate::build::ForGuard::{self, OutsideGuard, RefWithinGuard};
 use crate::build::{BlockAnd, BlockAndExtension, Builder};
 use crate::build::{GuardFrame, GuardFrameLocal, LocalsForNode};
@@ -544,7 +544,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
         let place = Place::Base(PlaceBase::Local(local_id));
         let var_ty = self.local_decls[local_id].ty;
         let region_scope = self.hir.region_scope_tree.var_scope(var.local_id);
-        self.schedule_drop(span, region_scope, &place, var_ty, DropKind::Storage { cached_block: CachedBlock::default() });
+        self.schedule_drop(span, region_scope, &place, var_ty, DropKind::Storage);
         place
     }
 
@@ -557,9 +557,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             region_scope,
             &Place::Base(PlaceBase::Local(local_id)),
             var_ty,
-            DropKind::Value {
-                cached_block: CachedBlock::default(),
-            },
+            DropKind::Value,
         );
     }
 

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -1,5 +1,5 @@
 use crate::build;
-use crate::build::scope::{CachedBlock, DropKind};
+use crate::build::scope::DropKind;
 use crate::hair::cx::Cx;
 use crate::hair::{LintLevel, BindingMode, PatternKind};
 use crate::shim;
@@ -912,8 +912,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             // Make sure we drop (parts of) the argument even when not matched on.
             self.schedule_drop(
                 pattern.as_ref().map_or(ast_body.span, |pat| pat.span),
-                argument_scope, &place, ty,
-                DropKind::Value { cached_block: CachedBlock::default() },
+                argument_scope, &place, ty, DropKind::Value,
             );
 
             if let Some(pattern) = pattern {

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -726,7 +726,7 @@ impl<'a, 'gcx, 'tcx> Builder<'a, 'gcx, 'tcx> {
             // Note that this code iterates scopes from the inner-most to the outer-most,
             // invalidating caches of each scope visited. This way bare minimum of the
             // caches gets invalidated. i.e., if a new drop is added into the middle scope, the
-            // cache of outer scpoe stays intact.
+            // cache of outer scope stays intact.
             scope.invalidate_cache(!needs_drop, self.is_generator, this_scope);
             if this_scope {
                 if let DropKind::Value = drop_kind {

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -43,16 +43,9 @@ impl<'a, 'tcx> BitDenotation<'tcx> for MaybeStorageLive<'a, 'tcx> {
     }
 
     fn terminator_effect(&self,
-                         sets: &mut BlockSets<'_, Local>,
-                         loc: Location) {
-        match &self.mir[loc.block].terminator().kind {
-            TerminatorKind::Drop { location, .. } => {
-                if let Some(l) = location.local_or_deref_local() {
-                    sets.kill(l);
-                }
-            }
-            _ => (),
-        }
+                         _sets: &mut BlockSets<'_, Local>,
+                         _loc: Location) {
+        // Terminators have no effect
     }
 
     fn propagate_call_return(

--- a/src/test/mir-opt/generator-storage-dead-unwind.rs
+++ b/src/test/mir-opt/generator-storage-dead-unwind.rs
@@ -1,0 +1,106 @@
+// ignore-wasm32-bare compiled with panic=abort by default
+
+// Test that we generate StorageDead on unwind paths for generators.
+//
+// Basic block and local names can safely change, but the StorageDead statements
+// should not go away.
+
+#![feature(generators, generator_trait)]
+
+struct Foo(i32);
+
+impl Drop for Foo {
+    fn drop(&mut self) {}
+}
+
+struct Bar(i32);
+
+fn take<T>(_x: T) {}
+
+fn main() {
+    let _gen = || {
+        let a = Foo(5);
+        let b = Bar(6);
+        yield;
+        take(a);
+        take(b);
+    };
+}
+
+// END RUST SOURCE
+
+// START rustc.main-{{closure}}.StateTransform.before.mir
+// ...
+// let _2: Foo;
+// ...
+// let mut _7: Foo;
+// ...
+// let mut _9: Bar;
+// scope 1 {
+//     let _3: Bar;
+//     scope 2 {
+//     }
+// }
+// bb0: {
+//     StorageLive(_2);
+//     _2 = Foo(const 5i32,);
+//     StorageLive(_3);
+//     _3 = Bar(const 6i32,);
+//     ...
+//     _1 = suspend(move _5) -> [resume: bb2, drop: bb4];
+// }
+// bb1 (cleanup): {
+//     resume;
+// }
+// bb2: {
+//     ...
+//     StorageLive(_7);
+//     _7 = move _2;
+//     _6 = const take::<Foo>(move _7) -> [return: bb9, unwind: bb8];
+// }
+// bb3 (cleanup): {
+//     StorageDead(_2);
+//     drop(_1) -> bb1;
+// }
+// bb4: {
+//     ...
+//     StorageDead(_3);
+//     drop(_2) -> [return: bb5, unwind: bb3];
+// }
+// bb5: {
+//     StorageDead(_2);
+//     drop(_1) -> [return: bb6, unwind: bb1];
+// }
+// bb6: {
+//     generator_drop;
+// }
+// bb7 (cleanup): {
+//     StorageDead(_3);
+//     StorageDead(_2);
+//     drop(_1) -> bb1;
+// }
+// bb8 (cleanup): {
+//     StorageDead(_7);
+//     goto -> bb7;
+// }
+// bb9: {
+//     StorageDead(_7);
+//     StorageLive(_9);
+//     _9 = move _3;
+//     _8 = const take::<Bar>(move _9) -> [return: bb10, unwind: bb11];
+// }
+// bb10: {
+//     StorageDead(_9);
+//     ...
+//     StorageDead(_3);
+//     StorageDead(_2);
+//     drop(_1) -> [return: bb12, unwind: bb1];
+// }
+// bb11 (cleanup): {
+//     StorageDead(_9);
+//     goto -> bb7;
+// }
+// bb12: {
+//     return;
+// }
+// END rustc.main-{{closure}}.StateTransform.before.mir

--- a/src/test/run-pass/generator/drop-and-replace.rs
+++ b/src/test/run-pass/generator/drop-and-replace.rs
@@ -1,0 +1,44 @@
+// Regression test for incorrect DropAndReplace behavior introduced in #60840
+// and fixed in #61373. When combined with the optimization implemented in
+// #60187, this produced incorrect code for generators when a saved local was
+// re-assigned.
+
+#![feature(generators, generator_trait)]
+
+use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
+
+#[derive(Debug, PartialEq)]
+struct Foo(i32);
+
+impl Drop for Foo {
+    fn drop(&mut self) { }
+}
+
+fn main() {
+    let mut a = || {
+        let mut x = Foo(4);
+        yield;
+        assert_eq!(x.0, 4);
+
+        // At one point this tricked our dataflow analysis into thinking `x` was
+        // StorageDead after the assignment.
+        x = Foo(5);
+        assert_eq!(x.0, 5);
+
+        {
+            let y = Foo(6);
+            yield;
+            assert_eq!(y.0, 6);
+        }
+
+        assert_eq!(x.0, 5);
+    };
+
+    loop {
+        match Pin::new(&mut a).resume() {
+            GeneratorState::Complete(()) => break,
+            _ => (),
+        }
+    }
+}


### PR DESCRIPTION
Completion of the work done in #60840. That PR made a change to implicitly consider a local `StorageDead` after Drop, but that was incorrect for DropAndReplace (see also #61060 which tried to fix this in a different way).

This finally enables the optimization implemented in #60187.

r? @eddyb 
cc @Zoxc @cramertj @RalfJung 