### PR TITLE
Use statx on Linux

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -18,7 +18,8 @@ alloc = { path = "../liballoc" }
 panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 core = { path = "../libcore" }
-libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of-std'] }
+# libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { git = "https://github.com/rust-lang/libc", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.15" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }

--- a/src/libstd/os/linux/fs.rs
+++ b/src/libstd/os/linux/fs.rs
@@ -72,6 +72,10 @@ pub trait MetadataExt {
     ///     Ok(())
     /// }
     /// ```
+    #[unstable(feature = "metadata_linux_statx", issue = "59743")]
+    fn st_dev_major(&self) -> u32;
+    #[unstable(feature = "metadata_linux_statx", issue = "59743")]
+    fn st_dev_minor(&self) -> u32;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_ino(&self) -> u64;
     /// Returns the file type and mode.
@@ -177,6 +181,10 @@ pub trait MetadataExt {
     ///     Ok(())
     /// }
     /// ```
+    #[unstable(feature = "metadata_linux_statx", issue = "59743")]
+    fn st_rdev_major(&self) -> u32;
+    #[unstable(feature = "metadata_linux_statx", issue = "59743")]
+    fn st_rdev_minor(&self) -> u32;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_size(&self) -> u64;
     /// Returns the last access time of the file, in seconds since Unix Epoch.
@@ -230,6 +238,10 @@ pub trait MetadataExt {
     ///     Ok(())
     /// }
     /// ```
+    #[unstable(feature = "linux_statx", issue = "59743")]
+    fn st_btime(&self) -> i64;
+    #[unstable(feature = "linux_statx", issue= "59743")]
+    fn st_btime_nsec(&self) -> i64;
     #[stable(feature = "metadata_ext2", since = "1.8.0")]
     fn st_mtime(&self) -> i64;
     /// Returns the last modification time of the file, in nanoseconds since [`st_mtime`].
@@ -328,56 +340,74 @@ impl MetadataExt for Metadata {
     #[allow(deprecated)]
     fn as_raw_stat(&self) -> &raw::stat {
         unsafe {
-            &*(self.as_inner().as_inner() as *const libc::stat64
+            &*(self.as_inner().as_inner() as *const libc::statx
                                           as *const raw::stat)
         }
     }
     fn st_dev(&self) -> u64 {
-        self.as_inner().as_inner().st_dev as u64
+        (unsafe { libc::makedev(self.st_dev_major(), self.st_dev_minor()) }) as u64
+    }
+    fn st_dev_major(&self) -> u32 {
+        self.as_inner().as_inner().stx_dev_major as u32
+    }
+    fn st_dev_minor(&self) -> u32 {
+        self.as_inner().as_inner().stx_dev_minor as u32
     }
     fn st_ino(&self) -> u64 {
-        self.as_inner().as_inner().st_ino as u64
+        self.as_inner().as_inner().stx_ino as u64
     }
     fn st_mode(&self) -> u32 {
-        self.as_inner().as_inner().st_mode as u32
+        self.as_inner().as_inner().stx_mode as u32
     }
     fn st_nlink(&self) -> u64 {
-        self.as_inner().as_inner().st_nlink as u64
+        self.as_inner().as_inner().stx_nlink as u64
     }
     fn st_uid(&self) -> u32 {
-        self.as_inner().as_inner().st_uid as u32
+        self.as_inner().as_inner().stx_uid as u32
     }
     fn st_gid(&self) -> u32 {
-        self.as_inner().as_inner().st_gid as u32
+        self.as_inner().as_inner().stx_gid as u32
     }
     fn st_rdev(&self) -> u64 {
-        self.as_inner().as_inner().st_rdev as u64
+        (unsafe { libc::makedev(self.st_rdev_major(), self.st_rdev_minor()) }) as u64
+    }
+    fn st_rdev_major(&self) -> u32 {
+        self.as_inner().as_inner().stx_rdev_major as u32
+    }
+    fn st_rdev_minor(&self) -> u32 {
+        self.as_inner().as_inner().stx_rdev_minor as u32
     }
     fn st_size(&self) -> u64 {
-        self.as_inner().as_inner().st_size as u64
+        self.as_inner().as_inner().stx_size as u64
     }
     fn st_atime(&self) -> i64 {
-        self.as_inner().as_inner().st_atime as i64
+        self.as_inner().as_inner().stx_atime.tv_sec as i64
     }
     fn st_atime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_atime_nsec as i64
+        self.as_inner().as_inner().stx_atime.tv_nsec as i64
+    }
+    fn st_btime(&self) -> i64 {
+        self.as_inner().as_inner().stx_btime.tv_sec as i64
+    }
+    fn st_btime_nsec(&self) -> i64 {
+        self.as_inner().as_inner().stx_btime.tv_nsec as i64
     }
     fn st_mtime(&self) -> i64 {
-        self.as_inner().as_inner().st_mtime as i64
+        self.as_inner().as_inner().stx_mtime.tv_sec as i64
     }
     fn st_mtime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_mtime_nsec as i64
+        self.as_inner().as_inner().stx_mtime.tv_nsec as i64
     }
     fn st_ctime(&self) -> i64 {
-        self.as_inner().as_inner().st_ctime as i64
+        self.as_inner().as_inner().stx_ctime.tv_sec as i64
     }
     fn st_ctime_nsec(&self) -> i64 {
-        self.as_inner().as_inner().st_ctime_nsec as i64
+        self.as_inner().as_inner().stx_ctime.tv_nsec as i64
     }
     fn st_blksize(&self) -> u64 {
-        self.as_inner().as_inner().st_blksize as u64
+        self.as_inner().as_inner().stx_blksize as u64
     }
     fn st_blocks(&self) -> u64 {
-        self.as_inner().as_inner().st_blocks as u64
+        self.as_inner().as_inner().stx_blocks as u64
     }
 }


### PR DESCRIPTION
Fix #59743

Using `statx` on Linux notably gives us access to `stx_btime` so we can return a value for `Metadata::created()`.

I implemented the feature but need time to improve the code:

- [ ] Update the
- [ ] Find how to fallback in an efficient way when glibc version < 2.28
    - [ ] `stat64` and `statx` returns different `struct`s, and it seems that right now it’s not possible to know the glibc version at compile-time. I can make `FileAttr` an `enum` which can be either one.
  - [ ] Should I use `sys::os::glibc_version()` or something like https://github.com/rust-lang/rust/blob/9ebf47851a357faa4cd97f4b1dc7835f6376e639/src/libstd/sys/unix/fast_thread_local.rs#L24
- [ ] I added `st_{r,}dev_{major,minor}`, but I’m not sure it’s the proper way to do it.
- [ ] Being able to access all fields of `statx` as functions like the other information is probably something that you’d like to have.