### PR TITLE
Re-implement async fn drop order lowering 

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -262,9 +262,6 @@ pub trait Visitor<'v> : Sized {
     fn visit_pat(&mut self, p: &'v Pat) {
         walk_pat(self, p)
     }
-    fn visit_argument_source(&mut self, s: &'v ArgSource) {
-        walk_argument_source(self, s)
-    }
     fn visit_anon_const(&mut self, c: &'v AnonConst) {
         walk_anon_const(self, c)
     }
@@ -402,15 +399,8 @@ pub fn walk_body<'v, V: Visitor<'v>>(visitor: &mut V, body: &'v Body) {
     for argument in &body.arguments {
         visitor.visit_id(argument.hir_id);
         visitor.visit_pat(&argument.pat);
-        visitor.visit_argument_source(&argument.source);
     }
     visitor.visit_expr(&body.value);
-}
-
-pub fn walk_argument_source<'v, V: Visitor<'v>>(visitor: &mut V, source: &'v ArgSource) {
-    if let ArgSource::AsyncFn(pat) = source {
-        visitor.visit_pat(pat);
-    }
 }
 
 pub fn walk_local<'v, V: Visitor<'v>>(visitor: &mut V, local: &'v Local) {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -3092,7 +3092,7 @@ impl<'a> LoweringContext<'a> {
                                                    new_argument_id, ident, None),
                         span: desugared_span,
                     }),
-                    source: hir::ArgSource::AsyncFn(argument.pat.hir_id),
+                    source: hir::ArgSource::AsyncFn,
                 };
 
                 let construct_stmt = |this: &mut LoweringContext<'_>, pat: P<hir::Pat>,

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2285,7 +2285,6 @@ impl<'a> LoweringContext<'a> {
         hir::Arg {
             hir_id: self.lower_node_id(arg.id),
             pat: self.lower_pat(&arg.pat),
-            source: hir::ArgSource::Normal,
         }
     }
 
@@ -3091,7 +3090,6 @@ impl<'a> LoweringContext<'a> {
                 let new_argument = hir::Arg {
                     hir_id: argument.hir_id,
                     pat: new_argument_pat,
-                    source: hir::ArgSource::AsyncFn
                 };
 
                 if is_simple_argument {

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -699,19 +699,6 @@ impl<'hir> Map<'hir> {
         }
     }
 
-    /// Returns the `HirId` of this pattern, or, if this is an `async fn` desugaring, the `HirId`
-    /// of the original pattern that the user wrote.
-    pub fn original_pat_of_argument(&self, arg: &'hir Arg) -> &'hir Pat {
-        match &arg.source {
-            ArgSource::Normal => &*arg.pat,
-            ArgSource::AsyncFn(hir_id) => match self.find_by_hir_id(*hir_id) {
-                Some(Node::Pat(pat)) | Some(Node::Binding(pat)) => &pat,
-                Some(Node::Local(local)) => &*local.pat,
-                x => bug!("ArgSource::AsyncFn HirId not a pattern/binding/local: {:?}", x),
-            },
-        }
-    }
-
     pub fn is_const_scope(&self, hir_id: HirId) -> bool {
         self.walk_parent_nodes(hir_id, |node| match *node {
             Node::Item(Item { node: ItemKind::Const(_, _), .. }) => true,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1937,8 +1937,8 @@ pub struct Arg {
 pub enum ArgSource {
     /// Argument as specified by the user.
     Normal,
-    /// Generated argument from `async fn` lowering, `HirId` is the original pattern.
-    AsyncFn(HirId),
+    /// Generated argument from `async fn` lowering.
+    AsyncFn,
 }
 
 /// Represents the header (not the body) of a function declaration.

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1932,23 +1932,13 @@ pub struct Arg {
     pub source: ArgSource,
 }
 
-impl Arg {
-    /// Returns the pattern representing the original binding for this argument.
-    pub fn original_pat(&self) -> &P<Pat> {
-        match &self.source {
-            ArgSource::Normal => &self.pat,
-            ArgSource::AsyncFn(pat) => &pat,
-        }
-    }
-}
-
 /// Represents the source of an argument in a function header.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
 pub enum ArgSource {
     /// Argument as specified by the user.
     Normal,
-    /// Generated argument from `async fn` lowering, contains the original binding pattern.
-    AsyncFn(P<Pat>),
+    /// Generated argument from `async fn` lowering, `HirId` is the original pattern.
+    AsyncFn(HirId),
 }
 
 /// Represents the header (not the body) of a function declaration.

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1929,16 +1929,6 @@ pub struct InlineAsm {
 pub struct Arg {
     pub pat: P<Pat>,
     pub hir_id: HirId,
-    pub source: ArgSource,
-}
-
-/// Represents the source of an argument in a function header.
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]
-pub enum ArgSource {
-    /// Argument as specified by the user.
-    Normal,
-    /// Generated argument from `async fn` lowering.
-    AsyncFn,
 }
 
 /// Represents the header (not the body) of a function declaration.

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -86,12 +86,14 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         let sub_is_ret_type =
             self.is_return_type_anon(scope_def_id_sub, bregion_sub, ty_fndecl_sub);
 
-        let span_label_var1 = match anon_arg_sup.original_pat().simple_ident() {
+        let arg_sup_pat = self.tcx().hir().original_pat_of_argument(anon_arg_sup);
+        let span_label_var1 = match arg_sup_pat.simple_ident() {
             Some(simple_ident) => format!(" from `{}`", simple_ident),
             None => String::new(),
         };
 
-        let span_label_var2 = match anon_arg_sub.original_pat().simple_ident() {
+        let arg_sub_pat = self.tcx().hir().original_pat_of_argument(anon_arg_sub);
+        let span_label_var2 = match arg_sub_pat.simple_ident() {
             Some(simple_ident) => format!(" into `{}`", simple_ident),
             None => String::new(),
         };

--- a/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/different_lifetimes.rs
@@ -86,14 +86,12 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
         let sub_is_ret_type =
             self.is_return_type_anon(scope_def_id_sub, bregion_sub, ty_fndecl_sub);
 
-        let arg_sup_pat = self.tcx().hir().original_pat_of_argument(anon_arg_sup);
-        let span_label_var1 = match arg_sup_pat.simple_ident() {
+        let span_label_var1 = match anon_arg_sup.pat.simple_ident() {
             Some(simple_ident) => format!(" from `{}`", simple_ident),
             None => String::new(),
         };
 
-        let arg_sub_pat = self.tcx().hir().original_pat_of_argument(anon_arg_sub);
-        let span_label_var2 = match arg_sub_pat.simple_ident() {
+        let span_label_var2 = match anon_arg_sub.pat.simple_ident() {
             Some(simple_ident) => format!(" into `{}`", simple_ident),
             None => String::new(),
         };

--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -95,7 +95,8 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             }
         }
 
-        let (error_var, span_label_var) = match arg.original_pat().simple_ident() {
+        let arg_pat = self.tcx().hir().original_pat_of_argument(arg);
+        let (error_var, span_label_var) = match arg_pat.simple_ident() {
             Some(simple_ident) => (
                 format!("the type of `{}`", simple_ident),
                 format!("the type of `{}`", simple_ident),

--- a/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/named_anon_conflict.rs
@@ -95,8 +95,7 @@ impl<'a, 'gcx, 'tcx> NiceRegionError<'a, 'gcx, 'tcx> {
             }
         }
 
-        let arg_pat = self.tcx().hir().original_pat_of_argument(arg);
-        let (error_var, span_label_var) = match arg_pat.simple_ident() {
+        let (error_var, span_label_var) = match arg.pat.simple_ident() {
             Some(simple_ident) => (
                 format!("the type of `{}`", simple_ident),
                 format!("the type of `{}`", simple_ident),

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -1335,30 +1335,6 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
 
         run_early_pass!(self, check_mac, mac);
     }
-
-    fn visit_fn_header(&mut self, header: &'a ast::FnHeader) {
-        // Unlike in HIR lowering and name resolution, the `AsyncArgument` statements are not added
-        // to the function body and the arguments do not replace those in the declaration. They are
-        // still visited manually here so that buffered lints can be emitted.
-        if let ast::IsAsync::Async { ref arguments, .. } = header.asyncness.node {
-            for a in arguments {
-                // Visit the argument..
-                if let Some(arg) = &a.arg {
-                    self.visit_pat(&arg.pat);
-                    if let ast::ArgSource::AsyncFn(pat) = &arg.source {
-                        self.visit_pat(pat);
-                    }
-                    self.visit_ty(&arg.ty);
-                }
-
-                // ..and the statement.
-                self.visit_stmt(&a.move_stmt);
-                if let Some(pat_stmt) = &a.pat_stmt {
-                    self.visit_stmt(&pat_stmt);
-                }
-            }
-        }
-    }
 }
 
 struct LateLintPassObjects<'a> {

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2416,7 +2416,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
             let help_name = if let Some(body) = parent {
                 let arg = &self.tcx.hir().body(body).arguments[index];
-                format!("`{}`", self.tcx.hir().hir_to_pretty_string(arg.original_pat().hir_id))
+                let original_pat = self.tcx.hir().original_pat_of_argument(arg);
+                format!("`{}`", self.tcx.hir().hir_to_pretty_string(original_pat.hir_id))
             } else {
                 format!("argument {}", index + 1)
             };

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -2414,10 +2414,10 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 have_bound_regions,
             } = info;
 
-            let help_name = if let Some(body) = parent {
-                let arg = &self.tcx.hir().body(body).arguments[index];
-                let original_pat = self.tcx.hir().original_pat_of_argument(arg);
-                format!("`{}`", self.tcx.hir().hir_to_pretty_string(original_pat.hir_id))
+            let help_name = if let Some(ident) = parent.and_then(|body| {
+                self.tcx.hir().body(body).arguments[index].pat.simple_ident()
+            }) {
+                format!("`{}`", ident)
             } else {
                 format!("argument {}", index + 1)
             };

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -222,7 +222,7 @@ impl<'a> AstValidator<'a> {
         }
     }
 
-    fn check_trait_fn_not_async(&self, span: Span, asyncness: &IsAsync) {
+    fn check_trait_fn_not_async(&self, span: Span, asyncness: IsAsync) {
         if asyncness.is_async() {
             struct_span_err!(self.session, span, E0706,
                              "trait fns cannot be declared `async`").emit()
@@ -561,7 +561,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     self.invalid_visibility(&impl_item.vis, None);
                     if let ImplItemKind::Method(ref sig, _) = impl_item.node {
                         self.check_trait_fn_not_const(sig.header.constness);
-                        self.check_trait_fn_not_async(impl_item.span, &sig.header.asyncness.node);
+                        self.check_trait_fn_not_async(impl_item.span, sig.header.asyncness.node);
                     }
                 }
             }
@@ -633,7 +633,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.no_questions_in_bounds(bounds, "supertraits", true);
                 for trait_item in trait_items {
                     if let TraitItemKind::Method(ref sig, ref block) = trait_item.node {
-                        self.check_trait_fn_not_async(trait_item.span, &sig.header.asyncness.node);
+                        self.check_trait_fn_not_async(trait_item.span, sig.header.asyncness.node);
                         self.check_trait_fn_not_const(sig.header.constness);
                         if block.is_none() {
                             self.check_decl_no_pat(&sig.decl, |span, mut_ident| {

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -948,16 +948,6 @@ impl<'a, 'tcx> Visitor<'tcx> for NamePrivacyVisitor<'a, 'tcx> {
 
         intravisit::walk_pat(self, pat);
     }
-
-    fn visit_argument_source(&mut self, s: &'tcx hir::ArgSource) {
-        match s {
-            // Don't visit the pattern in `ArgSource::AsyncFn`, it contains a pattern which has
-            // a `NodeId` w/out a type, as it is only used for getting the name of the original
-            // pattern for diagnostics where only an `hir::Arg` is present.
-            hir::ArgSource::AsyncFn(..) => {},
-            _ => intravisit::walk_argument_source(self, s),
-        }
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1145,16 +1135,6 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
         }
 
         intravisit::walk_pat(self, pattern);
-    }
-
-    fn visit_argument_source(&mut self, s: &'tcx hir::ArgSource) {
-        match s {
-            // Don't visit the pattern in `ArgSource::AsyncFn`, it contains a pattern which has
-            // a `NodeId` w/out a type, as it is only used for getting the name of the original
-            // pattern for diagnostics where only an `hir::Arg` is present.
-            hir::ArgSource::AsyncFn(..) => {},
-            _ => intravisit::walk_argument_source(self, s),
-        }
     }
 
     fn visit_local(&mut self, local: &'tcx hir::Local) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -855,15 +855,10 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
                 _: NodeId)
     {
         debug!("(resolving function) entering function");
-        let (rib_kind, asyncness) = match function_kind {
-            FnKind::ItemFn(_, ref header, ..) =>
-                (FnItemRibKind, &header.asyncness.node),
-            FnKind::Method(_, ref sig, _, _) =>
-                (AssocItemRibKind, &sig.header.asyncness.node),
-            FnKind::Closure(_) =>
-                // Async closures aren't resolved through `visit_fn`-- they're
-                // processed separately
-                (NormalRibKind, &IsAsync::NotAsync),
+        let rib_kind = match function_kind {
+            FnKind::ItemFn(..) => FnItemRibKind,
+            FnKind::Method(..) => AssocItemRibKind,
+            FnKind::Closure(_) => NormalRibKind,
         };
 
         // Create a value rib for the function.
@@ -874,45 +869,20 @@ impl<'a, 'tcx> Visitor<'tcx> for Resolver<'a> {
 
         // Add each argument to the rib.
         let mut bindings_list = FxHashMap::default();
-        let mut add_argument = |argument: &ast::Arg| {
+        for argument in &declaration.inputs {
             self.resolve_pattern(&argument.pat, PatternSource::FnParam, &mut bindings_list);
+
             self.visit_ty(&argument.ty);
+
             debug!("(resolving function) recorded argument");
-        };
-
-        // Walk the generated async arguments if this is an `async fn`, otherwise walk the
-        // normal arguments.
-        if let IsAsync::Async { ref arguments, .. } = asyncness {
-            for (i, a) in arguments.iter().enumerate() {
-                if let Some(arg) = &a.arg {
-                    add_argument(&arg);
-                } else {
-                    add_argument(&declaration.inputs[i]);
-                }
-            }
-        } else {
-            for a in &declaration.inputs { add_argument(a); }
         }
-
         visit::walk_fn_ret_ty(self, &declaration.output);
 
         // Resolve the function body, potentially inside the body of an async closure
         match function_kind {
-            FnKind::ItemFn(.., body) | FnKind::Method(.., body) => {
-                if let IsAsync::Async { ref arguments, .. } = asyncness {
-                    let mut body = body.clone();
-                    // Insert the generated statements into the body before attempting to
-                    // resolve names.
-                    for a in arguments.iter().rev() {
-                        if let Some(pat_stmt) = a.pat_stmt.clone() {
-                            body.stmts.insert(0, pat_stmt);
-                        }
-                        body.stmts.insert(0, a.move_stmt.clone());
-                    }
-                    self.visit_block(&body);
-                } else {
-                    self.visit_block(body);
-                }
+            FnKind::ItemFn(.., body) |
+            FnKind::Method(.., body) => {
+                self.visit_block(body);
             }
             FnKind::Closure(body) => {
                 self.visit_expr(body);
@@ -4178,7 +4148,7 @@ impl<'a> Resolver<'a> {
         let add_module_candidates = |module: Module<'_>, names: &mut Vec<TypoSuggestion>| {
             for (&(ident, _), resolution) in module.resolutions.borrow().iter() {
                 if let Some(binding) = resolution.borrow().binding {
-                    if !ident.is_gensymed() && filter_fn(binding.res()) {
+                    if filter_fn(binding.res()) {
                         names.push(TypoSuggestion {
                             candidate: ident.name,
                             article: binding.res().article(),
@@ -4196,7 +4166,7 @@ impl<'a> Resolver<'a> {
             for rib in self.ribs[ns].iter().rev() {
                 // Locals and type parameters
                 for (ident, &res) in &rib.bindings {
-                    if !ident.is_gensymed() && filter_fn(res) {
+                    if filter_fn(res) {
                         names.push(TypoSuggestion {
                             candidate: ident.name,
                             article: res.article(),
@@ -4226,7 +4196,7 @@ impl<'a> Resolver<'a> {
                                             },
                                         );
 
-                                        if !ident.is_gensymed() && filter_fn(crate_mod) {
+                                        if filter_fn(crate_mod) {
                                             Some(TypoSuggestion {
                                                 candidate: ident.name,
                                                 article: "a",
@@ -4249,15 +4219,13 @@ impl<'a> Resolver<'a> {
             // Add primitive types to the mix
             if filter_fn(Res::PrimTy(Bool)) {
                 names.extend(
-                    self.primitive_type_table.primitive_types
-                        .iter()
-                        .map(|(name, _)| {
-                            TypoSuggestion {
-                                candidate: *name,
-                                article: "a",
-                                kind: "primitive type",
-                            }
-                        })
+                    self.primitive_type_table.primitive_types.iter().map(|(name, _)| {
+                        TypoSuggestion {
+                            candidate: *name,
+                            article: "a",
+                            kind: "primitive type",
+                        }
+                    })
                 )
             }
         } else {

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -374,7 +374,7 @@ impl Sig for ast::Item {
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            ast::ItemKind::Fn(ref decl, ref header, ref generics, _) => {
+            ast::ItemKind::Fn(ref decl, header, ref generics, _) => {
                 let mut text = String::new();
                 if header.constness.node == ast::Constness::Const {
                     text.push_str("const ");

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1009,16 +1009,6 @@ impl<'a, 'gcx, 'tcx> Visitor<'gcx> for GatherLocalsVisitor<'a, 'gcx, 'tcx> {
     // Don't descend into the bodies of nested closures
     fn visit_fn(&mut self, _: intravisit::FnKind<'gcx>, _: &'gcx hir::FnDecl,
                 _: hir::BodyId, _: Span, _: hir::HirId) { }
-
-    fn visit_argument_source(&mut self, s: &'gcx hir::ArgSource) {
-        match s {
-            // Don't visit the pattern in `ArgSource::AsyncFn`, it contains a pattern which has
-            // a `NodeId` w/out a type, as it is only used for getting the name of the original
-            // pattern for diagnostics where only an `hir::Arg` is present.
-            hir::ArgSource::AsyncFn(..) => {},
-            _ => intravisit::walk_argument_source(self, s),
-        }
-    }
 }
 
 /// When `check_fn` is invoked on a generator (i.e., a body that

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -311,16 +311,6 @@ impl<'cx, 'gcx, 'tcx> Visitor<'gcx> for WritebackCx<'cx, 'gcx, 'tcx> {
         let ty = self.resolve(&ty, &hir_ty.span);
         self.write_ty_to_tables(hir_ty.hir_id, ty);
     }
-
-    fn visit_argument_source(&mut self, s: &'gcx hir::ArgSource) {
-        match s {
-            // Don't visit the pattern in `ArgSource::AsyncFn`, it contains a pattern which has
-            // a `NodeId` w/out a type, as it is only used for getting the name of the original
-            // pattern for diagnostics where only an `hir::Arg` is present.
-            hir::ArgSource::AsyncFn(..) => {},
-            _ => intravisit::walk_argument_source(self, s),
-        }
-    }
 }
 
 impl<'cx, 'gcx, 'tcx> WritebackCx<'cx, 'gcx, 'tcx> {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2018,9 +2018,8 @@ impl<'a> Clean<Arguments> for (&'a [hir::Ty], hir::BodyId) {
 
         Arguments {
             values: self.0.iter().enumerate().map(|(i, ty)| {
-                let original_pat = cx.tcx.hir().original_pat_of_argument(&body.arguments[i]);
                 Argument {
-                    name: name_from_pat(original_pat),
+                    name: name_from_pat(&body.arguments[i].pat),
                     type_: ty.clean(cx),
                 }
             }).collect()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2018,8 +2018,9 @@ impl<'a> Clean<Arguments> for (&'a [hir::Ty], hir::BodyId) {
 
         Arguments {
             values: self.0.iter().enumerate().map(|(i, ty)| {
+                let original_pat = cx.tcx.hir().original_pat_of_argument(&body.arguments[i]);
                 Argument {
-                    name: name_from_pat(&body.arguments[i].original_pat()),
+                    name: name_from_pat(original_pat),
                     type_: ty.clean(cx),
                 }
             }).collect()

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -879,17 +879,6 @@ pub struct Local {
     pub id: NodeId,
     pub span: Span,
     pub attrs: ThinVec<Attribute>,
-    /// Origin of this local variable.
-    pub source: LocalSource,
-}
-
-#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
-pub enum LocalSource {
-    /// Local was parsed from source.
-    Normal,
-    /// Within `ast::IsAsync::Async`, a local is generated that will contain the moved arguments
-    /// of an `async fn`.
-    AsyncFn,
 }
 
 /// An arm of a 'match'.
@@ -1770,16 +1759,6 @@ pub struct Arg {
     pub ty: P<Ty>,
     pub pat: P<Pat>,
     pub id: NodeId,
-    pub source: ArgSource,
-}
-
-/// The source of an argument in a function header.
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub enum ArgSource {
-    /// Argument as written by the user.
-    Normal,
-    /// Argument from `async fn` lowering, contains the original binding pattern.
-    AsyncFn(P<Pat>),
 }
 
 /// Alternative representation for `Arg`s describing `self` parameter of methods.
@@ -1839,7 +1818,6 @@ impl Arg {
             }),
             ty,
             id: DUMMY_NODE_ID,
-            source: ArgSource::Normal,
         };
         match eself.node {
             SelfKind::Explicit(ty, mutbl) => arg(mutbl, ty),
@@ -1894,39 +1872,18 @@ pub enum Unsafety {
     Normal,
 }
 
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct AsyncArgument {
-    /// `__arg0`
-    pub ident: Ident,
-    /// `__arg0: <ty>` argument to replace existing function argument `<pat>: <ty>`. Only if
-    /// argument is not a simple binding.
-    pub arg: Option<Arg>,
-    /// `let __arg0 = __arg0;` statement to be inserted at the start of the block.
-    pub move_stmt: Stmt,
-    /// `let <pat> = __arg0;` statement to be inserted at the start of the block, after matching
-    /// move statement. Only if argument is not a simple binding.
-    pub pat_stmt: Option<Stmt>,
-}
-
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum IsAsync {
     Async {
         closure_id: NodeId,
         return_impl_trait_id: NodeId,
-        /// This field stores the arguments and statements that are used in HIR lowering to
-        /// ensure that `async fn` arguments are dropped at the correct time.
-        ///
-        /// The argument and statements here are generated at parse time as they are required in
-        /// both the hir lowering, def collection and name resolution and this stops them needing
-        /// to be created in each place.
-        arguments: Vec<AsyncArgument>,
     },
     NotAsync,
 }
 
 impl IsAsync {
-    pub fn is_async(&self) -> bool {
-        if let IsAsync::Async { .. } = *self {
+    pub fn is_async(self) -> bool {
+        if let IsAsync::Async { .. } = self {
             true
         } else {
             false
@@ -1934,12 +1891,12 @@ impl IsAsync {
     }
 
     /// In ths case this is an `async` return, the `NodeId` for the generated `impl Trait` item.
-    pub fn opt_return_id(&self) -> Option<NodeId> {
+    pub fn opt_return_id(self) -> Option<NodeId> {
         match self {
             IsAsync::Async {
                 return_impl_trait_id,
                 ..
-            } => Some(*return_impl_trait_id),
+            } => Some(return_impl_trait_id),
             IsAsync::NotAsync => None,
         }
     }
@@ -2279,7 +2236,7 @@ impl Item {
 ///
 /// All the information between the visibility and the name of the function is
 /// included in this struct (e.g., `async unsafe fn` or `const extern "C" fn`).
-#[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
 pub struct FnHeader {
     pub unsafety: Unsafety,
     pub asyncness: Spanned<IsAsync>,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -516,7 +516,6 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span: sp,
             attrs: ThinVec::new(),
-            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -545,7 +544,6 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span: sp,
             attrs: ThinVec::new(),
-            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -563,7 +561,6 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span,
             attrs: ThinVec::new(),
-            source: ast::LocalSource::Normal,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -971,8 +968,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         ast::Arg {
             ty,
             pat: arg_pat,
-            id: ast::DUMMY_NODE_ID,
-            source: ast::ArgSource::Normal,
+            id: ast::DUMMY_NODE_ID
         }
     }
 

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -27,7 +27,7 @@ crate fn dummy_arg(ident: Ident) -> Arg {
         span: ident.span,
         id: ast::DUMMY_NODE_ID
     };
-    Arg { ty: P(ty), pat: pat, id: ast::DUMMY_NODE_ID, source: ast::ArgSource::Normal }
+    Arg { ty: P(ty), pat: pat, id: ast::DUMMY_NODE_ID }
 }
 
 pub enum Error {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1,9 +1,9 @@
 // ignore-tidy-filelength
 
-use crate::ast::{AngleBracketedArgs, AsyncArgument, ParenthesizedArgs, AttrStyle, BareFnTy};
+use crate::ast::{AngleBracketedArgs, ParenthesizedArgs, AttrStyle, BareFnTy};
 use crate::ast::{GenericBound, TraitBoundModifier};
 use crate::ast::Unsafety;
-use crate::ast::{Mod, AnonConst, Arg, ArgSource, Arm, Guard, Attribute, BindingMode, TraitItemKind};
+use crate::ast::{Mod, AnonConst, Arg, Arm, Guard, Attribute, BindingMode, TraitItemKind};
 use crate::ast::Block;
 use crate::ast::{BlockCheckMode, CaptureBy, Movability};
 use crate::ast::{Constness, Crate};
@@ -16,7 +16,7 @@ use crate::ast::{GenericParam, GenericParamKind};
 use crate::ast::GenericArg;
 use crate::ast::{Ident, ImplItem, IsAsync, IsAuto, Item, ItemKind};
 use crate::ast::{Label, Lifetime};
-use crate::ast::{Local, LocalSource};
+use crate::ast::Local;
 use crate::ast::MacStmtStyle;
 use crate::ast::{Mac, Mac_, MacDelimiter};
 use crate::ast::{MutTy, Mutability};
@@ -51,7 +51,7 @@ use crate::parse::diagnostics::{Error, dummy_arg};
 
 use errors::{Applicability, DiagnosticBuilder, DiagnosticId, FatalError};
 use rustc_target::spec::abi::{self, Abi};
-use syntax_pos::{Span, BytePos, DUMMY_SP, FileName, hygiene::CompilerDesugaringKind};
+use syntax_pos::{Span, BytePos, DUMMY_SP, FileName};
 use log::debug;
 
 use std::borrow::Cow;
@@ -1126,7 +1126,6 @@ impl<'a> Parser<'a> {
             IsAsync::Async {
                 closure_id: ast::DUMMY_NODE_ID,
                 return_impl_trait_id: ast::DUMMY_NODE_ID,
-                arguments: Vec::new(),
             }
         } else {
             IsAsync::NotAsync
@@ -1185,12 +1184,12 @@ impl<'a> Parser<'a> {
             // trait item macro.
             (Ident::invalid(), ast::TraitItemKind::Macro(mac), ast::Generics::default())
         } else {
-            let (constness, unsafety, mut asyncness, abi) = self.parse_fn_front_matter()?;
+            let (constness, unsafety, asyncness, abi) = self.parse_fn_front_matter()?;
 
             let ident = self.parse_ident()?;
             let mut generics = self.parse_generics()?;
 
-            let mut decl = self.parse_fn_decl_with_self(|p: &mut Parser<'a>| {
+            let decl = self.parse_fn_decl_with_self(|p: &mut Parser<'a>| {
                 // This is somewhat dubious; We don't want to allow
                 // argument names to be left off if there is a
                 // definition...
@@ -1199,7 +1198,6 @@ impl<'a> Parser<'a> {
                 p.parse_arg_general(p.span.rust_2018(), true, false)
             })?;
             generics.where_clause = self.parse_where_clause()?;
-            self.construct_async_arguments(&mut asyncness, &mut decl);
 
             let sig = ast::MethodSig {
                 header: FnHeader {
@@ -1563,7 +1561,7 @@ impl<'a> Parser<'a> {
             }
         };
 
-        Ok(Arg { ty, pat, id: ast::DUMMY_NODE_ID, source: ast::ArgSource::Normal })
+        Ok(Arg { ty, pat, id: ast::DUMMY_NODE_ID })
     }
 
     /// Parses an argument in a lambda header (e.g., `|arg, arg|`).
@@ -1581,8 +1579,7 @@ impl<'a> Parser<'a> {
         Ok(Arg {
             ty: t,
             pat,
-            id: ast::DUMMY_NODE_ID,
-            source: ast::ArgSource::Normal,
+            id: ast::DUMMY_NODE_ID
         })
     }
 
@@ -4213,7 +4210,6 @@ impl<'a> Parser<'a> {
             id: ast::DUMMY_NODE_ID,
             span: lo.to(hi),
             attrs,
-            source: LocalSource::Normal,
         }))
     }
 
@@ -5660,16 +5656,15 @@ impl<'a> Parser<'a> {
     /// Parses an item-position function declaration.
     fn parse_item_fn(&mut self,
                      unsafety: Unsafety,
-                     mut asyncness: Spanned<IsAsync>,
+                     asyncness: Spanned<IsAsync>,
                      constness: Spanned<Constness>,
                      abi: Abi)
                      -> PResult<'a, ItemInfo> {
         let (ident, mut generics) = self.parse_fn_header()?;
         let allow_c_variadic = abi == Abi::C && unsafety == Unsafety::Unsafe;
-        let mut decl = self.parse_fn_decl(allow_c_variadic)?;
+        let decl = self.parse_fn_decl(allow_c_variadic)?;
         generics.where_clause = self.parse_where_clause()?;
         let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
-        self.construct_async_arguments(&mut asyncness, &mut decl);
         let header = FnHeader { unsafety, asyncness, constness, abi };
         Ok((ident, ItemKind::Fn(decl, header, generics, body), Some(inner_attrs)))
     }
@@ -5849,14 +5844,13 @@ impl<'a> Parser<'a> {
             Ok((Ident::invalid(), vec![], ast::Generics::default(),
                 ast::ImplItemKind::Macro(mac)))
         } else {
-            let (constness, unsafety, mut asyncness, abi) = self.parse_fn_front_matter()?;
+            let (constness, unsafety, asyncness, abi) = self.parse_fn_front_matter()?;
             let ident = self.parse_ident()?;
             let mut generics = self.parse_generics()?;
-            let mut decl = self.parse_fn_decl_with_self(|p| {
+            let decl = self.parse_fn_decl_with_self(|p| {
                 p.parse_arg_general(true, true, false)
             })?;
             generics.where_clause = self.parse_where_clause()?;
-            self.construct_async_arguments(&mut asyncness, &mut decl);
             *at_end = true;
             let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
             let header = ast::FnHeader { abi, unsafety, constness, asyncness };
@@ -7218,7 +7212,6 @@ impl<'a> Parser<'a> {
                                     respan(async_span, IsAsync::Async {
                                         closure_id: ast::DUMMY_NODE_ID,
                                         return_impl_trait_id: ast::DUMMY_NODE_ID,
-                                        arguments: Vec::new(),
                                     }),
                                     respan(fn_span, Constness::NotConst),
                                     Abi::Rust)?;
@@ -7848,116 +7841,6 @@ impl<'a> Parser<'a> {
             ';'.to_string(),
             Applicability::MaybeIncorrect,
         ).emit();
-    }
-
-    /// When lowering a `async fn` to the HIR, we need to move all of the arguments of the function
-    /// into the generated closure so that they are dropped when the future is polled and not when
-    /// it is created.
-    ///
-    /// The arguments of the function are replaced in HIR lowering with the arguments created by
-    /// this function and the statements created here are inserted at the top of the closure body.
-    fn construct_async_arguments(&mut self, asyncness: &mut Spanned<IsAsync>, decl: &mut FnDecl) {
-        // FIXME(davidtwco): This function should really live in the HIR lowering but because
-        // the types constructed here need to be used in parts of resolve so that the correct
-        // locals are considered upvars, it is currently easier for it to live here in the parser,
-        // where it can be constructed once.
-        if let IsAsync::Async { ref mut arguments, .. } = asyncness.node {
-            for (index, input) in decl.inputs.iter_mut().enumerate() {
-                let id = ast::DUMMY_NODE_ID;
-                let span = input.pat.span;
-                let desugared_span = self.sess.source_map()
-                    .mark_span_with_reason(CompilerDesugaringKind::Async, span, None);
-
-                // Construct a name for our temporary argument.
-                let name = format!("__arg{}", index);
-                let ident = Ident::from_str(&name).gensym();
-
-                // Check if this is a ident pattern, if so, we can optimize and avoid adding a
-                // `let <pat> = __argN;` statement, instead just adding a `let <pat> = <pat>;`
-                // statement.
-                let (binding_mode, ident, is_simple_pattern) = match input.pat.node {
-                    PatKind::Ident(binding_mode @ BindingMode::ByValue(_), ident, _) => {
-                        // Simple patterns like this don't have a generated argument, but they are
-                        // moved into the closure with a statement, so any `mut` bindings on the
-                        // argument will be unused. This binding mode can't be removed, because
-                        // this would affect the input to procedural macros, but they can have
-                        // their span marked as being the result of a compiler desugaring so
-                        // that they aren't linted against.
-                        input.pat.span = desugared_span;
-
-                        (binding_mode, ident, true)
-                    }
-                    _ => (BindingMode::ByValue(Mutability::Mutable), ident, false),
-                };
-
-                // Construct an argument representing `__argN: <ty>` to replace the argument of the
-                // async function if it isn't a simple pattern.
-                let arg = if is_simple_pattern {
-                    None
-                } else {
-                    Some(Arg {
-                        ty: input.ty.clone(),
-                        id,
-                        pat: P(Pat {
-                            id,
-                            node: PatKind::Ident(
-                                BindingMode::ByValue(Mutability::Immutable), ident, None,
-                            ),
-                            span: desugared_span,
-                        }),
-                        source: ArgSource::AsyncFn(input.pat.clone()),
-                    })
-                };
-
-                // Construct a `let __argN = __argN;` statement to insert at the top of the
-                // async closure. This makes sure that the argument is captured by the closure and
-                // that the drop order is correct.
-                let move_local = Local {
-                    pat: P(Pat {
-                        id,
-                        node: PatKind::Ident(binding_mode, ident, None),
-                        span: desugared_span,
-                    }),
-                    // We explicitly do not specify the type for this statement. When the user's
-                    // argument type is `impl Trait` then this would require the
-                    // `impl_trait_in_bindings` feature to also be present for that same type to
-                    // be valid in this binding. At the time of writing (13 Mar 19),
-                    // `impl_trait_in_bindings` is not stable.
-                    ty: None,
-                    init: Some(P(Expr {
-                        id,
-                        node: ExprKind::Path(None, ast::Path {
-                            span,
-                            segments: vec![PathSegment { ident, id, args: None }],
-                        }),
-                        span,
-                        attrs: ThinVec::new(),
-                    })),
-                    id,
-                    span,
-                    attrs: ThinVec::new(),
-                    source: LocalSource::AsyncFn,
-                };
-
-                // Construct a `let <pat> = __argN;` statement to insert at the top of the
-                // async closure if this isn't a simple pattern.
-                let pat_stmt = if is_simple_pattern {
-                    None
-                } else {
-                    Some(Stmt {
-                        id,
-                        node: StmtKind::Local(P(Local {
-                            pat: input.pat.clone(),
-                            ..move_local.clone()
-                        })),
-                        span,
-                    })
-                };
-
-                let move_stmt = Stmt { id, node: StmtKind::Local(P(move_local)), span };
-                arguments.push(AsyncArgument { ident, arg, pat_stmt, move_stmt });
-            }
-        }
     }
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -357,7 +357,7 @@ pub fn vis_to_string(v: &ast::Visibility) -> String {
 }
 
 pub fn fun_to_string(decl: &ast::FnDecl,
-                     header: &ast::FnHeader,
+                     header: ast::FnHeader,
                      name: ast::Ident,
                      generics: &ast::Generics)
                      -> String {
@@ -1040,7 +1040,7 @@ impl<'a> State<'a> {
         match item.node {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
                 self.head("")?;
-                self.print_fn(decl, &ast::FnHeader::default(),
+                self.print_fn(decl, ast::FnHeader::default(),
                               Some(item.ident),
                               generics, &item.vis)?;
                 self.end()?; // end head-ibox
@@ -1170,7 +1170,7 @@ impl<'a> State<'a> {
                 self.s.word(";")?;
                 self.end()?; // end the outer cbox
             }
-            ast::ItemKind::Fn(ref decl, ref header, ref param_names, ref body) => {
+            ast::ItemKind::Fn(ref decl, header, ref param_names, ref body) => {
                 self.head("")?;
                 self.print_fn(
                     decl,
@@ -1522,7 +1522,7 @@ impl<'a> State<'a> {
                             vis: &ast::Visibility)
                             -> io::Result<()> {
         self.print_fn(&m.decl,
-                      &m.header,
+                      m.header,
                       Some(ident),
                       &generics,
                       vis)
@@ -2113,7 +2113,7 @@ impl<'a> State<'a> {
                 self.bclose_(expr.span, INDENT_UNIT)?;
             }
             ast::ExprKind::Closure(
-                capture_clause, ref asyncness, movability, ref decl, ref body, _) => {
+                capture_clause, asyncness, movability, ref decl, ref body, _) => {
                 self.print_movability(movability)?;
                 self.print_asyncness(asyncness)?;
                 self.print_capture_clause(capture_clause)?;
@@ -2710,7 +2710,7 @@ impl<'a> State<'a> {
 
     pub fn print_fn(&mut self,
                     decl: &ast::FnDecl,
-                    header: &ast::FnHeader,
+                    header: ast::FnHeader,
                     name: Option<ast::Ident>,
                     generics: &ast::Generics,
                     vis: &ast::Visibility) -> io::Result<()> {
@@ -2765,7 +2765,8 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_asyncness(&mut self, asyncness: &ast::IsAsync) -> io::Result<()> {
+    pub fn print_asyncness(&mut self, asyncness: ast::IsAsync)
+                                -> io::Result<()> {
         if asyncness.is_async() {
             self.word_nbsp("async")?;
         }
@@ -3037,7 +3038,7 @@ impl<'a> State<'a> {
             span: syntax_pos::DUMMY_SP,
         };
         self.print_fn(decl,
-                      &ast::FnHeader { unsafety, abi, ..ast::FnHeader::default() },
+                      ast::FnHeader { unsafety, abi, ..ast::FnHeader::default() },
                       name,
                       &generics,
                       &source_map::dummy_spanned(ast::VisibilityKind::Inherited))?;
@@ -3100,7 +3101,7 @@ impl<'a> State<'a> {
     }
 
     pub fn print_fn_header_info(&mut self,
-                                header: &ast::FnHeader,
+                                header: ast::FnHeader,
                                 vis: &ast::Visibility) -> io::Result<()> {
         self.s.word(visibility_qualified(vis, ""))?;
 
@@ -3109,7 +3110,7 @@ impl<'a> State<'a> {
             ast::Constness::Const => self.word_nbsp("const")?
         }
 
-        self.print_asyncness(&header.asyncness.node)?;
+        self.print_asyncness(header.asyncness.node)?;
         self.print_unsafety(header.unsafety)?;
 
         if header.abi != Abi::Rust {
@@ -3158,7 +3159,7 @@ mod tests {
             assert_eq!(
                 fun_to_string(
                     &decl,
-                    &ast::FnHeader {
+                    ast::FnHeader {
                         unsafety: ast::Unsafety::Normal,
                         constness: source_map::dummy_spanned(ast::Constness::NotConst),
                         asyncness: source_map::dummy_spanned(ast::IsAsync::NotAsync),

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -935,27 +935,6 @@ impl SourceMap {
 
         None
     }
-
-    /// Reuses the span but adds information like the kind of the desugaring and features that are
-    /// allowed inside this span.
-    pub fn mark_span_with_reason(
-        &self,
-        reason: hygiene::CompilerDesugaringKind,
-        span: Span,
-        allow_internal_unstable: Option<Lrc<[symbol::Symbol]>>,
-    ) -> Span {
-        let mark = Mark::fresh(Mark::root());
-        mark.set_expn_info(ExpnInfo {
-            call_site: span,
-            def_site: Some(span),
-            format: CompilerDesugaring(reason),
-            allow_internal_unstable,
-            allow_internal_unsafe: false,
-            local_inner_macros: false,
-            edition: edition::Edition::from_session(),
-        });
-        span.with_ctxt(SyntaxContext::empty().apply_mark(mark))
-    }
 }
 
 impl SourceMapper for SourceMap {

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -544,9 +544,6 @@ pub fn walk_fn_ret_ty<'a, V: Visitor<'a>>(visitor: &mut V, ret_ty: &'a FunctionR
 pub fn walk_fn_decl<'a, V: Visitor<'a>>(visitor: &mut V, function_declaration: &'a FnDecl) {
     for argument in &function_declaration.inputs {
         visitor.visit_pat(&argument.pat);
-        if let ArgSource::AsyncFn(pat) = &argument.source {
-            visitor.visit_pat(pat);
-        }
         visitor.visit_ty(&argument.ty)
     }
     visitor.visit_fn_ret_ty(&function_declaration.output)

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -129,7 +129,6 @@ fn stmt_let_undescore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast
         id: ast::DUMMY_NODE_ID,
         span: sp,
         attrs: ThinVec::new(),
-        source: ast::LocalSource::Normal,
     });
     ast::Stmt {
         id: ast::DUMMY_NODE_ID,

--- a/src/test/ui/async-await/issues/issue-61187.rs
+++ b/src/test/ui/async-await/issues/issue-61187.rs
@@ -1,0 +1,9 @@
+// edition:2018
+#![feature(async_await)]
+
+fn main() {
+}
+
+async fn response(data: Vec<u8>) {
+    data.reverse(); //~ ERROR E0596
+}

--- a/src/test/ui/async-await/issues/issue-61187.stderr
+++ b/src/test/ui/async-await/issues/issue-61187.stderr
@@ -1,0 +1,11 @@
+error[E0596]: cannot borrow `data` as mutable, as it is not declared as mutable
+  --> $DIR/issue-61187.rs:8:5
+   |
+LL | async fn response(data: Vec<u8>) {
+   |                   ---- help: consider changing this to be mutable: `mut data`
+LL |     data.reverse();
+   |     ^^^^ cannot borrow as mutable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0596`.

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -30,7 +30,7 @@ error[E0106]: missing lifetime specifier
 LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |                                   ^^ expected lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_` or `y`
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
 
 error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This PR re-implements the async fn drop order lowering changes so
that it all takes place in HIR lowering, building atop the work done by
@eddyb to refactor `Res::Upvar`.

Previously, this types involved in the lowering were constructed in
libsyntax as they had to be used during name resolution and HIR
lowering. This was awful because none of that logic should have existed
in libsyntax.

This commit also changes `ArgSource` to keep a `HirId` to the original
argument pattern rather than a cloned copy of the pattern.

Only b7aa4ed and 71fb8fa should be reviewed, any other commits
are from #61276 (though 447e336 might end up staying in this PR).

As a nice side effect, it also fixes #61187 (cc #61192).

r? @eddyb 
cc @cramertj 