### PR TITLE
Improve determinism/security of CI environment

### DIFF
--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -29,6 +29,7 @@ ENV PATH=/rustroot/bin:$PATH
 ENV LD_LIBRARY_PATH=/rustroot/lib64:/rustroot/lib
 ENV PKG_CONFIG_PATH=/rustroot/lib/pkgconfig
 WORKDIR /tmp
+COPY scripts/secure-download.sh /tmp/
 COPY dist-x86_64-linux/shared.sh /tmp/
 
 # We need a build of openssl which supports SNI to download artifacts from

--- a/src/ci/docker/dist-x86_64-linux/build-binutils.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-binutils.sh
@@ -4,7 +4,10 @@ set -ex
 
 source shared.sh
 
-curl https://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2 | tar xfj -
+URL=https://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2
+SHA256=b5b14added7d78a8d1ca70b5cb75fef57ce2197264f4f5835326b0df22ac9f22
+
+./secure-download.sh $URL $SHA256 | tar xfj -
 
 mkdir binutils-build
 cd binutils-build

--- a/src/ci/docker/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-clang.sh
@@ -5,12 +5,13 @@ set -ex
 source shared.sh
 
 LLVM=llvmorg-8.0.0-rc2
+URL=https://github.com/llvm/llvm-project/archive/$LLVM.tar.gz
+SHA256=1ff35c058e58274faea2dc92388baa31e51baff207070613e96489b4b2d9bdd9
 
 mkdir llvm-project
 cd llvm-project
 
-curl -L https://github.com/llvm/llvm-project/archive/$LLVM.tar.gz | \
-  tar xzf - --strip-components=1
+../secure-download.sh $URL $SHA256 | tar xzf - --strip-components=1
 
 mkdir clang-build
 cd clang-build

--- a/src/ci/docker/dist-x86_64-linux/build-cmake.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-cmake.sh
@@ -3,7 +3,10 @@
 set -ex
 source shared.sh
 
-curl https://cmake.org/files/v3.6/cmake-3.6.3.tar.gz | tar xzf -
+URL=https://cmake.org/files/v3.6/cmake-3.6.3.tar.gz
+SHA256=7d73ee4fae572eb2d7cd3feb48971aea903bb30a20ea5ae8b4da826d8ccad5fe
+
+./secure-download.sh $URL $SHA256 | tar xzf -
 
 mkdir cmake-build
 cd cmake-build

--- a/src/ci/docker/dist-x86_64-linux/build-curl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-curl.sh
@@ -4,8 +4,10 @@ set -ex
 source shared.sh
 
 VERSION=7.51.0
+URL=http://cool.haxx.se/download/curl-$VERSION.tar.bz2
+SHA256=7f8240048907e5030f67be0a6129bc4b333783b9cca1391026d700835a788dde
 
-curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | tar xjf -
+./secure-download.sh $URL $SHA256 | tar xjf -
 
 mkdir curl-build
 cd curl-build

--- a/src/ci/docker/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-gcc.sh
@@ -4,8 +4,10 @@ set -ex
 source shared.sh
 
 GCC=5.5.0
+URL=https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz
+SHA256=530cea139d82fe542b358961130c69cfde8b3d14556370b65823d2f91f0ced87
 
-curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
+./secure-download.sh $URL $SHA256 | xzcat | tar xf -
 cd gcc-$GCC
 
 # FIXME(#49246): Remove the `sed` below.
@@ -24,6 +26,7 @@ cd gcc-$GCC
 #
 sed -i'' 's|ftp://gcc\.gnu\.org/|http://gcc.gnu.org/|g' ./contrib/download_prerequisites
 
+# FIXME this doesn't verify hashes and is subject to software supply chain attacks.
 ./contrib/download_prerequisites
 mkdir ../gcc-build
 cd ../gcc-build

--- a/src/ci/docker/dist-x86_64-linux/build-git.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-git.sh
@@ -3,7 +3,10 @@
 set -ex
 source shared.sh
 
-curl -L https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz | tar xzf -
+URL=https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz
+SHA256=207cfce8cc0a36497abb66236817ef449a45f6ff9141f586bbe2aafd7bc3d90b
+
+./secure-download.sh $URL $SHA256 | tar xzf -
 
 cd git-2.10.0
 make configure

--- a/src/ci/docker/dist-x86_64-linux/build-git.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-git.sh
@@ -3,16 +3,17 @@
 set -ex
 source shared.sh
 
-URL=https://www.kernel.org/pub/software/scm/git/git-2.10.0.tar.gz
-SHA256=207cfce8cc0a36497abb66236817ef449a45f6ff9141f586bbe2aafd7bc3d90b
+VERSION=2.21.0
+URL=https://www.kernel.org/pub/software/scm/git/git-$VERSION.tar.gz
+SHA256=85eca51c7404da75e353eba587f87fea9481ba41e162206a6f70ad8118147bee
 
 ./secure-download.sh $URL $SHA256 | tar xzf -
 
-cd git-2.10.0
+cd git-$VERSION
 make configure
 hide_output ./configure --prefix=/rustroot
 hide_output make -j10
 hide_output make install
 
 cd ..
-rm -rf git-2.10.0
+rm -rf git-$VERSION

--- a/src/ci/docker/dist-x86_64-linux/build-headers.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-headers.sh
@@ -3,7 +3,10 @@
 set -ex
 source shared.sh
 
-curl https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.2.84.tar.xz | unxz | tar x
+URL=https://cdn.kernel.org/pub/linux/kernel/v3.x/linux-3.2.84.tar.xz
+SHA256=66e329b56487a88f07274a4fa8ec1dfdab8a3df5c3812dd03589d393941b1d47
+
+./secure-download.sh $URL $SHA256 | unxz | tar x
 
 cd linux-3.2.84
 hide_output make mrproper

--- a/src/ci/docker/dist-x86_64-linux/build-openssl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-openssl.sh
@@ -5,8 +5,9 @@ source shared.sh
 
 VERSION=1.0.2k
 URL=https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/openssl-$VERSION.tar.gz
+SHA256=6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0
 
-curl $URL | tar xzf -
+./secure-download.sh $URL $SHA256 | tar xzf -
 
 cd openssl-$VERSION
 hide_output ./config --prefix=/rustroot shared -fPIC

--- a/src/ci/docker/dist-x86_64-linux/build-perl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-perl.sh
@@ -3,8 +3,10 @@
 set -ex
 source shared.sh
 
-curl https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz | \
-  tar xzf -
+URL=https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz
+SHA256=7e929f64d4cb0e9d1159d4a59fc89394e27fa1f7004d0836ca0d514685406ea8
+
+./secure-download.sh $URL $SHA256 | tar xzf -
 
 cd perl-5.28.0
 

--- a/src/ci/docker/dist-x86_64-linux/build-python.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-python.sh
@@ -3,8 +3,10 @@
 set -ex
 source shared.sh
 
-curl https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz | \
-  tar xzf -
+URL=https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz
+SHA256=3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6
+
+./secure-download.sh $URL $SHA256 | tar xzf -
 
 mkdir python-build
 cd python-build

--- a/src/ci/docker/scripts/musl-toolchain.sh
+++ b/src/ci/docker/scripts/musl-toolchain.sh
@@ -33,8 +33,11 @@ shift
 # Apparently applying `-fPIC` everywhere allows them to link successfully.
 export CFLAGS="-fPIC $CFLAGS"
 
-git clone https://github.com/richfelker/musl-cross-make -b v0.9.8
+git clone https://github.com/richfelker/musl-cross-make
 cd musl-cross-make
+# A full hash is used because unlike branch names and tags, hashes are immutable over time.
+# Corresponds to v0.9.8.
+git reset --hard 629189831f61b73ba1053624eee12ff6a816438f
 
 hide_output make -j$(nproc) TARGET=$TARGET
 hide_output make install TARGET=$TARGET OUTPUT=$OUTPUT

--- a/src/ci/docker/scripts/secure-download.sh
+++ b/src/ci/docker/scripts/secure-download.sh
@@ -1,0 +1,21 @@
+/bin/bash
+
+set -ex
+
+if [[ -z "$2" ]]; then
+  echo "usage: secure-download.sh <URL> <SHA256>"
+  exit 1
+fi
+
+URL=$1
+SHA256=$2
+BASENAME=`basename ${URL}`
+
+ON_EXIT="rm -f ${BASENAME}"
+
+trap "rm -f ${BASENAME}" EXIT
+curl -L ${URL} > ${BASENAME}
+echo "${SHA256} *${BASENAME}" | sha256sum --status -c -
+cat ${BASENAME}
+rm -f ${BASENAME}
+trap - EXIT


### PR DESCRIPTION
I wrote detailed commit messages explaining each of the changes I made. GitHub's PR UI (sadly) doesn't reward me for doing so by not giving me an opportunity to easily surface them in the PR description. Please read the commit messages for rationale behind this PR.

The short version is these commits improve the security of Rust's toolchain build environment. The commits are far from a comprehensive solution to the myriad of software supply chain weaknesses I found in Rust's CI. But they are a good start. I hope that with this PR I enlighten Rust maintainers about the existing non-deterministic, non-reproducible nature of Rust's CI and the security risks intrinsic to these properties. My goal is for Rust to commit to deterministic, reproducible CI for toolchain builds (at least as far as it concerns dependencies) so Rust toolchains aren't susceptible to software supply chain attacks via non-deterministic dependencies.