### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -120,7 +120,6 @@
 #![feature(const_str_len)]
 #![feature(const_int_conversion)]
 #![feature(const_transmute)]
-#![feature(reverse_bits)]
 #![feature(non_exhaustive)]
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -463,15 +463,12 @@ assert_eq!(m, ", $swapped, ");
 Basic usage:
 
 ```
-#![feature(reverse_bits)]
-
 let n = ", $swap_op, stringify!($SelfT), ";
 let m = n.reverse_bits();
 
 assert_eq!(m, ", $reversed, ");
 ```"),
-            #[unstable(feature = "reverse_bits", issue = "48763")]
-            #[rustc_const_unstable(feature = "const_int_conversion")]
+            #[stable(feature = "reverse_bits", since = "1.37.0")]
             #[inline]
             #[must_use]
             pub const fn reverse_bits(self) -> Self {
@@ -2514,14 +2511,12 @@ assert_eq!(m, ", $swapped, ");
 Basic usage:
 
 ```
-#![feature(reverse_bits)]
-
 let n = ", $swap_op, stringify!($SelfT), ";
 let m = n.reverse_bits();
 
 assert_eq!(m, ", $reversed, ");
 ```"),
-            #[unstable(feature = "reverse_bits", issue = "48763")]
+            #[stable(feature = "reverse_bits", since = "1.37.0")]
             #[inline]
             #[must_use]
             pub const fn reverse_bits(self) -> Self {

--- a/src/libcore/num/wrapping.rs
+++ b/src/libcore/num/wrapping.rs
@@ -511,7 +511,6 @@ assert_eq!(n.trailing_zeros(), 3);
             /// Basic usage:
             ///
             /// ```
-            /// #![feature(reverse_bits)]
             /// use std::num::Wrapping;
             ///
             /// let n = Wrapping(0b0000000_01010101i16);
@@ -522,7 +521,7 @@ assert_eq!(n.trailing_zeros(), 3);
             /// assert_eq!(m.0 as u16, 0b10101010_00000000);
             /// assert_eq!(m, Wrapping(-22016));
             /// ```
-            #[unstable(feature = "reverse_bits", issue = "48763")]
+            #[stable(feature = "reverse_bits", since = "1.37.0")]
             #[inline]
             #[must_use]
             pub const fn reverse_bits(self) -> Self {

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -25,7 +25,6 @@
 #![feature(test)]
 #![feature(trusted_len)]
 #![feature(try_trait)]
-#![feature(reverse_bits)]
 #![feature(inner_deref)]
 #![feature(slice_internals)]
 #![feature(slice_partition_dedup)]

--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -19,6 +19,14 @@ use smallvec::SmallVec;
 macro_rules! arena_types {
     ($macro:path, $args:tt, $tcx:lifetime) => (
         $macro!($args, [
+            [] layouts: rustc::ty::layout::LayoutDetails,
+            [] generics: rustc::ty::Generics,
+            [] trait_def: rustc::ty::TraitDef,
+            [] adt_def: rustc::ty::AdtDef,
+            [] steal_mir: rustc::ty::steal::Steal<rustc::mir::Body<$tcx>>,
+            [] mir: rustc::mir::Body<$tcx>,
+            [] tables: rustc::ty::TypeckTables<$tcx>,
+            [] const_allocs: rustc::mir::interpret::Allocation,
             [] vtable_method: Option<(
                 rustc::hir::def_id::DefId,
                 rustc::ty::subst::SubstsRef<$tcx>

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -100,7 +100,6 @@ for ty::RegionKind {
             ty::ReClosureBound(vid) => {
                 vid.hash_stable(hcx, hasher);
             }
-            ty::ReLateBound(..) |
             ty::ReVar(..) |
             ty::RePlaceholder(..) => {
                 bug!("StableHasher: unexpected region {:?}", *self)

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -218,10 +218,6 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
                     format!("the anonymous lifetime #{} defined on", idx + 1),
                     self.hir().span_by_hir_id(node),
                 ),
-                ty::BrFresh(_) => (
-                    "an anonymous lifetime defined on".to_owned(),
-                    self.hir().span_by_hir_id(node),
-                ),
                 _ => (
                     format!("the lifetime {} as defined on", region),
                     cm.def_span(self.hir().span_by_hir_id(node)),

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -42,7 +42,7 @@ rustc_queries! {
             load_cached(tcx, id) {
                 let generics: Option<ty::Generics> = tcx.queries.on_disk_cache
                                                         .try_load_query_result(tcx, id);
-                generics.map(|x| tcx.alloc_generics(x))
+                generics.map(|x| &*tcx.arena.alloc(x))
             }
         }
 
@@ -118,7 +118,7 @@ rustc_queries! {
             load_cached(tcx, id) {
                 let mir: Option<crate::mir::Body<'tcx>> = tcx.queries.on_disk_cache
                                                             .try_load_query_result(tcx, id);
-                mir.map(|x| tcx.alloc_mir(x))
+                mir.map(|x| &*tcx.arena.alloc(x))
             }
         }
     }
@@ -353,7 +353,7 @@ rustc_queries! {
                     .queries.on_disk_cache
                     .try_load_query_result(tcx, id);
 
-                typeck_tables.map(|tables| tcx.alloc_tables(tables))
+                typeck_tables.map(|tables| &*tcx.arena.alloc(tables))
             }
         }
     }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -75,7 +75,7 @@ pub use self::sty::TyKind::*;
 pub use self::binding::BindingMode;
 pub use self::binding::BindingMode::*;
 
-pub use self::context::{TyCtxt, FreeRegionInfo, GlobalArenas, AllArenas, tls, keep_local};
+pub use self::context::{TyCtxt, FreeRegionInfo, AllArenas, tls, keep_local};
 pub use self::context::{Lift, TypeckTables, CtxtInterners, GlobalCtxt};
 pub use self::context::{
     UserTypeAnnotationIndex, UserType, CanonicalUserType,

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -1441,7 +1441,6 @@ impl<F: fmt::Write> FmtPrinter<'_, 'gcx, 'tcx, F> {
                     br
                 }
                 ty::BrAnon(_) |
-                ty::BrFresh(_) |
                 ty::BrEnv => {
                     let name = loop {
                         let name = name_by_region_index(region_index);

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -94,7 +94,6 @@ impl fmt::Debug for ty::BoundRegion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             ty::BrAnon(n) => write!(f, "BrAnon({:?})", n),
-            ty::BrFresh(n) => write!(f, "BrFresh({:?})", n),
             ty::BrNamed(did, name) => {
                 write!(f, "BrNamed({:?}:{:?}, {})",
                         did.krate, did.index, name)

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -56,9 +56,6 @@ pub enum BoundRegion {
     /// the event of shadowing.
     BrNamed(DefId, InternedString),
 
-    /// Fresh bound identifiers created during GLB computations.
-    BrFresh(u32),
-
     /// Anonymous region for the implicit env pointer parameter
     /// to a closure
     BrEnv,

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -94,7 +94,7 @@ impl IntoArgs for (CrateNum, DefId) {
 provide! { <'tcx> tcx, def_id, other, cdata,
     type_of => { cdata.get_type(def_id.index, tcx) }
     generics_of => {
-        tcx.alloc_generics(cdata.get_generics(def_id.index, tcx.sess))
+        tcx.arena.alloc(cdata.get_generics(def_id.index, tcx.sess))
     }
     predicates_of => { tcx.arena.alloc(cdata.get_predicates(def_id.index, tcx)) }
     predicates_defined_on => {
@@ -102,7 +102,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     }
     super_predicates_of => { tcx.arena.alloc(cdata.get_super_predicates(def_id.index, tcx)) }
     trait_def => {
-        tcx.alloc_trait_def(cdata.get_trait_def(def_id.index, tcx.sess))
+        tcx.arena.alloc(cdata.get_trait_def(def_id.index, tcx.sess))
     }
     adt_def => { cdata.get_adt_def(def_id.index, tcx) }
     adt_destructor => {
@@ -129,7 +129,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
             bug!("get_optimized_mir: missing MIR for `{:?}`", def_id)
         });
 
-        let mir = tcx.alloc_mir(mir);
+        let mir = tcx.arena.alloc(mir);
 
         mir
     }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -274,7 +274,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     }
                 }
 
-                ty::BoundRegion::BrAnon(_) | ty::BoundRegion::BrFresh(_) => None,
+                ty::BoundRegion::BrAnon(_) => None,
             },
 
             ty::ReLateBound(..)

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -243,7 +243,7 @@ pub(super) fn from_known_layout<'tcx>(
 }
 
 impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> {
-    /// Try reading an immediate in memory; this is interesting particularly for ScalarPair.
+    /// Try reading an immediate in memory; this is interesting particularly for `ScalarPair`.
     /// Returns `None` if the layout does not permit loading this as a value.
     fn try_read_immediate_from_mplace(
         &self,
@@ -444,7 +444,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
         Ok(OpTy { op, layout })
     }
 
-    /// Every place can be read from, so we can turm them into an operand
+    /// Every place can be read from, so we can turn them into an operand
     #[inline(always)]
     pub fn place_to_op(
         &self,
@@ -500,7 +500,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
     }
 
     /// Evaluate the operand, returning a place where you can then find the data.
-    /// if you already know the layout, you can save two some table lookups
+    /// If you already know the layout, you can save two table lookups
     /// by passing it in here.
     pub fn eval_operand(
         &self,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -346,8 +346,8 @@ where
         Ok(place)
     }
 
-    /// Offset a pointer to project to a field. Unlike place_field, this is always
-    /// possible without allocating, so it can take &self. Also return the field's layout.
+    /// Offset a pointer to project to a field. Unlike `place_field`, this is always
+    /// possible without allocating, so it can take `&self`. Also return the field's layout.
     /// This supports both struct and array fields.
     #[inline(always)]
     pub fn mplace_field(
@@ -722,7 +722,7 @@ where
     }
 
     /// Write an immediate to memory.
-    /// If you use this you are responsible for validating that things git copied at the
+    /// If you use this you are responsible for validating that things got copied at the
     /// right type.
     fn write_immediate_to_mplace_no_validate(
         &mut self,
@@ -805,7 +805,7 @@ where
 
     /// Copies the data from an operand to a place. This does not support transmuting!
     /// Use `copy_op_transmute` if the layouts could disagree.
-    /// Also, if you use this you are responsible for validating that things git copied at the
+    /// Also, if you use this you are responsible for validating that things get copied at the
     /// right type.
     fn copy_op_no_validate(
         &mut self,

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -613,7 +613,7 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
     /// is an indirect operand.
     /// It will error if the bits at the destination do not match the ones described by the layout.
     ///
-    /// `ref_tracking` can be None to avoid recursive checking below references.
+    /// `ref_tracking` can be `None` to avoid recursive checking below references.
     /// This also toggles between "run-time" (no recursion) and "compile-time" (with recursion)
     /// validation (e.g., pointer values are fine in integers at runtime).
     pub fn validate_operand(

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -22,7 +22,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(unicode_internals)]
 #![feature(step_trait)]
 #![feature(slice_concat_ext)]
-#![feature(reverse_bits)]
 #![feature(try_blocks)]
 
 #![recursion_limit="256"]

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -125,7 +125,7 @@ fn make_shim<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>,
 
     debug!("make_shim({:?}) = {:?}", instance, result);
 
-    tcx.alloc_mir(result)
+    tcx.arena.alloc(result)
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -290,5 +290,5 @@ fn optimized_mir<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx 
         &add_call_guards::CriticalCallEdges,
         &dump_mir::Marker("PreCodegen"),
     ]);
-    tcx.alloc_mir(mir)
+    tcx.arena.alloc(mir)
 }

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2048,7 +2048,7 @@ impl<'o, 'gcx: 'tcx, 'tcx> dyn AstConv<'gcx, 'tcx> + 'o {
         for br in late_bound_in_ret.difference(&late_bound_in_args) {
             let lifetime_name = match *br {
                 ty::BrNamed(_, name) => format!("lifetime `{}`,", name),
-                ty::BrAnon(_) | ty::BrFresh(_) | ty::BrEnv => "an anonymous lifetime".to_string(),
+                ty::BrAnon(_) | ty::BrEnv => "an anonymous lifetime".to_string(),
             };
             let mut err = struct_span_err!(tcx.sess,
                                            decl.output.span(),

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -81,7 +81,7 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
             item_def_id, wbcx.tables
         );
 
-        self.tcx.alloc_tables(wbcx.tables)
+        self.tcx.arena.alloc(wbcx.tables)
     }
 }
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -763,7 +763,7 @@ fn trait_def<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty::
     let is_marker = tcx.has_attr(def_id, sym::marker);
     let def_path_hash = tcx.def_path_hash(def_id);
     let def = ty::TraitDef::new(def_id, unsafety, paren_sugar, is_auto, is_marker, def_path_hash);
-    tcx.alloc_trait_def(def)
+    tcx.arena.alloc(def)
 }
 
 fn has_late_bound_regions<'a, 'tcx>(
@@ -1110,7 +1110,7 @@ fn generics_of<'a, 'tcx>(tcx: TyCtxt<'a, 'tcx, 'tcx>, def_id: DefId) -> &'tcx ty
         .map(|param| (param.def_id, param.index))
         .collect();
 
-    tcx.alloc_generics(ty::Generics {
+    tcx.arena.alloc(ty::Generics {
         parent: parent_def_id,
         parent_count,
         params,

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -3804,7 +3804,7 @@ fn render_attributes(w: &mut dyn fmt::Write, it: &clean::Item, top: bool) -> fmt
         }
     }
     if attrs.len() > 0 {
-        write!(w, "<div class=\"docblock attributes{}\">{}</div>",
+        write!(w, "<span class=\"docblock attributes{}\">{}</span>",
                if top { " top-attr" } else { "" }, &attrs)?;
     }
     Ok(())

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -111,7 +111,7 @@ pub fn find_unwind_attr(diagnostic: Option<&Handler>, attrs: &[Attribute]) -> Op
 }
 
 /// Represents the #[stable], #[unstable], #[rustc_{deprecated,const_unstable}] attributes.
-#[derive(RustcEncodable, RustcDecodable, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(RustcEncodable, RustcDecodable, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Stability {
     pub level: StabilityLevel,
     pub feature: Symbol,
@@ -127,7 +127,7 @@ pub struct Stability {
 }
 
 /// The available stability levels.
-#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Clone, Debug, Eq, Hash)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Copy, Clone, Debug, Eq, Hash)]
 pub enum StabilityLevel {
     // Reason for the current stability level and the relevant rust-lang issue
     Unstable { reason: Option<Symbol>, issue: u32 },
@@ -151,7 +151,7 @@ impl StabilityLevel {
     }
 }
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Clone, Debug, Eq, Hash)]
+#[derive(RustcEncodable, RustcDecodable, PartialEq, PartialOrd, Copy, Clone, Debug, Eq, Hash)]
 pub struct RustcDeprecation {
     pub since: Symbol,
     pub reason: Symbol,

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1536,7 +1536,7 @@ fn calc_result(desc: &TestDesc, task_result: Result<(), Box<dyn Any + Send>>) ->
                 if desc.allow_fail {
                     TrAllowedFail
                 } else {
-                    TrFailedMsg(format!("Panic did not include expected string '{}'", msg))
+                    TrFailedMsg(format!("panic did not include expected string '{}'", msg))
                 }
             }
         }
@@ -1890,7 +1890,7 @@ mod tests {
             panic!("an error message");
         }
         let expected = "foobar";
-        let failed_msg = "Panic did not include expected string";
+        let failed_msg = "panic did not include expected string";
         let desc = TestDescAndFn {
             desc: TestDesc {
                 name: StaticTestName("whatever"),

--- a/src/test/run-pass/const-int-conversion.rs
+++ b/src/test/run-pass/const-int-conversion.rs
@@ -1,4 +1,4 @@
-#![feature(const_int_conversion, reverse_bits)]
+#![feature(const_int_conversion)]
 
 const REVERSE: u32 = 0x12345678_u32.reverse_bits();
 const FROM_BE_BYTES: i32 = i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]);

--- a/src/test/rustdoc/trait-attributes.rs
+++ b/src/test/rustdoc/trait-attributes.rs
@@ -3,7 +3,7 @@
 // ignore-tidy-linelength
 
 pub trait Foo {
-    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/trait.Foo.html '//h3[@id="tymethod.foo"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     fn foo();
 }
@@ -12,11 +12,11 @@ pub trait Foo {
 pub struct Bar;
 
 impl Bar {
-    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     pub fn bar() {}
 
-    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//div[@class="docblock attributes"]' '#[must_use]'
+    // @has foo/struct.Bar.html '//h4[@id="method.bar2"]//span[@class="docblock attributes"]' '#[must_use]'
     #[must_use]
     pub fn bar2() {}
 }

--- a/src/test/ui/consts/const-int-conversion.rs
+++ b/src/test/ui/consts/const-int-conversion.rs
@@ -1,5 +1,3 @@
-#![feature(reverse_bits)]
-
 fn main() {
     let x: &'static i32 = &(5_i32.reverse_bits());
         //~^ ERROR temporary value dropped while borrowed

--- a/src/test/ui/consts/const-int-conversion.stderr
+++ b/src/test/ui/consts/const-int-conversion.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:4:28
+  --> $DIR/const-int-conversion.rs:2:28
    |
 LL |     let x: &'static i32 = &(5_i32.reverse_bits());
    |            ------------    ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -10,7 +10,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:6:28
+  --> $DIR/const-int-conversion.rs:4:28
    |
 LL |     let y: &'static i32 = &(i32::from_be_bytes([0x12, 0x34, 0x56, 0x78]));
    |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -21,7 +21,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:8:28
+  --> $DIR/const-int-conversion.rs:6:28
    |
 LL |     let z: &'static i32 = &(i32::from_le_bytes([0x12, 0x34, 0x56, 0x78]));
    |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -32,7 +32,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:10:28
+  --> $DIR/const-int-conversion.rs:8:28
    |
 LL |     let a: &'static i32 = &(i32::from_be(i32::from_ne_bytes([0x80, 0, 0, 0])));
    |            ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -43,7 +43,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:12:29
+  --> $DIR/const-int-conversion.rs:10:29
    |
 LL |     let b: &'static [u8] = &(0x12_34_56_78_i32.to_be_bytes());
    |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -54,7 +54,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:14:29
+  --> $DIR/const-int-conversion.rs:12:29
    |
 LL |     let c: &'static [u8] = &(0x12_34_56_78_i32.to_le_bytes());
    |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use
@@ -65,7 +65,7 @@ LL | }
    | - temporary value is freed at the end of this statement
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/const-int-conversion.rs:16:29
+  --> $DIR/const-int-conversion.rs:14:29
    |
 LL |     let d: &'static [u8] = &(i32::min_value().to_be().to_ne_bytes());
    |            -------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use

--- a/src/test/ui/extern/extern-const.fixed
+++ b/src/test/ui/extern/extern-const.fixed
@@ -6,7 +6,7 @@
 
 // run-rustfix
 // ignore-wasm32 no external library to link to.
-// compile-flags: -g -Z continue-parse-after-error
+// compile-flags: -g
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/src/test/ui/extern/extern-const.rs
+++ b/src/test/ui/extern/extern-const.rs
@@ -6,7 +6,7 @@
 
 // run-rustfix
 // ignore-wasm32 no external library to link to.
-// compile-flags: -g -Z continue-parse-after-error
+// compile-flags: -g
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/src/test/ui/fmt/format-string-error-2.rs
+++ b/src/test/ui/fmt/format-string-error-2.rs
@@ -1,4 +1,3 @@
-
 // ignore-tidy-tab
 
 fn main() {

--- a/src/test/ui/fmt/format-string-error-2.rs
+++ b/src/test/ui/fmt/format-string-error-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 // ignore-tidy-tab
 
 fn main() {

--- a/src/test/ui/fmt/format-string-error-2.stderr
+++ b/src/test/ui/fmt/format-string-error-2.stderr
@@ -1,5 +1,5 @@
 error: incorrect unicode escape sequence
-  --> $DIR/format-string-error-2.rs:78:20
+  --> $DIR/format-string-error-2.rs:77:20
    |
 LL |     println!("\x7B}\u8 {", 1);
    |                    ^^-
@@ -7,7 +7,7 @@ LL |     println!("\x7B}\u8 {", 1);
    |                      help: format of unicode escape sequences uses braces: `\u{8}`
 
 error: invalid format string: expected `'}'`, found `'a'`
-  --> $DIR/format-string-error-2.rs:6:5
+  --> $DIR/format-string-error-2.rs:5:5
    |
 LL |     format!("{
    |              - because of this opening brace
@@ -17,7 +17,7 @@ LL |     a");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'b'`
-  --> $DIR/format-string-error-2.rs:10:5
+  --> $DIR/format-string-error-2.rs:9:5
    |
 LL |     format!("{ \
    |              - because of this opening brace
@@ -28,7 +28,7 @@ LL |     b");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'\'`
-  --> $DIR/format-string-error-2.rs:12:18
+  --> $DIR/format-string-error-2.rs:11:18
    |
 LL |     format!(r#"{ \
    |                - ^ expected `}` in format string
@@ -38,7 +38,7 @@ LL |     format!(r#"{ \
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'\'`
-  --> $DIR/format-string-error-2.rs:16:18
+  --> $DIR/format-string-error-2.rs:15:18
    |
 LL |     format!(r#"{ \n
    |                - ^ expected `}` in format string
@@ -48,7 +48,7 @@ LL |     format!(r#"{ \n
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'e'`
-  --> $DIR/format-string-error-2.rs:22:5
+  --> $DIR/format-string-error-2.rs:21:5
    |
 LL |     format!("{ \n
    |              - because of this opening brace
@@ -59,7 +59,7 @@ LL |     e");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'a'`
-  --> $DIR/format-string-error-2.rs:26:5
+  --> $DIR/format-string-error-2.rs:25:5
    |
 LL |     {
    |     - because of this opening brace
@@ -69,7 +69,7 @@ LL |     a");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'a'`
-  --> $DIR/format-string-error-2.rs:30:5
+  --> $DIR/format-string-error-2.rs:29:5
    |
 LL |     {
    |     - because of this opening brace
@@ -79,7 +79,7 @@ LL |     a
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'b'`
-  --> $DIR/format-string-error-2.rs:36:5
+  --> $DIR/format-string-error-2.rs:35:5
    |
 LL |     { \
    |     - because of this opening brace
@@ -90,7 +90,7 @@ LL |     b");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'b'`
-  --> $DIR/format-string-error-2.rs:41:5
+  --> $DIR/format-string-error-2.rs:40:5
    |
 LL |     { \
    |     - because of this opening brace
@@ -101,7 +101,7 @@ LL |     b \
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'\'`
-  --> $DIR/format-string-error-2.rs:46:8
+  --> $DIR/format-string-error-2.rs:45:8
    |
 LL | raw  { \
    |      - ^ expected `}` in format string
@@ -111,7 +111,7 @@ LL | raw  { \
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'\'`
-  --> $DIR/format-string-error-2.rs:51:8
+  --> $DIR/format-string-error-2.rs:50:8
    |
 LL | raw  { \n
    |      - ^ expected `}` in format string
@@ -121,7 +121,7 @@ LL | raw  { \n
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'e'`
-  --> $DIR/format-string-error-2.rs:58:5
+  --> $DIR/format-string-error-2.rs:57:5
    |
 LL |   { \n
    |   - because of this opening brace
@@ -132,7 +132,7 @@ LL |     e");
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `'}'`, found `'a'`
-  --> $DIR/format-string-error-2.rs:68:5
+  --> $DIR/format-string-error-2.rs:67:5
    |
 LL |     {
    |     - because of this opening brace
@@ -142,13 +142,13 @@ LL |     asdf}
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: 1 positional argument in format string, but no arguments were given
-  --> $DIR/format-string-error-2.rs:71:17
+  --> $DIR/format-string-error-2.rs:70:17
    |
 LL |     println!("\t{}");
    |                 ^^
 
 error: invalid format string: expected `'}'` but string was terminated
-  --> $DIR/format-string-error-2.rs:75:27
+  --> $DIR/format-string-error-2.rs:74:27
    |
 LL |     println!("\x7B}\u{8} {", 1);
    |                          -^ expected `'}'` in format string
@@ -158,7 +158,7 @@ LL |     println!("\x7B}\u{8} {", 1);
    = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: unmatched `}` found
-  --> $DIR/format-string-error-2.rs:82:21
+  --> $DIR/format-string-error-2.rs:81:21
    |
 LL |     println!(r#"\x7B}\u{8} {"#, 1);
    |                     ^ unmatched `}` in format string
@@ -166,7 +166,7 @@ LL |     println!(r#"\x7B}\u{8} {"#, 1);
    = note: if you intended to print `}`, you can escape it using `}}`
 
 error: invalid format string: unmatched `}` found
-  --> $DIR/format-string-error-2.rs:85:21
+  --> $DIR/format-string-error-2.rs:84:21
    |
 LL |     println!(r#"\x7B}\u8 {"#, 1);
    |                     ^ unmatched `}` in format string

--- a/src/test/ui/impl-trait/impl-trait-plus-priority.rs
+++ b/src/test/ui/impl-trait/impl-trait-plus-priority.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z parse-only -Z continue-parse-after-error
+// compile-flags: -Z parse-only
 
 fn f() -> impl A + {} // OK
 fn f() -> impl A + B {} // OK

--- a/src/test/ui/issues/issue-28433.rs
+++ b/src/test/ui/issues/issue-28433.rs
@@ -1,5 +1,3 @@
-
-
 enum Bird {
     pub Duck,
     //~^ ERROR unnecessary visibility qualifier

--- a/src/test/ui/issues/issue-28433.rs
+++ b/src/test/ui/issues/issue-28433.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 enum Bird {
     pub Duck,

--- a/src/test/ui/issues/issue-28433.stderr
+++ b/src/test/ui/issues/issue-28433.stderr
@@ -1,11 +1,11 @@
 error: unnecessary visibility qualifier
-  --> $DIR/issue-28433.rs:4:5
+  --> $DIR/issue-28433.rs:2:5
    |
 LL |     pub Duck,
    |     ^^^ `pub` not permitted here
 
 error: unnecessary visibility qualifier
-  --> $DIR/issue-28433.rs:7:5
+  --> $DIR/issue-28433.rs:5:5
    |
 LL |     pub(crate) Dove
    |     ^^^^^^^^^^ `pub` not permitted here

--- a/src/test/ui/issues/issue-36638.rs
+++ b/src/test/ui/issues/issue-36638.rs
@@ -1,5 +1,3 @@
-
-
 struct Foo<Self>(Self);
 //~^ ERROR expected identifier, found keyword `Self`
 //~^^ ERROR E0392

--- a/src/test/ui/issues/issue-36638.rs
+++ b/src/test/ui/issues/issue-36638.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct Foo<Self>(Self);
 //~^ ERROR expected identifier, found keyword `Self`

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -1,17 +1,17 @@
 error: expected identifier, found keyword `Self`
-  --> $DIR/issue-36638.rs:3:12
+  --> $DIR/issue-36638.rs:1:12
    |
 LL | struct Foo<Self>(Self);
    |            ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/issue-36638.rs:7:11
+  --> $DIR/issue-36638.rs:5:11
    |
 LL | trait Bar<Self> {}
    |           ^^^^ expected identifier, found keyword
 
 error[E0392]: parameter `Self` is never used
-  --> $DIR/issue-36638.rs:3:12
+  --> $DIR/issue-36638.rs:1:12
    |
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter

--- a/src/test/ui/parser/associated-types-project-from-hrtb-explicit.rs
+++ b/src/test/ui/parser/associated-types-project-from-hrtb-explicit.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 // Test you can't use a higher-ranked trait bound inside of a qualified
 // path (just won't parse).

--- a/src/test/ui/parser/associated-types-project-from-hrtb-explicit.rs
+++ b/src/test/ui/parser/associated-types-project-from-hrtb-explicit.rs
@@ -1,5 +1,3 @@
-
-
 // Test you can't use a higher-ranked trait bound inside of a qualified
 // path (just won't parse).
 

--- a/src/test/ui/parser/associated-types-project-from-hrtb-explicit.stderr
+++ b/src/test/ui/parser/associated-types-project-from-hrtb-explicit.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `for`
-  --> $DIR/associated-types-project-from-hrtb-explicit.rs:12:21
+  --> $DIR/associated-types-project-from-hrtb-explicit.rs:10:21
    |
 LL | fn foo2<I>(x: <I as for<'x> Foo<&'x isize>>::A)
    |                     ^^^ expected identifier, found keyword
@@ -9,7 +9,7 @@ LL | fn foo2<I>(x: <I as r#for<'x> Foo<&'x isize>>::A)
    |                     ^^^^^
 
 error: expected one of `::` or `>`, found `Foo`
-  --> $DIR/associated-types-project-from-hrtb-explicit.rs:12:29
+  --> $DIR/associated-types-project-from-hrtb-explicit.rs:10:29
    |
 LL | fn foo2<I>(x: <I as for<'x> Foo<&'x isize>>::A)
    |                             ^^^ expected one of `::` or `>` here

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 
 extern

--- a/src/test/ui/parser/bad-lit-suffixes.rs
+++ b/src/test/ui/parser/bad-lit-suffixes.rs
@@ -1,6 +1,3 @@
-
-
-
 extern
     "C"suffix //~ ERROR suffixes on an ABI spec are invalid
     fn foo() {}

--- a/src/test/ui/parser/bad-lit-suffixes.stderr
+++ b/src/test/ui/parser/bad-lit-suffixes.stderr
@@ -1,53 +1,53 @@
 error: suffixes on an ABI spec are invalid
-  --> $DIR/bad-lit-suffixes.rs:5:5
+  --> $DIR/bad-lit-suffixes.rs:2:5
    |
 LL |     "C"suffix
    |     ^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on an ABI spec are invalid
-  --> $DIR/bad-lit-suffixes.rs:9:5
+  --> $DIR/bad-lit-suffixes.rs:6:5
    |
 LL |     "C"suffix
    |     ^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a string literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:13:5
+  --> $DIR/bad-lit-suffixes.rs:10:5
    |
 LL |     ""suffix;
    |     ^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a byte string literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:14:5
+  --> $DIR/bad-lit-suffixes.rs:11:5
    |
 LL |     b""suffix;
    |     ^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a string literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:15:5
+  --> $DIR/bad-lit-suffixes.rs:12:5
    |
 LL |     r#""#suffix;
    |     ^^^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a byte string literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:16:5
+  --> $DIR/bad-lit-suffixes.rs:13:5
    |
 LL |     br#""#suffix;
    |     ^^^^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a char literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:17:5
+  --> $DIR/bad-lit-suffixes.rs:14:5
    |
 LL |     'a'suffix;
    |     ^^^^^^^^^ invalid suffix `suffix`
 
 error: suffixes on a byte literal are invalid
-  --> $DIR/bad-lit-suffixes.rs:18:5
+  --> $DIR/bad-lit-suffixes.rs:15:5
    |
 LL |     b'a'suffix;
    |     ^^^^^^^^^^ invalid suffix `suffix`
 
 error: invalid width `1024` for integer literal
-  --> $DIR/bad-lit-suffixes.rs:20:5
+  --> $DIR/bad-lit-suffixes.rs:17:5
    |
 LL |     1234u1024;
    |     ^^^^^^^^^
@@ -55,7 +55,7 @@ LL |     1234u1024;
    = help: valid widths are 8, 16, 32, 64 and 128
 
 error: invalid width `1024` for integer literal
-  --> $DIR/bad-lit-suffixes.rs:21:5
+  --> $DIR/bad-lit-suffixes.rs:18:5
    |
 LL |     1234i1024;
    |     ^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     1234i1024;
    = help: valid widths are 8, 16, 32, 64 and 128
 
 error: invalid width `1024` for float literal
-  --> $DIR/bad-lit-suffixes.rs:22:5
+  --> $DIR/bad-lit-suffixes.rs:19:5
    |
 LL |     1234f1024;
    |     ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     1234f1024;
    = help: valid widths are 32 and 64
 
 error: invalid width `1024` for float literal
-  --> $DIR/bad-lit-suffixes.rs:23:5
+  --> $DIR/bad-lit-suffixes.rs:20:5
    |
 LL |     1234.5f1024;
    |     ^^^^^^^^^^^
@@ -79,7 +79,7 @@ LL |     1234.5f1024;
    = help: valid widths are 32 and 64
 
 error: invalid suffix `suffix` for integer literal
-  --> $DIR/bad-lit-suffixes.rs:25:5
+  --> $DIR/bad-lit-suffixes.rs:22:5
    |
 LL |     1234suffix;
    |     ^^^^^^^^^^ invalid suffix `suffix`
@@ -87,7 +87,7 @@ LL |     1234suffix;
    = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
 
 error: invalid suffix `suffix` for integer literal
-  --> $DIR/bad-lit-suffixes.rs:26:5
+  --> $DIR/bad-lit-suffixes.rs:23:5
    |
 LL |     0b101suffix;
    |     ^^^^^^^^^^^ invalid suffix `suffix`
@@ -95,7 +95,7 @@ LL |     0b101suffix;
    = help: the suffix must be one of the integral types (`u32`, `isize`, etc)
 
 error: invalid suffix `suffix` for float literal
-  --> $DIR/bad-lit-suffixes.rs:27:5
+  --> $DIR/bad-lit-suffixes.rs:24:5
    |
 LL |     1.0suffix;
    |     ^^^^^^^^^ invalid suffix `suffix`
@@ -103,7 +103,7 @@ LL |     1.0suffix;
    = help: valid suffixes are `f32` and `f64`
 
 error: invalid suffix `suffix` for float literal
-  --> $DIR/bad-lit-suffixes.rs:28:5
+  --> $DIR/bad-lit-suffixes.rs:25:5
    |
 LL |     1.0e10suffix;
    |     ^^^^^^^^^^^^ invalid suffix `suffix`

--- a/src/test/ui/parser/bounds-type.rs
+++ b/src/test/ui/parser/bounds-type.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z parse-only -Z continue-parse-after-error
+// compile-flags: -Z parse-only
 
 struct S<
     T: 'a + Tr, // OK

--- a/src/test/ui/parser/doc-after-struct-field.rs
+++ b/src/test/ui/parser/doc-after-struct-field.rs
@@ -1,5 +1,3 @@
-
-
 struct X {
     a: u8 /** document a */,
     //~^ ERROR found a documentation comment that doesn't document anything

--- a/src/test/ui/parser/doc-after-struct-field.rs
+++ b/src/test/ui/parser/doc-after-struct-field.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct X {
     a: u8 /** document a */,

--- a/src/test/ui/parser/doc-after-struct-field.stderr
+++ b/src/test/ui/parser/doc-after-struct-field.stderr
@@ -1,5 +1,5 @@
 error[E0585]: found a documentation comment that doesn't document anything
-  --> $DIR/doc-after-struct-field.rs:4:11
+  --> $DIR/doc-after-struct-field.rs:2:11
    |
 LL |     a: u8 /** document a */,
    |           ^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     a: u8 /** document a */,
    = help: doc comments must come before what they document, maybe a comment was intended with `//`?
 
 error[E0585]: found a documentation comment that doesn't document anything
-  --> $DIR/doc-after-struct-field.rs:10:11
+  --> $DIR/doc-after-struct-field.rs:8:11
    |
 LL |     a: u8 /// document a
    |           ^^^^^^^^^^^^^^

--- a/src/test/ui/parser/doc-before-fn-rbrace.rs
+++ b/src/test/ui/parser/doc-before-fn-rbrace.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     /// document

--- a/src/test/ui/parser/doc-before-fn-rbrace.rs
+++ b/src/test/ui/parser/doc-before-fn-rbrace.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     /// document
     //~^ ERROR found a documentation comment that doesn't document anything

--- a/src/test/ui/parser/doc-before-fn-rbrace.stderr
+++ b/src/test/ui/parser/doc-before-fn-rbrace.stderr
@@ -1,5 +1,5 @@
 error[E0585]: found a documentation comment that doesn't document anything
-  --> $DIR/doc-before-fn-rbrace.rs:4:5
+  --> $DIR/doc-before-fn-rbrace.rs:2:5
    |
 LL |     /// document
    |     ^^^^^^^^^^^^

--- a/src/test/ui/parser/doc-before-identifier.rs
+++ b/src/test/ui/parser/doc-before-identifier.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn /// document
 foo() {}

--- a/src/test/ui/parser/doc-before-identifier.rs
+++ b/src/test/ui/parser/doc-before-identifier.rs
@@ -1,5 +1,3 @@
-
-
 fn /// document
 foo() {}
 //~^^ ERROR expected identifier, found doc comment `/// document`

--- a/src/test/ui/parser/doc-before-identifier.stderr
+++ b/src/test/ui/parser/doc-before-identifier.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found doc comment `/// document`
-  --> $DIR/doc-before-identifier.rs:3:4
+  --> $DIR/doc-before-identifier.rs:1:4
    |
 LL | fn /// document
    |    ^^^^^^^^^^^^ expected identifier, found doc comment

--- a/src/test/ui/parser/doc-before-mod-rbrace.rs
+++ b/src/test/ui/parser/doc-before-mod-rbrace.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 mod Foo {
     /// document

--- a/src/test/ui/parser/doc-before-mod-rbrace.rs
+++ b/src/test/ui/parser/doc-before-mod-rbrace.rs
@@ -1,5 +1,3 @@
-
-
 mod Foo {
     /// document
     //~^ ERROR expected item after doc comment

--- a/src/test/ui/parser/doc-before-mod-rbrace.stderr
+++ b/src/test/ui/parser/doc-before-mod-rbrace.stderr
@@ -1,5 +1,5 @@
 error: expected item after doc comment
-  --> $DIR/doc-before-mod-rbrace.rs:4:5
+  --> $DIR/doc-before-mod-rbrace.rs:2:5
    |
 LL |     /// document
    |     ^^^^^^^^^^^^ this doc comment doesn't document anything

--- a/src/test/ui/parser/doc-before-struct-rbrace-1.rs
+++ b/src/test/ui/parser/doc-before-struct-rbrace-1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct X {
     a: u8,

--- a/src/test/ui/parser/doc-before-struct-rbrace-1.rs
+++ b/src/test/ui/parser/doc-before-struct-rbrace-1.rs
@@ -1,5 +1,3 @@
-
-
 struct X {
     a: u8,
     /// document

--- a/src/test/ui/parser/doc-before-struct-rbrace-1.stderr
+++ b/src/test/ui/parser/doc-before-struct-rbrace-1.stderr
@@ -1,5 +1,5 @@
 error[E0585]: found a documentation comment that doesn't document anything
-  --> $DIR/doc-before-struct-rbrace-1.rs:5:5
+  --> $DIR/doc-before-struct-rbrace-1.rs:3:5
    |
 LL |     /// document
    |     ^^^^^^^^^^^^

--- a/src/test/ui/parser/doc-before-struct-rbrace-2.rs
+++ b/src/test/ui/parser/doc-before-struct-rbrace-2.rs
@@ -1,5 +1,3 @@
-
-
 struct X {
     a: u8 /// document
     //~^ ERROR found a documentation comment that doesn't document anything

--- a/src/test/ui/parser/doc-before-struct-rbrace-2.rs
+++ b/src/test/ui/parser/doc-before-struct-rbrace-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct X {
     a: u8 /// document

--- a/src/test/ui/parser/doc-before-struct-rbrace-2.stderr
+++ b/src/test/ui/parser/doc-before-struct-rbrace-2.stderr
@@ -1,5 +1,5 @@
 error[E0585]: found a documentation comment that doesn't document anything
-  --> $DIR/doc-before-struct-rbrace-2.rs:4:11
+  --> $DIR/doc-before-struct-rbrace-2.rs:2:11
    |
 LL |     a: u8 /// document
    |           ^^^^^^^^^^^^

--- a/src/test/ui/parser/issue-17904-2.rs
+++ b/src/test/ui/parser/issue-17904-2.rs
@@ -1,5 +1,3 @@
-
-
 struct Bar<T> { x: T } where T: Copy //~ ERROR expected item, found keyword `where`
 
 fn main() {}

--- a/src/test/ui/parser/issue-17904-2.rs
+++ b/src/test/ui/parser/issue-17904-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct Bar<T> { x: T } where T: Copy //~ ERROR expected item, found keyword `where`
 

--- a/src/test/ui/parser/issue-17904-2.stderr
+++ b/src/test/ui/parser/issue-17904-2.stderr
@@ -1,5 +1,5 @@
 error: expected item, found keyword `where`
-  --> $DIR/issue-17904-2.rs:3:24
+  --> $DIR/issue-17904-2.rs:1:24
    |
 LL | struct Bar<T> { x: T } where T: Copy
    |                        ^^^^^ expected item

--- a/src/test/ui/parser/issue-17904.rs
+++ b/src/test/ui/parser/issue-17904.rs
@@ -1,5 +1,3 @@
-
-
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.
 struct Baz<U>(U) where U: Eq; // This rightfully signals no error as well.

--- a/src/test/ui/parser/issue-17904.rs
+++ b/src/test/ui/parser/issue-17904.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.

--- a/src/test/ui/parser/issue-17904.stderr
+++ b/src/test/ui/parser/issue-17904.stderr
@@ -1,5 +1,5 @@
 error: expected one of `:`, `==`, or `=`, found `;`
-  --> $DIR/issue-17904.rs:6:33
+  --> $DIR/issue-17904.rs:4:33
    |
 LL | struct Foo<T> where T: Copy, (T);
    |                                 ^ expected one of `:`, `==`, or `=` here

--- a/src/test/ui/parser/issue-32214.rs
+++ b/src/test/ui/parser/issue-32214.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 trait Trait<T> { type Item; }
 

--- a/src/test/ui/parser/issue-32214.rs
+++ b/src/test/ui/parser/issue-32214.rs
@@ -1,5 +1,3 @@
-
-
 trait Trait<T> { type Item; }
 
 pub fn test<W, I: Trait<Item=(), W> >() {}

--- a/src/test/ui/parser/issue-32214.stderr
+++ b/src/test/ui/parser/issue-32214.stderr
@@ -1,5 +1,5 @@
 error: associated type bindings must be declared after generic parameters
-  --> $DIR/issue-32214.rs:5:25
+  --> $DIR/issue-32214.rs:3:25
    |
 LL | pub fn test<W, I: Trait<Item=(), W> >() {}
    |                         -------^^^

--- a/src/test/ui/parser/issue-32505.rs
+++ b/src/test/ui/parser/issue-32505.rs
@@ -1,5 +1,3 @@
-
-
 pub fn test() {
     foo(|_|) //~ ERROR expected expression, found `)`
 }

--- a/src/test/ui/parser/issue-32505.rs
+++ b/src/test/ui/parser/issue-32505.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 pub fn test() {
     foo(|_|) //~ ERROR expected expression, found `)`

--- a/src/test/ui/parser/issue-32505.stderr
+++ b/src/test/ui/parser/issue-32505.stderr
@@ -1,5 +1,5 @@
 error: expected expression, found `)`
-  --> $DIR/issue-32505.rs:4:12
+  --> $DIR/issue-32505.rs:2:12
    |
 LL |     foo(|_|)
    |            ^ expected expression

--- a/src/test/ui/parser/lex-bad-binary-literal.rs
+++ b/src/test/ui/parser/lex-bad-binary-literal.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     0b121; //~ ERROR invalid digit for a base 2 literal
     0b10_10301; //~ ERROR invalid digit for a base 2 literal

--- a/src/test/ui/parser/lex-bad-binary-literal.rs
+++ b/src/test/ui/parser/lex-bad-binary-literal.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     0b121; //~ ERROR invalid digit for a base 2 literal

--- a/src/test/ui/parser/lex-bad-binary-literal.stderr
+++ b/src/test/ui/parser/lex-bad-binary-literal.stderr
@@ -1,53 +1,53 @@
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:4:8
+  --> $DIR/lex-bad-binary-literal.rs:2:8
    |
 LL |     0b121;
    |        ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:5:12
+  --> $DIR/lex-bad-binary-literal.rs:3:12
    |
 LL |     0b10_10301;
    |            ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:6:7
+  --> $DIR/lex-bad-binary-literal.rs:4:7
    |
 LL |     0b30;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:7:7
+  --> $DIR/lex-bad-binary-literal.rs:5:7
    |
 LL |     0b41;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:8:7
+  --> $DIR/lex-bad-binary-literal.rs:6:7
    |
 LL |     0b5;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:9:7
+  --> $DIR/lex-bad-binary-literal.rs:7:7
    |
 LL |     0b6;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:10:7
+  --> $DIR/lex-bad-binary-literal.rs:8:7
    |
 LL |     0b7;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:11:7
+  --> $DIR/lex-bad-binary-literal.rs:9:7
    |
 LL |     0b8;
    |       ^
 
 error: invalid digit for a base 2 literal
-  --> $DIR/lex-bad-binary-literal.rs:12:7
+  --> $DIR/lex-bad-binary-literal.rs:10:7
    |
 LL |     0b9;
    |       ^

--- a/src/test/ui/parser/lex-bad-numeric-literals.rs
+++ b/src/test/ui/parser/lex-bad-numeric-literals.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     0o1.0; //~ ERROR: octal float literal is not supported

--- a/src/test/ui/parser/lex-bad-numeric-literals.rs
+++ b/src/test/ui/parser/lex-bad-numeric-literals.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     0o1.0; //~ ERROR: octal float literal is not supported
     0o2f32; //~ ERROR: octal float literal is not supported

--- a/src/test/ui/parser/lex-bad-numeric-literals.stderr
+++ b/src/test/ui/parser/lex-bad-numeric-literals.stderr
@@ -1,116 +1,122 @@
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:4:5
+  --> $DIR/lex-bad-numeric-literals.rs:2:5
    |
 LL |     0o1.0;
    |     ^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:6:5
+  --> $DIR/lex-bad-numeric-literals.rs:4:5
    |
 LL |     0o3.0f32;
    |     ^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:7:5
+  --> $DIR/lex-bad-numeric-literals.rs:5:5
    |
 LL |     0o4e4;
    |     ^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:8:5
+  --> $DIR/lex-bad-numeric-literals.rs:6:5
    |
 LL |     0o5.0e5;
    |     ^^^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:9:5
+  --> $DIR/lex-bad-numeric-literals.rs:7:5
    |
 LL |     0o6e6f32;
    |     ^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:10:5
+  --> $DIR/lex-bad-numeric-literals.rs:8:5
    |
 LL |     0o7.0e7f64;
    |     ^^^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:11:5
+  --> $DIR/lex-bad-numeric-literals.rs:9:5
    |
 LL |     0x8.0e+9;
    |     ^^^^^^^^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:12:5
+  --> $DIR/lex-bad-numeric-literals.rs:10:5
    |
 LL |     0x9.0e-9;
    |     ^^^^^^^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:13:5
+  --> $DIR/lex-bad-numeric-literals.rs:11:5
    |
 LL |     0o;
    |     ^^
 
 error: expected at least one digit in exponent
-  --> $DIR/lex-bad-numeric-literals.rs:14:8
+  --> $DIR/lex-bad-numeric-literals.rs:12:8
    |
 LL |     1e+;
    |        ^
 
 error: hexadecimal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:15:5
+  --> $DIR/lex-bad-numeric-literals.rs:13:5
    |
 LL |     0x539.0;
    |     ^^^^^^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:20:5
+  --> $DIR/lex-bad-numeric-literals.rs:18:5
    |
 LL |     0x;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:21:5
+  --> $DIR/lex-bad-numeric-literals.rs:19:5
    |
 LL |     0xu32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:22:5
+  --> $DIR/lex-bad-numeric-literals.rs:20:5
    |
 LL |     0ou32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:23:5
+  --> $DIR/lex-bad-numeric-literals.rs:21:5
    |
 LL |     0bu32;
    |     ^^
 
 error: no valid digits found for number
-  --> $DIR/lex-bad-numeric-literals.rs:24:5
+  --> $DIR/lex-bad-numeric-literals.rs:22:5
    |
 LL |     0b;
    |     ^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:26:5
+  --> $DIR/lex-bad-numeric-literals.rs:24:5
    |
 LL |     0o123.456;
    |     ^^^^^^^^^
 
 error: binary float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:28:5
+  --> $DIR/lex-bad-numeric-literals.rs:26:5
    |
 LL |     0b111.101;
    |     ^^^^^^^^^
 
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:5:5
+  --> $DIR/lex-bad-numeric-literals.rs:3:5
    |
 LL |     0o2f32;
    |     ^^^^^^ not supported
+
+error: integer literal is too large
+  --> $DIR/lex-bad-numeric-literals.rs:14:5
+   |
+LL |     9900000000000000000000000000999999999999999999999999999999;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: integer literal is too large
   --> $DIR/lex-bad-numeric-literals.rs:16:5
@@ -118,20 +124,14 @@ error: integer literal is too large
 LL |     9900000000000000000000000000999999999999999999999999999999;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: integer literal is too large
-  --> $DIR/lex-bad-numeric-literals.rs:18:5
-   |
-LL |     9900000000000000000000000000999999999999999999999999999999;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: octal float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:25:5
+  --> $DIR/lex-bad-numeric-literals.rs:23:5
    |
 LL |     0o123f64;
    |     ^^^^^^^^ not supported
 
 error: binary float literal is not supported
-  --> $DIR/lex-bad-numeric-literals.rs:27:5
+  --> $DIR/lex-bad-numeric-literals.rs:25:5
    |
 LL |     0b101f64;
    |     ^^^^^^^^ not supported

--- a/src/test/ui/parser/lex-bad-octal-literal.rs
+++ b/src/test/ui/parser/lex-bad-octal-literal.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     0o18; //~ ERROR invalid digit for a base 8 literal
     0o1234_9_5670;  //~ ERROR invalid digit for a base 8 literal

--- a/src/test/ui/parser/lex-bad-octal-literal.rs
+++ b/src/test/ui/parser/lex-bad-octal-literal.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     0o18; //~ ERROR invalid digit for a base 8 literal

--- a/src/test/ui/parser/lex-bad-octal-literal.stderr
+++ b/src/test/ui/parser/lex-bad-octal-literal.stderr
@@ -1,11 +1,11 @@
 error: invalid digit for a base 8 literal
-  --> $DIR/lex-bad-octal-literal.rs:4:8
+  --> $DIR/lex-bad-octal-literal.rs:2:8
    |
 LL |     0o18;
    |        ^
 
 error: invalid digit for a base 8 literal
-  --> $DIR/lex-bad-octal-literal.rs:5:12
+  --> $DIR/lex-bad-octal-literal.rs:3:12
    |
 LL |     0o1234_9_5670;
    |            ^

--- a/src/test/ui/parser/macro/macro-incomplete-parse.rs
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.rs
@@ -1,5 +1,3 @@
-
-
 macro_rules! ignored_item {
     () => {
         fn foo() {}

--- a/src/test/ui/parser/macro/macro-incomplete-parse.rs
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 macro_rules! ignored_item {
     () => {

--- a/src/test/ui/parser/macro/macro-incomplete-parse.stderr
+++ b/src/test/ui/parser/macro/macro-incomplete-parse.stderr
@@ -1,5 +1,5 @@
 error: macro expansion ignores token `,` and any following
-  --> $DIR/macro-incomplete-parse.rs:7:9
+  --> $DIR/macro-incomplete-parse.rs:5:9
    |
 LL |         ,
    |         ^
@@ -10,7 +10,7 @@ LL | ignored_item!();
    = note: the usage of `ignored_item!` is likely invalid in item context
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `,`
-  --> $DIR/macro-incomplete-parse.rs:12:14
+  --> $DIR/macro-incomplete-parse.rs:10:14
    |
 LL |     () => ( 1,
    |              ^ expected one of `.`, `;`, `?`, `}`, or an operator here
@@ -19,7 +19,7 @@ LL |     ignored_expr!();
    |     ---------------- in this macro invocation
 
 error: macro expansion ignores token `,` and any following
-  --> $DIR/macro-incomplete-parse.rs:18:14
+  --> $DIR/macro-incomplete-parse.rs:16:14
    |
 LL |     () => ( 1, 2 )
    |              ^

--- a/src/test/ui/parser/new-unicode-escapes-4.rs
+++ b/src/test/ui/parser/new-unicode-escapes-4.rs
@@ -1,5 +1,3 @@
-
-
 pub fn main() {
     let s = "\u{lol}";
      //~^ ERROR invalid character in unicode escape: l

--- a/src/test/ui/parser/new-unicode-escapes-4.rs
+++ b/src/test/ui/parser/new-unicode-escapes-4.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 pub fn main() {
     let s = "\u{lol}";

--- a/src/test/ui/parser/new-unicode-escapes-4.stderr
+++ b/src/test/ui/parser/new-unicode-escapes-4.stderr
@@ -1,5 +1,5 @@
 error: invalid character in unicode escape: l
-  --> $DIR/new-unicode-escapes-4.rs:4:17
+  --> $DIR/new-unicode-escapes-4.rs:2:17
    |
 LL |     let s = "\u{lol}";
    |                 ^

--- a/src/test/ui/parser/no-unsafe-self.rs
+++ b/src/test/ui/parser/no-unsafe-self.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 trait A {
     fn foo(*mut self); //~ ERROR cannot pass `self` by raw pointer

--- a/src/test/ui/parser/no-unsafe-self.rs
+++ b/src/test/ui/parser/no-unsafe-self.rs
@@ -1,5 +1,3 @@
-
-
 trait A {
     fn foo(*mut self); //~ ERROR cannot pass `self` by raw pointer
     fn baz(*const self); //~ ERROR cannot pass `self` by raw pointer

--- a/src/test/ui/parser/no-unsafe-self.stderr
+++ b/src/test/ui/parser/no-unsafe-self.stderr
@@ -1,35 +1,35 @@
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:4:17
+  --> $DIR/no-unsafe-self.rs:2:17
    |
 LL |     fn foo(*mut self);
    |                 ^^^^ cannot pass `self` by raw pointer
 
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:5:19
+  --> $DIR/no-unsafe-self.rs:3:19
    |
 LL |     fn baz(*const self);
    |                   ^^^^ cannot pass `self` by raw pointer
 
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:6:13
+  --> $DIR/no-unsafe-self.rs:4:13
    |
 LL |     fn bar(*self);
    |             ^^^^ cannot pass `self` by raw pointer
 
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:11:17
+  --> $DIR/no-unsafe-self.rs:9:17
    |
 LL |     fn foo(*mut self) { }
    |                 ^^^^ cannot pass `self` by raw pointer
 
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:12:19
+  --> $DIR/no-unsafe-self.rs:10:19
    |
 LL |     fn baz(*const self) { }
    |                   ^^^^ cannot pass `self` by raw pointer
 
 error: cannot pass `self` by raw pointer
-  --> $DIR/no-unsafe-self.rs:13:13
+  --> $DIR/no-unsafe-self.rs:11:13
    |
 LL |     fn bar(*self) { }
    |             ^^^^ cannot pass `self` by raw pointer

--- a/src/test/ui/parser/range_inclusive_dotdotdot.rs
+++ b/src/test/ui/parser/range_inclusive_dotdotdot.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 // Make sure that inclusive ranges with `...` syntax don't parse.
 

--- a/src/test/ui/parser/range_inclusive_dotdotdot.rs
+++ b/src/test/ui/parser/range_inclusive_dotdotdot.rs
@@ -1,5 +1,3 @@
-
-
 // Make sure that inclusive ranges with `...` syntax don't parse.
 
 use std::ops::RangeToInclusive;

--- a/src/test/ui/parser/range_inclusive_dotdotdot.stderr
+++ b/src/test/ui/parser/range_inclusive_dotdotdot.stderr
@@ -1,5 +1,5 @@
 error: unexpected token: `...`
-  --> $DIR/range_inclusive_dotdotdot.rs:8:12
+  --> $DIR/range_inclusive_dotdotdot.rs:6:12
    |
 LL |     return ...1;
    |            ^^^
@@ -13,7 +13,7 @@ LL |     return ..=1;
    |            ^^^
 
 error: unexpected token: `...`
-  --> $DIR/range_inclusive_dotdotdot.rs:14:13
+  --> $DIR/range_inclusive_dotdotdot.rs:12:13
    |
 LL |     let x = ...0;
    |             ^^^
@@ -27,7 +27,7 @@ LL |     let x = ..=0;
    |             ^^^
 
 error: unexpected token: `...`
-  --> $DIR/range_inclusive_dotdotdot.rs:18:14
+  --> $DIR/range_inclusive_dotdotdot.rs:16:14
    |
 LL |     let x = 5...5;
    |              ^^^
@@ -41,7 +41,7 @@ LL |     let x = 5..=5;
    |              ^^^
 
 error: unexpected token: `...`
-  --> $DIR/range_inclusive_dotdotdot.rs:22:15
+  --> $DIR/range_inclusive_dotdotdot.rs:20:15
    |
 LL |     for _ in 0...1 {}
    |               ^^^

--- a/src/test/ui/parser/raw-byte-string-literals.rs
+++ b/src/test/ui/parser/raw-byte-string-literals.rs
@@ -1,6 +1,3 @@
-
-
-
 pub fn main() {
     br"é";  //~ ERROR raw byte string must be ASCII
     br##~"a"~##;  //~ ERROR only `#` is allowed in raw string delimitation

--- a/src/test/ui/parser/raw-byte-string-literals.rs
+++ b/src/test/ui/parser/raw-byte-string-literals.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 
 pub fn main() {

--- a/src/test/ui/parser/raw-byte-string-literals.stderr
+++ b/src/test/ui/parser/raw-byte-string-literals.stderr
@@ -1,11 +1,11 @@
 error: raw byte string must be ASCII: \u{e9}
-  --> $DIR/raw-byte-string-literals.rs:5:8
+  --> $DIR/raw-byte-string-literals.rs:2:8
    |
 LL |     br"é";
    |        ^
 
 error: found invalid character; only `#` is allowed in raw string delimitation: ~
-  --> $DIR/raw-byte-string-literals.rs:6:6
+  --> $DIR/raw-byte-string-literals.rs:3:6
    |
 LL |     br##~"a"~##;
    |      ^^^

--- a/src/test/ui/parser/recover-enum.rs
+++ b/src/test/ui/parser/recover-enum.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     enum Test {
         Very

--- a/src/test/ui/parser/recover-enum.rs
+++ b/src/test/ui/parser/recover-enum.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     enum Test {

--- a/src/test/ui/parser/recover-enum.stderr
+++ b/src/test/ui/parser/recover-enum.stderr
@@ -1,17 +1,17 @@
 error: missing comma
-  --> $DIR/recover-enum.rs:5:13
+  --> $DIR/recover-enum.rs:3:13
    |
 LL |         Very
    |             ^ help: missing comma
 
 error: missing comma
-  --> $DIR/recover-enum.rs:7:19
+  --> $DIR/recover-enum.rs:5:19
    |
 LL |         Bad(usize)
    |                   ^ help: missing comma
 
 error: missing comma
-  --> $DIR/recover-enum.rs:9:27
+  --> $DIR/recover-enum.rs:7:27
    |
 LL |         Stuff { a: usize }
    |                           ^ help: missing comma

--- a/src/test/ui/parser/recover-enum2.rs
+++ b/src/test/ui/parser/recover-enum2.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     enum Test {
         Var1,

--- a/src/test/ui/parser/recover-enum2.rs
+++ b/src/test/ui/parser/recover-enum2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     enum Test {

--- a/src/test/ui/parser/recover-enum2.stderr
+++ b/src/test/ui/parser/recover-enum2.stderr
@@ -1,11 +1,11 @@
 error: expected type, found `{`
-  --> $DIR/recover-enum2.rs:8:18
+  --> $DIR/recover-enum2.rs:6:18
    |
 LL |             abc: {},
    |                  ^
 
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `{`
-  --> $DIR/recover-enum2.rs:27:22
+  --> $DIR/recover-enum2.rs:25:22
    |
 LL |             Nope(i32 {})
    |                      ^ expected one of 7 possible tokens here

--- a/src/test/ui/parser/recover-struct.rs
+++ b/src/test/ui/parser/recover-struct.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 fn main() {
     struct Test {

--- a/src/test/ui/parser/recover-struct.rs
+++ b/src/test/ui/parser/recover-struct.rs
@@ -1,5 +1,3 @@
-
-
 fn main() {
     struct Test {
         Very

--- a/src/test/ui/parser/recover-struct.stderr
+++ b/src/test/ui/parser/recover-struct.stderr
@@ -1,5 +1,5 @@
 error: expected `:`, found `Bad`
-  --> $DIR/recover-struct.rs:6:9
+  --> $DIR/recover-struct.rs:4:9
    |
 LL |         Very
    |             - expected `:`

--- a/src/test/ui/parser/removed-syntax-field-let.rs
+++ b/src/test/ui/parser/removed-syntax-field-let.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 struct S {
     let foo: (),

--- a/src/test/ui/parser/removed-syntax-field-let.rs
+++ b/src/test/ui/parser/removed-syntax-field-let.rs
@@ -1,5 +1,3 @@
-
-
 struct S {
     let foo: (),
     //~^  ERROR expected identifier, found keyword `let`

--- a/src/test/ui/parser/removed-syntax-field-let.stderr
+++ b/src/test/ui/parser/removed-syntax-field-let.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `let`
-  --> $DIR/removed-syntax-field-let.rs:4:5
+  --> $DIR/removed-syntax-field-let.rs:2:5
    |
 LL |     let foo: (),
    |     ^^^ expected identifier, found keyword
@@ -9,7 +9,7 @@ LL |     r#let foo: (),
    |     ^^^^^
 
 error: expected `:`, found `foo`
-  --> $DIR/removed-syntax-field-let.rs:4:9
+  --> $DIR/removed-syntax-field-let.rs:2:9
    |
 LL |     let foo: (),
    |         ^^^ expected `:`

--- a/src/test/ui/parser/trailing-plus-in-bounds.rs
+++ b/src/test/ui/parser/trailing-plus-in-bounds.rs
@@ -1,6 +1,5 @@
 // compile-pass
 
-
 #![feature(box_syntax)]
 #![allow(bare_trait_objects)]
 

--- a/src/test/ui/parser/trailing-plus-in-bounds.rs
+++ b/src/test/ui/parser/trailing-plus-in-bounds.rs
@@ -1,5 +1,5 @@
 // compile-pass
-// compile-flags: -Z continue-parse-after-error
+
 
 #![feature(box_syntax)]
 #![allow(bare_trait_objects)]

--- a/src/test/ui/parser/trait-bounds-not-on-impl.rs
+++ b/src/test/ui/parser/trait-bounds-not-on-impl.rs
@@ -1,11 +1,7 @@
-
-
-trait Foo {
-}
+trait Foo {}
 
 struct Bar;
 
-impl Foo + Owned for Bar { //~ ERROR expected a trait, found type
-}
+impl Foo + Owned for Bar {} //~ ERROR expected a trait, found type
 
 fn main() { }

--- a/src/test/ui/parser/trait-bounds-not-on-impl.rs
+++ b/src/test/ui/parser/trait-bounds-not-on-impl.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 trait Foo {
 }

--- a/src/test/ui/parser/trait-bounds-not-on-impl.stderr
+++ b/src/test/ui/parser/trait-bounds-not-on-impl.stderr
@@ -1,7 +1,7 @@
 error: expected a trait, found type
-  --> $DIR/trait-bounds-not-on-impl.rs:8:6
+  --> $DIR/trait-bounds-not-on-impl.rs:5:6
    |
-LL | impl Foo + Owned for Bar {
+LL | impl Foo + Owned for Bar {}
    |      ^^^^^^^^^^^
 
 error: aborting due to previous error

--- a/src/test/ui/parser/trait-object-bad-parens.rs
+++ b/src/test/ui/parser/trait-object-bad-parens.rs
@@ -1,5 +1,3 @@
-
-
 #![feature(optin_builtin_traits)]
 #![allow(bare_trait_objects)]
 

--- a/src/test/ui/parser/trait-object-bad-parens.rs
+++ b/src/test/ui/parser/trait-object-bad-parens.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 #![feature(optin_builtin_traits)]
 #![allow(bare_trait_objects)]

--- a/src/test/ui/parser/trait-object-bad-parens.stderr
+++ b/src/test/ui/parser/trait-object-bad-parens.stderr
@@ -1,23 +1,23 @@
 error[E0178]: expected a path on the left-hand side of `+`, not `((Auto))`
-  --> $DIR/trait-object-bad-parens.rs:9:16
+  --> $DIR/trait-object-bad-parens.rs:7:16
    |
 LL |     let _: Box<((Auto)) + Auto>;
    |                ^^^^^^^^^^^^^^^ expected a path
 
 error[E0178]: expected a path on the left-hand side of `+`, not `(Auto + Auto)`
-  --> $DIR/trait-object-bad-parens.rs:11:16
+  --> $DIR/trait-object-bad-parens.rs:9:16
    |
 LL |     let _: Box<(Auto + Auto) + Auto>;
    |                ^^^^^^^^^^^^^^^^^^^^ expected a path
 
 error[E0178]: expected a path on the left-hand side of `+`, not `(Auto)`
-  --> $DIR/trait-object-bad-parens.rs:13:16
+  --> $DIR/trait-object-bad-parens.rs:11:16
    |
 LL |     let _: Box<(Auto +) + Auto>;
    |                ^^^^^^^^^^^^^^^ expected a path
 
 error[E0178]: expected a path on the left-hand side of `+`, not `(dyn Auto)`
-  --> $DIR/trait-object-bad-parens.rs:15:16
+  --> $DIR/trait-object-bad-parens.rs:13:16
    |
 LL |     let _: Box<(dyn Auto) + Auto>;
    |                ^^^^^^^^^^^^^^^^^ expected a path

--- a/src/test/ui/parser/trait-object-lifetime-parens.rs
+++ b/src/test/ui/parser/trait-object-lifetime-parens.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 #![allow(bare_trait_objects)]
 

--- a/src/test/ui/parser/trait-object-lifetime-parens.rs
+++ b/src/test/ui/parser/trait-object-lifetime-parens.rs
@@ -1,5 +1,3 @@
-
-
 #![allow(bare_trait_objects)]
 
 trait Trait {}

--- a/src/test/ui/parser/trait-object-lifetime-parens.stderr
+++ b/src/test/ui/parser/trait-object-lifetime-parens.stderr
@@ -1,23 +1,23 @@
 error: parenthesized lifetime bounds are not supported
-  --> $DIR/trait-object-lifetime-parens.rs:7:21
+  --> $DIR/trait-object-lifetime-parens.rs:5:21
    |
 LL | fn f<'a, T: Trait + ('a)>() {}
    |                     ^^^^ help: remove the parentheses
 
 error: parenthesized lifetime bounds are not supported
-  --> $DIR/trait-object-lifetime-parens.rs:10:24
+  --> $DIR/trait-object-lifetime-parens.rs:8:24
    |
 LL |     let _: Box<Trait + ('a)>;
    |                        ^^^^ help: remove the parentheses
 
 error: expected `:`, found `)`
-  --> $DIR/trait-object-lifetime-parens.rs:11:19
+  --> $DIR/trait-object-lifetime-parens.rs:9:19
    |
 LL |     let _: Box<('a) + Trait>;
    |                   ^ expected `:`
 
 error: chained comparison operators require parentheses
-  --> $DIR/trait-object-lifetime-parens.rs:11:15
+  --> $DIR/trait-object-lifetime-parens.rs:9:15
    |
 LL |     let _: Box<('a) + Trait>;
    |               ^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     let _: Box<('a) + Trait>;
    = help: or use `(...)` if you meant to specify fn arguments
 
 error: expected type, found `'a`
-  --> $DIR/trait-object-lifetime-parens.rs:11:17
+  --> $DIR/trait-object-lifetime-parens.rs:9:17
    |
 LL |     let _: Box<('a) + Trait>;
    |         -       ^^

--- a/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.rs
+++ b/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 use std::any:: as foo; //~ ERROR expected identifier, found keyword `as`
 //~^ ERROR: expected one of `::`, `;`, or `as`, found `foo`

--- a/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.rs
+++ b/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.rs
@@ -1,4 +1,2 @@
-
-
 use std::any:: as foo; //~ ERROR expected identifier, found keyword `as`
 //~^ ERROR: expected one of `::`, `;`, or `as`, found `foo`

--- a/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.stderr
+++ b/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found keyword `as`
-  --> $DIR/use-as-where-use-ends-with-mod-sep.rs:3:16
+  --> $DIR/use-as-where-use-ends-with-mod-sep.rs:1:16
    |
 LL | use std::any:: as foo;
    |                ^^ expected identifier, found keyword
@@ -9,7 +9,7 @@ LL | use std::any:: r#as foo;
    |                ^^^^
 
 error: expected one of `::`, `;`, or `as`, found `foo`
-  --> $DIR/use-as-where-use-ends-with-mod-sep.rs:3:19
+  --> $DIR/use-as-where-use-ends-with-mod-sep.rs:1:19
    |
 LL | use std::any:: as foo;
    |                   ^^^ expected one of `::`, `;`, or `as` here

--- a/src/test/ui/parser/where-clauses-no-bounds-or-predicates.rs
+++ b/src/test/ui/parser/where-clauses-no-bounds-or-predicates.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 // Empty predicate list is OK
 fn equal1<T>(_: &T, _: &T) -> bool where {

--- a/src/test/ui/parser/where-clauses-no-bounds-or-predicates.rs
+++ b/src/test/ui/parser/where-clauses-no-bounds-or-predicates.rs
@@ -1,5 +1,3 @@
-
-
 // Empty predicate list is OK
 fn equal1<T>(_: &T, _: &T) -> bool where {
     true

--- a/src/test/ui/parser/where-clauses-no-bounds-or-predicates.stderr
+++ b/src/test/ui/parser/where-clauses-no-bounds-or-predicates.stderr
@@ -1,5 +1,5 @@
 error: expected `:`, found `{`
-  --> $DIR/where-clauses-no-bounds-or-predicates.rs:13:23
+  --> $DIR/where-clauses-no-bounds-or-predicates.rs:11:23
    |
 LL | fn foo<'a>() where 'a {}
    |                       ^ expected `:`

--- a/src/test/ui/self/self_type_keyword.rs
+++ b/src/test/ui/self/self_type_keyword.rs
@@ -1,5 +1,3 @@
-
-
 mod foo {
   struct Self;
   //~^ ERROR expected identifier, found keyword `Self`

--- a/src/test/ui/self/self_type_keyword.rs
+++ b/src/test/ui/self/self_type_keyword.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Z continue-parse-after-error
+
 
 mod foo {
   struct Self;

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -1,65 +1,65 @@
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:4:10
+  --> $DIR/self_type_keyword.rs:2:10
    |
 LL |   struct Self;
    |          ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:16:13
+  --> $DIR/self_type_keyword.rs:14:13
    |
 LL |         ref Self => (),
    |             ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:18:13
+  --> $DIR/self_type_keyword.rs:16:13
    |
 LL |         mut Self => (),
    |             ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:20:17
+  --> $DIR/self_type_keyword.rs:18:17
    |
 LL |         ref mut Self => (),
    |                 ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:24:15
+  --> $DIR/self_type_keyword.rs:22:15
    |
 LL |         Foo { Self } => (),
    |               ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:30:26
+  --> $DIR/self_type_keyword.rs:28:26
    |
 LL |     extern crate core as Self;
    |                          ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:35:32
+  --> $DIR/self_type_keyword.rs:33:32
    |
 LL |     use std::option::Option as Self;
    |                                ^^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `Self`
-  --> $DIR/self_type_keyword.rs:40:11
+  --> $DIR/self_type_keyword.rs:38:11
    |
 LL |     trait Self {}
    |           ^^^^ expected identifier, found keyword
 
 error: lifetimes cannot use keyword names
-  --> $DIR/self_type_keyword.rs:8:12
+  --> $DIR/self_type_keyword.rs:6:12
    |
 LL | struct Bar<'Self>;
    |            ^^^^^
 
 error: cannot find macro `Self!` in this scope
-  --> $DIR/self_type_keyword.rs:22:9
+  --> $DIR/self_type_keyword.rs:20:9
    |
 LL |         Self!() => (),
    |         ^^^^
 
 error[E0392]: parameter `'Self` is never used
-  --> $DIR/self_type_keyword.rs:8:12
+  --> $DIR/self_type_keyword.rs:6:12
    |
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter

--- a/src/test/ui/traits/trait-object-vs-lifetime-2.rs
+++ b/src/test/ui/traits/trait-object-vs-lifetime-2.rs
@@ -1,8 +1,6 @@
 // A few contrived examples where lifetime should (or should not) be parsed as an object type.
 // Lifetimes parsed as types are still rejected later by semantic checks.
 
-
-
 // `'static` is a lifetime, `'static +` is a type, `'a` is a type
 fn g() where
     'static: 'static,

--- a/src/test/ui/traits/trait-object-vs-lifetime-2.rs
+++ b/src/test/ui/traits/trait-object-vs-lifetime-2.rs
@@ -1,7 +1,7 @@
 // A few contrived examples where lifetime should (or should not) be parsed as an object type.
 // Lifetimes parsed as types are still rejected later by semantic checks.
 
-// compile-flags: -Z continue-parse-after-error
+
 
 // `'static` is a lifetime, `'static +` is a type, `'a` is a type
 fn g() where

--- a/src/test/ui/traits/trait-object-vs-lifetime-2.stderr
+++ b/src/test/ui/traits/trait-object-vs-lifetime-2.stderr
@@ -1,5 +1,5 @@
 error[E0224]: at least one non-builtin trait is required for an object type
-  --> $DIR/trait-object-vs-lifetime-2.rs:9:5
+  --> $DIR/trait-object-vs-lifetime-2.rs:7:5
    |
 LL |     dyn 'static +: 'static + Copy,
    |     ^^^^^^^^^^^^^


### PR DESCRIPTION
Successful merges:

 - #60729 (Expand dynamic drop tests for cases in #47949)
 - #61263 (Don't generate div inside header (h4/h3/h...) elements)
 - #61364 (Stabilize reverse_bits feature)
 - #61375 (Make "panic did not include expected string" message consistent)
 - #61387 (Remove ty::BrFresh and RegionConstraintCollector::new_bound)
 - #61389 (Remove GlobalArenas and use Arena instead)
 - #61391 (Doc comment fixes for `rustc::mir::interpret::InterpretCx`)
 - #61403 (Remove unnecessary `-Z continue-parse-after-error` from tests)

Failed merges:


r? @ghost