### PR TITLE
Suggest using `as_ref` on `*const T`

### DIFF
--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -324,6 +324,11 @@ impl<'a, 'gcx, 'tcx> FnCtxt<'a, 'gcx, 'tcx> {
                                 );
                             }
                         }
+                        if let ty::RawPtr(_) = &actual.sty {
+                            err.note("try using `<*const T>::as_ref()` to get a reference to the \
+                                      type behind the pointer: https://doc.rust-lang.org/std/\
+                                      primitive.pointer.html#method.as_ref");
+                        }
                         err
                     }
                 } else {

--- a/src/test/ui/issues/issue-21596.rs
+++ b/src/test/ui/issues/issue-21596.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let x = 8u8;
+    let z: *const u8 = &x;
+    println!("{}", z.to_string());  //~ ERROR E0599
+}

--- a/src/test/ui/issues/issue-21596.stderr
+++ b/src/test/ui/issues/issue-21596.stderr
@@ -1,0 +1,13 @@
+error[E0599]: no method named `to_string` found for type `*const u8` in the current scope
+  --> $DIR/issue-21596.rs:4:22
+   |
+LL |     println!("{}", z.to_string());
+   |                      ^^^^^^^^^
+   |
+   = note: try using `<*const T>::as_ref()` to get a reference to the type behind the pointer: https://doc.rust-lang.org/std/primitive.pointer.html#method.as_ref
+   = note: the method `to_string` exists but the following trait bounds were not satisfied:
+           `*const u8 : std::string::ToString`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fix #21596.