### PR TITLE
On TerminatorKind::DropAndReplace still handle unused_mut correctly

### DIFF
--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -52,6 +52,24 @@ struct GatherUsedMutsVisitor<'visit, 'cx: 'visit, 'gcx: 'tcx, 'tcx: 'cx> {
     mbcx: &'visit mut MirBorrowckCtxt<'cx, 'gcx, 'tcx>,
 }
 
+impl<'visit, 'cx, 'gcx, 'tcx> GatherUsedMutsVisitor<'visit, 'cx, 'gcx, 'tcx> {
+    fn remove_never_initialized_mut_locals(into: &Place) {
+        // Remove any locals that we found were initialized from the
+        // `never_initialized_mut_locals` set. At the end, the only remaining locals will
+        // be those that were never initialized - we will consider those as being used as
+        // they will either have been removed by unreachable code optimizations; or linted
+        // as unused variables.
+        if let Some(local) = into.base_local() {
+            debug!(
+                "visit_statement: statement={:?} local={:?} \
+                 never_initialized_mut_locals={:?}",
+                statement, local, self.never_initialized_mut_locals
+            );
+            let _ = self.never_initialized_mut_locals.remove(&local);
+        }
+    }
+}
+
 impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'gcx, 'tcx> {
     fn visit_terminator_kind(
         &mut self,
@@ -61,14 +79,10 @@ impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'c
         debug!("visit_terminator_kind: kind={:?}", kind);
         match &kind {
             TerminatorKind::Call { destination: Some((into, _)), .. } => {
-                if let Some(local) = into.base_local() {
-                    debug!(
-                        "visit_terminator_kind: kind={:?} local={:?} \
-                         never_initialized_mut_locals={:?}",
-                        kind, local, self.never_initialized_mut_locals
-                    );
-                    let _ = self.never_initialized_mut_locals.remove(&local);
-                }
+                self.remove_never_initialized_mut_locals(&into);
+            },
+            TerminatorKind::DropAndReplace { location, .. } => {
+                self.remove_never_initialized_mut_locals(&location);
             },
             _ => {},
         }
@@ -81,19 +95,7 @@ impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'c
     ) {
         match &statement.kind {
             StatementKind::Assign(into, _) => {
-                // Remove any locals that we found were initialized from the
-                // `never_initialized_mut_locals` set. At the end, the only remaining locals will
-                // be those that were never initialized - we will consider those as being used as
-                // they will either have been removed by unreachable code optimizations; or linted
-                // as unused variables.
-                if let Some(local) = into.base_local() {
-                    debug!(
-                        "visit_statement: statement={:?} local={:?} \
-                         never_initialized_mut_locals={:?}",
-                        statement, local, self.never_initialized_mut_locals
-                    );
-                    let _ = self.never_initialized_mut_locals.remove(&local);
-                }
+                self.remove_never_initialized_mut_locals(into);
             },
             _ => {},
         }

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -52,7 +52,7 @@ struct GatherUsedMutsVisitor<'visit, 'cx: 'visit, 'gcx: 'tcx, 'tcx: 'cx> {
     mbcx: &'visit mut MirBorrowckCtxt<'cx, 'gcx, 'tcx>,
 }
 
-impl<'visit, 'cx, 'gcx, 'tcx> GatherUsedMutsVisitor<'visit, 'cx, 'gcx, 'tcx> {
+impl GatherUsedMutsVisitor<'_, '_, '_, '_> {
     fn remove_never_initialized_mut_locals(into: &Place) {
         // Remove any locals that we found were initialized from the
         // `never_initialized_mut_locals` set. At the end, the only remaining locals will

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -53,7 +53,7 @@ struct GatherUsedMutsVisitor<'visit, 'cx: 'visit, 'gcx: 'tcx, 'tcx: 'cx> {
 }
 
 impl GatherUsedMutsVisitor<'_, '_, '_, '_> {
-    fn remove_never_initialized_mut_locals(&mut self, into: &Place) {
+    fn remove_never_initialized_mut_locals(&mut self, into: &Place<'_>) {
         // Remove any locals that we found were initialized from the
         // `never_initialized_mut_locals` set. At the end, the only remaining locals will
         // be those that were never initialized - we will consider those as being used as

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -60,11 +60,6 @@ impl GatherUsedMutsVisitor<'_, '_, '_, '_> {
         // they will either have been removed by unreachable code optimizations; or linted
         // as unused variables.
         if let Some(local) = into.base_local() {
-            debug!(
-                "visit_statement: statement={:?} local={:?} \
-                 never_initialized_mut_locals={:?}",
-                statement, local, self.never_initialized_mut_locals
-            );
             let _ = self.never_initialized_mut_locals.remove(&local);
         }
     }
@@ -95,6 +90,13 @@ impl<'visit, 'cx, 'gcx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'c
     ) {
         match &statement.kind {
             StatementKind::Assign(into, _) => {
+                if let Some(local) = into.base_local() {
+                    debug!(
+                        "visit_statement: statement={:?} local={:?} \
+                         never_initialized_mut_locals={:?}",
+                        statement, local, self.never_initialized_mut_locals
+                    );
+                }
                 self.remove_never_initialized_mut_locals(into);
             },
             _ => {},

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -53,7 +53,7 @@ struct GatherUsedMutsVisitor<'visit, 'cx: 'visit, 'gcx: 'tcx, 'tcx: 'cx> {
 }
 
 impl GatherUsedMutsVisitor<'_, '_, '_, '_> {
-    fn remove_never_initialized_mut_locals(into: &Place) {
+    fn remove_never_initialized_mut_locals(&mut self, into: &Place) {
         // Remove any locals that we found were initialized from the
         // `never_initialized_mut_locals` set. At the end, the only remaining locals will
         // be those that were never initialized - we will consider those as being used as

--- a/src/test/ui/nll/issue-61424.rs
+++ b/src/test/ui/nll/issue-61424.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     let mut x; //~ ERROR: variable does not need to be mutable
-    x = 0;
-    dbg!(0);
+    x = String::new();
+    dbg!(x);
 }

--- a/src/test/ui/nll/issue-61424.rs
+++ b/src/test/ui/nll/issue-61424.rs
@@ -1,0 +1,7 @@
+#![deny(unused_mut)]
+
+fn main() {
+    let mut x; //~ ERROR: variable does not need to be mutable
+    x = 0;
+    dbg!(0);
+}

--- a/src/test/ui/nll/issue-61424.stderr
+++ b/src/test/ui/nll/issue-61424.stderr
@@ -1,0 +1,16 @@
+error: variable does not need to be mutable
+  --> $DIR/issue-61424.rs:4:9
+   |
+LL |     let mut x;
+   |         ----^
+   |         |
+   |         help: remove this `mut`
+   |
+note: lint level defined here
+  --> $DIR/issue-61424.rs:1:9
+   |
+LL | #![deny(unused_mut)]
+   |         ^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Closes #61424

- [x] Todo add regression test