### PR TITLE
Fix missing semicolon in doc

### DIFF
--- a/src/libstd/macros.rs
+++ b/src/libstd/macros.rs
@@ -405,7 +405,7 @@ mod builtin {
     ///
     /// ```compile_fail
     /// #[cfg(not(any(feature = "foo", feature = "bar")))]
-    /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.")
+    /// compile_error!("Either feature \"foo\" or \"bar\" must be enabled for this crate.");
     /// ```
     ///
     /// [`panic!`]: ../std/macro.panic.html


### PR DESCRIPTION
A semicolon is missing in the examples of compile_error.
Macros that expand to items must be delimited with braces or followed by a semicolon.