### PR TITLE
Avoid more hygiene lookups

### DIFF
--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -3101,15 +3101,13 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
     }
 
     pub fn adjust_ident(self, mut ident: Ident, scope: DefId) -> Ident {
-        ident = ident.modern();
-        ident.span.adjust(self.expansion_that_defined(scope));
+        ident.span.modernize_and_adjust(self.expansion_that_defined(scope));
         ident
     }
 
     pub fn adjust_ident_and_get_scope(self, mut ident: Ident, scope: DefId, block: hir::HirId)
                                       -> (Ident, DefId) {
-        ident = ident.modern();
-        let scope = match ident.span.adjust(self.expansion_that_defined(scope)) {
+        let scope = match ident.span.modernize_and_adjust(self.expansion_that_defined(scope)) {
             Some(actual_expansion) =>
                 self.hir().definitions().parent_module_of_macro_def(actual_expansion),
             None => self.hir().get_module_parent_by_hir_id(block),

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -3089,7 +3089,8 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
         // comparison fails frequently, and we want to avoid the expensive
         // `modern()` calls required for the span comparison whenever possible.
         use_name.name == def_name.name &&
-        self.adjust_ident(use_name, def_parent_def_id).span.ctxt() == def_name.modern().span.ctxt()
+        use_name.span.ctxt().hygienic_eq(def_name.span.ctxt(),
+                                         self.expansion_that_defined(def_parent_def_id))
     }
 
     fn expansion_that_defined(self, scope: DefId) -> Mark {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -844,9 +844,8 @@ impl<'enc, 'a, 'tcx, E> SpecializedEncoder<Span> for CacheEncoder<'enc, 'a, 'tcx
         if span_data.ctxt == SyntaxContext::empty() {
             TAG_NO_EXPANSION_INFO.encode(self)
         } else {
-            let mark = span_data.ctxt.outer();
-
-            if let Some(expn_info) = mark.expn_info() {
+            let (mark, expn_info) = span_data.ctxt.outer_and_expn_info();
+            if let Some(expn_info) = expn_info {
                 if let Some(pos) = self.expn_info_shorthands.get(&mark).cloned() {
                     TAG_EXPANSION_INFO_SHORTHAND.encode(self)?;
                     pos.encode(self)

--- a/src/librustc_codegen_ssa/mir/mod.rs
+++ b/src/librustc_codegen_ssa/mir/mod.rs
@@ -128,14 +128,7 @@ impl<'a, 'tcx: 'a, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             // Walk up the macro expansion chain until we reach a non-expanded span.
             // We also stop at the function body level because no line stepping can occur
             // at the level above that.
-            let mut span = source_info.span;
-            while span.ctxt() != NO_EXPANSION && span.ctxt() != self.mir.span.ctxt() {
-                if let Some(info) = span.ctxt().outer_expn_info() {
-                    span = info.call_site;
-                } else {
-                    break;
-                }
-            }
+            let span = syntax_pos::hygiene::walk_chain(source_info.span, self.mir.span.ctxt());
             let scope = self.scope_metadata_for_loc(source_info.scope, span.lo());
             // Use span of the outermost expansion site, while keeping the original lexical scope.
             (scope, span)

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4525,7 +4525,7 @@ impl<'a> Resolver<'a> {
                 let mut ident = ident;
                 if ident.span.glob_adjust(
                     module.expansion,
-                    binding.span.ctxt().modern(),
+                    binding.span,
                 ).is_none() {
                     continue
                 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2330,14 +2330,12 @@ impl<'a> Resolver<'a> {
         let orig_current_module = self.current_module;
         match module {
             ModuleOrUniformRoot::Module(module) => {
-                ident.span = ident.span.modern();
-                if let Some(def) = ident.span.adjust(module.expansion) {
+                if let Some(def) = ident.span.modernize_and_adjust(module.expansion) {
                     self.current_module = self.macro_def_scope(def);
                 }
             }
             ModuleOrUniformRoot::ExternPrelude => {
-                ident.span = ident.span.modern();
-                ident.span.adjust(Mark::root());
+                ident.span.modernize_and_adjust(Mark::root());
             }
             ModuleOrUniformRoot::CrateRootAndExternPrelude |
             ModuleOrUniformRoot::CurrentScope => {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -388,7 +388,7 @@ impl<'a> Resolver<'a> {
                 None => return Err((Undetermined, Weak::Yes)),
             };
             let (orig_current_module, mut ident) = (self.current_module, ident.modern());
-            match ident.span.glob_adjust(module.expansion, glob_import.span.ctxt().modern()) {
+            match ident.span.glob_adjust(module.expansion, glob_import.span) {
                 Some(Some(def)) => self.current_module = self.macro_def_scope(def),
                 Some(None) => {}
                 None => continue,
@@ -605,8 +605,7 @@ impl<'a> Resolver<'a> {
         // Define `binding` in `module`s glob importers.
         for directive in module.glob_importers.borrow_mut().iter() {
             let mut ident = ident.modern();
-            let scope = match ident.span.reverse_glob_adjust(module.expansion,
-                                                             directive.span.ctxt().modern()) {
+            let scope = match ident.span.reverse_glob_adjust(module.expansion, directive.span) {
                 Some(Some(def)) => self.macro_def_scope(def),
                 Some(None) => directive.parent_scope.module,
                 None => continue,
@@ -1359,8 +1358,7 @@ impl<'a, 'b:'a> ImportResolver<'a, 'b> {
             resolution.borrow().binding().map(|binding| (ident, binding))
         }).collect::<Vec<_>>();
         for ((mut ident, ns), binding) in bindings {
-            let scope = match ident.span.reverse_glob_adjust(module.expansion,
-                                                             directive.span.ctxt().modern()) {
+            let scope = match ident.span.reverse_glob_adjust(module.expansion, directive.span) {
                 Some(Some(def)) => self.macro_def_scope(def),
                 Some(None) => self.current_module,
                 None => continue,

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -98,7 +98,7 @@ impl Mark {
 
     #[inline]
     pub fn expn_info(self) -> Option<ExpnInfo> {
-        HygieneData::with(|data| data.marks[self.0 as usize].expn_info.clone())
+        HygieneData::with(|data| data.expn_info(self))
     }
 
     #[inline]
@@ -214,6 +214,10 @@ impl HygieneData {
         true
     }
 
+    fn default_transparency(&self, mark: Mark) -> Transparency {
+        self.marks[mark.0 as usize].default_transparency
+    }
+
     fn modern(&self, ctxt: SyntaxContext) -> SyntaxContext {
         self.syntax_contexts[ctxt.0 as usize].opaque
     }
@@ -287,7 +291,7 @@ impl SyntaxContext {
     pub fn apply_mark(self, mark: Mark) -> SyntaxContext {
         assert_ne!(mark, Mark::root());
         self.apply_mark_with_transparency(
-            mark, HygieneData::with(|data| data.marks[mark.0 as usize].default_transparency)
+            mark, HygieneData::with(|data| data.default_transparency(mark))
         )
     }
 

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -244,6 +244,19 @@ impl HygieneData {
         outer_mark
     }
 
+    fn marks(&self, mut ctxt: SyntaxContext) -> Vec<(Mark, Transparency)> {
+        let mut marks = Vec::new();
+        while ctxt != SyntaxContext::empty() {
+            let outer_mark = self.outer(ctxt);
+            let transparency = self.transparency(ctxt);
+            let prev_ctxt = self.prev_ctxt(ctxt);
+            marks.push((outer_mark, transparency));
+            ctxt = prev_ctxt;
+        }
+        marks.reverse();
+        marks
+    }
+
     fn adjust(&self, ctxt: &mut SyntaxContext, expansion: Mark) -> Option<Mark> {
         let mut scope = None;
         while !self.is_descendant_of(expansion, self.outer(*ctxt)) {
@@ -423,19 +436,8 @@ impl SyntaxContext {
         HygieneData::with(|data| data.remove_mark(self))
     }
 
-    pub fn marks(mut self) -> Vec<(Mark, Transparency)> {
-        HygieneData::with(|data| {
-            let mut marks = Vec::new();
-            while self != SyntaxContext::empty() {
-                let outer_mark = data.outer(self);
-                let transparency = data.transparency(self);
-                let prev_ctxt = data.prev_ctxt(self);
-                marks.push((outer_mark, transparency));
-                self = prev_ctxt;
-            }
-            marks.reverse();
-            marks
-        })
+    pub fn marks(self) -> Vec<(Mark, Transparency)> {
+        HygieneData::with(|data| data.marks(self))
     }
 
     /// Adjust this context for resolution in a scope created by the given expansion.

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -257,6 +257,17 @@ impl HygieneData {
         marks
     }
 
+    fn walk_chain(&self, mut span: Span, to: SyntaxContext) -> Span {
+        while span.ctxt() != crate::NO_EXPANSION && span.ctxt() != to {
+            if let Some(info) = self.expn_info(self.outer(span.ctxt())) {
+                span = info.call_site;
+            } else {
+                break;
+            }
+        }
+        span
+    }
+
     fn adjust(&self, ctxt: &mut SyntaxContext, expansion: Mark) -> Option<Mark> {
         let mut scope = None;
         while !self.is_descendant_of(expansion, self.outer(*ctxt)) {
@@ -364,6 +375,10 @@ impl HygieneData {
 
 pub fn clear_markings() {
     HygieneData::with(|data| data.markings = FxHashMap::default());
+}
+
+pub fn walk_chain(span: Span, to: SyntaxContext) -> Span {
+    HygieneData::with(|data| data.walk_chain(span, to))
 }
 
 impl SyntaxContext {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -463,9 +463,9 @@ impl SyntaxContext {
     /// ```
     /// This returns `None` if the context cannot be glob-adjusted.
     /// Otherwise, it returns the scope to use when privacy checking (see `adjust` for details).
-    pub fn glob_adjust(&mut self, expansion: Mark, mut glob_ctxt: SyntaxContext)
-                       -> Option<Option<Mark>> {
+    pub fn glob_adjust(&mut self, expansion: Mark, glob_span: Span) -> Option<Option<Mark>> {
         let mut scope = None;
+        let mut glob_ctxt = glob_span.ctxt().modern();
         while !expansion.outer_is_descendant_of(glob_ctxt) {
             scope = Some(glob_ctxt.remove_mark());
             if self.remove_mark() != scope.unwrap() {
@@ -485,12 +485,13 @@ impl SyntaxContext {
     ///     assert!(self.glob_adjust(expansion, glob_ctxt) == Some(privacy_checking_scope));
     /// }
     /// ```
-    pub fn reverse_glob_adjust(&mut self, expansion: Mark, mut glob_ctxt: SyntaxContext)
+    pub fn reverse_glob_adjust(&mut self, expansion: Mark, glob_span: Span)
                                -> Option<Option<Mark>> {
         if self.adjust(expansion).is_some() {
             return None;
         }
 
+        let mut glob_ctxt = glob_span.ctxt().modern();
         let mut marks = Vec::new();
         while !expansion.outer_is_descendant_of(glob_ctxt) {
             marks.push(glob_ctxt.remove_mark());

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -508,6 +508,14 @@ impl SyntaxContext {
         HygieneData::with(|data| data.adjust(self, expansion))
     }
 
+    /// Like `SyntaxContext::adjust`, but also modernizes `self`.
+    pub fn modernize_and_adjust(&mut self, expansion: Mark) -> Option<Mark> {
+        HygieneData::with(|data| {
+            *self = data.modern(*self);
+            data.adjust(self, expansion)
+        })
+    }
+
     /// Adjust this context for resolution in a scope created by the given expansion
     /// via a glob import with the given `SyntaxContext`.
     /// For example:

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -237,6 +237,12 @@ impl HygieneData {
     fn prev_ctxt(&self, ctxt: SyntaxContext) -> SyntaxContext {
         self.syntax_contexts[ctxt.0 as usize].prev_ctxt
     }
+
+    fn remove_mark(&self, ctxt: &mut SyntaxContext) -> Mark {
+        let outer_mark = self.syntax_contexts[ctxt.0 as usize].outer_mark;
+        *ctxt = self.prev_ctxt(*ctxt);
+        outer_mark
+    }
 }
 
 pub fn clear_markings() {
@@ -406,11 +412,7 @@ impl SyntaxContext {
     /// invocation of f that created g1.
     /// Returns the mark that was removed.
     pub fn remove_mark(&mut self) -> Mark {
-        HygieneData::with(|data| {
-            let outer_mark = data.syntax_contexts[self.0 as usize].outer_mark;
-            *self = data.prev_ctxt(*self);
-            outer_mark
-        })
+        HygieneData::with(|data| data.remove_mark(self))
     }
 
     pub fn marks(mut self) -> Vec<(Mark, Transparency)> {

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -543,6 +543,14 @@ impl SyntaxContext {
         })
     }
 
+    pub fn hygienic_eq(self, other: SyntaxContext, mark: Mark) -> bool {
+        HygieneData::with(|data| {
+            let mut self_modern = data.modern(self);
+            data.adjust(&mut self_modern, mark);
+            self_modern == data.modern(other)
+        })
+    }
+
     #[inline]
     pub fn modern(self) -> SyntaxContext {
         HygieneData::with(|data| data.modern(self))

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -565,6 +565,16 @@ impl SyntaxContext {
         HygieneData::with(|data| data.expn_info(data.outer(self)))
     }
 
+    /// `ctxt.outer_and_expn_info()` is equivalent to but faster than
+    /// `{ let outer = ctxt.outer(); (outer, outer.expn_info()) }`.
+    #[inline]
+    pub fn outer_and_expn_info(self) -> (Mark, Option<ExpnInfo>) {
+        HygieneData::with(|data| {
+            let outer = data.outer(self);
+            (outer, data.expn_info(outer))
+        })
+    }
+
     pub fn dollar_crate_name(self) -> Symbol {
         HygieneData::with(|data| data.syntax_contexts[self.0 as usize].dollar_crate_name)
     }

--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -265,6 +265,11 @@ impl HygieneData {
         scope
     }
 
+    fn apply_mark(&mut self, ctxt: SyntaxContext, mark: Mark) -> SyntaxContext {
+        assert_ne!(mark, Mark::root());
+        self.apply_mark_with_transparency(ctxt, mark, self.default_transparency(mark))
+    }
+
     fn apply_mark_with_transparency(&mut self, ctxt: SyntaxContext, mark: Mark,
                                     transparency: Transparency) -> SyntaxContext {
         assert_ne!(mark, Mark::root());
@@ -407,10 +412,7 @@ impl SyntaxContext {
 
     /// Extend a syntax context with a given mark and default transparency for that mark.
     pub fn apply_mark(self, mark: Mark) -> SyntaxContext {
-        assert_ne!(mark, Mark::root());
-        self.apply_mark_with_transparency(
-            mark, HygieneData::with(|data| data.default_transparency(mark))
-        )
+        HygieneData::with(|data| data.apply_mark(self, mark))
     }
 
     /// Extend a syntax context with a given mark and transparency

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -535,6 +535,14 @@ impl Span {
     }
 
     #[inline]
+    pub fn modernize_and_adjust(&mut self, expansion: Mark) -> Option<Mark> {
+        let mut span = self.data();
+        let mark = span.ctxt.modernize_and_adjust(expansion);
+        *self = Span::new(span.lo, span.hi, span.ctxt);
+        mark
+    }
+
+    #[inline]
     pub fn glob_adjust(&mut self, expansion: Mark, glob_span: Span) -> Option<Option<Mark>> {
         let mut span = self.data();
         let mark = span.ctxt.glob_adjust(expansion, glob_span);

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -535,19 +535,18 @@ impl Span {
     }
 
     #[inline]
-    pub fn glob_adjust(&mut self, expansion: Mark, glob_ctxt: SyntaxContext)
-                       -> Option<Option<Mark>> {
+    pub fn glob_adjust(&mut self, expansion: Mark, glob_span: Span) -> Option<Option<Mark>> {
         let mut span = self.data();
-        let mark = span.ctxt.glob_adjust(expansion, glob_ctxt);
+        let mark = span.ctxt.glob_adjust(expansion, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }
 
     #[inline]
-    pub fn reverse_glob_adjust(&mut self, expansion: Mark, glob_ctxt: SyntaxContext)
+    pub fn reverse_glob_adjust(&mut self, expansion: Mark, glob_span: Span)
                                -> Option<Option<Mark>> {
         let mut span = self.data();
-        let mark = span.ctxt.reverse_glob_adjust(expansion, glob_ctxt);
+        let mark = span.ctxt.reverse_glob_adjust(expansion, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }


### PR DESCRIPTION
Mostly by combining multiple `HygieneData::with` calls into a single call on hot paths.

r? @petrochenkov 