### PR TITLE
azure: retry s3 upload if it fails

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -118,6 +118,7 @@ steps:
 # bucket.
 - bash: |
     set -e
+    source src/ci/shared.sh
     if [ "$AGENT_OS" = "Linux" ]; then
         rm -rf obj/build/dist/doc
         upload_dir=obj/build/dist
@@ -130,7 +131,7 @@ steps:
     if [ "$DEPLOY_ALT" == "1" ]; then
         deploy_dir=rustc-builds-alt
     fi
-    aws s3 cp --no-progress --recursive --acl public-read ./$upload_dir s3://$DEPLOY_BUCKET/$deploy_dir/$BUILD_SOURCEVERSION
+    retry aws s3 cp --no-progress --recursive --acl public-read ./$upload_dir s3://$DEPLOY_BUCKET/$deploy_dir/$BUILD_SOURCEVERSION
   env:
     AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
   condition: and(succeeded(), or(eq(variables.DEPLOY, '1'), eq(variables.DEPLOY_ALT, '1')))


### PR DESCRIPTION
We had some cases (like [this](https://dev.azure.com/rust-lang/e71b0ddf-dd27-435a-873c-e30f86eea377/_apis/build/builds/370/logs/734) a few hours ago) when uploading to S3 fails with a network error. This retries the upload if it fails.

r? @alexcrichton 