### PR TITLE
ci: Reenable step timings on AppVeyor

### DIFF
--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -35,6 +35,8 @@ function isOSX {
 function getCIBranch {
   if [ "$TRAVIS" = "true" ]; then
     echo "$TRAVIS_BRANCH"
+  elif [ "$APPVEYOR" = "True" ]; then
+    echo "$APPVEYOR_REPO_BRANCH"
   else
     echo "$BUILD_SOURCEBRANCHNAME"
   fi;


### PR DESCRIPTION
This was accidentally regressed in #60777 by accident, and we've stopped
printing out step timings on AppVeyor recently reducing the ability for
us to track build times over time!