### PR TITLE
Add "type_name" support in emulate_intrinsic()

### DIFF
--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -11,7 +11,7 @@ use rustc::mir::interpret::{
 };
 
 use super::{
-    Machine, PlaceTy, OpTy, InterpretCx,
+    Machine, PlaceTy, OpTy, InterpretCx, Immediate,
 };
 
 mod type_name;

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -78,6 +78,16 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
                 let id_val = Scalar::from_uint(type_id, dest.layout.size);
                 self.write_scalar(id_val, dest)?;
             }
+
+            "type_name" => {
+                let alloc = alloc_type_name(self.tcx.tcx, substs.type_at(0));
+                let name_id = self.tcx.alloc_map.lock().create_memory_alloc(alloc);
+                let id_ptr = self.memory.tag_static_base_pointer(name_id.into());
+                let alloc_len = alloc.bytes.len() as u64;
+                let name_val = Immediate::new_slice(Scalar::Ptr(id_ptr), alloc_len, self);
+                self.write_immediate(name_val, dest)?;
+            }
+
             | "ctpop"
             | "cttz"
             | "cttz_nonzero"

--- a/src/test/run-pass/ctfe/const-fn-type-name.rs
+++ b/src/test/run-pass/ctfe/const-fn-type-name.rs
@@ -1,0 +1,37 @@
+// run-pass
+
+#![feature(core_intrinsics)]
+#![feature(const_fn)]
+#![allow(dead_code)]
+
+const fn type_name_wrapper<T>(_: &T) -> &'static str {
+    unsafe { core::intrinsics::type_name::<T>() }
+}
+
+struct Struct<TA, TB, TC> {
+    a: TA,
+    b: TB,
+    c: TC,
+}
+
+type StructInstantiation = Struct<i8, f64, bool>;
+
+const CONST_STRUCT: StructInstantiation = StructInstantiation {
+    a: 12,
+    b: 13.7,
+    c: false,
+};
+
+const CONST_STRUCT_NAME: &'static str = type_name_wrapper(&CONST_STRUCT);
+
+fn main() {
+    let non_const_struct = StructInstantiation {
+        a: 87,
+        b: 65.99,
+        c: true,
+    };
+
+    let non_const_struct_name = type_name_wrapper(&non_const_struct);
+
+    assert_eq!(CONST_STRUCT_NAME, non_const_struct_name);
+}


### PR DESCRIPTION
I did some dumb Git things and deleted my original fork repo semi-accidentally (but probably for the best as I'd messed up the history.)

This is the same issue as #61399, which was obviously auto-closed, to be clear.