### PR TITLE
Hide gen_future API from documentation

### DIFF
--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -16,12 +16,14 @@ pub use core::future::*;
 ///
 /// This function returns a `GenFuture` underneath, but hides it in `impl Trait` to give
 /// better error messages (`impl Future` rather than `GenFuture<[closure.....]>`).
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 pub fn from_generator<T: Generator<Yield = ()>>(x: T) -> impl Future<Output = T::Return> {
     GenFuture(x)
 }
 
 /// A wrapper around generators used to implement `Future` for `async`/`await` code.
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 struct GenFuture<T: Generator<Yield = ()>>(T);
@@ -30,6 +32,7 @@ struct GenFuture<T: Generator<Yield = ()>>(T);
 // self-referential borrows in the underlying generator.
 impl<T: Generator<Yield = ()>> !Unpin for GenFuture<T> {}
 
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 impl<T: Generator<Yield = ()>> Future for GenFuture<T> {
     type Output = T::Return;
@@ -57,6 +60,7 @@ impl Drop for SetOnDrop {
     }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 /// Sets the thread-local task context used by async/await futures.
 pub fn set_task_context<F, R>(cx: &mut Context<'_>, f: F) -> R
@@ -74,6 +78,7 @@ where
     f()
 }
 
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 /// Retrieves the thread-local task context used by async/await futures.
 ///
@@ -105,6 +110,7 @@ where
     unsafe { f(cx_ptr.as_mut()) }
 }
 
+#[doc(hidden)]
 #[unstable(feature = "gen_future", issue = "50547")]
 /// Polls a future in the current thread-local task waker.
 pub fn poll_with_tls_context<F>(f: Pin<&mut F>) -> Poll<F::Output>


### PR DESCRIPTION
This is internal rustc only API which should never be used outside code created by the current `async` transform, if it is used then the panic messages don't make sense as they're written from the perspective of that meaning there is a bug in the `async` transform (e.g. #61482).