### PR TITLE
Edit docs of ExitStatus

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1153,7 +1153,7 @@ impl From<fs::File> for Stdio {
 ///
 /// This `struct` is used to represent the exit status of a child process.
 /// Child processes are created via the [`Command`] struct and their exit
-/// status is exposed through the [`status`] method, or the [`wait`] method 
+/// status is exposed through the [`status`] method, or the [`wait`] method
 /// of a [`Child`] process.
 ///
 /// [`Command`]: struct.Command.html

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1153,10 +1153,13 @@ impl From<fs::File> for Stdio {
 ///
 /// This `struct` is used to represent the exit status of a child process.
 /// Child processes are created via the [`Command`] struct and their exit
-/// status is exposed through the [`status`] method.
+/// status is exposed through the [`status`] method, or the [`wait`] method 
+/// of a [`Child`] process.
 ///
 /// [`Command`]: struct.Command.html
+/// [`Child`]: struct.Child.html
 /// [`status`]: struct.Command.html#method.status
+/// [`wait`]: struct.Child.html#method.wait
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 #[stable(feature = "process", since = "1.0.0")]
 pub struct ExitStatus(imp::ExitStatus);


### PR DESCRIPTION
The documentation of [`ExitStatus`] are extended to be at the same depth as [`Output`].