### PR TITLE
Coherence test when a generic type param has a default value from an associated type

### DIFF
--- a/src/test/run-pass/coherence/auxiliary/re_rebalance_coherence_lib.rs
+++ b/src/test/run-pass/coherence/auxiliary/re_rebalance_coherence_lib.rs
@@ -20,3 +20,12 @@ pub struct BatchInsert<'a, T: 'a, Tab> {
 impl<'a, T:'a, Tab, DB> QueryFragment<DB> for BatchInsert<'a, T, Tab>
 where DB: SupportsDefaultKeyword + Backend,
 {}
+
+pub trait LibToOwned {
+    type Owned;
+}
+
+pub struct LibCow<T: LibToOwned, Owned = <T as LibToOwned>::Owned> {
+    pub t: T,
+    pub o: Owned,
+}

--- a/src/test/run-pass/coherence/re-rebalance-coherence-default-generic-associated-type.rs
+++ b/src/test/run-pass/coherence/re-rebalance-coherence-default-generic-associated-type.rs
@@ -1,0 +1,27 @@
+// run-pass
+// aux-build:re_rebalance_coherence_lib.rs
+
+#![allow(dead_code)]
+#![feature(re_rebalance_coherence)]
+// check that a generic type with a default value from an associated type can be used without
+// specifying the value, and without invoking coherence errors.
+
+extern crate re_rebalance_coherence_lib as lib;
+use lib::*;
+
+struct MyString {}
+
+impl LibToOwned for MyString {
+    type Owned = String;
+}
+
+impl PartialEq<MyString> for LibCow<MyString> {
+    fn eq(&self, _other: &MyString) -> bool {
+        // Test that the default type is used.
+        let _s: &String = &self.o;
+
+        false
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
A followup on #61400.
Before `re_rebalance_coherence`, this fails to compile (even though it should be accepted).
`re_rebalance_coherence` had no direct test for this, and I wanted to (a) make sure it doesn't regress in the future and (b) get it on record that this is actually the intended behavior.