### PR TITLE
Don't use GNU noexec stack note

### DIFF
--- a/src/librustc_target/spec/netbsd_base.rs
+++ b/src/librustc_target/spec/netbsd_base.rs
@@ -9,9 +9,6 @@ pub fn opts() -> TargetOptions {
         // libraries which follow this flag.  Thus, use it before
         // specifying libraries to link to.
         "-Wl,--as-needed".to_string(),
-
-        // Always enable NX protection when it is available
-        "-Wl,-z,noexecstack".to_string(),
     ]);
 
     TargetOptions {


### PR DESCRIPTION
NetBSD ignores this note and marks the stack no-exec unconditionally