### PR TITLE
azure: Fix some minor issues which have broken our configuration 

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -102,6 +102,10 @@ steps:
 
 - bash: |
     set -e
+    # Remove any preexisting rustup installation since it can interfere
+    # with the cargotest step and its auto-detection of things like Clippy in
+    # the environment
+    rustup self uninstall -y || true
     if [ "$IMAGE" = "" ]; then
       src/ci/run.sh
     else

--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -50,6 +50,7 @@ steps:
 # on since libstd tests require it
 - bash: |
     set -e
+    sudo mkdir -p /etc/docker
     echo '{"ipv6":true,"fixed-cidr-v6":"fd9a:8454:6789:13f7::/64"}' | sudo tee /etc/docker/daemon.json
     sudo service docker restart
   displayName: Enable IPv6


### PR DESCRIPTION
* Ensure that when we enable IPv6 for Docker on Linux that the various directories before writing a config file
* Delete a previously installed rustup if any since it seems to interfere with Cargo's test suite.