### PR TITLE
Change visit api

### DIFF
--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -151,17 +151,17 @@ macro_rules! make_mir_visitor {
                 self.super_place(place, context, location);
             }
 
-            fn visit_projection(&mut self,
-                                place: & $($mutability)? Projection<'tcx>,
+            fn visit_place_base(&mut self,
+                                place_base: & $($mutability)? PlaceBase<'tcx>,
                                 context: PlaceContext,
                                 location: Location) {
-                self.super_projection(place, context, location);
+                self.super_place_base(place_base, context, location);
             }
 
-            fn visit_projection_elem(&mut self,
-                                     place: & $($mutability)? PlaceElem<'tcx>,
-                                     location: Location) {
-                self.super_projection_elem(place, location);
+            fn visit_projection(&mut self,
+                                place: & $($mutability)? Projection<'tcx>,
+                                location: Location) {
+                self.super_projection(place, location);
             }
 
             fn visit_constant(&mut self,
@@ -676,36 +676,40 @@ macro_rules! make_mir_visitor {
                             context: PlaceContext,
                             location: Location) {
                 match place {
-                    Place::Base(PlaceBase::Local(local)) => {
-                        self.visit_local(local, context, location);
-                    }
-                    Place::Base(PlaceBase::Static(box Static { kind: _, ty })) => {
-                        self.visit_ty(& $($mutability)? *ty, TyContext::Location(location));
+                    Place::Base(place_base) => {
+                        self.visit_place_base(place_base, context, location);
                     }
                     Place::Projection(proj) => {
-                        self.visit_projection(proj, context, location);
+                        let context = if context.is_mutating_use() {
+                            PlaceContext::MutatingUse(MutatingUseContext::Projection)
+                        } else {
+                            PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
+                        };
+
+                        self.visit_place(& $($mutability)? proj.base, context, location);
+                        self.visit_projection(proj, location);
+                    }
+                }
+            }
+
+            fn super_place_base(&mut self,
+                                place_base: & $($mutability)? PlaceBase<'tcx>,
+                                context: PlaceContext,
+                                location: Location) {
+                match place_base {
+                    PlaceBase::Local(local) => {
+                        self.visit_local(local, context, location);
+                    }
+                    PlaceBase::Static(box Static { kind: _, ty }) => {
+                        self.visit_ty(& $($mutability)? *ty, TyContext::Location(location));
                     }
                 }
             }
 
             fn super_projection(&mut self,
                                 proj: & $($mutability)? Projection<'tcx>,
-                                context: PlaceContext,
                                 location: Location) {
-                let Projection { base, elem } = proj;
-                let context = if context.is_mutating_use() {
-                    PlaceContext::MutatingUse(MutatingUseContext::Projection)
-                } else {
-                    PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
-                };
-                self.visit_place(base, context, location);
-                self.visit_projection_elem(elem, location);
-            }
-
-            fn super_projection_elem(&mut self,
-                                     proj: & $($mutability)? PlaceElem<'tcx>,
-                                     location: Location) {
-                match proj {
+                match & $($mutability)? proj.elem {
                     ProjectionElem::Deref => {
                     }
                     ProjectionElem::Subslice { from: _, to: _ } => {


### PR DESCRIPTION
r? @oli-obk 

In the [first commit](https://github.com/rust-lang/rust/commit/37386d366a816bc2e63749c7b6045108a6167135) of this PR, I'm changing `visit_place` to be the function that traverses the `Place` and have only that responsibility. Then there are two other functions `visit_place_base` and `visit_projection` which are the ones in charge of visiting the base and the projection. Visitor implementors can implement any of those.

In the [second commit](https://github.com/rust-lang/rust/commit/e786f631b815d171051279e0d6cfe055c75bec2e) we can already see some things that confuses me, which I think this division will make more clear. The old code, first checked if the place was a base, did something with it and then called `super_place` [here](https://github.com/rust-lang/rust/commit/e786f631b815d171051279e0d6cfe055c75bec2e#diff-d583e4efe1a72516e274158e53223633L678). `super_place` checks again if it's a base [here](https://github.com/rust-lang/rust/blob/master/src/librustc/mir/visit.rs#L679-L684) and in case is a local, visits the local and stuff like that. That's not very obvious on the code, and if I'm not wrong it's not needed. In this PR or we have [this](https://github.com/rust-lang/rust/commit/e786f631b815d171051279e0d6cfe055c75bec2e#diff-d583e4efe1a72516e274158e53223633R673) as I did or we can just do `- => self.super_place_base(...)` and that will be obvious that I'm letting the default implementation process the base.