### PR TITLE
librustc_errors: Rename AnnotateRs -> AnnotateSnippet

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -2003,7 +2003,7 @@ pub fn build_session_options_and_crate_config(
             None |
             Some("human") => ErrorOutputType::HumanReadable(HumanReadableErrorType::Default(color)),
             Some("human-annotate-rs") => {
-                ErrorOutputType::HumanReadable(HumanReadableErrorType::AnnotateRs(color))
+                ErrorOutputType::HumanReadable(HumanReadableErrorType::AnnotateSnippet(color))
             },
             Some("json") => ErrorOutputType::Json { pretty: false, json_rendered },
             Some("pretty-json") => ErrorOutputType::Json { pretty: true, json_rendered },
@@ -2041,7 +2041,7 @@ pub fn build_session_options_and_crate_config(
                 "--error-format=pretty-json is unstable",
             );
         }
-        if let ErrorOutputType::HumanReadable(HumanReadableErrorType::AnnotateRs(_)) =
+        if let ErrorOutputType::HumanReadable(HumanReadableErrorType::AnnotateSnippet(_)) =
             error_format {
             early_error(
                 ErrorOutputType::Json { pretty: false, json_rendered },

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -24,7 +24,7 @@ use rustc_data_structures::sync::{
 use errors::{DiagnosticBuilder, DiagnosticId, Applicability};
 use errors::emitter::{Emitter, EmitterWriter};
 use errors::emitter::HumanReadableErrorType;
-use errors::annotate_rs_emitter::{AnnotateRsEmitterWriter};
+use errors::annotate_snippet_emitter_writer::{AnnotateSnippetEmitterWriter};
 use syntax::ast::{self, NodeId};
 use syntax::edition::Edition;
 use syntax::feature_gate::{self, AttributeType};
@@ -1034,8 +1034,8 @@ fn default_emitter(
         (config::ErrorOutputType::HumanReadable(kind), dst) => {
             let (short, color_config) = kind.unzip();
 
-            if let HumanReadableErrorType::AnnotateRs(_) = kind {
-                let emitter = AnnotateRsEmitterWriter::new(
+            if let HumanReadableErrorType::AnnotateSnippet(_) = kind {
+                let emitter = AnnotateSnippetEmitterWriter::new(
                     Some(source_map.clone()),
                     short,
                 );

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -1,9 +1,9 @@
-/// Emit diagnostics using the `annotate-snippets` library
-///
-/// This is the equivalent of `./emitter.rs` but making use of the
-/// [`annotate-snippets`][annotate_snippets] library instead of building the output ourselves.
-///
-/// [annotate_snippets]: https://docs.rs/crate/annotate-snippets/
+//! Emit diagnostics using the `annotate-snippets` library
+//!
+//! This is the equivalent of `./emitter.rs` but making use of the
+//! [`annotate-snippets`][annotate_snippets] library instead of building the output ourselves.
+//!
+//! [annotate_snippets]: https://docs.rs/crate/annotate-snippets/
 
 use syntax_pos::{SourceFile, MultiSpan, Loc};
 use crate::{
@@ -18,8 +18,8 @@ use annotate_snippets::display_list::DisplayList;
 use annotate_snippets::formatter::DisplayListFormatter;
 
 
-/// Generates diagnostics using annotate-rs
-pub struct AnnotateRsEmitterWriter {
+/// Generates diagnostics using annotate-snippet
+pub struct AnnotateSnippetEmitterWriter {
     source_map: Option<Lrc<SourceMapperDyn>>,
     /// If true, hides the longer explanation text
     short_message: bool,
@@ -27,7 +27,7 @@ pub struct AnnotateRsEmitterWriter {
     ui_testing: bool,
 }
 
-impl Emitter for AnnotateRsEmitterWriter {
+impl Emitter for AnnotateSnippetEmitterWriter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, db: &DiagnosticBuilder<'_>) {
         let primary_span = db.span.clone();
@@ -158,7 +158,7 @@ impl<'a>  DiagnosticConverter<'a> {
     }
 }
 
-impl AnnotateRsEmitterWriter {
+impl AnnotateSnippetEmitterWriter {
     pub fn new(
         source_map: Option<Lrc<SourceMapperDyn>>,
         short_message: bool

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -24,7 +24,7 @@ use termcolor::{WriteColor, Color, Buffer};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HumanReadableErrorType {
     Default(ColorConfig),
-    AnnotateRs(ColorConfig),
+    AnnotateSnippet(ColorConfig),
     Short(ColorConfig),
 }
 
@@ -34,7 +34,7 @@ impl HumanReadableErrorType {
         match self {
             HumanReadableErrorType::Default(cc) => (false, cc),
             HumanReadableErrorType::Short(cc) => (true, cc),
-            HumanReadableErrorType::AnnotateRs(cc) => (false, cc),
+            HumanReadableErrorType::AnnotateSnippet(cc) => (false, cc),
         }
     }
     pub fn new_emitter(

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -33,7 +33,7 @@ use termcolor::{ColorSpec, Color};
 mod diagnostic;
 mod diagnostic_builder;
 pub mod emitter;
-pub mod annotate_rs_emitter;
+pub mod annotate_snippet_emitter_writer;
 mod snippet;
 pub mod registry;
 mod styled_buffer;


### PR DESCRIPTION
The proper name of the library is `annotate-snippet`, not `annotate-rs`,
this PR should get rid of any confusing `AnnotateRs` names.

1. Renames `annotate_rs_emitter.rs` to
   `annotate_snippet_emitter_writer.rs` so that the difference between the
   `Emitter` trait and the implementers is more clear.
2. Renames `AnnotateRsEmitterWriter` to `AnnotateSnippetEmitterWriter`
3. Renames `HumanReadableErrorType::AnnotateRs` to `HumanReadableErrorType::AnnotateSnippet`