### PR TITLE
Fix HIR visit order

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -1055,8 +1055,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(left_hand_expression)
         }
         ExprKind::AssignOp(_, ref left_expression, ref right_expression) => {
-            visitor.visit_expr(left_expression);
             visitor.visit_expr(right_expression);
+            visitor.visit_expr(left_expression);
         }
         ExprKind::Field(ref subexpression, ident) => {
             visitor.visit_expr(subexpression);

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -1055,8 +1055,8 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr) {
             visitor.visit_expr(left_hand_expression)
         }
         ExprKind::AssignOp(_, ref left_expression, ref right_expression) => {
+            visitor.visit_expr(left_expression);
             visitor.visit_expr(right_expression);
-            visitor.visit_expr(left_expression)
         }
         ExprKind::Field(ref subexpression, ident) => {
             visitor.visit_expr(subexpression);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -371,14 +371,14 @@ struct RegionResolutionVisitor<'tcx> {
 
     // The number of expressions and patterns visited in the current body
     expr_and_pat_count: usize,
-    // When this is 'true', we record the Scopes we encounter
+    // When this is `true`, we record the `Scopes` we encounter
     // when processing a Yield expression. This allows us to fix
     // up their indices.
     pessimistic_yield: bool,
     // Stores scopes when pessimistic_yield is true.
     // Each time we encounter an ExprKind::AssignOp, we push
-    // a new Vec into the outermost Vec. This inner Vec is uesd
-    // to store any scopes we encounter when visiting the inenr expressions
+    // a new Vec into the outermost Vec. This inner Vec is used
+    // to store any scopes we encounter when visiting the inner expressions
     // of the AssignOp. Once we finish visiting the inner expressions, we pop
     // off the inner Vec, and process the Scopes it contains.
     // This allows us to handle nested AssignOps - while a terrible idea,
@@ -963,9 +963,9 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
     let prev_pessimistic = visitor.pessimistic_yield;
 
     // Ordinarily, we can rely on the visit order of HIR intravisit
-    // to correspond to the actual exectuion order of statements.
+    // to correspond to the actual execution order of statements.
     // However, there's a weird corner case with compund assignment
-    // operators (e.g. 'a += b'). The evaluation order depends on whether
+    // operators (e.g. `a += b`). The evaluation order depends on whether
     // or not the operator is overloaded (e.g. whether or not a trait
     // like AddAssign is implemented).
 
@@ -996,10 +996,10 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
     // To determine the actual execution order, we need to perform
     // trait resolution. Unfortunately, we need to be able to compute
     // yield_in_scope before type checking is even done, as it gets
-    // used by AST borrowcheck
+    // used by AST borrowcheck.
     //
     // Fortunately, we don't need to know the actual execution order.
-    // It sufficies to know the 'worst case' order with respect to yields.
+    // It suffices to know the 'worst case' order with respect to yields.
     // Specifically, we need to know the highest 'expr_and_pat_count'
     // that we could assign to the yield expression. To do this,
     // we pick the greater of the two values from the left-hand
@@ -1029,7 +1029,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
 
             // If the actual execution order turns out to be right-to-left,
             // then we're fine. However, if the actual execution order is left-to-right,
-            // then we'll assign too low of a count to any 'yield' expressions
+            // then we'll assign too low a count to any `yield` expressions
             // we encounter in 'right_expression' - they should really occur after all of the
             // expressions in 'left_expression'.
             visitor.visit_expr(&right_expression);
@@ -1474,7 +1474,7 @@ fn region_scope_tree<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx ScopeTree 
             },
             terminating_scopes: Default::default(),
             pessimistic_yield: false,
-            fixup_scopes: vec![]
+            fixup_scopes: vec![],
         };
 
         let body = tcx.hir().body(body_id);

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -1044,9 +1044,9 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
             debug!("resolve_expr - fixing up counts to {}", visitor.expr_and_pat_count);
 
             for scope in target_scopes {
-                let (span, count) = visitor.scope_tree.yield_in_scope.get_mut(&scope).unwrap();
-                let count = *count;
-                let span = *span;
+                let mut yield_data = visitor.scope_tree.yield_in_scope.get_mut(&scope).unwrap();
+                let count = yield_data.expr_and_pat_count;
+                let span = yield_data.span;
 
                 // expr_and_pat_count never decreases. Since we recorded counts in yield_in_scope
                 // before walking the left-hand side, it should be impossible for the recorded
@@ -1059,7 +1059,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
                 debug!("resolve_expr - increasing count for scope {:?} from {} to {} at span {:?}",
                        scope, count, new_count, span);
 
-                visitor.scope_tree.yield_in_scope.insert(scope, (span, new_count));
+                yield_data.expr_and_pat_count = new_count;
             }
 
         }

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -34,8 +34,6 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
 
         let live_across_yield = scope.map(|s| {
             self.region_scope_tree.yield_in_scope(s).and_then(|yield_data| {
-
-
                 // If we are recording an expression that is the last yield
                 // in the scope, or that has a postorder CFG index larger
                 // than the one of all of the yields, then its value can't

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -28,8 +28,14 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
               source_span: Span) {
         use syntax_pos::DUMMY_SP;
 
+        debug!("generator_interior: attempting to record type {:?} {:?} {:?} {:?}",
+               ty, scope, expr, source_span);
+
+
         let live_across_yield = scope.map(|s| {
             self.region_scope_tree.yield_in_scope(s).and_then(|yield_data| {
+
+
                 // If we are recording an expression that is the last yield
                 // in the scope, or that has a postorder CFG index larger
                 // than the one of all of the yields, then its value can't

--- a/src/test/run-pass/generator/addassign-yield.rs
+++ b/src/test/run-pass/generator/addassign-yield.rs
@@ -1,3 +1,9 @@
+// Regression test for broken MIR error (#61442)
+// Due to the two possible evaluation orders for
+// a '+=' expression (depending on whether or not the 'AddAssign' trait
+// is being used), we were failing to account for all types that might
+// possibly be live across a yield point.
+
 #![feature(generators)]
 
 fn foo() {

--- a/src/test/run-pass/issues/issue-61442.rs
+++ b/src/test/run-pass/issues/issue-61442.rs
@@ -5,6 +5,22 @@ fn foo() {
         let mut s = String::new();
         s += { yield; "" };
     };
+
+    let _y = static || {
+        let x = &mut 0;
+        *{ yield; x } += match String::new() { _ => 0 };
+    };
+
+    // Please don't ever actually write something like this
+    let _z = static || {
+        let x = &mut 0;
+        *{
+            let inner = &mut 1;
+            *{ yield (); inner } += match String::new() { _ => 1};
+            yield;
+            x
+        } += match String::new() { _ => 2 };
+    };
 }
 
 fn main() {

--- a/src/test/run-pass/issues/issue-61442.rs
+++ b/src/test/run-pass/issues/issue-61442.rs
@@ -1,0 +1,12 @@
+#![feature(generators)]
+
+fn foo() {
+    let _x = static || {
+        let mut s = String::new();
+        s += { yield; "" };
+    };
+}
+
+fn main() {
+    foo()
+}


### PR DESCRIPTION
Fixes #61442

When rustc::middle::region::ScopeTree computes its yield_in_scope
field, it relies on the HIR visitor order to properly compute which
types must be live across yield points. In order for the computed scopes
to agree with the generated MIR, we must ensure that expressions
evaluated before a yield point are visited before the 'yield'
expression.

However, the visitor order for ExprKind::AssignOp
was incorrect. The left-hand side of a compund assignment expression is
evaluated before the right-hand side, but the right-hand expression was
being visited before the left-hand expression. If the left-hand
expression caused a new type to be introduced (e.g. through a
deref-coercion), the new type would be incorrectly seen as occuring
*after* the yield point, instead of before. This leads to a mismatch
between the computed generator types and the MIR, since the MIR will
correctly see the type as being live across the yield point.

To fix this, we correct the visitor order for ExprKind::AssignOp
to reflect the actual evaulation order.