### PR TITLE
Make `Span::edition` use one `GLOBALS.with` call, not two.

### DIFF
--- a/src/libsyntax_pos/hygiene.rs
+++ b/src/libsyntax_pos/hygiene.rs
@@ -640,6 +640,15 @@ impl SyntaxContext {
                     "$crate name is reset for a syntax context");
         })
     }
+
+    #[inline]
+    pub fn edition(self) -> Edition {
+        GLOBALS.with(|globals| {
+            let data = globals.hygiene_data.borrow_mut();
+            data.expn_info(data.outer(self))
+                .map_or(globals.edition, |einfo| einfo.edition)
+        })
+    }
 }
 
 impl fmt::Debug for SyntaxContext {

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -359,9 +359,7 @@ impl Span {
 
     /// Edition of the crate from which this span came.
     pub fn edition(self) -> edition::Edition {
-        self.ctxt().outer_expn_info().map_or_else(|| {
-            Edition::from_session()
-        }, |einfo| einfo.edition)
+        self.ctxt().edition()
     }
 
     #[inline]


### PR DESCRIPTION
This reduces the number of `GLOBALS` accesses by 15% on some benchmarks
with large constants, such as `tuple-stress` and `ucd`.

r? @petrochenkov 