### PR TITLE
Add ?Sized bounds to all the RangeBounds impls

### DIFF
--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -850,7 +850,7 @@ impl<T> RangeBounds<T> for (Bound<T>, Bound<T>) {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<'a, T: ?Sized + 'a> RangeBounds<T> for (Bound<&'a T>, Bound<&'a T>) {
+impl<T: ?Sized> RangeBounds<T> for (Bound<&T>, Bound<&T>) {
     fn start_bound(&self) -> Bound<&T> {
         self.0
     }
@@ -861,7 +861,7 @@ impl<'a, T: ?Sized + 'a> RangeBounds<T> for (Bound<&'a T>, Bound<&'a T>) {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeFrom<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeFrom<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
@@ -871,7 +871,7 @@ impl<T> RangeBounds<T> for RangeFrom<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeTo<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeTo<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
@@ -881,7 +881,7 @@ impl<T> RangeBounds<T> for RangeTo<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for Range<&T> {
+impl<T: ?Sized> RangeBounds<T> for Range<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
@@ -891,7 +891,7 @@ impl<T> RangeBounds<T> for Range<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeInclusive<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeInclusive<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
@@ -901,7 +901,7 @@ impl<T> RangeBounds<T> for RangeInclusive<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeToInclusive<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeToInclusive<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }


### PR DESCRIPTION
We found that all the `RangeBounds` implementations on the real range types (i.e. `RangeFull`, `RangeFrom`...) should have some size relaxation. Therefore I added the `?Sized` trait bound to all the implementations of the `RangeBounds` trait.

This pull request emerged after having seen the problem on [one of my reddit post](https://old.reddit.com/r/rust/comments/bxests/borrow_not_implemented_for_vec_i_understand_that/).