### PR TITLE
ci: Disable LLVM/debug assertions for distcheck

### DIFF
--- a/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-distcheck/Dockerfile
@@ -21,3 +21,10 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu --set rust.ignore-git=false
 ENV SCRIPT python2.7 ../x.py test distcheck
 ENV DIST_SRC 1
+
+# The purpose of this builder is to test that we can `./x.py test` successfully
+# from a tarball, not to test LLVM/rustc's own set of assertions. These cause a
+# significant hit to CI compile time (over a half hour as observed in #61185),
+# so disable assertions for this builder.
+ENV NO_LLVM_ASSERTIONS=1
+ENV NO_DEBUG_ASSERTIONS=1


### PR DESCRIPTION
The purpose of distcheck is to test `./x.py test` from a tarball, not to
test that all assertions pass all the time. These assertions are largely
just redundant with other builders, so skip the assertions for now and
save a good chunk of time on CI.

cc #61185