### PR TITLE
Handle index out of bound errors during const eval without panic

### DIFF
--- a/src/test/ui/consts/array-literal-index-oob.rs
+++ b/src/test/ui/consts/array-literal-index-oob.rs
@@ -1,0 +1,6 @@
+fn main() {
+    &{[1, 2, 3][4]};
+    //~^ ERROR index out of bounds
+    //~| ERROR reaching this expression at runtime will panic or abort
+    //~| ERROR this expression will panic at runtime
+}

--- a/src/test/ui/consts/array-literal-index-oob.stderr
+++ b/src/test/ui/consts/array-literal-index-oob.stderr
@@ -1,0 +1,24 @@
+error: index out of bounds: the len is 3 but the index is 4
+  --> $DIR/array-literal-index-oob.rs:2:7
+   |
+LL |     &{[1, 2, 3][4]};
+   |       ^^^^^^^^^^^^
+   |
+   = note: #[deny(const_err)] on by default
+
+error: this expression will panic at runtime
+  --> $DIR/array-literal-index-oob.rs:2:5
+   |
+LL |     &{[1, 2, 3][4]};
+   |     ^^^^^^^^^^^^^^^ index out of bounds: the len is 3 but the index is 4
+
+error: reaching this expression at runtime will panic or abort
+  --> $DIR/array-literal-index-oob.rs:2:7
+   |
+LL |     &{[1, 2, 3][4]};
+   |     --^^^^^^^^^^^^-
+   |       |
+   |       index out of bounds: the len is 3 but the index is 4
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fix #61595