### PR TITLE
Increases heap size available during testing for SGX

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -87,3 +87,5 @@ std_detect_dlsym_getauxval = []
 [package.metadata.fortanix-sgx]
 # Maximum possible number of threads when testing
 threads = 125
+# Maximum heap size
+heap_size = 0x8000000


### PR DESCRIPTION
PR [61540](https://github.com/rust-lang/rust/pull/61540) causes at least one test to fail when run for the SGX platform due to lack of memory. This PR increases the heapsize available during tests, which is a good thing regardless of the status of that PR.