### PR TITLE
More save analysis

### DIFF
--- a/src/test/run-make-fulldeps/save-analysis/Makefile
+++ b/src/test/run-make-fulldeps/save-analysis/Makefile
@@ -1,10 +1,22 @@
 -include ../tools.mk
+
+export RUST_BACKTRACE=1
+export RUST_LOG=rustc_save_analysis=debug
+export RUST_SAVE_ANALYSIS_CONFIG={"output_file": null,"full_docs": true,"pub_only": false,"reachable_only": false,"distro_crate": false,"signatures": true,"borrow_data": true}
+
 all: check
 krate2: krate2.rs
 	$(RUSTC) $<
 code: foo.rs krate2
-	$(RUSTC) foo.rs -Zsave-analysis
+	$(RUSTC) foo.rs -Zsave-analysis 2>/dev/null
 check: code
-	mkdir -p $(TMPDIR)/intermediate
+	mkdir -p $(TMPDIR)/sigs
 	cat $(TMPDIR)/save-analysis/test.json | "$(PYTHON)" validate_json.py $(TMPDIR)/sigs
-	$(foreach sig,$(wildcard $(TMPDIR)/sigs/*),rustc -Z unstable-options --pretty normal $(sig))
+	@echo 'Checking that all signatures parse as valid rust code...'
+
+	@for file in $$(ls $(TMPDIR)/sigs); do \
+		echo Parsing signature $(TMPDIR)/sigs/$$file...; \
+		$(RUSTC) -Zunstable-options --pretty=normal $(TMPDIR)/sigs/$$file ; \
+	done
+
+	exit 1

--- a/src/test/run-make-fulldeps/save-analysis/Makefile
+++ b/src/test/run-make-fulldeps/save-analysis/Makefile
@@ -1,6 +1,10 @@
 -include ../tools.mk
-all: code
+all: check
 krate2: krate2.rs
 	$(RUSTC) $<
 code: foo.rs krate2
 	$(RUSTC) foo.rs -Zsave-analysis
+check: code
+	mkdir -p $(TMPDIR)/intermediate
+	cat $(TMPDIR)/save-analysis/test.json | "$(PYTHON)" validate_json.py $(TMPDIR)/sigs
+	$(foreach sig,$(wildcard $(TMPDIR)/sigs/*),rustc -Z unstable-options --pretty normal $(sig))

--- a/src/test/run-make-fulldeps/save-analysis/Makefile
+++ b/src/test/run-make-fulldeps/save-analysis/Makefile
@@ -1,22 +1,24 @@
 -include ../tools.mk
 
 export RUST_BACKTRACE=1
-export RUST_LOG=rustc_save_analysis=debug
+export RUSTC_LOG=rustc_save_analysis=debug
 export RUST_SAVE_ANALYSIS_CONFIG={"output_file": null,"full_docs": true,"pub_only": false,"reachable_only": false,"distro_crate": false,"signatures": true,"borrow_data": true}
 
 all: check
 krate2: krate2.rs
 	$(RUSTC) $<
 code: foo.rs krate2
-	$(RUSTC) foo.rs -Zsave-analysis 2>/dev/null
+	$(RUSTC) foo.rs -Zsave-analysis
 check: code
+	rm -rf $(TMPDIR)/sigs
 	mkdir -p $(TMPDIR)/sigs
 	cat $(TMPDIR)/save-analysis/test.json | "$(PYTHON)" validate_json.py $(TMPDIR)/sigs
 	@echo 'Checking that all signatures parse as valid rust code...'
 
 	@for file in $$(ls $(TMPDIR)/sigs); do \
-		echo Parsing signature $(TMPDIR)/sigs/$$file...; \
-		$(RUSTC) -Zunstable-options --pretty=normal $(TMPDIR)/sigs/$$file ; \
+		$(RUSTC) -Zunstable-options --pretty=normal $(TMPDIR)/sigs/$$file > /dev/null 2>$(TMPDIR)/sigs/$$file.out & \
+	done; \
+	wait; \
+	for file in $$(ls $(TMPDIR)/sigs | grep .out | sort); do \
+		cat $(TMPDIR)/sigs/$$file; \
 	done
-
-	exit 1

--- a/src/test/run-make-fulldeps/save-analysis/foo.rs
+++ b/src/test/run-make-fulldeps/save-analysis/foo.rs
@@ -3,6 +3,7 @@
 #![feature(rustc_private)]
 #![feature(associated_type_defaults)]
 #![feature(external_doc)]
+#![allow(warnings)]
 
 extern crate graphviz;
 // A simple rust project

--- a/src/test/run-make-fulldeps/save-analysis/validate_json.py
+++ b/src/test/run-make-fulldeps/save-analysis/validate_json.py
@@ -68,19 +68,21 @@ for def_ in analysis['defs']:
     if 'sig' not in def_ or def_['sig'] is None:
         continue
 
+    out = os.path.join(out_dir, def_['name'] + '.rs')
+
     # write out sigs to check parsing
-    with open(os.path.join(out_dir, def_['name'] + '.rs'), 'w') as f:
+    with open(out, 'w+') as f:
         if def_['kind'] in ['Function', 'Struct', 'Enum']:
             f.write(def_['sig']['text'])
-        if def_['kind'] == 'Field':
+        elif def_['kind'] == 'Field':
             f.write('struct _test {')
             f.write(def_['sig']['text'])
             f.write('}')
-        if def_['kind'] in ['TupleVariant', 'StructVariant']:
+        elif def_['kind'] in ['TupleVariant', 'StructVariant']:
             f.write('enum _test {')
             f.write(def_['sig']['text'])
             f.write('}')
-        if def_['kind'] == 'Method':
+        elif def_['kind'] == 'Method':
             f.write('impl _test {')
             f.write(def_['sig']['text'])
             f.write('}')

--- a/src/test/run-make-fulldeps/save-analysis/validate_json.py
+++ b/src/test/run-make-fulldeps/save-analysis/validate_json.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python2
+from __future__ import print_function
+
+# some sanity checks for save-analysis
+
+# pylint: disable=C,R
+
+import sys
+import json
+import os.path
+
+out_dir = sys.argv[1]
+analysis = json.loads(sys.stdin.readline().strip())
+
+for def_ in analysis['defs']:
+    assert def_['id']['krate'] == 0, "defines must have local ids"
+
+defs = {
+    d['id']['index']: d for d in analysis['defs']
+}
+
+assert 'prelude' in analysis and analysis[
+    'prelude'] is not None, "need prelude for sanity checks"
+
+externals = {c['num'] for c in analysis['prelude']['external_crates']}
+
+
+def check_sane_ids(data, debug_path=None):
+    # check that all Ids refer to something plausible, return count
+    if debug_path is None:
+        debug_path = []
+
+    if isinstance(data, dict):
+        if len(data.keys()) == 2 and 'krate' in data and 'index' in data:
+            # FIXME: wherever this value exists we should be using Option
+            # instead >:(
+            if data['krate'] == 0xffffffff or data['index'] == 0xffffffff:
+                return 1
+
+            if data['krate'] == 0:
+                # FIXME: run this check! it's weird we don't pass it
+                # assert data['index'] in defs, "unknown index {} [{}]".format(data[
+                #     'index'], debug_path)
+                pass
+            else:
+                assert data['krate'] in externals, "unknown external crate {} [{}]".format(data[
+                    'krate'], debug_path)
+
+            return 1
+        else:
+            # not an index
+            count = 0
+            for k, v in data.items():
+                count += check_sane_ids(v, debug_path + [k])
+            return count
+    elif isinstance(data, list):
+        count = 0
+        for i, v in enumerate(data):
+            count += check_sane_ids(v, debug_path + [i])
+        return count
+    else:
+        return 0
+
+assert check_sane_ids(
+    analysis) > 0, "didn't find anything that looked like an rls_data::Id, did the format change?"
+
+for def_ in analysis['defs']:
+    if 'sig' not in def_ or def_['sig'] is None:
+        continue
+
+    # write out sigs to check parsing
+    with open(os.path.join(out_dir, def_['name'] + '.rs'), 'w') as f:
+        if def_['kind'] in ['Function', 'Struct', 'Enum']:
+            f.write(def_['sig']['text'])
+        if def_['kind'] == 'Field':
+            f.write('struct _test {')
+            f.write(def_['sig']['text'])
+            f.write('}')
+        if def_['kind'] in ['TupleVariant', 'StructVariant']:
+            f.write('enum _test {')
+            f.write(def_['sig']['text'])
+            f.write('}')
+        if def_['kind'] == 'Method':
+            f.write('impl _test {')
+            f.write(def_['sig']['text'])
+            f.write('}')

--- a/src/test/run-make-fulldeps/save-analysis/validate_json.py
+++ b/src/test/run-make-fulldeps/save-analysis/validate_json.py
@@ -75,14 +75,14 @@ for def_ in analysis['defs']:
         if def_['kind'] in ['Function', 'Struct', 'Enum']:
             f.write(def_['sig']['text'])
         elif def_['kind'] == 'Field':
-            f.write('struct _test {')
+            f.write('struct _test { ')
             f.write(def_['sig']['text'])
-            f.write('}')
+            f.write(' }')
         elif def_['kind'] in ['TupleVariant', 'StructVariant']:
-            f.write('enum _test {')
+            f.write('enum _test { ')
             f.write(def_['sig']['text'])
-            f.write('}')
+            f.write(' }')
         elif def_['kind'] == 'Method':
-            f.write('impl _test {')
+            f.write('impl _test { ')
             f.write(def_['sig']['text'])
-            f.write('}')
+            f.write(' }')


### PR DESCRIPTION
I'm writing some tooling that relies on save-analysis signatures to work; unfortunately those signatures are currently missing a lot of information. So, I'm adding it in!

Thus far I've added a couple of sanity tests to the save-analysis test suite, and refactored `rustc_save_analysis::sig` to be more manageable by adding a struct to track the state of the in-progress signature. Next I want to go through most of the FIXMEs and fix them, get refs for all the different signature elements. Might also be able to address some of the other save-analysis issues as I go.

Question: Is there a reason signatures are disabled by default? Performance, or just instability?

cc @nrc 