### PR TITLE
Support `impl Trait` in inlined documentation

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -217,8 +217,9 @@ fn build_external_function(cx: &DocContext<'_>, did: DefId) -> clean::Function {
     };
 
     let predicates = cx.tcx.predicates_of(did);
-    let generics = (cx.tcx.generics_of(did), &predicates).clean(cx);
-    let decl = (did, sig).clean(cx);
+    let (generics, decl) = clean::enter_impl_trait(cx, || {
+        ((cx.tcx.generics_of(did), &predicates).clean(cx), (did, sig).clean(cx))
+    });
     let (all_types, ret_types) = clean::get_all_types(&generics, &decl, cx);
     clean::Function {
         decl,
@@ -372,7 +373,9 @@ pub fn build_impl(cx: &DocContext<'_>, did: DefId, attrs: Option<Attrs<'_>>,
                     None
                 }
             }).collect::<Vec<_>>(),
-            (tcx.generics_of(did), &predicates).clean(cx),
+            clean::enter_impl_trait(cx, || {
+                (tcx.generics_of(did), &predicates).clean(cx)
+            }),
         )
     };
     let polarity = tcx.impl_polarity(did);

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -61,8 +61,8 @@ pub struct DocContext<'tcx> {
     pub lt_substs: RefCell<FxHashMap<DefId, clean::Lifetime>>,
     /// Table `DefId` of const parameter -> substituted const
     pub ct_substs: RefCell<FxHashMap<DefId, clean::Constant>>,
-    /// Table DefId of `impl Trait` in argument position -> bounds
-    pub impl_trait_bounds: RefCell<FxHashMap<DefId, Vec<clean::GenericBound>>>,
+    /// Table synthetic type parameter for `impl Trait` in argument position -> bounds
+    pub impl_trait_bounds: RefCell<FxHashMap<ImplTraitParam, Vec<clean::GenericBound>>>,
     pub fake_def_ids: RefCell<FxHashMap<CrateNum, DefId>>,
     pub all_fake_def_ids: RefCell<FxHashSet<DefId>>,
     /// Auto-trait or blanket impls processed so far, as `(self_ty, trait_def_id)`.
@@ -458,4 +458,24 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             (krate, ctxt.renderinfo.into_inner(), render_options)
         })
     })
+}
+
+/// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter
+/// for `impl Trait` in argument position.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ImplTraitParam {
+    DefId(DefId),
+    ParamIndex(u32),
+}
+
+impl From<DefId> for ImplTraitParam {
+    fn from(did: DefId) -> Self {
+        ImplTraitParam::DefId(did)
+    }
+}
+
+impl From<u32> for ImplTraitParam {
+    fn from(idx: u32) -> Self {
+        ImplTraitParam::ParamIndex(idx)
+    }
 }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -462,7 +462,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
 /// `DefId` or parameter index (`ty::ParamTy.index`) of a synthetic type parameter
 /// for `impl Trait` in argument position.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ImplTraitParam {
     DefId(DefId),
     ParamIndex(u32),

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -1,0 +1,7 @@
+pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
+
+pub struct Foo;
+
+impl Foo {
+    pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
+}

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -2,7 +2,10 @@ use std::ops::Deref;
 
 pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
 
-pub fn func2<T>(_x: impl Deref<Target = Option<T>> + Iterator<Item = T>, _y: impl Iterator<Item = u8>) {}
+pub fn func2<T>(
+    _x: impl Deref<Target = Option<T>> + Iterator<Item = T>,
+    _y: impl Iterator<Item = u8>,
+) {}
 
 pub fn func3(_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone) {}
 

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -1,4 +1,8 @@
+use std::ops::Deref;
+
 pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
+
+pub fn func2<T>(_x: impl Deref<Target = Option<T>> + Iterator<Item = T>, _y: impl Iterator<Item = u8>) {}
 
 pub struct Foo;
 

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -9,6 +9,8 @@ pub fn func2<T>(
 
 pub fn func3(_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone) {}
 
+pub fn func4<T: Iterator<Item = impl Clone>>(_x: T) {}
+
 pub struct Foo;
 
 impl Foo {

--- a/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/impl_trait_aux.rs
@@ -4,6 +4,8 @@ pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a) {}
 
 pub fn func2<T>(_x: impl Deref<Target = Option<T>> + Iterator<Item = T>, _y: impl Iterator<Item = u8>) {}
 
+pub fn func3(_x: impl Iterator<Item = impl Iterator<Item = u8>> + Clone) {}
+
 pub struct Foo;
 
 impl Foo {

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -20,6 +20,12 @@ pub use impl_trait_aux::func2;
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func3;
 
+
+// @has impl_trait/fn.func4.html
+// @has - '//pre[@class="rust fn"]' "func4<T>("
+// @has - '//pre[@class="rust fn"]' "T: Iterator<Item = impl Clone>,"
+pub use impl_trait_aux::func4;
+
 // @has impl_trait/struct.Foo.html
 // @has - '//code[@id="method.v"]' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
 // @!has - '//code[@id="method.v"]' 'where'

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -15,7 +15,8 @@ pub use impl_trait_aux::func;
 pub use impl_trait_aux::func2;
 
 // @has impl_trait/fn.func3.html
-// @has - '//pre[@class="rust fn"]' "func3(_x: impl Clone + Iterator<Item = impl Iterator<Item = u8>>)"
+// @has - '//pre[@class="rust fn"]' "func3("
+// @has - '//pre[@class="rust fn"]' "_x: impl Clone + Iterator<Item = impl Iterator<Item = u8>>)"
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func3;
 

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -8,10 +8,16 @@ extern crate impl_trait_aux;
 pub use impl_trait_aux::func;
 
 // @has impl_trait/fn.func2.html
+// @has - '//pre[@class="rust fn"]' "func2<T>("
 // @has - '//pre[@class="rust fn"]' "_x: impl Deref<Target = Option<T>> + Iterator<Item = T>,"
 // @has - '//pre[@class="rust fn"]' "_y: impl Iterator<Item = u8>)"
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func2;
+
+// @has impl_trait/fn.func3.html
+// @has - '//pre[@class="rust fn"]' "func3(_x: impl Clone + Iterator<Item = impl Iterator<Item = u8>>)"
+// @!has - '//pre[@class="rust fn"]' 'where'
+pub use impl_trait_aux::func3;
 
 // @has impl_trait/struct.Foo.html
 // @has - '//code[@id="method.v"]' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -7,6 +7,12 @@ extern crate impl_trait_aux;
 // @!has - '//pre[@class="rust fn"]' 'where'
 pub use impl_trait_aux::func;
 
+// @has impl_trait/fn.func2.html
+// @has - '//pre[@class="rust fn"]' "_x: impl Deref<Target = Option<T>> + Iterator<Item = T>,"
+// @has - '//pre[@class="rust fn"]' "_y: impl Iterator<Item = u8>)"
+// @!has - '//pre[@class="rust fn"]' 'where'
+pub use impl_trait_aux::func2;
+
 // @has impl_trait/struct.Foo.html
 // @has - '//code[@id="method.v"]' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
 // @!has - '//code[@id="method.v"]' 'where'

--- a/src/test/rustdoc/inline_cross/impl_trait.rs
+++ b/src/test/rustdoc/inline_cross/impl_trait.rs
@@ -1,0 +1,13 @@
+// aux-build:impl_trait_aux.rs
+
+extern crate impl_trait_aux;
+
+// @has impl_trait/fn.func.html
+// @has - '//pre[@class="rust fn"]' "pub fn func<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
+// @!has - '//pre[@class="rust fn"]' 'where'
+pub use impl_trait_aux::func;
+
+// @has impl_trait/struct.Foo.html
+// @has - '//code[@id="method.v"]' "pub fn method<'a>(_x: impl Clone + Into<Vec<u8>> + 'a)"
+// @!has - '//code[@id="method.v"]' 'where'
+pub use impl_trait_aux::Foo;


### PR DESCRIPTION
`impl Trait` in argument position was not properly rendered when inlined from other crates. ([a live example on docs.rs](https://docs.rs/libp2p/0.8.1/libp2p/floodsub/struct.Floodsub.html#method.unsubscribe))

![old](https://user-images.githubusercontent.com/7091080/59089838-14ba9900-8946-11e9-830b-53b317bdecb4.png)
↓
![new](https://user-images.githubusercontent.com/7091080/59089844-16845c80-8946-11e9-9fe3-8998af9d73ce.png)
