### PR TITLE
parser: Remove `Deref` impl from `Parser`

### DIFF
--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -735,9 +735,9 @@ pub fn inject(mut krate: ast::Crate, parse_sess: &ParseSess, attrs: &[String]) -
             raw_attr.clone(),
         );
 
-        let start_span = parser.span;
+        let start_span = parser.token.span;
         let (path, tokens) = panictry!(parser.parse_meta_item_unrestricted());
-        let end_span = parser.span;
+        let end_span = parser.token.span;
         if parser.token != token::Eof {
             parse_sess.span_diagnostic
                 .span_err(start_span.to(end_span), "invalid crate attribute");

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -121,7 +121,7 @@ impl<'a> StripUnconfigured<'a> {
             let mut expanded_attrs = Vec::with_capacity(1);
 
             while !parser.check(&token::CloseDelim(token::Paren)) {
-                let lo = parser.span.lo();
+                let lo = parser.token.span.lo();
                 let (path, tokens) = parser.parse_meta_item_unrestricted()?;
                 expanded_attrs.push((path, tokens, parser.prev_span.with_lo(lo)));
                 parser.expect_one_of(&[token::Comma], &[token::CloseDelim(token::Paren)])?;

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1041,7 +1041,7 @@ impl<'a> Parser<'a> {
             let msg = format!("macro expansion ignores token `{}` and any following",
                               self.this_token_to_string());
             // Avoid emitting backtrace info twice.
-            let def_site_span = self.span.with_ctxt(SyntaxContext::empty());
+            let def_site_span = self.token.span.with_ctxt(SyntaxContext::empty());
             let mut err = self.diagnostic().struct_span_err(def_site_span, &msg);
             err.span_label(span, "caused by the macro expansion here");
             let msg = format!(

--- a/src/libsyntax/ext/source_util.rs
+++ b/src/libsyntax/ext/source_util.rs
@@ -105,7 +105,7 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt<'_>, sp: Span, tts: &[tokenstrea
             while self.p.token != token::Eof {
                 match panictry!(self.p.parse_item()) {
                     Some(item) => ret.push(item),
-                    None => self.p.diagnostic().span_fatal(self.p.span,
+                    None => self.p.diagnostic().span_fatal(self.p.token.span,
                                                            &format!("expected item, found `{}`",
                                                                     self.p.this_token_to_string()))
                                                .raise()

--- a/src/libsyntax/ext/tt/macro_parser.rs
+++ b/src/libsyntax/ext/tt/macro_parser.rs
@@ -675,7 +675,7 @@ pub fn parse(
     //
     // This MatcherPos instance is allocated on the stack. All others -- and
     // there are frequently *no* others! -- are allocated on the heap.
-    let mut initial = initial_matcher_pos(ms, parser.span);
+    let mut initial = initial_matcher_pos(ms, parser.token.span);
     let mut cur_items = smallvec![MatcherPosHandle::Ref(&mut initial)];
     let mut next_items = Vec::new();
 
@@ -721,15 +721,15 @@ pub fn parse(
                 return nameize(sess, ms, matches);
             } else if eof_items.len() > 1 {
                 return Error(
-                    parser.span,
+                    parser.token.span,
                     "ambiguity: multiple successful parses".to_string(),
                 );
             } else {
                 return Failure(
-                    Token::new(token::Eof, if parser.span.is_dummy() {
-                        parser.span
+                    Token::new(token::Eof, if parser.token.span.is_dummy() {
+                        parser.token.span
                     } else {
-                        sess.source_map().next_point(parser.span)
+                        sess.source_map().next_point(parser.token.span)
                     }),
                     "missing tokens in macro arguments",
                 );
@@ -753,7 +753,7 @@ pub fn parse(
                 .join(" or ");
 
             return Error(
-                parser.span,
+                parser.token.span,
                 format!(
                     "local ambiguity: multiple parsing options: {}",
                     match next_items.len() {
@@ -927,7 +927,7 @@ fn parse_nt<'a>(p: &mut Parser<'a>, sp: Span, name: Symbol) -> Nonterminal {
         sym::ty => token::NtTy(panictry!(p.parse_ty())),
         // this could be handled like a token, since it is one
         sym::ident => if let Some((name, is_raw)) = get_macro_name(&p.token) {
-            let span = p.span;
+            let span = p.token.span;
             p.bump();
             token::NtIdent(Ident::new(name, span), is_raw)
         } else {

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -47,7 +47,7 @@ impl<'a> ParserAnyMacro<'a> {
         let fragment = panictry!(parser.parse_ast_fragment(kind, true).map_err(|mut e| {
             if parser.token == token::Eof && e.message().ends_with(", found `<eof>`") {
                 if !e.span.is_dummy() {  // early end of macro arm (#52866)
-                    e.replace_span_with(parser.sess.source_map().next_point(parser.span));
+                    e.replace_span_with(parser.sess.source_map().next_point(parser.token.span));
                 }
                 let msg = &e.message[0];
                 e.message[0] = (
@@ -63,7 +63,7 @@ impl<'a> ParserAnyMacro<'a> {
                 if parser.sess.source_map().span_to_filename(arm_span).is_real() {
                     e.span_label(arm_span, "in this macro arm");
                 }
-            } else if !parser.sess.source_map().span_to_filename(parser.span).is_real() {
+            } else if !parser.sess.source_map().span_to_filename(parser.token.span).is_real() {
                 e.span_label(site_span, "in this macro invocation");
             }
             e

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -39,7 +39,7 @@ impl<'a> Parser<'a> {
                     just_parsed_doc_comment = false;
                 }
                 token::DocComment(s) => {
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.span);
+                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
                     if attr.style != ast::AttrStyle::Outer {
                         let mut err = self.fatal("expected outer doc comment");
                         err.note("inner doc comments like this (starting with \
@@ -83,7 +83,7 @@ impl<'a> Parser<'a> {
                self.token);
         let (span, path, tokens, style) = match self.token.kind {
             token::Pound => {
-                let lo = self.span;
+                let lo = self.token.span;
                 self.bump();
 
                 if let InnerAttributeParsePolicy::Permitted = inner_parse_policy {
@@ -93,7 +93,7 @@ impl<'a> Parser<'a> {
                     self.bump();
                     if let InnerAttributeParsePolicy::NotPermitted { reason } = inner_parse_policy
                     {
-                        let span = self.span;
+                        let span = self.token.span;
                         self.diagnostic()
                             .struct_span_err(span, reason)
                             .note("inner attributes, like `#![no_std]`, annotate the item \
@@ -201,7 +201,7 @@ impl<'a> Parser<'a> {
                 }
                 token::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.span);
+                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
                     if attr.style == ast::AttrStyle::Inner {
                         attrs.push(attr);
                         self.bump();
@@ -249,7 +249,7 @@ impl<'a> Parser<'a> {
             return Ok(meta);
         }
 
-        let lo = self.span;
+        let lo = self.token.span;
         let path = self.parse_path(PathStyle::Mod)?;
         let node = self.parse_meta_item_kind()?;
         let span = lo.to(self.prev_span);
@@ -284,7 +284,7 @@ impl<'a> Parser<'a> {
 
         let found = self.this_token_to_string();
         let msg = format!("expected unsuffixed literal or identifier, found `{}`", found);
-        Err(self.diagnostic().struct_span_err(self.span, &msg))
+        Err(self.diagnostic().struct_span_err(self.token.span, &msg))
     }
 
     /// matches meta_seq = ( COMMASEP(meta_item_inner) )

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -271,14 +271,13 @@ impl<'a> Parser<'a> {
         let mut recovered = None;
         if self.token == token::Dot {
             // Attempt to recover `.4` as `0.4`.
-            recovered = self.look_ahead(1, |t| {
+            recovered = self.look_ahead(1, |next_token| {
                 if let token::Literal(token::Lit { kind: token::Integer, symbol, suffix })
-                        = t.kind {
-                    let next_span = self.look_ahead_span(1);
-                    if self.token.span.hi() == next_span.lo() {
+                        = next_token.kind {
+                    if self.token.span.hi() == next_token.span.lo() {
                         let s = String::from("0.") + &symbol.as_str();
                         let kind = TokenKind::lit(token::Float, Symbol::intern(&s), suffix);
-                        return Some(Token::new(kind, self.token.span.to(next_span)));
+                        return Some(Token::new(kind, self.token.span.to(next_token.span)));
                     }
                 }
                 None

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -275,10 +275,10 @@ impl<'a> Parser<'a> {
                 if let token::Literal(token::Lit { kind: token::Integer, symbol, suffix })
                         = t.kind {
                     let next_span = self.look_ahead_span(1);
-                    if self.span.hi() == next_span.lo() {
+                    if self.token.span.hi() == next_span.lo() {
                         let s = String::from("0.") + &symbol.as_str();
                         let kind = TokenKind::lit(token::Float, Symbol::intern(&s), suffix);
-                        return Some(Token::new(kind, self.span.to(next_span)));
+                        return Some(Token::new(kind, self.token.span.to(next_span)));
                     }
                 }
                 None

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -239,8 +239,8 @@ fn maybe_source_file_to_parser(
     let (stream, unclosed_delims) = maybe_file_to_stream(sess, source_file, None)?;
     let mut parser = stream_to_parser(sess, stream, None);
     parser.unclosed_delims = unclosed_delims;
-    if parser.token == token::Eof && parser.span.is_dummy() {
-        parser.token.span = Span::new(end_pos, end_pos, parser.span.ctxt());
+    if parser.token == token::Eof && parser.token.span.is_dummy() {
+        parser.token.span = Span::new(end_pos, end_pos, parser.token.span.ctxt());
     }
 
     Ok(parser)

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -58,7 +58,6 @@ use log::debug;
 use std::borrow::Cow;
 use std::cmp;
 use std::mem;
-use std::ops::Deref;
 use std::path::{self, Path, PathBuf};
 use std::slice;
 
@@ -248,15 +247,6 @@ impl<'a> Drop for Parser<'a> {
     fn drop(&mut self) {
         let diag = self.diagnostic();
         emit_unclosed_delims(&mut self.unclosed_delims, diag);
-    }
-}
-
-// FIXME: Parser uses `self.span` all the time.
-// Remove this impl if you think that using `self.token.span` instead is acceptable.
-impl Deref for Parser<'_> {
-    type Target = Token;
-    fn deref(&self) -> &Self::Target {
-        &self.token
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1064,18 +1064,6 @@ impl<'a> Parser<'a> {
         })
     }
 
-    crate fn look_ahead_span(&self, dist: usize) -> Span {
-        if dist == 0 {
-            return self.token.span
-        }
-
-        match self.token_cursor.frame.tree_cursor.look_ahead(dist - 1) {
-            Some(TokenTree::Token(token)) => token.span,
-            Some(TokenTree::Delimited(span, ..)) => span.entire(),
-            None => self.look_ahead_span(dist - 1),
-        }
-    }
-
     /// Returns whether any of the given keywords are `dist` tokens ahead of the current one.
     fn is_keyword_ahead(&self, dist: usize, kws: &[Symbol]) -> bool {
         self.look_ahead(dist, |t| kws.iter().any(|&kw| t.is_keyword(kw)))
@@ -3067,7 +3055,7 @@ impl<'a> Parser<'a> {
                         let mut err =
                             self.sess.span_diagnostic.struct_span_err(self.token.span, &msg);
                         let span_after_type = parser_snapshot_after_type.token.span;
-                        err.span_label(self.look_ahead_span(1).to(span_after_type),
+                        err.span_label(self.look_ahead(1, |t| t.span).to(span_after_type),
                                        "interpreted as generic arguments");
                         err.span_label(self.token.span, format!("not interpreted as {}", op_noun));
 

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -85,7 +85,7 @@ fn parse_assert<'a>(
     if parser.token == token::Semi {
         let mut err = cx.struct_span_warn(sp, "macro requires an expression as an argument");
         err.span_suggestion(
-            parser.span,
+            parser.token.span,
             "try removing semicolon",
             String::new(),
             Applicability::MaybeIncorrect
@@ -105,7 +105,7 @@ fn parse_assert<'a>(
     // turned into an error.
     let custom_message = if let token::Literal(token::Lit { kind: token::Str, .. })
                                 = parser.token.kind {
-        let mut err = cx.struct_span_warn(parser.span, "unexpected string literal");
+        let mut err = cx.struct_span_warn(parser.token.span, "unexpected string literal");
         let comma_span = cx.source_map().next_point(parser.prev_span);
         err.span_suggestion_short(
             comma_span,

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -142,7 +142,7 @@ fn parse_args<'a>(
 
     while p.token != token::Eof {
         if !p.eat(&token::Comma) {
-            return Err(ecx.struct_span_err(p.span, "expected token: `,`"));
+            return Err(ecx.struct_span_err(p.token.span, "expected token: `,`"));
         }
         if p.token == token::Eof {
             break;
@@ -154,7 +154,7 @@ fn parse_args<'a>(
                 name
             } else {
                 return Err(ecx.struct_span_err(
-                    p.span,
+                    p.token.span,
                     "expected ident, positional arguments cannot follow named arguments",
                 ));
             };


### PR DESCRIPTION
Follow up to https://github.com/rust-lang/rust/pull/61541

You have to write `self.token.span` instead of `self.span` in the parser now, which is not nice, but not too bad either, I guess.
Not sure.
Probably still better than people using both and being confused about the definition point of `span`.

r? @oli-obk @estebank 