### PR TITLE
get rid of visit_place recursion

### DIFF
--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -712,7 +712,7 @@ macro_rules! make_mir_visitor {
                                 location: Location) {
                 // this is calling `super_place` in preparation for changing `Place` to be
                 // a struct with a base and a slice of projections. `visit_place` should only ever
-                // be called for the base place now.
+                // be called for the outermost place now.
                 self.super_place(& $($mutability)? proj.base, context, location);
                 match & $($mutability)? proj.elem {
                     ProjectionElem::Deref => {

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -710,23 +710,10 @@ macro_rules! make_mir_visitor {
                                 proj: & $($mutability)? Projection<'tcx>,
                                 context: PlaceContext,
                                 location: Location) {
-                // this is duplicated with `super_place` in preparation for changing `Place` to be
+                // this is calling `super_place` in preparation for changing `Place` to be
                 // a struct with a base and a slice of projections. `visit_place` should only ever
                 // be called for the base place now.
-                match & $($mutability)? proj.base {
-                    Place::Base(place_base) => {
-                        self.visit_place_base(place_base, context, location);
-                    }
-                    Place::Projection(proj) => {
-                        let context = if context.is_mutating_use() {
-                            PlaceContext::MutatingUse(MutatingUseContext::Projection)
-                        } else {
-                            PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
-                        };
-
-                        self.visit_projection(proj, context, location);
-                    }
-                }
+                self.super_place(& $($mutability)? proj.base, context, location);
                 match & $($mutability)? proj.elem {
                     ProjectionElem::Deref => {
                     }


### PR DESCRIPTION
r? @spastorino 	

this is groundwork for https://github.com/rust-lang/rust/pull/60913, since after that PR we won't be able to implement `visit_place` in a recursive manner without heavy cloning everywhere.

cc @eddyb this touches const qualif