### PR TITLE
remove useless ident() functions in const tests

### DIFF
--- a/src/test/run-pass/const-int-conversion.rs
+++ b/src/test/run-pass/const-int-conversion.rs
@@ -8,16 +8,12 @@ const TO_BE_BYTES: [u8; 4] = 0x12_34_56_78_i32.to_be_bytes();
 const TO_LE_BYTES: [u8; 4] = 0x12_34_56_78_i32.to_le_bytes();
 const TO_NE_BYTES: [u8; 4] = i32::min_value().to_be().to_ne_bytes();
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 fn main() {
-    assert_eq!(REVERSE, ident(0x1e6a2c48));
-    assert_eq!(FROM_BE_BYTES, ident(0x12_34_56_78));
-    assert_eq!(FROM_LE_BYTES, ident(0x78_56_34_12));
-    assert_eq!(FROM_NE_BYTES, ident(i32::min_value()));
-    assert_eq!(TO_BE_BYTES, ident([0x12, 0x34, 0x56, 0x78]));
-    assert_eq!(TO_LE_BYTES, ident([0x78, 0x56, 0x34, 0x12]));
-    assert_eq!(TO_NE_BYTES, ident([0x80, 0, 0, 0]));
+    assert_eq!(REVERSE, 0x1e6a2c48);
+    assert_eq!(FROM_BE_BYTES, 0x12_34_56_78);
+    assert_eq!(FROM_LE_BYTES, 0x78_56_34_12);
+    assert_eq!(FROM_NE_BYTES, i32::min_value());
+    assert_eq!(TO_BE_BYTES, [0x12, 0x34, 0x56, 0x78]);
+    assert_eq!(TO_LE_BYTES, [0x78, 0x56, 0x34, 0x12]);
+    assert_eq!(TO_NE_BYTES, [0x80, 0, 0, 0]);
 }

--- a/src/test/run-pass/const-int-overflowing.rs
+++ b/src/test/run-pass/const-int-overflowing.rs
@@ -16,26 +16,22 @@ const SHR_B: (u32, bool) = 0x10u32.overflowing_shr(132);
 const NEG_A: (u32, bool) = 0u32.overflowing_neg();
 const NEG_B: (u32, bool) = core::u32::MAX.overflowing_neg();
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 fn main() {
-    assert_eq!(ADD_A, ident((7, false)));
-    assert_eq!(ADD_B, ident((0, true)));
+    assert_eq!(ADD_A, (7, false));
+    assert_eq!(ADD_B, (0, true));
 
-    assert_eq!(SUB_A, ident((3, false)));
-    assert_eq!(SUB_B, ident((u32::max_value(), true)));
+    assert_eq!(SUB_A, (3, false));
+    assert_eq!(SUB_B, (u32::max_value(), true));
 
-    assert_eq!(MUL_A, ident((10, false)));
-    assert_eq!(MUL_B, ident((1410065408, true)));
+    assert_eq!(MUL_A, (10, false));
+    assert_eq!(MUL_B, (1410065408, true));
 
-    assert_eq!(SHL_A, ident((0x10, false)));
-    assert_eq!(SHL_B, ident((0x10, true)));
+    assert_eq!(SHL_A, (0x10, false));
+    assert_eq!(SHL_B, (0x10, true));
 
-    assert_eq!(SHR_A, ident((0x1, false)));
-    assert_eq!(SHR_B, ident((0x1, true)));
+    assert_eq!(SHR_A, (0x1, false));
+    assert_eq!(SHR_B, (0x1, true));
 
-    assert_eq!(NEG_A, ident((0, false)));
-    assert_eq!(NEG_B, ident((1, true)));
+    assert_eq!(NEG_A, (0, false));
+    assert_eq!(NEG_B, (1, true));
 }

--- a/src/test/run-pass/const-int-rotate.rs
+++ b/src/test/run-pass/const-int-rotate.rs
@@ -21,25 +21,21 @@ const ZERO_ROTATE_RIGHT: i8 = 0b0111_1001i8.rotate_right(0);
 const MULTIPLE_ROTATE_LEFT: i32 = 0b0010_0001i32.rotate_left(128);
 const MULTIPLE_ROTATE_RIGHT: i32 = 0b0010_0001i32.rotate_right(128);
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 fn main() {
-    assert_eq!(LEFT, ident(0xb301));
-    assert_eq!(RIGHT, ident(0x0100_00b3));
+    assert_eq!(LEFT, 0xb301);
+    assert_eq!(RIGHT, 0x0100_00b3);
 
-    assert_eq!(LEFT_OVERFLOW, ident(0));
-    assert_eq!(RIGHT_OVERFLOW, ident(0));
-    assert_eq!(ONE_LEFT_OVERFLOW, ident(0b0001_0000_0000_0000));
-    assert_eq!(ONE_RIGHT_OVERFLOW, ident(0b0001_0000));
+    assert_eq!(LEFT_OVERFLOW, 0);
+    assert_eq!(RIGHT_OVERFLOW, 0);
+    assert_eq!(ONE_LEFT_OVERFLOW, 0b0001_0000_0000_0000);
+    assert_eq!(ONE_RIGHT_OVERFLOW, 0b0001_0000);
 
-    assert_eq!(NON_ZERO_LEFT_OVERFLOW, ident(0b0010_0000_0000_0000));
-    assert_eq!(NON_ZERO_RIGHT_OVERFLOW, ident(0b0000_0000_0010_0000));
+    assert_eq!(NON_ZERO_LEFT_OVERFLOW, 0b0010_0000_0000_0000);
+    assert_eq!(NON_ZERO_RIGHT_OVERFLOW, 0b0000_0000_0010_0000);
 
-    assert_eq!(ZERO_ROTATE_LEFT, ident(0b0010_0001));
-    assert_eq!(ZERO_ROTATE_RIGHT, ident(0b0111_1001));
+    assert_eq!(ZERO_ROTATE_LEFT, 0b0010_0001);
+    assert_eq!(ZERO_ROTATE_RIGHT, 0b0111_1001);
 
-    assert_eq!(MULTIPLE_ROTATE_LEFT, ident(0b0010_0001));
-    assert_eq!(MULTIPLE_ROTATE_RIGHT, ident(0b0010_0001));
+    assert_eq!(MULTIPLE_ROTATE_LEFT, 0b0010_0001);
+    assert_eq!(MULTIPLE_ROTATE_RIGHT, 0b0010_0001);
 }

--- a/src/test/run-pass/const-int-wrapping.rs
+++ b/src/test/run-pass/const-int-wrapping.rs
@@ -16,26 +16,22 @@ const SHR_B: u32 = 128u32.wrapping_shr(128);
 const NEG_A: u32 = 5u32.wrapping_neg();
 const NEG_B: u32 = 1234567890u32.wrapping_neg();
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 fn main() {
-    assert_eq!(ADD_A, ident(255));
-    assert_eq!(ADD_B, ident(199));
+    assert_eq!(ADD_A, 255);
+    assert_eq!(ADD_B, 199);
 
-    assert_eq!(SUB_A, ident(0));
-    assert_eq!(SUB_B, ident(101));
+    assert_eq!(SUB_A, 0);
+    assert_eq!(SUB_B, 101);
 
-    assert_eq!(MUL_A, ident(120));
-    assert_eq!(MUL_B, ident(44));
+    assert_eq!(MUL_A, 120);
+    assert_eq!(MUL_B, 44);
 
-    assert_eq!(SHL_A, ident(128));
-    assert_eq!(SHL_B, ident(1));
+    assert_eq!(SHL_A, 128);
+    assert_eq!(SHL_B, 1);
 
-    assert_eq!(SHR_A, ident(1));
-    assert_eq!(SHR_B, ident(128));
+    assert_eq!(SHR_A, 1);
+    assert_eq!(SHR_B, 128);
 
-    assert_eq!(NEG_A, ident(4294967291));
-    assert_eq!(NEG_B, ident(3060399406));
+    assert_eq!(NEG_A, 4294967291);
+    assert_eq!(NEG_B, 3060399406);
 }

--- a/src/test/run-pass/consts/const-endianess.rs
+++ b/src/test/run-pass/consts/const-endianess.rs
@@ -2,7 +2,7 @@
 #![feature(test)]
 
 extern crate test;
-use test::black_box as b;
+use test::black_box as b; // prevent promotion of the argument and const-propagation of the result
 
 const BE_U32: u32 = 55u32.to_be();
 const LE_U32: u32 = 55u32.to_le();

--- a/src/test/run-pass/consts/const-ptr-nonnull.rs
+++ b/src/test/run-pass/consts/const-ptr-nonnull.rs
@@ -11,6 +11,7 @@ const DANGLING: NonNull<u32> = NonNull::dangling();
 const CASTED: NonNull<u32> = NonNull::cast(NonNull::<i32>::dangling());
 
 pub fn main() {
-    assert_eq!(DANGLING, b(NonNull::dangling)());
-    assert_eq!(CASTED, b(NonNull::dangling)());
+    // Be super-extra paranoid and cast the fn items to fn pointers before blackboxing them.
+    assert_eq!(DANGLING, b::<fn() -> _>(NonNull::dangling)());
+    assert_eq!(CASTED, b::<fn() -> _>(NonNull::dangling)());
 }

--- a/src/test/run-pass/consts/const-ptr-nonnull.rs
+++ b/src/test/run-pass/consts/const-ptr-nonnull.rs
@@ -1,15 +1,16 @@
 // run-pass
 
+#![feature(ptr_internals, test)]
+
+extern crate test;
+use test::black_box as b; // prevent promotion of the argument and const-propagation of the result
+
 use std::ptr::NonNull;
 
 const DANGLING: NonNull<u32> = NonNull::dangling();
 const CASTED: NonNull<u32> = NonNull::cast(NonNull::<i32>::dangling());
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 pub fn main() {
-    assert_eq!(DANGLING, ident(NonNull::dangling()));
-    assert_eq!(CASTED, ident(NonNull::dangling()));
+    assert_eq!(DANGLING, b(NonNull::dangling()));
+    assert_eq!(CASTED, b(NonNull::dangling()));
 }

--- a/src/test/run-pass/consts/const-ptr-nonnull.rs
+++ b/src/test/run-pass/consts/const-ptr-nonnull.rs
@@ -11,6 +11,6 @@ const DANGLING: NonNull<u32> = NonNull::dangling();
 const CASTED: NonNull<u32> = NonNull::cast(NonNull::<i32>::dangling());
 
 pub fn main() {
-    assert_eq!(DANGLING, b(NonNull::dangling()));
-    assert_eq!(CASTED, b(NonNull::dangling()));
+    assert_eq!(DANGLING, b(NonNull::dangling)());
+    assert_eq!(CASTED, b(NonNull::dangling)());
 }

--- a/src/test/run-pass/consts/const-ptr-unique.rs
+++ b/src/test/run-pass/consts/const-ptr-unique.rs
@@ -11,5 +11,5 @@ use std::ptr::Unique;
 const PTR: *mut u32 = Unique::empty().as_ptr();
 
 pub fn main() {
-    assert_eq!(PTR, b(Unique::<u32>::empty()).as_ptr());
+    assert_eq!(PTR, b(Unique::<u32>::empty)().as_ptr());
 }

--- a/src/test/run-pass/consts/const-ptr-unique.rs
+++ b/src/test/run-pass/consts/const-ptr-unique.rs
@@ -1,15 +1,15 @@
 // run-pass
 
-#![feature(ptr_internals)]
+#![feature(ptr_internals, test)]
+
+extern crate test;
+use test::black_box as b; // prevent promotion of the argument and const-propagation of the result
 
 use std::ptr::Unique;
 
+
 const PTR: *mut u32 = Unique::empty().as_ptr();
 
-fn ident<T>(ident: T) -> T {
-    ident
-}
-
 pub fn main() {
-    assert_eq!(PTR, ident(Unique::<u32>::empty().as_ptr()));
+    assert_eq!(PTR, b(Unique::<u32>::empty()).as_ptr());
 }

--- a/src/test/run-pass/consts/const-ptr-unique.rs
+++ b/src/test/run-pass/consts/const-ptr-unique.rs
@@ -11,5 +11,6 @@ use std::ptr::Unique;
 const PTR: *mut u32 = Unique::empty().as_ptr();
 
 pub fn main() {
-    assert_eq!(PTR, b(Unique::<u32>::empty)().as_ptr());
+    // Be super-extra paranoid and cast the fn items to fn pointers before blackboxing them.
+    assert_eq!(PTR, b::<fn() -> _>(Unique::<u32>::empty)().as_ptr());
 }


### PR DESCRIPTION
and replace the useful ones by black_box (with a comment)

r? @oli-obk