### PR TITLE
core: check for pointer equality when comparing Eq slices

### DIFF
--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -5294,13 +5294,7 @@ impl<A, B> SlicePartialEq<B> for [A]
             return false;
         }
 
-        for i in 0..self.len() {
-            if !self[i].eq(&other[i]) {
-                return false;
-            }
-        }
-
-        true
+        self.iter().zip(other.iter()).all(|(x, y)| x == y)
     }
 }
 
@@ -5317,13 +5311,7 @@ impl<A> SlicePartialEq<A> for [A]
             return true;
         }
 
-        for i in 0..self.len() {
-            if !self[i].eq(&other[i]) {
-                return false;
-            }
-        }
-
-        true
+        self.iter().zip(other.iter()).all(|(x, y)| x == y)
     }
 }
 


### PR DESCRIPTION
Because `Eq` types must be reflexively equal, an equal-length slice to the same memory location must be equal.

This is related to #33892 (and #32699) answering this comment from that PR:

> Great! One more easy question: why does this optimization not apply in the non-BytewiseEquality implementation directly above?

Because slices of non-reflexively equal types (like `f64`) are not equal even if it's the same slice. But if the types are `Eq`, we can use this same-address optimization, which this PR implements. Obviously this changes behavior if types violate the reflexivity condition of `Eq`, because their impls of `PartialEq` will no longer be called per-item, but 🤷‍♂ .

It's not clear how often this optimization comes up in the real world outside of the same-`&str` case covered by #33892, so **I'm requesting a perf run** (on MacOS today, so can't run `rustc_perf` myself). I'm going ahead and making the PR on the basis of being surprised things didn't already work this way.

This is my first time hacking rust itself, so as a perf sanity check I ran `./x.py bench --stage 0 src/lib{std,alloc}`, but the differences were noisy.

To make the existing specialization for `BytewiseEquality` explicit, it's now a supertrait of `Eq + Copy`. `Eq` should be sufficient, but `Copy` was included for clarity.