### PR TITLE
in which we decline to suggest the anonymous lifetime in declarations

### DIFF
--- a/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.rs
+++ b/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.rs
@@ -1,0 +1,10 @@
+#![deny(elided_lifetimes_in_paths)]
+
+// Previously, the elided-lifetimes-in-path lint would fire, but we don't want
+// that, because `'_` isn't legal in struct declarations.
+
+struct Betrayal<'a> { x: &'a u8 }
+
+struct Heartbreak(Betrayal);  //~ ERROR missing lifetime specifier
+
+fn main() {}

--- a/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
+++ b/src/test/ui/in-band-lifetimes/issue-61124-anon-lifetime-in-struct-declaration.stderr
@@ -1,0 +1,9 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-61124-anon-lifetime-in-struct-declaration.rs:8:19
+   |
+LL | struct Heartbreak(Betrayal);
+   |                   ^^^^^^^^ expected lifetime parameter
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
The elided-lifetimes-in-path lint (part of our suite of Rust 2018 idiom lints which we are hoping to promote to Warn status) was firing with an illegal suggestion to write an anonymous lifetime in a
struct/item declaration (where we don't allow it). The linting code was already deciding whether to act on the basis of a `ParamMode` enum, indicating whether the present path-segment was part of an
expression, or anywhere else. The present case seemed to be part of the "anywhere else", and yet meriting different rules as far as the lint was concerned, so it seemed expedient to introduce a new enum member. We yank out `TyKind::Path` arm into its own method so that we can call it with our new `ParamMode` specifically when lowering struct fields—one would have hoped to think of something more elegant than this, but it definitely beats changing the signature of `lower_ty` to take a `ParamMode`!

Resolves #61124.

cc @memoryruins 
r? @oli-obk 