### PR TITLE
Add Vec::flatten (as unstable, of course)

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -77,6 +77,7 @@
 #![feature(box_syntax)]
 #![feature(cfg_target_has_atomic)]
 #![feature(coerce_unsized)]
+#![cfg_attr(not(bootstrap), feature(const_generics))]
 #![feature(dispatch_from_dyn)]
 #![feature(core_intrinsics)]
 #![feature(custom_attribute)]


### PR DESCRIPTION
This has been a common question on IRC for years -- with people wanting to flatten Vecs of `[u8; 4]` colours or `[f32; 3]` linalg vectors.  I'm irrationally excited that const generics has a reached a state where this works now.

(Named after `Iterator::flatten`, which is the same conceptual operation, just slower and doesn't currently work right with array `Item`s.)