### PR TITLE
Update RLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "rls"
-version = "1.36.0"
+version = "1.37.0"
 dependencies = [
  "cargo 0.38.0",
  "cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This includes https://github.com/rust-lang/rls/pull/1482 which should finally fix the spurious tests RLS in Rust CI (test-pass -> test-fail).

r? @oli-obk 
cc @ehuss 