### PR TITLE
test more variants of enum-int-casting

### DIFF
--- a/src/test/run-pass/consts/const-enum-cast.rs
+++ b/src/test/run-pass/consts/const-enum-cast.rs
@@ -1,9 +1,8 @@
 // run-pass
-#![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 
 enum A { A1, A2 }
-enum B { B1=0, B2=2 }
+enum B { B1=4, B2=2 }
 
 pub fn main () {
     static c1: isize = A::A2 as isize;
@@ -14,4 +13,14 @@ pub fn main () {
     assert_eq!(c2, 2);
     assert_eq!(a1, 1);
     assert_eq!(a2, 2);
+
+    // Turns out that adding a let-binding generates totally different MIR.
+    static c1_2: isize = { let v = A::A1; v as isize };
+    static c2_2: isize = { let v = B::B1; v as isize };
+    let a1_2 = { let v = A::A1; v as isize };
+    let a2_2 = { let v = B::B1; v as isize };
+    assert_eq!(c1_2, 0);
+    assert_eq!(c2_2, 4);
+    assert_eq!(a1_2, 0);
+    assert_eq!(a2_2, 4);
 }


### PR DESCRIPTION
As I learned in https://github.com/rust-lang/rust/pull/61673#issuecomment-500213506, there is a code path we are not testing yet. Looks like enum-int-casting with and without an intermediate let-binding is totally different.

EDIT: The reason for this is to get rid of the cycle in definitions such as:
```rust
enum Foo {
    A = 0,
    B = Foo::A as isize + 2,
}
```
This has historically been supported, so a hack adding special treatment to `Enum::Variant as _` was added to keep supporting it.