### PR TITLE
Use Build::read_dir instead of fs::read_dir in Build::cp_r

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1214,8 +1214,7 @@ impl Build {
     /// when this function is called.
     pub fn cp_r(&self, src: &Path, dst: &Path) {
         if self.config.dry_run { return; }
-        for f in t!(fs::read_dir(src)) {
-            let f = t!(f);
+        for f in self.read_dir(src) {
             let path = f.path();
             let name = path.file_name().unwrap();
             let dst = dst.join(name);


### PR DESCRIPTION
Build::read_dir does better error handling when the directory doesn't
exist; it actually prints the name of the directory rather than just
printing the underlying error "No such file or directory" which on
its own isn't very useful.