### PR TITLE
Initial implementation of or-patterns

### DIFF
--- a/src/doc/unstable-book/src/language-features/or-patterns.md
+++ b/src/doc/unstable-book/src/language-features/or-patterns.md
@@ -1,0 +1,36 @@
+# `or_patterns`
+
+The tracking issue for this feature is: [#54883]
+
+[#54883]: https://github.com/rust-lang/rust/issues/54883
+
+------------------------
+
+The `or_pattern` language feature allows `|` to be arbitrarily nested within
+a pattern, for example, `Some(A(0) | B(1 | 2))` becomes a valid pattern.
+
+## Examples
+
+```rust,ignore
+#![feature(or_patterns)]
+
+pub enum Foo {
+    Bar,
+    Baz,
+    Quux,
+}
+
+pub fn example(maybe_foo: Option<Foo>) {
+    match maybe_foo {
+        Some(Foo::Bar | Foo::Baz) => {
+            println!("The value contained `Bar` or `Baz`");
+        }
+        Some(_) => {
+            println!("The value did not contain `Bar` or `Baz`");
+        }
+        None => {
+            println!("The value was `None`");
+        }
+    }
+}
+```

--- a/src/librustc/cfg/construct.rs
+++ b/src/librustc/cfg/construct.rs
@@ -140,6 +140,11 @@ impl<'a, 'tcx> CFGBuilder<'a, 'tcx> {
                 self.add_ast_node(pat.hir_id.local_id, &[pats_exit])
             }
 
+            PatKind::Or(ref pats) => {
+                let branches: Vec<_> = pats.iter().map(|p| self.pat(p, pred)).collect();
+                self.add_ast_node(pat.hir_id.local_id, &branches)
+            }
+
             PatKind::Slice(ref pre, ref vec, ref post) => {
                 let pre_exit = self.pats_all(pre.iter(), pred);
                 let vec_exit = self.pats_all(vec.iter(), pre_exit);

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -709,6 +709,7 @@ pub fn walk_pat<'v, V: Visitor<'v>>(visitor: &mut V, pattern: &'v Pat) {
                 visitor.visit_pat(&field.pat)
             }
         }
+        PatKind::Or(ref pats) => walk_list!(visitor, visit_pat, pats),
         PatKind::Tuple(ref tuple_elements, _) => {
             walk_list!(visitor, visit_pat, tuple_elements);
         }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2669,6 +2669,9 @@ impl<'a> LoweringContext<'a> {
                 let (pats, ddpos) = self.lower_pat_tuple(pats, "tuple struct");
                 hir::PatKind::TupleStruct(qpath, pats, ddpos)
             }
+            PatKind::Or(ref pats) => {
+                hir::PatKind::Or(pats.iter().map(|x| self.lower_pat(x)).collect())
+            }
             PatKind::Path(ref qself, ref path) => {
                 let qpath = self.lower_qpath(
                     p.id,

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -882,6 +882,7 @@ impl Pat {
             PatKind::TupleStruct(_, ref s, _) | PatKind::Tuple(ref s, _) => {
                 s.iter().all(|p| p.walk_(it))
             }
+            PatKind::Or(ref pats) => pats.iter().all(|p| p.walk_(it)),
             PatKind::Box(ref s) | PatKind::Ref(ref s, _) => {
                 s.walk_(it)
             }
@@ -975,6 +976,9 @@ pub enum PatKind {
     /// If the `..` pattern fragment is present, then `Option<usize>` denotes its position.
     /// `0 <= position <= subpats.len()`
     TupleStruct(QPath, HirVec<P<Pat>>, Option<usize>),
+
+    /// An or-pattern `A | B | C`.
+    Or(Vec<P<Pat>>),
 
     /// A path pattern for an unit struct/variant or a (maybe-associated) constant.
     Path(QPath),

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -978,7 +978,8 @@ pub enum PatKind {
     TupleStruct(QPath, HirVec<P<Pat>>, Option<usize>),
 
     /// An or-pattern `A | B | C`.
-    Or(Vec<P<Pat>>),
+    /// Invariant: `pats.len() >= 2`.
+    Or(HirVec<P<Pat>>),
 
     /// A path pattern for an unit struct/variant or a (maybe-associated) constant.
     Path(QPath),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -4,7 +4,7 @@ use syntax::source_map::{SourceMap, Spanned};
 use syntax::parse::ParseSess;
 use syntax::print::pp::{self, Breaks};
 use syntax::print::pp::Breaks::{Consistent, Inconsistent};
-use syntax::print::pprust::{self, Comments, PrintState};
+use syntax::print::pprust::{self, Comments, PrintState, SeparatorSpacing};
 use syntax::symbol::kw;
 use syntax::util::parser::{self, AssocOp, Fixity};
 use syntax_pos::{self, BytePos, FileName};
@@ -1686,6 +1686,10 @@ impl<'a> State<'a> {
                 }
                 self.s.space();
                 self.s.word("}");
+            }
+            PatKind::Or(ref pats) => {
+                let spacing = SeparatorSpacing::Both;
+                self.strsep("|", spacing, Inconsistent, &pats[..], |s, p| s.print_pat(&p))?;
             }
             PatKind::Tuple(ref elts, ddpos) => {
                 self.popen();

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -4,7 +4,7 @@ use syntax::source_map::{SourceMap, Spanned};
 use syntax::parse::ParseSess;
 use syntax::print::pp::{self, Breaks};
 use syntax::print::pp::Breaks::{Consistent, Inconsistent};
-use syntax::print::pprust::{self, Comments, PrintState, SeparatorSpacing};
+use syntax::print::pprust::{self, Comments, PrintState};
 use syntax::symbol::kw;
 use syntax::util::parser::{self, AssocOp, Fixity};
 use syntax_pos::{self, BytePos, FileName};
@@ -1688,8 +1688,7 @@ impl<'a> State<'a> {
                 self.s.word("}");
             }
             PatKind::Or(ref pats) => {
-                let spacing = SeparatorSpacing::Both;
-                self.strsep("|", spacing, Inconsistent, &pats[..], |s, p| s.print_pat(&p))?;
+                self.strsep("|", true, Inconsistent, &pats[..], |s, p| s.print_pat(&p));
             }
             PatKind::Tuple(ref elts, ddpos) => {
                 self.popen();

--- a/src/librustc/middle/mem_categorization.rs
+++ b/src/librustc/middle/mem_categorization.rs
@@ -1290,6 +1290,12 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
                 }
             }
 
+            PatKind::Or(ref pats) => {
+                for pat in pats {
+                    self.cat_pattern_(cmt.clone(), &pat, op)?;
+                }
+            }
+
             PatKind::Binding(.., Some(ref subpat)) => {
                 self.cat_pattern_(cmt, &subpat, op)?;
             }

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -657,6 +657,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     self.visit_bindings(&subpattern.pattern, subpattern_user_ty, f);
                 }
             }
+            PatternKind::Or { ref pats } => {
+                // FIXME(#47184): extract or handle `pattern_user_ty` somehow
+                for pat in pats {
+                    self.visit_bindings(&pat, &pattern_user_ty.clone(), f);
+                }
+            }
         }
     }
 }

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -658,9 +658,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
             PatternKind::Or { ref pats } => {
-                // FIXME(#47184): extract or handle `pattern_user_ty` somehow
                 for pat in pats {
-                    self.visit_bindings(&pat, &pattern_user_ty.clone(), f);
+                    self.visit_bindings(&pat, pattern_user_ty.clone(), f);
                 }
             }
         }

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -195,6 +195,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 candidate.match_pairs.push(MatchPair::new(place, subpattern));
                 Ok(())
             }
+
+            PatternKind::Or { .. } => {
+                Err(match_pair)
+            }
         }
     }
 }

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -87,6 +87,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PatternKind::AscribeUserType { .. } |
             PatternKind::Array { .. } |
             PatternKind::Wild |
+            PatternKind::Or { .. } |
             PatternKind::Binding { .. } |
             PatternKind::Leaf { .. } |
             PatternKind::Deref { .. } => {
@@ -130,6 +131,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PatternKind::Slice { .. } |
             PatternKind::Array { .. } |
             PatternKind::Wild |
+            PatternKind::Or { .. } |
             PatternKind::Binding { .. } |
             PatternKind::AscribeUserType { .. } |
             PatternKind::Leaf { .. } |

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -75,9 +75,6 @@
 ///                     D((r_1, p_(i,2), .., p_(i,n)))
 ///                     D((r_2, p_(i,2), .., p_(i,n)))
 ///
-///     Note that the OR-patterns are not always used directly in Rust, but are used to derive
-///     the exhaustive integer matching rules, so they're written here for posterity.
-///
 /// The algorithm for computing `U`
 /// -------------------------------
 /// The algorithm is inductive (on the number of columns: i.e., components of tuple patterns).
@@ -1359,6 +1356,9 @@ fn pat_constructors<'tcx>(cx: &mut MatchCheckCtxt<'_, 'tcx>,
                 Some(vec![Slice(pat_len)])
             }
         }
+        PatternKind::Or { .. } => {
+            bug!("support for or-patterns has not been fully implemented yet.");
+        }
     }
 }
 
@@ -1883,6 +1883,10 @@ fn specialize<'p, 'a: 'p, 'tcx>(
                 _ => span_bug!(pat.span,
                     "unexpected ctor {:?} for slice pat", constructor)
             }
+        }
+
+        PatternKind::Or { .. } => {
+            bug!("support for or-patterns has not been fully implemented yet.");
         }
     };
     debug!("specialize({:#?}, {:#?}) = {:#?}", r[0], wild_patterns, head);

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -75,6 +75,9 @@
 ///                     D((r_1, p_(i,2), .., p_(i,n)))
 ///                     D((r_2, p_(i,2), .., p_(i,n)))
 ///
+///     Note that the OR-patterns are not always used directly in Rust, but are used to derive
+///     the exhaustive integer matching rules, so they're written here for posterity.
+///
 /// The algorithm for computing `U`
 /// -------------------------------
 /// The algorithm is inductive (on the number of columns: i.e., components of tuple patterns).

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -175,6 +175,11 @@ pub enum PatternKind<'tcx> {
         slice: Option<Pattern<'tcx>>,
         suffix: Vec<Pattern<'tcx>>,
     },
+
+    /// or-pattern
+    Or {
+        pats: Vec<Pattern<'tcx>>,
+    },
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -186,6 +191,18 @@ pub struct PatternRange<'tcx> {
 
 impl<'tcx> fmt::Display for Pattern<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Printing lists is a chore.
+        let mut first = true;
+        let mut start_or_continue = |s| {
+            if first {
+                first = false;
+                ""
+            } else {
+                s
+            }
+        };
+        let mut start_or_comma = || start_or_continue(", ");
+
         match *self.kind {
             PatternKind::Wild => write!(f, "_"),
             PatternKind::AscribeUserType { ref subpattern, .. } =>
@@ -224,9 +241,6 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
                     }
                 };
 
-                let mut first = true;
-                let mut start_or_continue = || if first { first = false; "" } else { ", " };
-
                 if let Some(variant) = variant {
                     write!(f, "{}", variant.ident)?;
 
@@ -241,12 +255,12 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
                                 continue;
                             }
                             let name = variant.fields[p.field.index()].ident;
-                            write!(f, "{}{}: {}", start_or_continue(), name, p.pattern)?;
+                            write!(f, "{}{}: {}", start_or_comma(), name, p.pattern)?;
                             printed += 1;
                         }
 
                         if printed < variant.fields.len() {
-                            write!(f, "{}..", start_or_continue())?;
+                            write!(f, "{}..", start_or_comma())?;
                         }
 
                         return write!(f, " }}");
@@ -257,7 +271,7 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
                 if num_fields != 0 || variant.is_none() {
                     write!(f, "(")?;
                     for i in 0..num_fields {
-                        write!(f, "{}", start_or_continue())?;
+                        write!(f, "{}", start_or_comma())?;
 
                         // Common case: the field is where we expect it.
                         if let Some(p) = subpatterns.get(i) {
@@ -305,14 +319,12 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
             }
             PatternKind::Slice { ref prefix, ref slice, ref suffix } |
             PatternKind::Array { ref prefix, ref slice, ref suffix } => {
-                let mut first = true;
-                let mut start_or_continue = || if first { first = false; "" } else { ", " };
                 write!(f, "[")?;
                 for p in prefix {
-                    write!(f, "{}{}", start_or_continue(), p)?;
+                    write!(f, "{}{}", start_or_comma(), p)?;
                 }
                 if let Some(ref slice) = *slice {
-                    write!(f, "{}", start_or_continue())?;
+                    write!(f, "{}", start_or_comma())?;
                     match *slice.kind {
                         PatternKind::Wild => {}
                         _ => write!(f, "{}", slice)?
@@ -320,9 +332,15 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
                     write!(f, "..")?;
                 }
                 for p in suffix {
-                    write!(f, "{}{}", start_or_continue(), p)?;
+                    write!(f, "{}{}", start_or_comma(), p)?;
                 }
                 write!(f, "]")
+            }
+            PatternKind::Or { ref pats } => {
+                for pat in pats {
+                    write!(f, "{}{}", start_or_continue(" | "), pat)?;
+                }
+                Ok(())
             }
         }
     }
@@ -654,6 +672,12 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                           .collect();
 
                 self.lower_variant_or_leaf(res, pat.hir_id, pat.span, ty, subpatterns)
+            }
+
+            PatKind::Or(ref pats) => {
+                PatternKind::Or {
+                    pats: pats.iter().map(|p| self.lower_pattern(p)).collect(),
+                }
             }
         };
 
@@ -1436,6 +1460,7 @@ impl<'tcx> PatternFoldable<'tcx> for PatternKind<'tcx> {
                 slice: slice.fold_with(folder),
                 suffix: suffix.fold_with(folder)
             },
+            PatternKind::Or { ref pats } => PatternKind::Or { pats: pats.fold_with(folder) },
         }
     }
 }

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -176,7 +176,8 @@ pub enum PatternKind<'tcx> {
         suffix: Vec<Pattern<'tcx>>,
     },
 
-    /// or-pattern
+    /// An or-pattern, e.g. `p | q`.
+    /// Invariant: `pats.len() >= 2`.
     Or {
         pats: Vec<Pattern<'tcx>>,
     },

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -53,6 +53,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let is_non_ref_pat = match pat.node {
             PatKind::Struct(..) |
             PatKind::TupleStruct(..) |
+            PatKind::Or(_) |
             PatKind::Tuple(..) |
             PatKind::Box(_) |
             PatKind::Range(..) |
@@ -308,6 +309,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             PatKind::Struct(ref qpath, ref fields, etc) => {
                 self.check_pat_struct(pat, qpath, fields, etc, expected, def_bm, discrim_span)
+            }
+            PatKind::Or(ref pats) => {
+                let expected_ty = self.structurally_resolved_type(pat.span, expected);
+                for pat in pats {
+                    self.check_pat_walk(pat, expected, def_bm, false);
+                }
+                expected_ty
             }
             PatKind::Tuple(ref elements, ddpos) => {
                 let mut expected_len = elements.len();

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -313,7 +313,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             PatKind::Or(ref pats) => {
                 let expected_ty = self.structurally_resolved_type(pat.span, expected);
                 for pat in pats {
-                    self.check_pat_walk(pat, expected, def_bm, false);
+                    self.check_pat_walk(pat, expected, def_bm, discrim_span);
                 }
                 expected_ty
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -4107,6 +4107,9 @@ fn name_from_pat(p: &hir::Pat) -> String {
                 if etc { ", .." } else { "" }
             )
         }
+        PatKind::Or(ref pats) => {
+            pats.iter().map(|p| name_from_pat(&**p)).collect::<Vec<String>>().join(" | ")
+        }
         PatKind::Tuple(ref elts, _) => format!("({})", elts.iter().map(|p| name_from_pat(&**p))
                                             .collect::<Vec<String>>().join(", ")),
         PatKind::Box(ref p) => name_from_pat(&**p),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -650,6 +650,7 @@ pub enum PatKind {
     TupleStruct(Path, Vec<P<Pat>>),
 
     /// An or-pattern `A | B | C`.
+    /// Invariant: `pats.len() >= 2`.
     Or(Vec<P<Pat>>),
 
     /// A possibly qualified path pattern.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -572,9 +572,10 @@ impl Pat {
         match &self.node {
             PatKind::Ident(_, _, Some(p)) => p.walk(it),
             PatKind::Struct(_, fields, _) => fields.iter().all(|field| field.pat.walk(it)),
-            PatKind::TupleStruct(_, s) | PatKind::Tuple(s) | PatKind::Slice(s) => {
-                s.iter().all(|p| p.walk(it))
-            }
+            PatKind::TupleStruct(_, s)
+            | PatKind::Tuple(s)
+            | PatKind::Slice(s)
+            | PatKind::Or(s) => s.iter().all(|p| p.walk(it)),
             PatKind::Box(s) | PatKind::Ref(s, _) | PatKind::Paren(s) => s.walk(it),
             PatKind::Wild
             | PatKind::Rest
@@ -647,6 +648,9 @@ pub enum PatKind {
 
     /// A tuple struct/variant pattern (`Variant(x, y, .., z)`).
     TupleStruct(Path, Vec<P<Pat>>),
+
+    /// An or-pattern `A | B | C`.
+    Or(Vec<P<Pat>>),
 
     /// A possibly qualified path pattern.
     /// Unqualified path patterns `A::B::C` can legally refer to variants, structs, constants

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -559,6 +559,9 @@ declare_features! (
     // Allows `impl Trait` to be used inside type aliases (RFC 2515).
     (active, type_alias_impl_trait, "1.38.0", Some(63063), None),
 
+    // Allows the use of or-patterns, e.g. `0 | 1`.
+    (active, or_patterns, "1.38.0", Some(54883), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------
@@ -571,6 +574,7 @@ pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::impl_trait_in_bindings,
     sym::generic_associated_types,
     sym::const_generics,
+    sym::or_patterns,
     sym::let_chains,
 ];
 
@@ -2443,6 +2447,7 @@ pub fn check_crate(krate: &ast::Crate,
     gate_all!(let_chains_spans, let_chains, "`let` expressions in this position are experimental");
     gate_all!(async_closure_spans, async_closure, "async closures are unstable");
     gate_all!(yield_spans, generators, "yield syntax is experimental");
+    gate_all!(or_pattern_spans, or_patterns, "or-patterns syntax is experimental");
 
     let visitor = &mut PostExpansionVisitor {
         context: &ctx,

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1050,7 +1050,6 @@ pub fn noop_visit_pat<T: MutVisitor>(pat: &mut P<Pat>, vis: &mut T) {
                 vis.visit_span(span);
             };
         }
-        PatKind::Tuple(elems) => visit_vec(elems, |elem| vis.visit_pat(elem)),
         PatKind::Box(inner) => vis.visit_pat(inner),
         PatKind::Ref(inner, _mutbl) => vis.visit_pat(inner),
         PatKind::Range(e1, e2, Spanned { span: _, node: _ }) => {
@@ -1058,7 +1057,9 @@ pub fn noop_visit_pat<T: MutVisitor>(pat: &mut P<Pat>, vis: &mut T) {
             vis.visit_expr(e2);
             vis.visit_span(span);
         }
-        PatKind::Slice(elems) => visit_vec(elems, |elem| vis.visit_pat(elem)),
+        PatKind::Tuple(elems)
+        | PatKind::Slice(elems)
+        | PatKind::Or(elems) => visit_vec(elems, |elem| vis.visit_pat(elem)),
         PatKind::Paren(inner) => vis.visit_pat(inner),
         PatKind::Mac(mac) => vis.visit_mac(mac),
     }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -66,6 +66,8 @@ pub struct ParseSess {
     // Places where `yield e?` exprs were used and should be feature gated.
     pub yield_spans: Lock<Vec<Span>>,
     pub injected_crate_name: Once<Symbol>,
+    // Places where or-patterns e.g. `Some(Foo | Bar)` were used and should be feature gated.
+    pub or_pattern_spans: Lock<Vec<Span>>,
 }
 
 impl ParseSess {
@@ -96,6 +98,7 @@ impl ParseSess {
             async_closure_spans: Lock::new(Vec::new()),
             yield_spans: Lock::new(Vec::new()),
             injected_crate_name: Once::new(),
+            or_pattern_spans: Lock::new(Vec::new()),
         }
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -431,21 +431,46 @@ impl std::ops::DerefMut for State<'_> {
     }
 }
 
+pub enum SeparatorSpacing {
+    After,
+    Both,
+}
+
 pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefMut {
     fn comments(&mut self) -> &mut Option<Comments<'a>>;
     fn print_ident(&mut self, ident: ast::Ident);
     fn print_generic_args(&mut self, args: &ast::GenericArgs, colons_before_params: bool);
 
-    fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F)
+    fn strsep<T, F>(
+        &mut self,
+        sep: &'static str,
+        spacing: SeparatorSpacing,
+        b: Breaks,
+        elts: &[T],
+        mut op: F
+    ) -> io::Result<()>
         where F: FnMut(&mut Self, &T),
     {
         self.rbox(0, b);
         let mut first = true;
         for elt in elts {
-            if first { first = false; } else { self.word_space(","); }
+            if first {
+                first = false;
+            } else {
+                if let SeparatorSpacing::Both = spacing {
+                    self.writer().space();
+                }
+                self.word_space(sep);
+            }
             op(self, elt);
         }
         self.end();
+    }
+
+    fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F)
+        where F: FnMut(&mut Self, &T),
+    {
+        self.strsep(",", SeparatorSpacing::After, b, elts, op)
     }
 
     fn maybe_print_comment(&mut self, pos: BytePos) {
@@ -2352,6 +2377,10 @@ impl<'a> State<'a> {
                 self.popen();
                 self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
                 self.pclose();
+            }
+            PatKind::Or(ref pats) => {
+                let spacing = SeparatorSpacing::Both;
+                self.strsep("|", spacing, Inconsistent, &pats[..], |s, p| s.print_pat(p))?;
             }
             PatKind::Path(None, ref path) => {
                 self.print_path(path, true, 0);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -462,7 +462,7 @@ pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) {
             visitor.visit_expr(upper_bound);
         }
         PatKind::Wild | PatKind::Rest => {},
-        PatKind::Tuple(ref elems) => {
+        PatKind::Tuple(ref elems)
         | PatKind::Slice(ref elems)
         | PatKind::Or(ref elems) => {
             walk_list!(visitor, visit_pat, elems);

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -447,9 +447,6 @@ pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) {
                 visitor.visit_pat(&field.pat)
             }
         }
-        PatKind::Tuple(ref elems) => {
-            walk_list!(visitor, visit_pat, elems);
-        }
         PatKind::Box(ref subpattern) |
         PatKind::Ref(ref subpattern, _) |
         PatKind::Paren(ref subpattern) => {
@@ -465,7 +462,9 @@ pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) {
             visitor.visit_expr(upper_bound);
         }
         PatKind::Wild | PatKind::Rest => {},
-        PatKind::Slice(ref elems) => {
+        PatKind::Tuple(ref elems) => {
+        | PatKind::Slice(ref elems)
+        | PatKind::Or(ref elems) => {
             walk_list!(visitor, visit_pat, elems);
         }
         PatKind::Mac(ref mac) => visitor.visit_mac(mac),

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -469,6 +469,7 @@ symbols! {
         option_env,
         opt_out_copy,
         or,
+        or_patterns,
         Ord,
         Ordering,
         Output,

--- a/src/test/ui/feature-gate/feature-gate-or_patterns.rs
+++ b/src/test/ui/feature-gate/feature-gate-or_patterns.rs
@@ -1,0 +1,9 @@
+#![crate_type="lib"]
+
+pub fn example(x: Option<usize>) {
+    match x {
+        Some(0 | 1 | 2) => {}
+        //~^ ERROR: or-patterns syntax is experimental
+        _ => {}
+    }
+}

--- a/src/test/ui/feature-gate/feature-gate-or_patterns.stderr
+++ b/src/test/ui/feature-gate/feature-gate-or_patterns.stderr
@@ -1,0 +1,12 @@
+error[E0658]: or-patterns syntax is experimental
+  --> $DIR/feature-gate-or_patterns.rs:5:14
+   |
+LL |         Some(0 | 1 | 2) => {}
+   |              ^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54883
+   = help: add `#![feature(or_patterns)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/parser/pat-lt-bracket-6.rs
+++ b/src/test/ui/parser/pat-lt-bracket-6.rs
@@ -2,8 +2,9 @@ fn main() {
     struct Test(&'static u8, [u8; 0]);
     let x = Test(&0, []);
 
-    let Test(&desc[..]) = x; //~ ERROR: expected one of `)`, `,`, or `@`, found `[`
-    //~^ ERROR subslice patterns are unstable
+    let Test(&desc[..]) = x;
+    //~^ ERROR: expected one of `)`, `,`, `@`, or `|`, found `[`
+    //~^^ ERROR subslice patterns are unstable
 }
 
 const RECOVERY_WITNESS: () = 0; //~ ERROR mismatched types

--- a/src/test/ui/parser/pat-lt-bracket-6.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-6.stderr
@@ -1,8 +1,8 @@
-error: expected one of `)`, `,`, or `@`, found `[`
+error: expected one of `)`, `,`, `@`, or `|`, found `[`
   --> $DIR/pat-lt-bracket-6.rs:5:19
    |
 LL |     let Test(&desc[..]) = x;
-   |                   ^ expected one of `)`, `,`, or `@` here
+   |                   ^ expected one of `)`, `,`, `@`, or `|` here
 
 error[E0658]: subslice patterns are unstable
   --> $DIR/pat-lt-bracket-6.rs:5:20
@@ -14,7 +14,7 @@ LL |     let Test(&desc[..]) = x;
    = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
-  --> $DIR/pat-lt-bracket-6.rs:9:30
+  --> $DIR/pat-lt-bracket-6.rs:10:30
    |
 LL | const RECOVERY_WITNESS: () = 0;
    |                              ^ expected (), found integer

--- a/src/test/ui/parser/pat-lt-bracket-7.rs
+++ b/src/test/ui/parser/pat-lt-bracket-7.rs
@@ -2,7 +2,8 @@ fn main() {
     struct Thing(u8, [u8; 0]);
     let foo = core::iter::empty();
 
-    for Thing(x[]) in foo {} //~ ERROR: expected one of `)`, `,`, or `@`, found `[`
+    for Thing(x[]) in foo {}
+    //~^ ERROR: expected one of `)`, `,`, `@`, or `|`, found `[`
 }
 
 const RECOVERY_WITNESS: () = 0; //~ ERROR mismatched types

--- a/src/test/ui/parser/pat-lt-bracket-7.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-7.stderr
@@ -1,11 +1,11 @@
-error: expected one of `)`, `,`, or `@`, found `[`
+error: expected one of `)`, `,`, `@`, or `|`, found `[`
   --> $DIR/pat-lt-bracket-7.rs:5:16
    |
 LL |     for Thing(x[]) in foo {}
-   |                ^ expected one of `)`, `,`, or `@` here
+   |                ^ expected one of `)`, `,`, `@`, or `|` here
 
 error[E0308]: mismatched types
-  --> $DIR/pat-lt-bracket-7.rs:8:30
+  --> $DIR/pat-lt-bracket-7.rs:9:30
    |
 LL | const RECOVERY_WITNESS: () = 0;
    |                              ^ expected (), found integer

--- a/src/test/ui/parser/recover-for-loop-parens-around-head.rs
+++ b/src/test/ui/parser/recover-for-loop-parens-around-head.rs
@@ -8,7 +8,7 @@ fn main() {
     let vec = vec![1, 2, 3];
 
     for ( elem in vec ) {
-        //~^ ERROR expected one of `)`, `,`, or `@`, found `in`
+        //~^ ERROR expected one of `)`, `,`, `@`, or `|`, found `in`
         //~| ERROR unexpected closing `)`
         const RECOVERY_WITNESS: () = 0; //~ ERROR mismatched types
     }

--- a/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
+++ b/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
@@ -1,8 +1,8 @@
-error: expected one of `)`, `,`, or `@`, found `in`
+error: expected one of `)`, `,`, `@`, or `|`, found `in`
   --> $DIR/recover-for-loop-parens-around-head.rs:10:16
    |
 LL |     for ( elem in vec ) {
-   |                ^^ expected one of `)`, `,`, or `@` here
+   |                ^^ expected one of `)`, `,`, `@`, or `|` here
 
 error: unexpected closing `)`
   --> $DIR/recover-for-loop-parens-around-head.rs:10:23


### PR DESCRIPTION
An incomplete implementation of or-patterns (e.g. `Some(0 | 1)` as a pattern). This patch set aims to implement initial parsing of `or-patterns`.

Related to: #54883

CC @alexreg @varkor 
r? @Centril 