### PR TITLE
Add a method to create an arbitrary OpTy from outside rustc_mir

### DIFF
--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -12,10 +12,7 @@ use rustc::mir::interpret::{
     InterpResult, InterpError, InboundsCheck,
     sign_extend, truncate,
 };
-use super::{
-    InterpretCx, Machine,
-    MemPlace, MPlaceTy, PlaceTy, Place,
-};
+use super::{InterpretCx, Machine, MemPlace, MPlaceTy, PlaceTy, Place};
 pub use rustc::mir::interpret::ScalarMaybeUndef;
 
 /// A `Value` represents a single immediate self-contained Rust value.
@@ -187,6 +184,19 @@ impl<'tcx, Tag: Copy> ImmTy<'tcx, Tag>
     #[inline]
     pub fn to_bits(self) -> InterpResult<'tcx, u128> {
         self.to_scalar()?.to_bits(self.layout.size)
+    }
+}
+
+impl<'tcx, Tag> OpTy<'tcx, Tag>
+{
+    /// This is used by [priroda](https://github.com/oli-obk/priroda) to create an `OpTy`.
+    ///
+    /// Do not use this from inside rustc.
+    pub fn from_op_and_layout_unchecked(op: Operand<Tag>, layout: TyLayout<'tcx>) -> Self {
+        OpTy {
+            op,
+            layout,
+        }
     }
 }
 
@@ -395,7 +405,6 @@ impl<'a, 'mir, 'tcx, M: Machine<'a, 'mir, 'tcx>> InterpretCx<'a, 'mir, 'tcx, M> 
         })
     }
 
-    /// This is used by [priroda](https://github.com/oli-obk/priroda) to get an OpTy from a local
     pub fn access_local(
         &self,
         frame: &super::Frame<'mir, 'tcx, M::PointerTag, M::FrameExtra>,


### PR DESCRIPTION
r? @oli-obk

This is necessary to make priroda work again without the ugly catch panic hack at https://github.com/oli-obk/priroda/blob/0810d79b474f6ad66686c664925fd595f011c581/src/render/locals.rs#L39-L54.