### PR TITLE
Add `--filter-mode=run-pass,compile-pass` to compiletest

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1932,6 +1932,7 @@ mod __test {
             bless: false,
             compare_mode: None,
             rustfix_coverage: false,
+            filter_mode: None,
         };
 
         let build = Build::new(config);
@@ -1974,6 +1975,7 @@ mod __test {
             bless: false,
             compare_mode: None,
             rustfix_coverage: false,
+            filter_mode: None,
         };
 
         let build = Build::new(config);

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -58,6 +58,7 @@ pub enum Subcommand {
         /// Whether to automatically update stderr/stdout files
         bless: bool,
         compare_mode: Option<String>,
+        filter_mode: Option<String>,
         test_args: Vec<String>,
         rustc_args: Vec<String>,
         fail_fast: bool,
@@ -198,6 +199,12 @@ To learn more about a subcommand, run `./x.py <subcommand> -h`"
                     "compare-mode",
                     "mode describing what file the actual ui output will be compared to",
                     "COMPARE MODE",
+                );
+                opts.optopt(
+                    "",
+                    "filter-mode",
+                    "only test files matching any of the comma separated list of modes",
+                    "MODES",
                 );
                 opts.optflag(
                     "",
@@ -401,6 +408,7 @@ Arguments:
                 paths,
                 bless: matches.opt_present("bless"),
                 compare_mode: matches.opt_str("compare-mode"),
+                filter_mode: matches.opt_str("filter-mode"),
                 test_args: matches.opt_strs("test-args"),
                 rustc_args: matches.opt_strs("rustc-args"),
                 fail_fast: !matches.opt_present("no-fail-fast"),
@@ -521,6 +529,15 @@ impl Subcommand {
             Subcommand::Test {
                 ref compare_mode, ..
             } => compare_mode.as_ref().map(|s| &s[..]),
+            _ => None,
+        }
+    }
+
+    pub fn filter_mode(&self) -> Option<&str> {
+        match *self {
+            Subcommand::Test {
+                ref filter_mode, ..
+            } => filter_mode.as_ref().map(|s| &s[..]),
             _ => None,
         }
     }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1065,6 +1065,11 @@ impl Step for Compiletest {
             }
         });
 
+        if let Some(ref filter_mode) = builder.config.cmd.filter_mode() {
+            cmd.arg("--filter-mode");
+            cmd.arg(filter_mode);
+        }
+
         if let Some(ref nodejs) = builder.config.nodejs {
             cmd.arg("--nodejs").arg(nodejs);
         }

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -99,6 +99,33 @@ impl fmt::Display for Mode {
     }
 }
 
+/// Mode with extra forms.
+/// Used for `--filter-mode` to allow `compile-pass` to be used.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ExtraMode {
+    Mode(Mode),
+    CompilePass,
+}
+
+impl FromStr for ExtraMode {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
+            "compile-pass" => Ok(ExtraMode::CompilePass),
+            s => Mode::from_str(s).map(ExtraMode::Mode),
+        }
+    }
+}
+
+impl fmt::Display for ExtraMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ExtraMode::CompilePass => fmt::Display::fmt("compile-pass", f),
+            ExtraMode::Mode(mode) => mode.fmt(f),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum CompareMode {
     Nll,
@@ -183,6 +210,9 @@ pub struct Config {
 
     /// Exactly match the filter, rather than a substring
     pub filter_exact: bool,
+
+    /// Only run tests that match any of these modes.
+    pub filter_mode: Option<Vec<ExtraMode>>,
 
     /// Write out a parseable log of tests that were run
     pub logfile: Option<PathBuf>,


### PR DESCRIPTION
Add a `--filter-mode` option to `compiletest` and expose it through `./x.py`.

The `--filter-mode` flag will take a comma separated list of modes:
+ `compile-pass`
+ `compile-fail`
+ `run-pass`
+ `ui`
+ and more: <details>
    + `run-fail`
    + `run-pass-valgrind`
    + `pretty`
    + `debuginfo-cdb`
    + `debuginfo-gdb+lldb`
    + `debuginfo-lldb`
    + `debuginfo-gdb`
    + `codegen`
    + `rustdoc`
    + `codegen-units`
    + `incremental`
    + `run-make`
    + `js-doc-test`
    + `mir-opt`
    + `assembly`
</details>

When the mode is `ui` (e.g. `src/test/ui`) then:
+ `// compile-pass` is interpreted as provided mode `compile-pass`.
+ `// run-pass` is interpreted as provided mode `run-pass`.
+ Absence of those two is interpreted as mode `compile-fail`.

When `--filter-mode` is used, only tests fitting the modes included in the flag are retained. Other tests are ignored.

As an example run, you can use `./x.py -i test --stage 1 --filter-mode run-pass` to execute all run-pass tests whether they are in `src/test/ui` or inside `src/test/run-pass`.

Another example is `./x.py -i test src/test/ui --stage 1 --filter-mode run-pass,compile-pass` which will cover both run-pass and compile-pass tests in `src/test/ui` specifically.

This PR moves us towards a more systematic testing scheme in the spirit of https://github.com/rust-lang/rust/issues/61712 and may enable moving `src/test/run-pass` altogether to `src/test/ui`.

r? @petrochenkov 