### PR TITLE
Add binary dependencies to dep-info files

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1468,6 +1468,8 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
     symbol_mangling_version: SymbolManglingVersion = (SymbolManglingVersion::Legacy,
         parse_symbol_mangling_version, [TRACKED],
         "which mangling version to use for symbol names"),
+    binary_dep_depinfo: bool = (false, parse_bool, [TRACKED],
+        "include artifacts (sysroot, crate dependencies) used during compilation in dep-info"),
 }
 
 pub fn default_lib_output() -> CrateType {

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -545,6 +545,9 @@ impl Session {
     pub fn print_llvm_passes(&self) -> bool {
         self.opts.debugging_opts.print_llvm_passes
     }
+    pub fn binary_dep_depinfo(&self) -> bool {
+        self.opts.debugging_opts.binary_dep_depinfo
+    }
 
     /// Gets the features enabled for the current compilation session.
     /// DO NOT USE THIS METHOD if there is a TyCtxt available, as it circumvents

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -677,17 +677,19 @@ fn write_out_deps(compiler: &Compiler, outputs: &OutputFilenames, out_filenames:
             .map(|fmap| escape_dep_filename(&fmap.name))
             .collect();
 
-        for cnum in compiler.cstore.crates_untracked() {
-            let metadata = compiler.cstore.crate_data_as_rc_any(cnum);
-            let metadata = metadata.downcast_ref::<cstore::CrateMetadata>().unwrap();
-            if let Some((path, _)) = &metadata.source.dylib {
-                files.push(escape_dep_filename(&FileName::Real(path.clone())));
-            }
-            if let Some((path, _)) = &metadata.source.rlib {
-                files.push(escape_dep_filename(&FileName::Real(path.clone())));
-            }
-            if let Some((path, _)) = &metadata.source.rmeta {
-                files.push(escape_dep_filename(&FileName::Real(path.clone())));
+        if sess.binary_dep_depinfo() {
+            for cnum in compiler.cstore.crates_untracked() {
+                let metadata = compiler.cstore.crate_data_as_rc_any(cnum);
+                let metadata = metadata.downcast_ref::<cstore::CrateMetadata>().unwrap();
+                if let Some((path, _)) = &metadata.source.dylib {
+                    files.push(escape_dep_filename(&FileName::Real(path.clone())));
+                }
+                if let Some((path, _)) = &metadata.source.rlib {
+                    files.push(escape_dep_filename(&FileName::Real(path.clone())));
+                }
+                if let Some((path, _)) = &metadata.source.rmeta {
+                    files.push(escape_dep_filename(&FileName::Real(path.clone())));
+                }
             }
         }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -9,6 +9,7 @@ use rustc::hir::lowering::lower_crate;
 use rustc::hir::def_id::{CrateNum, LOCAL_CRATE};
 use rustc::lint;
 use rustc::middle::{self, reachable, resolve_lifetime, stability};
+use rustc::middle::cstore::CrateStore;
 use rustc::middle::privacy::AccessLevels;
 use rustc::ty::{self, AllArenas, Resolutions, TyCtxt, GlobalCtxt};
 use rustc::ty::steal::Steal;
@@ -657,7 +658,8 @@ fn escape_dep_filename(filename: &FileName) -> String {
     filename.to_string().replace(" ", "\\ ")
 }
 
-fn write_out_deps(sess: &Session, outputs: &OutputFilenames, out_filenames: &[PathBuf]) {
+fn write_out_deps(compiler: &Compiler, outputs: &OutputFilenames, out_filenames: &[PathBuf]) {
+    let sess = &compiler.sess;
     // Write out dependency rules to the dep-info file if requested
     if !sess.opts.output_types.contains_key(&OutputType::DepInfo) {
         return;
@@ -667,13 +669,28 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, out_filenames: &[Pa
     let result = (|| -> io::Result<()> {
         // Build a list of files used to compile the output and
         // write Makefile-compatible dependency rules
-        let files: Vec<String> = sess.source_map()
+        let mut files: Vec<String> = sess.source_map()
             .files()
             .iter()
             .filter(|fmap| fmap.is_real_file())
             .filter(|fmap| !fmap.is_imported())
             .map(|fmap| escape_dep_filename(&fmap.name))
             .collect();
+
+        for cnum in compiler.cstore.crates_untracked() {
+            let metadata = compiler.cstore.crate_data_as_rc_any(cnum);
+            let metadata = metadata.downcast_ref::<cstore::CrateMetadata>().unwrap();
+            if let Some((path, _)) = &metadata.source.dylib {
+                files.push(escape_dep_filename(&FileName::Real(path.clone())));
+            }
+            if let Some((path, _)) = &metadata.source.rlib {
+                files.push(escape_dep_filename(&FileName::Real(path.clone())));
+            }
+            if let Some((path, _)) = &metadata.source.rmeta {
+                files.push(escape_dep_filename(&FileName::Real(path.clone())));
+            }
+        }
+
         let mut file = fs::File::create(&deps_filename)?;
         for path in out_filenames {
             writeln!(file, "{}: {}\n", path.display(), files.join(" "))?;
@@ -750,7 +767,7 @@ pub fn prepare_outputs(
         }
     }
 
-    write_out_deps(sess, &outputs, &output_paths);
+    write_out_deps(compiler, &outputs, &output_paths);
 
     let only_dep_info = sess.opts.output_types.contains_key(&OutputType::DepInfo)
         && sess.opts.output_types.len() == 1;


### PR DESCRIPTION
I'm not sure about the lack of incremental-tracking here, but since I'm pretty sure this runs on every compile anyway it might not matter? If there's a better place/way to get at the information I want, I'm happy to refactor the code to match.

r? @alexcrichton 