### PR TITLE
ci: Enable toolstate tracking on Azure

### DIFF
--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -140,7 +140,6 @@ jobs:
         IMAGE: x86_64-gnu-aux
       x86_64-gnu-tools:
         IMAGE: x86_64-gnu-tools
-      # FIXME if: branch = auto OR (type = pull_request AND commit_message =~ /(?i:^update.*\b(rls|rustfmt|clippy|miri|cargo)\b)/)
       x86_64-gnu-debug:
         IMAGE: x86_64-gnu-debug
       x86_64-gnu-nopt:

--- a/.azure-pipelines/master.yml
+++ b/.azure-pipelines/master.yml
@@ -6,6 +6,9 @@ pr: none
 trigger:
   - master
 
+variables:
+- group: prod-credentials
+
 pool:
   vmImage: ubuntu-16.04
 
@@ -16,9 +19,7 @@ steps:
 - script: |
     export MESSAGE_FILE=$(mktemp -t msg.XXXXXX)
     . src/ci/docker/x86_64-gnu-tools/repo.sh
-    # FIXME(pietro): committing is disabled until we switch to Azure Pipelines
-    # as the source of truth, or until we setup a separate test repo.
-    #commit_toolstate_change "$MESSAGE_FILE" "$BUILD_SOURCESDIRECTORY/src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" "$(git log --format=%s -n1 HEAD)" "$MESSAGE_FILE" "$TOOLSTATE_REPO_ACCESS_TOKEN"
+    commit_toolstate_change "$MESSAGE_FILE" "$BUILD_SOURCESDIRECTORY/src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" "$(git log --format=%s -n1 HEAD)" "$MESSAGE_FILE" "$TOOLSTATE_REPO_ACCESS_TOKEN"
   displayName: Publish toolstate
   env:
-    TOOLSTATE_REPO_ACCESS_TOKEN: $(TOOLSTATE_REPO_ACCESS_TOKEN_SECRET)
+    TOOLSTATE_REPO_ACCESS_TOKEN: $(TOOLSTATE_REPO_ACCESS_TOKEN)

--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -4,10 +4,11 @@
 
 trigger: none
 pr:
-- master # FIXME: really just want any branch, but want an explicit "pr" property set so it's clear
+- master
 
 jobs:
 - job: Linux
+  timeoutInMinutes: 600
   pool:
     vmImage: ubuntu-16.04
   steps:
@@ -15,8 +16,18 @@ jobs:
   strategy:
     matrix:
       x86_64-gnu-llvm-6.0:
-        RUST_BACKTRACE: 1
+        IMAGE: x86_64-gnu-llvm-6.0
+      mingw-check:
+        IMAGE: mingw-check
 
-#      x86_64-gnu-tools: {}
-#      # if: branch = auto OR (type = pull_request AND commit_message =~ /(?i:^update.*\b(rls|rustfmt|clippy|miri|cargo)\b)/)
-#      mingw-check: {}
+# TODO: enable this job if the commit message matches this regex, need tools
+# figure out how to get the current commit message on azure and stick it in a
+# condition somewhere
+#     if: commit_message =~ /(?i:^update.*\b(rls|rustfmt|clippy|miri|cargo)\b)/
+# - job: Linux-x86_64-gnu-tools
+#   pool:
+#     vmImage: ubuntu-16.04
+#   steps:
+#     - template: steps/run.yml
+#   variables:
+#     IMAGE: x86_64-gnu-tools

--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -124,6 +124,7 @@ steps:
     CI: true
     SRC: .
     AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+    TOOLSTATE_REPO_ACCESS_TOKEN: $(TOOLSTATE_REPO_ACCESS_TOKEN)
   displayName: Run build
 
 # If we're a deploy builder, use the `aws` command to publish everything to our

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -149,6 +149,7 @@ exec docker \
   --env TF_BUILD \
   --env BUILD_SOURCEBRANCHNAME \
   --env TOOLSTATE_REPO_ACCESS_TOKEN \
+  --env TOOLSTATE_REPO \
   --env CI_JOB_NAME="${CI_JOB_NAME-$IMAGE}" \
   --volume "$HOME/.cargo:/cargo" \
   --volume "$HOME/rustsrc:$HOME/rustsrc" \

--- a/src/ci/docker/x86_64-gnu-tools/repo.sh
+++ b/src/ci/docker/x86_64-gnu-tools/repo.sh
@@ -55,7 +55,7 @@ commit_toolstate_change() {
     git config --global credential.helper store
     printf 'https://%s:x-oauth-basic@github.com\n' "$TOOLSTATE_REPO_ACCESS_TOKEN" \
         > "$HOME/.git-credentials"
-    git clone --depth=1 https://github.com/rust-lang-nursery/rust-toolstate.git
+    git clone --depth=1 $TOOLSTATE_REPO
 
     cd rust-toolstate
     FAILURE=1


### PR DESCRIPTION
Currently just run it through its paces but don't actually push to
official locations. Instead let's just push to a separate fork (mine) as
well as open issues in a separate fork (mine). Make sure that people
aren't pinged for these issues as well!

This should hopefully ensure that everything is working on Azure and
give us a chance to work through any issues that come up.

Fixes https://github.com/rust-lang/rust/issues/61790
Fixes https://github.com/rust-lang/rust/issues/61371