### PR TITLE
Fix rust-lldb wrapper scripts.

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -38,6 +38,7 @@ steps:
     brew update
     brew install xz
     brew install swig@3
+    brew link --force swig@3
   displayName: Install build dependencies (OSX)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['SCRIPT'],'./x.py dist'))
 

--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -37,7 +37,7 @@ steps:
     set -e
     brew update
     brew install xz
-    brew install swig
+    brew install swig@3
   displayName: Install build dependencies (OSX)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['SCRIPT'],'./x.py dist'))
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,6 +264,7 @@ install:
             travis_retry brew update &&
             travis_retry brew install xz &&
             travis_retry brew install swig@3;
+            brew link --force swig@3
           fi &&
           travis_retry curl -fo /usr/local/bin/sccache https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/2018-04-02-sccache-x86_64-apple-darwin &&
             chmod +x /usr/local/bin/sccache &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -263,7 +263,7 @@ install:
           if [[ "$SCRIPT" == "./x.py dist" ]]; then
             travis_retry brew update &&
             travis_retry brew install xz &&
-            travis_retry brew install swig;
+            travis_retry brew install swig@3;
           fi &&
           travis_retry curl -fo /usr/local/bin/sccache https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/2018-04-02-sccache-x86_64-apple-darwin &&
             chmod +x /usr/local/bin/sccache &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -263,8 +263,8 @@ install:
           if [[ "$SCRIPT" == "./x.py dist" ]]; then
             travis_retry brew update &&
             travis_retry brew install xz &&
-            travis_retry brew install swig@3;
-            brew link --force swig@3
+            travis_retry brew install swig@3 &&
+            brew link --force swig@3;
           fi &&
           travis_retry curl -fo /usr/local/bin/sccache https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rust-ci-mirror/2018-04-02-sccache-x86_64-apple-darwin &&
             chmod +x /usr/local/bin/sccache &&

--- a/src/etc/rust-lldb
+++ b/src/etc/rust-lldb
@@ -31,7 +31,7 @@ category_definition="type summary add --no-value --python-function lldb_rust_for
 category_enable="type category enable Rust"
 
 # Call LLDB with the commands added to the argument list
-exec "$lldb" --one-line-before-file="$script_import" \
-    --one-line-before-file="$category_definition" \
-    --one-line-before-file="$category_enable" \
+exec "$lldb" --one-line-before-file "$script_import" \
+    --one-line-before-file "$category_definition" \
+    --one-line-before-file "$category_enable" \
     "$@"


### PR DESCRIPTION
Currently the `rust-lldb` wrapper provided by Rust project is broken. The error messages it produces on launch are as follows: 
```
warning: ignoring unknown option: --one-line-before-file=command script import "/Users/kon/.rustup/toolchains/nightly-2019-05-02-x86_64-apple-darwin/lib/rustlib/etc/lldb_rust_formatters.py"
warning: ignoring unknown option: --one-line-before-file=type summary add --no-value --python-function lldb_rust_formatters.print_val -x ".*" --category Rust
warning: ignoring unknown option: --one-line-before-file=type category enable Rust
(lldb) target create "target/debug/nagare"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/kon/.rustup/toolchains/nightly-2019-05-02-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/python2.7/site-packages/lldb/__init__.py", line 1481, in <module>
    class SBAddress(object):
  File "/Users/kon/.rustup/toolchains/nightly-2019-05-02-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/python2.7/site-packages/lldb/__init__.py", line 1647, in SBAddress
    __swig_getmethods__["module"] = GetModule
NameError: name '__swig_getmethods__' is not defined
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'run_one_line' is not defined
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'run_one_line' is not defined
Traceback (most recent call last):
  File "<string>", line 1, in <module>
NameError: name 'run_one_line' is not defined
...etc.
```

The errors stem from two regressions: one caused by an LLVM upgrade and one caused by unintended upgrade to SWIG 4.0 (SWIG is a wrapper generator that is used to generate Python bindings for LLVM and LLDB.)

(Edit: found the exact dates) The SWIG breakage happened because of a Homebrew version upgrade on `nightly-2019-05-01-x86_64-apple-darwin` and the LLVM breakage happened on `nightly-2019-01-27-x86_64-apple-darwin` (likely to have been caused by https://github.com/rust-lang/rust/pull/57675 ).

The fix is to update the LLVM parameter syntax and to "downgrade" to SWIG 3.0.x. SWIG 3.0.x is not going to be supported by Homebrew forever, but should be good for now, until LLDB upgrades to  support SWIG 4.0.0. Here's some more info about Homebrew support: https://github.com/Homebrew/homebrew-core/pull/39929 & https://github.com/Homebrew/homebrew-core/pull/40882 I'm going to send a bug & fix to LLDB about SWIG 4.0.0 to get the situation fixed in the future.

It would be good to also backport this to beta, since it's such a small change, and will fix an obvious regression.