### PR TITLE
make sure we use cfg-if as a std dependency

### DIFF
--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 alloc = { path = "../liballoc" }
-cfg-if = "0.1.8"
+cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../libpanic_unwind", optional = true }
 panic_abort = { path = "../libpanic_abort" }
 core = { path = "../libcore" }


### PR DESCRIPTION
xargo currently fails to build libstd because this feature is missing. My guess is that it works in rustc because the feature is enabled elsewhere, but that does not help for a libstd-only build.

Miri is currently in a state where it is shipped but broken, which makes CI fail for projects that are tested in Miri. So this is kind of urgent.

Cc @alexcrichton  https://github.com/rust-lang/rust/pull/61720