### PR TITLE
ci: Add a script for generating CPU usage graphs

### DIFF
--- a/src/ci/cpu-usage-over-time.py
+++ b/src/ci/cpu-usage-over-time.py
@@ -30,23 +30,8 @@
 # the second column is always zero.
 #
 # Once you've downloaded a file there's various ways to plot it and visualize
-# it. For command line usage you can use a script like so:
-#
-#      set timefmt '%Y-%m-%dT%H:%M:%S'
-#      set xdata time
-#      set ylabel "Idle CPU %"
-#      set xlabel "Time"
-#      set datafile sep ','
-#      set term png
-#      set output "printme.png"
-#      set grid
-#      builder = "i686-apple"
-#      plot "cpu-".builder.".csv" using 1:2 with lines title builder
-#
-# Executed as `gnuplot < ./foo.plot` it will generate a graph called
-# `printme.png` which you can then open up. If you know how to improve this
-# script or the viewing process that would be much appreciated :) (or even if
-# you know how to automate it!)
+# it. For command line usage you use the `src/etc/cpu-usage-over-time-plot.sh`
+# script in this repository.
 
 import datetime
 import sys

--- a/src/etc/cpu-usage-over-time-plot.sh
+++ b/src/etc/cpu-usage-over-time-plot.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# A small script to help visualizing CPU usage over time data collected on CI
+# using `gnuplot`.
+#
+# This script is expected to be called with two arguments. The first is the full
+# commit SHA of the build you're interested in, and the second is the name of
+# the builder. For example:
+#
+#  ./src/etc/cpu-usage-over-time-plot.sh e699ea096fcc2fc9ce8e8bcf884e11496a31cc9f i686-mingw-1
+#
+# That will generate `$builder.png` in the current directory which you can open
+# up to see a hopefully pretty graph.
+#
+# Improvements to this script are greatly appreciated!
+
+set -ex
+
+bucket=rust-lang-ci-evalazure
+commit=$1
+builder=$2
+
+curl -O https://$bucket.s3.amazonaws.com/rustc-builds/$commit/cpu-$builder.csv
+
+gnuplot <<-EOF
+reset
+set timefmt '%Y-%m-%dT%H:%M:%S'
+set xdata time
+set ylabel "CPU Usage %"
+set xlabel "Time"
+set datafile sep ','
+set term png size 3000,1000
+set output "$builder.png"
+set grid
+
+f(x) = mean_y
+fit f(x) 'cpu-$builder.csv' using 1:(100-\$2) via mean_y
+
+set label 1 gprintf("Average = %g%%", mean_y) center font ",18"
+set label 1 at graph 0.50, 0.25
+set xtics rotate by 45 offset -2,-2.4 300
+set ytics 10
+set boxwidth 0.5
+
+plot \\
+   mean_y with lines linetype 1 linecolor rgb "#ff0000" title "average", \\
+   "cpu-$builder.csv" using 1:(100-\$2) with points pointtype 7 pointsize 0.4 title "$builder", \\
+   "" using 1:(100-\$2) smooth bezier linewidth 3 title "bezier"
+EOF


### PR DESCRIPTION
This commit checks in a script which generates CPU usage graphs over
time, expanding on the previous comment that was include in the
collection file.

Some example graphs from the [latest build](https://dev.azure.com/rust-lang/rust/_build/results?buildId=717) look like:

![dist-x86_64-apple](https://user-images.githubusercontent.com/64996/59520676-16c5b000-8e90-11e9-9188-27001911f270.png)

![x86_64-msvc-1](https://user-images.githubusercontent.com/64996/59520677-175e4680-8e90-11e9-8568-4b564807324e.png)

![x86_64-mingw-1](https://user-images.githubusercontent.com/64996/59520680-175e4680-8e90-11e9-939d-a73c7224582f.png)

![test-various](https://user-images.githubusercontent.com/64996/59520682-175e4680-8e90-11e9-9980-900ed4eeb8f4.png)



