### PR TITLE
Turn down the myriad-closures test

### DIFF
--- a/src/test/run-pass-fulldeps/myriad-closures.rs
+++ b/src/test/run-pass-fulldeps/myriad-closures.rs
@@ -32,7 +32,7 @@ macro_rules! mk_fn {
 }
 
 fn main() {
-    // Make 2^12 functions, each containing 16 closures,
-    // resulting in 2^16 closures overall.
-    go_bacterial!(mk_fn 1 1 1 1  1 1 1 1  1 1 1 1);
+    // Make 2^8 functions, each containing 16 closures,
+    // resulting in 2^12 closures overall.
+    go_bacterial!(mk_fn 1 1 1 1  1 1 1 1);
 }


### PR DESCRIPTION
This tests takes nearly 5 minutes to compile on CI where the CPUs we
have aren't exactly the fastest. This test does actually require all
closures to exist to exhibit the original bug, but it seems a little
excessive to test a single bug on CI on all platforms which simply pegs
a single CPU for 5 minutes with no parallelism opportunities, so this
turns down the test to still exercise it somewhat at least.