### PR TITLE
Add primitive docs to libcore

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -2,7 +2,7 @@
 //! up to a certain length. Eventually we should able to generalize
 //! to all lengths.
 //!
-//! *[See also the array primitive type](../../std/primitive.array.html).*
+//! *[See also the array primitive type](../primitive.array.html).*
 
 #![stable(feature = "core_array", since = "1.36.0")]
 

--- a/src/libcore/borrow.rs
+++ b/src/libcore/borrow.rs
@@ -40,12 +40,12 @@
 /// provide a reference to related type `T`, it is often better to use
 /// [`AsRef<T>`] as more types can safely implement it.
 ///
-/// [`AsRef<T>`]: ../../std/convert/trait.AsRef.html
+/// [`AsRef<T>`]: ../convert/trait.AsRef.html
 /// [`BorrowMut<T>`]: trait.BorrowMut.html
 /// [`Box<T>`]: ../../std/boxed/struct.Box.html
 /// [`Mutex<T>`]: ../../std/sync/struct.Mutex.html
 /// [`Rc<T>`]: ../../std/rc/struct.Rc.html
-/// [`str`]: ../../std/primitive.str.html
+/// [`str`]: ../primitive.str.html
 /// [`String`]: ../../std/string/struct.String.html
 /// [`borrow`]: #tymethod.borrow
 ///
@@ -152,10 +152,10 @@
 /// If it wants to allow others access to the underlying `str`, it can do
 /// that via `AsRef<str>` which doesn’t carry any extra requirements.
 ///
-/// [`Hash`]: ../../std/hash/trait.Hash.html
+/// [`Hash`]: ../hash/trait.Hash.html
 /// [`HashMap<K, V>`]: ../../std/collections/struct.HashMap.html
 /// [`String`]: ../../std/string/struct.String.html
-/// [`str`]: ../../std/primitive.str.html
+/// [`str`]: ../primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Borrow<Borrowed: ?Sized> {
     /// Immutably borrows from an owned value.

--- a/src/libcore/char/convert.rs
+++ b/src/libcore/char/convert.rs
@@ -23,8 +23,8 @@ use super::MAX;
 /// [`char`]s. `from_u32()` will return `None` if the input is not a valid value
 /// for a [`char`].
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: ../primitive.char.html
+/// [`u32`]: ../primitive.u32.html
 ///
 /// For an unsafe version of this function which ignores these checks, see
 /// [`from_u32_unchecked`].
@@ -74,8 +74,8 @@ pub fn from_u32(i: u32) -> Option<char> {
 /// [`char`]s. `from_u32_unchecked()` will ignore this, and blindly cast to
 /// [`char`], possibly creating an invalid one.
 ///
-/// [`char`]: ../../std/primitive.char.html
-/// [`u32`]: ../../std/primitive.u32.html
+/// [`char`]: ../primitive.char.html
+/// [`u32`]: ../primitive.u32.html
 ///
 /// # Safety
 ///

--- a/src/libcore/char/mod.rs
+++ b/src/libcore/char/mod.rs
@@ -9,7 +9,7 @@
 //! [Unicode code point]: http://www.unicode.org/glossary/#code_point
 //!
 //! This module exists for technical reasons, the primary documentation for
-//! `char` is directly on [the `char` primitive type](../../std/primitive.char.html)
+//! `char` is directly on [the `char` primitive type](../primitive.char.html)
 //! itself.
 //!
 //! This module is the home of the iterator implementations for the iterators
@@ -92,7 +92,7 @@ const MAX_THREE_B: u32 =  0x10000;
 /// Point], but only ones within a certain range. `MAX` is the highest valid
 /// code point that's a valid [Unicode Scalar Value].
 ///
-/// [`char`]: ../../std/primitive.char.html
+/// [`char`]: ../primitive.char.html
 /// [Unicode Scalar Value]: http://www.unicode.org/glossary/#unicode_scalar_value
 /// [Code Point]: http://www.unicode.org/glossary/#code_point
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -112,8 +112,8 @@ pub const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
 /// This `struct` is created by the [`escape_unicode`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_unicode`]: ../../std/primitive.char.html#method.escape_unicode
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_unicode`]: ../primitive.char.html#method.escape_unicode
+/// [`char`]: ../primitive.char.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeUnicode {
@@ -233,8 +233,8 @@ impl fmt::Display for EscapeUnicode {
 /// This `struct` is created by the [`escape_default`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`escape_default`]: ../../std/primitive.char.html#method.escape_default
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_default`]: ../primitive.char.html#method.escape_default
+/// [`char`]: ../primitive.char.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct EscapeDefault {
@@ -346,8 +346,8 @@ impl fmt::Display for EscapeDefault {
 /// This `struct` is created by the [`escape_debug`] method on [`char`]. See its
 /// documentation for more.
 ///
-/// [`escape_debug`]: ../../std/primitive.char.html#method.escape_debug
-/// [`char`]: ../../std/primitive.char.html
+/// [`escape_debug`]: ../primitive.char.html#method.escape_debug
+/// [`char`]: ../primitive.char.html
 #[stable(feature = "char_escape_debug", since = "1.20.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug(EscapeDefault);
@@ -377,8 +377,8 @@ impl fmt::Display for EscapeDebug {
 /// This `struct` is created by the [`to_lowercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_lowercase`]: ../../std/primitive.char.html#method.to_lowercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_lowercase`]: ../primitive.char.html#method.to_lowercase
+/// [`char`]: ../primitive.char.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToLowercase(CaseMappingIter);
@@ -405,8 +405,8 @@ impl ExactSizeIterator for ToLowercase {}
 /// This `struct` is created by the [`to_uppercase`] method on [`char`]. See
 /// its documentation for more.
 ///
-/// [`to_uppercase`]: ../../std/primitive.char.html#method.to_uppercase
-/// [`char`]: ../../std/primitive.char.html
+/// [`to_uppercase`]: ../primitive.char.html#method.to_uppercase
+/// [`char`]: ../primitive.char.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug, Clone)]
 pub struct ToUppercase(CaseMappingIter);

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -11,7 +11,7 @@
 //!
 //! [`Clone`]: trait.Clone.html
 //! [clone]: trait.Clone.html#tymethod.clone
-//! [`Drop`]: ../../std/ops/trait.Drop.html
+//! [`Drop`]: ../ops/trait.Drop.html
 //!
 //! Basic usage example:
 //!
@@ -74,7 +74,7 @@
 /// An example is a generic struct holding a function pointer. In this case, the
 /// implementation of `Clone` cannot be `derive`d, but can be implemented as:
 ///
-/// [`Copy`]: ../../std/marker/trait.Copy.html
+/// [`Copy`]: ../marker/trait.Copy.html
 /// [`clone`]: trait.Clone.html#tymethod.clone
 ///
 /// ```

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -112,13 +112,13 @@ pub const fn identity<T>(x: T) -> T { x }
 ///   equivalent to those of the owned value. For this reason, if you want to
 ///   borrow only a single field of a struct you can implement `AsRef`, but not `Borrow`.
 ///
-/// [`Borrow`]: ../../std/borrow/trait.Borrow.html
+/// [`Borrow`]: ../borrow/trait.Borrow.html
 ///
 /// **Note: This trait must not fail**. If the conversion can fail, use a
 /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
 ///
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: ../option/enum.Option.html
+/// [`Result<T, E>`]: ../result/enum.Result.html
 ///
 /// # Generic Implementations
 ///
@@ -164,8 +164,8 @@ pub trait AsRef<T: ?Sized> {
 /// **Note: This trait must not fail**. If the conversion can fail, use a
 /// dedicated method which returns an [`Option<T>`] or a [`Result<T, E>`].
 ///
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: ../option/enum.Option.html
+/// [`Result<T, E>`]: ../result/enum.Result.html
 ///
 /// # Generic Implementations
 ///
@@ -269,8 +269,8 @@ pub trait AsMut<T: ?Sized> {
 /// ```
 ///
 /// [`TryInto`]: trait.TryInto.html
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: ../option/enum.Option.html
+/// [`Result<T, E>`]: ../result/enum.Result.html
 /// [`String`]: ../../std/string/struct.String.html
 /// [`From`]: trait.From.html
 /// [`into`]: trait.Into.html#tymethod.into
@@ -358,8 +358,8 @@ pub trait Into<T>: Sized {
 /// ```
 ///
 /// [`TryFrom`]: trait.TryFrom.html
-/// [`Option<T>`]: ../../std/option/enum.Option.html
-/// [`Result<T, E>`]: ../../std/result/enum.Result.html
+/// [`Option<T>`]: ../option/enum.Option.html
+/// [`Result<T, E>`]: ../result/enum.Result.html
 /// [`String`]: ../../std/string/struct.String.html
 /// [`Into`]: trait.Into.html
 /// [`from`]: trait.From.html#tymethod.from
@@ -651,7 +651,7 @@ impl AsRef<str> for str {
 /// [`Result`]: ../result/enum.Result.html
 /// [`TryFrom`]: trait.TryFrom.html
 /// [`Into`]: trait.Into.html
-/// [never]: ../../std/primitive.never.html
+/// [never]: ../primitive.never.html
 #[stable(feature = "convert_infallible", since = "1.34.0")]
 #[derive(Copy)]
 pub enum Infallible {}

--- a/src/libcore/ffi.rs
+++ b/src/libcore/ffi.rs
@@ -16,7 +16,7 @@ use crate::fmt;
 /// stabilized, it is recommended to use a newtype wrapper around an empty
 /// byte array. See the [Nomicon] for details.
 ///
-/// [pointer]: ../../std/primitive.pointer.html
+/// [pointer]: ../primitive.pointer.html
 /// [Nomicon]: https://doc.rust-lang.org/nomicon/ffi.html#representing-opaque-structs
 // N.B., for LLVM to recognize the void pointer type and by extension
 //     functions like malloc(), we need to have it represented as i8* in

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -104,7 +104,7 @@ pub struct Error;
 /// library. The [`write!`] macro accepts an instance of [`io::Write`], and the
 /// [`io::Write`] trait is favored over implementing this trait.
 ///
-/// [`write!`]: ../../std/macro.write.html
+/// [`write!`]: ../macro.write.html
 /// [`io::Write`]: ../../std/io/trait.Write.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Write {
@@ -148,7 +148,7 @@ pub trait Write {
     ///
     /// This function will return an instance of [`Error`] on error.
     ///
-    /// [`char`]: ../../std/primitive.char.html
+    /// [`char`]: ../primitive.char.html
     /// [`Error`]: struct.Error.html
     ///
     /// # Examples
@@ -175,7 +175,7 @@ pub trait Write {
     /// This method should generally not be invoked manually, but rather through
     /// the [`write!`] macro itself.
     ///
-    /// [`write!`]: ../../std/macro.write.html
+    /// [`write!`]: ../macro.write.html
     ///
     /// # Examples
     ///
@@ -387,9 +387,9 @@ impl<'a> Arguments<'a> {
 /// assert_eq!(display, debug);
 /// ```
 ///
-/// [`format_args!`]: ../../std/macro.format_args.html
+/// [`format_args!`]: ../macro.format_args.html
 /// [`format`]: ../../std/fmt/fn.format.html
-/// [`write`]: ../../std/fmt/fn.write.html
+/// [`write`]: ../fmt/fn.write.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Copy, Clone)]
 pub struct Arguments<'a> {
@@ -485,8 +485,8 @@ impl Display for Arguments<'_> {
 /// `Debug` implementations using either `derive` or the debug builder API
 /// on [`Formatter`] support pretty-printing using the alternate flag: `{:#?}`.
 ///
-/// [debug_struct]: ../../std/fmt/struct.Formatter.html#method.debug_struct
-/// [`Formatter`]: ../../std/fmt/struct.Formatter.html
+/// [debug_struct]: ../fmt/struct.Formatter.html#method.debug_struct
+/// [`Formatter`]: ../fmt/struct.Formatter.html
 ///
 /// Pretty-printing with `#?`:
 ///
@@ -714,10 +714,10 @@ pub trait Octal {
 /// ```
 ///
 /// [module]: ../../std/fmt/index.html
-/// [`i8`]: ../../std/primitive.i8.html
-/// [`i128`]: ../../std/primitive.i128.html
-/// [`isize`]: ../../std/primitive.isize.html
-/// [`i32`]: ../../std/primitive.i32.html
+/// [`i8`]: ../primitive.i8.html
+/// [`i128`]: ../primitive.i128.html
+/// [`isize`]: ../primitive.isize.html
+/// [`i32`]: ../primitive.i32.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Binary {
     /// Formats the value using the given formatter.
@@ -992,7 +992,7 @@ pub trait UpperExp {
 /// assert_eq!(output, "Hello world!");
 /// ```
 ///
-/// [`write!`]: ../../std/macro.write.html
+/// [`write!`]: ../macro.write.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn write(output: &mut dyn Write, args: Arguments<'_>) -> Result {
     let mut formatter = Formatter {
@@ -1704,8 +1704,8 @@ impl<'a> Formatter<'a> {
     /// Creates a [`DebugStruct`] builder designed to assist with creation of
     /// [`fmt::Debug`] implementations for structs.
     ///
-    /// [`DebugStruct`]: ../../std/fmt/struct.DebugStruct.html
-    /// [`fmt::Debug`]: ../../std/fmt/trait.Debug.html
+    /// [`DebugStruct`]: ../fmt/struct.DebugStruct.html
+    /// [`fmt::Debug`]: ../fmt/trait.Debug.html
     ///
     /// # Examples
     ///
@@ -1818,7 +1818,7 @@ impl<'a> Formatter<'a> {
     /// println!("{:?}", Foo(vec![10, 11]));
     /// ```
     ///
-    /// [`format_args!`]: ../../std/macro.format_args.html
+    /// [`format_args!`]: ../macro.format_args.html
     ///
     /// In this more complex example, we use [`format_args!`] and `.debug_set()`
     /// to build a list of match arms:

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -149,7 +149,7 @@ mod sip;
 /// Thankfully, you won't need to worry about upholding this property when
 /// deriving both [`Eq`] and `Hash` with `#[derive(PartialEq, Eq, Hash)]`.
 ///
-/// [`Eq`]: ../../std/cmp/trait.Eq.html
+/// [`Eq`]: ../cmp/trait.Eq.html
 /// [`Hasher`]: trait.Hasher.html
 /// [`HashMap`]: ../../std/collections/struct.HashMap.html
 /// [`HashSet`]: ../../std/collections/struct.HashSet.html

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -48,487 +48,487 @@ extern "rust-intrinsic" {
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_acq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_rel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_acqrel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_relaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_failacq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_acq_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange`][compare_exchange].
     ///
-    /// [compare_exchange]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange
+    /// [compare_exchange]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange
     pub fn atomic_cxchg_acqrel_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_acq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_rel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_acqrel<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as both the `success` and `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_relaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_failacq<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_acq_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
     /// Stores a value if the current value is the same as the `old` value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `compare_exchange_weak` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `success` and
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `failure` parameters. For example,
     /// [`AtomicBool::compare_exchange_weak`][cew].
     ///
-    /// [cew]: ../../std/sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
+    /// [cew]: ../sync/atomic/struct.AtomicBool.html#method.compare_exchange_weak
     pub fn atomic_cxchgweak_acqrel_failrelaxed<T>(dst: *mut T, old: T, src: T) -> (T, bool);
 
     /// Loads the current value of the pointer.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](../sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load<T>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](../sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load_acq<T>(src: *const T) -> T;
     /// Loads the current value of the pointer.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `load` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::load`](../../std/sync/atomic/struct.AtomicBool.html#method.load).
+    /// [`AtomicBool::load`](../sync/atomic/struct.AtomicBool.html#method.load).
     pub fn atomic_load_relaxed<T>(src: *const T) -> T;
     pub fn atomic_load_unordered<T>(src: *const T) -> T;
 
     /// Stores the value at the specified memory location.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](../sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store<T>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](../sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store_rel<T>(dst: *mut T, val: T);
     /// Stores the value at the specified memory location.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `store` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::store`](../../std/sync/atomic/struct.AtomicBool.html#method.store).
+    /// [`AtomicBool::store`](../sync/atomic/struct.AtomicBool.html#method.store).
     pub fn atomic_store_relaxed<T>(dst: *mut T, val: T);
     pub fn atomic_store_unordered<T>(dst: *mut T, val: T);
 
     /// Stores the value at the specified memory location, returning the old value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](../sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg<T>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](../sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_acq<T>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](../sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_rel<T>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](../sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Stores the value at the specified memory location, returning the old value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `swap` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::swap`](../../std/sync/atomic/struct.AtomicBool.html#method.swap).
+    /// [`AtomicBool::swap`](../sync/atomic/struct.AtomicBool.html#method.swap).
     pub fn atomic_xchg_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Adds to the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](../sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd<T>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](../sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_acq<T>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](../sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_rel<T>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](../sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Adds to the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_add` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_add`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_add).
+    /// [`AtomicIsize::fetch_add`](../sync/atomic/struct.AtomicIsize.html#method.fetch_add).
     pub fn atomic_xadd_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Subtract from the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](../sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub<T>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](../sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_acq<T>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](../sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_rel<T>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](../sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Subtract from the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_sub` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicIsize::fetch_sub`](../../std/sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
+    /// [`AtomicIsize::fetch_sub`](../sync/atomic/struct.AtomicIsize.html#method.fetch_sub).
     pub fn atomic_xsub_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Bitwise and with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](../sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and<T>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](../sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_acq<T>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](../sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_rel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](../sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise and with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_and` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_and`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_and).
+    /// [`AtomicBool::fetch_and`](../sync/atomic/struct.AtomicBool.html#method.fetch_and).
     pub fn atomic_and_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Bitwise nand with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](../sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand<T>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](../sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_acq<T>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](../sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_rel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](../sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise nand with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic::AtomicBool` type via the `fetch_nand` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_nand`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_nand).
+    /// [`AtomicBool::fetch_nand`](../sync/atomic/struct.AtomicBool.html#method.fetch_nand).
     pub fn atomic_nand_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Bitwise or with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](../sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or<T>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](../sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_acq<T>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](../sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_rel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](../sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise or with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_or` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_or`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_or).
+    /// [`AtomicBool::fetch_or`](../sync/atomic/struct.AtomicBool.html#method.fetch_or).
     pub fn atomic_or_relaxed<T>(dst: *mut T, src: T) -> T;
 
     /// Bitwise xor with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::SeqCst`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::SeqCst`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](../sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor<T>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Acquire`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Acquire`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](../sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_acq<T>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Release`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Release`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](../sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_rel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::AcqRel`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::AcqRel`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](../sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_acqrel<T>(dst: *mut T, src: T) -> T;
     /// Bitwise xor with the current value, returning the previous value.
     /// The stabilized version of this intrinsic is available on the
     /// `std::sync::atomic` types via the `fetch_xor` method by passing
-    /// [`Ordering::Relaxed`](../../std/sync/atomic/enum.Ordering.html)
+    /// [`Ordering::Relaxed`](../sync/atomic/enum.Ordering.html)
     /// as the `order`. For example,
-    /// [`AtomicBool::fetch_xor`](../../std/sync/atomic/struct.AtomicBool.html#method.fetch_xor).
+    /// [`AtomicBool::fetch_xor`](../sync/atomic/struct.AtomicBool.html#method.fetch_xor).
     pub fn atomic_xor_relaxed<T>(dst: *mut T, src: T) -> T;
 
     pub fn atomic_max<T>(dst: *mut T, src: T) -> T;
@@ -630,7 +630,7 @@ extern "rust-intrinsic" {
     /// reach code marked with this function.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::hint::unreachable_unchecked`](../../std/hint/fn.unreachable_unchecked.html).
+    /// [`std::hint::unreachable_unchecked`](../hint/fn.unreachable_unchecked.html).
     pub fn unreachable() -> !;
 
     /// Informs the optimizer that a condition is always true.
@@ -664,7 +664,7 @@ extern "rust-intrinsic" {
     /// items of the same type, including alignment padding.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of`](../../std/mem/fn.size_of.html).
+    /// [`std::mem::size_of`](../mem/fn.size_of.html).
     pub fn size_of<T>() -> usize;
 
     /// Moves a value to an uninitialized memory location.
@@ -678,7 +678,7 @@ extern "rust-intrinsic" {
     /// The size of the referenced value in bytes.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::size_of_val`](../../std/mem/fn.size_of_val.html).
+    /// [`std::mem::size_of_val`](../mem/fn.size_of_val.html).
     pub fn size_of_val<T: ?Sized>(_: &T) -> usize;
     pub fn min_align_of_val<T: ?Sized>(_: &T) -> usize;
 
@@ -923,7 +923,7 @@ extern "rust-intrinsic" {
     /// `Copy`, then may return `true` or `false`.
     ///
     /// The stabilized version of this intrinsic is
-    /// [`std::mem::needs_drop`](../../std/mem/fn.needs_drop.html).
+    /// [`std::mem::needs_drop`](../mem/fn.needs_drop.html).
     pub fn needs_drop<T>() -> bool;
 
     /// Calculates the offset from a pointer.
@@ -977,11 +977,11 @@ extern "rust-intrinsic" {
 
     /// Performs a volatile load from the `src` pointer.
     /// The stabilized version of this intrinsic is
-    /// [`std::ptr::read_volatile`](../../std/ptr/fn.read_volatile.html).
+    /// [`std::ptr::read_volatile`](../ptr/fn.read_volatile.html).
     pub fn volatile_load<T>(src: *const T) -> T;
     /// Performs a volatile store to the `dst` pointer.
     /// The stabilized version of this intrinsic is
-    /// [`std::ptr::write_volatile`](../../std/ptr/fn.write_volatile.html).
+    /// [`std::ptr::write_volatile`](../ptr/fn.write_volatile.html).
     pub fn volatile_store<T>(dst: *mut T, val: T);
 
     /// Performs a volatile load from the `src` pointer
@@ -1220,19 +1220,19 @@ extern "rust-intrinsic" {
     /// Performs checked integer addition.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_add` method. For example,
-    /// [`std::u32::overflowing_add`](../../std/primitive.u32.html#method.overflowing_add)
+    /// [`std::u32::overflowing_add`](../primitive.u32.html#method.overflowing_add)
     pub fn add_with_overflow<T>(x: T, y: T) -> (T, bool);
 
     /// Performs checked integer subtraction
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_sub` method. For example,
-    /// [`std::u32::overflowing_sub`](../../std/primitive.u32.html#method.overflowing_sub)
+    /// [`std::u32::overflowing_sub`](../primitive.u32.html#method.overflowing_sub)
     pub fn sub_with_overflow<T>(x: T, y: T) -> (T, bool);
 
     /// Performs checked integer multiplication
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `overflowing_mul` method. For example,
-    /// [`std::u32::overflowing_mul`](../../std/primitive.u32.html#method.overflowing_mul)
+    /// [`std::u32::overflowing_mul`](../primitive.u32.html#method.overflowing_mul)
     pub fn mul_with_overflow<T>(x: T, y: T) -> (T, bool);
 
     /// Performs an exact division, resulting in undefined behavior where
@@ -1271,40 +1271,40 @@ extern "rust-intrinsic" {
     /// Performs rotate left.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_left` method. For example,
-    /// [`std::u32::rotate_left`](../../std/primitive.u32.html#method.rotate_left)
+    /// [`std::u32::rotate_left`](../primitive.u32.html#method.rotate_left)
     pub fn rotate_left<T>(x: T, y: T) -> T;
 
     /// Performs rotate right.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `rotate_right` method. For example,
-    /// [`std::u32::rotate_right`](../../std/primitive.u32.html#method.rotate_right)
+    /// [`std::u32::rotate_right`](../primitive.u32.html#method.rotate_right)
     pub fn rotate_right<T>(x: T, y: T) -> T;
 
     /// Returns (a + b) mod 2<sup>N</sup>, where N is the width of T in bits.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `wrapping_add` method. For example,
-    /// [`std::u32::wrapping_add`](../../std/primitive.u32.html#method.wrapping_add)
+    /// [`std::u32::wrapping_add`](../primitive.u32.html#method.wrapping_add)
     pub fn overflowing_add<T>(a: T, b: T) -> T;
     /// Returns (a - b) mod 2<sup>N</sup>, where N is the width of T in bits.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `wrapping_sub` method. For example,
-    /// [`std::u32::wrapping_sub`](../../std/primitive.u32.html#method.wrapping_sub)
+    /// [`std::u32::wrapping_sub`](../primitive.u32.html#method.wrapping_sub)
     pub fn overflowing_sub<T>(a: T, b: T) -> T;
     /// Returns (a * b) mod 2<sup>N</sup>, where N is the width of T in bits.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `wrapping_mul` method. For example,
-    /// [`std::u32::wrapping_mul`](../../std/primitive.u32.html#method.wrapping_mul)
+    /// [`std::u32::wrapping_mul`](../primitive.u32.html#method.wrapping_mul)
     pub fn overflowing_mul<T>(a: T, b: T) -> T;
 
     /// Computes `a + b`, while saturating at numeric bounds.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_add` method. For example,
-    /// [`std::u32::saturating_add`](../../std/primitive.u32.html#method.saturating_add)
+    /// [`std::u32::saturating_add`](../primitive.u32.html#method.saturating_add)
     pub fn saturating_add<T>(a: T, b: T) -> T;
     /// Computes `a - b`, while saturating at numeric bounds.
     /// The stabilized versions of this intrinsic are available on the integer
     /// primitives via the `saturating_sub` method. For example,
-    /// [`std::u32::saturating_sub`](../../std/primitive.u32.html#method.saturating_sub)
+    /// [`std::u32::saturating_sub`](../primitive.u32.html#method.saturating_sub)
     pub fn saturating_sub<T>(a: T, b: T) -> T;
 
     /// Returns the value of the discriminant for the variant in 'v',

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -55,7 +55,7 @@
 //!
 //! [`Iterator`]: trait.Iterator.html
 //! [`next`]: trait.Iterator.html#tymethod.next
-//! [`Option`]: ../../std/option/enum.Option.html
+//! [`Option`]: ../option/enum.Option.html
 //!
 //! # The three forms of iteration
 //!

--- a/src/libcore/iter/traits/accum.rs
+++ b/src/libcore/iter/traits/accum.rs
@@ -8,9 +8,9 @@ use crate::num::Wrapping;
 /// [`FromIterator`] this trait should rarely be called directly and instead
 /// interacted with through [`Iterator::sum`].
 ///
-/// [`sum`]: ../../std/iter/trait.Sum.html#tymethod.sum
-/// [`FromIterator`]: ../../std/iter/trait.FromIterator.html
-/// [`Iterator::sum`]: ../../std/iter/trait.Iterator.html#method.sum
+/// [`sum`]: ../iter/trait.Sum.html#tymethod.sum
+/// [`FromIterator`]: ../iter/trait.FromIterator.html
+/// [`Iterator::sum`]: ../iter/trait.Iterator.html#method.sum
 #[stable(feature = "iter_arith_traits", since = "1.12.0")]
 pub trait Sum<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by
@@ -27,9 +27,9 @@ pub trait Sum<A = Self>: Sized {
 /// [`FromIterator`] this trait should rarely be called directly and instead
 /// interacted with through [`Iterator::product`].
 ///
-/// [`product`]: ../../std/iter/trait.Product.html#tymethod.product
-/// [`FromIterator`]: ../../std/iter/trait.FromIterator.html
-/// [`Iterator::product`]: ../../std/iter/trait.Iterator.html#method.product
+/// [`product`]: ../iter/trait.Product.html#tymethod.product
+/// [`FromIterator`]: ../iter/trait.FromIterator.html
+/// [`Iterator::product`]: ../iter/trait.Iterator.html#method.product
 #[stable(feature = "iter_arith_traits", since = "1.12.0")]
 pub trait Product<A = Self>: Sized {
     /// Method which takes an iterator and generates `Self` from the elements by

--- a/src/libcore/iter/traits/double_ended.rs
+++ b/src/libcore/iter/traits/double_ended.rs
@@ -80,8 +80,8 @@ pub trait DoubleEndedIterator: Iterator {
     /// `nth_back()` will return [`None`] if `n` is greater than or equal to the length of the
     /// iterator.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
-    /// [`nth`]: ../../std/iter/trait.Iterator.html#method.nth
+    /// [`None`]: ../option/enum.Option.html#variant.None
+    /// [`nth`]: ../iter/trait.Iterator.html#method.nth
     ///
     /// # Examples
     ///
@@ -242,8 +242,8 @@ pub trait DoubleEndedIterator: Iterator {
     /// argument is a double reference. You can see this effect in the
     /// examples below, with `&&x`.
     ///
-    /// [`Some(element)`]: ../../std/option/enum.Option.html#variant.Some
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Some(element)`]: ../option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -100,8 +100,8 @@ pub trait Iterator {
     /// again may or may not eventually start returning [`Some(Item)`] again at some
     /// point.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
-    /// [`Some(Item)`]: ../../std/option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
+    /// [`Some(Item)`]: ../option/enum.Option.html#variant.Some
     ///
     /// # Examples
     ///
@@ -154,9 +154,9 @@ pub trait Iterator {
     /// The default implementation returns `(0, `[`None`]`)` which is correct for any
     /// iterator.
     ///
-    /// [`usize`]: ../../std/primitive.usize.html
-    /// [`Option`]: ../../std/option/enum.Option.html
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`usize`]: ../primitive.usize.html
+    /// [`Option`]: ../option/enum.Option.html
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -206,7 +206,7 @@ pub trait Iterator {
     /// times it called [`next`].
     ///
     /// [`next`]: #tymethod.next
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Overflow Behavior
     ///
@@ -220,7 +220,7 @@ pub trait Iterator {
     /// This function might panic if the iterator has more than [`usize::MAX`]
     /// elements.
     ///
-    /// [`usize::MAX`]: ../../std/usize/constant.MAX.html
+    /// [`usize::MAX`]: ../usize/constant.MAX.html
     ///
     /// # Examples
     ///
@@ -247,7 +247,7 @@ pub trait Iterator {
     /// doing so, it keeps track of the current element. After [`None`] is
     /// returned, `last()` will then return the last element it saw.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -281,7 +281,7 @@ pub trait Iterator {
     /// `nth()` will return [`None`] if `n` is greater than or equal to the length of the
     /// iterator.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -494,8 +494,8 @@ pub trait Iterator {
     /// ```
     ///
     /// [`enumerate`]: trait.Iterator.html#method.enumerate
-    /// [`next`]: ../../std/iter/trait.Iterator.html#tymethod.next
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`next`]: ../iter/trait.Iterator.html#tymethod.next
+    /// [`None`]: ../option/enum.Option.html#variant.None
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn zip<U>(self, other: U) -> Zip<Self, U::IntoIter> where
@@ -522,7 +522,7 @@ pub trait Iterator {
     /// more idiomatic to use [`for`] than `map()`.
     ///
     /// [`for`]: ../../book/ch03-05-control-flow.html#looping-through-a-collection-with-for
-    /// [`FnMut`]: ../../std/ops/trait.FnMut.html
+    /// [`FnMut`]: ../ops/trait.FnMut.html
     ///
     /// # Examples
     ///
@@ -718,9 +718,9 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), None);
     /// ```
     ///
-    /// [`Option<T>`]: ../../std/option/enum.Option.html
-    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Option<T>`]: ../option/enum.Option.html
+    /// [`Some`]: ../option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn filter_map<B, F>(self, f: F) -> FilterMap<Self, F> where
@@ -751,8 +751,8 @@ pub trait Iterator {
     /// The returned iterator might panic if the to-be-returned index would
     /// overflow a [`usize`].
     ///
-    /// [`usize::MAX`]: ../../std/usize/constant.MAX.html
-    /// [`usize`]: ../../std/primitive.usize.html
+    /// [`usize::MAX`]: ../usize/constant.MAX.html
+    /// [`usize`]: ../primitive.usize.html
     /// [`zip`]: #method.zip
     ///
     /// # Examples
@@ -786,7 +786,7 @@ pub trait Iterator {
     /// will occur.
     ///
     /// [`peek`]: struct.Peekable.html#method.peek
-    /// [`next`]: ../../std/iter/trait.Iterator.html#tymethod.next
+    /// [`next`]: ../iter/trait.Iterator.html#tymethod.next
     ///
     /// # Examples
     ///
@@ -1031,7 +1031,7 @@ pub trait Iterator {
     /// iterator and the return value from the closure, an [`Option`], is
     /// yielded by the iterator.
     ///
-    /// [`Option`]: ../../std/option/enum.Option.html
+    /// [`Option`]: ../option/enum.Option.html
     ///
     /// # Examples
     ///
@@ -1173,8 +1173,8 @@ pub trait Iterator {
     /// [`Some(T)`] again. `fuse()` adapts an iterator, ensuring that after a
     /// [`None`] is given, it will always return [`None`] forever.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
-    /// [`Some(T)`]: ../../std/option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
+    /// [`Some(T)`]: ../option/enum.Option.html#variant.Some
     ///
     /// # Examples
     ///
@@ -1455,10 +1455,10 @@ pub trait Iterator {
     /// assert_eq!(Ok(vec![1, 3]), result);
     /// ```
     ///
-    /// [`iter`]: ../../std/iter/trait.Iterator.html#tymethod.next
+    /// [`iter`]: ../iter/trait.Iterator.html#tymethod.next
     /// [`String`]: ../../std/string/struct.String.html
-    /// [`char`]: ../../std/primitive.char.html
-    /// [`Result`]: ../../std/result/enum.Result.html
+    /// [`char`]: ../primitive.char.html
+    /// [`Result`]: ../result/enum.Result.html
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead"]
@@ -1797,8 +1797,8 @@ pub trait Iterator {
     /// argument is a double reference. You can see this effect in the
     /// examples below, with `&&x`.
     ///
-    /// [`Some(element)`]: ../../std/option/enum.Option.html#variant.Some
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Some(element)`]: ../option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1887,9 +1887,9 @@ pub trait Iterator {
     /// This function might panic if the iterator has more than `usize::MAX`
     /// non-matching elements.
     ///
-    /// [`Some(index)`]: ../../std/option/enum.Option.html#variant.Some
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
-    /// [`usize::MAX`]: ../../std/usize/constant.MAX.html
+    /// [`Some(index)`]: ../option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
+    /// [`usize::MAX`]: ../usize/constant.MAX.html
     ///
     /// # Examples
     ///
@@ -1944,8 +1944,8 @@ pub trait Iterator {
     /// `rposition()` is short-circuiting; in other words, it will stop
     /// processing as soon as it finds a `true`.
     ///
-    /// [`Some(index)`]: ../../std/option/enum.Option.html#variant.Some
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Some(index)`]: ../option/enum.Option.html#variant.Some
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -1992,7 +1992,7 @@ pub trait Iterator {
     /// If several elements are equally maximum, the last element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2017,7 +2017,7 @@ pub trait Iterator {
     /// If several elements are equally minimum, the first element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2043,7 +2043,7 @@ pub trait Iterator {
     /// If several elements are equally maximum, the last element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2066,7 +2066,7 @@ pub trait Iterator {
     /// If several elements are equally maximum, the last element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2089,7 +2089,7 @@ pub trait Iterator {
     /// If several elements are equally minimum, the first element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2111,7 +2111,7 @@ pub trait Iterator {
     /// If several elements are equally minimum, the first element is
     /// returned. If the iterator is empty, [`None`] is returned.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -2229,7 +2229,7 @@ pub trait Iterator {
     /// This is useful when you have an iterator over `&T`, but you need an
     /// iterator over `T`.
     ///
-    /// [`clone`]: ../../std/clone/trait.Clone.html#tymethod.clone
+    /// [`clone`]: ../clone/trait.Clone.html#tymethod.clone
     ///
     /// # Examples
     ///
@@ -2259,7 +2259,7 @@ pub trait Iterator {
     /// from the beginning. After iterating again, it will start at the
     /// beginning again. And again. And again. Forever.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///

--- a/src/libcore/iter/traits/marker.rs
+++ b/src/libcore/iter/traits/marker.rs
@@ -9,9 +9,9 @@
 /// on the iterator. If the iterator is already fused, the additional [`Fuse`]
 /// wrapper will be a no-op with no performance penalty.
 ///
-/// [`None`]: ../../std/option/enum.Option.html#variant.None
-/// [`Iterator::fuse`]: ../../std/iter/trait.Iterator.html#method.fuse
-/// [`Fuse`]: ../../std/iter/struct.Fuse.html
+/// [`None`]: ../option/enum.Option.html#variant.None
+/// [`Iterator::fuse`]: ../iter/trait.Iterator.html#method.fuse
+/// [`Fuse`]: ../iter/struct.Fuse.html
 #[stable(feature = "fused", since = "1.26.0")]
 pub trait FusedIterator: Iterator {}
 
@@ -34,9 +34,9 @@ impl<I: FusedIterator + ?Sized> FusedIterator for &mut I {}
 /// This trait must only be implemented when the contract is upheld.
 /// Consumers of this trait must inspect [`.size_hint`]’s upper bound.
 ///
-/// [`None`]: ../../std/option/enum.Option.html#variant.None
-/// [`usize::MAX`]: ../../std/usize/constant.MAX.html
-/// [`.size_hint`]: ../../std/iter/trait.Iterator.html#method.size_hint
+/// [`None`]: ../option/enum.Option.html#variant.None
+/// [`usize::MAX`]: ../usize/constant.MAX.html
+/// [`.size_hint`]: ../iter/trait.Iterator.html#method.size_hint
 #[unstable(feature = "trusted_len", issue = "37572")]
 pub unsafe trait TrustedLen : Iterator {}
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -236,3 +236,8 @@ mod core_arch;
 
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub use core_arch::arch;
+
+// Include a number of private modules that exist solely to provide
+// the rustdoc documentation for primitive types. Using `include!`
+// because rustdoc only looks for these modules at the crate level.
+include!("primitive_docs.rs");

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -196,7 +196,7 @@ macro_rules! debug_assert {
 /// expensive to be present in a release build but may be helpful during
 /// development.
 ///
-/// [`assert_eq!`]: ../std/macro.assert_eq.html
+/// [`assert_eq!`]: macro.assert_eq.html
 ///
 /// # Examples
 ///
@@ -223,7 +223,7 @@ macro_rules! debug_assert_eq {
 /// expensive to be present in a release build but may be helpful during
 /// development.
 ///
-/// [`assert_ne!`]: ../std/macro.assert_ne.html
+/// [`assert_ne!`]: macro.assert_ne.html
 ///
 /// # Examples
 ///
@@ -257,7 +257,7 @@ macro_rules! debug_assert_ne {
 /// Because of the early return, `try!` can only be used in functions that
 /// return [`Result`].
 ///
-/// [`Result`]: ../std/result/enum.Result.html
+/// [`Result`]: result/enum.Result.html
 ///
 /// # Examples
 ///
@@ -325,9 +325,9 @@ macro_rules! r#try {
 /// See [`std::fmt`] for more information on the format string syntax.
 ///
 /// [`std::fmt`]: ../std/fmt/index.html
-/// [`std::fmt::Write`]: ../std/fmt/trait.Write.html
+/// [`std::fmt::Write`]: fmt/trait.Write.html
 /// [`std::io::Write`]: ../std/io/trait.Write.html
-/// [`std::fmt::Result`]: ../std/fmt/type.Result.html
+/// [`std::fmt::Result`]: fmt/type.Result.html
 /// [`io::Result`]: ../std/io/type.Result.html
 ///
 /// # Examples
@@ -450,15 +450,15 @@ macro_rules! writeln {
 /// The unsafe counterpart of this macro is the [`unreachable_unchecked`] function, which
 /// will cause undefined behavior if the code is reached.
 ///
-/// [`panic!`]:  ../std/macro.panic.html
-/// [`unreachable_unchecked`]: ../std/hint/fn.unreachable_unchecked.html
-/// [`std::hint`]: ../std/hint/index.html
+/// [`panic!`]:  macro.panic.html
+/// [`unreachable_unchecked`]: hint/fn.unreachable_unchecked.html
+/// [`std::hint`]: hint/index.html
 ///
 /// # Panics
 ///
 /// This will always [`panic!`]
 ///
-/// [`panic!`]: ../std/macro.panic.html
+/// [`panic!`]: macro.panic.html
 /// # Examples
 ///
 /// Match arms:

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -276,11 +276,11 @@ pub trait Unsize<T: ?Sized> {
 ///
 /// [`Vec<T>`]: ../../std/vec/struct.Vec.html
 /// [`String`]: ../../std/string/struct.String.html
-/// [`Drop`]: ../../std/ops/trait.Drop.html
-/// [`size_of::<T>`]: ../../std/mem/fn.size_of.html
+/// [`Drop`]: ../ops/trait.Drop.html
+/// [`size_of::<T>`]: ../mem/fn.size_of.html
 /// [`Clone`]: ../clone/trait.Clone.html
 /// [`String`]: ../../std/string/struct.String.html
-/// [`i32`]: ../../std/primitive.i32.html
+/// [`i32`]: ../primitive.i32.html
 /// [impls]: #implementors
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "copy"]
@@ -342,8 +342,8 @@ pub trait Copy : Clone {
 /// details about `Sync`.
 ///
 /// [send]: trait.Send.html
-/// [u8]: ../../std/primitive.u8.html
-/// [f64]: ../../std/primitive.f64.html
+/// [u8]: ../primitive.u8.html
+/// [f64]: ../primitive.f64.html
 /// [box]: ../../std/boxed/struct.Box.html
 /// [vec]: ../../std/vec/struct.Vec.html
 /// [cell]: ../cell/struct.Cell.html
@@ -355,7 +355,7 @@ pub trait Copy : Clone {
 /// [rwlock]: ../../std/sync/struct.RwLock.html
 /// [unsafecell]: ../cell/struct.UnsafeCell.html
 /// [ub]: ../../reference/behavior-considered-undefined.html
-/// [transmute]: ../../std/mem/fn.transmute.html
+/// [transmute]: ../mem/fn.transmute.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[lang = "sync"]
 #[rustc_on_unimplemented(
@@ -632,9 +632,9 @@ unsafe impl<T: ?Sized> Freeze for &mut T {}
 ///
 /// This trait is automatically implemented for almost every type.
 ///
-/// [`mem::replace`]: ../../std/mem/fn.replace.html
+/// [`mem::replace`]: ../mem/fn.replace.html
 /// [`Pin<P>`]: ../pin/struct.Pin.html
-/// [`pin module`]: ../../std/pin/index.html
+/// [`pin module`]: ../pin/index.html
 #[stable(feature = "pin", since = "1.33.0")]
 #[lang = "unpin"]
 pub auto trait Unpin {}

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -249,7 +249,7 @@ pub const fn size_of<T>() -> usize {
 /// statically-known size, e.g., a slice [`[T]`][slice] or a [trait object],
 /// then `size_of_val` can be used to get the dynamically-known size.
 ///
-/// [slice]: ../../std/primitive.slice.html
+/// [slice]: ../primitive.slice.html
 /// [trait object]: ../../book/ch17-02-trait-objects.html
 ///
 /// # Examples
@@ -551,7 +551,7 @@ pub fn swap<T>(x: &mut T, y: &mut T) {
 /// }
 /// ```
 ///
-/// [`Clone`]: ../../std/clone/trait.Clone.html
+/// [`Clone`]: ../clone/trait.Clone.html
 #[inline]
 #[unstable(feature = "mem_take", issue = "61129")]
 pub fn take<T: Default>(dest: &mut T) -> T {
@@ -608,7 +608,7 @@ pub fn take<T: Default>(dest: &mut T) -> T {
 /// }
 /// ```
 ///
-/// [`Clone`]: ../../std/clone/trait.Clone.html
+/// [`Clone`]: ../clone/trait.Clone.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn replace<T>(dest: &mut T, mut src: T) -> T {
@@ -676,8 +676,8 @@ pub fn replace<T>(dest: &mut T, mut src: T) -> T {
 /// println!("x: {}, y: {}", x, y.0); // still available
 /// ```
 ///
-/// [`RefCell`]: ../../std/cell/struct.RefCell.html
-/// [`Copy`]: ../../std/marker/trait.Copy.html
+/// [`RefCell`]: ../cell/struct.RefCell.html
+/// [`Copy`]: ../marker/trait.Copy.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub fn drop<T>(_x: T) { }

--- a/src/libcore/num/dec2flt/mod.rs
+++ b/src/libcore/num/dec2flt/mod.rs
@@ -166,8 +166,8 @@ from_str_float_impl!(f64);
 /// for [`f32`] and [`f64`].
 ///
 /// [`FromStr`]: ../str/trait.FromStr.html
-/// [`f32`]: ../../std/primitive.f32.html
-/// [`f64`]: ../../std/primitive.f64.html
+/// [`f32`]: ../primitive.f32.html
+/// [`f64`]: ../primitive.f64.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseFloatError {

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -1,7 +1,7 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f32` floating point data type.
 //!
-//! *[See also the `f32` primitive type](../../std/primitive.f32.html).*
+//! *[See also the `f32` primitive type](../primitive.f32.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -1,7 +1,7 @@
 //! This module provides constants which are specific to the implementation
 //! of the `f64` floating point data type.
 //!
-//! *[See also the `f64` primitive type](../../std/primitive.f64.html).*
+//! *[See also the `f64` primitive type](../primitive.f64.html).*
 //!
 //! Mathematically significant numbers are provided in the `consts` sub-module.
 

--- a/src/libcore/num/i128.rs
+++ b/src/libcore/num/i128.rs
@@ -1,6 +1,6 @@
 //! The 128-bit signed integer type.
 //!
-//! *[See also the `i128` primitive type](../../std/primitive.i128.html).*
+//! *[See also the `i128` primitive type](../primitive.i128.html).*
 
 #![stable(feature = "i128", since = "1.26.0")]
 

--- a/src/libcore/num/i16.rs
+++ b/src/libcore/num/i16.rs
@@ -1,6 +1,6 @@
 //! The 16-bit signed integer type.
 //!
-//! *[See also the `i16` primitive type](../../std/primitive.i16.html).*
+//! *[See also the `i16` primitive type](../primitive.i16.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i32.rs
+++ b/src/libcore/num/i32.rs
@@ -1,6 +1,6 @@
 //! The 32-bit signed integer type.
 //!
-//! *[See also the `i32` primitive type](../../std/primitive.i32.html).*
+//! *[See also the `i32` primitive type](../primitive.i32.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i64.rs
+++ b/src/libcore/num/i64.rs
@@ -1,6 +1,6 @@
 //! The 64-bit signed integer type.
 //!
-//! *[See also the `i64` primitive type](../../std/primitive.i64.html).*
+//! *[See also the `i64` primitive type](../primitive.i64.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/i8.rs
+++ b/src/libcore/num/i8.rs
@@ -1,6 +1,6 @@
 //! The 8-bit signed integer type.
 //!
-//! *[See also the `i8` primitive type](../../std/primitive.i8.html).*
+//! *[See also the `i8` primitive type](../primitive.i8.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/isize.rs
+++ b/src/libcore/num/isize.rs
@@ -1,6 +1,6 @@
 //! The pointer-sized signed integer type.
 //!
-//! *[See also the `isize` primitive type](../../std/primitive.isize.html).*
+//! *[See also the `isize` primitive type](../primitive.isize.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -4609,8 +4609,8 @@ impl usize {
 /// This `enum` is used as the return type for [`f32::classify`] and [`f64::classify`]. See
 /// their documentation for more.
 ///
-/// [`f32::classify`]: ../../std/primitive.f32.html#method.classify
-/// [`f64::classify`]: ../../std/primitive.f64.html#method.classify
+/// [`f32::classify`]: ../primitive.f32.html#method.classify
+/// [`f64::classify`]: ../primitive.f64.html#method.classify
 ///
 /// # Examples
 ///
@@ -5019,8 +5019,8 @@ fn from_str_radix<T: FromStrRadixHelper>(src: &str, radix: u32) -> Result<T, Par
 /// in the string e.g., when it is obtained from the standard input.
 /// Using the [`str.trim()`] method ensures that no whitespace remains before parsing.
 ///
-/// [`str.trim()`]: ../../std/primitive.str.html#method.trim
-/// [`i8::from_str_radix`]: ../../std/primitive.i8.html#method.from_str_radix
+/// [`str.trim()`]: ../primitive.str.html#method.trim
+/// [`i8::from_str_radix`]: ../primitive.i8.html#method.from_str_radix
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseIntError {

--- a/src/libcore/num/u128.rs
+++ b/src/libcore/num/u128.rs
@@ -1,6 +1,6 @@
 //! The 128-bit unsigned integer type.
 //!
-//! *[See also the `u128` primitive type](../../std/primitive.u128.html).*
+//! *[See also the `u128` primitive type](../primitive.u128.html).*
 
 #![stable(feature = "i128", since = "1.26.0")]
 uint_module! { u128, #[stable(feature = "i128", since="1.26.0")] }

--- a/src/libcore/num/u16.rs
+++ b/src/libcore/num/u16.rs
@@ -1,6 +1,6 @@
 //! The 16-bit unsigned integer type.
 //!
-//! *[See also the `u16` primitive type](../../std/primitive.u16.html).*
+//! *[See also the `u16` primitive type](../primitive.u16.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u32.rs
+++ b/src/libcore/num/u32.rs
@@ -1,6 +1,6 @@
 //! The 32-bit unsigned integer type.
 //!
-//! *[See also the `u32` primitive type](../../std/primitive.u32.html).*
+//! *[See also the `u32` primitive type](../primitive.u32.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u64.rs
+++ b/src/libcore/num/u64.rs
@@ -1,6 +1,6 @@
 //! The 64-bit unsigned integer type.
 //!
-//! *[See also the `u64` primitive type](../../std/primitive.u64.html).*
+//! *[See also the `u64` primitive type](../primitive.u64.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/u8.rs
+++ b/src/libcore/num/u8.rs
@@ -1,6 +1,6 @@
 //! The 8-bit unsigned integer type.
 //!
-//! *[See also the `u8` primitive type](../../std/primitive.u8.html).*
+//! *[See also the `u8` primitive type](../primitive.u8.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/num/usize.rs
+++ b/src/libcore/num/usize.rs
@@ -1,6 +1,6 @@
 //! The pointer-sized unsigned integer type.
 //!
-//! *[See also the `usize` primitive type](../../std/primitive.usize.html).*
+//! *[See also the `usize` primitive type](../primitive.usize.html).*
 
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/src/libcore/ops/drop.rs
+++ b/src/libcore/ops/drop.rs
@@ -101,7 +101,7 @@ pub trait Drop {
     ///
     /// [E0040]: ../../error-index.html#E0040
     /// [`panic!`]: ../macro.panic.html
-    /// [`std::mem::drop`]: ../../std/mem/fn.drop.html
+    /// [`std::mem::drop`]: ../mem/fn.drop.html
     #[stable(feature = "rust1", since = "1.0.0")]
     fn drop(&mut self);
 }

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -30,7 +30,7 @@
 /// [book]: ../../book/ch13-01-closures.html
 /// [`FnMut`]: trait.FnMut.html
 /// [`FnOnce`]: trait.FnOnce.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: ../primitive.fn.html
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
@@ -98,7 +98,7 @@ pub trait Fn<Args> : FnMut<Args> {
 /// [book]: ../../book/ch13-01-closures.html
 /// [`Fn`]: trait.Fn.html
 /// [`FnOnce`]: trait.FnOnce.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: ../primitive.fn.html
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
@@ -176,7 +176,7 @@ pub trait FnMut<Args> : FnOnce<Args> {
 /// [book]: ../../book/ch13-01-closures.html
 /// [`Fn`]: trait.Fn.html
 /// [`FnMut`]: trait.FnMut.html
-/// [function pointers]: ../../std/primitive.fn.html
+/// [function pointers]: ../primitive.fn.html
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples

--- a/src/libcore/ops/index.rs
+++ b/src/libcore/ops/index.rs
@@ -5,8 +5,8 @@
 /// [`IndexMut`] is used instead. This allows nice things such as
 /// `let value = v[index]` if the type of `value` implements [`Copy`].
 ///
-/// [`IndexMut`]: ../../std/ops/trait.IndexMut.html
-/// [`Copy`]: ../../std/marker/trait.Copy.html
+/// [`IndexMut`]: ../ops/trait.IndexMut.html
+/// [`Copy`]: ../marker/trait.Copy.html
 ///
 /// # Examples
 ///
@@ -75,7 +75,7 @@ pub trait Index<Idx: ?Sized> {
 /// an immutable value is requested, the [`Index`] trait is used instead. This
 /// allows nice things such as `v[index] = value`.
 ///
-/// [`Index`]: ../../std/ops/trait.Index.html
+/// [`Index`]: ../ops/trait.Index.html
 ///
 /// # Examples
 ///

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -131,7 +131,7 @@
 //! [`Some`]: enum.Option.html#variant.Some
 //! [`None`]: enum.Option.html#variant.None
 //! [`Box<T>`]: ../../std/boxed/struct.Box.html
-//! [`i32`]: ../../std/primitive.i32.html
+//! [`i32`]: ../primitive.i32.html
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
@@ -223,7 +223,7 @@ impl<T> Option<T> {
     ///
     /// [`map`]: enum.Option.html#method.map
     /// [`String`]: ../../std/string/struct.String.html
-    /// [`usize`]: ../../std/primitive.usize.html
+    /// [`usize`]: ../primitive.usize.html
     ///
     /// ```
     /// let text: Option<String> = Some("Hello, world!".to_string());
@@ -400,7 +400,7 @@ impl<T> Option<T> {
     /// Converts an `Option<`[`String`]`>` into an `Option<`[`usize`]`>`, consuming the original:
     ///
     /// [`String`]: ../../std/string/struct.String.html
-    /// [`usize`]: ../../std/primitive.usize.html
+    /// [`usize`]: ../primitive.usize.html
     ///
     /// ```
     /// let maybe_some_string = Some(String::from("Hello, World!"));
@@ -469,9 +469,9 @@ impl<T> Option<T> {
     /// result of a function call, it is recommended to use [`ok_or_else`], which is
     /// lazily evaluated.
     ///
-    /// [`Result<T, E>`]: ../../std/result/enum.Result.html
-    /// [`Ok(v)`]: ../../std/result/enum.Result.html#variant.Ok
-    /// [`Err(err)`]: ../../std/result/enum.Result.html#variant.Err
+    /// [`Result<T, E>`]: ../result/enum.Result.html
+    /// [`Ok(v)`]: ../result/enum.Result.html#variant.Ok
+    /// [`Err(err)`]: ../result/enum.Result.html#variant.Err
     /// [`None`]: #variant.None
     /// [`Some(v)`]: #variant.Some
     /// [`ok_or_else`]: #method.ok_or_else
@@ -497,9 +497,9 @@ impl<T> Option<T> {
     /// Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
     /// [`Ok(v)`] and [`None`] to [`Err(err())`].
     ///
-    /// [`Result<T, E>`]: ../../std/result/enum.Result.html
-    /// [`Ok(v)`]: ../../std/result/enum.Result.html#variant.Ok
-    /// [`Err(err())`]: ../../std/result/enum.Result.html#variant.Err
+    /// [`Result<T, E>`]: ../result/enum.Result.html
+    /// [`Ok(v)`]: ../result/enum.Result.html#variant.Ok
+    /// [`Err(err())`]: ../result/enum.Result.html#variant.Err
     /// [`None`]: #variant.None
     /// [`Some(v)`]: #variant.Some
     ///
@@ -977,8 +977,8 @@ impl<T: Default> Option<T> {
     /// [`Some`]: #variant.Some
     /// [`None`]: #variant.None
     /// [default value]: ../default/trait.Default.html#tymethod.default
-    /// [`parse`]: ../../std/primitive.str.html#method.parse
-    /// [`FromStr`]: ../../std/str/trait.FromStr.html
+    /// [`parse`]: ../primitive.str.html#method.parse
+    /// [`FromStr`]: ../str/trait.FromStr.html
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn unwrap_or_default(self) -> T {

--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -96,7 +96,7 @@ impl<'a> PanicInfo<'a> {
     /// This method will currently always return [`Some`], but this may change
     /// in future versions.
     ///
-    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
+    /// [`Some`]: ../option/enum.Option.html#variant.Some
     ///
     /// # Examples
     ///

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -250,15 +250,15 @@
 //! pinned, meaning pinning is *not* structural.
 //!
 //! [`Pin<P>`]: struct.Pin.html
-//! [`Unpin`]: ../../std/marker/trait.Unpin.html
-//! [`Deref`]: ../../std/ops/trait.Deref.html
-//! [`DerefMut`]: ../../std/ops/trait.DerefMut.html
-//! [`mem::swap`]: ../../std/mem/fn.swap.html
-//! [`mem::forget`]: ../../std/mem/fn.forget.html
+//! [`Unpin`]: ../marker/trait.Unpin.html
+//! [`Deref`]: ../ops/trait.Deref.html
+//! [`DerefMut`]: ../ops/trait.DerefMut.html
+//! [`mem::swap`]: ../mem/fn.swap.html
+//! [`mem::forget`]: ../mem/fn.forget.html
 //! [`Box<T>`]: ../../std/boxed/struct.Box.html
 //! [`Vec::set_len`]: ../../std/vec/struct.Vec.html#method.set_len
-//! [`None`]: ../../std/option/enum.Option.html#variant.None
-//! [`Some(v)`]: ../../std/option/enum.Option.html#variant.Some
+//! [`None`]: ../option/enum.Option.html#variant.None
+//! [`Some(v)`]: ../option/enum.Option.html#variant.Some
 //! [drop-impl]: #drop-implementation
 //! [drop-guarantee]: #drop-guarantee
 
@@ -277,8 +277,8 @@ use crate::ops::{Deref, DerefMut, Receiver, CoerceUnsized, DispatchFromDyn};
 ///
 /// *See the [`pin` module] documentation for an explanation of pinning.*
 ///
-/// [`Unpin`]: ../../std/marker/trait.Unpin.html
-/// [`pin` module]: ../../std/pin/index.html
+/// [`Unpin`]: ../marker/trait.Unpin.html
+/// [`pin` module]: ../pin/index.html
 //
 // Note: the derives below, and the explicit `PartialEq` and `PartialOrd`
 // implementations, are allowed because they all only use `&P`, so they cannot move
@@ -342,7 +342,7 @@ where
     /// Unlike `Pin::new_unchecked`, this method is safe because the pointer
     /// `P` dereferences to an [`Unpin`] type, which cancels the pinning guarantees.
     ///
-    /// [`Unpin`]: ../../std/marker/trait.Unpin.html
+    /// [`Unpin`]: ../marker/trait.Unpin.html
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
     pub fn new(pointer: P) -> Pin<P> {
@@ -356,7 +356,7 @@ where
     /// This requires that the data inside this `Pin` is [`Unpin`] so that we
     /// can ignore the pinning invariants when unwrapping it.
     ///
-    /// [`Unpin`]: ../../std/marker/trait.Unpin.html
+    /// [`Unpin`]: ../marker/trait.Unpin.html
     #[unstable(feature = "pin_into_inner", issue = "60245")]
     #[inline(always)]
     pub fn into_inner(pin: Pin<P>) -> P {
@@ -428,7 +428,7 @@ impl<P: Deref> Pin<P> {
     ///  }
     ///  ```
     ///
-    /// [`mem::swap`]: ../../std/mem/fn.swap.html
+    /// [`mem::swap`]: ../mem/fn.swap.html
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
     pub unsafe fn new_unchecked(pointer: P) -> Pin<P> {
@@ -462,7 +462,7 @@ impl<P: Deref> Pin<P> {
     /// If the underlying data is [`Unpin`], [`Pin::into_inner`] should be used
     /// instead.
     ///
-    /// [`Unpin`]: ../../std/marker/trait.Unpin.html
+    /// [`Unpin`]: ../marker/trait.Unpin.html
     /// [`Pin::into_inner`]: #method.into_inner
     #[unstable(feature = "pin_into_inner", issue = "60245")]
     #[inline(always)]
@@ -514,7 +514,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     /// because it is one of the fields of that value), and also that you do
     /// not move out of the argument you receive to the interior function.
     ///
-    /// [`pin` module]: ../../std/pin/index.html#projections-and-structural-pinning
+    /// [`pin` module]: ../pin/index.html#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]
     pub unsafe fn map_unchecked<U, F>(self: Pin<&'a T>, func: F) -> Pin<&'a U> where
         F: FnOnce(&T) -> &U,
@@ -540,7 +540,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     /// the `Pin` itself. This method allows turning the `Pin` into a reference
     /// with the same lifetime as the original `Pin`.
     ///
-    /// ["pinning projections"]: ../../std/pin/index.html#projections-and-structural-pinning
+    /// ["pinning projections"]: ../pin/index.html#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]
     #[inline(always)]
     pub fn get_ref(self: Pin<&'a T>) -> &'a T {
@@ -603,7 +603,7 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
     /// because it is one of the fields of that value), and also that you do
     /// not move out of the argument you receive to the interior function.
     ///
-    /// [`pin` module]: ../../std/pin/index.html#projections-and-structural-pinning
+    /// [`pin` module]: ../pin/index.html#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]
     pub unsafe fn map_unchecked_mut<U, F>(self: Pin<&'a mut T>, func: F) -> Pin<&'a mut U> where
         F: FnOnce(&mut T) -> &mut U,

--- a/src/libcore/primitive_docs.rs
+++ b/src/libcore/primitive_docs.rs
@@ -1,0 +1,230 @@
+#[doc(primitive = "bool")]
+#[doc(alias = "true")]
+#[doc(alias = "false")]
+//
+/// The boolean type.
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.bool.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_bool { }
+
+#[doc(primitive = "never")]
+#[doc(alias = "!")]
+//
+/// The `!` type, also called "never".
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.never.html).*
+#[unstable(feature = "never_type", issue = "35121")]
+mod prim_never { }
+
+#[doc(primitive = "char")]
+//
+/// A character type.
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.char.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_char { }
+
+#[doc(primitive = "unit")]
+//
+/// The `()` type, sometimes called "unit" or "nil".
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.unit.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_unit { }
+
+#[doc(primitive = "pointer")]
+//
+/// Raw, unsafe pointers, `*const T`, and `*mut T`.
+///
+/// *[See also the `ptr` module](ptr/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.pointer.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_pointer { }
+
+#[doc(primitive = "array")]
+//
+/// A fixed-size array, denoted `[T; N]`, for the element type, `T`, and the
+/// non-negative compile-time constant size, `N`.
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.array.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_array { }
+
+#[doc(primitive = "slice")]
+#[doc(alias = "[")]
+#[doc(alias = "]")]
+#[doc(alias = "[]")]
+/// A dynamically-sized view into a contiguous sequence, `[T]`.
+///
+/// *[See also the `slice` module](slice/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.slice.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_slice { }
+
+#[doc(primitive = "str")]
+//
+/// String slices.
+///
+/// *[See also the `str` module](str/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.str.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_str { }
+
+#[doc(primitive = "tuple")]
+#[doc(alias = "(")]
+#[doc(alias = ")")]
+#[doc(alias = "()")]
+//
+/// A finite heterogeneous sequence, `(T, U, ..)`.
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.tuple.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_tuple { }
+
+#[doc(primitive = "f32")]
+/// The 32-bit floating point type.
+///
+/// *[See also the `f32` module](f32/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.f32.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_f32 { }
+
+#[doc(primitive = "f64")]
+//
+/// The 64-bit floating point type.
+///
+/// *[See also the `f64` module](f64/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.f64.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_f64 { }
+
+#[doc(primitive = "i8")]
+//
+/// The 8-bit signed integer type.
+///
+/// *[See also the `i8` module](i8/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.i8.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i8 { }
+
+#[doc(primitive = "i16")]
+//
+/// The 16-bit signed integer type.
+///
+/// *[See also the `i16` module](i16/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.i16.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i16 { }
+
+#[doc(primitive = "i32")]
+//
+/// The 32-bit signed integer type.
+///
+/// *[See also the `i32` module](i32/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.i32.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i32 { }
+
+#[doc(primitive = "i64")]
+//
+/// The 64-bit signed integer type.
+///
+/// *[See also the `i64` module](i64/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.i64.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i64 { }
+
+#[doc(primitive = "i128")]
+//
+/// The 128-bit signed integer type.
+///
+/// *[See also the `i128` module](i128/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.i128.html).*
+#[stable(feature = "i128", since="1.26.0")]
+mod prim_i128 { }
+
+#[doc(primitive = "u8")]
+//
+/// The 8-bit unsigned integer type.
+///
+/// *[See also the `u8` module](u8/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.u8.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_u8 { }
+
+#[doc(primitive = "u16")]
+//
+/// The 16-bit unsigned integer type.
+///
+/// *[See also the `u16` module](u16/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.u16.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_u16 { }
+
+#[doc(primitive = "u32")]
+//
+/// The 32-bit unsigned integer type.
+///
+/// *[See also the `u32` module](u32/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.u32.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_u32 { }
+
+#[doc(primitive = "u64")]
+//
+/// The 64-bit unsigned integer type.
+///
+/// *[See also the `u64` module](u64/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.u64.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_u64 { }
+
+#[doc(primitive = "u128")]
+//
+/// The 128-bit unsigned integer type.
+///
+/// *[See also the `u128` module](u128/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.u128.html).*
+#[stable(feature = "i128", since="1.26.0")]
+mod prim_u128 { }
+
+#[doc(primitive = "isize")]
+//
+/// The pointer-sized signed integer type.
+///
+/// *[See also the `isize` module](isize/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.isize.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_isize { }
+
+#[doc(primitive = "usize")]
+//
+/// The pointer-sized unsigned integer type.
+///
+/// *[See also the `usize` module](usize/index.html) and
+/// [the primitive documentation in `std`](../std/primitive.usize.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_usize { }
+
+#[doc(primitive = "reference")]
+#[doc(alias = "&")]
+//
+/// References, both shared and mutable.
+///
+/// *[See also the primitive documentation in `std`](../std/primitive.reference.html).*
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_ref { }
+
+#[doc(primitive = "fn")]
+//
+/// Function pointers, like `fn(usize) -> bool`.
+///
+/// *See also the traits [`Fn`], [`FnMut`], and [`FnOnce`], and
+/// [the primitive documentation in `std`](../std/primitive.fn.html).*
+///
+/// [`Fn`]: ops/trait.Fn.html
+/// [`FnMut`]: ops/trait.FnMut.html
+/// [`FnOnce`]: ops/trait.FnOnce.html
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_fn { }

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1,6 +1,6 @@
 //! Manually manage memory through raw pointers.
 //!
-//! *[See also the pointer primitive types](../../std/primitive.pointer.html).*
+//! *[See also the pointer primitive types](../primitive.pointer.html).*
 //!
 //! # Safety
 //!
@@ -52,9 +52,9 @@
 //! [ub]: ../../reference/behavior-considered-undefined.html
 //! [null]: ./fn.null.html
 //! [zst]: ../../nomicon/exotic-sizes.html#zero-sized-types-zsts
-//! [atomic operations]: ../../std/sync/atomic/index.html
-//! [`copy`]: ../../std/ptr/fn.copy.html
-//! [`offset`]: ../../std/primitive.pointer.html#method.offset
+//! [atomic operations]: ../sync/atomic/index.html
+//! [`copy`]: ../ptr/fn.copy.html
+//! [`offset`]: ../primitive.pointer.html#method.offset
 //! [`read_unaligned`]: ./fn.read_unaligned.html
 //! [`write_unaligned`]: ./fn.write_unaligned.html
 //! [`read_volatile`]: ./fn.read_volatile.html

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -220,7 +220,7 @@
 //! [`Write`]: ../../std/io/trait.Write.html
 //! [`write_all`]: ../../std/io/trait.Write.html#method.write_all
 //! [`io::Result`]: ../../std/io/type.Result.html
-//! [`?`]: ../../std/macro.try.html
+//! [`?`]: ../macro.try.html
 //! [`Result`]: enum.Result.html
 //! [`Ok(T)`]: enum.Result.html#variant.Ok
 //! [`Err(E)`]: enum.Result.html#variant.Err
@@ -318,7 +318,7 @@ impl<T, E> Result<T, E> {
     /// Converts `self` into an [`Option<T>`], consuming `self`,
     /// and discarding the error, if any.
     ///
-    /// [`Option<T>`]: ../../std/option/enum.Option.html
+    /// [`Option<T>`]: ../option/enum.Option.html
     ///
     /// # Examples
     ///
@@ -345,7 +345,7 @@ impl<T, E> Result<T, E> {
     /// Converts `self` into an [`Option<E>`], consuming `self`,
     /// and discarding the success value, if any.
     ///
-    /// [`Option<E>`]: ../../std/option/enum.Option.html
+    /// [`Option<E>`]: ../option/enum.Option.html
     ///
     /// # Examples
     ///
@@ -913,8 +913,8 @@ impl<T: Default, E> Result<T, E> {
     /// assert_eq!(0, bad_year);
     /// ```
     ///
-    /// [`parse`]: ../../std/primitive.str.html#method.parse
-    /// [`FromStr`]: ../../std/str/trait.FromStr.html
+    /// [`parse`]: ../primitive.str.html#method.parse
+    /// [`FromStr`]: ../str/trait.FromStr.html
     /// [`Ok`]: enum.Result.html#variant.Ok
     /// [`Err`]: enum.Result.html#variant.Err
     #[inline]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -3278,8 +3278,8 @@ macro_rules! iterator {
 /// }
 /// ```
 ///
-/// [`iter`]: ../../std/primitive.slice.html#method.iter
-/// [slices]: ../../std/primitive.slice.html
+/// [`iter`]: ../primitive.slice.html#method.iter
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Iter<'a, T: 'a> {
     ptr: *const T,
@@ -3380,8 +3380,8 @@ impl<T> AsRef<[T]> for Iter<'_, T> {
 /// println!("{:?}", slice);
 /// ```
 ///
-/// [`iter_mut`]: ../../std/primitive.slice.html#method.iter_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`iter_mut`]: ../primitive.slice.html#method.iter_mut
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct IterMut<'a, T: 'a> {
     ptr: *mut T,
@@ -3489,8 +3489,8 @@ trait SplitIter: DoubleEndedIterator {
 ///
 /// This struct is created by the [`split`] method on [slices].
 ///
-/// [`split`]: ../../std/primitive.slice.html#method.split
-/// [slices]: ../../std/primitive.slice.html
+/// [`split`]: ../primitive.slice.html#method.split
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Split<'a, T:'a, P> where P: FnMut(&T) -> bool {
     v: &'a [T],
@@ -3580,8 +3580,8 @@ impl<T, P> FusedIterator for Split<'_, T, P> where P: FnMut(&T) -> bool {}
 ///
 /// This struct is created by the [`split_mut`] method on [slices].
 ///
-/// [`split_mut`]: ../../std/primitive.slice.html#method.split_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`split_mut`]: ../primitive.slice.html#method.split_mut
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitMut<'a, T:'a, P> where P: FnMut(&T) -> bool {
     v: &'a mut [T],
@@ -3678,8 +3678,8 @@ impl<T, P> FusedIterator for SplitMut<'_, T, P> where P: FnMut(&T) -> bool {}
 ///
 /// This struct is created by the [`rsplit`] method on [slices].
 ///
-/// [`rsplit`]: ../../std/primitive.slice.html#method.rsplit
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplit`]: ../primitive.slice.html#method.rsplit
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 #[derive(Clone)] // Is this correct, or does it incorrectly require `T: Clone`?
 pub struct RSplit<'a, T:'a, P> where P: FnMut(&T) -> bool {
@@ -3735,8 +3735,8 @@ impl<T, P> FusedIterator for RSplit<'_, T, P> where P: FnMut(&T) -> bool {}
 ///
 /// This struct is created by the [`rsplit_mut`] method on [slices].
 ///
-/// [`rsplit_mut`]: ../../std/primitive.slice.html#method.rsplit_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplit_mut`]: ../primitive.slice.html#method.rsplit_mut
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "slice_rsplit", since = "1.27.0")]
 pub struct RSplitMut<'a, T:'a, P> where P: FnMut(&T) -> bool {
     inner: SplitMut<'a, T, P>
@@ -3821,8 +3821,8 @@ impl<T, I: SplitIter<Item=T>> Iterator for GenericSplitN<I> {
 ///
 /// This struct is created by the [`splitn`] method on [slices].
 ///
-/// [`splitn`]: ../../std/primitive.slice.html#method.splitn
-/// [slices]: ../../std/primitive.slice.html
+/// [`splitn`]: ../primitive.slice.html#method.splitn
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitN<'a, T: 'a, P> where P: FnMut(&T) -> bool {
     inner: GenericSplitN<Split<'a, T, P>>
@@ -3843,8 +3843,8 @@ impl<T: fmt::Debug, P> fmt::Debug for SplitN<'_, T, P> where P: FnMut(&T) -> boo
 ///
 /// This struct is created by the [`rsplitn`] method on [slices].
 ///
-/// [`rsplitn`]: ../../std/primitive.slice.html#method.rsplitn
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplitn`]: ../primitive.slice.html#method.rsplitn
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RSplitN<'a, T: 'a, P> where P: FnMut(&T) -> bool {
     inner: GenericSplitN<RSplit<'a, T, P>>
@@ -3864,8 +3864,8 @@ impl<T: fmt::Debug, P> fmt::Debug for RSplitN<'_, T, P> where P: FnMut(&T) -> bo
 ///
 /// This struct is created by the [`splitn_mut`] method on [slices].
 ///
-/// [`splitn_mut`]: ../../std/primitive.slice.html#method.splitn_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`splitn_mut`]: ../primitive.slice.html#method.splitn_mut
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct SplitNMut<'a, T: 'a, P> where P: FnMut(&T) -> bool {
     inner: GenericSplitN<SplitMut<'a, T, P>>
@@ -3886,8 +3886,8 @@ impl<T: fmt::Debug, P> fmt::Debug for SplitNMut<'_, T, P> where P: FnMut(&T) -> 
 ///
 /// This struct is created by the [`rsplitn_mut`] method on [slices].
 ///
-/// [`rsplitn_mut`]: ../../std/primitive.slice.html#method.rsplitn_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rsplitn_mut`]: ../primitive.slice.html#method.rsplitn_mut
+/// [slices]: ../primitive.slice.html
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RSplitNMut<'a, T: 'a, P> where P: FnMut(&T) -> bool {
     inner: GenericSplitN<RSplitMut<'a, T, P>>
@@ -3936,8 +3936,8 @@ forward_iterator! { RSplitNMut: T, &'a mut [T] }
 ///
 /// This struct is created by the [`windows`] method on [slices].
 ///
-/// [`windows`]: ../../std/primitive.slice.html#method.windows
-/// [slices]: ../../std/primitive.slice.html
+/// [`windows`]: ../primitive.slice.html#method.windows
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Windows<'a, T:'a> {
@@ -4062,8 +4062,8 @@ unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
 ///
 /// This struct is created by the [`chunks`] method on [slices].
 ///
-/// [`chunks`]: ../../std/primitive.slice.html#method.chunks
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks`]: ../primitive.slice.html#method.chunks
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Chunks<'a, T:'a> {
@@ -4207,8 +4207,8 @@ unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
 ///
 /// This struct is created by the [`chunks_mut`] method on [slices].
 ///
-/// [`chunks_mut`]: ../../std/primitive.slice.html#method.chunks_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks_mut`]: ../primitive.slice.html#method.chunks_mut
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ChunksMut<'a, T:'a> {
@@ -4329,9 +4329,9 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
 ///
 /// This struct is created by the [`chunks_exact`] method on [slices].
 ///
-/// [`chunks_exact`]: ../../std/primitive.slice.html#method.chunks_exact
-/// [`remainder`]: ../../std/slice/struct.ChunksExact.html#method.remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks_exact`]: ../primitive.slice.html#method.chunks_exact
+/// [`remainder`]: ../slice/struct.ChunksExact.html#method.remainder
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 pub struct ChunksExact<'a, T:'a> {
@@ -4453,9 +4453,9 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
 ///
 /// This struct is created by the [`chunks_exact_mut`] method on [slices].
 ///
-/// [`chunks_exact_mut`]: ../../std/primitive.slice.html#method.chunks_exact_mut
-/// [`into_remainder`]: ../../std/slice/struct.ChunksExactMut.html#method.into_remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [`chunks_exact_mut`]: ../primitive.slice.html#method.chunks_exact_mut
+/// [`into_remainder`]: ../slice/struct.ChunksExactMut.html#method.into_remainder
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "chunks_exact", since = "1.31.0")]
 pub struct ChunksExactMut<'a, T:'a> {
@@ -4568,8 +4568,8 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
 ///
 /// This struct is created by the [`rchunks`] method on [slices].
 ///
-/// [`rchunks`]: ../../std/primitive.slice.html#method.rchunks
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks`]: ../primitive.slice.html#method.rchunks
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunks<'a, T:'a> {
@@ -4716,8 +4716,8 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
 ///
 /// This struct is created by the [`rchunks_mut`] method on [slices].
 ///
-/// [`rchunks_mut`]: ../../std/primitive.slice.html#method.rchunks_mut
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks_mut`]: ../primitive.slice.html#method.rchunks_mut
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksMut<'a, T:'a> {
@@ -4860,9 +4860,9 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
 ///
 /// This struct is created by the [`rchunks_exact`] method on [slices].
 ///
-/// [`rchunks_exact`]: ../../std/primitive.slice.html#method.rchunks_exact
-/// [`remainder`]: ../../std/slice/struct.ChunksExact.html#method.remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks_exact`]: ../primitive.slice.html#method.rchunks_exact
+/// [`remainder`]: ../slice/struct.ChunksExact.html#method.remainder
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksExact<'a, T:'a> {
@@ -5003,9 +5003,9 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
 ///
 /// This struct is created by the [`rchunks_exact_mut`] method on [slices].
 ///
-/// [`rchunks_exact_mut`]: ../../std/primitive.slice.html#method.rchunks_exact_mut
-/// [`into_remainder`]: ../../std/slice/struct.ChunksExactMut.html#method.into_remainder
-/// [slices]: ../../std/primitive.slice.html
+/// [`rchunks_exact_mut`]: ../primitive.slice.html#method.rchunks_exact_mut
+/// [`into_remainder`]: ../slice/struct.ChunksExactMut.html#method.into_remainder
+/// [slices]: ../primitive.slice.html
 #[derive(Debug)]
 #[stable(feature = "rchunks", since = "1.31.0")]
 pub struct RChunksExactMut<'a, T:'a> {
@@ -5174,8 +5174,8 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 /// assert_eq!(slice[0], 42);
 /// ```
 ///
-/// [`NonNull::dangling()`]: ../../std/ptr/struct.NonNull.html#method.dangling
-/// [`pointer::offset`]: ../../std/primitive.pointer.html#method.offset
+/// [`NonNull::dangling()`]: ../ptr/struct.NonNull.html#method.dangling
+/// [`pointer::offset`]: ../primitive.pointer.html#method.offset
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
@@ -5196,7 +5196,7 @@ pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
 ///
 /// See the documentation of [`from_raw_parts`] for more details.
 ///
-/// [`from_raw_parts`]: ../../std/slice/fn.from_raw_parts.html
+/// [`from_raw_parts`]: ../slice/fn.from_raw_parts.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -30,8 +30,8 @@ pub mod lossy;
 /// [`str`]'s [`parse`] method. See [`parse`]'s documentation for examples.
 ///
 /// [`from_str`]: #tymethod.from_str
-/// [`str`]: ../../std/primitive.str.html
-/// [`parse`]: ../../std/primitive.str.html#method.parse
+/// [`str`]: ../primitive.str.html
+/// [`parse`]: ../primitive.str.html#method.parse
 ///
 /// `FromStr` does not have a lifetime parameter, and so you can only parse types
 /// that do not contain a lifetime parameter themselves. In other words, you can
@@ -82,14 +82,14 @@ pub trait FromStr: Sized {
     /// when the string is ill-formatted return an error specific to the
     /// inside [`Err`]. The error type is specific to implementation of the trait.
     ///
-    /// [`Ok`]: ../../std/result/enum.Result.html#variant.Ok
-    /// [`Err`]: ../../std/result/enum.Result.html#variant.Err
+    /// [`Ok`]: ../result/enum.Result.html#variant.Ok
+    /// [`Err`]: ../result/enum.Result.html#variant.Err
     ///
     /// # Examples
     ///
     /// Basic usage with [`i32`][ithirtytwo], a type that implements `FromStr`:
     ///
-    /// [ithirtytwo]: ../../std/primitive.i32.html
+    /// [ithirtytwo]: ../primitive.i32.html
     ///
     /// ```
     /// use std::str::FromStr;
@@ -141,7 +141,7 @@ impl FromStr for bool {
 
 /// An error returned when parsing a `bool` using [`from_str`] fails
 ///
-/// [`from_str`]: ../../std/primitive.bool.html#method.from_str
+/// [`from_str`]: ../primitive.bool.html#method.from_str
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct ParseBoolError { _priv: () }
@@ -160,13 +160,13 @@ Section: Creating a string
 /// Errors which can occur when attempting to interpret a sequence of [`u8`]
 /// as a string.
 ///
-/// [`u8`]: ../../std/primitive.u8.html
+/// [`u8`]: ../primitive.u8.html
 ///
 /// As such, the `from_utf8` family of functions and methods for both [`String`]s
 /// and [`&str`]s make use of this error, for example.
 ///
 /// [`String`]: ../../std/string/struct.String.html#method.from_utf8
-/// [`&str`]: ../../std/str/fn.from_utf8.html
+/// [`&str`]: ../str/fn.from_utf8.html
 ///
 /// # Examples
 ///
@@ -245,7 +245,7 @@ impl Utf8Error {
     ///   (after inserting a [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD]) in case of
     ///   lossy decoding.
     ///
-    /// [U+FFFD]: ../../std/char/constant.REPLACEMENT_CHARACTER.html
+    /// [U+FFFD]: ../char/constant.REPLACEMENT_CHARACTER.html
     #[stable(feature = "utf8_error_error_len", since = "1.20.0")]
     pub fn error_len(&self) -> Option<usize> {
         self.error_len.map(|len| len as usize)
@@ -260,9 +260,9 @@ impl Utf8Error {
 /// that it is valid UTF-8. `from_utf8()` checks to ensure that the bytes are valid
 /// UTF-8, and then does the conversion.
 ///
-/// [`&str`]: ../../std/primitive.str.html
-/// [`u8`]: ../../std/primitive.u8.html
-/// [byteslice]: ../../std/primitive.slice.html
+/// [`&str`]: ../primitive.str.html
+/// [`u8`]: ../primitive.u8.html
+/// [byteslice]: ../primitive.slice.html
 ///
 /// If you are sure that the byte slice is valid UTF-8, and you don't want to
 /// incur the overhead of the validity check, there is an unsafe version of
@@ -281,7 +281,7 @@ impl Utf8Error {
 /// stack-allocated string. There is an example of this in the
 /// examples section below.
 ///
-/// [byteslice]: ../../std/primitive.slice.html
+/// [byteslice]: ../primitive.slice.html
 ///
 /// # Errors
 ///
@@ -390,7 +390,7 @@ pub fn from_utf8_mut(v: &mut [u8]) -> Result<&mut str, Utf8Error> {
 /// it are valid UTF-8. If this constraint is violated, undefined behavior
 /// results, as the rest of Rust assumes that [`&str`]s are valid UTF-8.
 ///
-/// [`&str`]: ../../std/primitive.str.html
+/// [`&str`]: ../primitive.str.html
 ///
 /// # Examples
 ///
@@ -457,13 +457,13 @@ Section: Iterators
 
 /// An iterator over the [`char`]s of a string slice.
 ///
-/// [`char`]: ../../std/primitive.char.html
+/// [`char`]: ../primitive.char.html
 ///
 /// This struct is created by the [`chars`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`chars`]: ../../std/primitive.str.html#method.chars
-/// [`str`]: ../../std/primitive.str.html
+/// [`chars`]: ../primitive.str.html#method.chars
+/// [`str`]: ../primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct Chars<'a> {
@@ -643,13 +643,13 @@ impl<'a> Chars<'a> {
 
 /// An iterator over the [`char`]s of a string slice, and their positions.
 ///
-/// [`char`]: ../../std/primitive.char.html
+/// [`char`]: ../primitive.char.html
 ///
 /// This struct is created by the [`char_indices`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`char_indices`]: ../../std/primitive.str.html#method.char_indices
-/// [`str`]: ../../std/primitive.str.html
+/// [`char_indices`]: ../primitive.str.html#method.char_indices
+/// [`str`]: ../primitive.str.html
 #[derive(Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct CharIndices<'a> {
@@ -723,8 +723,8 @@ impl<'a> CharIndices<'a> {
 /// This struct is created by the [`bytes`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`bytes`]: ../../std/primitive.str.html#method.bytes
-/// [`str`]: ../../std/primitive.str.html
+/// [`bytes`]: ../primitive.str.html#method.bytes
+/// [`str`]: ../primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
 pub struct Bytes<'a>(Cloned<slice::Iter<'a, u8>>);
@@ -1113,12 +1113,12 @@ generate_pattern_iterators! {
     forward:
         /// Created with the method [`split`].
         ///
-        /// [`split`]: ../../std/primitive.str.html#method.split
+        /// [`split`]: ../primitive.str.html#method.split
         struct Split;
     reverse:
         /// Created with the method [`rsplit`].
         ///
-        /// [`rsplit`]: ../../std/primitive.str.html#method.rsplit
+        /// [`rsplit`]: ../primitive.str.html#method.rsplit
         struct RSplit;
     stability:
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1131,12 +1131,12 @@ generate_pattern_iterators! {
     forward:
         /// Created with the method [`split_terminator`].
         ///
-        /// [`split_terminator`]: ../../std/primitive.str.html#method.split_terminator
+        /// [`split_terminator`]: ../primitive.str.html#method.split_terminator
         struct SplitTerminator;
     reverse:
         /// Created with the method [`rsplit_terminator`].
         ///
-        /// [`rsplit_terminator`]: ../../std/primitive.str.html#method.rsplit_terminator
+        /// [`rsplit_terminator`]: ../primitive.str.html#method.rsplit_terminator
         struct RSplitTerminator;
     stability:
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1191,12 +1191,12 @@ generate_pattern_iterators! {
     forward:
         /// Created with the method [`splitn`].
         ///
-        /// [`splitn`]: ../../std/primitive.str.html#method.splitn
+        /// [`splitn`]: ../primitive.str.html#method.splitn
         struct SplitN;
     reverse:
         /// Created with the method [`rsplitn`].
         ///
-        /// [`rsplitn`]: ../../std/primitive.str.html#method.rsplitn
+        /// [`rsplitn`]: ../primitive.str.html#method.rsplitn
         struct RSplitN;
     stability:
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -1242,12 +1242,12 @@ generate_pattern_iterators! {
     forward:
         /// Created with the method [`match_indices`].
         ///
-        /// [`match_indices`]: ../../std/primitive.str.html#method.match_indices
+        /// [`match_indices`]: ../primitive.str.html#method.match_indices
         struct MatchIndices;
     reverse:
         /// Created with the method [`rmatch_indices`].
         ///
-        /// [`rmatch_indices`]: ../../std/primitive.str.html#method.rmatch_indices
+        /// [`rmatch_indices`]: ../primitive.str.html#method.rmatch_indices
         struct RMatchIndices;
     stability:
         #[stable(feature = "str_match_indices", since = "1.5.0")]
@@ -1295,12 +1295,12 @@ generate_pattern_iterators! {
     forward:
         /// Created with the method [`matches`].
         ///
-        /// [`matches`]: ../../std/primitive.str.html#method.matches
+        /// [`matches`]: ../primitive.str.html#method.matches
         struct Matches;
     reverse:
         /// Created with the method [`rmatches`].
         ///
-        /// [`rmatches`]: ../../std/primitive.str.html#method.rmatches
+        /// [`rmatches`]: ../primitive.str.html#method.rmatches
         struct RMatches;
     stability:
         #[stable(feature = "str_matches", since = "1.2.0")]
@@ -1314,8 +1314,8 @@ generate_pattern_iterators! {
 /// This struct is created with the [`lines`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`lines`]: ../../std/primitive.str.html#method.lines
-/// [`str`]: ../../std/primitive.str.html
+/// [`lines`]: ../primitive.str.html#method.lines
+/// [`str`]: ../primitive.str.html
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Clone, Debug)]
 pub struct Lines<'a>(Map<SplitTerminator<'a, char>, LinesAnyMap>);
@@ -1348,7 +1348,7 @@ impl FusedIterator for Lines<'_> {}
 
 /// Created with the method [`lines_any`].
 ///
-/// [`lines_any`]: ../../std/primitive.str.html#method.lines_any
+/// [`lines_any`]: ../primitive.str.html#method.lines_any
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_deprecated(since = "1.4.0", reason = "use lines()/Lines instead now")]
 #[derive(Clone, Debug)]
@@ -4017,7 +4017,7 @@ impl str {
     /// Note: only extended grapheme codepoints that begin the string will be
     /// escaped.
     ///
-    /// [`char::escape_debug`]: ../std/primitive.char.html#method.escape_debug
+    /// [`char::escape_debug`]: primitive.char.html#method.escape_debug
     ///
     /// # Examples
     ///
@@ -4062,7 +4062,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_default`].
     ///
-    /// [`char::escape_default`]: ../std/primitive.char.html#method.escape_default
+    /// [`char::escape_default`]: primitive.char.html#method.escape_default
     ///
     /// # Examples
     ///
@@ -4100,7 +4100,7 @@ impl str {
 
     /// Return an iterator that escapes each char in `self` with [`char::escape_unicode`].
     ///
-    /// [`char::escape_unicode`]: ../std/primitive.char.html#method.escape_unicode
+    /// [`char::escape_unicode`]: primitive.char.html#method.escape_unicode
     ///
     /// # Examples
     ///
@@ -4179,8 +4179,8 @@ impl Default for &mut str {
 /// This struct is created by the [`split_whitespace`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`split_whitespace`]: ../../std/primitive.str.html#method.split_whitespace
-/// [`str`]: ../../std/primitive.str.html
+/// [`split_whitespace`]: ../primitive.str.html#method.split_whitespace
+/// [`str`]: ../primitive.str.html
 #[stable(feature = "split_whitespace", since = "1.1.0")]
 #[derive(Clone, Debug)]
 pub struct SplitWhitespace<'a> {
@@ -4193,8 +4193,8 @@ pub struct SplitWhitespace<'a> {
 /// This struct is created by the [`split_ascii_whitespace`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`split_ascii_whitespace`]: ../../std/primitive.str.html#method.split_ascii_whitespace
-/// [`str`]: ../../std/primitive.str.html
+/// [`split_ascii_whitespace`]: ../primitive.str.html#method.split_ascii_whitespace
+/// [`str`]: ../primitive.str.html
 #[stable(feature = "split_ascii_whitespace", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct SplitAsciiWhitespace<'a> {
@@ -4282,13 +4282,13 @@ impl FusedIterator for SplitAsciiWhitespace<'_> {}
 
 /// An iterator of [`u16`] over the string encoded as UTF-16.
 ///
-/// [`u16`]: ../../std/primitive.u16.html
+/// [`u16`]: ../primitive.u16.html
 ///
 /// This struct is created by the [`encode_utf16`] method on [`str`].
 /// See its documentation for more.
 ///
-/// [`encode_utf16`]: ../../std/primitive.str.html#method.encode_utf16
-/// [`str`]: ../../std/primitive.str.html
+/// [`encode_utf16`]: ../primitive.str.html#method.encode_utf16
+/// [`str`]: ../primitive.str.html
 #[derive(Clone)]
 #[stable(feature = "encode_utf16", since = "1.8.0")]
 pub struct EncodeUtf16<'a> {
@@ -4340,7 +4340,7 @@ impl FusedIterator for EncodeUtf16<'_> {}
 
 /// The return type of [`str::escape_debug`].
 ///
-/// [`str::escape_debug`]: ../../std/primitive.str.html#method.escape_debug
+/// [`str::escape_debug`]: ../primitive.str.html#method.escape_debug
 #[stable(feature = "str_escape", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDebug<'a> {
@@ -4352,7 +4352,7 @@ pub struct EscapeDebug<'a> {
 
 /// The return type of [`str::escape_default`].
 ///
-/// [`str::escape_default`]: ../../std/primitive.str.html#method.escape_default
+/// [`str::escape_default`]: ../primitive.str.html#method.escape_default
 #[stable(feature = "str_escape", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeDefault<'a> {
@@ -4361,7 +4361,7 @@ pub struct EscapeDefault<'a> {
 
 /// The return type of [`str::escape_unicode`].
 ///
-/// [`str::escape_unicode`]: ../../std/primitive.str.html#method.escape_unicode
+/// [`str::escape_unicode`]: ../primitive.str.html#method.escape_unicode
 #[stable(feature = "str_escape", since = "1.34.0")]
 #[derive(Clone, Debug)]
 pub struct EscapeUnicode<'a> {

--- a/src/libcore/sync/atomic.rs
+++ b/src/libcore/sync/atomic.rs
@@ -156,7 +156,7 @@ pub fn spin_loop_hint() {
 ///
 /// This type has the same in-memory representation as a [`bool`].
 ///
-/// [`bool`]: ../../../std/primitive.bool.html
+/// [`bool`]: ../../primitive.bool.html
 #[cfg(target_has_atomic = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(C, align(1))]
@@ -333,7 +333,7 @@ impl AtomicBool {
     /// This is safe because the mutable reference guarantees that no other threads are
     /// concurrently accessing the atomic data.
     ///
-    /// [`bool`]: ../../../std/primitive.bool.html
+    /// [`bool`]: ../../primitive.bool.html
     ///
     /// # Examples
     ///
@@ -480,7 +480,7 @@ impl AtomicBool {
     /// [`Release`]: enum.Ordering.html#variant.Release
     /// [`Acquire`]: enum.Ordering.html#variant.Acquire
     /// [`AcqRel`]: enum.Ordering.html#variant.AcqRel
-    /// [`bool`]: ../../../std/primitive.bool.html
+    /// [`bool`]: ../../primitive.bool.html
     ///
     /// # Examples
     ///
@@ -519,7 +519,7 @@ impl AtomicBool {
     /// and must be equivalent to or weaker than the success ordering.
     ///
     ///
-    /// [`bool`]: ../../../std/primitive.bool.html
+    /// [`bool`]: ../../primitive.bool.html
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
     /// [`Release`]: enum.Ordering.html#variant.Release
@@ -578,7 +578,7 @@ impl AtomicBool {
     /// [`Relaxed`]. The failure ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
     /// and must be equivalent to or weaker than the success ordering.
     ///
-    /// [`bool`]: ../../../std/primitive.bool.html
+    /// [`bool`]: ../../primitive.bool.html
     /// [`compare_exchange`]: #method.compare_exchange
     /// [`Ordering`]: enum.Ordering.html
     /// [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -1742,7 +1742,7 @@ of this operation [`Relaxed`], and using [`Release`] makes the final successful 
 [`Relaxed`]. The (failed) load ordering can only be [`SeqCst`], [`Acquire`] or [`Relaxed`]
 and must be equivalent to or weaker than the success ordering.
 
-[`bool`]: ../../../std/primitive.bool.html
+[`bool`]: ../../primitive.bool.html
 [`compare_exchange`]: #method.compare_exchange
 [`Ordering`]: enum.Ordering.html
 [`Relaxed`]: enum.Ordering.html#variant.Relaxed
@@ -1898,7 +1898,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i8", "../../../std/primitive.i8.html",
+    "i8", "../../primitive.i8.html",
     "",
     atomic_min, atomic_max,
     1,
@@ -1914,7 +1914,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u8", "../../../std/primitive.u8.html",
+    "u8", "../../primitive.u8.html",
     "",
     atomic_umin, atomic_umax,
     1,
@@ -1930,7 +1930,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i16", "../../../std/primitive.i16.html",
+    "i16", "../../primitive.i16.html",
     "",
     atomic_min, atomic_max,
     2,
@@ -1946,7 +1946,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u16", "../../../std/primitive.u16.html",
+    "u16", "../../primitive.u16.html",
     "",
     atomic_umin, atomic_umax,
     2,
@@ -1962,7 +1962,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i32", "../../../std/primitive.i32.html",
+    "i32", "../../primitive.i32.html",
     "",
     atomic_min, atomic_max,
     4,
@@ -1978,7 +1978,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u32", "../../../std/primitive.u32.html",
+    "u32", "../../primitive.u32.html",
     "",
     atomic_umin, atomic_umax,
     4,
@@ -1994,7 +1994,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i64", "../../../std/primitive.i64.html",
+    "i64", "../../primitive.i64.html",
     "",
     atomic_min, atomic_max,
     8,
@@ -2010,7 +2010,7 @@ atomic_int! {
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     stable(feature = "integer_atomics_stable", since = "1.34.0"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u64", "../../../std/primitive.u64.html",
+    "u64", "../../primitive.u64.html",
     "",
     atomic_umin, atomic_umax,
     8,
@@ -2026,7 +2026,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "i128", "../../../std/primitive.i128.html",
+    "i128", "../../primitive.i128.html",
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
     16,
@@ -2042,7 +2042,7 @@ atomic_int! {
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
     unstable(feature = "integer_atomics", issue = "32976"),
-    "u128", "../../../std/primitive.u128.html",
+    "u128", "../../primitive.u128.html",
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
     16,
@@ -2070,7 +2070,7 @@ atomic_int!{
     stable(feature = "atomic_from", since = "1.23.0"),
     stable(feature = "atomic_nand", since = "1.27.0"),
     stable(feature = "rust1", since = "1.0.0"),
-    "isize", "../../../std/primitive.isize.html",
+    "isize", "../../primitive.isize.html",
     "",
     atomic_min, atomic_max,
     ptr_width!(),
@@ -2086,7 +2086,7 @@ atomic_int!{
     stable(feature = "atomic_from", since = "1.23.0"),
     stable(feature = "atomic_nand", since = "1.27.0"),
     stable(feature = "rust1", since = "1.0.0"),
-    "usize", "../../../std/primitive.usize.html",
+    "usize", "../../primitive.usize.html",
     "",
     atomic_umin, atomic_umax,
     ptr_width!(),

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -33,9 +33,9 @@ const MICROS_PER_SEC: u64 = 1_000_000;
 /// `Duration`s implement many common traits, including [`Add`], [`Sub`], and other
 /// [`ops`] traits.
 ///
-/// [`Add`]: ../../std/ops/trait.Add.html
-/// [`Sub`]: ../../std/ops/trait.Sub.html
-/// [`ops`]: ../../std/ops/index.html
+/// [`Add`]: ../ops/trait.Add.html
+/// [`Sub`]: ../ops/trait.Sub.html
+/// [`ops`]: ../ops/index.html
 ///
 /// # Examples
 ///
@@ -362,7 +362,7 @@ impl Duration {
     /// Checked `Duration` addition. Computes `self + other`, returning [`None`]
     /// if overflow occurred.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -400,7 +400,7 @@ impl Duration {
     /// Checked `Duration` subtraction. Computes `self - other`, returning [`None`]
     /// if the result would be negative or if overflow occurred.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -436,7 +436,7 @@ impl Duration {
     /// Checked `Duration` multiplication. Computes `self * other`, returning
     /// [`None`] if overflow occurred.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -471,7 +471,7 @@ impl Duration {
     /// Checked `Duration` division. Computes `self / other`, returning [`None`]
     /// if `other == 0`.
     ///
-    /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`None`]: ../option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///

--- a/src/test/rustdoc/issue-15318.rs
+++ b/src/test/rustdoc/issue-15318.rs
@@ -1,7 +1,8 @@
 // aux-build:issue-15318.rs
 // ignore-cross-compile
 
-#![no_std]
+#![feature(no_core)]
+#![no_core]
 
 extern crate issue_15318;
 


### PR DESCRIPTION
This adds basic primitive documentation to `libcore`. At the top level these just refer to `std`, so we aren't duplicating that text, but the greater value comes from the `core`-specific list of methods and trait implementations. For example, `f64` has far fewer methods in `core`, but there previously wasn't any way to know which of its methods require `std`.

This also has the advantage that `core` docs will now get automatic links for the primitives in parameter lists and such, just like the `std` docs do. The second commit in this pull request also updates manual links to be `core`/`std` agnostic as much as possible.