### PR TITLE
librustc_codegen_llvm: Pass bitflags as raw integral types for FFI (#61306)

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1039,7 +1039,7 @@ impl<'ll> MemberDescription<'ll> {
                     None => None,
                     Some(value) => Some(cx.const_u64(value)),
                 },
-                self.flags,
+                self.flags.bits(),
                 self.type_metadata)
         }
     }
@@ -1837,7 +1837,7 @@ fn prepare_enum_metadata(
                 UNKNOWN_LINE_NUMBER,
                 layout.size.bits(),
                 layout.align.abi.bits() as u32,
-                DIFlags::FlagZero,
+                DIFlags::FlagZero.bits(),
                 None,
                 0, // RuntimeLang
                 unique_type_id_str.as_ptr())
@@ -1896,7 +1896,7 @@ fn prepare_enum_metadata(
                     size.bits(),
                     align.abi.bits() as u32,
                     layout.fields.offset(discr_index).bits(),
-                    DIFlags::FlagArtificial,
+                    DIFlags::FlagArtificial.bits(),
                     discr_metadata))
             }
         },
@@ -1921,7 +1921,7 @@ fn prepare_enum_metadata(
                     size.bits(),
                     align.bits() as u32,
                     layout.fields.offset(discr_index).bits(),
-                    DIFlags::FlagArtificial,
+                    DIFlags::FlagArtificial.bits(),
                     discr_metadata))
             }
         },
@@ -1958,7 +1958,7 @@ fn prepare_enum_metadata(
             UNKNOWN_LINE_NUMBER,
             layout.size.bits(),
             layout.align.abi.bits() as u32,
-            DIFlags::FlagZero,
+            DIFlags::FlagZero.bits(),
             discriminator_metadata,
             empty_array,
             variant_part_unique_type_id_str.as_ptr())
@@ -1976,7 +1976,7 @@ fn prepare_enum_metadata(
             UNKNOWN_LINE_NUMBER,
             layout.size.bits(),
             layout.align.abi.bits() as u32,
-            DIFlags::FlagZero,
+            DIFlags::FlagZero.bits(),
             None,
             type_array,
             0,
@@ -2142,7 +2142,7 @@ fn create_struct_stub(
             UNKNOWN_LINE_NUMBER,
             struct_size.bits(),
             struct_align.bits() as u32,
-            DIFlags::FlagZero,
+            DIFlags::FlagZero.bits(),
             None,
             empty_array,
             0,
@@ -2180,7 +2180,7 @@ fn create_union_stub(
             UNKNOWN_LINE_NUMBER,
             union_size.bits(),
             union_align.bits() as u32,
-            DIFlags::FlagZero,
+            DIFlags::FlagZero.bits(),
             Some(empty_array),
             0, // RuntimeLang
             unique_type_id.as_ptr())
@@ -2283,7 +2283,7 @@ pub fn create_vtable_metadata(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, vtable: &
             UNKNOWN_LINE_NUMBER,
             Size::ZERO.bits(),
             cx.tcx.data_layout.pointer_align.abi.bits() as u32,
-            DIFlags::FlagArtificial,
+            DIFlags::FlagArtificial.bits(),
             None,
             empty_array,
             0,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -187,7 +187,7 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                         loc.line as c_uint,
                         type_metadata,
                         cx.sess().opts.optimize != config::OptLevel::No,
-                        DIFlags::FlagZero,
+                        DIFlags::FlagZero.bits(),
                         argument_index,
                         align.bytes() as u32,
                     )
@@ -321,8 +321,8 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
                 loc.line as c_uint,
                 function_type_metadata,
                 scope_line as c_uint,
-                flags,
-                spflags,
+                flags.bits(),
+                spflags.bits(),
                 llfn,
                 template_parameters,
                 None)

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -2,7 +2,7 @@ use super::debuginfo::{
     DIBuilder, DIDescriptor, DIFile, DILexicalBlock, DISubprogram, DIType,
     DIBasicType, DIDerivedType, DICompositeType, DIScope, DIVariable,
     DIGlobalVariableExpression, DIArray, DISubrange, DITemplateTypeParameter, DIEnumerator,
-    DINameSpace, DIFlags, DISPFlags, DebugEmissionKind,
+    DINameSpace, DebugEmissionKind,
 };
 
 use libc::{c_uint, c_int, size_t, c_char};
@@ -564,9 +564,8 @@ pub mod debuginfo {
 
     // These values **must** match with LLVMRustDIFlags!!
     bitflags! {
-        #[repr(C)]
         #[derive(Default)]
-        pub struct DIFlags: ::libc::uint32_t {
+        pub struct DIFlags: u32 {
             const FlagZero                = 0;
             const FlagPrivate             = 1;
             const FlagProtected           = 2;
@@ -593,9 +592,8 @@ pub mod debuginfo {
 
     // These values **must** match with LLVMRustDISPFlags!!
     bitflags! {
-        #[repr(C)]
         #[derive(Default)]
-        pub struct DISPFlags: ::libc::uint32_t {
+        pub struct DISPFlags: u32 {
             const SPFlagZero              = 0;
             const SPFlagVirtual           = 1;
             const SPFlagPureVirtual       = 2;
@@ -1452,8 +1450,8 @@ extern "C" {
                                            LineNo: c_uint,
                                            Ty: &'a DIType,
                                            ScopeLine: c_uint,
-                                           Flags: DIFlags,
-                                           SPFlags: DISPFlags,
+                                           Flags: u32,
+                                           SPFlags: u32,
                                            Fn: &'a Value,
                                            TParam: &'a DIArray,
                                            Decl: Option<&'a DIDescriptor>)
@@ -1480,7 +1478,7 @@ extern "C" {
                                              LineNumber: c_uint,
                                              SizeInBits: u64,
                                              AlignInBits: u32,
-                                             Flags: DIFlags,
+                                             Flags: u32,
                                              DerivedFrom: Option<&'a DIType>,
                                              Elements: &'a DIArray,
                                              RunTimeLang: c_uint,
@@ -1496,7 +1494,7 @@ extern "C" {
                                              SizeInBits: u64,
                                              AlignInBits: u32,
                                              OffsetInBits: u64,
-                                             Flags: DIFlags,
+                                             Flags: u32,
                                              Ty: &'a DIType)
                                              -> &'a DIDerivedType;
 
@@ -1509,7 +1507,7 @@ extern "C" {
                                                     AlignInBits: u32,
                                                     OffsetInBits: u64,
                                                     Discriminant: Option<&'a Value>,
-                                                    Flags: DIFlags,
+                                                    Flags: u32,
                                                     Ty: &'a DIType)
                                                     -> &'a DIType;
 
@@ -1546,7 +1544,7 @@ extern "C" {
                                            LineNo: c_uint,
                                            Ty: &'a DIType,
                                            AlwaysPreserve: bool,
-                                           Flags: DIFlags,
+                                           Flags: u32,
                                            ArgNo: c_uint,
                                            AlignInBits: u32)
                                            -> &'a DIVariable;
@@ -1601,7 +1599,7 @@ extern "C" {
                                             LineNumber: c_uint,
                                             SizeInBits: u64,
                                             AlignInBits: u32,
-                                            Flags: DIFlags,
+                                            Flags: u32,
                                             Elements: Option<&'a DIArray>,
                                             RunTimeLang: c_uint,
                                             UniqueId: *const c_char)
@@ -1614,7 +1612,7 @@ extern "C" {
                                               LineNo: c_uint,
                                               SizeInBits: u64,
                                               AlignInBits: u32,
-                                              Flags: DIFlags,
+                                              Flags: u32,
                                               Discriminator: Option<&'a DIDerivedType>,
                                               Elements: &'a DIArray,
                                               UniqueId: *const c_char)


### PR DESCRIPTION
The C++ side uses enums with underlying integral types. However, Rust's bitflags types are a single-field struct containing an integral type, which are not always passed the same way in the C ABI. In particular, sparc64's ABI extends integral types to a full 64-bit value, but does not do the same for single-field structs. Thanks to Michael Karcher for finding this bug.