### PR TITLE
Clean up MIR drop generation

### DIFF
--- a/src/librustc_mir/build/block.rs
+++ b/src/librustc_mir/build/block.rs
@@ -78,7 +78,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let source_info = this.source_info(span);
         for stmt in stmts {
-            let Stmt { kind, opt_destruction_scope, span: stmt_span } = this.hir.mirror(stmt);
+            let Stmt { kind, opt_destruction_scope } = this.hir.mirror(stmt);
             match kind {
                 StmtKind::Expr { scope, expr } => {
                     this.block_context.push(BlockFrame::Statement { ignores_expr_result: true });
@@ -87,7 +87,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             let si = (scope, source_info);
                             this.in_scope(si, LintLevel::Inherited, |this| {
                                 let expr = this.hir.mirror(expr);
-                                this.stmt_expr(block, expr, Some(stmt_span))
+                                this.stmt_expr(block, expr, Some(scope))
                             })
                         }));
                 }

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -127,7 +127,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     this.schedule_drop_storage_and_value(
                         expr_span,
                         scope,
-                        &Place::from(result),
+                        result,
                         value.ty,
                     );
                 }
@@ -559,7 +559,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             this.schedule_drop_storage_and_value(
                 upvar_span,
                 temp_lifetime,
-                &Place::from(temp),
+                temp,
                 upvar_ty,
             );
         }

--- a/src/librustc_mir/build/expr/as_temp.rs
+++ b/src/librustc_mir/build/expr/as_temp.rs
@@ -88,7 +88,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 this.schedule_drop(
                     expr_span,
                     temp_lifetime,
-                    temp_place,
+                    temp,
                     expr_ty,
                     DropKind::Storage,
                 );
@@ -101,7 +101,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             this.schedule_drop(
                 expr_span,
                 temp_lifetime,
-                temp_place,
+                temp,
                 expr_ty,
                 DropKind::Value,
             );

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -179,19 +179,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         // conduct the test, if necessary
                         let body_block;
                         if let Some(cond_expr) = opt_cond_expr {
-                            let loop_block_end;
-                            let cond = unpack!(
-                                loop_block_end = this.as_local_operand(loop_block, cond_expr)
-                            );
-                            body_block = this.cfg.start_new_block();
-                            let false_block = this.cfg.start_new_block();
-                            let term = TerminatorKind::if_(
-                                this.hir.tcx(),
-                                cond,
-                                body_block,
-                                false_block,
-                            );
-                            this.cfg.terminate(loop_block_end, source_info, term);
+                            let cond_expr = this.hir.mirror(cond_expr);
+                            let (true_block, false_block)
+                                = this.test_bool(loop_block, cond_expr, source_info);
+                            body_block = true_block;
 
                             // if the test is false, there's no `break` to assign `destination`, so
                             // we have to do it

--- a/src/librustc_mir/build/expr/stmt.rs
+++ b/src/librustc_mir/build/expr/stmt.rs
@@ -1,6 +1,7 @@
 use crate::build::scope::BreakableScope;
 use crate::build::{BlockAnd, BlockAndExtension, BlockFrame, Builder};
 use crate::hair::*;
+use rustc::middle::region;
 use rustc::mir::*;
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
@@ -8,14 +9,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// If the original expression was an AST statement,
     /// (e.g., `some().code(&here());`) then `opt_stmt_span` is the
     /// span of that statement (including its semicolon, if any).
-    /// Diagnostics use this span (which may be larger than that of
-    /// `expr`) to identify when statement temporaries are dropped.
-    pub fn stmt_expr(&mut self,
-                     mut block: BasicBlock,
-                     expr: Expr<'tcx>,
-                     opt_stmt_span: Option<StatementSpan>)
-                     -> BlockAnd<()>
-    {
+    /// The scope is used if a statement temporary must be dropped.
+    pub fn stmt_expr(
+        &mut self,
+        mut block: BasicBlock,
+        expr: Expr<'tcx>,
+        statement_scope: Option<region::Scope>,
+    ) -> BlockAnd<()> {
         let this = self;
         let expr_span = expr.span;
         let source_info = this.source_info(expr.span);
@@ -30,7 +30,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             } => {
                 let value = this.hir.mirror(value);
                 this.in_scope((region_scope, source_info), lint_level, |this| {
-                    this.stmt_expr(block, value, opt_stmt_span)
+                    this.stmt_expr(block, value, statement_scope)
                 })
             }
             ExprKind::Assign { lhs, rhs } => {
@@ -199,7 +199,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block.unit()
             }
             _ => {
-                let expr_ty = expr.ty;
+                assert!(
+                    statement_scope.is_some(),
+                    "Should not be calling `stmt_expr` on a general expression \
+                     without a statement scope",
+                );
 
                 // Issue #54382: When creating temp for the value of
                 // expression like:
@@ -208,48 +212,34 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 //
                 // it is usually better to focus on `the_value` rather
                 // than the entirety of block(s) surrounding it.
-                let mut temp_span = expr_span;
-                let mut temp_in_tail_of_block = false;
-                if let ExprKind::Block { body } = expr.kind {
-                    if let Some(tail_expr) = &body.expr {
-                        let mut expr = tail_expr;
-                        while let rustc::hir::ExprKind::Block(subblock, _label) = &expr.node {
-                            if let Some(subtail_expr) = &subblock.expr {
-                                expr = subtail_expr
-                            } else {
-                                break;
+                let adjusted_span = (|| {
+                    if let ExprKind::Block { body } = expr.kind {
+                        if let Some(tail_expr) = &body.expr {
+                            let mut expr = tail_expr;
+                            while let rustc::hir::ExprKind::Block(subblock, _label) = &expr.node {
+                                if let Some(subtail_expr) = &subblock.expr {
+                                    expr = subtail_expr
+                                } else {
+                                    break;
+                                }
                             }
-                        }
-                        temp_span = expr.span;
-                        temp_in_tail_of_block = true;
-                    }
-                }
-
-                let temp = {
-                    let mut local_decl = LocalDecl::new_temp(expr.ty.clone(), temp_span);
-                    if temp_in_tail_of_block {
-                        if this.block_context.currently_ignores_tail_results() {
-                            local_decl = local_decl.block_tail(BlockTailInfo {
+                            this.block_context.push(BlockFrame::TailExpr {
                                 tail_result_is_ignored: true
                             });
+                            return Some(expr.span);
                         }
                     }
-                    let temp = this.local_decls.push(local_decl);
-                    let place = Place::from(temp);
-                    debug!("created temp {:?} for expr {:?} in block_context: {:?}",
-                           temp, expr, this.block_context);
-                    place
-                };
-                unpack!(block = this.into(&temp, block, expr));
+                    None
+                })();
 
-                // Attribute drops of the statement's temps to the
-                // semicolon at the statement's end.
-                let drop_point = this.hir.tcx().sess.source_map().end_point(match opt_stmt_span {
-                    None => expr_span,
-                    Some(StatementSpan(span)) => span,
-                });
+                let temp = unpack!(block =
+                    this.as_temp(block, statement_scope, expr, Mutability::Not));
 
-                unpack!(block = this.build_drop(block, drop_point, temp, expr_ty));
+                if let Some(span) = adjusted_span {
+                    this.local_decls[temp].source_info.span = span;
+                    this.block_context.pop();
+                }
+
                 block.unit()
             }
         }

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -531,11 +531,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 kind: StatementKind::StorageLive(local_id),
             },
         );
-        let place = Place::from(local_id);
         let var_ty = self.local_decls[local_id].ty;
         let region_scope = self.hir.region_scope_tree.var_scope(var.local_id);
-        self.schedule_drop(span, region_scope, &place, var_ty, DropKind::Storage);
-        place
+        self.schedule_drop(span, region_scope, local_id, var_ty, DropKind::Storage);
+        Place::Base(PlaceBase::Local(local_id))
     }
 
     pub fn schedule_drop_for_binding(&mut self, var: HirId, span: Span, for_guard: ForGuard) {
@@ -545,7 +544,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.schedule_drop(
             span,
             region_scope,
-            &Place::from(local_id),
+            local_id,
             var_ty,
             DropKind::Value,
         );

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1652,11 +1652,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // denotes *R.
             let ref_for_guard =
                 self.storage_live_binding(block, binding.var_id, binding.span, RefWithinGuard);
-            // Question: Why schedule drops if bindings are all
-            // shared-&'s?
-            // Answer: Because schedule_drop_for_binding also emits
-            // StorageDead's for those locals.
-            self.schedule_drop_for_binding(binding.var_id, binding.span, RefWithinGuard);
             match binding.binding_mode {
                 BindingMode::ByValue => {
                     let rvalue = Rvalue::Ref(re_erased, BorrowKind::Shared, binding.source.clone());
@@ -1666,11 +1661,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 BindingMode::ByRef(borrow_kind) => {
                     let value_for_arm = self.storage_live_binding(
                         block,
-                        binding.var_id,
-                        binding.span,
-                        OutsideGuard,
-                    );
-                    self.schedule_drop_for_binding(
                         binding.var_id,
                         binding.span,
                         OutsideGuard,

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -809,7 +809,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             // Make sure we drop (parts of) the argument even when not matched on.
             self.schedule_drop(
                 pattern.as_ref().map_or(ast_body.span, |pat| pat.span),
-                argument_scope, &place, ty, DropKind::Value,
+                argument_scope, local, ty, DropKind::Value,
             );
 
             if let Some(pattern) = pattern {

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -251,7 +251,7 @@ struct Builder<'a, 'tcx> {
 
     /// The current set of scopes, updated as we traverse;
     /// see the `scope` module for more details.
-    scopes: Vec<scope::Scope<'tcx>>,
+    scopes: scope::Scopes<'tcx>,
 
     /// The block-context: each time we build the code within an hair::Block,
     /// we push a frame here tracking whether we are building a statement or
@@ -273,10 +273,6 @@ struct Builder<'a, 'tcx> {
 
     /// The number of `push_unsafe_block` levels in scope.
     push_unsafe_count: usize,
-
-    /// The current set of breakables; see the `scope` module for more
-    /// details.
-    breakable_scopes: Vec<scope::BreakableScope<'tcx>>,
 
     /// The vector of all scopes that we have created thus far;
     /// we track this for debuginfo later.
@@ -714,7 +710,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             fn_span: span,
             arg_count,
             is_generator,
-            scopes: vec![],
+            scopes: Default::default(),
             block_context: BlockContext::new(),
             source_scopes: IndexVec::new(),
             source_scope: OUTERMOST_SOURCE_SCOPE,
@@ -722,7 +718,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             guard_context: vec![],
             push_unsafe_count: 0,
             unpushed_unsafe: safety,
-            breakable_scopes: vec![],
             local_decls: IndexVec::from_elem_n(
                 LocalDecl::new_return_place(return_ty, return_span),
                 1,
@@ -865,7 +860,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
 
         let body = self.hir.mirror(ast_body);
-        self.into(&Place::RETURN_PLACE, block, body)
+        // `return_block` is called when we evaluate a `return` expression, so
+        // we just use `START_BLOCK` here.
+        self.in_breakable_scope(None, START_BLOCK, Place::RETURN_PLACE, |this| {
+            this.into(&Place::RETURN_PLACE, block, body)
+        })
     }
 
     fn get_unit_temp(&mut self) -> Place<'tcx> {

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -806,27 +806,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     /// Utility function for *non*-scope code to build their own drops
-    pub fn build_drop(&mut self,
-                      block: BasicBlock,
-                      span: Span,
-                      location: Place<'tcx>,
-                      ty: Ty<'tcx>) -> BlockAnd<()> {
-        if !self.hir.needs_drop(ty) {
-            return block.unit();
-        }
-        let source_info = self.source_info(span);
-        let next_target = self.cfg.start_new_block();
-        let diverge_target = self.diverge_cleanup();
-        self.cfg.terminate(block, source_info,
-                           TerminatorKind::Drop {
-                               location,
-                               target: next_target,
-                               unwind: Some(diverge_target),
-                           });
-        next_target.unit()
-    }
-
-    /// Utility function for *non*-scope code to build their own drops
     pub fn build_drop_and_replace(&mut self,
                                   block: BasicBlock,
                                   span: Span,

--- a/src/librustc_mir/hair/cx/block.rs
+++ b/src/librustc_mir/hair/cx/block.rs
@@ -49,7 +49,6 @@ fn mirror_stmts<'a, 'tcx>(
     for (index, stmt) in stmts.iter().enumerate() {
         let hir_id = stmt.hir_id;
         let opt_dxn_ext = cx.region_scope_tree.opt_destruction_scope(hir_id.local_id);
-        let stmt_span = StatementSpan(cx.tcx.hir().span(hir_id));
         match stmt.node {
             hir::StmtKind::Expr(ref expr) |
             hir::StmtKind::Semi(ref expr) => {
@@ -62,7 +61,6 @@ fn mirror_stmts<'a, 'tcx>(
                         expr: expr.to_ref(),
                     },
                     opt_destruction_scope: opt_dxn_ext,
-                    span: stmt_span,
                 })))
             }
             hir::StmtKind::Item(..) => {
@@ -107,7 +105,6 @@ fn mirror_stmts<'a, 'tcx>(
                         lint_level: LintLevel::Explicit(local.hir_id),
                     },
                     opt_destruction_scope: opt_dxn_ext,
-                    span: stmt_span,
                 })));
             }
         }

--- a/src/librustc_mir/hair/mod.rs
+++ b/src/librustc_mir/hair/mod.rs
@@ -56,13 +56,9 @@ pub enum StmtRef<'tcx> {
 }
 
 #[derive(Clone, Debug)]
-pub struct StatementSpan(pub Span);
-
-#[derive(Clone, Debug)]
 pub struct Stmt<'tcx> {
     pub kind: StmtKind<'tcx>,
     pub opt_destruction_scope: Option<region::Scope>,
-    pub span: StatementSpan,
 }
 
 #[derive(Clone, Debug)]

--- a/src/test/mir-opt/box_expr.rs
+++ b/src/test/mir-opt/box_expr.rs
@@ -24,7 +24,7 @@ impl Drop for S {
 //     let mut _0: ();
 //     let _1: std::boxed::Box<S>;
 //     let mut _2: std::boxed::Box<S>;
-//     let mut _3: ();
+//     let _3: ();
 //     let mut _4: std::boxed::Box<S>;
 //     scope 1 {
 //     }
@@ -50,6 +50,7 @@ impl Drop for S {
 //
 //     bb4: {
 //         StorageDead(_2);
+//         StorageLive(_3);
 //         StorageLive(_4);
 //         _4 = move _1;
 //         _3 = const std::mem::drop::<std::boxed::Box<S>>(move _4) -> [return: bb5, unwind: bb7];
@@ -69,6 +70,7 @@ impl Drop for S {
 //
 //     bb8: {
 //         StorageDead(_4);
+//         StorageDead(_3);
 //         _0 = ();
 //         drop(_1) -> bb9;
 //     }

--- a/src/test/mir-opt/copy_propagation_arg.rs
+++ b/src/test/mir-opt/copy_propagation_arg.rs
@@ -61,12 +61,14 @@ fn main() {
 // END rustc.foo.CopyPropagation.after.mir
 // START rustc.bar.CopyPropagation.before.mir
 // bb0: {
+//     StorageLive(_2);
 //     StorageLive(_3);
 //     _3 = _1;
 //     _2 = const dummy(move _3) -> bb1;
 // }
 // bb1: {
 //     StorageDead(_3);
+//     StorageDead(_2);
 //     _1 = const 5u8;
 //     ...
 //     return;

--- a/src/test/mir-opt/generator-drop-cleanup.rs
+++ b/src/test/mir-opt/generator-drop-cleanup.rs
@@ -18,6 +18,7 @@ fn main() {
 // }
 // bb1: {
 //     StorageDead(_3);
+//     StorageDead(_2);
 //     goto -> bb5;
 // }
 // bb2: {
@@ -36,6 +37,7 @@ fn main() {
 //     goto -> bb3;
 // }
 // bb7: {
+//     StorageLive(_2);
 //     StorageLive(_3);
 //     goto -> bb1;
 // }

--- a/src/test/mir-opt/generator-storage-dead-unwind.rs
+++ b/src/test/mir-opt/generator-storage-dead-unwind.rs
@@ -54,6 +54,7 @@ fn main() {
 // }
 // bb2: {
 //     ...
+//     StorageLive(_6);
 //     StorageLive(_7);
 //     _7 = move _2;
 //     _6 = const take::<Foo>(move _7) -> [return: bb9, unwind: bb8];
@@ -81,16 +82,20 @@ fn main() {
 // }
 // bb8 (cleanup): {
 //     StorageDead(_7);
+//     StorageDead(_6);
 //     goto -> bb7;
 // }
 // bb9: {
 //     StorageDead(_7);
+//     StorageDead(_6);
+//     StorageLive(_8);
 //     StorageLive(_9);
 //     _9 = move _3;
 //     _8 = const take::<Bar>(move _9) -> [return: bb10, unwind: bb11];
 // }
 // bb10: {
 //     StorageDead(_9);
+//     StorageDead(_8);
 //     ...
 //     StorageDead(_3);
 //     StorageDead(_2);
@@ -98,6 +103,7 @@ fn main() {
 // }
 // bb11 (cleanup): {
 //     StorageDead(_9);
+//     StorageDead(_8);
 //     goto -> bb7;
 // }
 // bb12: {

--- a/src/test/mir-opt/issue-38669.rs
+++ b/src/test/mir-opt/issue-38669.rs
@@ -25,6 +25,7 @@ fn main() {
 //         falseUnwind -> [real: bb3, cleanup: bb1];
 //     }
 //     bb3: {
+//         StorageLive(_3);
 //         StorageLive(_4);
 //         _4 = _1;
 //         FakeRead(ForMatchedPlace, _4);
@@ -34,6 +35,7 @@ fn main() {
 //     bb5: {
 //         _3 = ();
 //         StorageDead(_4);
+//         StorageDead(_3);
 //         _1 = const true;
 //         _2 = ();
 //         goto -> bb2;
@@ -41,6 +43,7 @@ fn main() {
 //     bb6: {
 //         _0 = ();
 //         StorageDead(_4);
+//         StorageDead(_3);
 //         StorageDead(_1);
 //         return;
 //     }

--- a/src/test/mir-opt/issue-41110.rs
+++ b/src/test/mir-opt/issue-41110.rs
@@ -42,7 +42,7 @@ impl S {
 // START rustc.test.ElaborateDrops.after.mir
 //    let mut _0: ();
 //    let _1: S;
-//    let mut _3: ();
+//    let _3: ();
 //    let mut _4: S;
 //    let mut _5: S;
 //    let mut _6: bool;

--- a/src/test/mir-opt/issue-49232.rs
+++ b/src/test/mir-opt/issue-49232.rs
@@ -21,7 +21,7 @@ fn main() {
 //     let _2: i32;
 //     let mut _3: bool;
 //     let mut _4: !;
-//     let mut _5: ();
+//     let _5: ();
 //     let mut _6: &i32;
 //     scope 1 {
 //     }
@@ -73,12 +73,14 @@ fn main() {
 //     bb12: {
 //         FakeRead(ForLet, _2);
 //         StorageDead(_3);
+//         StorageLive(_5);
 //         StorageLive(_6);
 //         _6 = &_2;
 //         _5 = const std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb4];
 //     }
 //     bb13: {
 //         StorageDead(_6);
+//         StorageDead(_5);
 //         _1 = ();
 //         StorageDead(_2);
 //         goto -> bb1;

--- a/src/test/mir-opt/loop_test.rs
+++ b/src/test/mir-opt/loop_test.rs
@@ -25,6 +25,7 @@ fn main() {
 //    bb3: { // Entry into the loop
 //        _1 = ();
 //        StorageDead(_2);
+//        StorageDead(_1);
 //        goto -> bb5;
 //    }
 //    ...

--- a/src/test/mir-opt/match-arm-scopes.rs
+++ b/src/test/mir-opt/match-arm-scopes.rs
@@ -103,10 +103,6 @@ fn main() {
 // bb10: {                              // `else` block - first time
 //     _9 = (*_6);
 //     StorageDead(_10);
-//     FakeRead(ForMatchGuard, _3);
-//     FakeRead(ForMatchGuard, _4);
-//     FakeRead(ForGuardBinding, _6);
-//     FakeRead(ForGuardBinding, _8);
 //     switchInt(move _9) -> [false: bb16, otherwise: bb15];
 // }
 // bb11: {                              // `return 3` - first time
@@ -128,6 +124,10 @@ fn main() {
 // }
 // bb15: {
 //     StorageDead(_9);
+//     FakeRead(ForMatchGuard, _3);
+//     FakeRead(ForMatchGuard, _4);
+//     FakeRead(ForGuardBinding, _6);
+//     FakeRead(ForGuardBinding, _8);
 //     StorageLive(_5);
 //     _5 = (_2.1: bool);
 //     StorageLive(_7);
@@ -159,10 +159,6 @@ fn main() {
 // bb19: {                              // `else` block - second time
 //     _12 = (*_6);
 //     StorageDead(_13);
-//     FakeRead(ForMatchGuard, _3);
-//     FakeRead(ForMatchGuard, _4);
-//     FakeRead(ForGuardBinding, _6);
-//     FakeRead(ForGuardBinding, _8);
 //     switchInt(move _12) -> [false: bb22, otherwise: bb21];
 // }
 // bb20: {
@@ -175,6 +171,10 @@ fn main() {
 // }
 // bb21: {                              // bindings for arm 1
 //     StorageDead(_12);
+//     FakeRead(ForMatchGuard, _3);
+//     FakeRead(ForMatchGuard, _4);
+//     FakeRead(ForGuardBinding, _6);
+//     FakeRead(ForGuardBinding, _8);
 //     StorageLive(_5);
 //     _5 = (_2.0: bool);
 //     StorageLive(_7);

--- a/src/test/mir-opt/match_false_edges.rs
+++ b/src/test/mir-opt/match_false_edges.rs
@@ -71,12 +71,12 @@ fn main() {
 //      _7 = const guard() -> [return: bb7, unwind: bb1];
 //  }
 //  bb7: { // end of guard
-//      FakeRead(ForMatchGuard, _4);
-//      FakeRead(ForGuardBinding, _6);
 //      switchInt(move _7) -> [false: bb9, otherwise: bb8];
 //  }
 //  bb8: { // arm1
 //      StorageDead(_7);
+//      FakeRead(ForMatchGuard, _4);
+//      FakeRead(ForGuardBinding, _6);
 //      StorageLive(_5);
 //      _5 = ((_2 as Some).0: i32);
 //      StorageLive(_8);
@@ -138,12 +138,12 @@ fn main() {
 //      _7 = const guard() -> [return: bb6, unwind: bb1];
 //  }
 //  bb6: { // end of guard
-//      FakeRead(ForMatchGuard, _4);
-//      FakeRead(ForGuardBinding, _6);
 //      switchInt(move _7) -> [false: bb8, otherwise: bb7];
 //  }
 //  bb7: {
 //      StorageDead(_7);
+//      FakeRead(ForMatchGuard, _4);
+//      FakeRead(ForGuardBinding, _6);
 //      StorageLive(_5);
 //      _5 = ((_2 as Some).0: i32);
 //      StorageLive(_8);
@@ -209,12 +209,12 @@ fn main() {
 //      _8 = const guard() -> [return: bb6, unwind: bb1];
 //  }
 //  bb6: { //end of guard1
-//      FakeRead(ForMatchGuard, _5);
-//      FakeRead(ForGuardBinding, _7);
 //      switchInt(move _8) -> [false: bb8, otherwise: bb7];
 //  }
 //  bb7: {
 //      StorageDead(_8);
+//      FakeRead(ForMatchGuard, _5);
+//      FakeRead(ForGuardBinding, _7);
 //      StorageLive(_6);
 //      _6 = ((_2 as Some).0: i32);
 //      _1 = const 1i32;
@@ -245,12 +245,12 @@ fn main() {
 //  }
 //  bb11: { // end of guard2
 //      StorageDead(_13);
-//      FakeRead(ForMatchGuard, _5);
-//      FakeRead(ForGuardBinding, _11);
 //      switchInt(move _12) -> [false: bb13, otherwise: bb12];
 //  }
 //  bb12: { // binding4 & arm4
 //      StorageDead(_12);
+//      FakeRead(ForMatchGuard, _5);
+//      FakeRead(ForGuardBinding, _11);
 //      StorageLive(_10);
 //      _10 = ((_2 as Some).0: i32);
 //      _1 = const 3i32;

--- a/src/test/mir-opt/match_test.rs
+++ b/src/test/mir-opt/match_test.rs
@@ -75,6 +75,7 @@ fn main() {
 //        goto -> bb14;
 //    }
 //    bb14: {
+//        StorageDead(_3);
 //        _0 = ();
 //        StorageDead(_2);
 //        StorageDead(_1);

--- a/src/test/mir-opt/match_test.rs
+++ b/src/test/mir-opt/match_test.rs
@@ -54,11 +54,11 @@ fn main() {
 //        _8 = &shallow _1;
 //        StorageLive(_9);
 //        _9 = _2;
-//        FakeRead(ForMatchGuard, _8);
 //        switchInt(move _9) -> [false: bb11, otherwise: bb10];
 //    }
 //    bb10: {
 //        StorageDead(_9);
+//        FakeRead(ForMatchGuard, _8);
 //        _3 = const 0i32;
 //        goto -> bb14;
 //    }

--- a/src/test/mir-opt/nll/region-subtyping-basic.rs
+++ b/src/test/mir-opt/nll/region-subtyping-basic.rs
@@ -22,9 +22,9 @@ fn main() {
 
 // END RUST SOURCE
 // START rustc.main.nll.0.mir
-// | '_#2r | U0 | {bb2[0..=8], bb3[0], bb5[0..=1]}
-// | '_#3r | U0 | {bb2[1..=8], bb3[0], bb5[0..=1]}
-// | '_#4r | U0 | {bb2[4..=8], bb3[0], bb5[0..=1]}
+// | '_#2r | U0 | {bb2[0..=8], bb3[0], bb5[0..=2]}
+// | '_#3r | U0 | {bb2[1..=8], bb3[0], bb5[0..=2]}
+// | '_#4r | U0 | {bb2[4..=8], bb3[0], bb5[0..=2]}
 // END rustc.main.nll.0.mir
 // START rustc.main.nll.0.mir
 // let _2: &'_#3r usize;

--- a/src/test/mir-opt/remove_fake_borrows.rs
+++ b/src/test/mir-opt/remove_fake_borrows.rs
@@ -38,14 +38,14 @@ fn main() {
 //     _7 = &shallow (*(*((_1 as Some).0: &'<empty> &'<empty> i32)));
 //     StorageLive(_8);
 //     _8 = _2;
-//     FakeRead(ForMatchGuard, _4);
-//     FakeRead(ForMatchGuard, _5);
-//     FakeRead(ForMatchGuard, _6);
-//     FakeRead(ForMatchGuard, _7);
 //     switchInt(move _8) -> [false: bb6, otherwise: bb5];
 // }
 // bb5: {
 //     StorageDead(_8);
+//     FakeRead(ForMatchGuard, _4);
+//     FakeRead(ForMatchGuard, _5);
+//     FakeRead(ForMatchGuard, _6);
+//     FakeRead(ForMatchGuard, _7);
 //     _0 = const 0i32;
 //     goto -> bb7;
 // }
@@ -84,14 +84,14 @@ fn main() {
 //     nop;
 //     StorageLive(_8);
 //     _8 = _2;
-//     nop;
-//     nop;
-//     nop;
-//     nop;
 //     switchInt(move _8) -> [false: bb6, otherwise: bb5];
 // }
 // bb5: {
 //     StorageDead(_8);
+//     nop;
+//     nop;
+//     nop;
+//     nop;
 //     _0 = const 0i32;
 //     goto -> bb7;
 // }

--- a/src/test/mir-opt/storage_ranges.rs
+++ b/src/test/mir-opt/storage_ranges.rs
@@ -12,6 +12,7 @@ fn main() {
 //         StorageLive(_1);
 //         _1 = const 0i32;
 //         FakeRead(ForLet, _1);
+//         StorageLive(_2);
 //         StorageLive(_3);
 //         StorageLive(_4);
 //         StorageLive(_5);
@@ -23,6 +24,7 @@ fn main() {
 //         _2 = ();
 //         StorageDead(_4);
 //         StorageDead(_3);
+//         StorageDead(_2);
 //         StorageLive(_6);
 //         _6 = const 1i32;
 //         FakeRead(ForLet, _6);

--- a/src/test/mir-opt/while-storage.rs
+++ b/src/test/mir-opt/while-storage.rs
@@ -1,0 +1,59 @@
+// Test that we correctly generate StorageDead statements for while loop
+// conditions on all branches
+
+fn get_bool(c: bool) -> bool {
+    c
+}
+
+fn while_loop(c: bool) {
+    while get_bool(c) {
+        if get_bool(c) {
+            break;
+        }
+    }
+}
+
+fn main() {
+    while_loop(false);
+}
+
+// END RUST SOURCE
+
+// START rustc.while_loop.PreCodegen.after.mir
+// bb0: {
+//     StorageLive(_2);
+//     StorageLive(_3);
+//     _3 = _1;
+//     _2 = const get_bool(move _3) -> bb2;
+// }
+// bb1: {
+//     return;
+// }
+// bb2: {
+//     StorageDead(_3);
+//     switchInt(move _2) -> [false: bb4, otherwise: bb3];
+// }
+// bb3: {
+//     StorageDead(_2);
+//     StorageLive(_4);
+//     StorageLive(_5);
+//     _5 = _1;
+//     _4 = const get_bool(move _5) -> bb5;
+// }
+// bb4: {
+//     StorageDead(_2);
+//     goto -> bb1;
+// }
+// bb5: {
+//     StorageDead(_5);
+//     switchInt(_4) -> [false: bb6, otherwise: bb7];
+// }
+// bb6: {
+//     StorageDead(_4);
+//     goto -> bb0;
+// }
+// bb7: {
+//     StorageDead(_4);
+//     goto -> bb1;
+// }
+// END rustc.while_loop.PreCodegen.after.mir

--- a/src/test/ui/generator/issue-61442-stmt-expr-with-drop.rs
+++ b/src/test/ui/generator/issue-61442-stmt-expr-with-drop.rs
@@ -1,0 +1,32 @@
+// Test that we don't consider temporaries for statement expressions as live
+// across yields
+
+// check-pass
+// edition:2018
+
+#![feature(async_await, generators, generator_trait)]
+
+use std::ops::Generator;
+
+async fn drop_and_await() {
+    async {};
+    async {}.await;
+}
+
+fn drop_and_yield() {
+    let x = || {
+        String::new();
+        yield;
+    };
+    Box::pin(x).as_mut().resume();
+    let y = static || {
+        String::new();
+        yield;
+    };
+    Box::pin(y).as_mut().resume();
+}
+
+fn main() {
+    drop_and_await();
+    drop_and_yield();
+}

--- a/src/test/ui/nll/assign-while-to-immutable.rs
+++ b/src/test/ui/nll/assign-while-to-immutable.rs
@@ -1,0 +1,11 @@
+// We used to incorrectly assign to `x` twice when generating MIR for this
+// function, preventing this from compiling.
+
+// check-pass
+
+fn main() {
+    let x = while false {
+        break;
+    };
+    let y = 'l: while break 'l {};
+}


### PR DESCRIPTION
* Don't assign twice to the destination of a `while` loop containing a `break` expression
* Use `as_temp` to evaluate statement expression
* Avoid consecutive `StorageLive`s for the condition of a `while` loop
* Unify `return`, `break` and `continue` handling, and move it to `scopes.rs`
* Make some of the `scopes.rs` internals private
* Don't use `Place`s that are always `Local`s in MIR drop generation

Closes #42371
Closes #61579
Closes #61731
Closes #61834 
Closes #61910
Closes #62115