### PR TITLE
Remove the default type of `Rem::Output`

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -69,7 +69,6 @@
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]
 #![feature(asm)]
-#![feature(associated_type_defaults)]
 #![feature(bound_cloned)]
 #![feature(cfg_target_has_atomic)]
 #![feature(concat_idents)]

--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -508,7 +508,7 @@ div_impl_float! { f32 f64 }
 pub trait Rem<Rhs=Self> {
     /// The resulting type after applying the `%` operator.
     #[stable(feature = "rust1", since = "1.0.0")]
-    type Output = Self;
+    type Output;
 
     /// Performs the `%` operation.
     #[must_use]


### PR DESCRIPTION
Associated type defaults are not yet stable, and `Rem` is the only trait that specifies a default. Let's see what breaks when it's removed.

cc https://github.com/rust-lang/rust/pull/61812#issuecomment-502394566
cc @Centril 

@bors try