### PR TITLE
`non_ascii_idents` lint (part of RFC 2457)

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -30,6 +30,7 @@ mod nonstandard_style;
 pub mod builtin;
 mod types;
 mod unused;
+mod non_ascii_idents;
 
 use rustc::lint;
 use rustc::lint::{EarlyContext, LateContext, LateLintPass, EarlyLintPass, LintPass, LintArray};
@@ -61,6 +62,7 @@ use nonstandard_style::*;
 use builtin::*;
 use types::*;
 use unused::*;
+use non_ascii_idents::*;
 use rustc::lint::internal::*;
 
 /// Useful for other parts of the compiler.
@@ -97,6 +99,7 @@ macro_rules! early_lint_passes {
             NonCamelCaseTypes: NonCamelCaseTypes,
             DeprecatedAttr: DeprecatedAttr::new(),
             WhileTrue: WhileTrue,
+            NonAsciiIdents: NonAsciiIdents,
         ]);
     )
 }

--- a/src/librustc_lint/non_ascii_idents.rs
+++ b/src/librustc_lint/non_ascii_idents.rs
@@ -1,0 +1,22 @@
+use crate::lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use syntax::ast;
+
+declare_lint! {
+    pub NON_ASCII_IDENTS,
+    Allow,
+    "detects non-ASCII identifiers"
+}
+
+declare_lint_pass!(NonAsciiIdents => [NON_ASCII_IDENTS]);
+
+impl EarlyLintPass for NonAsciiIdents {
+    fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: ast::Ident) {
+        if !ident.name.as_str().is_ascii() {
+            cx.struct_span_lint(
+                NON_ASCII_IDENTS,
+                ident.span,
+                "identifier contains non-ASCII characters",
+            ).emit();
+        }
+    }
+}

--- a/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.rs
+++ b/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.rs
@@ -1,0 +1,11 @@
+#![feature(non_ascii_idents)]
+#![deny(non_ascii_idents)]
+
+const חלודה: usize = 2; //~ ERROR identifier contains non-ASCII characters
+
+fn coöperation() {} //~ ERROR identifier contains non-ASCII characters
+
+fn main() {
+    let naïveté = 2; //~ ERROR identifier contains non-ASCII characters
+    println!("{}", naïveté); //~ ERROR identifier contains non-ASCII characters
+}

--- a/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.stderr
+++ b/src/test/ui/lint/rfc-2457-non-ascii-idents/lint-non-ascii-idents.stderr
@@ -1,0 +1,32 @@
+error: identifier contains non-ASCII characters
+  --> $DIR/lint-non-ascii-idents.rs:4:7
+   |
+LL | const חלודה: usize = 2;
+   |       ^^^^^
+   |
+note: lint level defined here
+  --> $DIR/lint-non-ascii-idents.rs:2:9
+   |
+LL | #![deny(non_ascii_idents)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: identifier contains non-ASCII characters
+  --> $DIR/lint-non-ascii-idents.rs:6:4
+   |
+LL | fn coöperation() {}
+   |    ^^^^^^^^^^^
+
+error: identifier contains non-ASCII characters
+  --> $DIR/lint-non-ascii-idents.rs:9:9
+   |
+LL |     let naïveté = 2;
+   |         ^^^^^^^
+
+error: identifier contains non-ASCII characters
+  --> $DIR/lint-non-ascii-idents.rs:10:20
+   |
+LL |     println!("{}", naïveté);
+   |                    ^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
RFC 2457 [declares](https://github.com/rust-lang/rfcs/blob/121bbeff500c3274cea22c7e0ca176274d592646/text/2457-non-ascii-idents.md): "A `non_ascii_idents` lint is added to the compiler. This lint is allow by default."

(Part of #55467.)

r? @Manishearth 