### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -775,6 +775,10 @@ pub fn build_codegen_backend(builder: &Builder<'_>,
                     cargo.env("CFG_LLVM_ROOT", s);
                 }
             }
+            // Some LLVM linker flags (-L and -l) may be needed to link librustc_llvm.
+            if let Some(ref s) = builder.config.llvm_ldflags {
+                cargo.env("LLVM_LINKER_FLAGS", s);
+            }
             // Building with a static libstdc++ is only supported on linux right now,
             // not for MSVC or macOS
             if builder.config.llvm_static_stdcpp &&

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -804,6 +804,7 @@ fn copy_src_dirs(builder: &Builder<'_>, src_dirs: &[&str], exclude_dirs: &[&str]
 
         const LLVM_PROJECTS: &[&str] = &[
             "llvm-project/clang", "llvm-project\\clang",
+            "llvm-project/libunwind", "llvm-project\\libunwind",
             "llvm-project/lld", "llvm-project\\lld",
             "llvm-project/lldb", "llvm-project\\lldb",
             "llvm-project/llvm", "llvm-project\\llvm",

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2707,28 +2707,28 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
     }
 }
 
-/// Turn a `Vec` into a `VecDeque`.
+/// Turn a `Vec<T>` into a `VecDeque<T>`.
 ///
 /// This avoids reallocating where possible, but the conditions for that are
-/// strict, and subject to change, so shouldn't be relied upon unless the
-/// `Vec` came from `From<VecDeque>` has hasn't been reallocated.
+/// strict, and subject to change, and so shouldn't be relied upon unless the
+/// `Vec<T>` came from `From<VecDeque<T>>` has hasn't been reallocated.
 ///
 /// # Examples
 ///
 /// ```
 /// use std::collections::VecDeque;
 ///
-/// // Start with a VecDeque
+/// // Start with a `VecDeque<i32>`.
 /// let deque: VecDeque<_> = (1..5).collect();
 ///
-/// // Turn it into a Vec (no allocation needed)
+/// // Turn it into a `Vec<i32>` with no allocation needed.
 /// let mut vec = Vec::from(deque);
 ///
-/// // modify it, being careful to not trigger reallocation
+/// // Modify it, being careful not to trigger reallocation.
 /// vec.pop();
 /// vec.push(100);
 ///
-/// // Turn it back into a VecDeque (no allocation needed)
+/// // Turn it back into a `VecDeque<i32>` with no allocation needed.
 /// let ptr = vec.as_ptr();
 /// let deque = VecDeque::from(vec);
 /// assert_eq!(deque, [1, 2, 3, 100]);
@@ -2760,7 +2760,7 @@ impl<T> From<Vec<T>> for VecDeque<T> {
     }
 }
 
-/// Turn a `VecDeque` into a `Vec`.
+/// Turn a `VecDeque<T>` into a `Vec<T>`.
 ///
 /// This never needs to re-allocate, but does need to do O(n) data movement if
 /// the circular buffer doesn't happen to be at the beginning of the allocation.
@@ -2770,14 +2770,14 @@ impl<T> From<Vec<T>> for VecDeque<T> {
 /// ```
 /// use std::collections::VecDeque;
 ///
-/// // This one is O(1)
+/// // This one is O(1).
 /// let deque: VecDeque<_> = (1..5).collect();
 /// let ptr = deque.as_slices().0.as_ptr();
 /// let vec = Vec::from(deque);
 /// assert_eq!(vec, [1, 2, 3, 4]);
 /// assert_eq!(vec.as_ptr(), ptr);
 ///
-/// // This one need data rearranging
+/// // This one needs data rearranging.
 /// let mut deque: VecDeque<_> = (1..5).collect();
 /// deque.push_front(9);
 /// deque.push_front(8);

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2714,28 +2714,6 @@ impl<T> From<Vec<T>> for VecDeque<T> {
     /// This avoids reallocating where possible, but the conditions for that are
     /// strict, and subject to change, and so shouldn't be relied upon unless the
     /// `Vec<T>` came from `From<VecDeque<T>>` and hasn't been reallocated.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::collections::VecDeque;
-    ///
-    /// // Start with a `VecDeque<i32>`.
-    /// let deque: VecDeque<_> = (1..5).collect();
-    ///
-    /// // Turn it into a `Vec<i32>` with no allocation needed.
-    /// let mut vec = Vec::from(deque);
-    ///
-    /// // Modify it, being careful not to trigger reallocation.
-    /// vec.pop();
-    /// vec.push(100);
-    ///
-    /// // Turn it back into a `VecDeque<i32>` with no allocation needed.
-    /// let ptr = vec.as_ptr();
-    /// let deque = VecDeque::from(vec);
-    /// assert_eq!(deque, [1, 2, 3, 100]);
-    /// assert_eq!(deque.as_slices().0.as_ptr(), ptr);
-    /// ```
     fn from(mut other: Vec<T>) -> Self {
         unsafe {
             let other_buf = other.as_mut_ptr();

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2713,7 +2713,7 @@ impl<T> From<Vec<T>> for VecDeque<T> {
     ///
     /// This avoids reallocating where possible, but the conditions for that are
     /// strict, and subject to change, and so shouldn't be relied upon unless the
-    /// `Vec<T>` came from `From<VecDeque<T>>` has hasn't been reallocated.
+    /// `Vec<T>` came from `From<VecDeque<T>>` and hasn't been reallocated.
     ///
     /// # Examples
     ///

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2707,35 +2707,35 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
     }
 }
 
-/// Turn a `Vec<T>` into a `VecDeque<T>`.
-///
-/// This avoids reallocating where possible, but the conditions for that are
-/// strict, and subject to change, and so shouldn't be relied upon unless the
-/// `Vec<T>` came from `From<VecDeque<T>>` has hasn't been reallocated.
-///
-/// # Examples
-///
-/// ```
-/// use std::collections::VecDeque;
-///
-/// // Start with a `VecDeque<i32>`.
-/// let deque: VecDeque<_> = (1..5).collect();
-///
-/// // Turn it into a `Vec<i32>` with no allocation needed.
-/// let mut vec = Vec::from(deque);
-///
-/// // Modify it, being careful not to trigger reallocation.
-/// vec.pop();
-/// vec.push(100);
-///
-/// // Turn it back into a `VecDeque<i32>` with no allocation needed.
-/// let ptr = vec.as_ptr();
-/// let deque = VecDeque::from(vec);
-/// assert_eq!(deque, [1, 2, 3, 100]);
-/// assert_eq!(deque.as_slices().0.as_ptr(), ptr);
-/// ```
 #[stable(feature = "vecdeque_vec_conversions", since = "1.10.0")]
 impl<T> From<Vec<T>> for VecDeque<T> {
+    /// Turn a `Vec<T>` into a `VecDeque<T>`.
+    ///
+    /// This avoids reallocating where possible, but the conditions for that are
+    /// strict, and subject to change, and so shouldn't be relied upon unless the
+    /// `Vec<T>` came from `From<VecDeque<T>>` has hasn't been reallocated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::VecDeque;
+    ///
+    /// // Start with a `VecDeque<i32>`.
+    /// let deque: VecDeque<_> = (1..5).collect();
+    ///
+    /// // Turn it into a `Vec<i32>` with no allocation needed.
+    /// let mut vec = Vec::from(deque);
+    ///
+    /// // Modify it, being careful not to trigger reallocation.
+    /// vec.pop();
+    /// vec.push(100);
+    ///
+    /// // Turn it back into a `VecDeque<i32>` with no allocation needed.
+    /// let ptr = vec.as_ptr();
+    /// let deque = VecDeque::from(vec);
+    /// assert_eq!(deque, [1, 2, 3, 100]);
+    /// assert_eq!(deque.as_slices().0.as_ptr(), ptr);
+    /// ```
     fn from(mut other: Vec<T>) -> Self {
         unsafe {
             let other_buf = other.as_mut_ptr();
@@ -2760,34 +2760,34 @@ impl<T> From<Vec<T>> for VecDeque<T> {
     }
 }
 
-/// Turn a `VecDeque<T>` into a `Vec<T>`.
-///
-/// This never needs to re-allocate, but does need to do O(n) data movement if
-/// the circular buffer doesn't happen to be at the beginning of the allocation.
-///
-/// # Examples
-///
-/// ```
-/// use std::collections::VecDeque;
-///
-/// // This one is O(1).
-/// let deque: VecDeque<_> = (1..5).collect();
-/// let ptr = deque.as_slices().0.as_ptr();
-/// let vec = Vec::from(deque);
-/// assert_eq!(vec, [1, 2, 3, 4]);
-/// assert_eq!(vec.as_ptr(), ptr);
-///
-/// // This one needs data rearranging.
-/// let mut deque: VecDeque<_> = (1..5).collect();
-/// deque.push_front(9);
-/// deque.push_front(8);
-/// let ptr = deque.as_slices().1.as_ptr();
-/// let vec = Vec::from(deque);
-/// assert_eq!(vec, [8, 9, 1, 2, 3, 4]);
-/// assert_eq!(vec.as_ptr(), ptr);
-/// ```
 #[stable(feature = "vecdeque_vec_conversions", since = "1.10.0")]
 impl<T> From<VecDeque<T>> for Vec<T> {
+    /// Turn a `VecDeque<T>` into a `Vec<T>`.
+    ///
+    /// This never needs to re-allocate, but does need to do O(n) data movement if
+    /// the circular buffer doesn't happen to be at the beginning of the allocation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::collections::VecDeque;
+    ///
+    /// // This one is O(1).
+    /// let deque: VecDeque<_> = (1..5).collect();
+    /// let ptr = deque.as_slices().0.as_ptr();
+    /// let vec = Vec::from(deque);
+    /// assert_eq!(vec, [1, 2, 3, 4]);
+    /// assert_eq!(vec.as_ptr(), ptr);
+    ///
+    /// // This one needs data rearranging.
+    /// let mut deque: VecDeque<_> = (1..5).collect();
+    /// deque.push_front(9);
+    /// deque.push_front(8);
+    /// let ptr = deque.as_slices().1.as_ptr();
+    /// let vec = Vec::from(deque);
+    /// assert_eq!(vec, [8, 9, 1, 2, 3, 4]);
+    /// assert_eq!(vec.as_ptr(), ptr);
+    /// ```
     fn from(other: VecDeque<T>) -> Self {
         unsafe {
             let buf = other.buf.ptr();

--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2709,7 +2709,7 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
 
 #[stable(feature = "vecdeque_vec_conversions", since = "1.10.0")]
 impl<T> From<Vec<T>> for VecDeque<T> {
-    /// Turn a `Vec<T>` into a `VecDeque<T>`.
+    /// Turn a [`Vec<T>`] into a [`VecDeque<T>`].
     ///
     /// This avoids reallocating where possible, but the conditions for that are
     /// strict, and subject to change, and so shouldn't be relied upon unless the
@@ -2762,7 +2762,7 @@ impl<T> From<Vec<T>> for VecDeque<T> {
 
 #[stable(feature = "vecdeque_vec_conversions", since = "1.10.0")]
 impl<T> From<VecDeque<T>> for Vec<T> {
-    /// Turn a `VecDeque<T>` into a `Vec<T>`.
+    /// Turn a [`VecDeque<T>`] into a [`Vec<T>`].
     ///
     /// This never needs to re-allocate, but does need to do O(n) data movement if
     /// the circular buffer doesn't happen to be at the beginning of the allocation.

--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -307,7 +307,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
             let required_region_bounds = tcx.required_region_bounds(
                 opaque_type,
-                bounds.predicates.clone(),
+                bounds.predicates,
             );
             debug_assert!(!required_region_bounds.is_empty());
 

--- a/src/librustc/middle/liveness.rs
+++ b/src/librustc/middle/liveness.rs
@@ -1617,7 +1617,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
                     self.ir.tcx.lint_hir_note(
                         lint::builtin::UNUSED_VARIABLES,
                         hir_id,
-                        spans.clone(),
+                        spans,
                         &format!("variable `{}` is assigned to, but never used", name),
                         &format!("consider using `_{}` instead", name),
                     );

--- a/src/librustc_borrowck/borrowck/check_loans.rs
+++ b/src/librustc_borrowck/borrowck/check_loans.rs
@@ -36,7 +36,7 @@ fn owned_ptr_base_path<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> &'a LoanPath<
 
     return match helper(loan_path) {
         Some(new_loan_path) => new_loan_path,
-        None => loan_path.clone()
+        None => loan_path,
     };
 
     fn helper<'a, 'tcx>(loan_path: &'a LoanPath<'tcx>) -> Option<&'a LoanPath<'tcx>> {

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -279,7 +279,7 @@ fn fat_lto(cgcx: &CodegenContext<LlvmCodegenBackend>,
             }
         }));
         serialized_modules.extend(cached_modules.into_iter().map(|(buffer, wp)| {
-            (buffer, CString::new(wp.cgu_name.clone()).unwrap())
+            (buffer, CString::new(wp.cgu_name).unwrap())
         }));
 
         // For all serialized bitcode files we parse them and link them in as we did

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -459,7 +459,7 @@ impl CodegenCx<'b, 'tcx> {
         };
         let f = self.declare_cfn(name, fn_ty);
         llvm::SetUnnamedAddr(f, false);
-        self.intrinsics.borrow_mut().insert(name, f.clone());
+        self.intrinsics.borrow_mut().insert(name, f);
         f
     }
 

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -1609,7 +1609,7 @@ impl<'tcx> VariantInfo<'tcx> {
                 // with every variant, make each variant name be just the value
                 // of the discriminant. The struct name for the variant includes
                 // the actual variant description.
-                format!("{}", variant_index.as_usize()).to_string()
+                format!("{}", variant_index.as_usize())
             }
         }
     }

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -194,7 +194,7 @@ impl AnnotateSnippetEmitterWriter {
         let converter = DiagnosticConverter {
             source_map: self.source_map.clone(),
             level: level.clone(),
-            message: message.clone(),
+            message,
             code: code.clone(),
             msp: msp.clone(),
             children,

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -234,6 +234,21 @@ fn main() {
         }
     }
 
+    // Some LLVM linker flags (-L and -l) may be needed even when linking
+    // librustc_llvm, for example when using static libc++, we may need to
+    // manually specify the library search path and -ldl -lpthread as link
+    // dependencies.
+    let llvm_linker_flags = env::var_os("LLVM_LINKER_FLAGS");
+    if let Some(s) = llvm_linker_flags {
+        for lib in s.into_string().unwrap().split_whitespace() {
+            if lib.starts_with("-l") {
+                println!("cargo:rustc-link-lib={}", &lib[2..]);
+            } else if lib.starts_with("-L") {
+                println!("cargo:rustc-link-search=native={}", &lib[2..]);
+            }
+        }
+    }
+
     let llvm_static_stdcpp = env::var_os("LLVM_STATIC_STDCPP");
     let llvm_use_libcxx = env::var_os("LLVM_USE_LIBCXX");
 

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -236,7 +236,7 @@ impl<'a> CrateLoader<'a> {
                 let host_lib = host_lib.unwrap();
                 self.load_derive_macros(
                     &host_lib.metadata.get_root(),
-                    host_lib.dylib.clone().map(|p| p.0),
+                    host_lib.dylib.map(|p| p.0),
                     span
                 )
             } else {

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1737,7 +1737,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 pat_span,
             }))),
         };
-        let for_arm_body = self.local_decls.push(local.clone());
+        let for_arm_body = self.local_decls.push(local);
         let locals = if has_guard.0 {
             let ref_for_guard = self.local_decls.push(LocalDecl::<'tcx> {
                 // This variable isn't mutated but has a name, so has to be

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -922,7 +922,7 @@ fn receiver_is_valid<'fcx, 'tcx>(
         };
 
         let obligation = traits::Obligation::new(
-            cause.clone(),
+            cause,
             fcx.param_env,
             trait_ref.to_predicate()
         );

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -317,7 +317,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         // Ensure that rustdoc works even if rustc is feature-staged
         unstable_features: UnstableFeatures::Allow,
         actually_rustdoc: true,
-        debugging_opts: debugging_options.clone(),
+        debugging_opts: debugging_options,
         error_format,
         edition,
         describe_lints,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -740,7 +740,7 @@ impl Tester for Collector {
         debug!("Creating test {}: {}", name, test);
         self.tests.push(testing::TestDescAndFn {
             desc: testing::TestDesc {
-                name: testing::DynTestName(name.clone()),
+                name: testing::DynTestName(name),
                 ignore: config.ignore,
                 // compiler failures are test failures
                 should_panic: testing::ShouldPanic::No,

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -23,6 +23,7 @@ use log::debug;
 use rustc_data_structures::fx::{FxHashMap};
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
+use std::slice;
 
 use rustc_data_structures::sync::Lrc;
 use errors::Applicability;
@@ -358,10 +359,10 @@ pub fn compile(
 
     // don't abort iteration early, so that errors for multiple lhses can be reported
     for lhs in &lhses {
-        valid &= check_lhs_no_empty_seq(sess, &[lhs.clone()]);
+        valid &= check_lhs_no_empty_seq(sess, slice::from_ref(lhs));
         valid &= check_lhs_duplicate_matcher_bindings(
             sess,
-            &[lhs.clone()],
+            slice::from_ref(lhs),
             &mut FxHashMap::default(),
             def.id
         );

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -557,11 +557,10 @@ declare_features! (
     // Allows the user of associated type bounds.
     (active, associated_type_bounds, "1.34.0", Some(52662), None),
 
-    // Attributes on formal function params
+    // Attributes on formal function params.
     (active, param_attrs, "1.36.0", Some(60406), None),
 
-    // Allows calling constructor functions in `const fn`
-    // FIXME Create issue
+    // Allows calling constructor functions in `const fn`.
     (active, const_constructor, "1.37.0", Some(61456), None),
 
     // #[repr(transparent)] on enums.

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -887,7 +887,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt<'_>,
     };
 
     let fmt_str = &*fmt.node.0.as_str();  // for the suggestions below
-    let mut parser = parse::Parser::new(fmt_str, str_style, skips.clone(), append_newline);
+    let mut parser = parse::Parser::new(fmt_str, str_style, skips, append_newline);
 
     let mut unverified_pieces = Vec::new();
     while let Some(piece) = parser.next() {

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -409,7 +409,7 @@ impl server::TokenStream for Rustc<'_> {
     }
     fn from_str(&mut self, src: &str) -> Self::TokenStream {
         parse::parse_stream_from_source_str(
-            FileName::proc_macro_source_code(src.clone()),
+            FileName::proc_macro_source_code(src),
             src.to_string(),
             self.sess,
             Some(self.call_site),


### PR DESCRIPTION
Successful merges:

 - #61447 (Add some Vec <-> VecDeque documentation)
 - #61704 (Pass LLVM linker flags to librustc_llvm build)
 - #61829 (rustbuild: include llvm-libunwind in dist tarball)
 - #61832 (update miri)
 - #61866 (Remove redundant `clone()`s)
 - #61869 (Cleanup some new active feature gates)

Failed merges:


r? @ghost