### PR TITLE
weird-exprs: if if if if

### DIFF
--- a/src/test/run-pass/weird-exprs.rs
+++ b/src/test/run-pass/weird-exprs.rs
@@ -149,6 +149,14 @@ fn i_yield() {
     };
 }
 
+fn match_nested_if() {
+    let val = match () {
+        () if if if if true {true} else {false} {true} else {false} {true} else {false} => true,
+        _ => false,
+    };
+    assert!(val);
+}
+
 pub fn main() {
     strange();
     funny();
@@ -166,4 +174,5 @@ pub fn main() {
     punch_card();
     r#match();
     i_yield();
+    match_nested_if();
 }


### PR DESCRIPTION
The `if` keyword can be chained as long as there are enough `{...} else {...}` following, and they all return a `bool` (not required for the last one).
`if` expression can be also put inside a `match` arm guard, thus making the whole thing a little bit more confusing.

Discovered this clusterfunk while reading the reference because I have nothing better to do.