### PR TITLE
rustdoc: resolve intra-doc links to builtin macros

### DIFF
--- a/src/test/rustdoc/intra-link-builtin-macros.rs
+++ b/src/test/rustdoc/intra-link-builtin-macros.rs
@@ -1,0 +1,3 @@
+// @has intra_link_builtin_macros/index.html
+// @has - '//a/@href' 'https://doc.rust-lang.org/nightly/std/macro.cfg.html'
+//! [cfg]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/61804

When rustdoc encounters an intra-doc link that resolves to a built-in macro, it attempts to load up the crate's name as it saves the information about the link target. However, this causes an ICE since the built-in macros don't come from a regular crate. This PR attempts to work around this by handling built-in macros separately, similarly to how it handles primitives - by linking to the standard library's documentation, where there are documentation stubs available to link against.