### PR TITLE
Fix hyperlinks in From impls between Vec and VecDeque

### DIFF
--- a/src/liballoc/collections/vec_deque.rs
+++ b/src/liballoc/collections/vec_deque.rs
@@ -2711,6 +2711,9 @@ impl<T: fmt::Debug> fmt::Debug for VecDeque<T> {
 impl<T> From<Vec<T>> for VecDeque<T> {
     /// Turn a [`Vec<T>`] into a [`VecDeque<T>`].
     ///
+    /// [`Vec<T>`]: crate::vec::Vec
+    /// [`VecDeque<T>`]: crate::collections::VecDeque
+    ///
     /// This avoids reallocating where possible, but the conditions for that are
     /// strict, and subject to change, and so shouldn't be relied upon unless the
     /// `Vec<T>` came from `From<VecDeque<T>>` and hasn't been reallocated.
@@ -2741,6 +2744,9 @@ impl<T> From<Vec<T>> for VecDeque<T> {
 #[stable(feature = "vecdeque_vec_conversions", since = "1.10.0")]
 impl<T> From<VecDeque<T>> for Vec<T> {
     /// Turn a [`VecDeque<T>`] into a [`Vec<T>`].
+    ///
+    /// [`Vec<T>`]: crate::vec::Vec
+    /// [`VecDeque<T>`]: crate::collections::VecDeque
     ///
     /// This never needs to re-allocate, but does need to do O(n) data movement if
     /// the circular buffer doesn't happen to be at the beginning of the allocation.


### PR DESCRIPTION
I'd been trying to link them, but apparently actually just added brackets: <https://doc.rust-lang.org/nightly/std/collections/struct.VecDeque.html#impl-From%3CVec%3CT%3E%3E>

~~This reverts commit 5168f5d220d0b30d322f254f51142931a9054056.~~

~~(I'd previously tried to make relative links, but those failed linkcheck because the types are exported at different levels.  So just skip the links -- they're already linked in the function signature anyway.)~~

This makes the links now work.