### PR TITLE
Remove mentions of removed `offset_to` method from `align_offset` docs

### DIFF
--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1534,7 +1534,7 @@ impl<T: ?Sized> *const T {
     /// `usize::max_value()`.
     ///
     /// The offset is expressed in number of `T` elements, and not bytes. The value returned can be
-    /// used with the `offset` or `offset_to` methods.
+    /// used with the `offset` method.
     ///
     /// There are no guarantees whatsover that offsetting the pointer will not overflow or go
     /// beyond the allocation that the pointer points into. It is up to the caller to ensure that
@@ -2335,7 +2335,7 @@ impl<T: ?Sized> *mut T {
     /// `usize::max_value()`.
     ///
     /// The offset is expressed in number of `T` elements, and not bytes. The value returned can be
-    /// used with the `offset` or `offset_to` methods.
+    /// used with the `offset` method.
     ///
     /// There are no guarantees whatsover that offsetting the pointer will not overflow or go
     /// beyond the allocation that the pointer points into. It is up to the caller to ensure that

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1534,7 +1534,7 @@ impl<T: ?Sized> *const T {
     /// `usize::max_value()`.
     ///
     /// The offset is expressed in number of `T` elements, and not bytes. The value returned can be
-    /// used with the `offset` method.
+    /// used with the `add` method.
     ///
     /// There are no guarantees whatsover that offsetting the pointer will not overflow or go
     /// beyond the allocation that the pointer points into. It is up to the caller to ensure that
@@ -2335,7 +2335,7 @@ impl<T: ?Sized> *mut T {
     /// `usize::max_value()`.
     ///
     /// The offset is expressed in number of `T` elements, and not bytes. The value returned can be
-    /// used with the `offset` method.
+    /// used with the `add` method.
     ///
     /// There are no guarantees whatsover that offsetting the pointer will not overflow or go
     /// beyond the allocation that the pointer points into. It is up to the caller to ensure that


### PR DESCRIPTION
The `offset_to` method was deleted in https://github.com/rust-lang/rust/pull/52814.

The replacement for the removed method is `wrapping_offset_from`. However, neither method takes an `usize` as argument, so I don't think that it makes sense to mention them.