### PR TITLE
resolve: Temporarily make `panic` available with `no_implicit_prelude`

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -673,7 +673,8 @@ impl<'a> Resolver<'a> {
                     }
                 }
                 WhereToResolve::MacroUsePrelude => {
-                    if use_prelude || rust_2015 {
+                    // FIXME: Remove `panic` from here once its uses in std/core are hygienized.
+                    if use_prelude || rust_2015 || ident.name.as_str() == "panic" {
                         match self.macro_use_prelude.get(&ident.name).cloned() {
                             Some(binding) =>
                                 Ok((binding, Flags::PRELUDE | Flags::MISC_FROM_PRELUDE)),

--- a/src/test/ui/hygiene/no_implicit_prelude.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude.rs
@@ -13,7 +13,7 @@ mod bar {
     }
     fn f() {
         ::foo::m!();
-        assert_eq!(0, 0); //~ ERROR cannot find macro `panic!` in this scope
+        assert_eq!(0, 0); // OK, the inner `panic` is available due to compiler special casing
     }
 }
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -7,15 +7,6 @@ LL |     fn f() { ::bar::m!(); }
 LL |         Vec::new();
    |         ^^^ use of undeclared type or module `Vec`
 
-error: cannot find macro `panic!` in this scope
-  --> $DIR/no_implicit_prelude.rs:16:9
-   |
-LL |         assert_eq!(0, 0);
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = help: have you added the `#[macro_use]` on the module/import?
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
 error[E0599]: no method named `clone` found for type `()` in the current scope
   --> $DIR/no_implicit_prelude.rs:12:12
    |
@@ -29,7 +20,7 @@ LL |         ().clone()
    = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
            `use std::clone::Clone;`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0433, E0599.
 For more information about an error, try `rustc --explain E0433`.


### PR DESCRIPTION
Until uses of `panic` in the standard library are hygienized somehow (https://github.com/rust-lang/rust/pull/61629).
Closes https://github.com/rust-lang/rust/issues/61567 (which was introduced by migration or `core`/`std` to 2018 edition).

Alternative: Close https://github.com/rust-lang/rust/issues/61567 as wontfix, this PR is a hack and makes `panic` available even if it's not nested in a standard macro, and `no_implicit_prelude` is almost never used in practice, and the proper solution wont' be ready until the release.