### PR TITLE
Switch AppVeyor to the standard Visual Studio 2017 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   # This is required for at least an AArch64 compiler in one image, and is also
   # going to soon be required for compiling LLVM.
-  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017 Preview
+  APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
   # By default schannel checks revocation of certificates unlike some other SSL
   # backends, but we've historically had problems on CI where a revocation


### PR DESCRIPTION
We were previously using the preview image but there doesn't seem to be a reason why, as the commit that originally added it didn't replace the standard image, but just used the preview from the start.

AppVeyor Support recommended switching to the standard image [in this support thread](https://help.appveyor.com/discussions/problems/24057-build-job-has-failed-to-start-but-backup-cloud-is-not-configured#comment_47365011).

r? @alexcrichton 
fixes #61931