### PR TITLE
First question mark in doctest

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -335,11 +335,14 @@ macro_rules! r#try {
 /// ```
 /// use std::io::Write;
 ///
-/// let mut w = Vec::new();
-/// write!(&mut w, "test").unwrap();
-/// write!(&mut w, "formatted {}", "arguments").unwrap();
+/// fn main() -> std::io::Result<()> {
+///     let mut w = Vec::new();
+///     write!(&mut w, "test")?;
+///     write!(&mut w, "formatted {}", "arguments")?;
 ///
-/// assert_eq!(w, b"testformatted arguments");
+///     assert_eq!(w, b"testformatted arguments");
+///     Ok(())
+/// }
 /// ```
 ///
 /// A module can import both `std::fmt::Write` and `std::io::Write` and call `write!` on objects


### PR DESCRIPTION
We have had `?` for `Result`s in doctests for some time, but so far haven't used them in doctests. With this PR, I want to start the de-`unwrap`ping of doctests – and the discussion on where to do so.

There is one downside, which is that the code can no longer be copied into a plain `main()` method, on the other hand, there should be a workable error if one does this.