### PR TITLE
rustc_mir: support type parameters by printing them as `_`.

### DIFF
--- a/src/test/run-pass/issues/issue-61894.rs
+++ b/src/test/run-pass/issues/issue-61894.rs
@@ -1,0 +1,19 @@
+#![feature(core_intrinsics)]
+
+use std::intrinsics::type_name;
+
+struct Bar<M>(M);
+
+impl<M> Bar<M> {
+    fn foo(&self) -> &'static str {
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            unsafe { type_name::<T>() }
+        }
+        type_name_of(f)
+    }
+}
+
+fn main() {
+    assert_eq!(Bar(()).foo(), "issue_61894::Bar<_>::foo::f");
+}


### PR DESCRIPTION
Fixes #61894.
r? @oli-obk