### PR TITLE
[experiment] Introduce a reliable way to refer to the standard library and use it for calling `panic`

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -50,7 +50,12 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
+                    #[cfg(bootstrap)]
                     panic!(r#"assertion failed: `(left == right)`
+  left: `{:?}`,
+ right: `{:?}`"#, &*left_val, &*right_val);
+                    #[cfg(not(bootstrap))]
+                    __rustc_standard_library::panic!(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`"#, &*left_val, &*right_val)
                 }
@@ -67,7 +72,13 @@ macro_rules! assert_eq {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
+                    #[cfg(bootstrap)]
                     panic!(r#"assertion failed: `(left == right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#, &*left_val, &*right_val,
+                           format_args!($($arg)+));
+                    #[cfg(not(bootstrap))]
+                    __rustc_standard_library::panic!(r#"assertion failed: `(left == right)`
   left: `{:?}`,
  right: `{:?}`: {}"#, &*left_val, &*right_val,
                            format_args!($($arg)+))
@@ -107,7 +118,12 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
+                    #[cfg(bootstrap)]
                     panic!(r#"assertion failed: `(left != right)`
+  left: `{:?}`,
+ right: `{:?}`"#, &*left_val, &*right_val);
+                    #[cfg(not(bootstrap))]
+                    __rustc_standard_library::panic!(r#"assertion failed: `(left != right)`
   left: `{:?}`,
  right: `{:?}`"#, &*left_val, &*right_val)
                 }
@@ -124,7 +140,13 @@ macro_rules! assert_ne {
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
+                    #[cfg(bootstrap)]
                     panic!(r#"assertion failed: `(left != right)`
+  left: `{:?}`,
+ right: `{:?}`: {}"#, &*left_val, &*right_val,
+                           format_args!($($arg)+));
+                    #[cfg(not(bootstrap))]
+                    __rustc_standard_library::panic!(r#"assertion failed: `(left != right)`
   left: `{:?}`,
  right: `{:?}`: {}"#, &*left_val, &*right_val,
                            format_args!($($arg)+))
@@ -491,7 +513,10 @@ macro_rules! writeln {
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! unreachable {
     () => ({
-        panic!("internal error: entered unreachable code")
+        #[cfg(bootstrap)]
+        panic!("internal error: entered unreachable code");
+        #[cfg(not(bootstrap))]
+        __rustc_standard_library::panic!("internal error: entered unreachable code")
     });
     ($msg:expr) => ({
         $crate::unreachable!("{}", $msg)
@@ -500,7 +525,12 @@ macro_rules! unreachable {
         $crate::unreachable!($msg)
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        panic!(concat!("internal error: entered unreachable code: ", $fmt), $($arg)*)
+        #[cfg(bootstrap)]
+        panic!(concat!("internal error: entered unreachable code: ", $fmt), $($arg)*);
+        #[cfg(not(bootstrap))]
+        __rustc_standard_library::panic!(
+            concat!("internal error: entered unreachable code: ", $fmt), $($arg)*
+        )
     });
 }
 
@@ -554,6 +584,16 @@ macro_rules! unreachable {
 ///     // we aren't even using baz() yet, so this is fine.
 /// }
 /// ```
+#[cfg(not(bootstrap))]
+#[macro_export]
+#[stable(feature = "rust1", since = "1.0.0")]
+macro_rules! unimplemented {
+    () => (__rustc_standard_library::panic!("not yet implemented"));
+    ($($arg:tt)+) =>
+        (__rustc_standard_library::panic!("not yet implemented: {}", format_args!($($arg)*)));
+}
+/// Bootstrap doc
+#[cfg(bootstrap)]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 macro_rules! unimplemented {
@@ -613,6 +653,16 @@ macro_rules! unimplemented {
 ///     // we aren't even using baz() yet, so this is fine.
 /// }
 /// ```
+#[cfg(not(bootstrap))]
+#[macro_export]
+#[unstable(feature = "todo_macro", issue = "59277")]
+macro_rules! todo {
+    () => (__rustc_standard_library::panic!("not yet implemented"));
+    ($($arg:tt)+) =>
+        (__rustc_standard_library::panic!("not yet implemented: {}", format_args!($($arg)*)));
+}
+/// Bootstrap doc
+#[cfg(bootstrap)]
 #[macro_export]
 #[unstable(feature = "todo_macro", issue = "59277")]
 macro_rules! todo {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3756,6 +3756,12 @@ impl<'a> Resolver<'a> {
                             self.resolve_crate_root(ident)));
                         continue;
                     }
+                    if name == kw::StdLib {
+                        // `__rustc_standard_library::a::b`
+                        module = Some(ModuleOrUniformRoot::Module(
+                            self.injected_crate.unwrap_or(self.graph_root)));
+                        continue;
+                    }
                 }
             }
 

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -8,7 +8,7 @@ use syntax::parse::token::{self, TokenKind};
 use syntax::parse::parser::Parser;
 use syntax::print::pprust;
 use syntax::ptr::P;
-use syntax::symbol::{sym, Symbol};
+use syntax::symbol::{kw, sym, Symbol};
 use syntax::tokenstream::{TokenStream, TokenTree};
 use syntax_pos::{Span, DUMMY_SP};
 
@@ -27,7 +27,13 @@ pub fn expand_assert<'cx>(
 
     let sp = sp.apply_mark(cx.current_expansion.mark);
     let panic_call = Mac_ {
-        path: Path::from_ident(Ident::new(sym::panic, sp)),
+        path: Path {
+            segments: vec![
+                PathSegment::from_ident(Ident::new(kw::StdLib, sp)),
+                PathSegment::from_ident(Ident::new(sym::panic, sp)),
+            ],
+            span: sp,
+        },
         tts: custom_message.unwrap_or_else(|| {
             TokenStream::from(TokenTree::token(
                 TokenKind::lit(token::Str, Symbol::intern(&format!(

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -27,6 +27,7 @@ symbols! {
         PathRoot:           "{{root}}",
         DollarCrate:        "$crate",
         Underscore:         "_",
+        StdLib:             "__rustc_standard_library",
 
         // Keywords that are used in stable Rust.
         As:                 "as",
@@ -1043,7 +1044,8 @@ impl Symbol {
         self == kw::SelfUpper ||
         self == kw::Crate ||
         self == kw::PathRoot ||
-        self == kw::DollarCrate
+        self == kw::DollarCrate ||
+        self == kw::StdLib
     }
 
     /// This symbol can be a raw identifier.

--- a/src/test/ui/hygiene/no_implicit_prelude.rs
+++ b/src/test/ui/hygiene/no_implicit_prelude.rs
@@ -13,7 +13,8 @@ mod bar {
     }
     fn f() {
         ::foo::m!();
-        assert_eq!(0, 0); //~ ERROR cannot find macro `panic!` in this scope
+        assert!(true); // OK
+        assert_eq!(0, 0); // OK
     }
 }
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -7,15 +7,6 @@ LL |     fn f() { ::bar::m!(); }
 LL |         Vec::new();
    |         ^^^ use of undeclared type or module `Vec`
 
-error: cannot find macro `panic!` in this scope
-  --> $DIR/no_implicit_prelude.rs:16:9
-   |
-LL |         assert_eq!(0, 0);
-   |         ^^^^^^^^^^^^^^^^^
-   |
-   = help: have you added the `#[macro_use]` on the module/import?
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
 error[E0599]: no method named `clone` found for type `()` in the current scope
   --> $DIR/no_implicit_prelude.rs:12:12
    |
@@ -29,7 +20,7 @@ LL |         ().clone()
    = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
            `use std::clone::Clone;`
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0433, E0599.
 For more information about an error, try `rustc --explain E0433`.


### PR DESCRIPTION
The second part of https://github.com/rust-lang/rust/pull/61629.

- A new reserved identifier `__rustc_standard_library` is introduced (it can be further uglified as much as necessary, but it must be a valid identifier).
- `__rustc_standard_library` refers to the standard library crate when used in a path.
- "Standard library" means libstd or libcore depending on `#![no_std]` settings, regardless of shadowing or renaming.

This PR is minimal, but `__rustc_standard_library` could also be used for std paths like `std::option::Option` in built-in derives, which currently use a special compiler hack (`$crate` in built-in macros specifically is re-routed to the standard library).
Unlike `$crate` re-routing, this PR's approach feels like a "proper" solution to the problem to me, the only downside is an introduction of a niche keyword.

TODO: Feature gating.