### PR TITLE
publish_toolstate: don't use 'new' from inside the loop

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -167,9 +167,9 @@ def update_latest(
                 except IOError as e:
                     # network errors will simply end up not creating an issue, but that's better
                     # than failing the entire build job
-                    print("I/O error: {0}".format(e))
+                    print("I/O error when creating issue for status regression: {0}".format(e))
                 except:
-                    print("Unexpected error: {0}".format(sys.exc_info()[0]))
+                    print("Unexpected error when creating issue for status regression: {0}".format(sys.exc_info()[0]))
                     raise
 
             if changed:

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -166,9 +166,11 @@ def update_latest(
                         tool, create_issue_for_status, MAINTAINERS.get(tool, ''),
                         relevant_pr_number, relevant_pr_user, pr_reviewer,
                     )
-                except IOError as e:
+                except urllib2.HTTPError as e:
                     # network errors will simply end up not creating an issue, but that's better
                     # than failing the entire build job
+                    print("HTTPError when creating issue for status regression: {0}\n{1}".format(e, e.read()))
+                except IOError as e:
                     print("I/O error when creating issue for status regression: {0}".format(e))
                 except:
                     print("Unexpected error when creating issue for status regression: {0}"

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -72,7 +72,6 @@ def issue(
 ):
     # Open an issue about the toolstate failure.
     assignees = [x.strip() for x in maintainers.split('@') if x != '']
-    assignees.append(relevant_pr_user)
     if status == 'test-fail':
         status_description = 'has failing tests'
     else:

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -135,13 +135,13 @@ def update_latest(
         for status in latest:
             tool = status['tool']
             changed = False
-            create_issue = False
+            create_issue_for_status = None # set to the status that caused the issue
 
             for os, s in current_status.items():
                 old = status[os]
                 new = s.get(tool, old)
                 status[os] = new
-                if new > old:
+                if new > old: # comparing the strings, but they are ordered appropriately!
                     # things got fixed or at least the status quo improved
                     changed = True
                     message += '🎉 {} on {}: {} → {} (cc {}, @rust-lang/infra).\n' \
@@ -156,12 +156,12 @@ def update_latest(
                     # Most tools only create issues for build failures.
                     # Other failures can be spurious.
                     if new == 'build-fail' or (tool == 'miri' and new == 'test-fail'):
-                        create_issue = True
+                        create_issue_for_status = new
 
-            if create_issue:
+            if create_issue_for_status is not None:
                 try:
                     issue(
-                        tool, new, MAINTAINERS.get(tool, ''),
+                        tool, create_issue_for_status, MAINTAINERS.get(tool, ''),
                         relevant_pr_number, relevant_pr_user, pr_reviewer,
                     )
                 except IOError as e:

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -171,7 +171,8 @@ def update_latest(
                     # than failing the entire build job
                     print("I/O error when creating issue for status regression: {0}".format(e))
                 except:
-                    print("Unexpected error when creating issue for status regression: {0}".format(sys.exc_info()[0]))
+                    print("Unexpected error when creating issue for status regression: {0}"
+                          .format(sys.exc_info()[0]))
                     raise
 
             if changed:

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -168,7 +168,8 @@ def update_latest(
                 except urllib2.HTTPError as e:
                     # network errors will simply end up not creating an issue, but that's better
                     # than failing the entire build job
-                    print("HTTPError when creating issue for status regression: {0}\n{1}".format(e, e.read()))
+                    print("HTTPError when creating issue for status regression: {0}\n{1}"
+                          .format(e, e.read()))
                 except IOError as e:
                     print("I/O error when creating issue for status regression: {0}".format(e))
                 except:


### PR DESCRIPTION
I think I made a mistake in https://github.com/rust-lang/rust/pull/61938 by using `new` outside the inner loop. This PR fixes that.

However, no issue got created at all for https://github.com/rust-lang/rust/pull/62003#issuecomment-504356964, and I don't know why that is.   The script should be [triggered by Traivs](https://github.com/rust-lang/rust/blob/56a12b2ad058f22f1ef090713df15598525ba4a4/.travis.yml#L240), and I can find no trace of that in [the build log](https://travis-ci.com/rust-lang/rust/jobs/209880042).