### PR TITLE
Make dep node indices persistent between sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3802,6 +3802,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_fs_util",
  "rustc_hir",
+ "rustc_query_system",
  "rustc_session",
  "rustc_span",
  "serialize",

--- a/src/librustc/dep_graph/mod.rs
+++ b/src/librustc/dep_graph/mod.rs
@@ -11,8 +11,8 @@ mod dep_node;
 
 pub(crate) use rustc_query_system::dep_graph::DepNodeParams;
 pub use rustc_query_system::dep_graph::{
-    debug, hash_result, DepContext, DepNodeColor, DepNodeIndex, SerializedDepNodeIndex,
-    WorkProduct, WorkProductFileKind, WorkProductId,
+    debug, hash_result, DepContext, DepNodeColor, DepNodeIndex, WorkProduct, WorkProductFileKind,
+    WorkProductId,
 };
 
 pub use dep_node::{label_strs, DepConstructor, DepKind, DepNode, DepNodeExt};
@@ -159,8 +159,8 @@ impl<'tcx> DepContext for TyCtxt<'tcx> {
         try_load_from_on_disk_cache(*self, dep_node)
     }
 
-    fn load_diagnostics(&self, prev_dep_node_index: SerializedDepNodeIndex) -> Vec<Diagnostic> {
-        self.queries.on_disk_cache.load_diagnostics(*self, prev_dep_node_index)
+    fn load_diagnostics(&self, dep_node_index: DepNodeIndex) -> Vec<Diagnostic> {
+        self.queries.on_disk_cache.load_diagnostics(*self, dep_node_index)
     }
 
     fn store_diagnostics(&self, dep_node_index: DepNodeIndex, diagnostics: ThinVec<Diagnostic>) {

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -1,4 +1,4 @@
-use crate::dep_graph::SerializedDepNodeIndex;
+use crate::dep_graph::DepNodeIndex;
 use crate::mir;
 use crate::mir::interpret::{GlobalId, LitToConstInput};
 use crate::traits;

--- a/src/librustc_incremental/Cargo.toml
+++ b/src/librustc_incremental/Cargo.toml
@@ -21,3 +21,4 @@ rustc_ast = { path = "../librustc_ast" }
 rustc_span = { path = "../librustc_span" }
 rustc_fs_util = { path = "../librustc_fs_util" }
 rustc_session = { path = "../librustc_session" }
+rustc_query_system = { path = "../librustc_query_system" }

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -191,16 +191,15 @@ impl<'tcx> Queries<'tcx> {
             Ok(match self.dep_graph_future()?.take() {
                 None => DepGraph::new_disabled(),
                 Some(future) => {
-                    let (prev_graph, prev_work_products) =
-                        self.session().time("blocked_on_dep_graph_loading", || {
-                            future
-                                .open()
-                                .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
-                                    message: format!("could not decode incremental cache: {:?}", e),
-                                })
-                                .open(self.session())
-                        });
-                    DepGraph::new(prev_graph, prev_work_products)
+                    let args = self.session().time("blocked_on_dep_graph_loading", || {
+                        future
+                            .open()
+                            .unwrap_or_else(|e| rustc_incremental::LoadResult::Error {
+                                message: format!("could not decode incremental cache: {:?}", e),
+                            })
+                            .open(self.session())
+                    });
+                    DepGraph::new(args)
                 }
             })
         })

--- a/src/librustc_macros/src/query.rs
+++ b/src/librustc_macros/src/query.rs
@@ -324,7 +324,7 @@ fn add_query_description_impl(
                 #[inline]
                 fn try_load_from_disk(
                     #tcx: TyCtxt<'tcx>,
-                    #id: SerializedDepNodeIndex
+                    #id: DepNodeIndex
                 ) -> Option<Self::Value> {
                     #block
                 }
@@ -335,7 +335,7 @@ fn add_query_description_impl(
                 #[inline]
                 fn try_load_from_disk(
                     tcx: TyCtxt<'tcx>,
-                    id: SerializedDepNodeIndex
+                    id: DepNodeIndex
                 ) -> Option<Self::Value> {
                     tcx.queries.on_disk_cache.try_load_query_result(tcx, id)
                 }

--- a/src/librustc_query_system/dep_graph/prev.rs
+++ b/src/librustc_query_system/dep_graph/prev.rs
@@ -1,47 +1,73 @@
-use super::serialized::{SerializedDepGraph, SerializedDepNodeIndex};
-use super::{DepKind, DepNode};
+use super::serialized::SerializedDepGraph;
+use super::{DepKind, DepNode, DepNodeIndex, DepNodeState};
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::sync::AtomicCell;
+use rustc_index::vec::IndexVec;
 
-#[derive(Debug, RustcEncodable, RustcDecodable)]
+#[derive(Debug)]
 pub struct PreviousDepGraph<K: DepKind> {
-    data: SerializedDepGraph<K>,
-    index: FxHashMap<DepNode<K>, SerializedDepNodeIndex>,
+    pub(super) data: SerializedDepGraph<K>,
+    pub(super) index: FxHashMap<DepNode<K>, DepNodeIndex>,
+    pub(super) unused: Vec<DepNodeIndex>,
 }
 
 impl<K: DepKind> Default for PreviousDepGraph<K> {
     fn default() -> Self {
-        PreviousDepGraph { data: Default::default(), index: Default::default() }
+        Self { data: Default::default(), index: Default::default(), unused: Default::default() }
     }
 }
 
 impl<K: DepKind> PreviousDepGraph<K> {
-    pub fn new(data: SerializedDepGraph<K>) -> PreviousDepGraph<K> {
+    pub fn new_and_state(
+        data: SerializedDepGraph<K>,
+    ) -> (Self, IndexVec<DepNodeIndex, AtomicCell<DepNodeState>>) {
+        let mut unused = Vec::new();
+
+        let state: IndexVec<_, _> = data
+            .nodes
+            .iter_enumerated()
+            .map(|(index, node)| {
+                if node.kind == DepKind::NULL {
+                    // There might be `DepKind::NULL` nodes due to thread-local dep node indices
+                    // that didn't get assigned anything.
+                    // We also changed outdated nodes to `DepKind::NULL`.
+                    unused.push(index);
+                    AtomicCell::new(DepNodeState::Invalid)
+                } else {
+                    AtomicCell::new(DepNodeState::Unknown)
+                }
+            })
+            .collect();
+
         let index: FxHashMap<_, _> =
-            data.nodes.iter_enumerated().map(|(idx, &dep_node)| (dep_node, idx)).collect();
-        PreviousDepGraph { data, index }
+            data.nodes
+                .iter_enumerated()
+                .filter_map(|(idx, &dep_node)| {
+                    if dep_node.kind == DepKind::NULL { None } else { Some((dep_node, idx)) }
+                })
+                .collect();
+
+        (PreviousDepGraph { data, index, unused }, state)
     }
 
     #[inline]
-    pub fn edge_targets_from(
-        &self,
-        dep_node_index: SerializedDepNodeIndex,
-    ) -> &[SerializedDepNodeIndex] {
+    pub fn edge_targets_from(&self, dep_node_index: DepNodeIndex) -> &[DepNodeIndex] {
         self.data.edge_targets_from(dep_node_index)
     }
 
     #[inline]
-    pub fn index_to_node(&self, dep_node_index: SerializedDepNodeIndex) -> DepNode<K> {
+    pub fn index_to_node(&self, dep_node_index: DepNodeIndex) -> DepNode<K> {
         self.data.nodes[dep_node_index]
     }
 
     #[inline]
-    pub fn node_to_index(&self, dep_node: &DepNode<K>) -> SerializedDepNodeIndex {
+    pub fn node_to_index(&self, dep_node: &DepNode<K>) -> DepNodeIndex {
         self.index[dep_node]
     }
 
     #[inline]
-    pub fn node_to_index_opt(&self, dep_node: &DepNode<K>) -> Option<SerializedDepNodeIndex> {
+    pub fn node_to_index_opt(&self, dep_node: &DepNode<K>) -> Option<DepNodeIndex> {
         self.index.get(dep_node).cloned()
     }
 
@@ -51,11 +77,11 @@ impl<K: DepKind> PreviousDepGraph<K> {
     }
 
     #[inline]
-    pub fn fingerprint_by_index(&self, dep_node_index: SerializedDepNodeIndex) -> Fingerprint {
+    pub fn fingerprint_by_index(&self, dep_node_index: DepNodeIndex) -> Fingerprint {
         self.data.fingerprints[dep_node_index]
     }
 
     pub fn node_count(&self) -> usize {
-        self.index.len()
+        self.data.nodes.len()
     }
 }

--- a/src/librustc_query_system/dep_graph/serialized.rs
+++ b/src/librustc_query_system/dep_graph/serialized.rs
@@ -1,28 +1,24 @@
 //! The data that we will serialize and deserialize.
 
-use super::{DepKind, DepNode};
+use super::{DepKind, DepNode, DepNodeIndex};
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_index::vec::IndexVec;
-
-rustc_index::newtype_index! {
-    pub struct SerializedDepNodeIndex { .. }
-}
 
 /// Data for use when recompiling the **current crate**.
 #[derive(Debug, RustcEncodable, RustcDecodable)]
 pub struct SerializedDepGraph<K: DepKind> {
     /// The set of all DepNodes in the graph
-    pub nodes: IndexVec<SerializedDepNodeIndex, DepNode<K>>,
+    pub nodes: IndexVec<DepNodeIndex, DepNode<K>>,
     /// The set of all Fingerprints in the graph. Each Fingerprint corresponds to
     /// the DepNode at the same index in the nodes vector.
-    pub fingerprints: IndexVec<SerializedDepNodeIndex, Fingerprint>,
+    pub fingerprints: IndexVec<DepNodeIndex, Fingerprint>,
     /// For each DepNode, stores the list of edges originating from that
     /// DepNode. Encoded as a [start, end) pair indexing into edge_list_data,
     /// which holds the actual DepNodeIndices of the target nodes.
-    pub edge_list_indices: IndexVec<SerializedDepNodeIndex, (u32, u32)>,
+    pub edge_list_indices: IndexVec<DepNodeIndex, (u32, u32)>,
     /// A flattened list of all edge targets in the graph. Edge sources are
     /// implicit in edge_list_indices.
-    pub edge_list_data: Vec<SerializedDepNodeIndex>,
+    pub edge_list_data: Vec<DepNodeIndex>,
 }
 
 impl<K: DepKind> Default for SerializedDepGraph<K> {
@@ -38,7 +34,7 @@ impl<K: DepKind> Default for SerializedDepGraph<K> {
 
 impl<K: DepKind> SerializedDepGraph<K> {
     #[inline]
-    pub fn edge_targets_from(&self, source: SerializedDepNodeIndex) -> &[SerializedDepNodeIndex] {
+    pub fn edge_targets_from(&self, source: DepNodeIndex) -> &[DepNodeIndex] {
         let targets = self.edge_list_indices[source];
         &self.edge_list_data[targets.0 as usize..targets.1 as usize]
     }

--- a/src/librustc_query_system/query/config.rs
+++ b/src/librustc_query_system/query/config.rs
@@ -1,7 +1,7 @@
 //! Query configuration and description traits.
 
 use crate::dep_graph::DepNode;
-use crate::dep_graph::SerializedDepNodeIndex;
+use crate::dep_graph::DepNodeIndex;
 use crate::query::caches::QueryCache;
 use crate::query::plumbing::CycleError;
 use crate::query::{QueryContext, QueryState};
@@ -54,7 +54,7 @@ pub trait QueryDescription<CTX: QueryContext>: QueryAccessors<CTX> {
         false
     }
 
-    fn try_load_from_disk(_: CTX, _: SerializedDepNodeIndex) -> Option<Self::Value> {
+    fn try_load_from_disk(_: CTX, _: DepNodeIndex) -> Option<Self::Value> {
         panic!("QueryDescription::load_from_disk() called for an unsupported query.")
     }
 }
@@ -76,7 +76,7 @@ where
         false
     }
 
-    default fn try_load_from_disk(_: CTX, _: SerializedDepNodeIndex) -> Option<Self::Value> {
+    default fn try_load_from_disk(_: CTX, _: DepNodeIndex) -> Option<Self::Value> {
         panic!("QueryDescription::load_from_disk() called for an unsupported query.")
     }
 }


### PR DESCRIPTION
This makes marking dep nodes green faster (and lock free in the case with no diagnostics). This change is split out from https://github.com/rust-lang/rust/pull/60035.

Unlike https://github.com/rust-lang/rust/pull/60035 this makes loading the dep graph slower because it loads 2 copies of the dep graph, one immutable and one mutable.

Based on https://github.com/rust-lang/rust/pull/61845.