### PR TITLE
Add suggestion for missing `.await` keyword

### DIFF
--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -25,6 +25,7 @@ use crate::task::{Context, Poll};
 #[doc(spotlight)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[stable(feature = "futures_api", since = "1.36.0")]
+#[cfg_attr(not(bootstrap), lang = "future_trait")]
 pub trait Future {
     /// The type of value produced on completion.
     #[stable(feature = "futures_api", since = "1.36.0")]

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -320,6 +320,7 @@ language_item_table! {
     FnMutTraitLangItem,          "fn_mut",             fn_mut_trait,            Target::Trait;
     FnOnceTraitLangItem,         "fn_once",            fn_once_trait,           Target::Trait;
 
+    FutureTraitLangItem,         "future_trait",       future_trait,            Target::Trait;
     GeneratorStateLangItem,      "generator_state",    gen_state,               Target::Enum;
     GeneratorTraitLangItem,      "generator",          gen_trait,               Target::Trait;
     UnpinTraitLangItem,          "unpin",              unpin_trait,             Target::Trait;

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -127,6 +127,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         self.suggest_compatible_variants(&mut err, expr, expected, expr_ty);
         self.suggest_ref_or_into(&mut err, expr, expected, expr_ty);
+        self.suggest_missing_await(&mut err, expr, expected, expr_ty);
 
         (expected, Some(err))
     }

--- a/src/test/ui/async-await/dont-suggest-missing-await.rs
+++ b/src/test/ui/async-await/dont-suggest-missing-await.rs
@@ -1,0 +1,21 @@
+// edition:2018
+
+// This test ensures we don't make the suggestion in bodies that aren't `async`.
+
+#![feature(async_await)]
+
+fn take_u32(x: u32) {}
+
+async fn make_u32() -> u32 {
+    22
+}
+
+async fn dont_suggest_await_in_closure() {
+    || {
+        let x = make_u32();
+        take_u32(x)
+        //~^ ERROR mismatched types [E0308]
+    };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/dont-suggest-missing-await.stderr
+++ b/src/test/ui/async-await/dont-suggest-missing-await.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/dont-suggest-missing-await.rs:16:18
+   |
+LL |         take_u32(x)
+   |                  ^ expected u32, found opaque type
+   |
+   = note: expected type `u32`
+              found type `impl std::future::Future`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/async-await/suggest-missing-await.fixed
+++ b/src/test/ui/async-await/suggest-missing-await.fixed
@@ -1,0 +1,32 @@
+// edition:2018
+// run-rustfix
+
+#![feature(async_await)]
+
+fn take_u32(_x: u32) {}
+
+async fn make_u32() -> u32 {
+    22
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_fn() {
+    let x = make_u32();
+    take_u32(x.await)
+    //~^ ERROR mismatched types [E0308]
+    //~| HELP consider using `.await` here
+    //~| SUGGESTION x.await
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_closure() {
+    async || {
+        let x = make_u32();
+        take_u32(x.await)
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP consider using `.await` here
+        //~| SUGGESTION x.await
+    };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await.rs
+++ b/src/test/ui/async-await/suggest-missing-await.rs
@@ -1,0 +1,32 @@
+// edition:2018
+// run-rustfix
+
+#![feature(async_await)]
+
+fn take_u32(_x: u32) {}
+
+async fn make_u32() -> u32 {
+    22
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_fn() {
+    let x = make_u32();
+    take_u32(x)
+    //~^ ERROR mismatched types [E0308]
+    //~| HELP consider using `.await` here
+    //~| SUGGESTION x.await
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_closure() {
+    async || {
+        let x = make_u32();
+        take_u32(x)
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP consider using `.await` here
+        //~| SUGGESTION x.await
+    };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -1,0 +1,27 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await.rs:15:14
+   |
+LL |     take_u32(x)
+   |              ^
+   |              |
+   |              expected u32, found opaque type
+   |              help: consider using `.await` here: `x.await`
+   |
+   = note: expected type `u32`
+              found type `impl std::future::Future`
+
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await.rs:25:18
+   |
+LL |         take_u32(x)
+   |                  ^
+   |                  |
+   |                  expected u32, found opaque type
+   |                  help: consider using `.await` here: `x.await`
+   |
+   = note: expected type `u32`
+              found type `impl std::future::Future`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This commit adds a suggestion diagnostic for missing `.await`. In order to do this, the trait `Future` is promoted to a lang item.

Compiling code of the form:

```rust
#![feature(async_await)]

fn take_u32(x: u32) {}

async fn make_u32() -> u32 {
    22
}

async fn foo() {
    let x = make_u32();
    take_u32(x)
}

fn main() {}
```

Will now result in the suggestion:

```
error[E0308]: mismatched types
  --> src/main.rs:11:18
   |
11 |         take_u32(x)
   |                  ^
   |                  |
   |                  expected u32, found opaque type
   |                  help: consider using `.await` here: `x.await`
   |
   = note: expected type `u32`
              found type `impl std::future::Future`
```

This commit does not cover chained expressions and therefore only covers the case originally pointed out in #61076. Cases I can think of that still need to be covered:

- [ ] Return places for functions
- [ ] Field access
- [ ] Method invocation

I'm planning to submit PRs for each of these separately as and when I have figured them out.