### PR TITLE
Remove built-in derive macros `Send` and `Sync`

### DIFF
--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -1022,6 +1022,12 @@ impl<'a> Resolver<'a> {
 
     fn suggest_macro_name(&mut self, name: Symbol, kind: MacroKind,
                           err: &mut DiagnosticBuilder<'a>, span: Span) {
+        if kind == MacroKind::Derive && (name.as_str() == "Send" || name.as_str() == "Sync") {
+            let msg = format!("unsafe traits like `{}` should be implemented explicitly", name);
+            err.span_note(span, &msg);
+            return;
+        }
+
         // First check if this is a locally-defined bang macro.
         let suggestion = if let MacroKind::Bang = kind {
             find_best_match_for_name(

--- a/src/libsyntax_ext/deriving/bounds.rs
+++ b/src/libsyntax_ext/deriving/bounds.rs
@@ -6,14 +6,6 @@ use syntax::ast::MetaItem;
 use syntax::ext::base::{Annotatable, ExtCtxt};
 use syntax_pos::Span;
 
-pub fn expand_deriving_unsafe_bound(cx: &mut ExtCtxt<'_>,
-                                    span: Span,
-                                    _: &MetaItem,
-                                    _: &Annotatable,
-                                    _: &mut dyn FnMut(Annotatable)) {
-    cx.span_err(span, "this unsafe trait should be implemented explicitly");
-}
-
 pub fn expand_deriving_copy(cx: &mut ExtCtxt<'_>,
                             span: Span,
                             mitem: &MetaItem,

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -111,8 +111,6 @@ derive_traits! {
 
     "Default" => default::expand_deriving_default,
 
-    "Send" => bounds::expand_deriving_unsafe_bound,
-    "Sync" => bounds::expand_deriving_unsafe_bound,
     "Copy" => bounds::expand_deriving_copy,
 
     // deprecated

--- a/src/test/ui/derives/deriving-bounds.rs
+++ b/src/test/ui/derives/deriving-bounds.rs
@@ -1,9 +1,9 @@
 #[derive(Send)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+//~^ ERROR cannot find derive macro `Send` in this scope
 struct Test;
 
 #[derive(Sync)]
-//~^ ERROR this unsafe trait should be implemented explicitly
+//~^ ERROR cannot find derive macro `Sync` in this scope
 struct Test1;
 
 pub fn main() {}

--- a/src/test/ui/derives/deriving-bounds.stderr
+++ b/src/test/ui/derives/deriving-bounds.stderr
@@ -1,10 +1,22 @@
-error: this unsafe trait should be implemented explicitly
+error: cannot find derive macro `Send` in this scope
+  --> $DIR/deriving-bounds.rs:1:10
+   |
+LL | #[derive(Send)]
+   |          ^^^^
+   |
+note: unsafe traits like `Send` should be implemented explicitly
   --> $DIR/deriving-bounds.rs:1:10
    |
 LL | #[derive(Send)]
    |          ^^^^
 
-error: this unsafe trait should be implemented explicitly
+error: cannot find derive macro `Sync` in this scope
+  --> $DIR/deriving-bounds.rs:5:10
+   |
+LL | #[derive(Sync)]
+   |          ^^^^
+   |
+note: unsafe traits like `Sync` should be implemented explicitly
   --> $DIR/deriving-bounds.rs:5:10
    |
 LL | #[derive(Sync)]

--- a/src/test/ui/issues/issue-33571.rs
+++ b/src/test/ui/issues/issue-33571.rs
@@ -1,5 +1,5 @@
 #[derive(Clone,
-         Sync, //~ ERROR this unsafe trait should be implemented explicitly
+         Sync, //~ ERROR cannot find derive macro `Sync` in this scope
          Copy)]
 enum Foo {}
 

--- a/src/test/ui/issues/issue-33571.stderr
+++ b/src/test/ui/issues/issue-33571.stderr
@@ -1,4 +1,10 @@
-error: this unsafe trait should be implemented explicitly
+error: cannot find derive macro `Sync` in this scope
+  --> $DIR/issue-33571.rs:2:10
+   |
+LL |          Sync,
+   |          ^^^^
+   |
+note: unsafe traits like `Sync` should be implemented explicitly
   --> $DIR/issue-33571.rs:2:10
    |
 LL |          Sync,


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/62050