### PR TITLE
Always inline arithmetic operators

### DIFF
--- a/src/libcore/ops/arith.rs
+++ b/src/libcore/ops/arith.rs
@@ -95,8 +95,8 @@ macro_rules! add_impl {
         impl Add for $t {
             type Output = $t;
 
-            #[inline]
             #[rustc_inherit_overflow_checks]
+            #[inline(always)]
             fn add(self, other: $t) -> $t { self + other }
         }
 
@@ -193,7 +193,7 @@ macro_rules! sub_impl {
         impl Sub for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn sub(self, other: $t) -> $t { self - other }
         }
@@ -313,7 +313,7 @@ macro_rules! mul_impl {
         impl Mul for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn mul(self, other: $t) -> $t { self * other }
         }
@@ -439,7 +439,7 @@ macro_rules! div_impl_integer {
         impl Div for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             fn div(self, other: $t) -> $t { self / other }
         }
 
@@ -455,7 +455,7 @@ macro_rules! div_impl_float {
         impl Div for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             fn div(self, other: $t) -> $t { self / other }
         }
 
@@ -524,7 +524,7 @@ macro_rules! rem_impl_integer {
         impl Rem for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             fn rem(self, other: $t) -> $t { self % other }
         }
 
@@ -556,7 +556,7 @@ macro_rules! rem_impl_float {
         impl Rem for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             fn rem(self, other: $t) -> $t { self % other }
         }
 
@@ -624,7 +624,7 @@ macro_rules! neg_impl_core {
         impl Neg for $t {
             type Output = $t;
 
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn neg(self) -> $t { let $id = self; $body }
         }
@@ -693,7 +693,7 @@ macro_rules! add_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl AddAssign for $t {
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn add_assign(&mut self, other: $t) { *self += other }
         }
@@ -749,7 +749,7 @@ macro_rules! sub_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl SubAssign for $t {
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn sub_assign(&mut self, other: $t) { *self -= other }
         }
@@ -796,7 +796,7 @@ macro_rules! mul_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl MulAssign for $t {
-            #[inline]
+            #[inline(always)]
             #[rustc_inherit_overflow_checks]
             fn mul_assign(&mut self, other: $t) { *self *= other }
         }
@@ -843,7 +843,7 @@ macro_rules! div_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl DivAssign for $t {
-            #[inline]
+            #[inline(always)]
             fn div_assign(&mut self, other: $t) { *self /= other }
         }
 
@@ -893,7 +893,7 @@ macro_rules! rem_assign_impl {
     ($($t:ty)+) => ($(
         #[stable(feature = "op_assign_traits", since = "1.8.0")]
         impl RemAssign for $t {
-            #[inline]
+            #[inline(always)]
             fn rem_assign(&mut self, other: $t) { *self %= other }
         }
 


### PR DESCRIPTION
In release mode, this has no effect, as they're inlined anyway, but in
debug mode LLVM otherwise lowers these to a call instruction -- much
more expensive than the inlined version.

Fixes #12279

If we decide not to land this I think we should close #12279 as won't fix.

r? @alexcrichton 