### PR TITLE
Remove io::Result from syntax::print

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -25,7 +25,6 @@ use crate::hir::print::Nested;
 use crate::util::nodemap::FxHashMap;
 use crate::util::common::time;
 
-use std::io;
 use std::result::Result::Err;
 use crate::ty::query::Providers;
 
@@ -1187,7 +1186,7 @@ pub fn map_crate<'hir>(sess: &crate::session::Session,
 /// Identical to the `PpAnn` implementation for `hir::Crate`,
 /// except it avoids creating a dependency on the whole crate.
 impl<'hir> print::PpAnn for Map<'hir> {
-    fn nested(&self, state: &mut print::State<'_>, nested: print::Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut print::State<'_>, nested: print::Nested) {
         match nested {
             Nested::Item(id) => state.print_item(self.expect_item(id.id)),
             Nested::TraitItem(id) => state.print_trait_item(self.trait_item(id)),
@@ -1199,7 +1198,7 @@ impl<'hir> print::PpAnn for Map<'hir> {
 }
 
 impl<'a> print::State<'a> {
-    pub fn print_node(&mut self, node: Node<'_>) -> io::Result<()> {
+    pub fn print_node(&mut self, node: Node<'_>) {
         match node {
             Node::Item(a)         => self.print_item(&a),
             Node::ForeignItem(a)  => self.print_foreign_item(&a),
@@ -1219,9 +1218,9 @@ impl<'a> print::State<'a> {
                 use syntax::print::pprust::PrintState;
 
                 // containing cbox, will be closed by print-block at }
-                self.cbox(print::indent_unit)?;
+                self.cbox(print::indent_unit);
                 // head-ibox, will be closed by print-block after {
-                self.ibox(0)?;
+                self.ibox(0);
                 self.print_block(&a)
             }
             Node::Lifetime(a)     => self.print_lifetime(&a),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -17,7 +17,7 @@ use crate::hir::{GenericParam, GenericParamKind, GenericArg};
 
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::io::{self, Read};
+use std::io::Read;
 use std::vec;
 
 pub enum AnnNode<'a> {
@@ -38,14 +38,11 @@ pub enum Nested {
 }
 
 pub trait PpAnn {
-    fn nested(&self, _state: &mut State<'_>, _nested: Nested) -> io::Result<()> {
-        Ok(())
+    fn nested(&self, _state: &mut State<'_>, _nested: Nested) {
     }
-    fn pre(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> {
-        Ok(())
+    fn pre(&self, _state: &mut State<'_>, _node: AnnNode<'_>) {
     }
-    fn post(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> {
-        Ok(())
+    fn post(&self, _state: &mut State<'_>, _node: AnnNode<'_>) {
     }
     fn try_fetch_item(&self, _: hir::HirId) -> Option<&hir::Item> {
         None
@@ -60,7 +57,7 @@ impl PpAnn for hir::Crate {
     fn try_fetch_item(&self, item: hir::HirId) -> Option<&hir::Item> {
         Some(self.item(item))
     }
-    fn nested(&self, state: &mut State<'_>, nested: Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut State<'_>, nested: Nested) {
         match nested {
             Nested::Item(id) => state.print_item(self.item(id.id)),
             Nested::TraitItem(id) => state.print_trait_item(self.trait_item(id)),
@@ -110,14 +107,14 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
                        input: &mut dyn Read,
                        out: &'a mut String,
                        ann: &'a dyn PpAnn)
-                       -> io::Result<()> {
+                       {
     let mut s = State::new_from_input(cm, sess, filename, input, out, ann);
 
     // When printing the AST, we sometimes need to inject `#[no_std]` here.
     // Since you can't compile the HIR, it's not necessary.
 
-    s.print_mod(&krate.module, &krate.attrs)?;
-    s.print_remaining_comments()?;
+    s.print_mod(&krate.module, &krate.attrs);
+    s.print_remaining_comments();
     s.s.eof()
 }
 
@@ -150,7 +147,7 @@ impl<'a> State<'a> {
 }
 
 pub fn to_string<F>(ann: &dyn PpAnn, f: F) -> String
-    where F: FnOnce(&mut State<'_>) -> io::Result<()>
+    where F: FnOnce(&mut State<'_>)
 {
     let mut wr = String::new();
     {
@@ -162,53 +159,52 @@ pub fn to_string<F>(ann: &dyn PpAnn, f: F) -> String
             boxes: Vec::new(),
             ann,
         };
-        f(&mut printer).unwrap();
-        printer.s.eof().unwrap();
+        f(&mut printer);
+        printer.s.eof();
     }
     wr
 }
 
 pub fn visibility_qualified<S: Into<Cow<'static, str>>>(vis: &hir::Visibility, w: S) -> String {
     to_string(NO_ANN, |s| {
-        s.print_visibility(vis)?;
+        s.print_visibility(vis);
         s.s.word(w)
     })
 }
 
 impl<'a> State<'a> {
-    pub fn cbox(&mut self, u: usize) -> io::Result<()> {
+    pub fn cbox(&mut self, u: usize) {
         self.boxes.push(pp::Breaks::Consistent);
-        self.s.cbox(u)
+        self.s.cbox(u);
     }
 
-    pub fn nbsp(&mut self) -> io::Result<()> {
+    pub fn nbsp(&mut self) {
         self.s.word(" ")
     }
 
-    pub fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
-        self.s.word(w)?;
+    pub fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) {
+        self.s.word(w);
         self.nbsp()
     }
 
-    pub fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
+    pub fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) {
         let w = w.into();
         // outer-box is consistent
-        self.cbox(indent_unit)?;
+        self.cbox(indent_unit);
         // head-box is inconsistent
-        self.ibox(w.len() + 1)?;
+        self.ibox(w.len() + 1);
         // keyword that starts the head
         if !w.is_empty() {
-            self.word_nbsp(w)?;
+            self.word_nbsp(w);
         }
-        Ok(())
     }
 
-    pub fn bopen(&mut self) -> io::Result<()> {
-        self.s.word("{")?;
-        self.end() // close the head-box
+    pub fn bopen(&mut self) {
+        self.s.word("{");
+        self.end(); // close the head-box
     }
 
-    pub fn bclose_(&mut self, span: syntax_pos::Span, indented: usize) -> io::Result<()> {
+    pub fn bclose_(&mut self, span: syntax_pos::Span, indented: usize) {
         self.bclose_maybe_open(span, indented, true)
     }
 
@@ -216,17 +212,16 @@ impl<'a> State<'a> {
                              span: syntax_pos::Span,
                              indented: usize,
                              close_box: bool)
-                             -> io::Result<()> {
-        self.maybe_print_comment(span.hi())?;
-        self.break_offset_if_not_bol(1, -(indented as isize))?;
-        self.s.word("}")?;
+                             {
+        self.maybe_print_comment(span.hi());
+        self.break_offset_if_not_bol(1, -(indented as isize));
+        self.s.word("}");
         if close_box {
-            self.end()?; // close the outer-box
+            self.end(); // close the outer-box
         }
-        Ok(())
     }
 
-    pub fn bclose(&mut self, span: syntax_pos::Span) -> io::Result<()> {
+    pub fn bclose(&mut self, span: syntax_pos::Span) {
         self.bclose_(span, indent_unit)
     }
 
@@ -237,14 +232,13 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn space_if_not_bol(&mut self) -> io::Result<()> {
+    pub fn space_if_not_bol(&mut self) {
         if !self.is_bol() {
-            self.s.space()?;
+            self.s.space();
         }
-        Ok(())
     }
 
-    pub fn break_offset_if_not_bol(&mut self, n: usize, off: isize) -> io::Result<()> {
+    pub fn break_offset_if_not_bol(&mut self, n: usize, off: isize) {
         if !self.is_bol() {
             self.s.break_offset(n, off)
         } else {
@@ -254,17 +248,16 @@ impl<'a> State<'a> {
                 // break into the previous hardbreak.
                 self.s.replace_last_token(pp::Printer::hardbreak_tok_offset(off));
             }
-            Ok(())
         }
     }
 
     // Synthesizes a comment that was not textually present in the original source
     // file.
-    pub fn synth_comment(&mut self, text: String) -> io::Result<()> {
-        self.s.word("/*")?;
-        self.s.space()?;
-        self.s.word(text)?;
-        self.s.space()?;
+    pub fn synth_comment(&mut self, text: String) {
+        self.s.word("/*");
+        self.s.space();
+        self.s.word(text);
+        self.s.space();
         self.s.word("*/")
     }
 
@@ -273,97 +266,93 @@ impl<'a> State<'a> {
                                   elts: &[T],
                                   mut op: F,
                                   mut get_span: G)
-                                  -> io::Result<()>
-        where F: FnMut(&mut State<'_>, &T) -> io::Result<()>,
+        where F: FnMut(&mut State<'_>, &T),
               G: FnMut(&T) -> syntax_pos::Span
     {
-        self.rbox(0, b)?;
+        self.rbox(0, b);
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            self.maybe_print_comment(get_span(elt).hi())?;
-            op(self, elt)?;
+            self.maybe_print_comment(get_span(elt).hi());
+            op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",")?;
-                self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()))?;
-                self.space_if_not_bol()?;
+                self.s.word(",");
+                self.maybe_print_trailing_comment(get_span(elt), Some(get_span(&elts[i]).hi()));
+                self.space_if_not_bol();
             }
         }
-        self.end()
+        self.end();
     }
 
-    pub fn commasep_exprs(&mut self, b: Breaks, exprs: &[hir::Expr]) -> io::Result<()> {
+    pub fn commasep_exprs(&mut self, b: Breaks, exprs: &[hir::Expr]) {
         self.commasep_cmnt(b, exprs, |s, e| s.print_expr(&e), |e| e.span)
     }
 
-    pub fn print_mod(&mut self, _mod: &hir::Mod, attrs: &[ast::Attribute]) -> io::Result<()> {
-        self.print_inner_attributes(attrs)?;
+    pub fn print_mod(&mut self, _mod: &hir::Mod, attrs: &[ast::Attribute]) {
+        self.print_inner_attributes(attrs);
         for &item_id in &_mod.item_ids {
-            self.ann.nested(self, Nested::Item(item_id))?;
+            self.ann.nested(self, Nested::Item(item_id));
         }
-        Ok(())
     }
 
     pub fn print_foreign_mod(&mut self,
                              nmod: &hir::ForeignMod,
                              attrs: &[ast::Attribute])
-                             -> io::Result<()> {
-        self.print_inner_attributes(attrs)?;
+                             {
+        self.print_inner_attributes(attrs);
         for item in &nmod.items {
-            self.print_foreign_item(item)?;
+            self.print_foreign_item(item);
         }
-        Ok(())
     }
 
-    pub fn print_opt_lifetime(&mut self, lifetime: &hir::Lifetime) -> io::Result<()> {
+    pub fn print_opt_lifetime(&mut self, lifetime: &hir::Lifetime) {
         if !lifetime.is_elided() {
-            self.print_lifetime(lifetime)?;
-            self.nbsp()?;
+            self.print_lifetime(lifetime);
+            self.nbsp();
         }
-        Ok(())
     }
 
-    pub fn print_type(&mut self, ty: &hir::Ty) -> io::Result<()> {
-        self.maybe_print_comment(ty.span.lo())?;
-        self.ibox(0)?;
+    pub fn print_type(&mut self, ty: &hir::Ty) {
+        self.maybe_print_comment(ty.span.lo());
+        self.ibox(0);
         match ty.node {
             hir::TyKind::Slice(ref ty) => {
-                self.s.word("[")?;
-                self.print_type(&ty)?;
-                self.s.word("]")?;
+                self.s.word("[");
+                self.print_type(&ty);
+                self.s.word("]");
             }
             hir::TyKind::Ptr(ref mt) => {
-                self.s.word("*")?;
+                self.s.word("*");
                 match mt.mutbl {
-                    hir::MutMutable => self.word_nbsp("mut")?,
-                    hir::MutImmutable => self.word_nbsp("const")?,
+                    hir::MutMutable => self.word_nbsp("mut"),
+                    hir::MutImmutable => self.word_nbsp("const"),
                 }
-                self.print_type(&mt.ty)?;
+                self.print_type(&mt.ty);
             }
             hir::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&")?;
-                self.print_opt_lifetime(lifetime)?;
-                self.print_mt(mt)?;
+                self.s.word("&");
+                self.print_opt_lifetime(lifetime);
+                self.print_mt(mt);
             }
             hir::TyKind::Never => {
-                self.s.word("!")?;
+                self.s.word("!");
             },
             hir::TyKind::Tup(ref elts) => {
-                self.popen()?;
-                self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty))?;
+                self.popen();
+                self.commasep(Inconsistent, &elts[..], |s, ty| s.print_type(&ty));
                 if elts.len() == 1 {
-                    self.s.word(",")?;
+                    self.s.word(",");
                 }
-                self.pclose()?;
+                self.pclose();
             }
             hir::TyKind::BareFn(ref f) => {
                 self.print_ty_fn(f.abi, f.unsafety, &f.decl, None, &f.generic_params,
-                                 &f.arg_names[..])?;
+                                 &f.arg_names[..]);
             }
             hir::TyKind::Def(..) => {},
             hir::TyKind::Path(ref qpath) => {
-                self.print_qpath(qpath, false)?
+                self.print_qpath(qpath, false)
             }
             hir::TyKind::TraitObject(ref bounds, ref lifetime) => {
                 let mut first = true;
@@ -371,51 +360,51 @@ impl<'a> State<'a> {
                     if first {
                         first = false;
                     } else {
-                        self.nbsp()?;
-                        self.word_space("+")?;
+                        self.nbsp();
+                        self.word_space("+");
                     }
-                    self.print_poly_trait_ref(bound)?;
+                    self.print_poly_trait_ref(bound);
                 }
                 if !lifetime.is_elided() {
-                    self.nbsp()?;
-                    self.word_space("+")?;
-                    self.print_lifetime(lifetime)?;
+                    self.nbsp();
+                    self.word_space("+");
+                    self.print_lifetime(lifetime);
                 }
             }
             hir::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[")?;
-                self.print_type(&ty)?;
-                self.s.word("; ")?;
-                self.print_anon_const(length)?;
-                self.s.word("]")?;
+                self.s.word("[");
+                self.print_type(&ty);
+                self.s.word("; ");
+                self.print_anon_const(length);
+                self.s.word("]");
             }
             hir::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(")?;
-                self.print_anon_const(e)?;
-                self.s.word(")")?;
+                self.s.word("typeof(");
+                self.print_anon_const(e);
+                self.s.word(")");
             }
             hir::TyKind::Infer => {
-                self.s.word("_")?;
+                self.s.word("_");
             }
             hir::TyKind::Err => {
-                self.popen()?;
-                self.s.word("/*ERROR*/")?;
-                self.pclose()?;
+                self.popen();
+                self.s.word("/*ERROR*/");
+                self.pclose();
             }
             hir::TyKind::CVarArgs(_) => {
-                self.s.word("...")?;
+                self.s.word("...");
             }
         }
         self.end()
     }
 
-    pub fn print_foreign_item(&mut self, item: &hir::ForeignItem) -> io::Result<()> {
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo())?;
-        self.print_outer_attributes(&item.attrs)?;
+    pub fn print_foreign_item(&mut self, item: &hir::ForeignItem) {
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(item.span.lo());
+        self.print_outer_attributes(&item.attrs);
         match item.node {
             hir::ForeignItemKind::Fn(ref decl, ref arg_names, ref generics) => {
-                self.head("")?;
+                self.head("");
                 self.print_fn(decl,
                               hir::FnHeader {
                                   unsafety: hir::Unsafety::Normal,
@@ -427,28 +416,28 @@ impl<'a> State<'a> {
                               generics,
                               &item.vis,
                               arg_names,
-                              None)?;
-                self.end()?; // end head-ibox
-                self.s.word(";")?;
+                              None);
+                self.end(); // end head-ibox
+                self.s.word(";");
                 self.end() // end the outer fn box
             }
             hir::ForeignItemKind::Static(ref t, m) => {
-                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.head(visibility_qualified(&item.vis, "static"));
                 if m == hir::MutMutable {
-                    self.word_space("mut")?;
+                    self.word_space("mut");
                 }
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(&t)?;
-                self.s.word(";")?;
-                self.end()?; // end the head-ibox
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(&t);
+                self.s.word(";");
+                self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
             hir::ForeignItemKind::Type => {
-                self.head(visibility_qualified(&item.vis, "type"))?;
-                self.print_ident(item.ident)?;
-                self.s.word(";")?;
-                self.end()?; // end the head-ibox
+                self.head(visibility_qualified(&item.vis, "type"));
+                self.print_ident(item.ident);
+                self.s.word(";");
+                self.end(); // end the head-ibox
                 self.end() // end the outer cbox
             }
         }
@@ -459,16 +448,16 @@ impl<'a> State<'a> {
                               ty: &hir::Ty,
                               default: Option<hir::BodyId>,
                               vis: &hir::Visibility)
-                              -> io::Result<()> {
-        self.s.word(visibility_qualified(vis, ""))?;
-        self.word_space("const")?;
-        self.print_ident(ident)?;
-        self.word_space(":")?;
-        self.print_type(ty)?;
+                              {
+        self.s.word(visibility_qualified(vis, ""));
+        self.word_space("const");
+        self.print_ident(ident);
+        self.word_space(":");
+        self.print_type(ty);
         if let Some(expr) = default {
-            self.s.space()?;
-            self.word_space("=")?;
-            self.ann.nested(self, Nested::Body(expr))?;
+            self.s.space();
+            self.word_space("=");
+            self.ann.nested(self, Nested::Body(expr));
         }
         self.s.word(";")
     }
@@ -477,168 +466,168 @@ impl<'a> State<'a> {
                              ident: ast::Ident,
                              bounds: Option<&hir::GenericBounds>,
                              ty: Option<&hir::Ty>)
-                             -> io::Result<()> {
-        self.word_space("type")?;
-        self.print_ident(ident)?;
+                             {
+        self.word_space("type");
+        self.print_ident(ident);
         if let Some(bounds) = bounds {
-            self.print_bounds(":", bounds)?;
+            self.print_bounds(":", bounds);
         }
         if let Some(ty) = ty {
-            self.s.space()?;
-            self.word_space("=")?;
-            self.print_type(ty)?;
+            self.s.space();
+            self.word_space("=");
+            self.print_type(ty);
         }
         self.s.word(";")
     }
 
     /// Pretty-print an item
-    pub fn print_item(&mut self, item: &hir::Item) -> io::Result<()> {
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo())?;
-        self.print_outer_attributes(&item.attrs)?;
-        self.ann.pre(self, AnnNode::Item(item))?;
+    pub fn print_item(&mut self, item: &hir::Item) {
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(item.span.lo());
+        self.print_outer_attributes(&item.attrs);
+        self.ann.pre(self, AnnNode::Item(item));
         match item.node {
             hir::ItemKind::ExternCrate(orig_name) => {
-                self.head(visibility_qualified(&item.vis, "extern crate"))?;
+                self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
-                    self.print_name(orig_name)?;
-                    self.s.space()?;
-                    self.s.word("as")?;
-                    self.s.space()?;
+                    self.print_name(orig_name);
+                    self.s.space();
+                    self.s.word("as");
+                    self.s.space();
                 }
-                self.print_ident(item.ident)?;
-                self.s.word(";")?;
-                self.end()?; // end inner head-block
-                self.end()?; // end outer head-block
+                self.print_ident(item.ident);
+                self.s.word(";");
+                self.end(); // end inner head-block
+                self.end(); // end outer head-block
             }
             hir::ItemKind::Use(ref path, kind) => {
-                self.head(visibility_qualified(&item.vis, "use"))?;
-                self.print_path(path, false)?;
+                self.head(visibility_qualified(&item.vis, "use"));
+                self.print_path(path, false);
 
                 match kind {
                     hir::UseKind::Single => {
                         if path.segments.last().unwrap().ident != item.ident {
-                            self.s.space()?;
-                            self.word_space("as")?;
-                            self.print_ident(item.ident)?;
+                            self.s.space();
+                            self.word_space("as");
+                            self.print_ident(item.ident);
                         }
-                        self.s.word(";")?;
+                        self.s.word(";");
                     }
-                    hir::UseKind::Glob => self.s.word("::*;")?,
-                    hir::UseKind::ListStem => self.s.word("::{};")?
+                    hir::UseKind::Glob => self.s.word("::*;"),
+                    hir::UseKind::ListStem => self.s.word("::{};")
                 }
-                self.end()?; // end inner head-block
-                self.end()?; // end outer head-block
+                self.end(); // end inner head-block
+                self.end(); // end outer head-block
             }
             hir::ItemKind::Static(ref ty, m, expr) => {
-                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.head(visibility_qualified(&item.vis, "static"));
                 if m == hir::MutMutable {
-                    self.word_space("mut")?;
+                    self.word_space("mut");
                 }
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(&ty)?;
-                self.s.space()?;
-                self.end()?; // end the head-ibox
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(&ty);
+                self.s.space();
+                self.end(); // end the head-ibox
 
-                self.word_space("=")?;
-                self.ann.nested(self, Nested::Body(expr))?;
-                self.s.word(";")?;
-                self.end()?; // end the outer cbox
+                self.word_space("=");
+                self.ann.nested(self, Nested::Body(expr));
+                self.s.word(";");
+                self.end(); // end the outer cbox
             }
             hir::ItemKind::Const(ref ty, expr) => {
-                self.head(visibility_qualified(&item.vis, "const"))?;
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(&ty)?;
-                self.s.space()?;
-                self.end()?; // end the head-ibox
+                self.head(visibility_qualified(&item.vis, "const"));
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(&ty);
+                self.s.space();
+                self.end(); // end the head-ibox
 
-                self.word_space("=")?;
-                self.ann.nested(self, Nested::Body(expr))?;
-                self.s.word(";")?;
-                self.end()?; // end the outer cbox
+                self.word_space("=");
+                self.ann.nested(self, Nested::Body(expr));
+                self.s.word(";");
+                self.end(); // end the outer cbox
             }
             hir::ItemKind::Fn(ref decl, header, ref param_names, body) => {
-                self.head("")?;
+                self.head("");
                 self.print_fn(decl,
                               header,
                               Some(item.ident.name),
                               param_names,
                               &item.vis,
                               &[],
-                              Some(body))?;
-                self.s.word(" ")?;
-                self.end()?; // need to close a box
-                self.end()?; // need to close a box
-                self.ann.nested(self, Nested::Body(body))?;
+                              Some(body));
+                self.s.word(" ");
+                self.end(); // need to close a box
+                self.end(); // need to close a box
+                self.ann.nested(self, Nested::Body(body));
             }
             hir::ItemKind::Mod(ref _mod) => {
-                self.head(visibility_qualified(&item.vis, "mod"))?;
-                self.print_ident(item.ident)?;
-                self.nbsp()?;
-                self.bopen()?;
-                self.print_mod(_mod, &item.attrs)?;
-                self.bclose(item.span)?;
+                self.head(visibility_qualified(&item.vis, "mod"));
+                self.print_ident(item.ident);
+                self.nbsp();
+                self.bopen();
+                self.print_mod(_mod, &item.attrs);
+                self.bclose(item.span);
             }
             hir::ItemKind::ForeignMod(ref nmod) => {
-                self.head("extern")?;
-                self.word_nbsp(nmod.abi.to_string())?;
-                self.bopen()?;
-                self.print_foreign_mod(nmod, &item.attrs)?;
-                self.bclose(item.span)?;
+                self.head("extern");
+                self.word_nbsp(nmod.abi.to_string());
+                self.bopen();
+                self.print_foreign_mod(nmod, &item.attrs);
+                self.bclose(item.span);
             }
             hir::ItemKind::GlobalAsm(ref ga) => {
-                self.head(visibility_qualified(&item.vis, "global asm"))?;
-                self.s.word(ga.asm.as_str().to_string())?;
-                self.end()?
+                self.head(visibility_qualified(&item.vis, "global asm"));
+                self.s.word(ga.asm.as_str().to_string());
+                self.end()
             }
             hir::ItemKind::Ty(ref ty, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "type"))?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
-                self.end()?; // end the inner ibox
+                self.head(visibility_qualified(&item.vis, "type"));
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
+                self.end(); // end the inner ibox
 
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.space()?;
-                self.word_space("=")?;
-                self.print_type(&ty)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer ibox
+                self.print_where_clause(&generics.where_clause);
+                self.s.space();
+                self.word_space("=");
+                self.print_type(&ty);
+                self.s.word(";");
+                self.end(); // end the outer ibox
             }
             hir::ItemKind::Existential(ref exist) => {
-                self.head(visibility_qualified(&item.vis, "existential type"))?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&exist.generics.params)?;
-                self.end()?; // end the inner ibox
+                self.head(visibility_qualified(&item.vis, "existential type"));
+                self.print_ident(item.ident);
+                self.print_generic_params(&exist.generics.params);
+                self.end(); // end the inner ibox
 
-                self.print_where_clause(&exist.generics.where_clause)?;
-                self.s.space()?;
+                self.print_where_clause(&exist.generics.where_clause);
+                self.s.space();
                 let mut real_bounds = Vec::with_capacity(exist.bounds.len());
                 for b in exist.bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space()?;
-                        self.word_space("for ?")?;
-                        self.print_trait_ref(&ptr.trait_ref)?;
+                        self.s.space();
+                        self.word_space("for ?");
+                        self.print_trait_ref(&ptr.trait_ref);
                     } else {
                         real_bounds.push(b);
                     }
                 }
-                self.print_bounds(":", real_bounds)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer ibox
+                self.print_bounds(":", real_bounds);
+                self.s.word(";");
+                self.end(); // end the outer ibox
             }
             hir::ItemKind::Enum(ref enum_definition, ref params) => {
                 self.print_enum_def(enum_definition, params, item.ident.name, item.span,
-                                    &item.vis)?;
+                                    &item.vis);
             }
             hir::ItemKind::Struct(ref struct_def, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "struct"))?;
-                self.print_struct(struct_def, generics, item.ident.name, item.span, true)?;
+                self.head(visibility_qualified(&item.vis, "struct"));
+                self.print_struct(struct_def, generics, item.ident.name, item.span, true);
             }
             hir::ItemKind::Union(ref struct_def, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "union"))?;
-                self.print_struct(struct_def, generics, item.ident.name, item.span, true)?;
+                self.head(visibility_qualified(&item.vis, "union"));
+                self.print_struct(struct_def, generics, item.ident.name, item.span, true);
             }
             hir::ItemKind::Impl(unsafety,
                           polarity,
@@ -647,109 +636,108 @@ impl<'a> State<'a> {
                           ref opt_trait,
                           ref ty,
                           ref impl_items) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.print_defaultness(defaultness)?;
-                self.print_unsafety(unsafety)?;
-                self.word_nbsp("impl")?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.print_defaultness(defaultness);
+                self.print_unsafety(unsafety);
+                self.word_nbsp("impl");
 
                 if !generics.params.is_empty() {
-                    self.print_generic_params(&generics.params)?;
-                    self.s.space()?;
+                    self.print_generic_params(&generics.params);
+                    self.s.space();
                 }
 
                 if let hir::ImplPolarity::Negative = polarity {
-                    self.s.word("!")?;
+                    self.s.word("!");
                 }
 
                 if let Some(ref t) = opt_trait {
-                    self.print_trait_ref(t)?;
-                    self.s.space()?;
-                    self.word_space("for")?;
+                    self.print_trait_ref(t);
+                    self.s.space();
+                    self.word_space("for");
                 }
 
-                self.print_type(&ty)?;
-                self.print_where_clause(&generics.where_clause)?;
+                self.print_type(&ty);
+                self.print_where_clause(&generics.where_clause);
 
-                self.s.space()?;
-                self.bopen()?;
-                self.print_inner_attributes(&item.attrs)?;
+                self.s.space();
+                self.bopen();
+                self.print_inner_attributes(&item.attrs);
                 for impl_item in impl_items {
-                    self.ann.nested(self, Nested::ImplItem(impl_item.id))?;
+                    self.ann.nested(self, Nested::ImplItem(impl_item.id));
                 }
-                self.bclose(item.span)?;
+                self.bclose(item.span);
             }
             hir::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref trait_items) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.print_is_auto(is_auto)?;
-                self.print_unsafety(unsafety)?;
-                self.word_nbsp("trait")?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.print_is_auto(is_auto);
+                self.print_unsafety(unsafety);
+                self.word_nbsp("trait");
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space()?;
-                        self.word_space("for ?")?;
-                        self.print_trait_ref(&ptr.trait_ref)?;
+                        self.s.space();
+                        self.word_space("for ?");
+                        self.print_trait_ref(&ptr.trait_ref);
                     } else {
                         real_bounds.push(b);
                     }
                 }
-                self.print_bounds(":", real_bounds)?;
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.word(" ")?;
-                self.bopen()?;
+                self.print_bounds(":", real_bounds);
+                self.print_where_clause(&generics.where_clause);
+                self.s.word(" ");
+                self.bopen();
                 for trait_item in trait_items {
-                    self.ann.nested(self, Nested::TraitItem(trait_item.id))?;
+                    self.ann.nested(self, Nested::TraitItem(trait_item.id));
                 }
-                self.bclose(item.span)?;
+                self.bclose(item.span);
             }
             hir::ItemKind::TraitAlias(ref generics, ref bounds) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.word_nbsp("trait")?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.word_nbsp("trait");
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, hir::TraitBoundModifier::Maybe) = *b {
-                        self.s.space()?;
-                        self.word_space("for ?")?;
-                        self.print_trait_ref(&ptr.trait_ref)?;
+                        self.s.space();
+                        self.word_space("for ?");
+                        self.print_trait_ref(&ptr.trait_ref);
                     } else {
                         real_bounds.push(b);
                     }
                 }
-                self.nbsp()?;
-                self.print_bounds("=", real_bounds)?;
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.word(";")?;
+                self.nbsp();
+                self.print_bounds("=", real_bounds);
+                self.print_where_clause(&generics.where_clause);
+                self.s.word(";");
             }
         }
         self.ann.post(self, AnnNode::Item(item))
     }
 
-    pub fn print_trait_ref(&mut self, t: &hir::TraitRef) -> io::Result<()> {
+    pub fn print_trait_ref(&mut self, t: &hir::TraitRef) {
         self.print_path(&t.path, false)
     }
 
     fn print_formal_generic_params(
         &mut self,
         generic_params: &[hir::GenericParam]
-    ) -> io::Result<()> {
+    ) {
         if !generic_params.is_empty() {
-            self.s.word("for")?;
-            self.print_generic_params(generic_params)?;
-            self.nbsp()?;
+            self.s.word("for");
+            self.print_generic_params(generic_params);
+            self.nbsp();
         }
-        Ok(())
     }
 
-    fn print_poly_trait_ref(&mut self, t: &hir::PolyTraitRef) -> io::Result<()> {
-        self.print_formal_generic_params(&t.bound_generic_params)?;
+    fn print_poly_trait_ref(&mut self, t: &hir::PolyTraitRef) {
+        self.print_formal_generic_params(&t.bound_generic_params);
         self.print_trait_ref(&t.trait_ref)
     }
 
@@ -759,63 +747,60 @@ impl<'a> State<'a> {
                           name: ast::Name,
                           span: syntax_pos::Span,
                           visibility: &hir::Visibility)
-                          -> io::Result<()> {
-        self.head(visibility_qualified(visibility, "enum"))?;
-        self.print_name(name)?;
-        self.print_generic_params(&generics.params)?;
-        self.print_where_clause(&generics.where_clause)?;
-        self.s.space()?;
+                          {
+        self.head(visibility_qualified(visibility, "enum"));
+        self.print_name(name);
+        self.print_generic_params(&generics.params);
+        self.print_where_clause(&generics.where_clause);
+        self.s.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
     pub fn print_variants(&mut self,
                           variants: &[hir::Variant],
                           span: syntax_pos::Span)
-                          -> io::Result<()> {
-        self.bopen()?;
+                          {
+        self.bopen();
         for v in variants {
-            self.space_if_not_bol()?;
-            self.maybe_print_comment(v.span.lo())?;
-            self.print_outer_attributes(&v.node.attrs)?;
-            self.ibox(indent_unit)?;
-            self.print_variant(v)?;
-            self.s.word(",")?;
-            self.end()?;
-            self.maybe_print_trailing_comment(v.span, None)?;
+            self.space_if_not_bol();
+            self.maybe_print_comment(v.span.lo());
+            self.print_outer_attributes(&v.node.attrs);
+            self.ibox(indent_unit);
+            self.print_variant(v);
+            self.s.word(",");
+            self.end();
+            self.maybe_print_trailing_comment(v.span, None);
         }
         self.bclose(span)
     }
 
-    pub fn print_visibility(&mut self, vis: &hir::Visibility) -> io::Result<()> {
+    pub fn print_visibility(&mut self, vis: &hir::Visibility) {
         match vis.node {
-            hir::VisibilityKind::Public => self.word_nbsp("pub")?,
-            hir::VisibilityKind::Crate(ast::CrateSugar::JustCrate) => self.word_nbsp("crate")?,
-            hir::VisibilityKind::Crate(ast::CrateSugar::PubCrate) => self.word_nbsp("pub(crate)")?,
+            hir::VisibilityKind::Public => self.word_nbsp("pub"),
+            hir::VisibilityKind::Crate(ast::CrateSugar::JustCrate) => self.word_nbsp("crate"),
+            hir::VisibilityKind::Crate(ast::CrateSugar::PubCrate) => self.word_nbsp("pub(crate)"),
             hir::VisibilityKind::Restricted { ref path, .. } => {
-                self.s.word("pub(")?;
+                self.s.word("pub(");
                 if path.segments.len() == 1 &&
                    path.segments[0].ident.name == kw::Super {
                     // Special case: `super` can print like `pub(super)`.
-                    self.s.word("super")?;
+                    self.s.word("super");
                 } else {
                     // Everything else requires `in` at present.
-                    self.word_nbsp("in")?;
-                    self.print_path(path, false)?;
+                    self.word_nbsp("in");
+                    self.print_path(path, false);
                 }
-                self.word_nbsp(")")?;
+                self.word_nbsp(")");
             }
             hir::VisibilityKind::Inherited => ()
         }
-
-        Ok(())
     }
 
-    pub fn print_defaultness(&mut self, defaultness: hir::Defaultness) -> io::Result<()> {
+    pub fn print_defaultness(&mut self, defaultness: hir::Defaultness) {
         match defaultness {
-            hir::Defaultness::Default { .. } => self.word_nbsp("default")?,
+            hir::Defaultness::Default { .. } => self.word_nbsp("default"),
             hir::Defaultness::Final => (),
         }
-        Ok(())
     }
 
     pub fn print_struct(&mut self,
@@ -824,43 +809,43 @@ impl<'a> State<'a> {
                         name: ast::Name,
                         span: syntax_pos::Span,
                         print_finalizer: bool)
-                        -> io::Result<()> {
-        self.print_name(name)?;
-        self.print_generic_params(&generics.params)?;
+                        {
+        self.print_name(name);
+        self.print_generic_params(&generics.params);
         match struct_def {
             hir::VariantData::Tuple(..) | hir::VariantData::Unit(..) => {
                 if let hir::VariantData::Tuple(..) = struct_def {
-                    self.popen()?;
+                    self.popen();
                     self.commasep(Inconsistent, struct_def.fields(), |s, field| {
-                        s.maybe_print_comment(field.span.lo())?;
-                        s.print_outer_attributes(&field.attrs)?;
-                        s.print_visibility(&field.vis)?;
+                        s.maybe_print_comment(field.span.lo());
+                        s.print_outer_attributes(&field.attrs);
+                        s.print_visibility(&field.vis);
                         s.print_type(&field.ty)
-                    })?;
-                    self.pclose()?;
+                    });
+                    self.pclose();
                 }
-                self.print_where_clause(&generics.where_clause)?;
+                self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";")?;
+                    self.s.word(";");
                 }
-                self.end()?;
+                self.end();
                 self.end() // close the outer-box
             }
             hir::VariantData::Struct(..) => {
-                self.print_where_clause(&generics.where_clause)?;
-                self.nbsp()?;
-                self.bopen()?;
-                self.hardbreak_if_not_bol()?;
+                self.print_where_clause(&generics.where_clause);
+                self.nbsp();
+                self.bopen();
+                self.hardbreak_if_not_bol();
 
                 for field in struct_def.fields() {
-                    self.hardbreak_if_not_bol()?;
-                    self.maybe_print_comment(field.span.lo())?;
-                    self.print_outer_attributes(&field.attrs)?;
-                    self.print_visibility(&field.vis)?;
-                    self.print_ident(field.ident)?;
-                    self.word_nbsp(":")?;
-                    self.print_type(&field.ty)?;
-                    self.s.word(",")?;
+                    self.hardbreak_if_not_bol();
+                    self.maybe_print_comment(field.span.lo());
+                    self.print_outer_attributes(&field.attrs);
+                    self.print_visibility(&field.vis);
+                    self.print_ident(field.ident);
+                    self.word_nbsp(":");
+                    self.print_type(&field.ty);
+                    self.s.word(",");
                 }
 
                 self.bclose(span)
@@ -868,16 +853,15 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_variant(&mut self, v: &hir::Variant) -> io::Result<()> {
-        self.head("")?;
+    pub fn print_variant(&mut self, v: &hir::Variant) {
+        self.head("");
         let generics = hir::Generics::empty();
-        self.print_struct(&v.node.data, &generics, v.node.ident.name, v.span, false)?;
+        self.print_struct(&v.node.data, &generics, v.node.ident.name, v.span, false);
         if let Some(ref d) = v.node.disr_expr {
-            self.s.space()?;
-            self.word_space("=")?;
-            self.print_anon_const(d)?;
+            self.s.space();
+            self.word_space("=");
+            self.print_anon_const(d);
         }
-        Ok(())
     }
     pub fn print_method_sig(&mut self,
                             ident: ast::Ident,
@@ -886,7 +870,7 @@ impl<'a> State<'a> {
                             vis: &hir::Visibility,
                             arg_names: &[ast::Ident],
                             body_id: Option<hir::BodyId>)
-                            -> io::Result<()> {
+                            {
         self.print_fn(&m.decl,
                       m.header,
                       Some(ident.name),
@@ -896,67 +880,67 @@ impl<'a> State<'a> {
                       body_id)
     }
 
-    pub fn print_trait_item(&mut self, ti: &hir::TraitItem) -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ti.hir_id))?;
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ti.span.lo())?;
-        self.print_outer_attributes(&ti.attrs)?;
+    pub fn print_trait_item(&mut self, ti: &hir::TraitItem) {
+        self.ann.pre(self, AnnNode::SubItem(ti.hir_id));
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(ti.span.lo());
+        self.print_outer_attributes(&ti.attrs);
         match ti.node {
             hir::TraitItemKind::Const(ref ty, default) => {
                 let vis = Spanned { span: syntax_pos::DUMMY_SP,
                                     node: hir::VisibilityKind::Inherited };
-                self.print_associated_const(ti.ident, &ty, default, &vis)?;
+                self.print_associated_const(ti.ident, &ty, default, &vis);
             }
             hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Required(ref arg_names)) => {
                 let vis = Spanned { span: syntax_pos::DUMMY_SP,
                                     node: hir::VisibilityKind::Inherited };
-                self.print_method_sig(ti.ident, sig, &ti.generics, &vis, arg_names, None)?;
-                self.s.word(";")?;
+                self.print_method_sig(ti.ident, sig, &ti.generics, &vis, arg_names, None);
+                self.s.word(";");
             }
             hir::TraitItemKind::Method(ref sig, hir::TraitMethod::Provided(body)) => {
                 let vis = Spanned { span: syntax_pos::DUMMY_SP,
                                     node: hir::VisibilityKind::Inherited };
-                self.head("")?;
-                self.print_method_sig(ti.ident, sig, &ti.generics, &vis, &[], Some(body))?;
-                self.nbsp()?;
-                self.end()?; // need to close a box
-                self.end()?; // need to close a box
-                self.ann.nested(self, Nested::Body(body))?;
+                self.head("");
+                self.print_method_sig(ti.ident, sig, &ti.generics, &vis, &[], Some(body));
+                self.nbsp();
+                self.end(); // need to close a box
+                self.end(); // need to close a box
+                self.ann.nested(self, Nested::Body(body));
             }
             hir::TraitItemKind::Type(ref bounds, ref default) => {
                 self.print_associated_type(ti.ident,
                                            Some(bounds),
-                                           default.as_ref().map(|ty| &**ty))?;
+                                           default.as_ref().map(|ty| &**ty));
             }
         }
         self.ann.post(self, AnnNode::SubItem(ti.hir_id))
     }
 
-    pub fn print_impl_item(&mut self, ii: &hir::ImplItem) -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ii.hir_id))?;
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ii.span.lo())?;
-        self.print_outer_attributes(&ii.attrs)?;
-        self.print_defaultness(ii.defaultness)?;
+    pub fn print_impl_item(&mut self, ii: &hir::ImplItem) {
+        self.ann.pre(self, AnnNode::SubItem(ii.hir_id));
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(ii.span.lo());
+        self.print_outer_attributes(&ii.attrs);
+        self.print_defaultness(ii.defaultness);
 
         match ii.node {
             hir::ImplItemKind::Const(ref ty, expr) => {
-                self.print_associated_const(ii.ident, &ty, Some(expr), &ii.vis)?;
+                self.print_associated_const(ii.ident, &ty, Some(expr), &ii.vis);
             }
             hir::ImplItemKind::Method(ref sig, body) => {
-                self.head("")?;
-                self.print_method_sig(ii.ident, sig, &ii.generics, &ii.vis, &[], Some(body))?;
-                self.nbsp()?;
-                self.end()?; // need to close a box
-                self.end()?; // need to close a box
-                self.ann.nested(self, Nested::Body(body))?;
+                self.head("");
+                self.print_method_sig(ii.ident, sig, &ii.generics, &ii.vis, &[], Some(body));
+                self.nbsp();
+                self.end(); // need to close a box
+                self.end(); // need to close a box
+                self.ann.nested(self, Nested::Body(body));
             }
             hir::ImplItemKind::Type(ref ty) => {
-                self.print_associated_type(ii.ident, None, Some(ty))?;
+                self.print_associated_type(ii.ident, None, Some(ty));
             }
             hir::ImplItemKind::Existential(ref bounds) => {
-                self.word_space("existential")?;
-                self.print_associated_type(ii.ident, Some(bounds), None)?;
+                self.word_space("existential");
+                self.print_associated_type(ii.ident, Some(bounds), None);
             }
         }
         self.ann.post(self, AnnNode::SubItem(ii.hir_id))
@@ -965,68 +949,68 @@ impl<'a> State<'a> {
     pub fn print_local(
         &mut self,
         init: Option<&hir::Expr>,
-        decl: impl Fn(&mut Self) -> io::Result<()>
-    ) -> io::Result<()> {
-        self.space_if_not_bol()?;
-        self.ibox(indent_unit)?;
-        self.word_nbsp("let")?;
+        decl: impl Fn(&mut Self)
+    ) {
+        self.space_if_not_bol();
+        self.ibox(indent_unit);
+        self.word_nbsp("let");
 
-        self.ibox(indent_unit)?;
-        decl(self)?;
-        self.end()?;
+        self.ibox(indent_unit);
+        decl(self);
+        self.end();
 
         if let Some(ref init) = init {
-            self.nbsp()?;
-            self.word_space("=")?;
-            self.print_expr(&init)?;
+            self.nbsp();
+            self.word_space("=");
+            self.print_expr(&init);
         }
         self.end()
     }
 
-    pub fn print_stmt(&mut self, st: &hir::Stmt) -> io::Result<()> {
-        self.maybe_print_comment(st.span.lo())?;
+    pub fn print_stmt(&mut self, st: &hir::Stmt) {
+        self.maybe_print_comment(st.span.lo());
         match st.node {
             hir::StmtKind::Local(ref loc) => {
-                self.print_local(loc.init.deref(), |this| this.print_local_decl(&loc))?;
+                self.print_local(loc.init.deref(), |this| this.print_local_decl(&loc));
             }
             hir::StmtKind::Item(item) => {
-                self.ann.nested(self, Nested::Item(item))?
+                self.ann.nested(self, Nested::Item(item))
             }
             hir::StmtKind::Expr(ref expr) => {
-                self.space_if_not_bol()?;
-                self.print_expr(&expr)?;
+                self.space_if_not_bol();
+                self.print_expr(&expr);
             }
             hir::StmtKind::Semi(ref expr) => {
-                self.space_if_not_bol()?;
-                self.print_expr(&expr)?;
-                self.s.word(";")?;
+                self.space_if_not_bol();
+                self.print_expr(&expr);
+                self.s.word(";");
             }
         }
         if stmt_ends_with_semi(&st.node) {
-            self.s.word(";")?;
+            self.s.word(";");
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
 
-    pub fn print_block(&mut self, blk: &hir::Block) -> io::Result<()> {
+    pub fn print_block(&mut self, blk: &hir::Block) {
         self.print_block_with_attrs(blk, &[])
     }
 
-    pub fn print_block_unclosed(&mut self, blk: &hir::Block) -> io::Result<()> {
+    pub fn print_block_unclosed(&mut self, blk: &hir::Block) {
         self.print_block_unclosed_indent(blk, indent_unit)
     }
 
     pub fn print_block_unclosed_indent(&mut self,
                                        blk: &hir::Block,
                                        indented: usize)
-                                       -> io::Result<()> {
+                                       {
         self.print_block_maybe_unclosed(blk, indented, &[], false)
     }
 
     pub fn print_block_with_attrs(&mut self,
                                   blk: &hir::Block,
                                   attrs: &[ast::Attribute])
-                                  -> io::Result<()> {
+                                  {
         self.print_block_maybe_unclosed(blk, indent_unit, attrs, true)
     }
 
@@ -1035,56 +1019,55 @@ impl<'a> State<'a> {
                                       indented: usize,
                                       attrs: &[ast::Attribute],
                                       close_box: bool)
-                                      -> io::Result<()> {
+                                      {
         match blk.rules {
-            hir::UnsafeBlock(..) => self.word_space("unsafe")?,
-            hir::PushUnsafeBlock(..) => self.word_space("push_unsafe")?,
-            hir::PopUnsafeBlock(..) => self.word_space("pop_unsafe")?,
+            hir::UnsafeBlock(..) => self.word_space("unsafe"),
+            hir::PushUnsafeBlock(..) => self.word_space("push_unsafe"),
+            hir::PopUnsafeBlock(..) => self.word_space("pop_unsafe"),
             hir::DefaultBlock => (),
         }
-        self.maybe_print_comment(blk.span.lo())?;
-        self.ann.pre(self, AnnNode::Block(blk))?;
-        self.bopen()?;
+        self.maybe_print_comment(blk.span.lo());
+        self.ann.pre(self, AnnNode::Block(blk));
+        self.bopen();
 
-        self.print_inner_attributes(attrs)?;
+        self.print_inner_attributes(attrs);
 
         for st in &blk.stmts {
-            self.print_stmt(st)?;
+            self.print_stmt(st);
         }
         if let Some(ref expr) = blk.expr {
-            self.space_if_not_bol()?;
-            self.print_expr(&expr)?;
-            self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()))?;
+            self.space_if_not_bol();
+            self.print_expr(&expr);
+            self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()));
         }
-        self.bclose_maybe_open(blk.span, indented, close_box)?;
+        self.bclose_maybe_open(blk.span, indented, close_box);
         self.ann.post(self, AnnNode::Block(blk))
     }
 
-    pub fn print_anon_const(&mut self, constant: &hir::AnonConst) -> io::Result<()> {
+    pub fn print_anon_const(&mut self, constant: &hir::AnonConst) {
         self.ann.nested(self, Nested::Body(constant.body))
     }
 
-    fn print_call_post(&mut self, args: &[hir::Expr]) -> io::Result<()> {
-        self.popen()?;
-        self.commasep_exprs(Inconsistent, args)?;
+    fn print_call_post(&mut self, args: &[hir::Expr]) {
+        self.popen();
+        self.commasep_exprs(Inconsistent, args);
         self.pclose()
     }
 
-    pub fn print_expr_maybe_paren(&mut self, expr: &hir::Expr, prec: i8) -> io::Result<()> {
+    pub fn print_expr_maybe_paren(&mut self, expr: &hir::Expr, prec: i8) {
         let needs_par = expr.precedence().order() < prec;
         if needs_par {
-            self.popen()?;
+            self.popen();
         }
-        self.print_expr(expr)?;
+        self.print_expr(expr);
         if needs_par {
-            self.pclose()?;
+            self.pclose();
         }
-        Ok(())
     }
 
     /// Print an expr using syntax that's acceptable in a condition position, such as the `cond` in
     /// `if cond { ... }`.
-    pub fn print_expr_as_cond(&mut self, expr: &hir::Expr) -> io::Result<()> {
+    pub fn print_expr_as_cond(&mut self, expr: &hir::Expr) {
         let needs_par = match expr.node {
             // These cases need parens due to the parse error observed in #26461: `if return {}`
             // parses as the erroneous construct `if (return {})`, not `if (return) {}`.
@@ -1096,30 +1079,29 @@ impl<'a> State<'a> {
         };
 
         if needs_par {
-            self.popen()?;
+            self.popen();
         }
-        self.print_expr(expr)?;
+        self.print_expr(expr);
         if needs_par {
-            self.pclose()?;
+            self.pclose();
         }
-        Ok(())
     }
 
-    fn print_expr_vec(&mut self, exprs: &[hir::Expr]) -> io::Result<()> {
-        self.ibox(indent_unit)?;
-        self.s.word("[")?;
-        self.commasep_exprs(Inconsistent, exprs)?;
-        self.s.word("]")?;
+    fn print_expr_vec(&mut self, exprs: &[hir::Expr]) {
+        self.ibox(indent_unit);
+        self.s.word("[");
+        self.commasep_exprs(Inconsistent, exprs);
+        self.s.word("]");
         self.end()
     }
 
-    fn print_expr_repeat(&mut self, element: &hir::Expr, count: &hir::AnonConst) -> io::Result<()> {
-        self.ibox(indent_unit)?;
-        self.s.word("[")?;
-        self.print_expr(element)?;
-        self.word_space(";")?;
-        self.print_anon_const(count)?;
-        self.s.word("]")?;
+    fn print_expr_repeat(&mut self, element: &hir::Expr, count: &hir::AnonConst) {
+        self.ibox(indent_unit);
+        self.s.word("[");
+        self.print_expr(element);
+        self.word_space(";");
+        self.print_anon_const(count);
+        self.s.word("]");
         self.end()
     }
 
@@ -1127,72 +1109,71 @@ impl<'a> State<'a> {
                          qpath: &hir::QPath,
                          fields: &[hir::Field],
                          wth: &Option<P<hir::Expr>>)
-                         -> io::Result<()> {
-        self.print_qpath(qpath, true)?;
-        self.s.word("{")?;
+                         {
+        self.print_qpath(qpath, true);
+        self.s.word("{");
         self.commasep_cmnt(Consistent,
                            &fields[..],
                            |s, field| {
-                               s.ibox(indent_unit)?;
+                               s.ibox(indent_unit);
                                if !field.is_shorthand {
-                                    s.print_ident(field.ident)?;
-                                    s.word_space(":")?;
+                                    s.print_ident(field.ident);
+                                    s.word_space(":");
                                }
-                               s.print_expr(&field.expr)?;
+                               s.print_expr(&field.expr);
                                s.end()
                            },
-                           |f| f.span)?;
+                           |f| f.span);
         match *wth {
             Some(ref expr) => {
-                self.ibox(indent_unit)?;
+                self.ibox(indent_unit);
                 if !fields.is_empty() {
-                    self.s.word(",")?;
-                    self.s.space()?;
+                    self.s.word(",");
+                    self.s.space();
                 }
-                self.s.word("..")?;
-                self.print_expr(&expr)?;
-                self.end()?;
+                self.s.word("..");
+                self.print_expr(&expr);
+                self.end();
             }
             _ => if !fields.is_empty() {
-                self.s.word(",")?
+                self.s.word(",")
             },
         }
-        self.s.word("}")?;
-        Ok(())
+        self.s.word("}");
     }
 
-    fn print_expr_tup(&mut self, exprs: &[hir::Expr]) -> io::Result<()> {
-        self.popen()?;
-        self.commasep_exprs(Inconsistent, exprs)?;
+    fn print_expr_tup(&mut self, exprs: &[hir::Expr]) {
+        self.popen();
+        self.commasep_exprs(Inconsistent, exprs);
         if exprs.len() == 1 {
-            self.s.word(",")?;
+            self.s.word(",");
         }
         self.pclose()
     }
 
-    fn print_expr_call(&mut self, func: &hir::Expr, args: &[hir::Expr]) -> io::Result<()> {
+    fn print_expr_call(&mut self, func: &hir::Expr, args: &[hir::Expr]) {
         let prec =
             match func.node {
                 hir::ExprKind::Field(..) => parser::PREC_FORCE_PAREN,
                 _ => parser::PREC_POSTFIX,
             };
 
-        self.print_expr_maybe_paren(func, prec)?;
+        self.print_expr_maybe_paren(func, prec);
         self.print_call_post(args)
     }
 
     fn print_expr_method_call(&mut self,
                               segment: &hir::PathSegment,
                               args: &[hir::Expr])
-                              -> io::Result<()> {
+                              {
         let base_args = &args[1..];
-        self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX)?;
-        self.s.word(".")?;
-        self.print_ident(segment.ident)?;
+        self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
+        self.s.word(".");
+        self.print_ident(segment.ident);
 
         let generic_args = segment.generic_args();
         if !generic_args.args.is_empty() || !generic_args.bindings.is_empty() {
-            self.print_generic_args(generic_args, segment.infer_args, true)?;
+            self.print_generic_args(generic_args, segment.infer_args, true);
         }
 
         self.print_call_post(base_args)
@@ -1202,7 +1183,7 @@ impl<'a> State<'a> {
                          op: hir::BinOp,
                          lhs: &hir::Expr,
                          rhs: &hir::Expr)
-                         -> io::Result<()> {
+                         {
         let assoc_op = bin_op_to_assoc_op(op.node);
         let prec = assoc_op.precedence() as i8;
         let fixity = assoc_op.fixity();
@@ -1222,220 +1203,220 @@ impl<'a> State<'a> {
             _ => left_prec,
         };
 
-        self.print_expr_maybe_paren(lhs, left_prec)?;
-        self.s.space()?;
-        self.word_space(op.node.as_str())?;
+        self.print_expr_maybe_paren(lhs, left_prec);
+        self.s.space();
+        self.word_space(op.node.as_str());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
-    fn print_expr_unary(&mut self, op: hir::UnOp, expr: &hir::Expr) -> io::Result<()> {
-        self.s.word(op.as_str())?;
+    fn print_expr_unary(&mut self, op: hir::UnOp, expr: &hir::Expr) {
+        self.s.word(op.as_str());
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
     fn print_expr_addr_of(&mut self,
                           mutability: hir::Mutability,
                           expr: &hir::Expr)
-                          -> io::Result<()> {
-        self.s.word("&")?;
-        self.print_mutability(mutability)?;
+                          {
+        self.s.word("&");
+        self.print_mutability(mutability);
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
-    fn print_literal(&mut self, lit: &hir::Lit) -> io::Result<()> {
-        self.maybe_print_comment(lit.span.lo())?;
+    fn print_literal(&mut self, lit: &hir::Lit) {
+        self.maybe_print_comment(lit.span.lo());
         self.writer().word(pprust::literal_to_string(lit.node.to_lit_token()))
     }
 
-    pub fn print_expr(&mut self, expr: &hir::Expr) -> io::Result<()> {
-        self.maybe_print_comment(expr.span.lo())?;
-        self.print_outer_attributes(&expr.attrs)?;
-        self.ibox(indent_unit)?;
-        self.ann.pre(self, AnnNode::Expr(expr))?;
+    pub fn print_expr(&mut self, expr: &hir::Expr) {
+        self.maybe_print_comment(expr.span.lo());
+        self.print_outer_attributes(&expr.attrs);
+        self.ibox(indent_unit);
+        self.ann.pre(self, AnnNode::Expr(expr));
         match expr.node {
             hir::ExprKind::Box(ref expr) => {
-                self.word_space("box")?;
-                self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)?;
+                self.word_space("box");
+                self.print_expr_maybe_paren(expr, parser::PREC_PREFIX);
             }
             hir::ExprKind::Array(ref exprs) => {
-                self.print_expr_vec(exprs)?;
+                self.print_expr_vec(exprs);
             }
             hir::ExprKind::Repeat(ref element, ref count) => {
-                self.print_expr_repeat(&element, count)?;
+                self.print_expr_repeat(&element, count);
             }
             hir::ExprKind::Struct(ref qpath, ref fields, ref wth) => {
-                self.print_expr_struct(qpath, &fields[..], wth)?;
+                self.print_expr_struct(qpath, &fields[..], wth);
             }
             hir::ExprKind::Tup(ref exprs) => {
-                self.print_expr_tup(exprs)?;
+                self.print_expr_tup(exprs);
             }
             hir::ExprKind::Call(ref func, ref args) => {
-                self.print_expr_call(&func, args)?;
+                self.print_expr_call(&func, args);
             }
             hir::ExprKind::MethodCall(ref segment, _, ref args) => {
-                self.print_expr_method_call(segment, args)?;
+                self.print_expr_method_call(segment, args);
             }
             hir::ExprKind::Binary(op, ref lhs, ref rhs) => {
-                self.print_expr_binary(op, &lhs, &rhs)?;
+                self.print_expr_binary(op, &lhs, &rhs);
             }
             hir::ExprKind::Unary(op, ref expr) => {
-                self.print_expr_unary(op, &expr)?;
+                self.print_expr_unary(op, &expr);
             }
             hir::ExprKind::AddrOf(m, ref expr) => {
-                self.print_expr_addr_of(m, &expr)?;
+                self.print_expr_addr_of(m, &expr);
             }
             hir::ExprKind::Lit(ref lit) => {
-                self.print_literal(&lit)?;
+                self.print_literal(&lit);
             }
             hir::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
-                self.print_expr_maybe_paren(&expr, prec)?;
-                self.s.space()?;
-                self.word_space("as")?;
-                self.print_type(&ty)?;
+                self.print_expr_maybe_paren(&expr, prec);
+                self.s.space();
+                self.word_space("as");
+                self.print_type(&ty);
             }
             hir::ExprKind::Type(ref expr, ref ty) => {
                 let prec = AssocOp::Colon.precedence() as i8;
-                self.print_expr_maybe_paren(&expr, prec)?;
-                self.word_space(":")?;
-                self.print_type(&ty)?;
+                self.print_expr_maybe_paren(&expr, prec);
+                self.word_space(":");
+                self.print_type(&ty);
             }
             hir::ExprKind::DropTemps(ref init) => {
                 // Print `{`:
-                self.cbox(indent_unit)?;
-                self.ibox(0)?;
-                self.bopen()?;
+                self.cbox(indent_unit);
+                self.ibox(0);
+                self.bopen();
 
                 // Print `let _t = $init;`:
                 let temp = ast::Ident::from_str("_t");
-                self.print_local(Some(init), |this| this.print_ident(temp))?;
-                self.s.word(";")?;
+                self.print_local(Some(init), |this| this.print_ident(temp));
+                self.s.word(";");
 
                 // Print `_t`:
-                self.space_if_not_bol()?;
-                self.print_ident(temp)?;
+                self.space_if_not_bol();
+                self.print_ident(temp);
 
                 // Print `}`:
-                self.bclose_maybe_open(expr.span, indent_unit, true)?;
+                self.bclose_maybe_open(expr.span, indent_unit, true);
             }
             hir::ExprKind::While(ref test, ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
-                self.head("while")?;
-                self.print_expr_as_cond(&test)?;
-                self.s.space()?;
-                self.print_block(&blk)?;
+                self.head("while");
+                self.print_expr_as_cond(&test);
+                self.s.space();
+                self.print_block(&blk);
             }
             hir::ExprKind::Loop(ref blk, opt_label, _) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
-                self.head("loop")?;
-                self.s.space()?;
-                self.print_block(&blk)?;
+                self.head("loop");
+                self.s.space();
+                self.print_block(&blk);
             }
             hir::ExprKind::Match(ref expr, ref arms, _) => {
-                self.cbox(indent_unit)?;
-                self.ibox(4)?;
-                self.word_nbsp("match")?;
-                self.print_expr_as_cond(&expr)?;
-                self.s.space()?;
-                self.bopen()?;
+                self.cbox(indent_unit);
+                self.ibox(4);
+                self.word_nbsp("match");
+                self.print_expr_as_cond(&expr);
+                self.s.space();
+                self.bopen();
                 for arm in arms {
-                    self.print_arm(arm)?;
+                    self.print_arm(arm);
                 }
-                self.bclose_(expr.span, indent_unit)?;
+                self.bclose_(expr.span, indent_unit);
             }
             hir::ExprKind::Closure(capture_clause, ref decl, body, _fn_decl_span, _gen) => {
-                self.print_capture_clause(capture_clause)?;
+                self.print_capture_clause(capture_clause);
 
-                self.print_closure_args(&decl, body)?;
-                self.s.space()?;
+                self.print_closure_args(&decl, body);
+                self.s.space();
 
                 // this is a bare expression
-                self.ann.nested(self, Nested::Body(body))?;
-                self.end()?; // need to close a box
+                self.ann.nested(self, Nested::Body(body));
+                self.end(); // need to close a box
 
                 // a box will be closed by print_expr, but we didn't want an overall
                 // wrapper so we closed the corresponding opening. so create an
                 // empty box to satisfy the close.
-                self.ibox(0)?;
+                self.ibox(0);
             }
             hir::ExprKind::Block(ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
                 // containing cbox, will be closed by print-block at }
-                self.cbox(indent_unit)?;
+                self.cbox(indent_unit);
                 // head-box, will be closed by print-block after {
-                self.ibox(0)?;
-                self.print_block(&blk)?;
+                self.ibox(0);
+                self.print_block(&blk);
             }
             hir::ExprKind::Assign(ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
-                self.print_expr_maybe_paren(&lhs, prec + 1)?;
-                self.s.space()?;
-                self.word_space("=")?;
-                self.print_expr_maybe_paren(&rhs, prec)?;
+                self.print_expr_maybe_paren(&lhs, prec + 1);
+                self.s.space();
+                self.word_space("=");
+                self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
-                self.print_expr_maybe_paren(&lhs, prec + 1)?;
-                self.s.space()?;
-                self.s.word(op.node.as_str())?;
-                self.word_space("=")?;
-                self.print_expr_maybe_paren(&rhs, prec)?;
+                self.print_expr_maybe_paren(&lhs, prec + 1);
+                self.s.space();
+                self.s.word(op.node.as_str());
+                self.word_space("=");
+                self.print_expr_maybe_paren(&rhs, prec);
             }
             hir::ExprKind::Field(ref expr, ident) => {
-                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX)?;
-                self.s.word(".")?;
-                self.print_ident(ident)?;
+                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
+                self.s.word(".");
+                self.print_ident(ident);
             }
             hir::ExprKind::Index(ref expr, ref index) => {
-                self.print_expr_maybe_paren(&expr, parser::PREC_POSTFIX)?;
-                self.s.word("[")?;
-                self.print_expr(&index)?;
-                self.s.word("]")?;
+                self.print_expr_maybe_paren(&expr, parser::PREC_POSTFIX);
+                self.s.word("[");
+                self.print_expr(&index);
+                self.s.word("]");
             }
             hir::ExprKind::Path(ref qpath) => {
-                self.print_qpath(qpath, true)?
+                self.print_qpath(qpath, true)
             }
             hir::ExprKind::Break(destination, ref opt_expr) => {
-                self.s.word("break")?;
-                self.s.space()?;
+                self.s.word("break");
+                self.s.space();
                 if let Some(label) = destination.label {
-                    self.print_ident(label.ident)?;
-                    self.s.space()?;
+                    self.print_ident(label.ident);
+                    self.s.space();
                 }
                 if let Some(ref expr) = *opt_expr {
-                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP)?;
-                    self.s.space()?;
+                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
+                    self.s.space();
                 }
             }
             hir::ExprKind::Continue(destination) => {
-                self.s.word("continue")?;
-                self.s.space()?;
+                self.s.word("continue");
+                self.s.space();
                 if let Some(label) = destination.label {
-                    self.print_ident(label.ident)?;
-                    self.s.space()?
+                    self.print_ident(label.ident);
+                    self.s.space()
                 }
             }
             hir::ExprKind::Ret(ref result) => {
-                self.s.word("return")?;
+                self.s.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ")?;
-                    self.print_expr_maybe_paren(&expr, parser::PREC_JUMP)?;
+                    self.s.word(" ");
+                    self.print_expr_maybe_paren(&expr, parser::PREC_JUMP);
                 }
             }
             hir::ExprKind::InlineAsm(ref a, ref outputs, ref inputs) => {
-                self.s.word("asm!")?;
-                self.popen()?;
-                self.print_string(&a.asm.as_str(), a.asm_str_style)?;
-                self.word_space(":")?;
+                self.s.word("asm!");
+                self.popen();
+                self.print_string(&a.asm.as_str(), a.asm_str_style);
+                self.word_space(":");
 
                 let mut out_idx = 0;
                 self.commasep(Inconsistent, &a.outputs, |s, out| {
@@ -1444,35 +1425,32 @@ impl<'a> State<'a> {
                     match ch.next() {
                         Some('=') if out.is_rw => {
                             s.print_string(&format!("+{}", ch.as_str()),
-                                           ast::StrStyle::Cooked)?
+                                           ast::StrStyle::Cooked)
                         }
-                        _ => s.print_string(&constraint, ast::StrStyle::Cooked)?,
+                        _ => s.print_string(&constraint, ast::StrStyle::Cooked),
                     }
-                    s.popen()?;
-                    s.print_expr(&outputs[out_idx])?;
-                    s.pclose()?;
+                    s.popen();
+                    s.print_expr(&outputs[out_idx]);
+                    s.pclose();
                     out_idx += 1;
-                    Ok(())
-                })?;
-                self.s.space()?;
-                self.word_space(":")?;
+                });
+                self.s.space();
+                self.word_space(":");
 
                 let mut in_idx = 0;
                 self.commasep(Inconsistent, &a.inputs, |s, co| {
-                    s.print_string(&co.as_str(), ast::StrStyle::Cooked)?;
-                    s.popen()?;
-                    s.print_expr(&inputs[in_idx])?;
-                    s.pclose()?;
+                    s.print_string(&co.as_str(), ast::StrStyle::Cooked);
+                    s.popen();
+                    s.print_expr(&inputs[in_idx]);
+                    s.pclose();
                     in_idx += 1;
-                    Ok(())
-                })?;
-                self.s.space()?;
-                self.word_space(":")?;
+                });
+                self.s.space();
+                self.word_space(":");
 
                 self.commasep(Inconsistent, &a.clobbers, |s, co| {
-                    s.print_string(&co.as_str(), ast::StrStyle::Cooked)?;
-                    Ok(())
-                })?;
+                    s.print_string(&co.as_str(), ast::StrStyle::Cooked);
+                });
 
                 let mut options = vec![];
                 if a.volatile {
@@ -1486,131 +1464,126 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space()?;
-                    self.word_space(":")?;
+                    self.s.space();
+                    self.word_space(":");
                     self.commasep(Inconsistent, &options, |s, &co| {
-                        s.print_string(co, ast::StrStyle::Cooked)?;
-                        Ok(())
-                    })?;
+                        s.print_string(co, ast::StrStyle::Cooked);
+                    });
                 }
 
-                self.pclose()?;
+                self.pclose();
             }
             hir::ExprKind::Yield(ref expr, _) => {
-                self.word_space("yield")?;
-                self.print_expr_maybe_paren(&expr, parser::PREC_JUMP)?;
+                self.word_space("yield");
+                self.print_expr_maybe_paren(&expr, parser::PREC_JUMP);
             }
             hir::ExprKind::Err => {
-                self.popen()?;
-                self.s.word("/*ERROR*/")?;
-                self.pclose()?;
+                self.popen();
+                self.s.word("/*ERROR*/");
+                self.pclose();
             }
         }
-        self.ann.post(self, AnnNode::Expr(expr))?;
+        self.ann.post(self, AnnNode::Expr(expr));
         self.end()
     }
 
-    pub fn print_local_decl(&mut self, loc: &hir::Local) -> io::Result<()> {
-        self.print_pat(&loc.pat)?;
+    pub fn print_local_decl(&mut self, loc: &hir::Local) {
+        self.print_pat(&loc.pat);
         if let Some(ref ty) = loc.ty {
-            self.word_space(":")?;
-            self.print_type(&ty)?;
+            self.word_space(":");
+            self.print_type(&ty);
         }
-        Ok(())
     }
 
-    pub fn print_usize(&mut self, i: usize) -> io::Result<()> {
+    pub fn print_usize(&mut self, i: usize) {
         self.s.word(i.to_string())
     }
 
-    pub fn print_ident(&mut self, ident: ast::Ident) -> io::Result<()> {
+    pub fn print_ident(&mut self, ident: ast::Ident) {
         if ident.is_raw_guess() {
-            self.s.word(format!("r#{}", ident.name))?;
+            self.s.word(format!("r#{}", ident.name));
         } else {
-            self.s.word(ident.as_str().to_string())?;
+            self.s.word(ident.as_str().to_string());
         }
         self.ann.post(self, AnnNode::Name(&ident.name))
     }
 
-    pub fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
+    pub fn print_name(&mut self, name: ast::Name) {
         self.print_ident(ast::Ident::with_empty_ctxt(name))
     }
 
-    pub fn print_for_decl(&mut self, loc: &hir::Local, coll: &hir::Expr) -> io::Result<()> {
-        self.print_local_decl(loc)?;
-        self.s.space()?;
-        self.word_space("in")?;
+    pub fn print_for_decl(&mut self, loc: &hir::Local, coll: &hir::Expr) {
+        self.print_local_decl(loc);
+        self.s.space();
+        self.word_space("in");
         self.print_expr(coll)
     }
 
     pub fn print_path(&mut self,
                       path: &hir::Path,
                       colons_before_params: bool)
-                      -> io::Result<()> {
-        self.maybe_print_comment(path.span.lo())?;
+                      {
+        self.maybe_print_comment(path.span.lo());
 
         for (i, segment) in path.segments.iter().enumerate() {
             if i > 0 {
-                self.s.word("::")?
+                self.s.word("::")
             }
             if segment.ident.name != kw::PathRoot {
-                self.print_ident(segment.ident)?;
+                self.print_ident(segment.ident);
                 self.print_generic_args(segment.generic_args(), segment.infer_args,
-                                        colons_before_params)?;
+                                        colons_before_params);
             }
         }
-
-        Ok(())
     }
 
-    pub fn print_path_segment(&mut self, segment: &hir::PathSegment) -> io::Result<()> {
+    pub fn print_path_segment(&mut self, segment: &hir::PathSegment) {
         if segment.ident.name != kw::PathRoot {
-            self.print_ident(segment.ident)?;
-            self.print_generic_args(segment.generic_args(), segment.infer_args, false)?;
+            self.print_ident(segment.ident);
+            self.print_generic_args(segment.generic_args(), segment.infer_args, false);
         }
-        Ok(())
     }
 
     pub fn print_qpath(&mut self,
                        qpath: &hir::QPath,
                        colons_before_params: bool)
-                       -> io::Result<()> {
+                       {
         match *qpath {
             hir::QPath::Resolved(None, ref path) => {
                 self.print_path(path, colons_before_params)
             }
             hir::QPath::Resolved(Some(ref qself), ref path) => {
-                self.s.word("<")?;
-                self.print_type(qself)?;
-                self.s.space()?;
-                self.word_space("as")?;
+                self.s.word("<");
+                self.print_type(qself);
+                self.s.space();
+                self.word_space("as");
 
                 for (i, segment) in path.segments[..path.segments.len() - 1].iter().enumerate() {
                     if i > 0 {
-                        self.s.word("::")?
+                        self.s.word("::")
                     }
                     if segment.ident.name != kw::PathRoot {
-                        self.print_ident(segment.ident)?;
+                        self.print_ident(segment.ident);
                         self.print_generic_args(segment.generic_args(),
                                                 segment.infer_args,
-                                                colons_before_params)?;
+                                                colons_before_params);
                     }
                 }
 
-                self.s.word(">")?;
-                self.s.word("::")?;
+                self.s.word(">");
+                self.s.word("::");
                 let item_segment = path.segments.last().unwrap();
-                self.print_ident(item_segment.ident)?;
+                self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),
                                         item_segment.infer_args,
                                         colons_before_params)
             }
             hir::QPath::TypeRelative(ref qself, ref item_segment) => {
-                self.s.word("<")?;
-                self.print_type(qself)?;
-                self.s.word(">")?;
-                self.s.word("::")?;
-                self.print_ident(item_segment.ident)?;
+                self.s.word("<");
+                self.print_type(qself);
+                self.s.word(">");
+                self.s.word("::");
+                self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),
                                         item_segment.infer_args,
                                         colons_before_params)
@@ -1622,15 +1595,15 @@ impl<'a> State<'a> {
                              generic_args: &hir::GenericArgs,
                              infer_args: bool,
                              colons_before_params: bool)
-                             -> io::Result<()> {
+                             {
         if generic_args.parenthesized {
-            self.s.word("(")?;
-            self.commasep(Inconsistent, generic_args.inputs(), |s, ty| s.print_type(&ty))?;
-            self.s.word(")")?;
+            self.s.word("(");
+            self.commasep(Inconsistent, generic_args.inputs(), |s, ty| s.print_type(&ty));
+            self.s.word(")");
 
-            self.space_if_not_bol()?;
-            self.word_space("->")?;
-            self.print_type(generic_args.bindings[0].ty())?;
+            self.space_if_not_bol();
+            self.word_space("->");
+            self.print_type(generic_args.bindings[0].ty());
         } else {
             let start = if colons_before_params { "::<" } else { "<" };
             let empty = Cell::new(true);
@@ -1653,153 +1626,151 @@ impl<'a> State<'a> {
             });
 
             if nonelided_generic_args {
-                start_or_comma(self)?;
+                start_or_comma(self);
                 self.commasep(Inconsistent, &generic_args.args, |s, generic_arg| {
                     match generic_arg {
                         GenericArg::Lifetime(lt) if !elide_lifetimes => s.print_lifetime(lt),
-                        GenericArg::Lifetime(_) => Ok(()),
+                        GenericArg::Lifetime(_) => {},
                         GenericArg::Type(ty) => s.print_type(ty),
                         GenericArg::Const(ct) => s.print_anon_const(&ct.value),
                     }
-                })?;
+                });
             }
 
             // FIXME(eddyb): this would leak into error messages (e.g.,
             // "non-exhaustive patterns: `Some::<..>(_)` not covered").
             if infer_args && false {
-                start_or_comma(self)?;
-                self.s.word("..")?;
+                start_or_comma(self);
+                self.s.word("..");
             }
 
             for binding in generic_args.bindings.iter() {
-                start_or_comma(self)?;
-                self.print_ident(binding.ident)?;
-                self.s.space()?;
+                start_or_comma(self);
+                self.print_ident(binding.ident);
+                self.s.space();
                 match generic_args.bindings[0].kind {
                     hir::TypeBindingKind::Equality { ref ty } => {
-                        self.word_space("=")?;
-                        self.print_type(ty)?;
+                        self.word_space("=");
+                        self.print_type(ty);
                     }
                     hir::TypeBindingKind::Constraint { ref bounds } => {
-                        self.print_bounds(":", bounds)?;
+                        self.print_bounds(":", bounds);
                     }
                 }
             }
 
             if !empty.get() {
-                self.s.word(">")?
+                self.s.word(">")
             }
         }
-
-        Ok(())
     }
 
-    pub fn print_pat(&mut self, pat: &hir::Pat) -> io::Result<()> {
-        self.maybe_print_comment(pat.span.lo())?;
-        self.ann.pre(self, AnnNode::Pat(pat))?;
+    pub fn print_pat(&mut self, pat: &hir::Pat) {
+        self.maybe_print_comment(pat.span.lo());
+        self.ann.pre(self, AnnNode::Pat(pat));
         // Pat isn't normalized, but the beauty of it
         // is that it doesn't matter
         match pat.node {
-            PatKind::Wild => self.s.word("_")?,
+            PatKind::Wild => self.s.word("_"),
             PatKind::Binding(binding_mode, _, ident, ref sub) => {
                 match binding_mode {
                     hir::BindingAnnotation::Ref => {
-                        self.word_nbsp("ref")?;
-                        self.print_mutability(hir::MutImmutable)?;
+                        self.word_nbsp("ref");
+                        self.print_mutability(hir::MutImmutable);
                     }
                     hir::BindingAnnotation::RefMut => {
-                        self.word_nbsp("ref")?;
-                        self.print_mutability(hir::MutMutable)?;
+                        self.word_nbsp("ref");
+                        self.print_mutability(hir::MutMutable);
                     }
                     hir::BindingAnnotation::Unannotated => {}
                     hir::BindingAnnotation::Mutable => {
-                        self.word_nbsp("mut")?;
+                        self.word_nbsp("mut");
                     }
                 }
-                self.print_ident(ident)?;
+                self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.word("@")?;
-                    self.print_pat(&p)?;
+                    self.s.word("@");
+                    self.print_pat(&p);
                 }
             }
             PatKind::TupleStruct(ref qpath, ref elts, ddpos) => {
-                self.print_qpath(qpath, true)?;
-                self.popen()?;
+                self.print_qpath(qpath, true);
+                self.popen();
                 if let Some(ddpos) = ddpos {
-                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p))?;
+                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p));
                     if ddpos != 0 {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",")?;
-                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p))?;
+                        self.s.word(",");
+                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
-                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p))?;
+                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p));
                 }
-                self.pclose()?;
+                self.pclose();
             }
             PatKind::Path(ref qpath) => {
-                self.print_qpath(qpath, true)?;
+                self.print_qpath(qpath, true);
             }
             PatKind::Struct(ref qpath, ref fields, etc) => {
-                self.print_qpath(qpath, true)?;
-                self.nbsp()?;
-                self.word_space("{")?;
+                self.print_qpath(qpath, true);
+                self.nbsp();
+                self.word_space("{");
                 self.commasep_cmnt(Consistent,
                                    &fields[..],
                                    |s, f| {
-                                       s.cbox(indent_unit)?;
+                                       s.cbox(indent_unit);
                                        if !f.node.is_shorthand {
-                                           s.print_ident(f.node.ident)?;
-                                           s.word_nbsp(":")?;
+                                           s.print_ident(f.node.ident);
+                                           s.word_nbsp(":");
                                        }
-                                       s.print_pat(&f.node.pat)?;
+                                       s.print_pat(&f.node.pat);
                                        s.end()
                                    },
-                                   |f| f.node.pat.span)?;
+                                   |f| f.node.pat.span);
                 if etc {
                     if !fields.is_empty() {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                 }
-                self.s.space()?;
-                self.s.word("}")?;
+                self.s.space();
+                self.s.word("}");
             }
             PatKind::Tuple(ref elts, ddpos) => {
-                self.popen()?;
+                self.popen();
                 if let Some(ddpos) = ddpos {
-                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p))?;
+                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(&p));
                     if ddpos != 0 {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",")?;
-                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p))?;
+                        self.s.word(",");
+                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(&p));
                     }
                 } else {
-                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p))?;
+                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(&p));
                     if elts.len() == 1 {
-                        self.s.word(",")?;
+                        self.s.word(",");
                     }
                 }
-                self.pclose()?;
+                self.pclose();
             }
             PatKind::Box(ref inner) => {
                 let is_range_inner = match inner.node {
                     PatKind::Range(..) => true,
                     _ => false,
                 };
-                self.s.word("box ")?;
+                self.s.word("box ");
                 if is_range_inner {
-                    self.popen()?;
+                    self.popen();
                 }
-                self.print_pat(&inner)?;
+                self.print_pat(&inner);
                 if is_range_inner {
-                    self.pclose()?;
+                    self.pclose();
                 }
             }
             PatKind::Ref(ref inner, mutbl) => {
@@ -1807,101 +1778,101 @@ impl<'a> State<'a> {
                     PatKind::Range(..) => true,
                     _ => false,
                 };
-                self.s.word("&")?;
+                self.s.word("&");
                 if mutbl == hir::MutMutable {
-                    self.s.word("mut ")?;
+                    self.s.word("mut ");
                 }
                 if is_range_inner {
-                    self.popen()?;
+                    self.popen();
                 }
-                self.print_pat(&inner)?;
+                self.print_pat(&inner);
                 if is_range_inner {
-                    self.pclose()?;
+                    self.pclose();
                 }
             }
-            PatKind::Lit(ref e) => self.print_expr(&e)?,
+            PatKind::Lit(ref e) => self.print_expr(&e),
             PatKind::Range(ref begin, ref end, ref end_kind) => {
-                self.print_expr(&begin)?;
-                self.s.space()?;
+                self.print_expr(&begin);
+                self.s.space();
                 match *end_kind {
-                    RangeEnd::Included => self.s.word("...")?,
-                    RangeEnd::Excluded => self.s.word("..")?,
+                    RangeEnd::Included => self.s.word("..."),
+                    RangeEnd::Excluded => self.s.word(".."),
                 }
-                self.print_expr(&end)?;
+                self.print_expr(&end);
             }
             PatKind::Slice(ref before, ref slice, ref after) => {
-                self.s.word("[")?;
-                self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p))?;
+                self.s.word("[");
+                self.commasep(Inconsistent, &before[..], |s, p| s.print_pat(&p));
                 if let Some(ref p) = *slice {
                     if !before.is_empty() {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
                     if let PatKind::Wild = p.node {
                         // Print nothing
                     } else {
-                        self.print_pat(&p)?;
+                        self.print_pat(&p);
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                     if !after.is_empty() {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
                 }
-                self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p))?;
-                self.s.word("]")?;
+                self.commasep(Inconsistent, &after[..], |s, p| s.print_pat(&p));
+                self.s.word("]");
             }
         }
         self.ann.post(self, AnnNode::Pat(pat))
     }
 
-    pub fn print_arm(&mut self, arm: &hir::Arm) -> io::Result<()> {
+    pub fn print_arm(&mut self, arm: &hir::Arm) {
         // I have no idea why this check is necessary, but here it
         // is :(
         if arm.attrs.is_empty() {
-            self.s.space()?;
+            self.s.space();
         }
-        self.cbox(indent_unit)?;
-        self.ibox(0)?;
-        self.print_outer_attributes(&arm.attrs)?;
+        self.cbox(indent_unit);
+        self.ibox(0);
+        self.print_outer_attributes(&arm.attrs);
         let mut first = true;
         for p in &arm.pats {
             if first {
                 first = false;
             } else {
-                self.s.space()?;
-                self.word_space("|")?;
+                self.s.space();
+                self.word_space("|");
             }
-            self.print_pat(&p)?;
+            self.print_pat(&p);
         }
-        self.s.space()?;
+        self.s.space();
         if let Some(ref g) = arm.guard {
             match g {
                 hir::Guard::If(e) => {
-                    self.word_space("if")?;
-                    self.print_expr(&e)?;
-                    self.s.space()?;
+                    self.word_space("if");
+                    self.print_expr(&e);
+                    self.s.space();
                 }
             }
         }
-        self.word_space("=>")?;
+        self.word_space("=>");
 
         match arm.body.node {
             hir::ExprKind::Block(ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
                 // the block will close the pattern's ibox
-                self.print_block_unclosed_indent(&blk, indent_unit)?;
+                self.print_block_unclosed_indent(&blk, indent_unit);
 
                 // If it is a user-provided unsafe block, print a comma after it
                 if let hir::UnsafeBlock(hir::UserProvided) = blk.rules {
-                    self.s.word(",")?;
+                    self.s.word(",");
                 }
             }
             _ => {
-                self.end()?; // close the ibox for the pattern
-                self.print_expr(&arm.body)?;
-                self.s.word(",")?;
+                self.end(); // close the ibox for the pattern
+                self.print_expr(&arm.body);
+                self.s.word(",");
             }
         }
         self.end() // close enclosing cbox
@@ -1915,82 +1886,82 @@ impl<'a> State<'a> {
                     vis: &hir::Visibility,
                     arg_names: &[ast::Ident],
                     body_id: Option<hir::BodyId>)
-                    -> io::Result<()> {
-        self.print_fn_header_info(header, vis)?;
+                    {
+        self.print_fn_header_info(header, vis);
 
         if let Some(name) = name {
-            self.nbsp()?;
-            self.print_name(name)?;
+            self.nbsp();
+            self.print_name(name);
         }
-        self.print_generic_params(&generics.params)?;
+        self.print_generic_params(&generics.params);
 
-        self.popen()?;
+        self.popen();
         let mut i = 0;
         // Make sure we aren't supplied *both* `arg_names` and `body_id`.
         assert!(arg_names.is_empty() || body_id.is_none());
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
-            s.ibox(indent_unit)?;
+            s.ibox(indent_unit);
             if let Some(arg_name) = arg_names.get(i) {
-                s.s.word(arg_name.as_str().to_string())?;
-                s.s.word(":")?;
-                s.s.space()?;
+                s.s.word(arg_name.as_str().to_string());
+                s.s.word(":");
+                s.s.space();
             } else if let Some(body_id) = body_id {
-                s.ann.nested(s, Nested::BodyArgPat(body_id, i))?;
-                s.s.word(":")?;
-                s.s.space()?;
+                s.ann.nested(s, Nested::BodyArgPat(body_id, i));
+                s.s.word(":");
+                s.s.space();
             }
             i += 1;
-            s.print_type(ty)?;
+            s.print_type(ty);
             s.end()
-        })?;
+        });
         if decl.c_variadic {
-            self.s.word(", ...")?;
+            self.s.word(", ...");
         }
-        self.pclose()?;
+        self.pclose();
 
-        self.print_fn_output(decl)?;
+        self.print_fn_output(decl);
         self.print_where_clause(&generics.where_clause)
     }
 
-    fn print_closure_args(&mut self, decl: &hir::FnDecl, body_id: hir::BodyId) -> io::Result<()> {
-        self.s.word("|")?;
+    fn print_closure_args(&mut self, decl: &hir::FnDecl, body_id: hir::BodyId) {
+        self.s.word("|");
         let mut i = 0;
         self.commasep(Inconsistent, &decl.inputs, |s, ty| {
-            s.ibox(indent_unit)?;
+            s.ibox(indent_unit);
 
-            s.ann.nested(s, Nested::BodyArgPat(body_id, i))?;
+            s.ann.nested(s, Nested::BodyArgPat(body_id, i));
             i += 1;
 
             if let hir::TyKind::Infer = ty.node {
                 // Print nothing
             } else {
-                s.s.word(":")?;
-                s.s.space()?;
-                s.print_type(ty)?;
+                s.s.word(":");
+                s.s.space();
+                s.print_type(ty);
             }
-            s.end()
-        })?;
-        self.s.word("|")?;
+            s.end();
+        });
+        self.s.word("|");
 
         if let hir::DefaultReturn(..) = decl.output {
-            return Ok(());
+            return;
         }
 
-        self.space_if_not_bol()?;
-        self.word_space("->")?;
+        self.space_if_not_bol();
+        self.word_space("->");
         match decl.output {
             hir::Return(ref ty) => {
-                self.print_type(&ty)?;
+                self.print_type(&ty);
                 self.maybe_print_comment(ty.span.lo())
             }
             hir::DefaultReturn(..) => unreachable!(),
         }
     }
 
-    pub fn print_capture_clause(&mut self, capture_clause: hir::CaptureClause) -> io::Result<()> {
+    pub fn print_capture_clause(&mut self, capture_clause: hir::CaptureClause) {
         match capture_clause {
             hir::CaptureByValue => self.word_space("move"),
-            hir::CaptureByRef => Ok(()),
+            hir::CaptureByRef => {},
         }
     }
 
@@ -1998,55 +1969,53 @@ impl<'a> State<'a> {
         &mut self,
         prefix: &'static str,
         bounds: impl IntoIterator<Item = &'b hir::GenericBound>,
-    ) -> io::Result<()> {
+    ) {
         let mut first = true;
         for bound in bounds {
             if first {
-                self.s.word(prefix)?;
+                self.s.word(prefix);
             }
             if !(first && prefix.is_empty()) {
-                self.nbsp()?;
+                self.nbsp();
             }
             if first {
                 first = false;
             } else {
-                self.word_space("+")?;
+                self.word_space("+");
             }
 
             match bound {
                 GenericBound::Trait(tref, modifier) => {
                     if modifier == &TraitBoundModifier::Maybe {
-                        self.s.word("?")?;
+                        self.s.word("?");
                     }
-                    self.print_poly_trait_ref(tref)?;
+                    self.print_poly_trait_ref(tref);
                 }
                 GenericBound::Outlives(lt) => {
-                    self.print_lifetime(lt)?;
+                    self.print_lifetime(lt);
                 }
             }
         }
-        Ok(())
     }
 
-    pub fn print_generic_params(&mut self, generic_params: &[GenericParam]) -> io::Result<()> {
+    pub fn print_generic_params(&mut self, generic_params: &[GenericParam]) {
         if !generic_params.is_empty() {
-            self.s.word("<")?;
+            self.s.word("<");
 
             self.commasep(Inconsistent, generic_params, |s, param| {
                 s.print_generic_param(param)
-            })?;
+            });
 
-            self.s.word(">")?;
+            self.s.word(">");
         }
-        Ok(())
     }
 
-    pub fn print_generic_param(&mut self, param: &GenericParam) -> io::Result<()> {
+    pub fn print_generic_param(&mut self, param: &GenericParam) {
         if let GenericParamKind::Const { .. } = param.kind {
-            self.word_space("const")?;
+            self.word_space("const");
         }
 
-        self.print_ident(param.name.ident())?;
+        self.print_ident(param.name.ident());
 
         match param.kind {
             GenericParamKind::Lifetime { .. } => {
@@ -2054,48 +2023,47 @@ impl<'a> State<'a> {
                 for bound in &param.bounds {
                     match bound {
                         GenericBound::Outlives(lt) => {
-                            self.s.word(sep)?;
-                            self.print_lifetime(lt)?;
+                            self.s.word(sep);
+                            self.print_lifetime(lt);
                             sep = "+";
                         }
                         _ => bug!(),
                     }
                 }
-                Ok(())
             }
             GenericParamKind::Type { ref default, .. } => {
-                self.print_bounds(":", &param.bounds)?;
+                self.print_bounds(":", &param.bounds);
                 match default {
                     Some(default) => {
-                        self.s.space()?;
-                        self.word_space("=")?;
+                        self.s.space();
+                        self.word_space("=");
                         self.print_type(&default)
                     }
-                    _ => Ok(()),
+                    _ => {}
                 }
             }
             GenericParamKind::Const { ref ty } => {
-                self.word_space(":")?;
+                self.word_space(":");
                 self.print_type(ty)
             }
         }
     }
 
-    pub fn print_lifetime(&mut self, lifetime: &hir::Lifetime) -> io::Result<()> {
+    pub fn print_lifetime(&mut self, lifetime: &hir::Lifetime) {
         self.print_ident(lifetime.name.ident())
     }
 
-    pub fn print_where_clause(&mut self, where_clause: &hir::WhereClause) -> io::Result<()> {
+    pub fn print_where_clause(&mut self, where_clause: &hir::WhereClause) {
         if where_clause.predicates.is_empty() {
-            return Ok(());
+            return;
         }
 
-        self.s.space()?;
-        self.word_space("where")?;
+        self.s.space();
+        self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
             if i != 0 {
-                self.word_space(",")?;
+                self.word_space(",");
             }
 
             match predicate {
@@ -2105,72 +2073,70 @@ impl<'a> State<'a> {
                     ref bounds,
                     ..
                 }) => {
-                    self.print_formal_generic_params(bound_generic_params)?;
-                    self.print_type(&bounded_ty)?;
-                    self.print_bounds(":", bounds)?;
+                    self.print_formal_generic_params(bound_generic_params);
+                    self.print_type(&bounded_ty);
+                    self.print_bounds(":", bounds);
                 }
                 &hir::WherePredicate::RegionPredicate(hir::WhereRegionPredicate{ref lifetime,
                                                                                 ref bounds,
                                                                                 ..}) => {
-                    self.print_lifetime(lifetime)?;
-                    self.s.word(":")?;
+                    self.print_lifetime(lifetime);
+                    self.s.word(":");
 
                     for (i, bound) in bounds.iter().enumerate() {
                         match bound {
                             GenericBound::Outlives(lt) => {
-                                self.print_lifetime(lt)?;
+                                self.print_lifetime(lt);
                             }
                             _ => bug!(),
                         }
 
                         if i != 0 {
-                            self.s.word(":")?;
+                            self.s.word(":");
                         }
                     }
                 }
                 &hir::WherePredicate::EqPredicate(hir::WhereEqPredicate{ref lhs_ty,
                                                                         ref rhs_ty,
                                                                         ..}) => {
-                    self.print_type(lhs_ty)?;
-                    self.s.space()?;
-                    self.word_space("=")?;
-                    self.print_type(rhs_ty)?;
+                    self.print_type(lhs_ty);
+                    self.s.space();
+                    self.word_space("=");
+                    self.print_type(rhs_ty);
                 }
             }
         }
-
-        Ok(())
     }
 
-    pub fn print_mutability(&mut self, mutbl: hir::Mutability) -> io::Result<()> {
+    pub fn print_mutability(&mut self, mutbl: hir::Mutability) {
         match mutbl {
             hir::MutMutable => self.word_nbsp("mut"),
-            hir::MutImmutable => Ok(()),
+            hir::MutImmutable => {},
         }
     }
 
-    pub fn print_mt(&mut self, mt: &hir::MutTy) -> io::Result<()> {
-        self.print_mutability(mt.mutbl)?;
+    pub fn print_mt(&mut self, mt: &hir::MutTy) {
+        self.print_mutability(mt.mutbl);
         self.print_type(&mt.ty)
     }
 
-    pub fn print_fn_output(&mut self, decl: &hir::FnDecl) -> io::Result<()> {
+    pub fn print_fn_output(&mut self, decl: &hir::FnDecl) {
         if let hir::DefaultReturn(..) = decl.output {
-            return Ok(());
+            return;
         }
 
-        self.space_if_not_bol()?;
-        self.ibox(indent_unit)?;
-        self.word_space("->")?;
+        self.space_if_not_bol();
+        self.ibox(indent_unit);
+        self.word_space("->");
         match decl.output {
             hir::DefaultReturn(..) => unreachable!(),
-            hir::Return(ref ty) => self.print_type(&ty)?,
+            hir::Return(ref ty) => self.print_type(&ty),
         }
-        self.end()?;
+        self.end();
 
         match decl.output {
             hir::Return(ref output) => self.maybe_print_comment(output.span.lo()),
-            _ => Ok(()),
+            _ => {},
         }
     }
 
@@ -2181,11 +2147,11 @@ impl<'a> State<'a> {
                        name: Option<ast::Name>,
                        generic_params: &[hir::GenericParam],
                        arg_names: &[ast::Ident])
-                       -> io::Result<()> {
-        self.ibox(indent_unit)?;
+                       {
+        self.ibox(indent_unit);
         if !generic_params.is_empty() {
-            self.s.word("for")?;
-            self.print_generic_params(generic_params)?;
+            self.s.word("for");
+            self.print_generic_params(generic_params);
         }
         let generics = hir::Generics {
             params: hir::HirVec::new(),
@@ -2207,21 +2173,21 @@ impl<'a> State<'a> {
                       &Spanned { span: syntax_pos::DUMMY_SP,
                                  node: hir::VisibilityKind::Inherited },
                       arg_names,
-                      None)?;
-        self.end()
+                      None);
+        self.end();
     }
 
     pub fn maybe_print_trailing_comment(&mut self,
                                         span: syntax_pos::Span,
                                         next_pos: Option<BytePos>)
-                                        -> io::Result<()> {
+                                        {
         let cm = match self.cm {
             Some(cm) => cm,
-            _ => return Ok(()),
+            _ => return,
         };
         if let Some(ref cmnt) = self.next_comment() {
             if (*cmnt).style != comments::Trailing {
-                return Ok(());
+                return;
             }
             let span_line = cm.lookup_char_pos(span.hi());
             let comment_line = cm.lookup_char_pos((*cmnt).pos);
@@ -2231,84 +2197,82 @@ impl<'a> State<'a> {
             }
             if span.hi() < (*cmnt).pos && (*cmnt).pos < next &&
                span_line.line == comment_line.line {
-                self.print_comment(cmnt)?;
+                self.print_comment(cmnt);
             }
         }
-        Ok(())
     }
 
-    pub fn print_remaining_comments(&mut self) -> io::Result<()> {
+    pub fn print_remaining_comments(&mut self) {
         // If there aren't any remaining comments, then we need to manually
         // make sure there is a line break at the end.
         if self.next_comment().is_none() {
-            self.s.hardbreak()?;
+            self.s.hardbreak();
         }
         while let Some(ref cmnt) = self.next_comment() {
-            self.print_comment(cmnt)?
+            self.print_comment(cmnt)
         }
-        Ok(())
     }
 
     pub fn print_opt_abi_and_extern_if_nondefault(&mut self,
                                                   opt_abi: Option<Abi>)
-                                                  -> io::Result<()> {
+                                                  {
         match opt_abi {
-            Some(Abi::Rust) => Ok(()),
+            Some(Abi::Rust) => {},
             Some(abi) => {
-                self.word_nbsp("extern")?;
+                self.word_nbsp("extern");
                 self.word_nbsp(abi.to_string())
             }
-            None => Ok(()),
+            None => {},
         }
     }
 
-    pub fn print_extern_opt_abi(&mut self, opt_abi: Option<Abi>) -> io::Result<()> {
+    pub fn print_extern_opt_abi(&mut self, opt_abi: Option<Abi>) {
         match opt_abi {
             Some(abi) => {
-                self.word_nbsp("extern")?;
+                self.word_nbsp("extern");
                 self.word_nbsp(abi.to_string())
             }
-            None => Ok(()),
+            None => {},
         }
     }
 
     pub fn print_fn_header_info(&mut self,
                                 header: hir::FnHeader,
                                 vis: &hir::Visibility)
-                                -> io::Result<()> {
-        self.s.word(visibility_qualified(vis, ""))?;
+                                {
+        self.s.word(visibility_qualified(vis, ""));
 
         match header.constness {
             hir::Constness::NotConst => {}
-            hir::Constness::Const => self.word_nbsp("const")?,
+            hir::Constness::Const => self.word_nbsp("const"),
         }
 
         match header.asyncness {
             hir::IsAsync::NotAsync => {}
-            hir::IsAsync::Async => self.word_nbsp("async")?,
+            hir::IsAsync::Async => self.word_nbsp("async"),
         }
 
-        self.print_unsafety(header.unsafety)?;
+        self.print_unsafety(header.unsafety);
 
         if header.abi != Abi::Rust {
-            self.word_nbsp("extern")?;
-            self.word_nbsp(header.abi.to_string())?;
+            self.word_nbsp("extern");
+            self.word_nbsp(header.abi.to_string());
         }
 
         self.s.word("fn")
     }
 
-    pub fn print_unsafety(&mut self, s: hir::Unsafety) -> io::Result<()> {
+    pub fn print_unsafety(&mut self, s: hir::Unsafety) {
         match s {
-            hir::Unsafety::Normal => Ok(()),
+            hir::Unsafety::Normal => {}
             hir::Unsafety::Unsafe => self.word_nbsp("unsafe"),
         }
     }
 
-    pub fn print_is_auto(&mut self, s: hir::IsAuto) -> io::Result<()> {
+    pub fn print_is_auto(&mut self, s: hir::IsAuto) {
         match s {
             hir::IsAuto::Yes => self.word_nbsp("auto"),
-            hir::IsAuto::No => Ok(()),
+            hir::IsAuto::No => {},
         }
     }
 }

--- a/src/librustc_borrowck/dataflow.rs
+++ b/src/librustc_borrowck/dataflow.rs
@@ -6,7 +6,6 @@
 use rustc::cfg;
 use rustc::cfg::CFGIndex;
 use rustc::ty::TyCtxt;
-use std::io;
 use std::mem;
 use std::usize;
 use syntax::print::pprust::PrintState;
@@ -98,23 +97,23 @@ impl<'tcx, O: DataFlowOperator> DataFlowContext<'tcx, O> {
 }
 
 impl<'tcx, O: DataFlowOperator> pprust::PpAnn for DataFlowContext<'tcx, O> {
-    fn nested(&self, state: &mut pprust::State<'_>, nested: pprust::Nested) -> io::Result<()> {
+    fn nested(&self, state: &mut pprust::State<'_>, nested: pprust::Nested) {
         pprust::PpAnn::nested(self.tcx.hir(), state, nested)
     }
     fn pre(&self,
            ps: &mut pprust::State<'_>,
-           node: pprust::AnnNode<'_>) -> io::Result<()> {
+           node: pprust::AnnNode<'_>) {
         let id = match node {
-            pprust::AnnNode::Name(_) => return Ok(()),
+            pprust::AnnNode::Name(_) => return,
             pprust::AnnNode::Expr(expr) => expr.hir_id.local_id,
             pprust::AnnNode::Block(blk) => blk.hir_id.local_id,
             pprust::AnnNode::Item(_) |
-            pprust::AnnNode::SubItem(_) => return Ok(()),
+            pprust::AnnNode::SubItem(_) => return,
             pprust::AnnNode::Pat(pat) => pat.hir_id.local_id
         };
 
         if !self.has_bitset_for_local_id(id) {
-            return Ok(());
+            return;
         }
 
         assert!(self.bits_per_id > 0);
@@ -147,10 +146,9 @@ impl<'tcx, O: DataFlowOperator> pprust::PpAnn for DataFlowContext<'tcx, O> {
 
             ps.synth_comment(
                 format!("id {}: {}{}{}{}", id.as_usize(), entry_str,
-                        gens_str, action_kills_str, scope_kills_str))?;
-            ps.s.space()?;
+                        gens_str, action_kills_str, scope_kills_str));
+            ps.s.space();
         }
-        Ok(())
     }
 }
 
@@ -531,8 +529,8 @@ impl<'tcx, O: DataFlowOperator + Clone + 'static> DataFlowContext<'tcx, O> {
 
         debug!("Dataflow result for {}:", self.analysis_name);
         debug!("{}", pprust::to_string(self, |s| {
-            s.cbox(pprust::indent_unit)?;
-            s.ibox(0)?;
+            s.cbox(pprust::indent_unit);
+            s.ibox(0);
             s.print_expr(&body.value)
         }));
     }

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -297,12 +297,9 @@ impl<'hir> HirPrinterSupport<'hir> for NoAnn<'hir> {
 
 impl<'hir> pprust::PpAnn for NoAnn<'hir> {}
 impl<'hir> pprust_hir::PpAnn for NoAnn<'hir> {
-    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested)
-              -> io::Result<()> {
+    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested) {
         if let Some(tcx) = self.tcx {
             pprust_hir::PpAnn::nested(tcx.hir(), state, nested)
-        } else {
-            Ok(())
         }
     }
 }
@@ -323,37 +320,37 @@ impl<'hir> PrinterSupport for IdentifiedAnnotation<'hir> {
 }
 
 impl<'hir> pprust::PpAnn for IdentifiedAnnotation<'hir> {
-    fn pre(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) -> io::Result<()> {
+    fn pre(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) {
         match node {
             pprust::AnnNode::Expr(_) => s.popen(),
-            _ => Ok(()),
+            _ => {}
         }
     }
-    fn post(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) -> io::Result<()> {
+    fn post(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) {
         match node {
             pprust::AnnNode::Ident(_) |
-            pprust::AnnNode::Name(_) => Ok(()),
+            pprust::AnnNode::Name(_) => {},
 
             pprust::AnnNode::Item(item) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(item.id.to_string())
             }
             pprust::AnnNode::SubItem(id) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(id.to_string())
             }
             pprust::AnnNode::Block(blk) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(format!("block {}", blk.id))
             }
             pprust::AnnNode::Expr(expr) => {
-                s.s.space()?;
-                s.synth_comment(expr.id.to_string())?;
+                s.s.space();
+                s.synth_comment(expr.id.to_string());
                 s.pclose()
             }
             pprust::AnnNode::Pat(pat) => {
-                s.s.space()?;
-                s.synth_comment(format!("pat {}", pat.id))
+                s.s.space();
+                s.synth_comment(format!("pat {}", pat.id));
             }
         }
     }
@@ -374,45 +371,42 @@ impl<'hir> HirPrinterSupport<'hir> for IdentifiedAnnotation<'hir> {
 }
 
 impl<'hir> pprust_hir::PpAnn for IdentifiedAnnotation<'hir> {
-    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested)
-              -> io::Result<()> {
+    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested) {
         if let Some(ref tcx) = self.tcx {
             pprust_hir::PpAnn::nested(tcx.hir(), state, nested)
-        } else {
-            Ok(())
         }
     }
-    fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) -> io::Result<()> {
+    fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         match node {
             pprust_hir::AnnNode::Expr(_) => s.popen(),
-            _ => Ok(()),
+            _ => {}
         }
     }
-    fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) -> io::Result<()> {
+    fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         match node {
-            pprust_hir::AnnNode::Name(_) => Ok(()),
+            pprust_hir::AnnNode::Name(_) => {},
             pprust_hir::AnnNode::Item(item) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(format!("hir_id: {} hir local_id: {}",
                                         item.hir_id, item.hir_id.local_id.as_u32()))
             }
             pprust_hir::AnnNode::SubItem(id) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(id.to_string())
             }
             pprust_hir::AnnNode::Block(blk) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(format!("block hir_id: {} hir local_id: {}",
                                         blk.hir_id, blk.hir_id.local_id.as_u32()))
             }
             pprust_hir::AnnNode::Expr(expr) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(format!("expr hir_id: {} hir local_id: {}",
-                                        expr.hir_id, expr.hir_id.local_id.as_u32()))?;
+                                        expr.hir_id, expr.hir_id.local_id.as_u32()));
                 s.pclose()
             }
             pprust_hir::AnnNode::Pat(pat) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(format!("pat hir_id: {} hir local_id: {}",
                                         pat.hir_id, pat.hir_id.local_id.as_u32()))
             }
@@ -435,19 +429,19 @@ impl<'a> PrinterSupport for HygieneAnnotation<'a> {
 }
 
 impl<'a> pprust::PpAnn for HygieneAnnotation<'a> {
-    fn post(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) -> io::Result<()> {
+    fn post(&self, s: &mut pprust::State<'_>, node: pprust::AnnNode<'_>) {
         match node {
             pprust::AnnNode::Ident(&ast::Ident { name, span }) => {
-                s.s.space()?;
+                s.s.space();
                 // FIXME #16420: this doesn't display the connections
                 // between syntax contexts
                 s.synth_comment(format!("{}{:?}", name.as_u32(), span.ctxt()))
             }
             pprust::AnnNode::Name(&name) => {
-                s.s.space()?;
+                s.s.space();
                 s.synth_comment(name.as_u32().to_string())
             }
-            _ => Ok(()),
+            _ => {}
         }
     }
 }
@@ -476,32 +470,30 @@ impl<'b, 'tcx> HirPrinterSupport<'tcx> for TypedAnnotation<'b, 'tcx> {
 }
 
 impl<'a, 'tcx> pprust_hir::PpAnn for TypedAnnotation<'a, 'tcx> {
-    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested)
-              -> io::Result<()> {
+    fn nested(&self, state: &mut pprust_hir::State<'_>, nested: pprust_hir::Nested) {
         let old_tables = self.tables.get();
         if let pprust_hir::Nested::Body(id) = nested {
             self.tables.set(self.tcx.body_tables(id));
         }
-        pprust_hir::PpAnn::nested(self.tcx.hir(), state, nested)?;
+        pprust_hir::PpAnn::nested(self.tcx.hir(), state, nested);
         self.tables.set(old_tables);
-        Ok(())
     }
-    fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) -> io::Result<()> {
+    fn pre(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         match node {
             pprust_hir::AnnNode::Expr(_) => s.popen(),
-            _ => Ok(()),
+            _ => {}
         }
     }
-    fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) -> io::Result<()> {
+    fn post(&self, s: &mut pprust_hir::State<'_>, node: pprust_hir::AnnNode<'_>) {
         match node {
             pprust_hir::AnnNode::Expr(expr) => {
-                s.s.space()?;
-                s.s.word("as")?;
-                s.s.space()?;
-                s.s.word(self.tables.get().expr_ty(expr).to_string())?;
-                s.pclose()
+                s.s.space();
+                s.s.word("as");
+                s.s.space();
+                s.s.word(self.tables.get().expr_ty(expr).to_string());
+                s.pclose();
             }
-            _ => Ok(()),
+            _ => {},
         }
     }
 }
@@ -744,7 +736,7 @@ pub fn print_after_parsing(sess: &Session,
                                 out,
                                 annotation.pp_ann(),
                                 false)
-        }).unwrap()
+        })
     } else {
         unreachable!();
     };
@@ -831,14 +823,14 @@ pub fn print_after_hir_lowering<'tcx>(
                     for node_id in uii.all_matching_node_ids(hir_map) {
                         let hir_id = tcx.hir().node_to_hir_id(node_id);
                         let node = hir_map.get(hir_id);
-                        pp_state.print_node(node)?;
-                        pp_state.s.space()?;
+                        pp_state.print_node(node);
+                        pp_state.s.space();
                         let path = annotation.node_path(hir_id)
                             .expect("-Z unpretty missing node paths");
-                        pp_state.synth_comment(path)?;
-                        pp_state.s.hardbreak()?;
+                        pp_state.synth_comment(path);
+                        pp_state.s.hardbreak();
                     }
-                    pp_state.s.eof()
+                    pp_state.s.eof();
                 })
             }
 
@@ -851,13 +843,11 @@ pub fn print_after_hir_lowering<'tcx>(
                         let node = tcx.hir().get(hir_id);
                         out.push_str(&format!("{:#?}", node));
                     }
-                    Ok(())
                 })
             }
 
             _ => unreachable!(),
         }
-        .unwrap();
 
     write_output(out.into_bytes(), ofile);
 }

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1261,7 +1261,6 @@ pub fn noop_visit_vis<T: MutVisitor>(Spanned { node, span }: &mut Visibility, vi
 
 #[cfg(test)]
 mod tests {
-    use std::io;
     use crate::ast::{self, Ident};
     use crate::util::parser_testing::{string_to_crate, matches_codepattern};
     use crate::print::pprust;
@@ -1271,7 +1270,7 @@ mod tests {
 
     // this version doesn't care about getting comments or docstrings in.
     fn fake_print_crate(s: &mut pprust::State<'_>,
-                        krate: &ast::Crate) -> io::Result<()> {
+                        krate: &ast::Crate) {
         s.print_mod(&krate.module, &krate.attrs)
     }
 

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -613,12 +613,12 @@ impl<'a> Parser<'a> {
                 let sum_with_parens = pprust::to_string(|s| {
                     use crate::print::pprust::PrintState;
 
-                    s.s.word("&")?;
-                    s.print_opt_lifetime(lifetime)?;
-                    s.print_mutability(mut_ty.mutbl)?;
-                    s.popen()?;
-                    s.print_type(&mut_ty.ty)?;
-                    s.print_type_bounds(" +", &bounds)?;
+                    s.s.word("&");
+                    s.print_opt_lifetime(lifetime);
+                    s.print_mutability(mut_ty.mutbl);
+                    s.popen();
+                    s.print_type(&mut_ty.ty);
+                    s.print_type_bounds(" +", &bounds);
                     s.pclose()
                 });
                 err.span_suggestion(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2572,12 +2572,12 @@ impl<'a> Parser<'a> {
                           };
                           let sugg = pprust::to_string(|s| {
                               use crate::print::pprust::PrintState;
-                              s.popen()?;
-                              s.print_expr(&e)?;
-                              s.s.word( ".")?;
-                              s.print_usize(float.trunc() as usize)?;
-                              s.pclose()?;
-                              s.s.word(".")?;
+                              s.popen();
+                              s.print_expr(&e);
+                              s.s.word( ".");
+                              s.print_usize(float.trunc() as usize);
+                              s.pclose();
+                              s.s.word(".");
                               s.s.word(fstr.splitn(2, ".").last().unwrap().to_string())
                           });
                           err.span_suggestion(
@@ -4634,9 +4634,9 @@ impl<'a> Parser<'a> {
                     }
                     let sugg = pprust::to_string(|s| {
                         use crate::print::pprust::{PrintState, INDENT_UNIT};
-                        s.ibox(INDENT_UNIT)?;
-                        s.bopen()?;
-                        s.print_stmt(&stmt)?;
+                        s.ibox(INDENT_UNIT);
+                        s.bopen();
+                        s.print_stmt(&stmt);
                         s.bclose_maybe_open(stmt.span, INDENT_UNIT, false)
                     });
                     e.span_suggestion(

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -172,7 +172,7 @@ pub enum Token {
 }
 
 impl Token {
-    pub fn is_eof(&self) -> bool {
+    crate fn is_eof(&self) -> bool {
         match *self {
             Token::Eof => true,
             _ => false,
@@ -223,13 +223,13 @@ fn buf_str(buf: &[BufEntry], left: usize, right: usize, lim: usize) -> String {
 }
 
 #[derive(Copy, Clone)]
-pub enum PrintStackBreak {
+crate enum PrintStackBreak {
     Fits,
     Broken(Breaks),
 }
 
 #[derive(Copy, Clone)]
-pub struct PrintStackElem {
+crate struct PrintStackElem {
     offset: isize,
     pbreak: PrintStackBreak
 }
@@ -386,7 +386,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn check_stream(&mut self) -> io::Result<()> {
+    crate fn check_stream(&mut self) -> io::Result<()> {
         debug!("check_stream Vec<{}, {}> with left_total={}, right_total={}",
                self.left, self.right, self.left_total, self.right_total);
         if self.right_total - self.left_total > self.space {
@@ -405,24 +405,24 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    pub fn scan_push(&mut self, x: usize) {
+    crate fn scan_push(&mut self, x: usize) {
         debug!("scan_push {}", x);
         self.scan_stack.push_front(x);
     }
 
-    pub fn scan_pop(&mut self) -> usize {
+    crate fn scan_pop(&mut self) -> usize {
         self.scan_stack.pop_front().unwrap()
     }
 
-    pub fn scan_top(&mut self) -> usize {
+    crate fn scan_top(&mut self) -> usize {
         *self.scan_stack.front().unwrap()
     }
 
-    pub fn scan_pop_bottom(&mut self) -> usize {
+    crate fn scan_pop_bottom(&mut self) -> usize {
         self.scan_stack.pop_back().unwrap()
     }
 
-    pub fn advance_right(&mut self) {
+    crate fn advance_right(&mut self) {
         self.right += 1;
         self.right %= self.buf_max_len;
         // Extend the buf if necessary.
@@ -432,7 +432,7 @@ impl<'a> Printer<'a> {
         assert_ne!(self.right, self.left);
     }
 
-    pub fn advance_left(&mut self) -> io::Result<()> {
+    crate fn advance_left(&mut self) -> io::Result<()> {
         debug!("advance_left Vec<{},{}>, sizeof({})={}", self.left, self.right,
                self.left, self.buf[self.left].size);
 
@@ -467,7 +467,7 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    pub fn check_stack(&mut self, k: isize) {
+    crate fn check_stack(&mut self, k: isize) {
         if !self.scan_stack.is_empty() {
             let x = self.scan_top();
             match self.buf[x].token {
@@ -495,7 +495,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn print_newline(&mut self, amount: isize) -> io::Result<()> {
+    crate fn print_newline(&mut self, amount: isize) -> io::Result<()> {
         debug!("NEWLINE {}", amount);
         let ret = writeln!(self.out);
         self.pending_indentation = 0;
@@ -503,12 +503,12 @@ impl<'a> Printer<'a> {
         ret
     }
 
-    pub fn indent(&mut self, amount: isize) {
+    crate fn indent(&mut self, amount: isize) {
         debug!("INDENT {}", amount);
         self.pending_indentation += amount;
     }
 
-    pub fn get_top(&mut self) -> PrintStackElem {
+    crate fn get_top(&mut self) -> PrintStackElem {
         match self.print_stack.last() {
             Some(el) => *el,
             None => PrintStackElem {
@@ -518,7 +518,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn print_begin(&mut self, b: BeginToken, l: isize) -> io::Result<()> {
+    crate fn print_begin(&mut self, b: BeginToken, l: isize) -> io::Result<()> {
         if l > self.space {
             let col = self.margin - self.space + b.offset;
             debug!("print Begin -> push broken block at col {}", col);
@@ -536,7 +536,7 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    pub fn print_end(&mut self) -> io::Result<()> {
+    crate fn print_end(&mut self) -> io::Result<()> {
         debug!("print End -> pop End");
         let print_stack = &mut self.print_stack;
         assert!(!print_stack.is_empty());
@@ -544,7 +544,7 @@ impl<'a> Printer<'a> {
         Ok(())
     }
 
-    pub fn print_break(&mut self, b: BreakToken, l: isize) -> io::Result<()> {
+    crate fn print_break(&mut self, b: BreakToken, l: isize) -> io::Result<()> {
         let top = self.get_top();
         match top.pbreak {
             PrintStackBreak::Fits => {
@@ -578,7 +578,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    pub fn print_string(&mut self, s: Cow<'static, str>, len: isize) -> io::Result<()> {
+    crate fn print_string(&mut self, s: Cow<'static, str>, len: isize) -> io::Result<()> {
         debug!("print String({})", s);
         // assert!(len <= space);
         self.space -= len;
@@ -603,7 +603,7 @@ impl<'a> Printer<'a> {
         write!(self.out, "{}", s)
     }
 
-    pub fn print(&mut self, token: Token, l: isize) -> io::Result<()> {
+    crate fn print(&mut self, token: Token, l: isize) -> io::Result<()> {
         debug!("print {} {} (remaining line space={})", token, l,
                self.space);
         debug!("{}", buf_str(&self.buf,
@@ -625,7 +625,7 @@ impl<'a> Printer<'a> {
     // Convenience functions to talk to the printer.
 
     /// "raw box"
-    pub fn rbox(&mut self, indent: usize, b: Breaks) -> io::Result<()> {
+    crate fn rbox(&mut self, indent: usize, b: Breaks) -> io::Result<()> {
         self.pretty_print_begin(BeginToken {
             offset: indent as isize,
             breaks: b
@@ -633,7 +633,7 @@ impl<'a> Printer<'a> {
     }
 
     /// Inconsistent breaking box
-    pub fn ibox(&mut self, indent: usize) -> io::Result<()> {
+    crate fn ibox(&mut self, indent: usize) -> io::Result<()> {
         self.rbox(indent, Breaks::Inconsistent)
     }
 
@@ -649,7 +649,7 @@ impl<'a> Printer<'a> {
         })
     }
 
-    pub fn end(&mut self) -> io::Result<()> {
+    crate fn end(&mut self) -> io::Result<()> {
         self.pretty_print_end()
     }
 
@@ -667,7 +667,7 @@ impl<'a> Printer<'a> {
         self.break_offset(n, 0)
     }
 
-    pub fn zerobreak(&mut self) -> io::Result<()> {
+    crate fn zerobreak(&mut self) -> io::Result<()> {
         self.spaces(0)
     }
 
@@ -683,7 +683,7 @@ impl<'a> Printer<'a> {
         Token::Break(BreakToken {offset: off, blank_space: SIZE_INFINITY})
     }
 
-    pub fn hardbreak_tok() -> Token {
+    crate fn hardbreak_tok() -> Token {
         Self::hardbreak_tok_offset(0)
     }
 }

--- a/src/libsyntax/print/pp.rs
+++ b/src/libsyntax/print/pp.rs
@@ -682,8 +682,4 @@ impl<'a> Printer<'a> {
     pub fn hardbreak_tok_offset(off: isize) -> Token {
         Token::Break(BreakToken {offset: off, blank_space: SIZE_INFINITY})
     }
-
-    crate fn hardbreak_tok() -> Token {
-        Self::hardbreak_tok_offset(0)
-    }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -22,7 +22,6 @@ use syntax_pos::{DUMMY_SP, FileName};
 
 use std::borrow::Cow;
 use std::io::Read;
-use std::vec;
 
 pub enum AnnNode<'a> {
     Ident(&'a ast::Ident),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -66,9 +66,9 @@ fn rust_printer<'a>(writer: Box<dyn Write+'a>, ann: &'a dyn PpAnn) -> State<'a> 
     }
 }
 
-pub const INDENT_UNIT: usize = 4;
+crate const INDENT_UNIT: usize = 4;
 
-pub const DEFAULT_COLUMNS: usize = 78;
+crate const DEFAULT_COLUMNS: usize = 78;
 
 /// Requires you to pass an input filename and reader so that
 /// it can scan the input text for comments to copy forward.
@@ -254,7 +254,7 @@ pub fn token_to_string(token: &Token) -> String {
     token_kind_to_string(&token.kind)
 }
 
-pub fn nonterminal_to_string(nt: &Nonterminal) -> String {
+crate fn nonterminal_to_string(nt: &Nonterminal) -> String {
     match *nt {
         token::NtExpr(ref e)        => expr_to_string(e),
         token::NtMeta(ref e)        => meta_item_to_string(e),
@@ -805,12 +805,12 @@ impl<'a> State<'a> {
         self.s.cbox(u)
     }
 
-    pub fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
+    crate fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
         self.s.word(w)?;
         self.nbsp()
     }
 
-    pub fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
+    crate fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
         let w = w.into();
         // outer-box is consistent
         self.cbox(INDENT_UNIT)?;
@@ -823,16 +823,16 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn bopen(&mut self) -> io::Result<()> {
+    crate fn bopen(&mut self) -> io::Result<()> {
         self.s.word("{")?;
         self.end() // close the head-box
     }
 
-    pub fn bclose_(&mut self, span: syntax_pos::Span,
+    crate fn bclose_(&mut self, span: syntax_pos::Span,
                    indented: usize) -> io::Result<()> {
         self.bclose_maybe_open(span, indented, true)
     }
-    pub fn bclose_maybe_open(&mut self, span: syntax_pos::Span,
+    crate fn bclose_maybe_open(&mut self, span: syntax_pos::Span,
                              indented: usize, close_box: bool) -> io::Result<()> {
         self.maybe_print_comment(span.hi())?;
         self.break_offset_if_not_bol(1, -(indented as isize))?;
@@ -842,18 +842,18 @@ impl<'a> State<'a> {
         }
         Ok(())
     }
-    pub fn bclose(&mut self, span: syntax_pos::Span) -> io::Result<()> {
+    crate fn bclose(&mut self, span: syntax_pos::Span) -> io::Result<()> {
         self.bclose_(span, INDENT_UNIT)
     }
 
-    pub fn in_cbox(&self) -> bool {
+    crate fn in_cbox(&self) -> bool {
         match self.boxes.last() {
             Some(&last_box) => last_box == pp::Breaks::Consistent,
             None => false
         }
     }
 
-    pub fn break_offset_if_not_bol(&mut self, n: usize,
+    crate fn break_offset_if_not_bol(&mut self, n: usize,
                                    off: isize) -> io::Result<()> {
         if !self.is_bol() {
             self.s.break_offset(n, off)
@@ -880,7 +880,7 @@ impl<'a> State<'a> {
 
 
 
-    pub fn commasep_cmnt<T, F, G>(&mut self,
+    crate fn commasep_cmnt<T, F, G>(&mut self,
                                   b: Breaks,
                                   elts: &[T],
                                   mut op: F,
@@ -905,12 +905,12 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    pub fn commasep_exprs(&mut self, b: Breaks,
+    crate fn commasep_exprs(&mut self, b: Breaks,
                           exprs: &[P<ast::Expr>]) -> io::Result<()> {
         self.commasep_cmnt(b, exprs, |s, e| s.print_expr(e), |e| e.span)
     }
 
-    pub fn print_mod(&mut self, _mod: &ast::Mod,
+    crate fn print_mod(&mut self, _mod: &ast::Mod,
                      attrs: &[ast::Attribute]) -> io::Result<()> {
         self.print_inner_attributes(attrs)?;
         for item in &_mod.items {
@@ -919,7 +919,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_foreign_mod(&mut self, nmod: &ast::ForeignMod,
+    crate fn print_foreign_mod(&mut self, nmod: &ast::ForeignMod,
                              attrs: &[ast::Attribute]) -> io::Result<()> {
         self.print_inner_attributes(attrs)?;
         for item in &nmod.items {
@@ -928,7 +928,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_opt_lifetime(&mut self, lifetime: &Option<ast::Lifetime>) -> io::Result<()> {
+    crate fn print_opt_lifetime(&mut self, lifetime: &Option<ast::Lifetime>) -> io::Result<()> {
         if let Some(lt) = *lifetime {
             self.print_lifetime(lt)?;
             self.nbsp()?;
@@ -936,7 +936,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_generic_arg(&mut self, generic_arg: &GenericArg) -> io::Result<()> {
+    crate fn print_generic_arg(&mut self, generic_arg: &GenericArg) -> io::Result<()> {
         match generic_arg {
             GenericArg::Lifetime(lt) => self.print_lifetime(*lt),
             GenericArg::Type(ty) => self.print_type(ty),
@@ -944,7 +944,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_type(&mut self, ty: &ast::Ty) -> io::Result<()> {
+    crate fn print_type(&mut self, ty: &ast::Ty) -> io::Result<()> {
         self.maybe_print_comment(ty.span.lo())?;
         self.ibox(0)?;
         match ty.node {
@@ -1036,7 +1036,7 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    pub fn print_foreign_item(&mut self,
+    crate fn print_foreign_item(&mut self,
                               item: &ast::ForeignItem) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
         self.maybe_print_comment(item.span.lo())?;
@@ -1119,7 +1119,7 @@ impl<'a> State<'a> {
     }
 
     /// Pretty-print an item
-    pub fn print_item(&mut self, item: &ast::Item) -> io::Result<()> {
+    crate fn print_item(&mut self, item: &ast::Item) -> io::Result<()> {
         self.hardbreak_if_not_bol()?;
         self.maybe_print_comment(item.span.lo())?;
         self.print_outer_attributes(&item.attrs)?;
@@ -1398,7 +1398,7 @@ impl<'a> State<'a> {
         self.print_trait_ref(&t.trait_ref)
     }
 
-    pub fn print_enum_def(&mut self, enum_definition: &ast::EnumDef,
+    crate fn print_enum_def(&mut self, enum_definition: &ast::EnumDef,
                           generics: &ast::Generics, ident: ast::Ident,
                           span: syntax_pos::Span,
                           visibility: &ast::Visibility) -> io::Result<()> {
@@ -1410,7 +1410,7 @@ impl<'a> State<'a> {
         self.print_variants(&enum_definition.variants, span)
     }
 
-    pub fn print_variants(&mut self,
+    crate fn print_variants(&mut self,
                           variants: &[ast::Variant],
                           span: syntax_pos::Span) -> io::Result<()> {
         self.bopen()?;
@@ -1427,7 +1427,7 @@ impl<'a> State<'a> {
         self.bclose(span)
     }
 
-    pub fn print_visibility(&mut self, vis: &ast::Visibility) -> io::Result<()> {
+    crate fn print_visibility(&mut self, vis: &ast::Visibility) -> io::Result<()> {
         match vis.node {
             ast::VisibilityKind::Public => self.word_nbsp("pub"),
             ast::VisibilityKind::Crate(sugar) => match sugar {
@@ -1446,14 +1446,14 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_defaultness(&mut self, defaultness: ast::Defaultness) -> io::Result<()> {
+    crate fn print_defaultness(&mut self, defaultness: ast::Defaultness) -> io::Result<()> {
         if let ast::Defaultness::Default = defaultness {
             self.word_nbsp("default")?;
         }
         Ok(())
     }
 
-    pub fn print_struct(&mut self,
+    crate fn print_struct(&mut self,
                         struct_def: &ast::VariantData,
                         generics: &ast::Generics,
                         ident: ast::Ident,
@@ -1505,7 +1505,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
+    crate fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
         self.head("")?;
         let generics = ast::Generics::default();
         self.print_struct(&v.node.data, &generics, v.node.ident, v.span, false)?;
@@ -1519,7 +1519,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_method_sig(&mut self,
+    crate fn print_method_sig(&mut self,
                             ident: ast::Ident,
                             generics: &ast::Generics,
                             m: &ast::MethodSig,
@@ -1532,7 +1532,7 @@ impl<'a> State<'a> {
                       vis)
     }
 
-    pub fn print_trait_item(&mut self, ti: &ast::TraitItem)
+    crate fn print_trait_item(&mut self, ti: &ast::TraitItem)
                             -> io::Result<()> {
         self.ann.pre(self, AnnNode::SubItem(ti.id))?;
         self.hardbreak_if_not_bol()?;
@@ -1579,7 +1579,7 @@ impl<'a> State<'a> {
         self.ann.post(self, AnnNode::SubItem(ti.id))
     }
 
-    pub fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
+    crate fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
         self.ann.pre(self, AnnNode::SubItem(ii.id))?;
         self.hardbreak_if_not_bol()?;
         self.maybe_print_comment(ii.span.lo())?;
@@ -1613,7 +1613,7 @@ impl<'a> State<'a> {
         self.ann.post(self, AnnNode::SubItem(ii.id))
     }
 
-    pub fn print_stmt(&mut self, st: &ast::Stmt) -> io::Result<()> {
+    crate fn print_stmt(&mut self, st: &ast::Stmt) -> io::Result<()> {
         self.maybe_print_comment(st.span.lo())?;
         match st.node {
             ast::StmtKind::Local(ref loc) => {
@@ -1659,32 +1659,32 @@ impl<'a> State<'a> {
         self.maybe_print_trailing_comment(st.span, None)
     }
 
-    pub fn print_block(&mut self, blk: &ast::Block) -> io::Result<()> {
+    crate fn print_block(&mut self, blk: &ast::Block) -> io::Result<()> {
         self.print_block_with_attrs(blk, &[])
     }
 
-    pub fn print_block_unclosed(&mut self, blk: &ast::Block) -> io::Result<()> {
+    crate fn print_block_unclosed(&mut self, blk: &ast::Block) -> io::Result<()> {
         self.print_block_unclosed_indent(blk, INDENT_UNIT)
     }
 
-    pub fn print_block_unclosed_with_attrs(&mut self, blk: &ast::Block,
+    crate fn print_block_unclosed_with_attrs(&mut self, blk: &ast::Block,
                                             attrs: &[ast::Attribute])
                                            -> io::Result<()> {
         self.print_block_maybe_unclosed(blk, INDENT_UNIT, attrs, false)
     }
 
-    pub fn print_block_unclosed_indent(&mut self, blk: &ast::Block,
+    crate fn print_block_unclosed_indent(&mut self, blk: &ast::Block,
                                        indented: usize) -> io::Result<()> {
         self.print_block_maybe_unclosed(blk, indented, &[], false)
     }
 
-    pub fn print_block_with_attrs(&mut self,
+    crate fn print_block_with_attrs(&mut self,
                                   blk: &ast::Block,
                                   attrs: &[ast::Attribute]) -> io::Result<()> {
         self.print_block_maybe_unclosed(blk, INDENT_UNIT, attrs, true)
     }
 
-    pub fn print_block_maybe_unclosed(&mut self,
+    crate fn print_block_maybe_unclosed(&mut self,
                                       blk: &ast::Block,
                                       indented: usize,
                                       attrs: &[ast::Attribute],
@@ -1716,7 +1716,7 @@ impl<'a> State<'a> {
     }
 
     /// Print a `let pats = scrutinee` expression.
-    pub fn print_let(&mut self, pats: &[P<ast::Pat>], scrutinee: &ast::Expr) -> io::Result<()> {
+    crate fn print_let(&mut self, pats: &[P<ast::Pat>], scrutinee: &ast::Expr) -> io::Result<()> {
         self.s.word("let ")?;
 
         self.print_pats(pats)?;
@@ -1761,7 +1761,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block,
+    crate fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block,
                     elseopt: Option<&ast::Expr>) -> io::Result<()> {
         self.head("if")?;
 
@@ -1772,7 +1772,7 @@ impl<'a> State<'a> {
         self.print_else(elseopt)
     }
 
-    pub fn print_mac(&mut self, m: &ast::Mac) -> io::Result<()> {
+    crate fn print_mac(&mut self, m: &ast::Mac) -> io::Result<()> {
         self.print_path(&m.node.path, false, 0)?;
         self.s.word("!")?;
         match m.node.delim {
@@ -1798,13 +1798,13 @@ impl<'a> State<'a> {
         self.pclose()
     }
 
-    pub fn print_expr_maybe_paren(&mut self, expr: &ast::Expr, prec: i8) -> io::Result<()> {
+    crate fn print_expr_maybe_paren(&mut self, expr: &ast::Expr, prec: i8) -> io::Result<()> {
         self.print_expr_cond_paren(expr, expr.precedence().order() < prec)
     }
 
     /// Print an expr using syntax that's acceptable in a condition position, such as the `cond` in
     /// `if cond { ... }`.
-    pub fn print_expr_as_cond(&mut self, expr: &ast::Expr) -> io::Result<()> {
+    crate fn print_expr_as_cond(&mut self, expr: &ast::Expr) -> io::Result<()> {
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr))
     }
 
@@ -1989,7 +1989,7 @@ impl<'a> State<'a> {
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
-    pub fn print_expr(&mut self, expr: &ast::Expr) -> io::Result<()> {
+    crate fn print_expr(&mut self, expr: &ast::Expr) -> io::Result<()> {
         self.print_expr_outer_attr_style(expr, true)
     }
 
@@ -2330,7 +2330,7 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    pub fn print_local_decl(&mut self, loc: &ast::Local) -> io::Result<()> {
+    crate fn print_local_decl(&mut self, loc: &ast::Local) -> io::Result<()> {
         self.print_pat(&loc.pat)?;
         if let Some(ref ty) = loc.ty {
             self.word_space(":")?;
@@ -2339,7 +2339,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_ident(&mut self, ident: ast::Ident) -> io::Result<()> {
+    crate fn print_ident(&mut self, ident: ast::Ident) -> io::Result<()> {
         if ident.is_raw_guess() {
             self.s.word(format!("r#{}", ident))?;
         } else {
@@ -2348,16 +2348,16 @@ impl<'a> State<'a> {
         self.ann.post(self, AnnNode::Ident(&ident))
     }
 
-    pub fn print_usize(&mut self, i: usize) -> io::Result<()> {
+    crate fn print_usize(&mut self, i: usize) -> io::Result<()> {
         self.s.word(i.to_string())
     }
 
-    pub fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
+    crate fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
         self.s.word(name.as_str().to_string())?;
         self.ann.post(self, AnnNode::Name(&name))
     }
 
-    pub fn print_for_decl(&mut self, loc: &ast::Local,
+    crate fn print_for_decl(&mut self, loc: &ast::Local,
                           coll: &ast::Expr) -> io::Result<()> {
         self.print_local_decl(loc)?;
         self.s.space()?;
@@ -2484,7 +2484,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_pat(&mut self, pat: &ast::Pat) -> io::Result<()> {
+    crate fn print_pat(&mut self, pat: &ast::Pat) -> io::Result<()> {
         self.maybe_print_comment(pat.span.lo())?;
         self.ann.pre(self, AnnNode::Pat(pat))?;
         /* Pat isn't normalized, but the beauty of it
@@ -2705,7 +2705,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_fn(&mut self,
+    crate fn print_fn(&mut self,
                     decl: &ast::FnDecl,
                     header: ast::FnHeader,
                     name: Option<ast::Ident>,
@@ -2722,7 +2722,7 @@ impl<'a> State<'a> {
         self.print_where_clause(&generics.where_clause)
     }
 
-    pub fn print_fn_args_and_ret(&mut self, decl: &ast::FnDecl)
+    crate fn print_fn_args_and_ret(&mut self, decl: &ast::FnDecl)
         -> io::Result<()> {
         self.popen()?;
         self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, false))?;
@@ -2731,7 +2731,7 @@ impl<'a> State<'a> {
         self.print_fn_output(decl)
     }
 
-    pub fn print_fn_block_args(
+    crate fn print_fn_block_args(
             &mut self,
             decl: &ast::FnDecl)
             -> io::Result<()> {
@@ -2754,7 +2754,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_movability(&mut self, movability: ast::Movability)
+    crate fn print_movability(&mut self, movability: ast::Movability)
                                 -> io::Result<()> {
         match movability {
             ast::Movability::Static => self.word_space("static"),
@@ -2762,7 +2762,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_asyncness(&mut self, asyncness: ast::IsAsync)
+    crate fn print_asyncness(&mut self, asyncness: ast::IsAsync)
                                 -> io::Result<()> {
         if asyncness.is_async() {
             self.word_nbsp("async")?;
@@ -2770,7 +2770,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_capture_clause(&mut self, capture_clause: ast::CaptureBy)
+    crate fn print_capture_clause(&mut self, capture_clause: ast::CaptureBy)
                                 -> io::Result<()> {
         match capture_clause {
             ast::CaptureBy::Value => self.word_space("move"),
@@ -2778,7 +2778,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound])
+    crate fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound])
                              -> io::Result<()> {
         if !bounds.is_empty() {
             self.s.word(prefix)?;
@@ -2807,11 +2807,11 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_lifetime(&mut self, lifetime: ast::Lifetime) -> io::Result<()> {
+    crate fn print_lifetime(&mut self, lifetime: ast::Lifetime) -> io::Result<()> {
         self.print_name(lifetime.ident.name)
     }
 
-    pub fn print_lifetime_bounds(&mut self, lifetime: ast::Lifetime, bounds: &ast::GenericBounds)
+    crate fn print_lifetime_bounds(&mut self, lifetime: ast::Lifetime, bounds: &ast::GenericBounds)
         -> io::Result<()>
     {
         self.print_lifetime(lifetime)?;
@@ -2830,7 +2830,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_generic_params(
+    crate fn print_generic_params(
         &mut self,
         generic_params: &[ast::GenericParam]
     ) -> io::Result<()> {
@@ -2876,7 +2876,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_where_clause(&mut self, where_clause: &ast::WhereClause)
+    crate fn print_where_clause(&mut self, where_clause: &ast::WhereClause)
                               -> io::Result<()> {
         if where_clause.predicates.is_empty() {
             return Ok(())
@@ -2920,7 +2920,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_use_tree(&mut self, tree: &ast::UseTree) -> io::Result<()> {
+    crate fn print_use_tree(&mut self, tree: &ast::UseTree) -> io::Result<()> {
         match tree.kind {
             ast::UseTreeKind::Simple(rename, ..) => {
                 self.print_path(&tree.prefix, false, 0)?;
@@ -2954,7 +2954,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_mutability(&mut self,
+    crate fn print_mutability(&mut self,
                             mutbl: ast::Mutability) -> io::Result<()> {
         match mutbl {
             ast::Mutability::Mutable => self.word_nbsp("mut"),
@@ -2962,12 +2962,12 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_mt(&mut self, mt: &ast::MutTy) -> io::Result<()> {
+    crate fn print_mt(&mut self, mt: &ast::MutTy) -> io::Result<()> {
         self.print_mutability(mt.mutbl)?;
         self.print_type(&mt.ty)
     }
 
-    pub fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) -> io::Result<()> {
+    crate fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) -> io::Result<()> {
         self.ibox(INDENT_UNIT)?;
         match input.ty.node {
             ast::TyKind::Infer if is_closure => self.print_pat(&input.pat)?,
@@ -2992,7 +2992,7 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    pub fn print_fn_output(&mut self, decl: &ast::FnDecl) -> io::Result<()> {
+    crate fn print_fn_output(&mut self, decl: &ast::FnDecl) -> io::Result<()> {
         if let ast::FunctionRetTy::Default(..) = decl.output {
             return Ok(());
         }
@@ -3013,7 +3013,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_ty_fn(&mut self,
+    crate fn print_ty_fn(&mut self,
                        abi: abi::Abi,
                        unsafety: ast::Unsafety,
                        decl: &ast::FnDecl,
@@ -3041,7 +3041,7 @@ impl<'a> State<'a> {
         self.end()
     }
 
-    pub fn maybe_print_trailing_comment(&mut self, span: syntax_pos::Span,
+    crate fn maybe_print_trailing_comment(&mut self, span: syntax_pos::Span,
                                         next_pos: Option<BytePos>)
         -> io::Result<()> {
         let cm = match self.cm {
@@ -3060,7 +3060,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_remaining_comments(&mut self) -> io::Result<()> {
+    crate fn print_remaining_comments(&mut self) -> io::Result<()> {
         // If there aren't any remaining comments, then we need to manually
         // make sure there is a line break at the end.
         if self.next_comment().is_none() {
@@ -3072,7 +3072,7 @@ impl<'a> State<'a> {
         Ok(())
     }
 
-    pub fn print_opt_abi_and_extern_if_nondefault(&mut self,
+    crate fn print_opt_abi_and_extern_if_nondefault(&mut self,
                                                   opt_abi: Option<Abi>)
         -> io::Result<()> {
         match opt_abi {
@@ -3085,7 +3085,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_extern_opt_abi(&mut self,
+    crate fn print_extern_opt_abi(&mut self,
                                 opt_abi: Option<Abi>) -> io::Result<()> {
         match opt_abi {
             Some(abi) => {
@@ -3096,7 +3096,7 @@ impl<'a> State<'a> {
         }
     }
 
-    pub fn print_fn_header_info(&mut self,
+    crate fn print_fn_header_info(&mut self,
                                 header: ast::FnHeader,
                                 vis: &ast::Visibility) -> io::Result<()> {
         self.s.word(visibility_qualified(vis, ""))?;
@@ -3117,14 +3117,14 @@ impl<'a> State<'a> {
         self.s.word("fn")
     }
 
-    pub fn print_unsafety(&mut self, s: ast::Unsafety) -> io::Result<()> {
+    crate fn print_unsafety(&mut self, s: ast::Unsafety) -> io::Result<()> {
         match s {
             ast::Unsafety::Normal => Ok(()),
             ast::Unsafety::Unsafe => self.word_nbsp("unsafe"),
         }
     }
 
-    pub fn print_is_auto(&mut self, s: ast::IsAuto) -> io::Result<()> {
+    crate fn print_is_auto(&mut self, s: ast::IsAuto) -> io::Result<()> {
         match s {
             ast::IsAuto::Yes => self.word_nbsp("auto"),
             ast::IsAuto::No => Ok(()),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -846,13 +846,6 @@ impl<'a> State<'a> {
         self.bclose_(span, INDENT_UNIT)
     }
 
-    crate fn in_cbox(&self) -> bool {
-        match self.boxes.last() {
-            Some(&last_box) => last_box == pp::Breaks::Consistent,
-            None => false
-        }
-    }
-
     crate fn break_offset_if_not_bol(&mut self, n: usize,
                                    off: isize) -> io::Result<()> {
         if !self.is_bol() {
@@ -1663,16 +1656,6 @@ impl<'a> State<'a> {
         self.print_block_with_attrs(blk, &[])
     }
 
-    crate fn print_block_unclosed(&mut self, blk: &ast::Block) -> io::Result<()> {
-        self.print_block_unclosed_indent(blk, INDENT_UNIT)
-    }
-
-    crate fn print_block_unclosed_with_attrs(&mut self, blk: &ast::Block,
-                                            attrs: &[ast::Attribute])
-                                           -> io::Result<()> {
-        self.print_block_maybe_unclosed(blk, INDENT_UNIT, attrs, false)
-    }
-
     crate fn print_block_unclosed_indent(&mut self, blk: &ast::Block,
                                        indented: usize) -> io::Result<()> {
         self.print_block_maybe_unclosed(blk, indented, &[], false)
@@ -2355,14 +2338,6 @@ impl<'a> State<'a> {
     crate fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
         self.s.word(name.as_str().to_string())?;
         self.ann.post(self, AnnNode::Name(&name))
-    }
-
-    crate fn print_for_decl(&mut self, loc: &ast::Local,
-                          coll: &ast::Expr) -> io::Result<()> {
-        self.print_local_decl(loc)?;
-        self.s.space()?;
-        self.word_space("in")?;
-        self.print_expr(coll)
     }
 
     fn print_path(&mut self,
@@ -3070,30 +3045,6 @@ impl<'a> State<'a> {
             self.print_comment(cmnt)?;
         }
         Ok(())
-    }
-
-    crate fn print_opt_abi_and_extern_if_nondefault(&mut self,
-                                                  opt_abi: Option<Abi>)
-        -> io::Result<()> {
-        match opt_abi {
-            Some(Abi::Rust) => Ok(()),
-            Some(abi) => {
-                self.word_nbsp("extern")?;
-                self.word_nbsp(abi.to_string())
-            }
-            None => Ok(())
-        }
-    }
-
-    crate fn print_extern_opt_abi(&mut self,
-                                opt_abi: Option<Abi>) -> io::Result<()> {
-        match opt_abi {
-            Some(abi) => {
-                self.word_nbsp("extern")?;
-                self.word_nbsp(abi.to_string())
-            }
-            None => Ok(())
-        }
     }
 
     crate fn print_fn_header_info(&mut self,

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -53,18 +53,6 @@ pub struct State<'a> {
     is_expanded: bool
 }
 
-fn rust_printer<'a>(writer: &'a mut String, ann: &'a dyn PpAnn) -> State<'a> {
-    State {
-        s: pp::mk_printer(writer),
-        cm: None,
-        comments: None,
-        cur_cmnt: 0,
-        boxes: Vec::new(),
-        ann,
-        is_expanded: false
-    }
-}
-
 crate const INDENT_UNIT: usize = 4;
 
 /// Requires you to pass an input filename and reader so that
@@ -137,8 +125,15 @@ pub fn to_string<F>(f: F) -> String where
 {
     let mut wr = String::new();
     {
-        let ann = NoAnn;
-        let mut printer = rust_printer(&mut wr, &ann);
+        let mut printer = State {
+            s: pp::mk_printer(&mut wr),
+            cm: None,
+            comments: None,
+            cur_cmnt: 0,
+            boxes: Vec::new(),
+            ann: &NoAnn,
+            is_expanded: false
+        };
         f(&mut printer);
         printer.s.eof();
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -21,7 +21,7 @@ use syntax_pos::{self, BytePos};
 use syntax_pos::{DUMMY_SP, FileName};
 
 use std::borrow::Cow;
-use std::io::{self, Read};
+use std::io::Read;
 use std::vec;
 
 pub enum AnnNode<'a> {
@@ -35,8 +35,8 @@ pub enum AnnNode<'a> {
 }
 
 pub trait PpAnn {
-    fn pre(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> { Ok(()) }
-    fn post(&self, _state: &mut State<'_>, _node: AnnNode<'_>) -> io::Result<()> { Ok(()) }
+    fn pre(&self, _state: &mut State<'_>, _node: AnnNode<'_>) { }
+    fn post(&self, _state: &mut State<'_>, _node: AnnNode<'_>) { }
 }
 
 #[derive(Copy, Clone)]
@@ -77,7 +77,7 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
                        input: &mut dyn Read,
                        out: &mut String,
                        ann: &'a dyn PpAnn,
-                       is_expanded: bool) -> io::Result<()> {
+                       is_expanded: bool) {
     let mut s = State::new_from_input(cm, sess, filename, input, out, ann, is_expanded);
 
     if is_expanded && std_inject::injected_crate_name().is_some() {
@@ -91,16 +91,16 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
         let list = attr::mk_list_item(
             DUMMY_SP, ast::Ident::with_empty_ctxt(sym::feature), vec![pi_nested]);
         let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), list);
-        s.print_attribute(&fake_attr)?;
+        s.print_attribute(&fake_attr);
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::no_std));
         let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), no_std_meta);
-        s.print_attribute(&fake_attr)?;
+        s.print_attribute(&fake_attr);
     }
 
-    s.print_mod(&krate.module, &krate.attrs)?;
-    s.print_remaining_comments()?;
+    s.print_mod(&krate.module, &krate.attrs);
+    s.print_remaining_comments();
     s.s.eof()
 }
 
@@ -134,14 +134,14 @@ impl<'a> State<'a> {
 }
 
 pub fn to_string<F>(f: F) -> String where
-    F: FnOnce(&mut State<'_>) -> io::Result<()>,
+    F: FnOnce(&mut State<'_>),
 {
     let mut wr = String::new();
     {
         let ann = NoAnn;
         let mut printer = rust_printer(&mut wr, &ann);
-        f(&mut printer).unwrap();
-        printer.s.eof().unwrap();
+        f(&mut printer);
+        printer.s.eof();
     }
     wr
 }
@@ -364,20 +364,20 @@ pub fn fun_to_string(decl: &ast::FnDecl,
                      generics: &ast::Generics)
                      -> String {
     to_string(|s| {
-        s.head("")?;
+        s.head("");
         s.print_fn(decl, header, Some(name),
-                   generics, &source_map::dummy_spanned(ast::VisibilityKind::Inherited))?;
-        s.end()?; // Close the head box
-        s.end() // Close the outer box
+                   generics, &source_map::dummy_spanned(ast::VisibilityKind::Inherited));
+        s.end(); // Close the head box
+        s.end(); // Close the outer box
     })
 }
 
 pub fn block_to_string(blk: &ast::Block) -> String {
     to_string(|s| {
         // containing cbox, will be closed by print-block at }
-        s.cbox(INDENT_UNIT)?;
+        s.cbox(INDENT_UNIT);
         // head-ibox, will be closed by print-block after {
-        s.ibox(0)?;
+        s.ibox(0);
         s.print_block(blk)
     })
 }
@@ -424,14 +424,14 @@ pub trait PrintState<'a> {
     fn comments(&mut self) -> &mut Option<Vec<comments::Comment>>;
     fn cur_cmnt(&mut self) -> &mut usize;
 
-    fn word_space<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
-        self.writer().word(w)?;
+    fn word_space<S: Into<Cow<'static, str>>>(&mut self, w: S) {
+        self.writer().word(w);
         self.writer().space()
     }
 
-    fn popen(&mut self) -> io::Result<()> { self.writer().word("(") }
+    fn popen(&mut self) { self.writer().word("(") }
 
-    fn pclose(&mut self) -> io::Result<()> { self.writer().word(")") }
+    fn pclose(&mut self) { self.writer().word(")") }
 
     fn is_begin(&mut self) -> bool {
         match self.writer().last_token() {
@@ -452,89 +452,86 @@ pub trait PrintState<'a> {
         self.writer().last_token().is_eof() || self.writer().last_token().is_hardbreak_tok()
     }
 
-    fn hardbreak_if_not_bol(&mut self) -> io::Result<()> {
+    fn hardbreak_if_not_bol(&mut self) {
         if !self.is_bol() {
-            self.writer().hardbreak()?
+            self.writer().hardbreak()
         }
-        Ok(())
     }
 
     // "raw box"
-    fn rbox(&mut self, u: usize, b: pp::Breaks) -> io::Result<()> {
+    fn rbox(&mut self, u: usize, b: pp::Breaks) {
         self.boxes().push(b);
         self.writer().rbox(u, b)
     }
 
-    fn ibox(&mut self, u: usize) -> io::Result<()> {
+    fn ibox(&mut self, u: usize) {
         self.boxes().push(pp::Breaks::Inconsistent);
-        self.writer().ibox(u)
+        self.writer().ibox(u);
     }
 
-    fn end(&mut self) -> io::Result<()> {
+    fn end(&mut self) {
         self.boxes().pop().unwrap();
         self.writer().end()
     }
 
-    fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F) -> io::Result<()>
-        where F: FnMut(&mut Self, &T) -> io::Result<()>,
+    fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F)
+        where F: FnMut(&mut Self, &T),
     {
-        self.rbox(0, b)?;
+        self.rbox(0, b);
         let mut first = true;
         for elt in elts {
-            if first { first = false; } else { self.word_space(",")?; }
-            op(self, elt)?;
+            if first { first = false; } else { self.word_space(","); }
+            op(self, elt);
         }
-        self.end()
+        self.end();
     }
 
-    fn maybe_print_comment(&mut self, pos: BytePos) -> io::Result<()> {
+    fn maybe_print_comment(&mut self, pos: BytePos) {
         while let Some(ref cmnt) = self.next_comment() {
             if cmnt.pos < pos {
-                self.print_comment(cmnt)?;
+                self.print_comment(cmnt);
             } else {
                 break
             }
         }
-        Ok(())
     }
 
     fn print_comment(&mut self,
-                     cmnt: &comments::Comment) -> io::Result<()> {
-        let r = match cmnt.style {
+                     cmnt: &comments::Comment) {
+        match cmnt.style {
             comments::Mixed => {
                 assert_eq!(cmnt.lines.len(), 1);
-                self.writer().zerobreak()?;
-                self.writer().word(cmnt.lines[0].clone())?;
+                self.writer().zerobreak();
+                self.writer().word(cmnt.lines[0].clone());
                 self.writer().zerobreak()
             }
             comments::Isolated => {
-                self.hardbreak_if_not_bol()?;
+                self.hardbreak_if_not_bol();
                 for line in &cmnt.lines {
                     // Don't print empty lines because they will end up as trailing
                     // whitespace
                     if !line.is_empty() {
-                        self.writer().word(line.clone())?;
+                        self.writer().word(line.clone());
                     }
-                    self.writer().hardbreak()?;
+                    self.writer().hardbreak();
                 }
-                Ok(())
             }
             comments::Trailing => {
                 if !self.is_bol() {
-                    self.writer().word(" ")?;
+                    self.writer().word(" ");
                 }
                 if cmnt.lines.len() == 1 {
-                    self.writer().word(cmnt.lines[0].clone())?;
+                    self.writer().word(cmnt.lines[0].clone());
                     self.writer().hardbreak()
                 } else {
-                    self.ibox(0)?;
+                    self.ibox(0);
                     for line in &cmnt.lines {
                         if !line.is_empty() {
-                            self.writer().word(line.clone())?;
+                            self.writer().word(line.clone());
                         }
-                        self.writer().hardbreak()?;
+                        self.writer().hardbreak();
                     }
-                    self.end()
+                    self.end();
                 }
             }
             comments::BlankLine => {
@@ -544,18 +541,12 @@ pub trait PrintState<'a> {
                     _ => false
                 };
                 if is_semi || self.is_begin() || self.is_end() {
-                    self.writer().hardbreak()?;
+                    self.writer().hardbreak();
                 }
-                self.writer().hardbreak()
+                self.writer().hardbreak();
             }
-        };
-        match r {
-            Ok(()) => {
-                *self.cur_cmnt() = *self.cur_cmnt() + 1;
-                Ok(())
-            }
-            Err(e) => Err(e),
         }
+        *self.cur_cmnt() = *self.cur_cmnt() + 1;
     }
 
     fn next_comment(&mut self) -> Option<comments::Comment> {
@@ -572,13 +563,13 @@ pub trait PrintState<'a> {
         }
     }
 
-    fn print_literal(&mut self, lit: &ast::Lit) -> io::Result<()> {
-        self.maybe_print_comment(lit.span.lo())?;
+    fn print_literal(&mut self, lit: &ast::Lit) {
+        self.maybe_print_comment(lit.span.lo());
         self.writer().word(literal_to_string(lit.token))
     }
 
     fn print_string(&mut self, st: &str,
-                    style: ast::StrStyle) -> io::Result<()> {
+                    style: ast::StrStyle) {
         let st = match style {
             ast::StrStyle::Cooked => {
                 (format!("\"{}\"", st.escape_debug()))
@@ -593,28 +584,28 @@ pub trait PrintState<'a> {
     }
 
     fn print_inner_attributes(&mut self,
-                              attrs: &[ast::Attribute]) -> io::Result<()> {
+                              attrs: &[ast::Attribute]) {
         self.print_either_attributes(attrs, ast::AttrStyle::Inner, false, true)
     }
 
     fn print_inner_attributes_no_trailing_hardbreak(&mut self,
                                                    attrs: &[ast::Attribute])
-                                                   -> io::Result<()> {
+                                                   {
         self.print_either_attributes(attrs, ast::AttrStyle::Inner, false, false)
     }
 
     fn print_outer_attributes(&mut self,
-                              attrs: &[ast::Attribute]) -> io::Result<()> {
+                              attrs: &[ast::Attribute]) {
         self.print_either_attributes(attrs, ast::AttrStyle::Outer, false, true)
     }
 
     fn print_inner_attributes_inline(&mut self,
-                                     attrs: &[ast::Attribute]) -> io::Result<()> {
+                                     attrs: &[ast::Attribute]) {
         self.print_either_attributes(attrs, ast::AttrStyle::Inner, true, true)
     }
 
     fn print_outer_attributes_inline(&mut self,
-                                     attrs: &[ast::Attribute]) -> io::Result<()> {
+                                     attrs: &[ast::Attribute]) {
         self.print_either_attributes(attrs, ast::AttrStyle::Outer, true, true)
     }
 
@@ -622,69 +613,67 @@ pub trait PrintState<'a> {
                               attrs: &[ast::Attribute],
                               kind: ast::AttrStyle,
                               is_inline: bool,
-                              trailing_hardbreak: bool) -> io::Result<()> {
+                              trailing_hardbreak: bool) {
         let mut count = 0;
         for attr in attrs {
             if attr.style == kind {
-                self.print_attribute_inline(attr, is_inline)?;
+                self.print_attribute_inline(attr, is_inline);
                 if is_inline {
-                    self.nbsp()?;
+                    self.nbsp();
                 }
                 count += 1;
             }
         }
         if count > 0 && trailing_hardbreak && !is_inline {
-            self.hardbreak_if_not_bol()?;
+            self.hardbreak_if_not_bol();
         }
-        Ok(())
     }
 
-    fn print_attribute_path(&mut self, path: &ast::Path) -> io::Result<()> {
+    fn print_attribute_path(&mut self, path: &ast::Path) {
         for (i, segment) in path.segments.iter().enumerate() {
             if i > 0 {
-                self.writer().word("::")?
+                self.writer().word("::");
             }
             if segment.ident.name != kw::PathRoot {
                 if segment.ident.name == kw::DollarCrate {
-                    self.print_dollar_crate(segment.ident)?;
+                    self.print_dollar_crate(segment.ident);
                 } else {
-                    self.writer().word(segment.ident.as_str().to_string())?;
+                    self.writer().word(segment.ident.as_str().to_string());
                 }
             }
         }
-        Ok(())
     }
 
-    fn print_attribute(&mut self, attr: &ast::Attribute) -> io::Result<()> {
+    fn print_attribute(&mut self, attr: &ast::Attribute) {
         self.print_attribute_inline(attr, false)
     }
 
     fn print_attribute_inline(&mut self, attr: &ast::Attribute,
-                              is_inline: bool) -> io::Result<()> {
+                              is_inline: bool) {
         if !is_inline {
-            self.hardbreak_if_not_bol()?;
+            self.hardbreak_if_not_bol();
         }
-        self.maybe_print_comment(attr.span.lo())?;
+        self.maybe_print_comment(attr.span.lo());
         if attr.is_sugared_doc {
-            self.writer().word(attr.value_str().unwrap().as_str().to_string())?;
+            self.writer().word(attr.value_str().unwrap().as_str().to_string());
             self.writer().hardbreak()
         } else {
             match attr.style {
-                ast::AttrStyle::Inner => self.writer().word("#![")?,
-                ast::AttrStyle::Outer => self.writer().word("#[")?,
+                ast::AttrStyle::Inner => self.writer().word("#!["),
+                ast::AttrStyle::Outer => self.writer().word("#["),
             }
             if let Some(mi) = attr.meta() {
-                self.print_meta_item(&mi)?
+                self.print_meta_item(&mi);
             } else {
-                self.print_attribute_path(&attr.path)?;
-                self.writer().space()?;
-                self.print_tts(attr.tokens.clone())?;
+                self.print_attribute_path(&attr.path);
+                self.writer().space();
+                self.print_tts(attr.tokens.clone());
             }
-            self.writer().word("]")
+            self.writer().word("]");
         }
     }
 
-    fn print_meta_list_item(&mut self, item: &ast::NestedMetaItem) -> io::Result<()> {
+    fn print_meta_list_item(&mut self, item: &ast::NestedMetaItem) {
         match item {
             ast::NestedMetaItem::MetaItem(ref mi) => {
                 self.print_meta_item(mi)
@@ -695,26 +684,26 @@ pub trait PrintState<'a> {
         }
     }
 
-    fn print_meta_item(&mut self, item: &ast::MetaItem) -> io::Result<()> {
-        self.ibox(INDENT_UNIT)?;
+    fn print_meta_item(&mut self, item: &ast::MetaItem) {
+        self.ibox(INDENT_UNIT);
         match item.node {
-            ast::MetaItemKind::Word => self.print_attribute_path(&item.path)?,
+            ast::MetaItemKind::Word => self.print_attribute_path(&item.path),
             ast::MetaItemKind::NameValue(ref value) => {
-                self.print_attribute_path(&item.path)?;
-                self.writer().space()?;
-                self.word_space("=")?;
-                self.print_literal(value)?;
+                self.print_attribute_path(&item.path);
+                self.writer().space();
+                self.word_space("=");
+                self.print_literal(value);
             }
             ast::MetaItemKind::List(ref items) => {
-                self.print_attribute_path(&item.path)?;
-                self.popen()?;
+                self.print_attribute_path(&item.path);
+                self.popen();
                 self.commasep(Consistent,
                               &items[..],
-                              |s, i| s.print_meta_list_item(i))?;
-                self.pclose()?;
+                              |s, i| s.print_meta_list_item(i));
+                self.pclose();
             }
         }
-        self.end()
+        self.end();
     }
 
     /// This doesn't deserve to be called "pretty" printing, but it should be
@@ -724,44 +713,43 @@ pub trait PrintState<'a> {
     /// appropriate macro, transcribe back into the grammar we just parsed from,
     /// and then pretty-print the resulting AST nodes (so, e.g., we print
     /// expression arguments as expressions). It can be done! I think.
-    fn print_tt(&mut self, tt: tokenstream::TokenTree) -> io::Result<()> {
+    fn print_tt(&mut self, tt: tokenstream::TokenTree) {
         match tt {
             TokenTree::Token(ref token) => {
-                self.writer().word(token_to_string(&token))?;
+                self.writer().word(token_to_string(&token));
                 match token.kind {
                     token::DocComment(..) => {
                         self.writer().hardbreak()
                     }
-                    _ => Ok(())
+                    _ => {}
                 }
             }
             TokenTree::Delimited(_, delim, tts) => {
-                self.writer().word(token_kind_to_string(&token::OpenDelim(delim)))?;
-                self.writer().space()?;
-                self.print_tts(tts)?;
-                self.writer().space()?;
+                self.writer().word(token_kind_to_string(&token::OpenDelim(delim)));
+                self.writer().space();
+                self.print_tts(tts);
+                self.writer().space();
                 self.writer().word(token_kind_to_string(&token::CloseDelim(delim)))
             },
         }
     }
 
-    fn print_tts(&mut self, tts: tokenstream::TokenStream) -> io::Result<()> {
-        self.ibox(0)?;
+    fn print_tts(&mut self, tts: tokenstream::TokenStream) {
+        self.ibox(0);
         for (i, tt) in tts.into_trees().enumerate() {
             if i != 0 {
-                self.writer().space()?;
+                self.writer().space();
             }
-            self.print_tt(tt)?;
+            self.print_tt(tt);
         }
-        self.end()
+        self.end();
     }
 
-    fn space_if_not_bol(&mut self) -> io::Result<()> {
-        if !self.is_bol() { self.writer().space()?; }
-        Ok(())
+    fn space_if_not_bol(&mut self) {
+        if !self.is_bol() { self.writer().space(); }
     }
 
-    fn nbsp(&mut self) -> io::Result<()> { self.writer().word(" ") }
+    fn nbsp(&mut self) { self.writer().word(" ") }
 
     // AST pretty-printer is used as a fallback for turning AST structures into token streams for
     // proc macros. Additionally, proc macros may stringify their input and expect it survive the
@@ -770,10 +758,10 @@ pub trait PrintState<'a> {
     // its hygiene data, most importantly name of the crate it refers to.
     // As a result we print `$crate` as `crate` if it refers to the local crate
     // and as `::other_crate_name` if it refers to some other crate.
-    fn print_dollar_crate(&mut self, ident: ast::Ident) -> io::Result<()> {
+    fn print_dollar_crate(&mut self, ident: ast::Ident) {
         let name = ident.span.ctxt().dollar_crate_name();
         if !ast::Ident::with_empty_ctxt(name).is_path_segment_keyword() {
-            self.writer().word("::")?;
+            self.writer().word("::");
         }
         self.writer().word(name.as_str().to_string())
     }
@@ -798,54 +786,52 @@ impl<'a> PrintState<'a> for State<'a> {
 }
 
 impl<'a> State<'a> {
-    pub fn cbox(&mut self, u: usize) -> io::Result<()> {
+    pub fn cbox(&mut self, u: usize) {
         self.boxes.push(pp::Breaks::Consistent);
-        self.s.cbox(u)
+        self.s.cbox(u);
     }
 
-    crate fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
-        self.s.word(w)?;
+    crate fn word_nbsp<S: Into<Cow<'static, str>>>(&mut self, w: S) {
+        self.s.word(w);
         self.nbsp()
     }
 
-    crate fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) -> io::Result<()> {
+    crate fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) {
         let w = w.into();
         // outer-box is consistent
-        self.cbox(INDENT_UNIT)?;
+        self.cbox(INDENT_UNIT);
         // head-box is inconsistent
-        self.ibox(w.len() + 1)?;
+        self.ibox(w.len() + 1);
         // keyword that starts the head
         if !w.is_empty() {
-            self.word_nbsp(w)?;
+            self.word_nbsp(w);
         }
-        Ok(())
     }
 
-    crate fn bopen(&mut self) -> io::Result<()> {
-        self.s.word("{")?;
-        self.end() // close the head-box
+    crate fn bopen(&mut self) {
+        self.s.word("{");
+        self.end(); // close the head-box
     }
 
     crate fn bclose_(&mut self, span: syntax_pos::Span,
-                   indented: usize) -> io::Result<()> {
+                   indented: usize) {
         self.bclose_maybe_open(span, indented, true)
     }
     crate fn bclose_maybe_open(&mut self, span: syntax_pos::Span,
-                             indented: usize, close_box: bool) -> io::Result<()> {
-        self.maybe_print_comment(span.hi())?;
-        self.break_offset_if_not_bol(1, -(indented as isize))?;
-        self.s.word("}")?;
+                             indented: usize, close_box: bool) {
+        self.maybe_print_comment(span.hi());
+        self.break_offset_if_not_bol(1, -(indented as isize));
+        self.s.word("}");
         if close_box {
-            self.end()?; // close the outer-box
+            self.end(); // close the outer-box
         }
-        Ok(())
     }
-    crate fn bclose(&mut self, span: syntax_pos::Span) -> io::Result<()> {
+    crate fn bclose(&mut self, span: syntax_pos::Span) {
         self.bclose_(span, INDENT_UNIT)
     }
 
     crate fn break_offset_if_not_bol(&mut self, n: usize,
-                                   off: isize) -> io::Result<()> {
+                                   off: isize) {
         if !self.is_bol() {
             self.s.break_offset(n, off)
         } else {
@@ -855,17 +841,16 @@ impl<'a> State<'a> {
                 // break into the previous hardbreak.
                 self.s.replace_last_token(pp::Printer::hardbreak_tok_offset(off));
             }
-            Ok(())
         }
     }
 
     // Synthesizes a comment that was not textually present in the original source
     // file.
-    pub fn synth_comment(&mut self, text: String) -> io::Result<()> {
-        self.s.word("/*")?;
-        self.s.space()?;
-        self.s.word(text)?;
-        self.s.space()?;
+    pub fn synth_comment(&mut self, text: String) {
+        self.s.word("/*");
+        self.s.space();
+        self.s.word(text);
+        self.s.space();
         self.s.word("*/")
     }
 
@@ -875,59 +860,56 @@ impl<'a> State<'a> {
                                   b: Breaks,
                                   elts: &[T],
                                   mut op: F,
-                                  mut get_span: G) -> io::Result<()> where
-        F: FnMut(&mut State<'_>, &T) -> io::Result<()>,
+                                  mut get_span: G) where
+        F: FnMut(&mut State<'_>, &T),
         G: FnMut(&T) -> syntax_pos::Span,
     {
-        self.rbox(0, b)?;
+        self.rbox(0, b);
         let len = elts.len();
         let mut i = 0;
         for elt in elts {
-            self.maybe_print_comment(get_span(elt).hi())?;
-            op(self, elt)?;
+            self.maybe_print_comment(get_span(elt).hi());
+            op(self, elt);
             i += 1;
             if i < len {
-                self.s.word(",")?;
+                self.s.word(",");
                 self.maybe_print_trailing_comment(get_span(elt),
-                                                  Some(get_span(&elts[i]).hi()))?;
-                self.space_if_not_bol()?;
+                                                  Some(get_span(&elts[i]).hi()));
+                self.space_if_not_bol();
             }
         }
-        self.end()
+        self.end();
     }
 
     crate fn commasep_exprs(&mut self, b: Breaks,
-                          exprs: &[P<ast::Expr>]) -> io::Result<()> {
+                          exprs: &[P<ast::Expr>]) {
         self.commasep_cmnt(b, exprs, |s, e| s.print_expr(e), |e| e.span)
     }
 
     crate fn print_mod(&mut self, _mod: &ast::Mod,
-                     attrs: &[ast::Attribute]) -> io::Result<()> {
-        self.print_inner_attributes(attrs)?;
+                     attrs: &[ast::Attribute]) {
+        self.print_inner_attributes(attrs);
         for item in &_mod.items {
-            self.print_item(item)?;
+            self.print_item(item);
         }
-        Ok(())
     }
 
     crate fn print_foreign_mod(&mut self, nmod: &ast::ForeignMod,
-                             attrs: &[ast::Attribute]) -> io::Result<()> {
-        self.print_inner_attributes(attrs)?;
+                             attrs: &[ast::Attribute]) {
+        self.print_inner_attributes(attrs);
         for item in &nmod.items {
-            self.print_foreign_item(item)?;
+            self.print_foreign_item(item);
         }
-        Ok(())
     }
 
-    crate fn print_opt_lifetime(&mut self, lifetime: &Option<ast::Lifetime>) -> io::Result<()> {
+    crate fn print_opt_lifetime(&mut self, lifetime: &Option<ast::Lifetime>) {
         if let Some(lt) = *lifetime {
-            self.print_lifetime(lt)?;
-            self.nbsp()?;
+            self.print_lifetime(lt);
+            self.nbsp();
         }
-        Ok(())
     }
 
-    crate fn print_generic_arg(&mut self, generic_arg: &GenericArg) -> io::Result<()> {
+    crate fn print_generic_arg(&mut self, generic_arg: &GenericArg) {
         match generic_arg {
             GenericArg::Lifetime(lt) => self.print_lifetime(*lt),
             GenericArg::Type(ty) => self.print_type(ty),
@@ -935,136 +917,136 @@ impl<'a> State<'a> {
         }
     }
 
-    crate fn print_type(&mut self, ty: &ast::Ty) -> io::Result<()> {
-        self.maybe_print_comment(ty.span.lo())?;
-        self.ibox(0)?;
+    crate fn print_type(&mut self, ty: &ast::Ty) {
+        self.maybe_print_comment(ty.span.lo());
+        self.ibox(0);
         match ty.node {
             ast::TyKind::Slice(ref ty) => {
-                self.s.word("[")?;
-                self.print_type(ty)?;
-                self.s.word("]")?;
+                self.s.word("[");
+                self.print_type(ty);
+                self.s.word("]");
             }
             ast::TyKind::Ptr(ref mt) => {
-                self.s.word("*")?;
+                self.s.word("*");
                 match mt.mutbl {
-                    ast::Mutability::Mutable => self.word_nbsp("mut")?,
-                    ast::Mutability::Immutable => self.word_nbsp("const")?,
+                    ast::Mutability::Mutable => self.word_nbsp("mut"),
+                    ast::Mutability::Immutable => self.word_nbsp("const"),
                 }
-                self.print_type(&mt.ty)?;
+                self.print_type(&mt.ty);
             }
             ast::TyKind::Rptr(ref lifetime, ref mt) => {
-                self.s.word("&")?;
-                self.print_opt_lifetime(lifetime)?;
-                self.print_mt(mt)?;
+                self.s.word("&");
+                self.print_opt_lifetime(lifetime);
+                self.print_mt(mt);
             }
             ast::TyKind::Never => {
-                self.s.word("!")?;
+                self.s.word("!");
             },
             ast::TyKind::Tup(ref elts) => {
-                self.popen()?;
+                self.popen();
                 self.commasep(Inconsistent, &elts[..],
-                              |s, ty| s.print_type(ty))?;
+                              |s, ty| s.print_type(ty));
                 if elts.len() == 1 {
-                    self.s.word(",")?;
+                    self.s.word(",");
                 }
-                self.pclose()?;
+                self.pclose();
             }
             ast::TyKind::Paren(ref typ) => {
-                self.popen()?;
-                self.print_type(typ)?;
-                self.pclose()?;
+                self.popen();
+                self.print_type(typ);
+                self.pclose();
             }
             ast::TyKind::BareFn(ref f) => {
                 self.print_ty_fn(f.abi,
                                  f.unsafety,
                                  &f.decl,
                                  None,
-                                 &f.generic_params)?;
+                                 &f.generic_params);
             }
             ast::TyKind::Path(None, ref path) => {
-                self.print_path(path, false, 0)?;
+                self.print_path(path, false, 0);
             }
             ast::TyKind::Path(Some(ref qself), ref path) => {
-                self.print_qpath(path, qself, false)?
+                self.print_qpath(path, qself, false)
             }
             ast::TyKind::TraitObject(ref bounds, syntax) => {
                 let prefix = if syntax == ast::TraitObjectSyntax::Dyn { "dyn" } else { "" };
-                self.print_type_bounds(prefix, &bounds[..])?;
+                self.print_type_bounds(prefix, &bounds[..]);
             }
             ast::TyKind::ImplTrait(_, ref bounds) => {
-                self.print_type_bounds("impl", &bounds[..])?;
+                self.print_type_bounds("impl", &bounds[..]);
             }
             ast::TyKind::Array(ref ty, ref length) => {
-                self.s.word("[")?;
-                self.print_type(ty)?;
-                self.s.word("; ")?;
-                self.print_expr(&length.value)?;
-                self.s.word("]")?;
+                self.s.word("[");
+                self.print_type(ty);
+                self.s.word("; ");
+                self.print_expr(&length.value);
+                self.s.word("]");
             }
             ast::TyKind::Typeof(ref e) => {
-                self.s.word("typeof(")?;
-                self.print_expr(&e.value)?;
-                self.s.word(")")?;
+                self.s.word("typeof(");
+                self.print_expr(&e.value);
+                self.s.word(")");
             }
             ast::TyKind::Infer => {
-                self.s.word("_")?;
+                self.s.word("_");
             }
             ast::TyKind::Err => {
-                self.popen()?;
-                self.s.word("/*ERROR*/")?;
-                self.pclose()?;
+                self.popen();
+                self.s.word("/*ERROR*/");
+                self.pclose();
             }
             ast::TyKind::ImplicitSelf => {
-                self.s.word("Self")?;
+                self.s.word("Self");
             }
             ast::TyKind::Mac(ref m) => {
-                self.print_mac(m)?;
+                self.print_mac(m);
             }
             ast::TyKind::CVarArgs => {
-                self.s.word("...")?;
+                self.s.word("...");
             }
         }
-        self.end()
+        self.end();
     }
 
     crate fn print_foreign_item(&mut self,
-                              item: &ast::ForeignItem) -> io::Result<()> {
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo())?;
-        self.print_outer_attributes(&item.attrs)?;
+                              item: &ast::ForeignItem) {
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(item.span.lo());
+        self.print_outer_attributes(&item.attrs);
         match item.node {
             ast::ForeignItemKind::Fn(ref decl, ref generics) => {
-                self.head("")?;
+                self.head("");
                 self.print_fn(decl, ast::FnHeader::default(),
                               Some(item.ident),
-                              generics, &item.vis)?;
-                self.end()?; // end head-ibox
-                self.s.word(";")?;
-                self.end() // end the outer fn box
+                              generics, &item.vis);
+                self.end(); // end head-ibox
+                self.s.word(";");
+                self.end(); // end the outer fn box
             }
             ast::ForeignItemKind::Static(ref t, m) => {
-                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.head(visibility_qualified(&item.vis, "static"));
                 if m == ast::Mutability::Mutable {
-                    self.word_space("mut")?;
+                    self.word_space("mut");
                 }
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(t)?;
-                self.s.word(";")?;
-                self.end()?; // end the head-ibox
-                self.end() // end the outer cbox
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(t);
+                self.s.word(";");
+                self.end(); // end the head-ibox
+                self.end(); // end the outer cbox
             }
             ast::ForeignItemKind::Ty => {
-                self.head(visibility_qualified(&item.vis, "type"))?;
-                self.print_ident(item.ident)?;
-                self.s.word(";")?;
-                self.end()?; // end the head-ibox
-                self.end() // end the outer cbox
+                self.head(visibility_qualified(&item.vis, "type"));
+                self.print_ident(item.ident);
+                self.s.word(";");
+                self.end(); // end the head-ibox
+                self.end(); // end the outer cbox
             }
             ast::ForeignItemKind::Macro(ref m) => {
-                self.print_mac(m)?;
+                self.print_mac(m);
                 match m.node.delim {
-                    MacDelimiter::Brace => Ok(()),
+                    MacDelimiter::Brace => {},
                     _ => self.s.word(";")
                 }
             }
@@ -1076,17 +1058,16 @@ impl<'a> State<'a> {
                               ty: &ast::Ty,
                               default: Option<&ast::Expr>,
                               vis: &ast::Visibility)
-                              -> io::Result<()>
     {
-        self.s.word(visibility_qualified(vis, ""))?;
-        self.word_space("const")?;
-        self.print_ident(ident)?;
-        self.word_space(":")?;
-        self.print_type(ty)?;
+        self.s.word(visibility_qualified(vis, ""));
+        self.word_space("const");
+        self.print_ident(ident);
+        self.word_space(":");
+        self.print_type(ty);
         if let Some(expr) = default {
-            self.s.space()?;
-            self.word_space("=")?;
-            self.print_expr(expr)?;
+            self.s.space();
+            self.word_space("=");
+            self.print_expr(expr);
         }
         self.s.word(";")
     }
@@ -1095,140 +1076,140 @@ impl<'a> State<'a> {
                              ident: ast::Ident,
                              bounds: Option<&ast::GenericBounds>,
                              ty: Option<&ast::Ty>)
-                             -> io::Result<()> {
-        self.word_space("type")?;
-        self.print_ident(ident)?;
+                             {
+        self.word_space("type");
+        self.print_ident(ident);
         if let Some(bounds) = bounds {
-            self.print_type_bounds(":", bounds)?;
+            self.print_type_bounds(":", bounds);
         }
         if let Some(ty) = ty {
-            self.s.space()?;
-            self.word_space("=")?;
-            self.print_type(ty)?;
+            self.s.space();
+            self.word_space("=");
+            self.print_type(ty);
         }
         self.s.word(";")
     }
 
     /// Pretty-print an item
-    crate fn print_item(&mut self, item: &ast::Item) -> io::Result<()> {
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(item.span.lo())?;
-        self.print_outer_attributes(&item.attrs)?;
-        self.ann.pre(self, AnnNode::Item(item))?;
+    crate fn print_item(&mut self, item: &ast::Item) {
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(item.span.lo());
+        self.print_outer_attributes(&item.attrs);
+        self.ann.pre(self, AnnNode::Item(item));
         match item.node {
             ast::ItemKind::ExternCrate(orig_name) => {
-                self.head(visibility_qualified(&item.vis, "extern crate"))?;
+                self.head(visibility_qualified(&item.vis, "extern crate"));
                 if let Some(orig_name) = orig_name {
-                    self.print_name(orig_name)?;
-                    self.s.space()?;
-                    self.s.word("as")?;
-                    self.s.space()?;
+                    self.print_name(orig_name);
+                    self.s.space();
+                    self.s.word("as");
+                    self.s.space();
                 }
-                self.print_ident(item.ident)?;
-                self.s.word(";")?;
-                self.end()?; // end inner head-block
-                self.end()?; // end outer head-block
+                self.print_ident(item.ident);
+                self.s.word(";");
+                self.end(); // end inner head-block
+                self.end(); // end outer head-block
             }
             ast::ItemKind::Use(ref tree) => {
-                self.head(visibility_qualified(&item.vis, "use"))?;
-                self.print_use_tree(tree)?;
-                self.s.word(";")?;
-                self.end()?; // end inner head-block
-                self.end()?; // end outer head-block
+                self.head(visibility_qualified(&item.vis, "use"));
+                self.print_use_tree(tree);
+                self.s.word(";");
+                self.end(); // end inner head-block
+                self.end(); // end outer head-block
             }
             ast::ItemKind::Static(ref ty, m, ref expr) => {
-                self.head(visibility_qualified(&item.vis, "static"))?;
+                self.head(visibility_qualified(&item.vis, "static"));
                 if m == ast::Mutability::Mutable {
-                    self.word_space("mut")?;
+                    self.word_space("mut");
                 }
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(ty)?;
-                self.s.space()?;
-                self.end()?; // end the head-ibox
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(ty);
+                self.s.space();
+                self.end(); // end the head-ibox
 
-                self.word_space("=")?;
-                self.print_expr(expr)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer cbox
+                self.word_space("=");
+                self.print_expr(expr);
+                self.s.word(";");
+                self.end(); // end the outer cbox
             }
             ast::ItemKind::Const(ref ty, ref expr) => {
-                self.head(visibility_qualified(&item.vis, "const"))?;
-                self.print_ident(item.ident)?;
-                self.word_space(":")?;
-                self.print_type(ty)?;
-                self.s.space()?;
-                self.end()?; // end the head-ibox
+                self.head(visibility_qualified(&item.vis, "const"));
+                self.print_ident(item.ident);
+                self.word_space(":");
+                self.print_type(ty);
+                self.s.space();
+                self.end(); // end the head-ibox
 
-                self.word_space("=")?;
-                self.print_expr(expr)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer cbox
+                self.word_space("=");
+                self.print_expr(expr);
+                self.s.word(";");
+                self.end(); // end the outer cbox
             }
             ast::ItemKind::Fn(ref decl, header, ref param_names, ref body) => {
-                self.head("")?;
+                self.head("");
                 self.print_fn(
                     decl,
                     header,
                     Some(item.ident),
                     param_names,
                     &item.vis
-                )?;
-                self.s.word(" ")?;
-                self.print_block_with_attrs(body, &item.attrs)?;
+                );
+                self.s.word(" ");
+                self.print_block_with_attrs(body, &item.attrs);
             }
             ast::ItemKind::Mod(ref _mod) => {
-                self.head(visibility_qualified(&item.vis, "mod"))?;
-                self.print_ident(item.ident)?;
+                self.head(visibility_qualified(&item.vis, "mod"));
+                self.print_ident(item.ident);
 
                 if _mod.inline || self.is_expanded {
-                    self.nbsp()?;
-                    self.bopen()?;
-                    self.print_mod(_mod, &item.attrs)?;
-                    self.bclose(item.span)?;
+                    self.nbsp();
+                    self.bopen();
+                    self.print_mod(_mod, &item.attrs);
+                    self.bclose(item.span);
                 } else {
-                    self.s.word(";")?;
-                    self.end()?; // end inner head-block
-                    self.end()?; // end outer head-block
+                    self.s.word(";");
+                    self.end(); // end inner head-block
+                    self.end(); // end outer head-block
                 }
 
             }
             ast::ItemKind::ForeignMod(ref nmod) => {
-                self.head("extern")?;
-                self.word_nbsp(nmod.abi.to_string())?;
-                self.bopen()?;
-                self.print_foreign_mod(nmod, &item.attrs)?;
-                self.bclose(item.span)?;
+                self.head("extern");
+                self.word_nbsp(nmod.abi.to_string());
+                self.bopen();
+                self.print_foreign_mod(nmod, &item.attrs);
+                self.bclose(item.span);
             }
             ast::ItemKind::GlobalAsm(ref ga) => {
-                self.head(visibility_qualified(&item.vis, "global_asm!"))?;
-                self.s.word(ga.asm.as_str().to_string())?;
-                self.end()?;
+                self.head(visibility_qualified(&item.vis, "global_asm!"));
+                self.s.word(ga.asm.as_str().to_string());
+                self.end();
             }
             ast::ItemKind::Ty(ref ty, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "type"))?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
-                self.end()?; // end the inner ibox
+                self.head(visibility_qualified(&item.vis, "type"));
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
+                self.end(); // end the inner ibox
 
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.space()?;
-                self.word_space("=")?;
-                self.print_type(ty)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer ibox
+                self.print_where_clause(&generics.where_clause);
+                self.s.space();
+                self.word_space("=");
+                self.print_type(ty);
+                self.s.word(";");
+                self.end(); // end the outer ibox
             }
             ast::ItemKind::Existential(ref bounds, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "existential type"))?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
-                self.end()?; // end the inner ibox
+                self.head(visibility_qualified(&item.vis, "existential type"));
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
+                self.end(); // end the inner ibox
 
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.space()?;
-                self.print_type_bounds(":", bounds)?;
-                self.s.word(";")?;
-                self.end()?; // end the outer ibox
+                self.print_where_clause(&generics.where_clause);
+                self.s.space();
+                self.print_type_bounds(":", bounds);
+                self.s.word(";");
+                self.end(); // end the outer ibox
             }
             ast::ItemKind::Enum(ref enum_definition, ref params) => {
                 self.print_enum_def(
@@ -1237,15 +1218,15 @@ impl<'a> State<'a> {
                     item.ident,
                     item.span,
                     &item.vis
-                )?;
+                );
             }
             ast::ItemKind::Struct(ref struct_def, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "struct"))?;
-                self.print_struct(struct_def, generics, item.ident, item.span, true)?;
+                self.head(visibility_qualified(&item.vis, "struct"));
+                self.print_struct(struct_def, generics, item.ident, item.span, true);
             }
             ast::ItemKind::Union(ref struct_def, ref generics) => {
-                self.head(visibility_qualified(&item.vis, "union"))?;
-                self.print_struct(struct_def, generics, item.ident, item.span, true)?;
+                self.head(visibility_qualified(&item.vis, "union"));
+                self.print_struct(struct_def, generics, item.ident, item.span, true);
             }
             ast::ItemKind::Impl(unsafety,
                           polarity,
@@ -1254,171 +1235,170 @@ impl<'a> State<'a> {
                           ref opt_trait,
                           ref ty,
                           ref impl_items) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.print_defaultness(defaultness)?;
-                self.print_unsafety(unsafety)?;
-                self.word_nbsp("impl")?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.print_defaultness(defaultness);
+                self.print_unsafety(unsafety);
+                self.word_nbsp("impl");
 
                 if !generics.params.is_empty() {
-                    self.print_generic_params(&generics.params)?;
-                    self.s.space()?;
+                    self.print_generic_params(&generics.params);
+                    self.s.space();
                 }
 
                 if polarity == ast::ImplPolarity::Negative {
-                    self.s.word("!")?;
+                    self.s.word("!");
                 }
 
                 if let Some(ref t) = *opt_trait {
-                    self.print_trait_ref(t)?;
-                    self.s.space()?;
-                    self.word_space("for")?;
+                    self.print_trait_ref(t);
+                    self.s.space();
+                    self.word_space("for");
                 }
 
-                self.print_type(ty)?;
-                self.print_where_clause(&generics.where_clause)?;
+                self.print_type(ty);
+                self.print_where_clause(&generics.where_clause);
 
-                self.s.space()?;
-                self.bopen()?;
-                self.print_inner_attributes(&item.attrs)?;
+                self.s.space();
+                self.bopen();
+                self.print_inner_attributes(&item.attrs);
                 for impl_item in impl_items {
-                    self.print_impl_item(impl_item)?;
+                    self.print_impl_item(impl_item);
                 }
-                self.bclose(item.span)?;
+                self.bclose(item.span);
             }
             ast::ItemKind::Trait(is_auto, unsafety, ref generics, ref bounds, ref trait_items) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.print_unsafety(unsafety)?;
-                self.print_is_auto(is_auto)?;
-                self.word_nbsp("trait")?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.print_unsafety(unsafety);
+                self.print_is_auto(is_auto);
+                self.word_nbsp("trait");
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space()?;
-                        self.word_space("for ?")?;
-                        self.print_trait_ref(&ptr.trait_ref)?;
+                        self.s.space();
+                        self.word_space("for ?");
+                        self.print_trait_ref(&ptr.trait_ref);
                     } else {
                         real_bounds.push(b.clone());
                     }
                 }
-                self.print_type_bounds(":", &real_bounds[..])?;
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.word(" ")?;
-                self.bopen()?;
+                self.print_type_bounds(":", &real_bounds[..]);
+                self.print_where_clause(&generics.where_clause);
+                self.s.word(" ");
+                self.bopen();
                 for trait_item in trait_items {
-                    self.print_trait_item(trait_item)?;
+                    self.print_trait_item(trait_item);
                 }
-                self.bclose(item.span)?;
+                self.bclose(item.span);
             }
             ast::ItemKind::TraitAlias(ref generics, ref bounds) => {
-                self.head("")?;
-                self.print_visibility(&item.vis)?;
-                self.word_nbsp("trait")?;
-                self.print_ident(item.ident)?;
-                self.print_generic_params(&generics.params)?;
+                self.head("");
+                self.print_visibility(&item.vis);
+                self.word_nbsp("trait");
+                self.print_ident(item.ident);
+                self.print_generic_params(&generics.params);
                 let mut real_bounds = Vec::with_capacity(bounds.len());
                 // FIXME(durka) this seems to be some quite outdated syntax
                 for b in bounds.iter() {
                     if let GenericBound::Trait(ref ptr, ast::TraitBoundModifier::Maybe) = *b {
-                        self.s.space()?;
-                        self.word_space("for ?")?;
-                        self.print_trait_ref(&ptr.trait_ref)?;
+                        self.s.space();
+                        self.word_space("for ?");
+                        self.print_trait_ref(&ptr.trait_ref);
                     } else {
                         real_bounds.push(b.clone());
                     }
                 }
-                self.nbsp()?;
-                self.print_type_bounds("=", &real_bounds[..])?;
-                self.print_where_clause(&generics.where_clause)?;
-                self.s.word(";")?;
+                self.nbsp();
+                self.print_type_bounds("=", &real_bounds[..]);
+                self.print_where_clause(&generics.where_clause);
+                self.s.word(";");
             }
             ast::ItemKind::Mac(ref mac) => {
                 if item.ident.name == kw::Invalid {
-                    self.print_mac(mac)?;
+                    self.print_mac(mac);
                     match mac.node.delim {
                         MacDelimiter::Brace => {}
-                        _ => self.s.word(";")?,
+                        _ => self.s.word(";"),
                     }
                 } else {
-                    self.print_path(&mac.node.path, false, 0)?;
-                    self.s.word("! ")?;
-                    self.print_ident(item.ident)?;
-                    self.cbox(INDENT_UNIT)?;
-                    self.popen()?;
-                    self.print_tts(mac.node.stream())?;
-                    self.pclose()?;
-                    self.s.word(";")?;
-                    self.end()?;
+                    self.print_path(&mac.node.path, false, 0);
+                    self.s.word("! ");
+                    self.print_ident(item.ident);
+                    self.cbox(INDENT_UNIT);
+                    self.popen();
+                    self.print_tts(mac.node.stream());
+                    self.pclose();
+                    self.s.word(";");
+                    self.end();
                 }
             }
             ast::ItemKind::MacroDef(ref tts) => {
-                self.s.word("macro_rules! ")?;
-                self.print_ident(item.ident)?;
-                self.cbox(INDENT_UNIT)?;
-                self.popen()?;
-                self.print_tts(tts.stream())?;
-                self.pclose()?;
-                self.s.word(";")?;
-                self.end()?;
+                self.s.word("macro_rules! ");
+                self.print_ident(item.ident);
+                self.cbox(INDENT_UNIT);
+                self.popen();
+                self.print_tts(tts.stream());
+                self.pclose();
+                self.s.word(";");
+                self.end();
             }
         }
         self.ann.post(self, AnnNode::Item(item))
     }
 
-    fn print_trait_ref(&mut self, t: &ast::TraitRef) -> io::Result<()> {
+    fn print_trait_ref(&mut self, t: &ast::TraitRef) {
         self.print_path(&t.path, false, 0)
     }
 
     fn print_formal_generic_params(
         &mut self,
         generic_params: &[ast::GenericParam]
-    ) -> io::Result<()> {
+    ) {
         if !generic_params.is_empty() {
-            self.s.word("for")?;
-            self.print_generic_params(generic_params)?;
-            self.nbsp()?;
+            self.s.word("for");
+            self.print_generic_params(generic_params);
+            self.nbsp();
         }
-        Ok(())
     }
 
-    fn print_poly_trait_ref(&mut self, t: &ast::PolyTraitRef) -> io::Result<()> {
-        self.print_formal_generic_params(&t.bound_generic_params)?;
+    fn print_poly_trait_ref(&mut self, t: &ast::PolyTraitRef) {
+        self.print_formal_generic_params(&t.bound_generic_params);
         self.print_trait_ref(&t.trait_ref)
     }
 
     crate fn print_enum_def(&mut self, enum_definition: &ast::EnumDef,
                           generics: &ast::Generics, ident: ast::Ident,
                           span: syntax_pos::Span,
-                          visibility: &ast::Visibility) -> io::Result<()> {
-        self.head(visibility_qualified(visibility, "enum"))?;
-        self.print_ident(ident)?;
-        self.print_generic_params(&generics.params)?;
-        self.print_where_clause(&generics.where_clause)?;
-        self.s.space()?;
+                          visibility: &ast::Visibility) {
+        self.head(visibility_qualified(visibility, "enum"));
+        self.print_ident(ident);
+        self.print_generic_params(&generics.params);
+        self.print_where_clause(&generics.where_clause);
+        self.s.space();
         self.print_variants(&enum_definition.variants, span)
     }
 
     crate fn print_variants(&mut self,
                           variants: &[ast::Variant],
-                          span: syntax_pos::Span) -> io::Result<()> {
-        self.bopen()?;
+                          span: syntax_pos::Span) {
+        self.bopen();
         for v in variants {
-            self.space_if_not_bol()?;
-            self.maybe_print_comment(v.span.lo())?;
-            self.print_outer_attributes(&v.node.attrs)?;
-            self.ibox(INDENT_UNIT)?;
-            self.print_variant(v)?;
-            self.s.word(",")?;
-            self.end()?;
-            self.maybe_print_trailing_comment(v.span, None)?;
+            self.space_if_not_bol();
+            self.maybe_print_comment(v.span.lo());
+            self.print_outer_attributes(&v.node.attrs);
+            self.ibox(INDENT_UNIT);
+            self.print_variant(v);
+            self.s.word(",");
+            self.end();
+            self.maybe_print_trailing_comment(v.span, None);
         }
         self.bclose(span)
     }
 
-    crate fn print_visibility(&mut self, vis: &ast::Visibility) -> io::Result<()> {
+    crate fn print_visibility(&mut self, vis: &ast::Visibility) {
         match vis.node {
             ast::VisibilityKind::Public => self.word_nbsp("pub"),
             ast::VisibilityKind::Crate(sugar) => match sugar {
@@ -1433,15 +1413,14 @@ impl<'a> State<'a> {
                     self.word_nbsp(format!("pub(in {})", path))
                 }
             }
-            ast::VisibilityKind::Inherited => Ok(())
+            ast::VisibilityKind::Inherited => {}
         }
     }
 
-    crate fn print_defaultness(&mut self, defaultness: ast::Defaultness) -> io::Result<()> {
+    crate fn print_defaultness(&mut self, defaultness: ast::Defaultness) {
         if let ast::Defaultness::Default = defaultness {
-            self.word_nbsp("default")?;
+            self.word_nbsp("default");
         }
-        Ok(())
     }
 
     crate fn print_struct(&mut self,
@@ -1449,46 +1428,46 @@ impl<'a> State<'a> {
                         generics: &ast::Generics,
                         ident: ast::Ident,
                         span: syntax_pos::Span,
-                        print_finalizer: bool) -> io::Result<()> {
-        self.print_ident(ident)?;
-        self.print_generic_params(&generics.params)?;
+                        print_finalizer: bool) {
+        self.print_ident(ident);
+        self.print_generic_params(&generics.params);
         match struct_def {
             ast::VariantData::Tuple(..) | ast::VariantData::Unit(..) => {
                 if let ast::VariantData::Tuple(..) = struct_def {
-                    self.popen()?;
+                    self.popen();
                     self.commasep(
                         Inconsistent, struct_def.fields(),
                         |s, field| {
-                            s.maybe_print_comment(field.span.lo())?;
-                            s.print_outer_attributes(&field.attrs)?;
-                            s.print_visibility(&field.vis)?;
+                            s.maybe_print_comment(field.span.lo());
+                            s.print_outer_attributes(&field.attrs);
+                            s.print_visibility(&field.vis);
                             s.print_type(&field.ty)
                         }
-                    )?;
-                    self.pclose()?;
+                    );
+                    self.pclose();
                 }
-                self.print_where_clause(&generics.where_clause)?;
+                self.print_where_clause(&generics.where_clause);
                 if print_finalizer {
-                    self.s.word(";")?;
+                    self.s.word(";");
                 }
-                self.end()?;
-                self.end() // close the outer-box
+                self.end();
+                self.end(); // close the outer-box
             }
             ast::VariantData::Struct(..) => {
-                self.print_where_clause(&generics.where_clause)?;
-                self.nbsp()?;
-                self.bopen()?;
-                self.hardbreak_if_not_bol()?;
+                self.print_where_clause(&generics.where_clause);
+                self.nbsp();
+                self.bopen();
+                self.hardbreak_if_not_bol();
 
                 for field in struct_def.fields() {
-                    self.hardbreak_if_not_bol()?;
-                    self.maybe_print_comment(field.span.lo())?;
-                    self.print_outer_attributes(&field.attrs)?;
-                    self.print_visibility(&field.vis)?;
-                    self.print_ident(field.ident.unwrap())?;
-                    self.word_nbsp(":")?;
-                    self.print_type(&field.ty)?;
-                    self.s.word(",")?;
+                    self.hardbreak_if_not_bol();
+                    self.maybe_print_comment(field.span.lo());
+                    self.print_outer_attributes(&field.attrs);
+                    self.print_visibility(&field.vis);
+                    self.print_ident(field.ident.unwrap());
+                    self.word_nbsp(":");
+                    self.print_type(&field.ty);
+                    self.s.word(",");
                 }
 
                 self.bclose(span)
@@ -1496,17 +1475,17 @@ impl<'a> State<'a> {
         }
     }
 
-    crate fn print_variant(&mut self, v: &ast::Variant) -> io::Result<()> {
-        self.head("")?;
+    crate fn print_variant(&mut self, v: &ast::Variant) {
+        self.head("");
         let generics = ast::Generics::default();
-        self.print_struct(&v.node.data, &generics, v.node.ident, v.span, false)?;
+        self.print_struct(&v.node.data, &generics, v.node.ident, v.span, false);
         match v.node.disr_expr {
             Some(ref d) => {
-                self.s.space()?;
-                self.word_space("=")?;
+                self.s.space();
+                self.word_space("=");
                 self.print_expr(&d.value)
             }
-            _ => Ok(())
+            _ => {}
         }
     }
 
@@ -1515,7 +1494,7 @@ impl<'a> State<'a> {
                             generics: &ast::Generics,
                             m: &ast::MethodSig,
                             vis: &ast::Visibility)
-                            -> io::Result<()> {
+                            {
         self.print_fn(&m.decl,
                       m.header,
                       Some(ident),
@@ -1524,11 +1503,11 @@ impl<'a> State<'a> {
     }
 
     crate fn print_trait_item(&mut self, ti: &ast::TraitItem)
-                            -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ti.id))?;
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ti.span.lo())?;
-        self.print_outer_attributes(&ti.attrs)?;
+                            {
+        self.ann.pre(self, AnnNode::SubItem(ti.id));
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(ti.span.lo());
+        self.print_outer_attributes(&ti.attrs);
         match ti.node {
             ast::TraitItemKind::Const(ref ty, ref default) => {
                 self.print_associated_const(
@@ -1536,132 +1515,132 @@ impl<'a> State<'a> {
                     ty,
                     default.as_ref().map(|expr| &**expr),
                     &source_map::respan(ti.span.shrink_to_lo(), ast::VisibilityKind::Inherited),
-                )?;
+                );
             }
             ast::TraitItemKind::Method(ref sig, ref body) => {
                 if body.is_some() {
-                    self.head("")?;
+                    self.head("");
                 }
                 self.print_method_sig(
                     ti.ident,
                     &ti.generics,
                     sig,
                     &source_map::respan(ti.span.shrink_to_lo(), ast::VisibilityKind::Inherited),
-                )?;
+                );
                 if let Some(ref body) = *body {
-                    self.nbsp()?;
-                    self.print_block_with_attrs(body, &ti.attrs)?;
+                    self.nbsp();
+                    self.print_block_with_attrs(body, &ti.attrs);
                 } else {
-                    self.s.word(";")?;
+                    self.s.word(";");
                 }
             }
             ast::TraitItemKind::Type(ref bounds, ref default) => {
                 self.print_associated_type(ti.ident, Some(bounds),
-                                           default.as_ref().map(|ty| &**ty))?;
+                                           default.as_ref().map(|ty| &**ty));
             }
             ast::TraitItemKind::Macro(ref mac) => {
-                self.print_mac(mac)?;
+                self.print_mac(mac);
                 match mac.node.delim {
                     MacDelimiter::Brace => {}
-                    _ => self.s.word(";")?,
+                    _ => self.s.word(";"),
                 }
             }
         }
         self.ann.post(self, AnnNode::SubItem(ti.id))
     }
 
-    crate fn print_impl_item(&mut self, ii: &ast::ImplItem) -> io::Result<()> {
-        self.ann.pre(self, AnnNode::SubItem(ii.id))?;
-        self.hardbreak_if_not_bol()?;
-        self.maybe_print_comment(ii.span.lo())?;
-        self.print_outer_attributes(&ii.attrs)?;
-        self.print_defaultness(ii.defaultness)?;
+    crate fn print_impl_item(&mut self, ii: &ast::ImplItem) {
+        self.ann.pre(self, AnnNode::SubItem(ii.id));
+        self.hardbreak_if_not_bol();
+        self.maybe_print_comment(ii.span.lo());
+        self.print_outer_attributes(&ii.attrs);
+        self.print_defaultness(ii.defaultness);
         match ii.node {
             ast::ImplItemKind::Const(ref ty, ref expr) => {
-                self.print_associated_const(ii.ident, ty, Some(expr), &ii.vis)?;
+                self.print_associated_const(ii.ident, ty, Some(expr), &ii.vis);
             }
             ast::ImplItemKind::Method(ref sig, ref body) => {
-                self.head("")?;
-                self.print_method_sig(ii.ident, &ii.generics, sig, &ii.vis)?;
-                self.nbsp()?;
-                self.print_block_with_attrs(body, &ii.attrs)?;
+                self.head("");
+                self.print_method_sig(ii.ident, &ii.generics, sig, &ii.vis);
+                self.nbsp();
+                self.print_block_with_attrs(body, &ii.attrs);
             }
             ast::ImplItemKind::Type(ref ty) => {
-                self.print_associated_type(ii.ident, None, Some(ty))?;
+                self.print_associated_type(ii.ident, None, Some(ty));
             }
             ast::ImplItemKind::Existential(ref bounds) => {
-                self.word_space("existential")?;
-                self.print_associated_type(ii.ident, Some(bounds), None)?;
+                self.word_space("existential");
+                self.print_associated_type(ii.ident, Some(bounds), None);
             }
             ast::ImplItemKind::Macro(ref mac) => {
-                self.print_mac(mac)?;
+                self.print_mac(mac);
                 match mac.node.delim {
                     MacDelimiter::Brace => {}
-                    _ => self.s.word(";")?,
+                    _ => self.s.word(";"),
                 }
             }
         }
         self.ann.post(self, AnnNode::SubItem(ii.id))
     }
 
-    crate fn print_stmt(&mut self, st: &ast::Stmt) -> io::Result<()> {
-        self.maybe_print_comment(st.span.lo())?;
+    crate fn print_stmt(&mut self, st: &ast::Stmt) {
+        self.maybe_print_comment(st.span.lo());
         match st.node {
             ast::StmtKind::Local(ref loc) => {
-                self.print_outer_attributes(&loc.attrs)?;
-                self.space_if_not_bol()?;
-                self.ibox(INDENT_UNIT)?;
-                self.word_nbsp("let")?;
+                self.print_outer_attributes(&loc.attrs);
+                self.space_if_not_bol();
+                self.ibox(INDENT_UNIT);
+                self.word_nbsp("let");
 
-                self.ibox(INDENT_UNIT)?;
-                self.print_local_decl(loc)?;
-                self.end()?;
+                self.ibox(INDENT_UNIT);
+                self.print_local_decl(loc);
+                self.end();
                 if let Some(ref init) = loc.init {
-                    self.nbsp()?;
-                    self.word_space("=")?;
-                    self.print_expr(init)?;
+                    self.nbsp();
+                    self.word_space("=");
+                    self.print_expr(init);
                 }
-                self.s.word(";")?;
-                self.end()?;
+                self.s.word(";");
+                self.end();
             }
-            ast::StmtKind::Item(ref item) => self.print_item(item)?,
+            ast::StmtKind::Item(ref item) => self.print_item(item),
             ast::StmtKind::Expr(ref expr) => {
-                self.space_if_not_bol()?;
-                self.print_expr_outer_attr_style(expr, false)?;
+                self.space_if_not_bol();
+                self.print_expr_outer_attr_style(expr, false);
                 if parse::classify::expr_requires_semi_to_be_stmt(expr) {
-                    self.s.word(";")?;
+                    self.s.word(";");
                 }
             }
             ast::StmtKind::Semi(ref expr) => {
-                self.space_if_not_bol()?;
-                self.print_expr_outer_attr_style(expr, false)?;
-                self.s.word(";")?;
+                self.space_if_not_bol();
+                self.print_expr_outer_attr_style(expr, false);
+                self.s.word(";");
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, style, ref attrs) = **mac;
-                self.space_if_not_bol()?;
-                self.print_outer_attributes(attrs)?;
-                self.print_mac(mac)?;
+                self.space_if_not_bol();
+                self.print_outer_attributes(attrs);
+                self.print_mac(mac);
                 if style == ast::MacStmtStyle::Semicolon {
-                    self.s.word(";")?;
+                    self.s.word(";");
                 }
             }
         }
         self.maybe_print_trailing_comment(st.span, None)
     }
 
-    crate fn print_block(&mut self, blk: &ast::Block) -> io::Result<()> {
+    crate fn print_block(&mut self, blk: &ast::Block) {
         self.print_block_with_attrs(blk, &[])
     }
 
     crate fn print_block_unclosed_indent(&mut self, blk: &ast::Block,
-                                       indented: usize) -> io::Result<()> {
+                                       indented: usize) {
         self.print_block_maybe_unclosed(blk, indented, &[], false)
     }
 
     crate fn print_block_with_attrs(&mut self,
                                   blk: &ast::Block,
-                                  attrs: &[ast::Attribute]) -> io::Result<()> {
+                                  attrs: &[ast::Attribute]) {
         self.print_block_maybe_unclosed(blk, INDENT_UNIT, attrs, true)
     }
 
@@ -1669,41 +1648,41 @@ impl<'a> State<'a> {
                                       blk: &ast::Block,
                                       indented: usize,
                                       attrs: &[ast::Attribute],
-                                      close_box: bool) -> io::Result<()> {
+                                      close_box: bool) {
         match blk.rules {
-            BlockCheckMode::Unsafe(..) => self.word_space("unsafe")?,
+            BlockCheckMode::Unsafe(..) => self.word_space("unsafe"),
             BlockCheckMode::Default => ()
         }
-        self.maybe_print_comment(blk.span.lo())?;
-        self.ann.pre(self, AnnNode::Block(blk))?;
-        self.bopen()?;
+        self.maybe_print_comment(blk.span.lo());
+        self.ann.pre(self, AnnNode::Block(blk));
+        self.bopen();
 
-        self.print_inner_attributes(attrs)?;
+        self.print_inner_attributes(attrs);
 
         for (i, st) in blk.stmts.iter().enumerate() {
             match st.node {
                 ast::StmtKind::Expr(ref expr) if i == blk.stmts.len() - 1 => {
-                    self.maybe_print_comment(st.span.lo())?;
-                    self.space_if_not_bol()?;
-                    self.print_expr_outer_attr_style(expr, false)?;
-                    self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()))?;
+                    self.maybe_print_comment(st.span.lo());
+                    self.space_if_not_bol();
+                    self.print_expr_outer_attr_style(expr, false);
+                    self.maybe_print_trailing_comment(expr.span, Some(blk.span.hi()));
                 }
-                _ => self.print_stmt(st)?,
+                _ => self.print_stmt(st),
             }
         }
 
-        self.bclose_maybe_open(blk.span, indented, close_box)?;
+        self.bclose_maybe_open(blk.span, indented, close_box);
         self.ann.post(self, AnnNode::Block(blk))
     }
 
     /// Print a `let pats = scrutinee` expression.
-    crate fn print_let(&mut self, pats: &[P<ast::Pat>], scrutinee: &ast::Expr) -> io::Result<()> {
-        self.s.word("let ")?;
+    crate fn print_let(&mut self, pats: &[P<ast::Pat>], scrutinee: &ast::Expr) {
+        self.s.word("let ");
 
-        self.print_pats(pats)?;
-        self.s.space()?;
+        self.print_pats(pats);
+        self.s.space();
 
-        self.word_space("=")?;
+        self.word_space("=");
         self.print_expr_cond_paren(
             scrutinee,
             Self::cond_needs_par(scrutinee)
@@ -1711,25 +1690,25 @@ impl<'a> State<'a> {
         )
     }
 
-    fn print_else(&mut self, els: Option<&ast::Expr>) -> io::Result<()> {
+    fn print_else(&mut self, els: Option<&ast::Expr>) {
         match els {
             Some(_else) => {
                 match _else.node {
                     // Another `else if` block.
                     ast::ExprKind::If(ref i, ref then, ref e) => {
-                        self.cbox(INDENT_UNIT - 1)?;
-                        self.ibox(0)?;
-                        self.s.word(" else if ")?;
-                        self.print_expr_as_cond(i)?;
-                        self.s.space()?;
-                        self.print_block(then)?;
+                        self.cbox(INDENT_UNIT - 1);
+                        self.ibox(0);
+                        self.s.word(" else if ");
+                        self.print_expr_as_cond(i);
+                        self.s.space();
+                        self.print_block(then);
                         self.print_else(e.as_ref().map(|e| &**e))
                     }
                     // Final `else` block.
                     ast::ExprKind::Block(ref b, _) => {
-                        self.cbox(INDENT_UNIT - 1)?;
-                        self.ibox(0)?;
-                        self.s.word(" else ")?;
+                        self.cbox(INDENT_UNIT - 1);
+                        self.ibox(0);
+                        self.s.word(" else ");
                         self.print_block(b)
                     }
                     // Constraints would be great here!
@@ -1738,33 +1717,33 @@ impl<'a> State<'a> {
                     }
                 }
             }
-            _ => Ok(())
+            _ => {}
         }
     }
 
     crate fn print_if(&mut self, test: &ast::Expr, blk: &ast::Block,
-                    elseopt: Option<&ast::Expr>) -> io::Result<()> {
-        self.head("if")?;
+                    elseopt: Option<&ast::Expr>) {
+        self.head("if");
 
-        self.print_expr_as_cond(test)?;
-        self.s.space()?;
+        self.print_expr_as_cond(test);
+        self.s.space();
 
-        self.print_block(blk)?;
+        self.print_block(blk);
         self.print_else(elseopt)
     }
 
-    crate fn print_mac(&mut self, m: &ast::Mac) -> io::Result<()> {
-        self.print_path(&m.node.path, false, 0)?;
-        self.s.word("!")?;
+    crate fn print_mac(&mut self, m: &ast::Mac) {
+        self.print_path(&m.node.path, false, 0);
+        self.s.word("!");
         match m.node.delim {
-            MacDelimiter::Parenthesis => self.popen()?,
-            MacDelimiter::Bracket => self.s.word("[")?,
+            MacDelimiter::Parenthesis => self.popen(),
+            MacDelimiter::Bracket => self.s.word("["),
             MacDelimiter::Brace => {
-                self.head("")?;
-                self.bopen()?;
+                self.head("");
+                self.bopen();
             }
         }
-        self.print_tts(m.node.stream())?;
+        self.print_tts(m.node.stream());
         match m.node.delim {
             MacDelimiter::Parenthesis => self.pclose(),
             MacDelimiter::Bracket => self.s.word("]"),
@@ -1773,19 +1752,19 @@ impl<'a> State<'a> {
     }
 
 
-    fn print_call_post(&mut self, args: &[P<ast::Expr>]) -> io::Result<()> {
-        self.popen()?;
-        self.commasep_exprs(Inconsistent, args)?;
+    fn print_call_post(&mut self, args: &[P<ast::Expr>]) {
+        self.popen();
+        self.commasep_exprs(Inconsistent, args);
         self.pclose()
     }
 
-    crate fn print_expr_maybe_paren(&mut self, expr: &ast::Expr, prec: i8) -> io::Result<()> {
+    crate fn print_expr_maybe_paren(&mut self, expr: &ast::Expr, prec: i8) {
         self.print_expr_cond_paren(expr, expr.precedence().order() < prec)
     }
 
     /// Print an expr using syntax that's acceptable in a condition position, such as the `cond` in
     /// `if cond { ... }`.
-    crate fn print_expr_as_cond(&mut self, expr: &ast::Expr) -> io::Result<()> {
+    crate fn print_expr_as_cond(&mut self, expr: &ast::Expr) {
         self.print_expr_cond_paren(expr, Self::cond_needs_par(expr))
     }
 
@@ -1803,114 +1782,112 @@ impl<'a> State<'a> {
     }
 
     /// Print `expr` or `(expr)` when `needs_par` holds.
-    fn print_expr_cond_paren(&mut self, expr: &ast::Expr, needs_par: bool) -> io::Result<()> {
+    fn print_expr_cond_paren(&mut self, expr: &ast::Expr, needs_par: bool) {
         if needs_par {
-            self.popen()?;
+            self.popen();
         }
-        self.print_expr(expr)?;
+        self.print_expr(expr);
         if needs_par {
-            self.pclose()?;
+            self.pclose();
         }
-        Ok(())
     }
 
     fn print_expr_vec(&mut self, exprs: &[P<ast::Expr>],
-                      attrs: &[Attribute]) -> io::Result<()> {
-        self.ibox(INDENT_UNIT)?;
-        self.s.word("[")?;
-        self.print_inner_attributes_inline(attrs)?;
-        self.commasep_exprs(Inconsistent, &exprs[..])?;
-        self.s.word("]")?;
-        self.end()
+                      attrs: &[Attribute]) {
+        self.ibox(INDENT_UNIT);
+        self.s.word("[");
+        self.print_inner_attributes_inline(attrs);
+        self.commasep_exprs(Inconsistent, &exprs[..]);
+        self.s.word("]");
+        self.end();
     }
 
     fn print_expr_repeat(&mut self,
                          element: &ast::Expr,
                          count: &ast::AnonConst,
-                         attrs: &[Attribute]) -> io::Result<()> {
-        self.ibox(INDENT_UNIT)?;
-        self.s.word("[")?;
-        self.print_inner_attributes_inline(attrs)?;
-        self.print_expr(element)?;
-        self.word_space(";")?;
-        self.print_expr(&count.value)?;
-        self.s.word("]")?;
-        self.end()
+                         attrs: &[Attribute]) {
+        self.ibox(INDENT_UNIT);
+        self.s.word("[");
+        self.print_inner_attributes_inline(attrs);
+        self.print_expr(element);
+        self.word_space(";");
+        self.print_expr(&count.value);
+        self.s.word("]");
+        self.end();
     }
 
     fn print_expr_struct(&mut self,
                          path: &ast::Path,
                          fields: &[ast::Field],
                          wth: &Option<P<ast::Expr>>,
-                         attrs: &[Attribute]) -> io::Result<()> {
-        self.print_path(path, true, 0)?;
-        self.s.word("{")?;
-        self.print_inner_attributes_inline(attrs)?;
+                         attrs: &[Attribute]) {
+        self.print_path(path, true, 0);
+        self.s.word("{");
+        self.print_inner_attributes_inline(attrs);
         self.commasep_cmnt(
             Consistent,
             &fields[..],
             |s, field| {
-                s.ibox(INDENT_UNIT)?;
+                s.ibox(INDENT_UNIT);
                 if !field.is_shorthand {
-                    s.print_ident(field.ident)?;
-                    s.word_space(":")?;
+                    s.print_ident(field.ident);
+                    s.word_space(":");
                 }
-                s.print_expr(&field.expr)?;
-                s.end()
+                s.print_expr(&field.expr);
+                s.end();
             },
-            |f| f.span)?;
+            |f| f.span);
         match *wth {
             Some(ref expr) => {
-                self.ibox(INDENT_UNIT)?;
+                self.ibox(INDENT_UNIT);
                 if !fields.is_empty() {
-                    self.s.word(",")?;
-                    self.s.space()?;
+                    self.s.word(",");
+                    self.s.space();
                 }
-                self.s.word("..")?;
-                self.print_expr(expr)?;
-                self.end()?;
+                self.s.word("..");
+                self.print_expr(expr);
+                self.end();
             }
             _ => if !fields.is_empty() {
-                self.s.word(",")?
+                self.s.word(",")
             }
         }
-        self.s.word("}")?;
-        Ok(())
+        self.s.word("}");
     }
 
     fn print_expr_tup(&mut self, exprs: &[P<ast::Expr>],
-                      attrs: &[Attribute]) -> io::Result<()> {
-        self.popen()?;
-        self.print_inner_attributes_inline(attrs)?;
-        self.commasep_exprs(Inconsistent, &exprs[..])?;
+                      attrs: &[Attribute]) {
+        self.popen();
+        self.print_inner_attributes_inline(attrs);
+        self.commasep_exprs(Inconsistent, &exprs[..]);
         if exprs.len() == 1 {
-            self.s.word(",")?;
+            self.s.word(",");
         }
         self.pclose()
     }
 
     fn print_expr_call(&mut self,
                        func: &ast::Expr,
-                       args: &[P<ast::Expr>]) -> io::Result<()> {
+                       args: &[P<ast::Expr>]) {
         let prec =
             match func.node {
                 ast::ExprKind::Field(..) => parser::PREC_FORCE_PAREN,
                 _ => parser::PREC_POSTFIX,
             };
 
-        self.print_expr_maybe_paren(func, prec)?;
+        self.print_expr_maybe_paren(func, prec);
         self.print_call_post(args)
     }
 
     fn print_expr_method_call(&mut self,
                               segment: &ast::PathSegment,
-                              args: &[P<ast::Expr>]) -> io::Result<()> {
+                              args: &[P<ast::Expr>]) {
         let base_args = &args[1..];
-        self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX)?;
-        self.s.word(".")?;
-        self.print_ident(segment.ident)?;
+        self.print_expr_maybe_paren(&args[0], parser::PREC_POSTFIX);
+        self.s.word(".");
+        self.print_ident(segment.ident);
         if let Some(ref args) = segment.args {
-            self.print_generic_args(args, true)?;
+            self.print_generic_args(args, true);
         }
         self.print_call_post(base_args)
     }
@@ -1918,7 +1895,7 @@ impl<'a> State<'a> {
     fn print_expr_binary(&mut self,
                          op: ast::BinOp,
                          lhs: &ast::Expr,
-                         rhs: &ast::Expr) -> io::Result<()> {
+                         rhs: &ast::Expr) {
         let assoc_op = AssocOp::from_ast_binop(op.node);
         let prec = assoc_op.precedence() as i8;
         let fixity = assoc_op.fixity();
@@ -1949,217 +1926,217 @@ impl<'a> State<'a> {
             _ => left_prec,
         };
 
-        self.print_expr_maybe_paren(lhs, left_prec)?;
-        self.s.space()?;
-        self.word_space(op.node.to_string())?;
+        self.print_expr_maybe_paren(lhs, left_prec);
+        self.s.space();
+        self.word_space(op.node.to_string());
         self.print_expr_maybe_paren(rhs, right_prec)
     }
 
     fn print_expr_unary(&mut self,
                         op: ast::UnOp,
-                        expr: &ast::Expr) -> io::Result<()> {
-        self.s.word(ast::UnOp::to_string(op))?;
+                        expr: &ast::Expr) {
+        self.s.word(ast::UnOp::to_string(op));
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
     fn print_expr_addr_of(&mut self,
                           mutability: ast::Mutability,
-                          expr: &ast::Expr) -> io::Result<()> {
-        self.s.word("&")?;
-        self.print_mutability(mutability)?;
+                          expr: &ast::Expr) {
+        self.s.word("&");
+        self.print_mutability(mutability);
         self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)
     }
 
-    crate fn print_expr(&mut self, expr: &ast::Expr) -> io::Result<()> {
+    crate fn print_expr(&mut self, expr: &ast::Expr) {
         self.print_expr_outer_attr_style(expr, true)
     }
 
     fn print_expr_outer_attr_style(&mut self,
                                   expr: &ast::Expr,
-                                  is_inline: bool) -> io::Result<()> {
-        self.maybe_print_comment(expr.span.lo())?;
+                                  is_inline: bool) {
+        self.maybe_print_comment(expr.span.lo());
 
         let attrs = &expr.attrs;
         if is_inline {
-            self.print_outer_attributes_inline(attrs)?;
+            self.print_outer_attributes_inline(attrs);
         } else {
-            self.print_outer_attributes(attrs)?;
+            self.print_outer_attributes(attrs);
         }
 
-        self.ibox(INDENT_UNIT)?;
-        self.ann.pre(self, AnnNode::Expr(expr))?;
+        self.ibox(INDENT_UNIT);
+        self.ann.pre(self, AnnNode::Expr(expr));
         match expr.node {
             ast::ExprKind::Box(ref expr) => {
-                self.word_space("box")?;
-                self.print_expr_maybe_paren(expr, parser::PREC_PREFIX)?;
+                self.word_space("box");
+                self.print_expr_maybe_paren(expr, parser::PREC_PREFIX);
             }
             ast::ExprKind::Array(ref exprs) => {
-                self.print_expr_vec(&exprs[..], attrs)?;
+                self.print_expr_vec(&exprs[..], attrs);
             }
             ast::ExprKind::Repeat(ref element, ref count) => {
-                self.print_expr_repeat(element, count, attrs)?;
+                self.print_expr_repeat(element, count, attrs);
             }
             ast::ExprKind::Struct(ref path, ref fields, ref wth) => {
-                self.print_expr_struct(path, &fields[..], wth, attrs)?;
+                self.print_expr_struct(path, &fields[..], wth, attrs);
             }
             ast::ExprKind::Tup(ref exprs) => {
-                self.print_expr_tup(&exprs[..], attrs)?;
+                self.print_expr_tup(&exprs[..], attrs);
             }
             ast::ExprKind::Call(ref func, ref args) => {
-                self.print_expr_call(func, &args[..])?;
+                self.print_expr_call(func, &args[..]);
             }
             ast::ExprKind::MethodCall(ref segment, ref args) => {
-                self.print_expr_method_call(segment, &args[..])?;
+                self.print_expr_method_call(segment, &args[..]);
             }
             ast::ExprKind::Binary(op, ref lhs, ref rhs) => {
-                self.print_expr_binary(op, lhs, rhs)?;
+                self.print_expr_binary(op, lhs, rhs);
             }
             ast::ExprKind::Unary(op, ref expr) => {
-                self.print_expr_unary(op, expr)?;
+                self.print_expr_unary(op, expr);
             }
             ast::ExprKind::AddrOf(m, ref expr) => {
-                self.print_expr_addr_of(m, expr)?;
+                self.print_expr_addr_of(m, expr);
             }
             ast::ExprKind::Lit(ref lit) => {
-                self.print_literal(lit)?;
+                self.print_literal(lit);
             }
             ast::ExprKind::Cast(ref expr, ref ty) => {
                 let prec = AssocOp::As.precedence() as i8;
-                self.print_expr_maybe_paren(expr, prec)?;
-                self.s.space()?;
-                self.word_space("as")?;
-                self.print_type(ty)?;
+                self.print_expr_maybe_paren(expr, prec);
+                self.s.space();
+                self.word_space("as");
+                self.print_type(ty);
             }
             ast::ExprKind::Type(ref expr, ref ty) => {
                 let prec = AssocOp::Colon.precedence() as i8;
-                self.print_expr_maybe_paren(expr, prec)?;
-                self.word_space(":")?;
-                self.print_type(ty)?;
+                self.print_expr_maybe_paren(expr, prec);
+                self.word_space(":");
+                self.print_type(ty);
             }
             ast::ExprKind::Let(ref pats, ref scrutinee) => {
-                self.print_let(pats, scrutinee)?;
+                self.print_let(pats, scrutinee);
             }
             ast::ExprKind::If(ref test, ref blk, ref elseopt) => {
-                self.print_if(test, blk, elseopt.as_ref().map(|e| &**e))?;
+                self.print_if(test, blk, elseopt.as_ref().map(|e| &**e));
             }
             ast::ExprKind::While(ref test, ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
-                self.head("while")?;
-                self.print_expr_as_cond(test)?;
-                self.s.space()?;
-                self.print_block_with_attrs(blk, attrs)?;
+                self.head("while");
+                self.print_expr_as_cond(test);
+                self.s.space();
+                self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::ForLoop(ref pat, ref iter, ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
-                self.head("for")?;
-                self.print_pat(pat)?;
-                self.s.space()?;
-                self.word_space("in")?;
-                self.print_expr_as_cond(iter)?;
-                self.s.space()?;
-                self.print_block_with_attrs(blk, attrs)?;
+                self.head("for");
+                self.print_pat(pat);
+                self.s.space();
+                self.word_space("in");
+                self.print_expr_as_cond(iter);
+                self.s.space();
+                self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Loop(ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
-                self.head("loop")?;
-                self.s.space()?;
-                self.print_block_with_attrs(blk, attrs)?;
+                self.head("loop");
+                self.s.space();
+                self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Match(ref expr, ref arms) => {
-                self.cbox(INDENT_UNIT)?;
-                self.ibox(4)?;
-                self.word_nbsp("match")?;
-                self.print_expr_as_cond(expr)?;
-                self.s.space()?;
-                self.bopen()?;
-                self.print_inner_attributes_no_trailing_hardbreak(attrs)?;
+                self.cbox(INDENT_UNIT);
+                self.ibox(4);
+                self.word_nbsp("match");
+                self.print_expr_as_cond(expr);
+                self.s.space();
+                self.bopen();
+                self.print_inner_attributes_no_trailing_hardbreak(attrs);
                 for arm in arms {
-                    self.print_arm(arm)?;
+                    self.print_arm(arm);
                 }
-                self.bclose_(expr.span, INDENT_UNIT)?;
+                self.bclose_(expr.span, INDENT_UNIT);
             }
             ast::ExprKind::Closure(
                 capture_clause, asyncness, movability, ref decl, ref body, _) => {
-                self.print_movability(movability)?;
-                self.print_asyncness(asyncness)?;
-                self.print_capture_clause(capture_clause)?;
+                self.print_movability(movability);
+                self.print_asyncness(asyncness);
+                self.print_capture_clause(capture_clause);
 
-                self.print_fn_block_args(decl)?;
-                self.s.space()?;
-                self.print_expr(body)?;
-                self.end()?; // need to close a box
+                self.print_fn_block_args(decl);
+                self.s.space();
+                self.print_expr(body);
+                self.end(); // need to close a box
 
                 // a box will be closed by print_expr, but we didn't want an overall
                 // wrapper so we closed the corresponding opening. so create an
                 // empty box to satisfy the close.
-                self.ibox(0)?;
+                self.ibox(0);
             }
             ast::ExprKind::Block(ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
                 // containing cbox, will be closed by print-block at }
-                self.cbox(INDENT_UNIT)?;
+                self.cbox(INDENT_UNIT);
                 // head-box, will be closed by print-block after {
-                self.ibox(0)?;
-                self.print_block_with_attrs(blk, attrs)?;
+                self.ibox(0);
+                self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Async(capture_clause, _, ref blk) => {
-                self.word_nbsp("async")?;
-                self.print_capture_clause(capture_clause)?;
-                self.s.space()?;
+                self.word_nbsp("async");
+                self.print_capture_clause(capture_clause);
+                self.s.space();
                 // cbox/ibox in analogy to the `ExprKind::Block` arm above
-                self.cbox(INDENT_UNIT)?;
-                self.ibox(0)?;
-                self.print_block_with_attrs(blk, attrs)?;
+                self.cbox(INDENT_UNIT);
+                self.ibox(0);
+                self.print_block_with_attrs(blk, attrs);
             }
             ast::ExprKind::Await(origin, ref expr) => {
                 match origin {
                     ast::AwaitOrigin::MacroLike => {
-                        self.s.word("await!")?;
-                        self.print_expr_maybe_paren(expr, parser::PREC_FORCE_PAREN)?;
+                        self.s.word("await!");
+                        self.print_expr_maybe_paren(expr, parser::PREC_FORCE_PAREN);
                     }
                     ast::AwaitOrigin::FieldLike => {
-                        self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX)?;
-                        self.s.word(".await")?;
+                        self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
+                        self.s.word(".await");
                     }
                 }
             }
             ast::ExprKind::Assign(ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
-                self.print_expr_maybe_paren(lhs, prec + 1)?;
-                self.s.space()?;
-                self.word_space("=")?;
-                self.print_expr_maybe_paren(rhs, prec)?;
+                self.print_expr_maybe_paren(lhs, prec + 1);
+                self.s.space();
+                self.word_space("=");
+                self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::AssignOp(op, ref lhs, ref rhs) => {
                 let prec = AssocOp::Assign.precedence() as i8;
-                self.print_expr_maybe_paren(lhs, prec + 1)?;
-                self.s.space()?;
-                self.s.word(op.node.to_string())?;
-                self.word_space("=")?;
-                self.print_expr_maybe_paren(rhs, prec)?;
+                self.print_expr_maybe_paren(lhs, prec + 1);
+                self.s.space();
+                self.s.word(op.node.to_string());
+                self.word_space("=");
+                self.print_expr_maybe_paren(rhs, prec);
             }
             ast::ExprKind::Field(ref expr, ident) => {
-                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX)?;
-                self.s.word(".")?;
-                self.print_ident(ident)?;
+                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
+                self.s.word(".");
+                self.print_ident(ident);
             }
             ast::ExprKind::Index(ref expr, ref index) => {
-                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX)?;
-                self.s.word("[")?;
-                self.print_expr(index)?;
-                self.s.word("]")?;
+                self.print_expr_maybe_paren(expr, parser::PREC_POSTFIX);
+                self.s.word("[");
+                self.print_expr(index);
+                self.s.word("]");
             }
             ast::ExprKind::Range(ref start, ref end, limits) => {
                 // Special case for `Range`.  `AssocOp` claims that `Range` has higher precedence
@@ -2168,55 +2145,55 @@ impl<'a> State<'a> {
                 // a "normal" binop gets parenthesized.  (`LOr` is the lowest-precedence binop.)
                 let fake_prec = AssocOp::LOr.precedence() as i8;
                 if let Some(ref e) = *start {
-                    self.print_expr_maybe_paren(e, fake_prec)?;
+                    self.print_expr_maybe_paren(e, fake_prec);
                 }
                 if limits == ast::RangeLimits::HalfOpen {
-                    self.s.word("..")?;
+                    self.s.word("..");
                 } else {
-                    self.s.word("..=")?;
+                    self.s.word("..=");
                 }
                 if let Some(ref e) = *end {
-                    self.print_expr_maybe_paren(e, fake_prec)?;
+                    self.print_expr_maybe_paren(e, fake_prec);
                 }
             }
             ast::ExprKind::Path(None, ref path) => {
-                self.print_path(path, true, 0)?
+                self.print_path(path, true, 0)
             }
             ast::ExprKind::Path(Some(ref qself), ref path) => {
-                self.print_qpath(path, qself, true)?
+                self.print_qpath(path, qself, true)
             }
             ast::ExprKind::Break(opt_label, ref opt_expr) => {
-                self.s.word("break")?;
-                self.s.space()?;
+                self.s.word("break");
+                self.s.space();
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.s.space()?;
+                    self.print_ident(label.ident);
+                    self.s.space();
                 }
                 if let Some(ref expr) = *opt_expr {
-                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP)?;
-                    self.s.space()?;
+                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
+                    self.s.space();
                 }
             }
             ast::ExprKind::Continue(opt_label) => {
-                self.s.word("continue")?;
-                self.s.space()?;
+                self.s.word("continue");
+                self.s.space();
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.s.space()?
+                    self.print_ident(label.ident);
+                    self.s.space()
                 }
             }
             ast::ExprKind::Ret(ref result) => {
-                self.s.word("return")?;
+                self.s.word("return");
                 if let Some(ref expr) = *result {
-                    self.s.word(" ")?;
-                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP)?;
+                    self.s.word(" ");
+                    self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                 }
             }
             ast::ExprKind::InlineAsm(ref a) => {
-                self.s.word("asm!")?;
-                self.popen()?;
-                self.print_string(&a.asm.as_str(), a.asm_str_style)?;
-                self.word_space(":")?;
+                self.s.word("asm!");
+                self.popen();
+                self.print_string(&a.asm.as_str(), a.asm_str_style);
+                self.word_space(":");
 
                 self.commasep(Inconsistent, &a.outputs, |s, out| {
                     let constraint = out.constraint.as_str();
@@ -2224,33 +2201,30 @@ impl<'a> State<'a> {
                     match ch.next() {
                         Some('=') if out.is_rw => {
                             s.print_string(&format!("+{}", ch.as_str()),
-                                           ast::StrStyle::Cooked)?
+                                           ast::StrStyle::Cooked)
                         }
-                        _ => s.print_string(&constraint, ast::StrStyle::Cooked)?
+                        _ => s.print_string(&constraint, ast::StrStyle::Cooked)
                     }
-                    s.popen()?;
-                    s.print_expr(&out.expr)?;
-                    s.pclose()?;
-                    Ok(())
-                })?;
-                self.s.space()?;
-                self.word_space(":")?;
+                    s.popen();
+                    s.print_expr(&out.expr);
+                    s.pclose();
+                });
+                self.s.space();
+                self.word_space(":");
 
                 self.commasep(Inconsistent, &a.inputs, |s, &(co, ref o)| {
-                    s.print_string(&co.as_str(), ast::StrStyle::Cooked)?;
-                    s.popen()?;
-                    s.print_expr(o)?;
-                    s.pclose()?;
-                    Ok(())
-                })?;
-                self.s.space()?;
-                self.word_space(":")?;
+                    s.print_string(&co.as_str(), ast::StrStyle::Cooked);
+                    s.popen();
+                    s.print_expr(o);
+                    s.pclose();
+                });
+                self.s.space();
+                self.word_space(":");
 
                 self.commasep(Inconsistent, &a.clobbers,
                                    |s, co| {
-                    s.print_string(&co.as_str(), ast::StrStyle::Cooked)?;
-                    Ok(())
-                })?;
+                    s.print_string(&co.as_str(), ast::StrStyle::Cooked);
+                });
 
                 let mut options = vec![];
                 if a.volatile {
@@ -2264,415 +2238,401 @@ impl<'a> State<'a> {
                 }
 
                 if !options.is_empty() {
-                    self.s.space()?;
-                    self.word_space(":")?;
+                    self.s.space();
+                    self.word_space(":");
                     self.commasep(Inconsistent, &options,
                                   |s, &co| {
-                                      s.print_string(co, ast::StrStyle::Cooked)?;
-                                      Ok(())
-                                  })?;
+                                      s.print_string(co, ast::StrStyle::Cooked);
+                                  });
                 }
 
-                self.pclose()?;
+                self.pclose();
             }
-            ast::ExprKind::Mac(ref m) => self.print_mac(m)?,
+            ast::ExprKind::Mac(ref m) => self.print_mac(m),
             ast::ExprKind::Paren(ref e) => {
-                self.popen()?;
-                self.print_inner_attributes_inline(attrs)?;
-                self.print_expr(e)?;
-                self.pclose()?;
+                self.popen();
+                self.print_inner_attributes_inline(attrs);
+                self.print_expr(e);
+                self.pclose();
             },
             ast::ExprKind::Yield(ref e) => {
-                self.s.word("yield")?;
+                self.s.word("yield");
                 match *e {
                     Some(ref expr) => {
-                        self.s.space()?;
-                        self.print_expr_maybe_paren(expr, parser::PREC_JUMP)?;
+                        self.s.space();
+                        self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
                     }
                     _ => ()
                 }
             }
             ast::ExprKind::Try(ref e) => {
-                self.print_expr_maybe_paren(e, parser::PREC_POSTFIX)?;
-                self.s.word("?")?
+                self.print_expr_maybe_paren(e, parser::PREC_POSTFIX);
+                self.s.word("?")
             }
             ast::ExprKind::TryBlock(ref blk) => {
-                self.head("try")?;
-                self.s.space()?;
-                self.print_block_with_attrs(blk, attrs)?
+                self.head("try");
+                self.s.space();
+                self.print_block_with_attrs(blk, attrs)
             }
             ast::ExprKind::Err => {
-                self.popen()?;
-                self.s.word("/*ERROR*/")?;
-                self.pclose()?
+                self.popen();
+                self.s.word("/*ERROR*/");
+                self.pclose()
             }
         }
-        self.ann.post(self, AnnNode::Expr(expr))?;
-        self.end()
+        self.ann.post(self, AnnNode::Expr(expr));
+        self.end();
     }
 
-    crate fn print_local_decl(&mut self, loc: &ast::Local) -> io::Result<()> {
-        self.print_pat(&loc.pat)?;
+    crate fn print_local_decl(&mut self, loc: &ast::Local) {
+        self.print_pat(&loc.pat);
         if let Some(ref ty) = loc.ty {
-            self.word_space(":")?;
-            self.print_type(ty)?;
+            self.word_space(":");
+            self.print_type(ty);
         }
-        Ok(())
     }
 
-    crate fn print_ident(&mut self, ident: ast::Ident) -> io::Result<()> {
+    crate fn print_ident(&mut self, ident: ast::Ident) {
         if ident.is_raw_guess() {
-            self.s.word(format!("r#{}", ident))?;
+            self.s.word(format!("r#{}", ident));
         } else {
-            self.s.word(ident.as_str().to_string())?;
+            self.s.word(ident.as_str().to_string());
         }
         self.ann.post(self, AnnNode::Ident(&ident))
     }
 
-    crate fn print_usize(&mut self, i: usize) -> io::Result<()> {
+    crate fn print_usize(&mut self, i: usize) {
         self.s.word(i.to_string())
     }
 
-    crate fn print_name(&mut self, name: ast::Name) -> io::Result<()> {
-        self.s.word(name.as_str().to_string())?;
+    crate fn print_name(&mut self, name: ast::Name) {
+        self.s.word(name.as_str().to_string());
         self.ann.post(self, AnnNode::Name(&name))
     }
 
     fn print_path(&mut self,
                   path: &ast::Path,
                   colons_before_params: bool,
-                  depth: usize)
-                  -> io::Result<()>
-    {
-        self.maybe_print_comment(path.span.lo())?;
+                  depth: usize) {
+        self.maybe_print_comment(path.span.lo());
 
         for (i, segment) in path.segments[..path.segments.len() - depth].iter().enumerate() {
             if i > 0 {
-                self.s.word("::")?
+                self.s.word("::")
             }
-            self.print_path_segment(segment, colons_before_params)?;
+            self.print_path_segment(segment, colons_before_params);
         }
-
-        Ok(())
     }
 
     fn print_path_segment(&mut self,
                           segment: &ast::PathSegment,
-                          colons_before_params: bool)
-                          -> io::Result<()>
-    {
+                          colons_before_params: bool) {
         if segment.ident.name != kw::PathRoot {
             if segment.ident.name == kw::DollarCrate {
-                self.print_dollar_crate(segment.ident)?;
+                self.print_dollar_crate(segment.ident);
             } else {
-                self.print_ident(segment.ident)?;
+                self.print_ident(segment.ident);
             }
             if let Some(ref args) = segment.args {
-                self.print_generic_args(args, colons_before_params)?;
+                self.print_generic_args(args, colons_before_params);
             }
         }
-        Ok(())
     }
 
     fn print_qpath(&mut self,
                    path: &ast::Path,
                    qself: &ast::QSelf,
                    colons_before_params: bool)
-                   -> io::Result<()>
     {
-        self.s.word("<")?;
-        self.print_type(&qself.ty)?;
+        self.s.word("<");
+        self.print_type(&qself.ty);
         if qself.position > 0 {
-            self.s.space()?;
-            self.word_space("as")?;
+            self.s.space();
+            self.word_space("as");
             let depth = path.segments.len() - qself.position;
-            self.print_path(path, false, depth)?;
+            self.print_path(path, false, depth);
         }
-        self.s.word(">")?;
-        self.s.word("::")?;
+        self.s.word(">");
+        self.s.word("::");
         let item_segment = path.segments.last().unwrap();
-        self.print_ident(item_segment.ident)?;
+        self.print_ident(item_segment.ident);
         match item_segment.args {
             Some(ref args) => self.print_generic_args(args, colons_before_params),
-            None => Ok(()),
+            None => {},
         }
     }
 
     fn print_generic_args(&mut self,
                           args: &ast::GenericArgs,
                           colons_before_params: bool)
-                          -> io::Result<()>
     {
         if colons_before_params {
-            self.s.word("::")?
+            self.s.word("::")
         }
 
         match *args {
             ast::GenericArgs::AngleBracketed(ref data) => {
-                self.s.word("<")?;
+                self.s.word("<");
 
                 self.commasep(Inconsistent, &data.args, |s, generic_arg| {
                     s.print_generic_arg(generic_arg)
-                })?;
+                });
 
                 let mut comma = data.args.len() != 0;
 
                 for constraint in data.constraints.iter() {
                     if comma {
-                        self.word_space(",")?
+                        self.word_space(",")
                     }
-                    self.print_ident(constraint.ident)?;
-                    self.s.space()?;
+                    self.print_ident(constraint.ident);
+                    self.s.space();
                     match constraint.kind {
                         ast::AssocTyConstraintKind::Equality { ref ty } => {
-                            self.word_space("=")?;
-                            self.print_type(ty)?;
+                            self.word_space("=");
+                            self.print_type(ty);
                         }
                         ast::AssocTyConstraintKind::Bound { ref bounds } => {
-                            self.print_type_bounds(":", &*bounds)?;
+                            self.print_type_bounds(":", &*bounds);
                         }
                     }
                     comma = true;
                 }
 
-                self.s.word(">")?
+                self.s.word(">")
             }
 
             ast::GenericArgs::Parenthesized(ref data) => {
-                self.s.word("(")?;
+                self.s.word("(");
                 self.commasep(
                     Inconsistent,
                     &data.inputs,
-                    |s, ty| s.print_type(ty))?;
-                self.s.word(")")?;
+                    |s, ty| s.print_type(ty));
+                self.s.word(")");
 
                 if let Some(ref ty) = data.output {
-                    self.space_if_not_bol()?;
-                    self.word_space("->")?;
-                    self.print_type(ty)?;
+                    self.space_if_not_bol();
+                    self.word_space("->");
+                    self.print_type(ty);
                 }
             }
         }
-
-        Ok(())
     }
 
-    crate fn print_pat(&mut self, pat: &ast::Pat) -> io::Result<()> {
-        self.maybe_print_comment(pat.span.lo())?;
-        self.ann.pre(self, AnnNode::Pat(pat))?;
+    crate fn print_pat(&mut self, pat: &ast::Pat) {
+        self.maybe_print_comment(pat.span.lo());
+        self.ann.pre(self, AnnNode::Pat(pat));
         /* Pat isn't normalized, but the beauty of it
          is that it doesn't matter */
         match pat.node {
-            PatKind::Wild => self.s.word("_")?,
+            PatKind::Wild => self.s.word("_"),
             PatKind::Ident(binding_mode, ident, ref sub) => {
                 match binding_mode {
                     ast::BindingMode::ByRef(mutbl) => {
-                        self.word_nbsp("ref")?;
-                        self.print_mutability(mutbl)?;
+                        self.word_nbsp("ref");
+                        self.print_mutability(mutbl);
                     }
                     ast::BindingMode::ByValue(ast::Mutability::Immutable) => {}
                     ast::BindingMode::ByValue(ast::Mutability::Mutable) => {
-                        self.word_nbsp("mut")?;
+                        self.word_nbsp("mut");
                     }
                 }
-                self.print_ident(ident)?;
+                self.print_ident(ident);
                 if let Some(ref p) = *sub {
-                    self.s.word("@")?;
-                    self.print_pat(p)?;
+                    self.s.word("@");
+                    self.print_pat(p);
                 }
             }
             PatKind::TupleStruct(ref path, ref elts, ddpos) => {
-                self.print_path(path, true, 0)?;
-                self.popen()?;
+                self.print_path(path, true, 0);
+                self.popen();
                 if let Some(ddpos) = ddpos {
-                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(p))?;
+                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(p));
                     if ddpos != 0 {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",")?;
-                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(p))?;
+                        self.s.word(",");
+                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(p));
                     }
                 } else {
-                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p))?;
+                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
                 }
-                self.pclose()?;
+                self.pclose();
             }
             PatKind::Path(None, ref path) => {
-                self.print_path(path, true, 0)?;
+                self.print_path(path, true, 0);
             }
             PatKind::Path(Some(ref qself), ref path) => {
-                self.print_qpath(path, qself, false)?;
+                self.print_qpath(path, qself, false);
             }
             PatKind::Struct(ref path, ref fields, etc) => {
-                self.print_path(path, true, 0)?;
-                self.nbsp()?;
-                self.word_space("{")?;
+                self.print_path(path, true, 0);
+                self.nbsp();
+                self.word_space("{");
                 self.commasep_cmnt(
                     Consistent, &fields[..],
                     |s, f| {
-                        s.cbox(INDENT_UNIT)?;
+                        s.cbox(INDENT_UNIT);
                         if !f.node.is_shorthand {
-                            s.print_ident(f.node.ident)?;
-                            s.word_nbsp(":")?;
+                            s.print_ident(f.node.ident);
+                            s.word_nbsp(":");
                         }
-                        s.print_pat(&f.node.pat)?;
-                        s.end()
+                        s.print_pat(&f.node.pat);
+                        s.end();
                     },
-                    |f| f.node.pat.span)?;
+                    |f| f.node.pat.span);
                 if etc {
-                    if !fields.is_empty() { self.word_space(",")?; }
-                    self.s.word("..")?;
+                    if !fields.is_empty() { self.word_space(","); }
+                    self.s.word("..");
                 }
-                self.s.space()?;
-                self.s.word("}")?;
+                self.s.space();
+                self.s.word("}");
             }
             PatKind::Tuple(ref elts, ddpos) => {
-                self.popen()?;
+                self.popen();
                 if let Some(ddpos) = ddpos {
-                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(p))?;
+                    self.commasep(Inconsistent, &elts[..ddpos], |s, p| s.print_pat(p));
                     if ddpos != 0 {
-                        self.word_space(",")?;
+                        self.word_space(",");
                     }
-                    self.s.word("..")?;
+                    self.s.word("..");
                     if ddpos != elts.len() {
-                        self.s.word(",")?;
-                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(p))?;
+                        self.s.word(",");
+                        self.commasep(Inconsistent, &elts[ddpos..], |s, p| s.print_pat(p));
                     }
                 } else {
-                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p))?;
+                    self.commasep(Inconsistent, &elts[..], |s, p| s.print_pat(p));
                     if elts.len() == 1 {
-                        self.s.word(",")?;
+                        self.s.word(",");
                     }
                 }
-                self.pclose()?;
+                self.pclose();
             }
             PatKind::Box(ref inner) => {
-                self.s.word("box ")?;
-                self.print_pat(inner)?;
+                self.s.word("box ");
+                self.print_pat(inner);
             }
             PatKind::Ref(ref inner, mutbl) => {
-                self.s.word("&")?;
+                self.s.word("&");
                 if mutbl == ast::Mutability::Mutable {
-                    self.s.word("mut ")?;
+                    self.s.word("mut ");
                 }
-                self.print_pat(inner)?;
+                self.print_pat(inner);
             }
-            PatKind::Lit(ref e) => self.print_expr(&**e)?,
+            PatKind::Lit(ref e) => self.print_expr(&**e),
             PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {
-                self.print_expr(begin)?;
-                self.s.space()?;
+                self.print_expr(begin);
+                self.s.space();
                 match *end_kind {
-                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.s.word("...")?,
-                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.s.word("..=")?,
-                    RangeEnd::Excluded => self.s.word("..")?,
+                    RangeEnd::Included(RangeSyntax::DotDotDot) => self.s.word("..."),
+                    RangeEnd::Included(RangeSyntax::DotDotEq) => self.s.word("..="),
+                    RangeEnd::Excluded => self.s.word(".."),
                 }
-                self.print_expr(end)?;
+                self.print_expr(end);
             }
             PatKind::Slice(ref before, ref slice, ref after) => {
-                self.s.word("[")?;
+                self.s.word("[");
                 self.commasep(Inconsistent,
                                    &before[..],
-                                   |s, p| s.print_pat(p))?;
+                                   |s, p| s.print_pat(p));
                 if let Some(ref p) = *slice {
-                    if !before.is_empty() { self.word_space(",")?; }
+                    if !before.is_empty() { self.word_space(","); }
                     if let PatKind::Wild = p.node {
                         // Print nothing
                     } else {
-                        self.print_pat(p)?;
+                        self.print_pat(p);
                     }
-                    self.s.word("..")?;
-                    if !after.is_empty() { self.word_space(",")?; }
+                    self.s.word("..");
+                    if !after.is_empty() { self.word_space(","); }
                 }
                 self.commasep(Inconsistent,
                                    &after[..],
-                                   |s, p| s.print_pat(p))?;
-                self.s.word("]")?;
+                                   |s, p| s.print_pat(p));
+                self.s.word("]");
             }
             PatKind::Paren(ref inner) => {
-                self.popen()?;
-                self.print_pat(inner)?;
-                self.pclose()?;
+                self.popen();
+                self.print_pat(inner);
+                self.pclose();
             }
-            PatKind::Mac(ref m) => self.print_mac(m)?,
+            PatKind::Mac(ref m) => self.print_mac(m),
         }
         self.ann.post(self, AnnNode::Pat(pat))
     }
 
-    fn print_pats(&mut self, pats: &[P<ast::Pat>]) -> io::Result<()> {
+    fn print_pats(&mut self, pats: &[P<ast::Pat>]) {
         let mut first = true;
         for p in pats {
             if first {
                 first = false;
             } else {
-                self.s.space()?;
-                self.word_space("|")?;
+                self.s.space();
+                self.word_space("|");
             }
-            self.print_pat(p)?;
+            self.print_pat(p);
         }
-        Ok(())
     }
 
-    fn print_arm(&mut self, arm: &ast::Arm) -> io::Result<()> {
+    fn print_arm(&mut self, arm: &ast::Arm) {
         // I have no idea why this check is necessary, but here it
         // is :(
         if arm.attrs.is_empty() {
-            self.s.space()?;
+            self.s.space();
         }
-        self.cbox(INDENT_UNIT)?;
-        self.ibox(0)?;
-        self.maybe_print_comment(arm.pats[0].span.lo())?;
-        self.print_outer_attributes(&arm.attrs)?;
-        self.print_pats(&arm.pats)?;
-        self.s.space()?;
+        self.cbox(INDENT_UNIT);
+        self.ibox(0);
+        self.maybe_print_comment(arm.pats[0].span.lo());
+        self.print_outer_attributes(&arm.attrs);
+        self.print_pats(&arm.pats);
+        self.s.space();
         if let Some(ref e) = arm.guard {
-            self.word_space("if")?;
-            self.print_expr(e)?;
-            self.s.space()?;
+            self.word_space("if");
+            self.print_expr(e);
+            self.s.space();
         }
-        self.word_space("=>")?;
+        self.word_space("=>");
 
         match arm.body.node {
             ast::ExprKind::Block(ref blk, opt_label) => {
                 if let Some(label) = opt_label {
-                    self.print_ident(label.ident)?;
-                    self.word_space(":")?;
+                    self.print_ident(label.ident);
+                    self.word_space(":");
                 }
 
                 // the block will close the pattern's ibox
-                self.print_block_unclosed_indent(blk, INDENT_UNIT)?;
+                self.print_block_unclosed_indent(blk, INDENT_UNIT);
 
                 // If it is a user-provided unsafe block, print a comma after it
                 if let BlockCheckMode::Unsafe(ast::UserProvided) = blk.rules {
-                    self.s.word(",")?;
+                    self.s.word(",");
                 }
             }
             _ => {
-                self.end()?; // close the ibox for the pattern
-                self.print_expr(&arm.body)?;
-                self.s.word(",")?;
+                self.end(); // close the ibox for the pattern
+                self.print_expr(&arm.body);
+                self.s.word(",");
             }
         }
-        self.end() // close enclosing cbox
+        self.end(); // close enclosing cbox
     }
 
-    fn print_explicit_self(&mut self, explicit_self: &ast::ExplicitSelf) -> io::Result<()> {
+    fn print_explicit_self(&mut self, explicit_self: &ast::ExplicitSelf) {
         match explicit_self.node {
             SelfKind::Value(m) => {
-                self.print_mutability(m)?;
+                self.print_mutability(m);
                 self.s.word("self")
             }
             SelfKind::Region(ref lt, m) => {
-                self.s.word("&")?;
-                self.print_opt_lifetime(lt)?;
-                self.print_mutability(m)?;
+                self.s.word("&");
+                self.print_opt_lifetime(lt);
+                self.print_mutability(m);
                 self.s.word("self")
             }
             SelfKind::Explicit(ref typ, m) => {
-                self.print_mutability(m)?;
-                self.s.word("self")?;
-                self.word_space(":")?;
+                self.print_mutability(m);
+                self.s.word("self");
+                self.word_space(":");
                 self.print_type(typ)
             }
         }
@@ -2683,184 +2643,167 @@ impl<'a> State<'a> {
                     header: ast::FnHeader,
                     name: Option<ast::Ident>,
                     generics: &ast::Generics,
-                    vis: &ast::Visibility) -> io::Result<()> {
-        self.print_fn_header_info(header, vis)?;
+                    vis: &ast::Visibility) {
+        self.print_fn_header_info(header, vis);
 
         if let Some(name) = name {
-            self.nbsp()?;
-            self.print_ident(name)?;
+            self.nbsp();
+            self.print_ident(name);
         }
-        self.print_generic_params(&generics.params)?;
-        self.print_fn_args_and_ret(decl)?;
+        self.print_generic_params(&generics.params);
+        self.print_fn_args_and_ret(decl);
         self.print_where_clause(&generics.where_clause)
     }
 
-    crate fn print_fn_args_and_ret(&mut self, decl: &ast::FnDecl)
-        -> io::Result<()> {
-        self.popen()?;
-        self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, false))?;
-        self.pclose()?;
+    crate fn print_fn_args_and_ret(&mut self, decl: &ast::FnDecl) {
+        self.popen();
+        self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, false));
+        self.pclose();
 
         self.print_fn_output(decl)
     }
 
-    crate fn print_fn_block_args(
-            &mut self,
-            decl: &ast::FnDecl)
-            -> io::Result<()> {
-        self.s.word("|")?;
-        self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, true))?;
-        self.s.word("|")?;
+    crate fn print_fn_block_args(&mut self, decl: &ast::FnDecl) {
+        self.s.word("|");
+        self.commasep(Inconsistent, &decl.inputs, |s, arg| s.print_arg(arg, true));
+        self.s.word("|");
 
         if let ast::FunctionRetTy::Default(..) = decl.output {
-            return Ok(());
+            return;
         }
 
-        self.space_if_not_bol()?;
-        self.word_space("->")?;
+        self.space_if_not_bol();
+        self.word_space("->");
         match decl.output {
             ast::FunctionRetTy::Ty(ref ty) => {
-                self.print_type(ty)?;
+                self.print_type(ty);
                 self.maybe_print_comment(ty.span.lo())
             }
             ast::FunctionRetTy::Default(..) => unreachable!(),
         }
     }
 
-    crate fn print_movability(&mut self, movability: ast::Movability)
-                                -> io::Result<()> {
+    crate fn print_movability(&mut self, movability: ast::Movability) {
         match movability {
             ast::Movability::Static => self.word_space("static"),
-            ast::Movability::Movable => Ok(()),
+            ast::Movability::Movable => {},
         }
     }
 
-    crate fn print_asyncness(&mut self, asyncness: ast::IsAsync)
-                                -> io::Result<()> {
+    crate fn print_asyncness(&mut self, asyncness: ast::IsAsync) {
         if asyncness.is_async() {
-            self.word_nbsp("async")?;
+            self.word_nbsp("async");
         }
-        Ok(())
     }
 
-    crate fn print_capture_clause(&mut self, capture_clause: ast::CaptureBy)
-                                -> io::Result<()> {
+    crate fn print_capture_clause(&mut self, capture_clause: ast::CaptureBy) {
         match capture_clause {
             ast::CaptureBy::Value => self.word_space("move"),
-            ast::CaptureBy::Ref => Ok(()),
+            ast::CaptureBy::Ref => {},
         }
     }
 
-    crate fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound])
-                             -> io::Result<()> {
+    crate fn print_type_bounds(&mut self, prefix: &'static str, bounds: &[ast::GenericBound]) {
         if !bounds.is_empty() {
-            self.s.word(prefix)?;
+            self.s.word(prefix);
             let mut first = true;
             for bound in bounds {
                 if !(first && prefix.is_empty()) {
-                    self.nbsp()?;
+                    self.nbsp();
                 }
                 if first {
                     first = false;
                 } else {
-                    self.word_space("+")?;
+                    self.word_space("+");
                 }
 
                 match bound {
                     GenericBound::Trait(tref, modifier) => {
                         if modifier == &TraitBoundModifier::Maybe {
-                            self.s.word("?")?;
+                            self.s.word("?");
                         }
-                        self.print_poly_trait_ref(tref)?;
+                        self.print_poly_trait_ref(tref);
                     }
-                    GenericBound::Outlives(lt) => self.print_lifetime(*lt)?,
+                    GenericBound::Outlives(lt) => self.print_lifetime(*lt),
                 }
             }
         }
-        Ok(())
     }
 
-    crate fn print_lifetime(&mut self, lifetime: ast::Lifetime) -> io::Result<()> {
+    crate fn print_lifetime(&mut self, lifetime: ast::Lifetime) {
         self.print_name(lifetime.ident.name)
     }
 
-    crate fn print_lifetime_bounds(&mut self, lifetime: ast::Lifetime, bounds: &ast::GenericBounds)
-        -> io::Result<()>
-    {
-        self.print_lifetime(lifetime)?;
+    crate fn print_lifetime_bounds(
+        &mut self, lifetime: ast::Lifetime, bounds: &ast::GenericBounds) {
+        self.print_lifetime(lifetime);
         if !bounds.is_empty() {
-            self.s.word(": ")?;
+            self.s.word(": ");
             for (i, bound) in bounds.iter().enumerate() {
                 if i != 0 {
-                    self.s.word(" + ")?;
+                    self.s.word(" + ");
                 }
                 match bound {
-                    ast::GenericBound::Outlives(lt) => self.print_lifetime(*lt)?,
+                    ast::GenericBound::Outlives(lt) => self.print_lifetime(*lt),
                     _ => panic!(),
                 }
             }
         }
-        Ok(())
     }
 
-    crate fn print_generic_params(
-        &mut self,
-        generic_params: &[ast::GenericParam]
-    ) -> io::Result<()> {
+    crate fn print_generic_params(&mut self, generic_params: &[ast::GenericParam]) {
         if generic_params.is_empty() {
-            return Ok(());
+            return;
         }
 
-        self.s.word("<")?;
+        self.s.word("<");
 
         self.commasep(Inconsistent, &generic_params, |s, param| {
             match param.kind {
                 ast::GenericParamKind::Lifetime => {
-                    s.print_outer_attributes_inline(&param.attrs)?;
+                    s.print_outer_attributes_inline(&param.attrs);
                     let lt = ast::Lifetime { id: param.id, ident: param.ident };
                     s.print_lifetime_bounds(lt, &param.bounds)
                 }
                 ast::GenericParamKind::Type { ref default } => {
-                    s.print_outer_attributes_inline(&param.attrs)?;
-                    s.print_ident(param.ident)?;
-                    s.print_type_bounds(":", &param.bounds)?;
+                    s.print_outer_attributes_inline(&param.attrs);
+                    s.print_ident(param.ident);
+                    s.print_type_bounds(":", &param.bounds);
                     match default {
                         Some(ref default) => {
-                            s.s.space()?;
-                            s.word_space("=")?;
+                            s.s.space();
+                            s.word_space("=");
                             s.print_type(default)
                         }
-                        _ => Ok(())
+                        _ => {}
                     }
                 }
                 ast::GenericParamKind::Const { ref ty } => {
-                    s.print_outer_attributes_inline(&param.attrs)?;
-                    s.word_space("const")?;
-                    s.print_ident(param.ident)?;
-                    s.s.space()?;
-                    s.word_space(":")?;
-                    s.print_type(ty)?;
+                    s.print_outer_attributes_inline(&param.attrs);
+                    s.word_space("const");
+                    s.print_ident(param.ident);
+                    s.s.space();
+                    s.word_space(":");
+                    s.print_type(ty);
                     s.print_type_bounds(":", &param.bounds)
                 }
             }
-        })?;
+        });
 
-        self.s.word(">")?;
-        Ok(())
+        self.s.word(">");
     }
 
-    crate fn print_where_clause(&mut self, where_clause: &ast::WhereClause)
-                              -> io::Result<()> {
+    crate fn print_where_clause(&mut self, where_clause: &ast::WhereClause) {
         if where_clause.predicates.is_empty() {
-            return Ok(())
+            return;
         }
 
-        self.s.space()?;
-        self.word_space("where")?;
+        self.s.space();
+        self.word_space("where");
 
         for (i, predicate) in where_clause.predicates.iter().enumerate() {
             if i != 0 {
-                self.word_space(",")?;
+                self.word_space(",");
             }
 
             match *predicate {
@@ -2870,83 +2813,78 @@ impl<'a> State<'a> {
                     ref bounds,
                     ..
                 }) => {
-                    self.print_formal_generic_params(bound_generic_params)?;
-                    self.print_type(bounded_ty)?;
-                    self.print_type_bounds(":", bounds)?;
+                    self.print_formal_generic_params(bound_generic_params);
+                    self.print_type(bounded_ty);
+                    self.print_type_bounds(":", bounds);
                 }
                 ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate{ref lifetime,
                                                                                ref bounds,
                                                                                ..}) => {
-                    self.print_lifetime_bounds(*lifetime, bounds)?;
+                    self.print_lifetime_bounds(*lifetime, bounds);
                 }
                 ast::WherePredicate::EqPredicate(ast::WhereEqPredicate{ref lhs_ty,
                                                                        ref rhs_ty,
                                                                        ..}) => {
-                    self.print_type(lhs_ty)?;
-                    self.s.space()?;
-                    self.word_space("=")?;
-                    self.print_type(rhs_ty)?;
+                    self.print_type(lhs_ty);
+                    self.s.space();
+                    self.word_space("=");
+                    self.print_type(rhs_ty);
                 }
             }
         }
-
-        Ok(())
     }
 
-    crate fn print_use_tree(&mut self, tree: &ast::UseTree) -> io::Result<()> {
+    crate fn print_use_tree(&mut self, tree: &ast::UseTree) {
         match tree.kind {
             ast::UseTreeKind::Simple(rename, ..) => {
-                self.print_path(&tree.prefix, false, 0)?;
+                self.print_path(&tree.prefix, false, 0);
                 if let Some(rename) = rename {
-                    self.s.space()?;
-                    self.word_space("as")?;
-                    self.print_ident(rename)?;
+                    self.s.space();
+                    self.word_space("as");
+                    self.print_ident(rename);
                 }
             }
             ast::UseTreeKind::Glob => {
                 if !tree.prefix.segments.is_empty() {
-                    self.print_path(&tree.prefix, false, 0)?;
-                    self.s.word("::")?;
+                    self.print_path(&tree.prefix, false, 0);
+                    self.s.word("::");
                 }
-                self.s.word("*")?;
+                self.s.word("*");
             }
             ast::UseTreeKind::Nested(ref items) => {
                 if tree.prefix.segments.is_empty() {
-                    self.s.word("{")?;
+                    self.s.word("{");
                 } else {
-                    self.print_path(&tree.prefix, false, 0)?;
-                    self.s.word("::{")?;
+                    self.print_path(&tree.prefix, false, 0);
+                    self.s.word("::{");
                 }
                 self.commasep(Inconsistent, &items[..], |this, &(ref tree, _)| {
                     this.print_use_tree(tree)
-                })?;
-                self.s.word("}")?;
+                });
+                self.s.word("}");
             }
         }
-
-        Ok(())
     }
 
-    crate fn print_mutability(&mut self,
-                            mutbl: ast::Mutability) -> io::Result<()> {
+    crate fn print_mutability(&mut self, mutbl: ast::Mutability) {
         match mutbl {
             ast::Mutability::Mutable => self.word_nbsp("mut"),
-            ast::Mutability::Immutable => Ok(()),
+            ast::Mutability::Immutable => {},
         }
     }
 
-    crate fn print_mt(&mut self, mt: &ast::MutTy) -> io::Result<()> {
-        self.print_mutability(mt.mutbl)?;
+    crate fn print_mt(&mut self, mt: &ast::MutTy) {
+        self.print_mutability(mt.mutbl);
         self.print_type(&mt.ty)
     }
 
-    crate fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) -> io::Result<()> {
-        self.ibox(INDENT_UNIT)?;
+    crate fn print_arg(&mut self, input: &ast::Arg, is_closure: bool) {
+        self.ibox(INDENT_UNIT);
         match input.ty.node {
-            ast::TyKind::Infer if is_closure => self.print_pat(&input.pat)?,
+            ast::TyKind::Infer if is_closure => self.print_pat(&input.pat),
             _ => {
                 if let Some(eself) = input.to_self() {
-                    self.print_explicit_self(&eself)?;
+                    self.print_explicit_self(&eself);
                 } else {
                     let invalid = if let PatKind::Ident(_, ident, _) = input.pat.node {
                         ident.name == kw::Invalid
@@ -2954,35 +2892,35 @@ impl<'a> State<'a> {
                         false
                     };
                     if !invalid {
-                        self.print_pat(&input.pat)?;
-                        self.s.word(":")?;
-                        self.s.space()?;
+                        self.print_pat(&input.pat);
+                        self.s.word(":");
+                        self.s.space();
                     }
-                    self.print_type(&input.ty)?;
+                    self.print_type(&input.ty);
                 }
             }
         }
-        self.end()
+        self.end();
     }
 
-    crate fn print_fn_output(&mut self, decl: &ast::FnDecl) -> io::Result<()> {
+    crate fn print_fn_output(&mut self, decl: &ast::FnDecl) {
         if let ast::FunctionRetTy::Default(..) = decl.output {
-            return Ok(());
+            return;
         }
 
-        self.space_if_not_bol()?;
-        self.ibox(INDENT_UNIT)?;
-        self.word_space("->")?;
+        self.space_if_not_bol();
+        self.ibox(INDENT_UNIT);
+        self.word_space("->");
         match decl.output {
             ast::FunctionRetTy::Default(..) => unreachable!(),
             ast::FunctionRetTy::Ty(ref ty) =>
-                self.print_type(ty)?
+                self.print_type(ty),
         }
-        self.end()?;
+        self.end();
 
         match decl.output {
             ast::FunctionRetTy::Ty(ref output) => self.maybe_print_comment(output.span.lo()),
-            _ => Ok(())
+            _ => {}
         }
     }
 
@@ -2992,11 +2930,11 @@ impl<'a> State<'a> {
                        decl: &ast::FnDecl,
                        name: Option<ast::Ident>,
                        generic_params: &[ast::GenericParam])
-                       -> io::Result<()> {
-        self.ibox(INDENT_UNIT)?;
+                       {
+        self.ibox(INDENT_UNIT);
         if !generic_params.is_empty() {
-            self.s.word("for")?;
-            self.print_generic_params(generic_params)?;
+            self.s.word("for");
+            self.print_generic_params(generic_params);
         }
         let generics = ast::Generics {
             params: Vec::new(),
@@ -3010,73 +2948,71 @@ impl<'a> State<'a> {
                       ast::FnHeader { unsafety, abi, ..ast::FnHeader::default() },
                       name,
                       &generics,
-                      &source_map::dummy_spanned(ast::VisibilityKind::Inherited))?;
-        self.end()
+                      &source_map::dummy_spanned(ast::VisibilityKind::Inherited));
+        self.end();
     }
 
     crate fn maybe_print_trailing_comment(&mut self, span: syntax_pos::Span,
                                         next_pos: Option<BytePos>)
-        -> io::Result<()> {
+        {
         let cm = match self.cm {
             Some(cm) => cm,
-            _ => return Ok(())
+            _ => return,
         };
         if let Some(ref cmnt) = self.next_comment() {
-            if cmnt.style != comments::Trailing { return Ok(()) }
+            if cmnt.style != comments::Trailing { return; }
             let span_line = cm.lookup_char_pos(span.hi());
             let comment_line = cm.lookup_char_pos(cmnt.pos);
             let next = next_pos.unwrap_or_else(|| cmnt.pos + BytePos(1));
             if span.hi() < cmnt.pos && cmnt.pos < next && span_line.line == comment_line.line {
-                self.print_comment(cmnt)?;
+                self.print_comment(cmnt);
             }
         }
-        Ok(())
     }
 
-    crate fn print_remaining_comments(&mut self) -> io::Result<()> {
+    crate fn print_remaining_comments(&mut self) {
         // If there aren't any remaining comments, then we need to manually
         // make sure there is a line break at the end.
         if self.next_comment().is_none() {
-            self.s.hardbreak()?;
+            self.s.hardbreak();
         }
         while let Some(ref cmnt) = self.next_comment() {
-            self.print_comment(cmnt)?;
+            self.print_comment(cmnt);
         }
-        Ok(())
     }
 
     crate fn print_fn_header_info(&mut self,
                                 header: ast::FnHeader,
-                                vis: &ast::Visibility) -> io::Result<()> {
-        self.s.word(visibility_qualified(vis, ""))?;
+                                vis: &ast::Visibility) {
+        self.s.word(visibility_qualified(vis, ""));
 
         match header.constness.node {
             ast::Constness::NotConst => {}
-            ast::Constness::Const => self.word_nbsp("const")?
+            ast::Constness::Const => self.word_nbsp("const")
         }
 
-        self.print_asyncness(header.asyncness.node)?;
-        self.print_unsafety(header.unsafety)?;
+        self.print_asyncness(header.asyncness.node);
+        self.print_unsafety(header.unsafety);
 
         if header.abi != Abi::Rust {
-            self.word_nbsp("extern")?;
-            self.word_nbsp(header.abi.to_string())?;
+            self.word_nbsp("extern");
+            self.word_nbsp(header.abi.to_string());
         }
 
         self.s.word("fn")
     }
 
-    crate fn print_unsafety(&mut self, s: ast::Unsafety) -> io::Result<()> {
+    crate fn print_unsafety(&mut self, s: ast::Unsafety) {
         match s {
-            ast::Unsafety::Normal => Ok(()),
+            ast::Unsafety::Normal => {},
             ast::Unsafety::Unsafe => self.word_nbsp("unsafe"),
         }
     }
 
-    crate fn print_is_auto(&mut self, s: ast::IsAuto) -> io::Result<()> {
+    crate fn print_is_auto(&mut self, s: ast::IsAuto) {
         match s {
             ast::IsAuto::Yes => self.word_nbsp("auto"),
-            ast::IsAuto::No => Ok(()),
+            ast::IsAuto::No => {}
         }
     }
 }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -26,7 +26,6 @@ use crate::mut_visit::{*, ExpectOne};
 use crate::feature_gate::Features;
 use crate::util::map_in_place::MapInPlace;
 use crate::parse::{token, ParseSess};
-use crate::print::pprust;
 use crate::ast::{self, Ident};
 use crate::ptr::P;
 use crate::symbol::{self, Symbol, kw, sym};


### PR DESCRIPTION
Since we're now writing directly to the vector, there's no need to
thread results through the whole printing infrastructure