### PR TITLE
Adjust warning of -C extra-filename with -o.

### DIFF
--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -642,13 +642,13 @@ pub fn build_output_filenames(
                 );
                 None
             } else {
+                if !sess.opts.cg.extra_filename.is_empty() {
+                    sess.warn("ignoring -C extra-filename flag due to -o flag");
+                }
                 Some(out_file.clone())
             };
             if *odir != None {
                 sess.warn("ignoring --out-dir flag due to -o flag");
-            }
-            if !sess.opts.cg.extra_filename.is_empty() {
-                sess.warn("ignoring -C extra-filename flag due to -o flag");
             }
 
             OutputFilenames {


### PR DESCRIPTION
If `--emit` includes multiple unnamed outputs, and `-o` was specified, and `-C extra-filename` was specified, the compiler would warn that `-C extra-filename` was ignored, but this is not true.  The "adapting" of the filenames includes the extra-filename info.

Since this is a little convoluted and hard to follow, here is a little chart to summarize when running with `rustc foo.rs -o xyz -C extra-filename=asdf`

`--emit` | Result
---------|--------
`link` | `xyz` (extra-filename ignored)
`link,dep-info` | `xyzasdf`, `xyzasdf.d` (this PR removes the incorrect warning)

As to whether or not this behavior is the best choice is another question.