### PR TITLE
ci: Disable assertions in PR builds

### DIFF
--- a/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
@@ -25,3 +25,9 @@ ENV RUST_CONFIGURE_ARGS \
       --llvm-root=/usr/lib/llvm-6.0 \
       --enable-llvm-link-shared
 ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test
+
+# The purpose of this container isn't to test with debug assertions and
+# this is run on all PRs, so let's get speedier builds by disabling these extra
+# checks.
+ENV NO_DEBUG_ASSERTIONS=1
+ENV NO_LLVM_ASSERTIONS=1


### PR DESCRIPTION
The PR builder on Azure currently takes 2.5h which is a bit long, so
this commit disables debug assertions and llvm assertions in an attempt
to speed up that builder and have PR builds come back a bit more
quickly. Other builders continue to enable debug assertions and test the
compiler there.