### PR TITLE
ci: Switch official `try` builds to happen on Azure

### DIFF
--- a/.azure-pipelines/try.yml
+++ b/.azure-pipelines/try.yml
@@ -1,13 +1,9 @@
-#
-# Azure Pipelines "auto" branch build for Rust on Linux, macOS, and Windows.
-#
-
 pr: none
 trigger:
 - try
 
 variables:
-- group: prod-credentials
+- group: real-prod-credentials
 
 jobs:
 - job: Linux
@@ -26,53 +22,57 @@ jobs:
         IMAGE: dist-x86_64-linux
         DEPLOY_ALT: 1
 
-- job: macOS
-  timeoutInMinutes: 600
-  pool:
-    vmImage: macos-10.13
-  steps:
-  - template: steps/run.yml
-  strategy:
-    matrix:
-      dist-x86_64-apple:
-        SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
-        DEPLOY: 1
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-        DIST_REQUIRE_ALL_TOOLS: 1
-
-      dist-x86_64-apple-alt:
-        SCRIPT: ./x.py dist
-        RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
-        DEPLOY_ALT: 1
-        RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
-        MACOSX_DEPLOYMENT_TARGET: 10.7
-        NO_LLVM_ASSERTIONS: 1
-        NO_DEBUG_ASSERTIONS: 1
-
-- job: Windows
-  timeoutInMinutes: 600
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - template: steps/run.yml
-  strategy:
-    matrix:
-      dist-x86_64-msvc:
-        RUST_CONFIGURE_ARGS: >
-          --build=x86_64-pc-windows-msvc
-          --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
-          --enable-full-tools
-          --enable-profiler
-        SCRIPT: python x.py dist
-        DIST_REQUIRE_ALL_TOOLS: 1
-        DEPLOY: 1
-
-      dist-x86_64-msvc-alt:
-        MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
-        SCRIPT: python x.py dist
-        DEPLOY_ALT: 1
+# The macOS and Windows builds here are currently disabled due to them not being
+# overly necessary on `try` builds. We also don't actually have anything that
+# consumes the artifacts currently. Perhaps one day we can reenable, but for now
+# it helps free up capacity on Azure.
+# - job: macOS
+#   timeoutInMinutes: 600
+#   pool:
+#     vmImage: macos-10.13
+#   steps:
+#   - template: steps/run.yml
+#   strategy:
+#     matrix:
+#       dist-x86_64-apple:
+#         SCRIPT: ./x.py dist
+#         RUST_CONFIGURE_ARGS: --target=aarch64-apple-ios,armv7-apple-ios,armv7s-apple-ios,i386-apple-ios,x86_64-apple-ios --enable-full-tools --enable-sanitizers --enable-profiler --enable-lldb --set rust.jemalloc
+#         DEPLOY: 1
+#         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+#         MACOSX_DEPLOYMENT_TARGET: 10.7
+#         NO_LLVM_ASSERTIONS: 1
+#         NO_DEBUG_ASSERTIONS: 1
+#         DIST_REQUIRE_ALL_TOOLS: 1
+#
+#       dist-x86_64-apple-alt:
+#         SCRIPT: ./x.py dist
+#         RUST_CONFIGURE_ARGS: --enable-extended --enable-profiler --enable-lldb --set rust.jemalloc
+#         DEPLOY_ALT: 1
+#         RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+#         MACOSX_DEPLOYMENT_TARGET: 10.7
+#         NO_LLVM_ASSERTIONS: 1
+#         NO_DEBUG_ASSERTIONS: 1
+#
+# - job: Windows
+#   timeoutInMinutes: 600
+#   pool:
+#     vmImage: 'vs2017-win2016'
+#   steps:
+#   - template: steps/run.yml
+#   strategy:
+#     matrix:
+#       dist-x86_64-msvc:
+#         RUST_CONFIGURE_ARGS: >
+#           --build=x86_64-pc-windows-msvc
+#           --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+#           --enable-full-tools
+#           --enable-profiler
+#         SCRIPT: python x.py dist
+#         DIST_REQUIRE_ALL_TOOLS: 1
+#         DEPLOY: 1
+#
+#       dist-x86_64-msvc-alt:
+#         MSYS_BITS: 64
+#         RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
+#         SCRIPT: python x.py dist
+#         DEPLOY_ALT: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,14 @@ matrix:
 
     - env: IMAGE=dist-x86_64-linux DEPLOY=1
       name: dist-x86_64-linux
-      if: branch = try OR branch = auto
+      if: branch = auto
 
     # "alternate" deployments, these are "nightlies" but have LLVM assertions
     # turned on, they're deployed to a different location primarily for
     # additional testing.
     - env: IMAGE=dist-x86_64-linux DEPLOY_ALT=1
       name: dist-x86_64-linux-alt
-      if: branch = try OR branch = auto
+      if: branch = auto
 
     - env: >
         SCRIPT="./x.py dist"


### PR DESCRIPTION
This commit switches the `try` builers to officially happen on Azure
Pipelines instead of Travis where they're currently run. This also cuts
back the number of builders to just the two we run on Travis, leaving
expansion as a possible future extension.