### PR TITLE
ci: Sync AppVeyor/Travis with Azure configuration

### DIFF
--- a/.azure-pipelines/auto.yml
+++ b/.azure-pipelines/auto.yml
@@ -325,7 +325,7 @@ jobs:
         DEPLOY: 1
       dist-i686-mingw:
         MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools
+        RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools --enable-profiler
         SCRIPT: python x.py dist
         MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
         MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
@@ -335,7 +335,7 @@ jobs:
       dist-x86_64-mingw:
         MSYS_BITS: 64
         SCRIPT: python x.py dist
-        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools
+        RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler
         MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
         MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
         MINGW_DIR: mingw64


### PR DESCRIPTION
Manually make sure that we do the same thing across all the services,
uncovering one spot where we needed to pass one more configure flag on
Azure but otherwise we're good to go!