### PR TITLE
Don't ICE on item in `.await` expression

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5795,7 +5795,6 @@ impl<'a> LoweringContext<'a> {
                     err.span_label(item_sp, "this is not `async`");
                 }
                 err.emit();
-                return hir::ExprKind::Err;
             }
         }
         let span = self.mark_span_with_reason(

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1713,7 +1713,7 @@ pub enum GeneratorMovability {
 }
 
 /// The yield kind that caused an `ExprKind::Yield`.
-#[derive(Copy, Clone, Debug, RustcEncodable, RustcDecodable, HashStable)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, RustcEncodable, RustcDecodable, HashStable)]
 pub enum YieldSource {
     /// An `<expr>.await`.
     Await,

--- a/src/test/ui/async-await/issues/issue-51719.rs
+++ b/src/test/ui/async-await/issues/issue-51719.rs
@@ -7,7 +7,8 @@
 async fn foo() {}
 
 fn make_generator() {
-    let _gen = || foo.await; //~ ERROR `await` is only allowed inside `async` functions and blocks
+    let _gen = || foo().await;
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
 }
 
 fn main() {}

--- a/src/test/ui/async-await/issues/issue-51719.stderr
+++ b/src/test/ui/async-await/issues/issue-51719.stderr
@@ -1,8 +1,8 @@
 error[E0728]: `await` is only allowed inside `async` functions and blocks
   --> $DIR/issue-51719.rs:10:19
    |
-LL |     let _gen = || foo.await;
-   |                -- ^^^^^^^^^ only allowed inside `async` functions and blocks
+LL |     let _gen = || foo().await;
+   |                -- ^^^^^^^^^^^ only allowed inside `async` functions and blocks
    |                |
    |                this is not `async`
 

--- a/src/test/ui/async-await/issues/issue-62009.rs
+++ b/src/test/ui/async-await/issues/issue-62009.rs
@@ -1,0 +1,19 @@
+// edition:2018
+
+#![feature(async_await)]
+
+async fn print_dur() {}
+
+fn main() {
+    async { let (); }.await;
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+    async {
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+        let task1 = print_dur().await;
+    }.await;
+    (async || 2333)().await;
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+    (|_| 2333).await;
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+    //~^^ ERROR
+}

--- a/src/test/ui/async-await/issues/issue-62009.stderr
+++ b/src/test/ui/async-await/issues/issue-62009.stderr
@@ -1,0 +1,49 @@
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-62009.rs:8:5
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+LL |     async { let (); }.await;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-62009.rs:10:5
+   |
+LL |   fn main() {
+   |      ---- this is not `async`
+...
+LL | /     async {
+LL | |
+LL | |         let task1 = print_dur().await;
+LL | |     }.await;
+   | |___________^ only allowed inside `async` functions and blocks
+
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-62009.rs:14:5
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+...
+LL |     (async || 2333)().await;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-62009.rs:16:5
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+...
+LL |     (|_| 2333).await;
+   |     ^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error[E0277]: the trait bound `[closure@$DIR/issue-62009.rs:16:5: 16:15]: std::future::Future` is not satisfied
+  --> $DIR/issue-62009.rs:16:5
+   |
+LL |     (|_| 2333).await;
+   |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009.rs:16:5: 16:15]`
+   |
+   = note: required by `std::future::poll_with_tls_context`
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
The code for lowering a `.await` expression missed that item IDs may already have been assigned for items inside of an `async` block, or for closures. This change means we no longer exit early after finding a `.await` in a block that isn't `async` and instead just emit the error. This avoids an ICE generated due to item IDs not being densely generated. (The `YieldSource` of the generated `yield` expression is  used to avoid errors generated about having `yield` expressions outside of generator literals.)

r? @cramertj 

Resolves #62009 and resolves #61685 