### PR TITLE
Add regression test for MIR drop generation in async loops

### DIFF
--- a/src/test/ui/async-await/issues/issue-61986.rs
+++ b/src/test/ui/async-await/issues/issue-61986.rs
@@ -1,0 +1,21 @@
+// compile-pass
+// edition:2018
+//
+// Tests that we properly handle StorageDead/StorageLives for temporaries
+// created in async loop bodies.
+
+#![feature(async_await)]
+
+async fn bar() -> Option<()> {
+    Some(())
+}
+
+async fn listen() {
+    while let Some(_) = bar().await {
+        String::new();
+    }
+}
+
+fn main() {
+    listen();
+}


### PR DESCRIPTION
Fixes #61986.

r? @Centril 