### PR TITLE
std: Move a process test out of libstd

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1765,33 +1765,6 @@ mod tests {
         assert_eq!(out, "foobar\n");
     }
 
-
-    #[test]
-    #[cfg_attr(target_os = "android", ignore)]
-    #[cfg(unix)]
-    fn uid_works() {
-        use crate::os::unix::prelude::*;
-
-        let mut p = Command::new("/bin/sh")
-                            .arg("-c").arg("true")
-                            .uid(unsafe { libc::getuid() })
-                            .gid(unsafe { libc::getgid() })
-                            .spawn().unwrap();
-        assert!(p.wait().unwrap().success());
-    }
-
-    #[test]
-    #[cfg_attr(target_os = "android", ignore)]
-    #[cfg(unix)]
-    fn uid_to_root_fails() {
-        use crate::os::unix::prelude::*;
-
-        // if we're already root, this isn't a valid test. Most of the bots run
-        // as non-root though (android is an exception).
-        if unsafe { libc::getuid() == 0 } { return }
-        assert!(Command::new("/bin/ls").uid(0).gid(0).spawn().is_err());
-    }
-
     #[test]
     #[cfg_attr(target_os = "android", ignore)]
     fn test_process_status() {

--- a/src/test/run-pass/command-uid-gid.rs
+++ b/src/test/run-pass/command-uid-gid.rs
@@ -1,0 +1,26 @@
+#![feature(rustc_private)]
+
+fn main() {
+    #[cfg(unix)]
+    run()
+}
+
+#[cfg(unix)]
+fn run() {
+    extern crate libc;
+    use std::process::Command;
+    use std::os::unix::prelude::*;
+
+    let mut p = Command::new("/bin/sh")
+        .arg("-c").arg("true")
+        .uid(unsafe { libc::getuid() })
+        .gid(unsafe { libc::getgid() })
+        .spawn().unwrap();
+    assert!(p.wait().unwrap().success());
+
+    // if we're already root, this isn't a valid test. Most of the bots run
+    // as non-root though (android is an exception).
+    if unsafe { libc::getuid() != 0 } {
+        assert!(Command::new("/bin/ls").uid(0).gid(0).spawn().is_err());
+    }
+}


### PR DESCRIPTION
This commit moves a test out of libstd which is causing deadlocks on
musl on CI. Looks like the recent update in musl versions brings in some
internal updates to musl which makes `setgid` and `setuid` invalid to
call after a `fork` in a multithreaded program. The issue seen here is
that the child thread was attempting to grab a lock held by a
nonexistent thread, meaning that the child process simply deadlocked
causing the whole test to deadlock.

This commit moves the test to its own file with no threads which should
work.