### PR TITLE
Rename ManuallyDrop::take to read

### DIFF
--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -85,27 +85,30 @@ impl<T> ManuallyDrop<T> {
         slot.value
     }
 
-    /// Takes the contained value out.
+    /// Reads the value from the `ManuallyDrop<T>` container. The resulting `T` is subject
+    /// to the usual drop handling.
     ///
     /// This method is primarily intended for moving out values in drop.
     /// Instead of using [`ManuallyDrop::drop`] to manually drop the value,
-    /// you can use this method to take the value and use it however desired.
-    /// `Drop` will be invoked on the returned value following normal end-of-scope rules.
+    /// you can use this method to read the value and use it however desired.
     ///
-    /// If you have ownership of the container, you can use [`ManuallyDrop::into_inner`] instead.
+    /// Whenever possible, it is preferable to use [`into_inner`][`ManuallyDrop::into_inner`]
+    /// instead, which prevents duplicating the content of the `ManuallyDrop<T>`.
     ///
     /// # Safety
     ///
-    /// This function semantically moves out the contained value without preventing further usage.
-    /// It is up to the user of this method to ensure that this container is not used again.
+    /// Like [`std::ptr::read`], this function semantically moves out the contained value
+    /// without preventing further usage, leaving the state of the container unchanged.
+    /// It is your responsibility to ensure that this `ManuallyDrop` is not reused after `read`.
     ///
     /// [`ManuallyDrop::drop`]: #method.drop
     /// [`ManuallyDrop::into_inner`]: #method.into_inner
+    /// [`std::ptr::read`]: ../ptr/fn.read.html
     #[must_use = "if you don't need the value, you can use `ManuallyDrop::drop` instead"]
     #[unstable(feature = "manually_drop_take", issue = "55422")]
     #[inline]
-    pub unsafe fn take(slot: &mut ManuallyDrop<T>) -> T {
-        ManuallyDrop::into_inner(ptr::read(slot))
+    pub unsafe fn read(slot: &mut ManuallyDrop<T>) -> T {
+        ptr::read(&mut slot.value)
     }
 }
 

--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -108,7 +108,7 @@ impl<T> ManuallyDrop<T> {
     #[unstable(feature = "manually_drop_take", issue = "55422")]
     #[inline]
     pub unsafe fn read(slot: &mut ManuallyDrop<T>) -> T {
-        ptr::read(&mut slot.value)
+        ptr::read(&slot.value)
     }
 }
 


### PR DESCRIPTION
Tracking issue: #55422 

Renames `ManuallyDrop::take` to match `ptr::read` and `MaybeUninit::read`, and updates the documentation to more mirror `MaybeUninit::read`'s documentation.