### PR TITLE
wfcheck: no need for ICE on unresolved type expression

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -270,12 +270,7 @@ fn check_type_defn<'tcx, F>(
                     let ty = variant.fields.last().unwrap().ty;
                     fcx.tcx.erase_regions(&ty).lift_to_tcx(fcx_tcx)
                         .map(|ty| ty.needs_drop(fcx_tcx, fcx_tcx.param_env(def_id)))
-                        .unwrap_or_else(|| {
-                            fcx_tcx.sess.delay_span_bug(
-                                item.span, &format!("inference variables in {:?}", ty));
-                            // Just treat unresolved type expression as if it needs drop.
-                            true
-                        })
+                        .unwrap_or(true) // #61402 treat unresolved type expression as needs-drop
                 }
             };
             let all_sized =

--- a/src/test/run-pass/packed-with-inference-vars-issue-61402.rs
+++ b/src/test/run-pass/packed-with-inference-vars-issue-61402.rs
@@ -1,0 +1,22 @@
+// rust-lang/rust#61402: if a struct is packed and the last
+// field of the struct needs drop glue, then the compiler's well-formedness check
+// will put a Sized bound on that last field.
+//
+// However, we do not want to ICE the compiler in our attempt to
+// avoid adding that Sized bound; it is better to just let a
+// potentially unneeded constraint through.
+
+#![allow(unused_imports, dead_code)]
+
+pub struct S;
+
+pub trait Trait<R> { type Assoc; }
+
+impl<X> Trait<X> for S { type Assoc = X; }
+
+#[repr(C, packed)]
+struct PackedAssocSized {
+    pos: Box<<S as Trait<usize>>::Assoc>,
+}
+
+fn main() { println!("Hello, world!"); }


### PR DESCRIPTION
wfcheck: when adding `field: Sized` constraints to the members of a struct, just assume needs-drop on unresolved type expression for last-field, rather than risk even a delayed ICE.

Fix #61402.