### PR TITLE
Normalize projections appearing in `impl Trait`

### DIFF
--- a/src/librustc/infer/opaque_types/mod.rs
+++ b/src/librustc/infer/opaque_types/mod.rs
@@ -1037,6 +1037,12 @@ impl<'a, 'tcx> Instantiator<'a, 'tcx> {
         let predicates_of = tcx.predicates_of(def_id);
         debug!("instantiate_opaque_types: predicates={:#?}", predicates_of,);
         let bounds = predicates_of.instantiate(tcx, substs);
+
+        let param_env = tcx.param_env(def_id);
+        let InferOk { value: bounds, obligations } =
+            infcx.partially_normalize_associated_types_in(span, self.body_id, param_env, &bounds);
+        self.obligations.extend(obligations);
+
         debug!("instantiate_opaque_types: bounds={:?}", bounds);
 
         let required_region_bounds = tcx.required_region_bounds(ty, bounds.predicates.clone());

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1065,6 +1065,7 @@ fn check_fn<'a, 'tcx>(
         &declared_ret_ty,
         decl.output.span(),
     );
+    debug!("check_fn: declared_ret_ty: {}, revealed_ret_ty: {}", declared_ret_ty, revealed_ret_ty);
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(revealed_ret_ty)));
     fn_sig = fcx.tcx.mk_fn_sig(
         fn_sig.inputs().iter().cloned(),

--- a/src/test/ui/async-await/bound-normalization.rs
+++ b/src/test/ui/async-await/bound-normalization.rs
@@ -1,0 +1,16 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+// See issue 60414
+
+trait Trait {
+    type Assoc;
+}
+
+async fn foo<T: Trait<Assoc=()>>() -> T::Assoc {
+    ()
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/bound-normalization-fail.rs
+++ b/src/test/ui/impl-trait/bound-normalization-fail.rs
@@ -1,0 +1,53 @@
+// compile-fail
+// edition:2018
+
+#![feature(async_await)]
+#![feature(existential_type)]
+#![feature(impl_trait_in_bindings)]
+//~^ WARNING the feature `impl_trait_in_bindings` is incomplete
+
+// See issue 60414
+
+/////////////////////////////////////////////
+// Reduction to `impl Trait`
+
+struct Foo<T>(T);
+
+trait FooLike { type Output; }
+
+impl<T> FooLike for Foo<T> {
+    type Output = T;
+}
+
+mod impl_trait {
+    use super::*;
+
+    trait Trait {
+        type Assoc;
+    }
+
+    /// `T::Assoc` can't be normalized any further here.
+    fn foo_fail<T: Trait>() -> impl FooLike<Output=T::Assoc> {
+        //~^ ERROR: type mismatch
+        Foo(())
+    }
+}
+
+/////////////////////////////////////////////
+// Same with lifetimes in the trait
+
+mod lifetimes {
+    use super::*;
+
+    trait Trait<'a> {
+        type Assoc;
+    }
+
+    /// Missing bound constraining `Assoc`, `T::Assoc` can't be normalized further.
+    fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
+        //~^ ERROR: type mismatch
+        Foo(())
+    }
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -1,0 +1,29 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/bound-normalization-fail.rs:6:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
+  --> $DIR/bound-normalization-fail.rs:30:32
+   |
+LL |     fn foo_fail<T: Trait>() -> impl FooLike<Output=T::Assoc> {
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found associated type
+   |
+   = note: expected type `()`
+              found type `<T as impl_trait::Trait>::Assoc`
+   = note: the return type of a function must have a statically known size
+
+error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
+  --> $DIR/bound-normalization-fail.rs:47:41
+   |
+LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found associated type
+   |
+   = note: expected type `()`
+              found type `<T as lifetimes::Trait<'static>>::Assoc`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/impl-trait/bound-normalization-pass.rs
+++ b/src/test/ui/impl-trait/bound-normalization-pass.rs
@@ -1,0 +1,103 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+#![feature(existential_type)]
+#![feature(impl_trait_in_bindings)]
+//~^ WARNING the feature `impl_trait_in_bindings` is incomplete
+
+// See issue 60414
+
+/////////////////////////////////////////////
+// Reduction to `impl Trait`
+
+struct Foo<T>(T);
+
+trait FooLike { type Output; }
+
+impl<T> FooLike for Foo<T> {
+    type Output = T;
+}
+
+mod impl_trait {
+    use super::*;
+
+    trait Trait {
+        type Assoc;
+    }
+
+    /// `T::Assoc` should be normalized to `()` here.
+    fn foo_pass<T: Trait<Assoc=()>>() -> impl FooLike<Output=T::Assoc> {
+        Foo(())
+    }
+}
+
+/////////////////////////////////////////////
+// Same with lifetimes in the trait
+
+mod lifetimes {
+    use super::*;
+
+    trait Trait<'a> {
+        type Assoc;
+    }
+
+    /// Like above.
+    fn foo2_pass<'a, T: Trait<'a, Assoc=()> + 'a>() -> impl FooLike<Output=T::Assoc> + 'a {
+        Foo(())
+    }
+
+    /// Normalization to type containing bound region.
+    fn foo2_pass2<'a, T: Trait<'a, Assoc=&'a ()> + 'a>() -> impl FooLike<Output=T::Assoc> + 'a {
+        Foo(&())
+    }
+}
+
+/////////////////////////////////////////////
+// Reduction using `impl Trait` in bindings
+
+mod impl_trait_in_bindings {
+    struct Foo;
+
+    trait FooLike { type Output; }
+
+    impl FooLike for Foo {
+        type Output = u32;
+    }
+
+    trait Trait {
+        type Assoc;
+    }
+
+    fn foo<T: Trait<Assoc=u32>>() {
+        let _: impl FooLike<Output=T::Assoc> = Foo;
+    }
+}
+
+/////////////////////////////////////////////
+// The same applied to `existential type`s
+
+mod existential_types {
+    trait Implemented {
+        type Assoc;
+    }
+    impl<T> Implemented for T {
+        type Assoc = u8;
+    }
+
+    trait Trait {
+        type Out;
+    }
+
+    impl Trait for () {
+        type Out = u8;
+    }
+
+    existential type Ex: Trait<Out = <() as Implemented>::Assoc>;
+
+    fn define() -> Ex {
+        ()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/bound-normalization-pass.rs
+++ b/src/test/ui/impl-trait/bound-normalization-pass.rs
@@ -43,12 +43,18 @@ mod lifetimes {
     }
 
     /// Like above.
-    fn foo2_pass<'a, T: Trait<'a, Assoc=()> + 'a>() -> impl FooLike<Output=T::Assoc> + 'a {
+    ///
+    /// FIXME(#51525) -- the shorter notation `T::Assoc` winds up referencing `'static` here
+    fn foo2_pass<'a, T: Trait<'a, Assoc=()> + 'a>(
+    ) -> impl FooLike<Output=<T as Trait<'a>>::Assoc> + 'a {
         Foo(())
     }
 
     /// Normalization to type containing bound region.
-    fn foo2_pass2<'a, T: Trait<'a, Assoc=&'a ()> + 'a>() -> impl FooLike<Output=T::Assoc> + 'a {
+    ///
+    /// FIXME(#51525) -- the shorter notation `T::Assoc` winds up referencing `'static` here
+    fn foo2_pass2<'a, T: Trait<'a, Assoc=&'a ()> + 'a>(
+    ) -> impl FooLike<Output=<T as Trait<'a>>::Assoc> + 'a {
         Foo(&())
     }
 }

--- a/src/test/ui/impl-trait/bound-normalization-pass.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.stderr
@@ -1,0 +1,6 @@
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/bound-normalization-pass.rs:6:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+


### PR DESCRIPTION
Fixes #60414

This does not try to do the same for `existential type`s (which have the same bug), since that always seems to lead to cycle errors.