### PR TITLE
Enable intptrcast for explicit casts

### DIFF
--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -257,7 +257,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpretCx<'mir, 'tcx, M> {
                     Err(e) => Err(e),
                 }
             }
-            _ => return err!(Unimplemented(format!("ptr to {:?} cast", dest_layout.ty))),
+            _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }
     }
 


### PR DESCRIPTION
I checked locally that this does not break miri on master. r? @RalfJung 