### PR TITLE
Exit arm scopes

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -27,6 +27,7 @@ pub enum AnnNode<'a> {
     SubItem(hir::HirId),
     Expr(&'a hir::Expr),
     Pat(&'a hir::Pat),
+    Arm(&'a hir::Arm),
 }
 
 pub enum Nested {
@@ -1821,6 +1822,7 @@ impl<'a> State<'a> {
             self.s.space();
         }
         self.cbox(indent_unit);
+        self.ann.pre(self, AnnNode::Arm(arm));
         self.ibox(0);
         self.print_outer_attributes(&arm.attrs);
         let mut first = true;
@@ -1865,6 +1867,7 @@ impl<'a> State<'a> {
                 self.s.word(",");
             }
         }
+        self.ann.post(self, AnnNode::Arm(arm));
         self.end() // close enclosing cbox
     }
 

--- a/src/librustc_borrowck/dataflow.rs
+++ b/src/librustc_borrowck/dataflow.rs
@@ -109,7 +109,8 @@ impl<'tcx, O: DataFlowOperator> pprust::PpAnn for DataFlowContext<'tcx, O> {
             pprust::AnnNode::Block(blk) => blk.hir_id.local_id,
             pprust::AnnNode::Item(_) |
             pprust::AnnNode::SubItem(_) => return,
-            pprust::AnnNode::Pat(pat) => pat.hir_id.local_id
+            pprust::AnnNode::Pat(pat) => pat.hir_id.local_id,
+            pprust::AnnNode::Arm(arm) => arm.hir_id.local_id,
         };
 
         if !self.has_bitset_for_local_id(id) {

--- a/src/librustc_driver/pretty.rs
+++ b/src/librustc_driver/pretty.rs
@@ -387,28 +387,28 @@ impl<'hir> pprust_hir::PpAnn for IdentifiedAnnotation<'hir> {
             pprust_hir::AnnNode::Name(_) => {},
             pprust_hir::AnnNode::Item(item) => {
                 s.s.space();
-                s.synth_comment(format!("hir_id: {} hir local_id: {}",
-                                        item.hir_id, item.hir_id.local_id.as_u32()))
+                s.synth_comment(format!("hir_id: {}", item.hir_id));
             }
             pprust_hir::AnnNode::SubItem(id) => {
                 s.s.space();
-                s.synth_comment(id.to_string())
+                s.synth_comment(id.to_string());
             }
             pprust_hir::AnnNode::Block(blk) => {
                 s.s.space();
-                s.synth_comment(format!("block hir_id: {} hir local_id: {}",
-                                        blk.hir_id, blk.hir_id.local_id.as_u32()))
+                s.synth_comment(format!("block hir_id: {}", blk.hir_id));
             }
             pprust_hir::AnnNode::Expr(expr) => {
                 s.s.space();
-                s.synth_comment(format!("expr hir_id: {} hir local_id: {}",
-                                        expr.hir_id, expr.hir_id.local_id.as_u32()));
-                s.pclose()
+                s.synth_comment(format!("expr hir_id: {}", expr.hir_id));
+                s.pclose();
             }
             pprust_hir::AnnNode::Pat(pat) => {
                 s.s.space();
-                s.synth_comment(format!("pat hir_id: {} hir local_id: {}",
-                                        pat.hir_id, pat.hir_id.local_id.as_u32()))
+                s.synth_comment(format!("pat hir_id: {}", pat.hir_id));
+            }
+            pprust_hir::AnnNode::Arm(arm) => {
+                s.s.space();
+                s.synth_comment(format!("arm hir_id: {}", arm.hir_id));
             }
         }
     }

--- a/src/test/ui/borrowck/issue-62107-match-arm-scopes.rs
+++ b/src/test/ui/borrowck/issue-62107-match-arm-scopes.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let e: i32;
+    match e {
+        //~^ ERROR use of possibly uninitialized variable
+        ref u if true => {}
+        ref v if true => {
+            let tx = 0;
+            &tx;
+        }
+        _ => (),
+    }
+}

--- a/src/test/ui/borrowck/issue-62107-match-arm-scopes.stderr
+++ b/src/test/ui/borrowck/issue-62107-match-arm-scopes.stderr
@@ -1,0 +1,9 @@
+error[E0381]: use of possibly uninitialized variable: `e`
+  --> $DIR/issue-62107-match-arm-scopes.rs:3:11
+   |
+LL |     match e {
+   |           ^ use of possibly uninitialized `e`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
Due to a bug in the HIR CFG construction, borrows for arm scopes were incorrectly leaking into other arms.
This PR also includes some drive-by improvements to `-Zunpretty=hir,identified` that would have been helpful while investigating this.

Closes #62107 