### PR TITLE
Fix code block information icon position

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -146,6 +146,10 @@ img {
 	max-width: 100%;
 }
 
+li {
+	position: relative;
+}
+
 .source .content {
 	margin-top: 50px;
 	max-width: none;


### PR DESCRIPTION
Fixes #62118.

A screenshot of the fix:

<img width="720" alt="Screenshot 2019-06-29 at 18 28 59" src="https://user-images.githubusercontent.com/3050060/60386900-edb23b80-9a9b-11e9-9f4f-0f343674348c.png">

r? @rust-lang/rustdoc 