### PR TITLE
wfcheck: resolve the type-vars in `AdtField` types

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1103,6 +1103,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let field_ty = self.tcx.type_of(self.tcx.hir().local_def_id_from_hir_id(field.hir_id));
             let field_ty = self.normalize_associated_types_in(field.span,
                                                               &field_ty);
+            let field_ty = self.resolve_vars_if_possible(&field_ty);
+            debug!("non_enum_variant: type of field {:?} is {:?}", field, field_ty);
             AdtField { ty: field_ty, span: field.span }
         })
         .collect();

--- a/src/test/run-pass/packed/packed-with-inference-vars-issue-61402.rs
+++ b/src/test/run-pass/packed/packed-with-inference-vars-issue-61402.rs
@@ -1,0 +1,21 @@
+// If a struct is packed and its last field has drop glue, then that
+// field needs to be Sized (to allow it to be destroyed out-of-place).
+//
+// This is checked by the compiler during wfcheck. That check used
+// to have problems with associated types in the last field - test
+// that this doesn't ICE.
+
+#![allow(unused_imports, dead_code)]
+
+pub struct S;
+
+pub trait Trait<R> { type Assoc; }
+
+impl<X> Trait<X> for S { type Assoc = X; }
+
+#[repr(C, packed)]
+struct PackedAssocSized {
+    pos: Box<<S as Trait<usize>>::Assoc>,
+}
+
+fn main() { println!("Hello, world!"); }


### PR DESCRIPTION
Normalization can leave some type-vars unresolved in its return type.
Make sure to resolve them so we have an infcx-independent type that can
be used with `needs_drop`.

Fixes #61402.

Closes #62212 - this PR fixes the root cause.