### PR TITLE
Switch tracking issue for `#![feature(slice_patterns)]`

### DIFF
--- a/src/doc/unstable-book/src/language-features/slice-patterns.md
+++ b/src/doc/unstable-book/src/language-features/slice-patterns.md
@@ -1,8 +1,8 @@
 # `slice_patterns`
 
-The tracking issue for this feature is: [#23121]
+The tracking issue for this feature is: [#62254]
 
-[#23121]: https://github.com/rust-lang/rust/issues/23121
+[#62254]: https://github.com/rust-lang/rust/issues/62254
 
 ------------------------
 

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -458,7 +458,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 match ty.sty {
                                     ty::Array(..) | ty::Slice(..) => {
                                         err.help("the semantics of slice patterns changed \
-                                                  recently; see issue #23121");
+                                                  recently; see issue #62254");
                                     }
                                     _ => {}
                                 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -323,7 +323,7 @@ declare_features! (
     (active, nll, "1.0.0", Some(43234), None),
 
     // Allows using slice patterns.
-    (active, slice_patterns, "1.0.0", Some(23121), None),
+    (active, slice_patterns, "1.0.0", Some(62254), None),
 
     // Allows the definition of `const` functions with some advanced features.
     (active, const_fn, "1.2.0", Some(57563), None),
@@ -610,7 +610,7 @@ declare_features! (
     (removed, allocator, "1.0.0", None, None, None),
     (removed, simd, "1.0.0", Some(27731), None,
      Some("removed in favor of `#[repr(simd)]`")),
-    (removed, advanced_slice_patterns, "1.0.0", Some(23121), None,
+    (removed, advanced_slice_patterns, "1.0.0", Some(62254), None,
      Some("merged into `#![feature(slice_patterns)]`")),
     (removed, macro_reexport, "1.0.0", Some(29638), None,
      Some("subsumed by `pub use`")),

--- a/src/test/ui/feature-gates/feature-gate-slice-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-slice-patterns.stderr
@@ -4,7 +4,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [1, 2, ..] => {}
    |                ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
@@ -13,7 +13,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [1, .., 5] => {}
    |             ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
@@ -22,7 +22,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [.., 4, 5] => {}
    |          ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
@@ -31,7 +31,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [ xs.., 4, 5 ] => {}
    |           ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
@@ -40,7 +40,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [ 1, xs.., 5 ] => {}
    |              ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
@@ -49,7 +49,7 @@ error[E0658]: syntax for subslices in slice patterns is not yet stabilized
 LL |         [ 1, 2, xs.. ] => {}
    |                 ^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/23121
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62254
    = help: add #![feature(slice_patterns)] to the crate attributes to enable
 
 error: aborting due to 6 previous errors


### PR DESCRIPTION
Switches the tracking issue for `#![feature(slice_patterns)]` to a fresh one in https://github.com/rust-lang/rust/issues/62254 due to new RFCs.

Closes https://github.com/rust-lang/rust/issues/23121.

r? @varkor 