### PR TITLE
syntax: Unsupport `foo! bar { ... }` macros in the parser

### DIFF
--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -6,7 +6,7 @@ use rustc::util::nodemap::FxHashMap;
 
 use syntax::ext::base::{SyntaxExtension, SyntaxExtensionKind, NamedSyntaxExtension};
 use syntax::ext::base::MacroExpanderFn;
-use syntax::symbol::{Symbol, sym};
+use syntax::symbol::Symbol;
 use syntax::ast;
 use syntax::feature_gate::AttributeType;
 use syntax_pos::Span;
@@ -85,9 +85,6 @@ impl<'a> Registry<'a> {
     ///
     /// This is the most general hook into `libsyntax`'s expansion behavior.
     pub fn register_syntax_extension(&mut self, name: ast::Name, mut extension: SyntaxExtension) {
-        if name == sym::macro_rules {
-            panic!("user-defined macros may not be named `macro_rules`");
-        }
         if extension.def_info.is_none() {
             extension.def_info = Some((ast::CRATE_NODE_ID, self.krate_span));
         }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -1109,9 +1109,6 @@ impl<'a> Resolver<'a> {
                         current_legacy_scope: &mut LegacyScope<'a>) {
         self.local_macro_def_scopes.insert(item.id, self.current_module);
         let ident = item.ident;
-        if ident.name == sym::macro_rules {
-            self.session.span_err(item.span, "user-defined macros may not be named `macro_rules`");
-        }
 
         let def_id = self.definitions.local_def_id(item.id);
         let ext = Lrc::new(macro_rules::compile(&self.session.parse_sess,

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -13,8 +13,7 @@ use crate::parse::{DirectoryOwnership, PResult, ParseSess};
 use crate::parse::token;
 use crate::parse::parser::Parser;
 use crate::ptr::P;
-use crate::symbol::Symbol;
-use crate::symbol::{kw, sym};
+use crate::symbol::{sym, Symbol};
 use crate::tokenstream::{TokenStream, TokenTree};
 use crate::visit::{self, Visitor};
 use crate::util::map_in_place::MapInPlace;
@@ -197,7 +196,6 @@ pub struct Invocation {
 pub enum InvocationKind {
     Bang {
         mac: ast::Mac,
-        ident: Option<Ident>,
         span: Span,
     },
     Attr {
@@ -664,13 +662,12 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                          ext: &SyntaxExtension)
                          -> Option<AstFragment> {
         let kind = invoc.fragment_kind;
-        let (mac, ident, span) = match invoc.kind {
-            InvocationKind::Bang { mac, ident, span } => (mac, ident, span),
+        let (mac, span) = match invoc.kind {
+            InvocationKind::Bang { mac, span } => (mac, span),
             _ => unreachable!(),
         };
         let path = &mac.node.path;
 
-        let ident = ident.unwrap_or_else(|| Ident::invalid());
         let validate = |this: &mut Self| {
             // feature-gate the macro invocation
             if let Some((feature, issue)) = ext.unstable_feature {
@@ -690,12 +687,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 }
             }
 
-            if ident.name != kw::Invalid {
-                let msg = format!("macro {}! expects no ident argument, given '{}'", path, ident);
-                this.cx.span_err(path.span, &msg);
-                this.cx.trace_macros_diag();
-                return Err(kind.dummy(span));
-            }
             Ok(())
         };
 
@@ -729,19 +720,11 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
 
             SyntaxExtensionKind::Bang(expander) => {
-                if ident.name != kw::Invalid {
-                    let msg =
-                        format!("macro {}! expects no ident argument, given '{}'", path, ident);
-                    self.cx.span_err(path.span, &msg);
-                    self.cx.trace_macros_diag();
-                    kind.dummy(span)
-                } else {
-                    self.gate_proc_macro_expansion_kind(span, kind);
-                    let tok_result = expander.expand(self.cx, span, mac.node.stream());
-                    let result = self.parse_ast_fragment(tok_result, kind, path, span);
-                    self.gate_proc_macro_expansion(span, &result);
-                    result
-                }
+                self.gate_proc_macro_expansion_kind(span, kind);
+                let tok_result = expander.expand(self.cx, span, mac.node.stream());
+                let result = self.parse_ast_fragment(tok_result, kind, path, span);
+                self.gate_proc_macro_expansion(span, &result);
+                result
             }
         };
 
@@ -944,7 +927,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
     }
 
     fn collect_bang(&mut self, mac: ast::Mac, span: Span, kind: AstFragmentKind) -> AstFragment {
-        self.collect(kind, InvocationKind::Bang { mac, ident: None, span })
+        self.collect(kind, InvocationKind::Bang { mac, span })
     }
 
     fn collect_attr(&mut self,
@@ -1179,13 +1162,9 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             ast::ItemKind::Mac(..) => {
                 self.check_attributes(&item.attrs);
                 item.and_then(|item| match item.node {
-                    ItemKind::Mac(mac) => {
-                        self.collect(AstFragmentKind::Items, InvocationKind::Bang {
-                            mac,
-                            ident: Some(item.ident),
-                            span: item.span,
-                        }).make_items()
-                    }
+                    ItemKind::Mac(mac) => self.collect(
+                        AstFragmentKind::Items, InvocationKind::Bang { mac, span: item.span }
+                    ).make_items(),
                     _ => unreachable!(),
                 })
             }

--- a/src/test/run-pass/rfcs/rfc-2151-raw-identifiers/macros.rs
+++ b/src/test/run-pass/rfcs/rfc-2151-raw-identifiers/macros.rs
@@ -1,7 +1,7 @@
 // run-pass
 #![feature(decl_macro)]
 
-r#macro_rules! r#struct {
+macro_rules! r#struct {
     ($r#struct:expr) => { $r#struct }
 }
 

--- a/src/test/ui/issues/issue-10536.rs
+++ b/src/test/ui/issues/issue-10536.rs
@@ -11,13 +11,9 @@ macro_rules! foo{
 pub fn main() {
     foo!();
 
-    assert!({one! two()});
-    //~^ ERROR macros that expand to items
-    //~| ERROR cannot find macro `one!` in this scope
-    //~| ERROR mismatched types
+    assert!({one! two()}); //~ ERROR expected open delimiter
 
     // regardless of whether nested macro_rules works, the following should at
     // least throw a conventional error.
-    assert!({one! two});
-    //~^ ERROR expected `(` or `{`, found `}`
+    assert!({one! two}); //~ ERROR expected open delimiter
 }

--- a/src/test/ui/issues/issue-10536.stderr
+++ b/src/test/ui/issues/issue-10536.stderr
@@ -1,38 +1,14 @@
-error: macros that expand to items must be delimited with braces or followed by a semicolon
-  --> $DIR/issue-10536.rs:14:22
+error: expected open delimiter
+  --> $DIR/issue-10536.rs:14:19
    |
 LL |     assert!({one! two()});
-   |                      ^^
-help: change the delimiters to curly braces
-   |
-LL |     assert!({one! two {}});
-   |                       ^^
-help: add a semicolon
-   |
-LL |     assert!({one! two();});
-   |                        ^
+   |                   ^^^ expected open delimiter
 
-error: expected `(` or `{`, found `}`
-  --> $DIR/issue-10536.rs:21:22
+error: expected open delimiter
+  --> $DIR/issue-10536.rs:18:19
    |
 LL |     assert!({one! two});
-   |                      ^ expected `(` or `{`
+   |                   ^^^ expected open delimiter
 
-error: cannot find macro `one!` in this scope
-  --> $DIR/issue-10536.rs:14:14
-   |
-LL |     assert!({one! two()});
-   |              ^^^
+error: aborting due to 2 previous errors
 
-error[E0308]: mismatched types
-  --> $DIR/issue-10536.rs:14:13
-   |
-LL |     assert!({one! two()});
-   |             ^^^^^^^^^^^^ expected bool, found ()
-   |
-   = note: expected type `bool`
-              found type `()`
-
-error: aborting due to 4 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/macro-bad-delimiter-ident.rs
+++ b/src/test/ui/parser/macro-bad-delimiter-ident.rs
@@ -1,3 +1,3 @@
 fn main() {
-    foo! bar < //~ ERROR expected `(` or `{`, found `<`
+    foo! bar < //~ ERROR expected open delimiter
 }

--- a/src/test/ui/parser/macro-bad-delimiter-ident.stderr
+++ b/src/test/ui/parser/macro-bad-delimiter-ident.stderr
@@ -1,8 +1,8 @@
-error: expected `(` or `{`, found `<`
-  --> $DIR/macro-bad-delimiter-ident.rs:2:14
+error: expected open delimiter
+  --> $DIR/macro-bad-delimiter-ident.rs:2:10
    |
 LL |     foo! bar <
-   |              ^ expected `(` or `{`
+   |          ^^^ expected open delimiter
 
 error: aborting due to previous error
 

--- a/src/test/ui/user-defined-macro-rules.rs
+++ b/src/test/ui/user-defined-macro-rules.rs
@@ -1,5 +1,9 @@
-#![allow(unused_macros)]
+// check-pass
 
-macro_rules! macro_rules { () => {} } //~ ERROR user-defined macros may not be named `macro_rules`
+macro_rules! macro_rules { () => { struct S; } } // OK
 
-fn main() {}
+macro_rules! {} // OK, calls the macro defined above
+
+fn main() {
+    let s = S;
+}

--- a/src/test/ui/user-defined-macro-rules.stderr
+++ b/src/test/ui/user-defined-macro-rules.stderr
@@ -1,8 +1,0 @@
-error: user-defined macros may not be named `macro_rules`
-  --> $DIR/user-defined-macro-rules.rs:3:1
-   |
-LL | macro_rules! macro_rules { () => {} }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
-


### PR DESCRIPTION
Their support in expansion was removed in https://github.com/rust-lang/rust/pull/61606.

Also un-reserve `macro_rules` as a macro name, there's no ambiguity between `macro_rules` definitions and macro calls (it also wasn't reserved correctly).

cc https://github.com/rust-lang-nursery/wg-grammar/issues/51