### PR TITLE
Revert "implicit `Option`-returning doctests"

### DIFF
--- a/src/doc/rustdoc/src/documentation-tests.md
+++ b/src/doc/rustdoc/src/documentation-tests.md
@@ -253,19 +253,6 @@ conversion, so type inference fails because the type is not unique. Please note
 that you must write the `(())` in one sequence without intermediate whitespace
 so that rustdoc understands you want an implicit `Result`-returning function.
 
-As of version 1.37.0, this simplification also works with `Option`s, which can
-be handy to test e.g. iterators or checked arithmetic, for example:
-
-```ignore
-/// ```
-/// let _ = &[].iter().next()?;
-///# Some(())
-/// ```
-```
-
-Note that the result must be a `Some(())` and this has to be written in one go.
-In this case disambiguating the result isn't required.
-
 ## Documenting macros
 
 Here’s an example of documenting a macro:

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -528,13 +528,8 @@ pub fn make_test(s: &str,
         prog.push_str(everything_else);
     } else {
         let returns_result = everything_else.trim_end().ends_with("(())");
-        let returns_option = everything_else.trim_end().ends_with("Some(())");
         let (main_pre, main_post) = if returns_result {
-            (if returns_option {
-                "fn main() { fn _inner() -> Option<()> {"
-            } else {
-                "fn main() { fn _inner() -> Result<(), impl core::fmt::Debug> {"
-            },
+            ("fn main() { fn _inner() -> Result<(), impl core::fmt::Debug> {",
              "}\n_inner().unwrap() }")
         } else {
             ("fn main() {\n", "\n}")

--- a/src/test/rustdoc/process-termination.rs
+++ b/src/test/rustdoc/process-termination.rs
@@ -21,16 +21,4 @@
 /// Err("This is returned from `main`, leading to panic")?;
 /// Ok::<(), &'static str>(())
 /// ```
-///
-/// This also works with `Option<()>`s now:
-///
-/// ```rust
-/// Some(())
-/// ```
-///
-/// ```rust,should_panic
-/// let x: &[u32] = &[];
-/// let _ = x.iter().next()?;
-/// Some(())
-/// ```
 pub fn check_process_termination() {}


### PR DESCRIPTION
Reverts #61279 as discussed in #61360.

cc @Centril 