### PR TITLE
rustc_mir: follow FalseUnwind's real_target edge in qualify_consts.

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -890,6 +890,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
 
             let target = match body[bb].terminator().kind {
                 TerminatorKind::Goto { target } |
+                TerminatorKind::FalseUnwind { real_target: target, .. } |
                 TerminatorKind::Drop { target, .. } |
                 TerminatorKind::DropAndReplace { target, .. } |
                 TerminatorKind::Assert { target, .. } |
@@ -908,8 +909,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
                 TerminatorKind::GeneratorDrop |
                 TerminatorKind::Yield { .. } |
                 TerminatorKind::Unreachable |
-                TerminatorKind::FalseEdges { .. } |
-                TerminatorKind::FalseUnwind { .. } => None,
+                TerminatorKind::FalseEdges { .. } => None,
 
                 TerminatorKind::Return => {
                     break;

--- a/src/test/compile-fail/const-fn-error.rs
+++ b/src/test/compile-fail/const-fn-error.rs
@@ -6,6 +6,7 @@ const fn f(x: usize) -> usize {
     let mut sum = 0;
     for i in 0..x {
         //~^ ERROR E0015
+        //~| ERROR E0017
         //~| ERROR E0019
         //~| ERROR E0019
         //~| ERROR E0080

--- a/src/test/compile-fail/issue-52443.rs
+++ b/src/test/compile-fail/issue-52443.rs
@@ -1,10 +1,14 @@
 fn main() {
     [(); & { loop { continue } } ]; //~ ERROR mismatched types
     [(); loop { break }]; //~ ERROR mismatched types
-    [(); {while true {break}; 0}]; //~ ERROR constant contains unimplemented expression type
-    //~^ WARN denote infinite loops with
-    [(); { for _ in 0usize.. {}; 0}]; //~ ERROR calls in constants are limited to constant functions
+    [(); {while true {break}; 0}];
     //~^ ERROR constant contains unimplemented expression type
+    //~| ERROR constant contains unimplemented expression type
+    //~| WARN denote infinite loops with
+    [(); { for _ in 0usize.. {}; 0}];
+    //~^ ERROR calls in constants are limited to constant functions
+    //~| ERROR references in constants may only refer to immutable values
+    //~| ERROR constant contains unimplemented expression type
     //~| ERROR constant contains unimplemented expression type
     //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-eval/infinite_loop.rs
+++ b/src/test/ui/consts/const-eval/infinite_loop.rs
@@ -4,7 +4,9 @@ fn main() {
     let _ = [(); {
         //~^ WARNING Constant evaluating a complex constant, this might take some time
         let mut n = 113383; // #20 in https://oeis.org/A006884
-        while n != 0 { //~ ERROR constant contains unimplemented expression type
+        while n != 0 {
+        //~^ ERROR constant contains unimplemented expression type
+        //~| ERROR constant contains unimplemented expression type
             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
             //~^ ERROR evaluation of constant value failed
         }

--- a/src/test/ui/consts/const-eval/infinite_loop.stderr
+++ b/src/test/ui/consts/const-eval/infinite_loop.stderr
@@ -1,7 +1,15 @@
 error[E0019]: constant contains unimplemented expression type
+  --> $DIR/infinite_loop.rs:7:15
+   |
+LL |         while n != 0 {
+   |               ^^^^^^
+
+error[E0019]: constant contains unimplemented expression type
   --> $DIR/infinite_loop.rs:7:9
    |
 LL | /         while n != 0 {
+LL | |
+LL | |
 LL | |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
 LL | |
 LL | |         }
@@ -21,12 +29,12 @@ LL | |     }];
    | |_____^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/infinite_loop.rs:8:20
+  --> $DIR/infinite_loop.rs:10:20
    |
 LL |             n = if n % 2 == 0 { n/2 } else { 3*n + 1 };
    |                    ^^^^^^^^^^ duplicate interpreter state observed here, const evaluation will never terminate
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0019, E0080.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-eval/issue-52442.rs
+++ b/src/test/ui/consts/const-eval/issue-52442.rs
@@ -1,4 +1,5 @@
 fn main() {
-    [();  { &loop { break } as *const _ as usize } ]; //~ ERROR unimplemented expression type
-    //~^ ERROR it is undefined behavior to use this value
+    [();  { &loop { break } as *const _ as usize } ];
+    //~^ ERROR casting pointers to integers in constants is unstable
+    //~| ERROR it is undefined behavior to use this value
 }

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -1,8 +1,11 @@
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/issue-52442.rs:2:14
+error[E0658]: casting pointers to integers in constants is unstable
+  --> $DIR/issue-52442.rs:2:13
    |
 LL |     [();  { &loop { break } as *const _ as usize } ];
-   |              ^^^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/51910
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/issue-52442.rs:2:11
@@ -14,5 +17,5 @@ LL |     [();  { &loop { break } as *const _ as usize } ];
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0019, E0080.
-For more information about an error, try `rustc --explain E0019`.
+Some errors have detailed explanations: E0080, E0658.
+For more information about an error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-52475.rs
+++ b/src/test/ui/consts/const-eval/issue-52475.rs
@@ -3,7 +3,9 @@ fn main() {
         //~^ WARNING Constant evaluating a complex constant, this might take some time
         let mut x = &0;
         let mut n = 0;
-        while n < 5 { //~ ERROR constant contains unimplemented expression type
+        while n < 5 {
+        //~^ ERROR constant contains unimplemented expression type
+        //~| ERROR constant contains unimplemented expression type
             n = (n + 1) % 5; //~ ERROR evaluation of constant value failed
             x = &0; // Materialize a new AllocId
         }

--- a/src/test/ui/consts/const-eval/issue-52475.stderr
+++ b/src/test/ui/consts/const-eval/issue-52475.stderr
@@ -1,7 +1,15 @@
 error[E0019]: constant contains unimplemented expression type
+  --> $DIR/issue-52475.rs:6:15
+   |
+LL |         while n < 5 {
+   |               ^^^^^
+
+error[E0019]: constant contains unimplemented expression type
   --> $DIR/issue-52475.rs:6:9
    |
 LL | /         while n < 5 {
+LL | |
+LL | |
 LL | |             n = (n + 1) % 5;
 LL | |             x = &0; // Materialize a new AllocId
 LL | |         }
@@ -21,12 +29,12 @@ LL | |     }];
    | |_____^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/issue-52475.rs:7:17
+  --> $DIR/issue-52475.rs:9:17
    |
 LL |             n = (n + 1) % 5;
    |                 ^^^^^^^^^^^ duplicate interpreter state observed here, const evaluation will never terminate
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0019, E0080.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/consts/const-eval/issue-62272.rs
+++ b/src/test/ui/consts/const-eval/issue-62272.rs
@@ -1,0 +1,9 @@
+// run-pass
+
+// Tests that `loop`s unconditionally-broken-from are allowed in constants.
+
+const FOO: () = loop { break; };
+
+fn main() {
+    [FOO; { let x; loop { x = 5; break; } x }];
+}

--- a/src/test/ui/consts/const-labeled-break.rs
+++ b/src/test/ui/consts/const-labeled-break.rs
@@ -1,9 +1,10 @@
+// run-pass
+
 // Using labeled break in a while loop has caused an illegal instruction being
 // generated, and an ICE later.
 //
 // See https://github.com/rust-lang/rust/issues/51350 for more information.
 
 const CRASH: () = 'a: while break 'a {};
-//~^ ERROR constant contains unimplemented expression type
 
 fn main() {}

--- a/src/test/ui/consts/const-labeled-break.stderr
+++ b/src/test/ui/consts/const-labeled-break.stderr
@@ -1,9 +1,0 @@
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/const-labeled-break.rs:6:19
-   |
-LL | const CRASH: () = 'a: while break 'a {};
-   |                   ^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0019`.


### PR DESCRIPTION
As far as I can tell, this was accidentally omitted from #47802.
Fixes #62272.

r? @matthewjasper or @nikomatsakis 