### PR TITLE
rustc_mir: treat DropAndReplace as Drop + Assign in qualify_consts.

### DIFF
--- a/src/test/ui/consts/const-eval/const_let.rs
+++ b/src/test/ui/consts/const-eval/const_let.rs
@@ -9,10 +9,21 @@ impl Drop for FakeNeedsDrop {
 // ok
 const X: FakeNeedsDrop = { let x = FakeNeedsDrop; x };
 
+// ok (used to incorrectly error, see #62273)
+const X2: FakeNeedsDrop = { let x; x = FakeNeedsDrop; x };
+
 // error
 const Y: FakeNeedsDrop = { let mut x = FakeNeedsDrop; x = FakeNeedsDrop; x };
-//~^ ERROR constant contains unimplemented expression type
+//~^ ERROR destructors cannot be evaluated at compile-time
+
+// error
+const Y2: FakeNeedsDrop = { let mut x; x = FakeNeedsDrop; x = FakeNeedsDrop; x };
+//~^ ERROR destructors cannot be evaluated at compile-time
 
 // error
 const Z: () = { let mut x = None; x = Some(FakeNeedsDrop); };
-//~^ ERROR constant contains unimplemented expression type
+//~^ ERROR destructors cannot be evaluated at compile-time
+
+// error
+const Z2: () = { let mut x; x = None; x = Some(FakeNeedsDrop); };
+//~^ ERROR destructors cannot be evaluated at compile-time

--- a/src/test/ui/consts/const-eval/const_let.stderr
+++ b/src/test/ui/consts/const-eval/const_let.stderr
@@ -1,15 +1,26 @@
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/const_let.rs:13:55
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/const_let.rs:16:32
    |
 LL | const Y: FakeNeedsDrop = { let mut x = FakeNeedsDrop; x = FakeNeedsDrop; x };
-   |                                                       ^
+   |                                ^^^^^ constants cannot evaluate destructors
 
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/const_let.rs:17:35
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/const_let.rs:20:33
+   |
+LL | const Y2: FakeNeedsDrop = { let mut x; x = FakeNeedsDrop; x = FakeNeedsDrop; x };
+   |                                 ^^^^^ constants cannot evaluate destructors
+
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/const_let.rs:24:21
    |
 LL | const Z: () = { let mut x = None; x = Some(FakeNeedsDrop); };
-   |                                   ^
+   |                     ^^^^^ constants cannot evaluate destructors
 
-error: aborting due to 2 previous errors
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/const_let.rs:28:22
+   |
+LL | const Z2: () = { let mut x; x = None; x = Some(FakeNeedsDrop); };
+   |                      ^^^^^ constants cannot evaluate destructors
 
-For more information about this error, try `rustc --explain E0019`.
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
This slipped through the cracks and never got implemented (thankfully that just meant it was overly conservative and didn't allow assignments that don't *actually* drop the previous value).
Fixes #62273.

r? @oli-obk 