### PR TITLE
ci: explicitly disable CRLF conversion on Windows

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -8,6 +8,13 @@
 
 steps:
 
+# Disable automatic line ending conversion, which is enabled by default on
+# Azure's Windows image. Having the conversion enabled caused regressions both
+# in our test suite (it broke miri tests) and in the ecosystem, since we
+# started shipping install scripts with CRLF endings instead of the old LF.
+- bash: git config --global core.autocrlf false
+  displayName: "Disable git automatic line ending conversion"
+
 - checkout: self
   fetchDepth: 2
 


### PR DESCRIPTION
The Azure image enables CRLF conversion on Windows builders, but that caused regressions both in our test suite (the miri test suite broke) and in the ecosystem, since we started shipping install scripts with CRLF endings instead of the old LF. The [Godbolt Compiler Explorer](https://godbolt.org/) is one such case of breakage.

This adds a step to the build explicitly disabling the conversion before the repository is checked out.

r? @alexcrichton 
cc @gnzlbg 