### PR TITLE
Add support for pc-relative addressing on 64-bit RISC-V

### DIFF
--- a/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64gc_unknown_none_elf.rs
@@ -23,6 +23,7 @@ pub fn target() -> TargetResult {
             executables: true,
             panic_strategy: PanicStrategy::Abort,
             relocation_model: "static".to_string(),
+            code_model: Some("medium".to_string()),
             emit_debug_gdb_scripts: false,
             abi_blacklist: super::riscv_base::abi_blacklist(),
             eliminate_frame_pointer: false,

--- a/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
+++ b/src/librustc_target/spec/riscv64imac_unknown_none_elf.rs
@@ -23,6 +23,7 @@ pub fn target() -> TargetResult {
             executables: true,
             panic_strategy: PanicStrategy::Abort,
             relocation_model: "static".to_string(),
+            code_model: Some("medium".to_string()),
             emit_debug_gdb_scripts: false,
             abi_blacklist: super::riscv_base::abi_blacklist(),
             eliminate_frame_pointer: false,


### PR DESCRIPTION
These changes allow Rust to generate position-independent code on `riscv64` targets with code model `medium`.

Closes: https://github.com/rust-lang/rust/issues/59802
See also: https://github.com/rust-embedded/riscv-rt/issues/25, https://github.com/rust-embedded/wg/issues/218