### PR TITLE
Use link attributes on extern "C" blocks with llvm-libuwind

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -4,11 +4,13 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
 
-    if cfg!(feature = "llvm-libunwind") &&
+    // FIXME: the not(bootstrap) part is needed because of the issue addressed by #62286,
+    // and could be removed once that change is in beta.
+    if cfg!(all(not(bootstrap), feature = "llvm-libunwind")) &&
         (target.contains("linux") ||
          target.contains("fuchsia")) {
         // Build the unwinding from libunwind C/C++ source code.
-        #[cfg(feature = "llvm-libunwind")]
+        #[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
         llvm_libunwind::compile();
     } else if target.contains("linux") {
         if target.contains("musl") {
@@ -42,7 +44,7 @@ fn main() {
     }
 }
 
-#[cfg(feature = "llvm-libunwind")]
+#[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
 mod llvm_libunwind {
     use std::env;
     use std::path::Path;

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -67,6 +67,8 @@ pub enum _Unwind_Context {}
 
 pub type _Unwind_Exception_Cleanup_Fn = extern "C" fn(unwind_code: _Unwind_Reason_Code,
                                                       exception: *mut _Unwind_Exception);
+#[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
+           link(name = "unwind", kind = "static"))]
 extern "C" {
     #[unwind(allowed)]
     pub fn _Unwind_Resume(exception: *mut _Unwind_Exception) -> !;
@@ -91,6 +93,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     }
     pub use _Unwind_Action::*;
 
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
+               link(name = "unwind", kind = "static"))]
     extern "C" {
         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;
         pub fn _Unwind_SetGR(ctx: *mut _Unwind_Context, reg_index: c_int, value: _Unwind_Word);
@@ -144,6 +148,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;
 
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
+               link(name = "unwind", kind = "static"))]
     extern "C" {
         fn _Unwind_VRS_Get(ctx: *mut _Unwind_Context,
                            regclass: _Unwind_VRS_RegClass,
@@ -206,6 +212,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
 cfg_if::cfg_if! {
 if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     // Not 32-bit iOS
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
+               link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]
         pub fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwind_Reason_Code;
@@ -215,6 +223,8 @@ if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     }
 } else {
     // 32-bit iOS uses SjLj and does not provide _Unwind_Backtrace()
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
+               link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]
         pub fn _Unwind_SjLj_RaiseException(e: *mut _Unwind_Exception) -> _Unwind_Reason_Code;


### PR DESCRIPTION
When llvm-libunwind feature is enabled, we need to use link attribute on
extern "C" blocks to make sure that symbols provided by LLVM's libunwind
that's built as part of Rust's libunwind crate are re-exported.

This addresses issue #62088.