### PR TITLE
rustc: don't use Abi::ScalarPair for unions when padding is involved.

### DIFF
--- a/src/test/ui/union/union-padding-preserved.rs
+++ b/src/test/ui/union/union-padding-preserved.rs
@@ -1,0 +1,87 @@
+// run-pass
+
+// Test that unions don't lose padding bytes (i.e. not covered by any leaf field).
+
+#![feature(core_intrinsics, test, transparent_unions)]
+
+extern crate test;
+
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+union U<T: Copy> { _x: T, y: () }
+
+impl<T: Copy> U<T> {
+    fn uninit() -> Self {
+        U { y: () }
+    }
+
+    unsafe fn write(&mut self, i: usize, v: u8) {
+        (self as *mut _ as *mut u8).add(i).write(v);
+    }
+
+    #[inline(never)]
+    unsafe fn read_rust(self, i: usize) -> u8 {
+        test::black_box((&self as *const _ as *const u8).add(i)).read()
+    }
+
+    #[inline(never)]
+    unsafe extern "C" fn read_c(self, i: usize) -> u8 {
+        test::black_box((&self as *const _ as *const u8).add(i)).read()
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+struct Options {
+    demote_c_to_warning: bool,
+}
+
+unsafe fn check_at<T: Copy>(i: usize, v: u8, opts: Options) {
+    let mut u = U::<T>::uninit();
+    u.write(i, v);
+    let msg = |abi: &str| format!(
+        "check_at::<{}>: {} ABI failed at byte {}",
+        std::intrinsics::type_name::<T>(),
+        abi,
+        i,
+    );
+    if u.read_rust(i) != v {
+        panic!(msg("Rust"));
+    }
+    if u.read_c(i) != v {
+        if opts.demote_c_to_warning {
+            eprintln!("warning: {}", msg("C"));
+        } else {
+            panic!(msg("C"));
+        }
+    }
+}
+
+fn check_all<T: Copy>(opts: Options) {
+    for i in 0..std::mem::size_of::<T>() {
+        unsafe {
+            check_at::<T>(i, 100 + i as u8, opts);
+        }
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Copy, Clone)]
+struct Align16<T>(T);
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct Pair<A, B>(A, B);
+
+fn main() {
+    // NOTE(eddyb) we can't error for the `extern "C"` ABI in these cases, as
+    // the x86_64 SysV calling convention will drop padding bytes inside unions.
+    check_all::<Align16<u8>>(Options { demote_c_to_warning: true });
+    check_all::<Align16<f32>>(Options { demote_c_to_warning: true });
+    check_all::<Align16<f64>>(Options { demote_c_to_warning: true });
+
+    check_all::<(u8, u32)>(Options::default());
+    check_all::<(u8, u64)>(Options::default());
+
+    check_all::<Pair<u8, u32>>(Options::default());
+    check_all::<Pair<u8, u64>>(Options::default());
+}


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/60405#issuecomment-506973741 for the discussion (no issue was opened for that bug).
*Assuming* that we want to treat unions as opaque bags of bytes and preserve all of them uniformly, this PR disables the "scalar pair" optimization when it would cause some of those bytes to be ignored.

In the example given by @gnzlbg, `(u8, u32)`, bytes `1`, `2` and `3` are interior padding and `Abi::ScalarPair`, even if treated as aggregate by non-Rust calling conventions, will cause Rust copies of the whole value to only copy the `u8` and `u32` components separately, losing the original values in those 3 padding bytes (effectively replacing them with `undef`).

r? @rkruppe or @nagisa cc @RalfJung