### PR TITLE
test more possible overaligned requests

### DIFF
--- a/src/liballoc/tests/heap.rs
+++ b/src/liballoc/tests/heap.rs
@@ -12,21 +12,23 @@ fn std_heap_overaligned_request() {
 }
 
 fn check_overalign_requests<T: Alloc>(mut allocator: T) {
-    let size = 8;
-    let align = 16; // greater than size
-    let iterations = 100;
-    unsafe {
-        let pointers: Vec<_> = (0..iterations).map(|_| {
-            allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
-        }).collect();
-        for &ptr in &pointers {
-            assert_eq!((ptr.as_ptr() as usize) % align, 0,
-                       "Got a pointer less aligned than requested")
-        }
+    for &align in &[4, 8, 16, 32] { // less than and bigger than `MIN_ALIGN`
+        for &size in &[align/2, align-1] { // size less than alignment
+            let iterations = 128;
+            unsafe {
+                let pointers: Vec<_> = (0..iterations).map(|_| {
+                    allocator.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
+                }).collect();
+                for &ptr in &pointers {
+                    assert_eq!((ptr.as_ptr() as usize) % align, 0,
+                               "Got a pointer less aligned than requested")
+                }
 
-        // Clean up
-        for &ptr in &pointers {
-            allocator.dealloc(ptr, Layout::from_size_align(size, align).unwrap())
+                // Clean up
+                for &ptr in &pointers {
+                    allocator.dealloc(ptr, Layout::from_size_align(size, align).unwrap())
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In particular, test really small allocations, and test alignment both smaller and bigger than `MIN_ALIGN`.

The original test case is a special case still covered by the new test.

Cc https://github.com/rust-lang/rust/issues/62251