### PR TITLE
Use mem::take in compiletest

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -1,4 +1,5 @@
 #![crate_name = "compiletest"]
+#![feature(mem_take)]
 #![feature(test)]
 #![feature(vec_remove_item)]
 #![deny(warnings, rust_2018_idioms)]

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3608,7 +3608,7 @@ fn nocomment_mir_line(line: &str) -> &str {
 
 fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
     use crate::read2::read2;
-    use std::mem::replace;
+    use std::mem::take;
 
     const HEAD_LEN: usize = 160 * 1024;
     const TAIL_LEN: usize = 256 * 1024;
@@ -3632,7 +3632,7 @@ fn read2_abbreviated(mut child: Child) -> io::Result<Output> {
                         return;
                     }
                     let tail = bytes.split_off(new_len - TAIL_LEN).into_boxed_slice();
-                    let head = replace(bytes, Vec::new());
+                    let head = take(bytes);
                     let skipped = new_len - HEAD_LEN - TAIL_LEN;
                     ProcOutput::Abbreviated {
                         head,


### PR DESCRIPTION
This reverts commit 1443abcdefc53dac3d5041d7362da3e13ae787d0.

This has to wait for the next release of Rust afaict.   Split off from #62249 because it doesn't build right now.