### PR TITLE
provide thread name to OS for Solarish systems

### DIFF
--- a/src/libstd/sys/unix/thread.rs
+++ b/src/libstd/sys/unix/thread.rs
@@ -122,8 +122,21 @@ impl Thread {
                                      name.as_ptr() as *mut libc::c_void);
         }
     }
+
+    #[cfg(target_os = "solaris")]
+    pub fn set_name(name: &CStr) {
+        weak! {
+            fn pthread_setname_np(
+                libc::pthread_t, *const libc::c_char
+            ) -> libc::c_int
+        }
+
+        if let Some(f) = pthread_setname_np.get() {
+            unsafe { f(libc::pthread_self(), name.as_ptr()); }
+        }
+    }
+
     #[cfg(any(target_env = "newlib",
-              target_os = "solaris",
               target_os = "haiku",
               target_os = "l4re",
               target_os = "emscripten",


### PR DESCRIPTION
Fixes #62302

Passes a Linux bootstrap build. python x.py test src/tools/tidy happy.
I tested this with a small test binary that spawns a few threads, and verified
that:

 - on an illumos system lacking the libc function, the binary runs but no OS-level
    thread names are set
 - on an illumos system with the feature, the binary runs, and the thread names are
    visible and correct under tools like MDB, pstack, core dump, etc.