### PR TITLE
Add a query to get the `promoted`s for a `mir::Body`

### DIFF
--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -124,6 +124,8 @@ rustc_queries! {
                 mir.map(|x| &*tcx.arena.alloc(x))
             }
         }
+
+        query promoted_mir(key: DefId) -> &'tcx IndexVec<mir::Promoted, mir::Body<'tcx>> { }
     }
 
     TypeChecking {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -681,7 +681,7 @@ pub fn const_eval_raw_provider<'tcx>(
                 // promoting runtime code is only allowed to error if it references broken constants
                 // any other kind of error will be reported to the user as a deny-by-default lint
                 _ => if let Some(p) = cid.promoted {
-                    let span = tcx.optimized_mir(def_id).promoted[p].span;
+                    let span = tcx.promoted_mir(def_id)[p].span;
                     if let InterpError::ReferencedConstant = err.error {
                         err.report_as_error(
                             tcx.at(span),

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -1,4 +1,5 @@
 use crate::{build, shim};
+use rustc_data_structures::indexed_vec::IndexVec;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::mir::{Body, MirPhase, Promoted};
 use rustc::ty::{TyCtxt, InstanceDef};
@@ -46,6 +47,7 @@ pub(crate) fn provide(providers: &mut Providers<'_>) {
         mir_validated,
         optimized_mir,
         is_mir_available,
+        promoted_mir,
         ..*providers
     };
 }
@@ -295,4 +297,9 @@ fn optimized_mir<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx Body<'tcx> {
         &dump_mir::Marker("PreCodegen"),
     ]);
     tcx.arena.alloc(body)
+}
+
+fn promoted_mir<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> &'tcx IndexVec<Promoted, Body<'tcx>> {
+    let body = tcx.optimized_mir(def_id);
+    &body.promoted
 }

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -263,7 +263,7 @@ pub fn write_mir_pretty<'tcx>(
 
         write_mir_fn(tcx, MirSource::item(def_id), body, &mut |_, _| Ok(()), w)?;
 
-        for (i, body) in body.promoted.iter_enumerated() {
+        for (i, body) in tcx.promoted_mir(def_id).iter_enumerated() {
             writeln!(w, "")?;
             let src = MirSource {
                 instance: ty::InstanceDef::Item(def_id),


### PR DESCRIPTION
This is a builidng block toward removing a lot of duplicated code
between miri and the cosnt-propagator pass.

See this thread for more info:
https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/Using.20.60InterpCx.60.20more/near/169030661

r? @spastorino but feel free to hand it off to somebody else