### PR TITLE
rustdoc: stop space-splitting --test-args

### DIFF
--- a/src/doc/rustdoc/src/command-line-arguments.md
+++ b/src/doc/rustdoc/src/command-line-arguments.md
@@ -216,11 +216,17 @@ See also `--test-args`.
 Using this flag looks like this:
 
 ```bash
-$ rustdoc src/lib.rs --test --test-args ignored
+$ rustdoc src/lib.rs --test --test-args "--ignored"
 ```
 
 This flag will pass options to the test runner when running documentation tests.
 For more, see [the chapter on documentation tests](documentation-tests.md).
+
+To pass multiple arguments to the test runner, pass `--test-args` multiple times:
+
+```bash
+$ rustdoc src/lib.rs --test --test-args "--nocapture" --test-args "--test-threads=1"
+```
 
 See also `--test`.
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -340,7 +340,6 @@ impl Options {
 
         let test_args = matches.opt_strs("test-args");
         let test_args: Vec<String> = test_args.iter()
-                                              .flat_map(|s| s.split_whitespace())
                                               .map(|s| s.to_string())
                                               .collect();
 

--- a/src/test/run-make-fulldeps/rustdoc-doctest-filter/Makefile
+++ b/src/test/run-make-fulldeps/rustdoc-doctest-filter/Makefile
@@ -1,0 +1,8 @@
+-include ../tools.mk
+
+# Ensure that rustdoc doesn't erroneously space-split arguments given to --test-args, thus allowing
+# users to properly filter out tests by name and line number
+
+all:
+	$(RUSTDOC) lib.rs --test --test-args "(line 3)"
+	$(RUSTDOC) lib.rs --test --test-args "(line 3)" --test-args "--list" | $(CGREP) '1 test, 0 benchmarks'

--- a/src/test/run-make-fulldeps/rustdoc-doctest-filter/lib.rs
+++ b/src/test/run-make-fulldeps/rustdoc-doctest-filter/lib.rs
@@ -1,0 +1,12 @@
+/// so if we set up our filters to target just this test:
+///
+/// ```
+/// assert!(true);
+/// ```
+///
+/// this test shouldn't run when the makefile is executed:
+///
+/// ```
+/// assert!(false);
+/// ```
+pub struct SomeStruct;


### PR DESCRIPTION
The libtest harness allows you to filter out tests by specifying their name (or a substring) as arguments. Rustdoc allows you to specify arguments to the libtest main function via the `--test-args` argument, which can either be specified manually with `RUSTDOCFLAGS`/`cargo rustdoc` or is filled in automatically from loose arguments to `cargo test`. Rustdoc handles multiple `--test-args` arguments and stores them up to create the `args` list for the libtest runner.

However, it also whitespace-splits individual arguments to break them up, which causes problems because doctests have spaces in their names. You can't supply the full name to a test, because rustdoc will break up the name and supply it as multiple arguments. [And the test runner only takes the first filter argument when comparing against tests!](https://github.com/rust-lang/rust/blob/8c6fb028ca887dff9ec2fe0a90398b6d5bf5fb45/src/libtest/lib.rs#L557-L561) You're out of luck if you want to try to filter out all but one doctest, if another one lives on the same item.

This PR gives a fairly simple solution to the problem: Stop breaking up `--test-args`. The most common application of providing arguments to `--test-args` is via `cargo test`, which will already have properly parsed out arguments and provide them as separate `--test-args` arguments.

This has the possibility of breaking anyone who manually specified multiple arguments to `--test-args` in a single argument. I don't know if this practice was widespread, but it may be worth figuring out, since this is a change of behavior for a stable CLI flag.