### PR TITLE
simplify Option::get_or_insert

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -777,15 +777,7 @@ impl<T> Option<T> {
     #[inline]
     #[stable(feature = "option_entry", since = "1.20.0")]
     pub fn get_or_insert(&mut self, v: T) -> &mut T {
-        match *self {
-            None => *self = Some(v),
-            _ => (),
-        }
-
-        match *self {
-            Some(ref mut v) => v,
-            None => unsafe { hint::unreachable_unchecked() },
-        }
+        self.get_or_insert_with(|| v)
     }
 
     /// Inserts a value computed from `f` into the option if it is [`None`], then


### PR DESCRIPTION
I am pretty sure that the optimized result will be the same, and it's one `unsafe` less in the stdlib!