### PR TITLE
Document that ManuallyDrop::drop should not called more than once

### DIFF
--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -118,7 +118,8 @@ impl<T: ?Sized> ManuallyDrop<T> {
     ///
     /// This function runs the destructor of the contained value and thus the wrapped value
     /// now represents uninitialized data. It is up to the user of this method to ensure the
-    /// uninitialized data is not actually used, and that this function is called at most once
+    /// uninitialized data is not actually used.
+    /// In particular, this function can only be called called at most once
     /// for a given instance of `ManuallyDrop<T>`.
     ///
     /// [`ManuallyDrop::into_inner`]: #method.into_inner

--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -118,7 +118,8 @@ impl<T: ?Sized> ManuallyDrop<T> {
     ///
     /// This function runs the destructor of the contained value and thus the wrapped value
     /// now represents uninitialized data. It is up to the user of this method to ensure the
-    /// uninitialized data is not actually used.
+    /// uninitialized data is not actually used, and that this function is called at most once
+    /// for a given instance of ManuallyDrop
     ///
     /// [`ManuallyDrop::into_inner`]: #method.into_inner
     #[stable(feature = "manually_drop", since = "1.20.0")]

--- a/src/libcore/mem/manually_drop.rs
+++ b/src/libcore/mem/manually_drop.rs
@@ -119,7 +119,7 @@ impl<T: ?Sized> ManuallyDrop<T> {
     /// This function runs the destructor of the contained value and thus the wrapped value
     /// now represents uninitialized data. It is up to the user of this method to ensure the
     /// uninitialized data is not actually used, and that this function is called at most once
-    /// for a given instance of ManuallyDrop
+    /// for a given instance of `ManuallyDrop<T>`.
     ///
     /// [`ManuallyDrop::into_inner`]: #method.into_inner
     #[stable(feature = "manually_drop", since = "1.20.0")]


### PR DESCRIPTION
Double dropping is unsound (e.g. https://github.com/rust-lang/rust/issues/60977). This commit documents the fact that `ManuallyDrop::drop` should not be called multiple times on the same instance, as it might not be immediately obvious that this counts as a use of uninitialized data.