### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1336,7 +1336,7 @@ extern "rust-intrinsic" {
 /// Checks whether `ptr` is properly aligned with respect to
 /// `align_of::<T>()`.
 pub(crate) fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
-    return !ptr.is_null() && ptr as usize % mem::align_of::<T>() == 0;
+    !ptr.is_null() && ptr as usize % mem::align_of::<T>() == 0
 }
 
 /// Checks whether the regions of memory starting at `src` and `dst` of size

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -41,6 +41,8 @@
                    since = "1.18.0")]
 pub use crate::ptr::drop_in_place;
 
+use crate::mem;
+
 extern "rust-intrinsic" {
     // N.B., these intrinsics take raw pointers because they mutate aliased
     // memory, which is not valid for either `&` or `&mut`.
@@ -1331,6 +1333,26 @@ extern "rust-intrinsic" {
 // (`transmute` also falls into this category, but it cannot be wrapped due to the
 // check that `T` and `U` have the same size.)
 
+/// Checks whether `ptr` is properly aligned with respect to
+/// `align_of::<T>()`.
+pub(crate) fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
+    return !ptr.is_null() && ptr as usize % mem::align_of::<T>() == 0;
+}
+
+/// Checks whether the regions of memory starting at `src` and `dst` of size
+/// `count * size_of::<T>()` overlap.
+fn overlaps<T>(src: *const T, dst: *const T, count: usize) -> bool {
+    let src_usize = src as usize;
+    let dst_usize = dst as usize;
+    let size = mem::size_of::<T>().checked_mul(count).unwrap();
+    let diff = if src_usize > dst_usize {
+        src_usize - dst_usize
+    } else {
+        dst_usize - src_usize
+    };
+    size > diff
+}
+
 /// Copies `count * size_of::<T>()` bytes from `src` to `dst`. The source
 /// and destination must *not* overlap.
 ///
@@ -1420,7 +1442,11 @@ pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
-    copy_nonoverlapping(src, dst, count);
+
+    debug_assert!(is_aligned_and_not_null(src), "attempt to copy from unaligned or null pointer");
+    debug_assert!(is_aligned_and_not_null(dst), "attempt to copy to unaligned or null pointer");
+    debug_assert!(!overlaps(src, dst, count), "attempt to copy to overlapping memory");
+    copy_nonoverlapping(src, dst, count)
 }
 
 /// Copies `count * size_of::<T>()` bytes from `src` to `dst`. The source
@@ -1480,6 +1506,9 @@ pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
+
+    debug_assert!(is_aligned_and_not_null(src), "attempt to copy from unaligned or null pointer");
+    debug_assert!(is_aligned_and_not_null(dst), "attempt to copy to unaligned or null pointer");
     copy(src, dst, count)
 }
 
@@ -1561,6 +1590,8 @@ pub unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
     extern "rust-intrinsic" {
         fn write_bytes<T>(dst: *mut T, val: u8, count: usize);
     }
+
+    debug_assert!(is_aligned_and_not_null(dst), "attempt to write to unaligned or null pointer");
     write_bytes(dst, val, count)
 }
 

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -36,12 +36,12 @@
             issue = "0")]
 #![allow(missing_docs)]
 
+use crate::mem;
+
 #[stable(feature = "drop_in_place", since = "1.8.0")]
 #[rustc_deprecated(reason = "no longer an intrinsic - use `ptr::drop_in_place` directly",
                    since = "1.18.0")]
 pub use crate::ptr::drop_in_place;
-
-use crate::mem;
 
 extern "rust-intrinsic" {
     // N.B., these intrinsics take raw pointers because they mutate aliased

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -25,7 +25,7 @@
 use crate::cmp::Ordering::{self, Less, Equal, Greater};
 use crate::cmp;
 use crate::fmt;
-use crate::intrinsics::{assume, exact_div, unchecked_sub};
+use crate::intrinsics::{assume, exact_div, unchecked_sub, is_aligned_and_not_null};
 use crate::isize;
 use crate::iter::*;
 use crate::ops::{FnMut, Try, self};
@@ -5228,7 +5228,7 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
-    debug_assert!(data as usize % mem::align_of::<T>() == 0, "attempt to create unaligned slice");
+    debug_assert!(is_aligned_and_not_null(data), "attempt to create unaligned or null slice");
     debug_assert!(mem::size_of::<T>().saturating_mul(len) <= isize::MAX as usize,
                   "attempt to create slice covering half the address space");
     &*ptr::slice_from_raw_parts(data, len)
@@ -5249,7 +5249,7 @@ pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
-    debug_assert!(data as usize % mem::align_of::<T>() == 0, "attempt to create unaligned slice");
+    debug_assert!(is_aligned_and_not_null(data), "attempt to create unaligned or null slice");
     debug_assert!(mem::size_of::<T>().saturating_mul(len) <= isize::MAX as usize,
                   "attempt to create slice covering half the address space");
     &mut *ptr::slice_from_raw_parts_mut(data, len)

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -25,7 +25,7 @@
 use crate::cmp::Ordering::{self, Less, Equal, Greater};
 use crate::cmp;
 use crate::fmt;
-use crate::intrinsics::{assume, exact_div, unchecked_sub};
+use crate::intrinsics::{assume, exact_div, unchecked_sub, is_aligned_and_not_null};
 use crate::isize;
 use crate::iter::*;
 use crate::ops::{FnMut, Try, self};
@@ -5213,7 +5213,7 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
-    debug_assert!(data as usize % mem::align_of::<T>() == 0, "attempt to create unaligned slice");
+    debug_assert!(is_aligned_and_not_null(data), "attempt to create unaligned or null slice");
     debug_assert!(mem::size_of::<T>().saturating_mul(len) <= isize::MAX as usize,
                   "attempt to create slice covering half the address space");
     &*ptr::slice_from_raw_parts(data, len)
@@ -5234,7 +5234,7 @@ pub unsafe fn from_raw_parts<'a, T>(data: *const T, len: usize) -> &'a [T] {
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a mut [T] {
-    debug_assert!(data as usize % mem::align_of::<T>() == 0, "attempt to create unaligned slice");
+    debug_assert!(is_aligned_and_not_null(data), "attempt to create unaligned or null slice");
     debug_assert!(mem::size_of::<T>().saturating_mul(len) <= isize::MAX as usize,
                   "attempt to create slice covering half the address space");
     &mut *ptr::slice_from_raw_parts_mut(data, len)

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1736,7 +1736,9 @@ extern "C" {
     pub fn LLVMRustArchiveIteratorFree(AIR: &'a mut ArchiveIterator<'a>);
     pub fn LLVMRustDestroyArchive(AR: &'static mut Archive);
 
-    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>, data: &mut *const c_char) -> size_t;
+    #[allow(improper_ctypes)]
+    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>,
+                                  data: &mut Option<std::ptr::NonNull<c_char>>) -> size_t;
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTwineToString(T: &Twine, s: &RustString);

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -8,7 +8,6 @@ use rustc_data_structures::owning_ref::OwningRef;
 use rustc_codegen_ssa::METADATA_FILENAME;
 
 use std::path::Path;
-use std::ptr;
 use std::slice;
 use rustc_fs_util::path_to_c_string;
 
@@ -67,10 +66,14 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
     unsafe {
         let si = mk_section_iter(of.llof);
         while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
-            let mut name_buf = ptr::null();
+            let mut name_buf = None;
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
-            let name = slice::from_raw_parts(name_buf as *const u8, name_len as usize).to_vec();
-            let name = String::from_utf8(name).unwrap();
+            let name = name_buf.map_or(
+                "".to_string(),
+                |buf| String::from_utf8(
+                    slice::from_raw_parts(buf.as_ptr() as *const u8,
+                                          name_len as usize)
+                    .to_vec()).unwrap());
             debug!("get_metadata_section: name {}", name);
             if read_metadata_section_name(target) == name {
                 let cbuf = llvm::LLVMGetSectionContents(si.llsi);

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -69,11 +69,13 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
             let mut name_buf = None;
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
             let name = name_buf.map_or(
-                "".to_string(),
+                String::new(), // we got a NULL ptr, ignore `name_len`
                 |buf| String::from_utf8(
                     slice::from_raw_parts(buf.as_ptr() as *const u8,
                                           name_len as usize)
-                    .to_vec()).unwrap());
+                    .to_vec()
+                ).unwrap()
+            );
             debug!("get_metadata_section: name {}", name);
             if read_metadata_section_name(target) == name {
                 let cbuf = llvm::LLVMGetSectionContents(si.llsi);

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -69,7 +69,7 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
             let mut name_buf = None;
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
             let name = name_buf.map_or(
-                String::new(), // we got a NULL ptr, ignore `name_len`
+                String::new(), // We got a NULL ptr, ignore `name_len`.
                 |buf| String::from_utf8(
                     slice::from_raw_parts(buf.as_ptr() as *const u8,
                                           name_len as usize)

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1452,6 +1452,7 @@ mod tests {
             ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
             param_attr_spans: Lock::new(Vec::new()),
             let_chains_spans: Lock::new(Vec::new()),
+            async_closure_spans: Lock::new(Vec::new()),
         }
     }
 

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1474,6 +1474,7 @@ mod tests {
             ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
             param_attr_spans: Lock::new(Vec::new()),
             let_chains_spans: Lock::new(Vec::new()),
+            async_closure_spans: Lock::new(Vec::new()),
         }
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -57,6 +57,8 @@ pub struct ParseSess {
     pub param_attr_spans: Lock<Vec<Span>>,
     // Places where `let` exprs were used and should be feature gated according to `let_chains`.
     pub let_chains_spans: Lock<Vec<Span>>,
+    // Places where `async || ..` exprs were used and should be feature gated.
+    pub async_closure_spans: Lock<Vec<Span>>,
 }
 
 impl ParseSess {
@@ -84,6 +86,7 @@ impl ParseSess {
             ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
             param_attr_spans: Lock::new(Vec::new()),
             let_chains_spans: Lock::new(Vec::new()),
+            async_closure_spans: Lock::new(Vec::new()),
         }
     }
 

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -146,6 +146,7 @@ symbols! {
         associated_type_defaults,
         associated_types,
         async_await,
+        async_closure,
         attr,
         attributes,
         attr_literals,

--- a/src/test/codegen/issue-45222.rs
+++ b/src/test/codegen/issue-45222.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/issue-45466.rs
+++ b/src/test/codegen/issue-45466.rs
@@ -1,4 +1,5 @@
 // compile-flags: -O
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type="rlib"]
 

--- a/src/test/codegen/swap-small-types.rs
+++ b/src/test/codegen/swap-small-types.rs
@@ -1,5 +1,6 @@
 // compile-flags: -O
 // only-x86_64
+// ignore-debug: the debug assertions get in the way
 
 #![crate_type = "lib"]
 

--- a/src/test/run-pass/async-await/async-fn-size.rs
+++ b/src/test/run-pass/async-await/async-fn-size.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 #[path = "../auxiliary/arc_wake.rs"]
 mod arc_wake;
@@ -58,31 +58,31 @@ fn wait(fut: impl Future<Output = u8>) -> u8 {
 fn base() -> WakeOnceThenComplete { WakeOnceThenComplete(false, 1) }
 
 async fn await1_level1() -> u8 {
-    await!(base())
+    base().await
 }
 
 async fn await2_level1() -> u8 {
-    await!(base()) + await!(base())
+    base().await + base().await
 }
 
 async fn await3_level1() -> u8 {
-    await!(base()) + await!(base()) + await!(base())
+    base().await + base().await + base().await
 }
 
 async fn await3_level2() -> u8 {
-    await!(await3_level1()) + await!(await3_level1()) + await!(await3_level1())
+    await3_level1().await + await3_level1().await + await3_level1().await
 }
 
 async fn await3_level3() -> u8 {
-    await!(await3_level2()) + await!(await3_level2()) + await!(await3_level2())
+    await3_level2().await + await3_level2().await + await3_level2().await
 }
 
 async fn await3_level4() -> u8 {
-    await!(await3_level3()) + await!(await3_level3()) + await!(await3_level3())
+    await3_level3().await + await3_level3().await + await3_level3().await
 }
 
 async fn await3_level5() -> u8 {
-    await!(await3_level4()) + await!(await3_level4()) + await!(await3_level4())
+    await3_level4().await + await3_level4().await + await3_level4().await
 }
 
 fn main() {

--- a/src/test/run-pass/async-await/issue-60709.rs
+++ b/src/test/run-pass/async-await/issue-60709.rs
@@ -2,7 +2,7 @@
 // handled incorrectly in generators.
 // compile-flags: -Copt-level=z -Cdebuginfo=2 --edition=2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![allow(unused)]
 
 use std::future::Future;
@@ -22,7 +22,7 @@ impl Future for Never {
 fn main() {
     let fut = async {
         let _rc = Rc::new(()); // Also crashes with Arc
-        await!(Never());
+        Never().await;
     };
     let _bla = fut; // Moving the future is required.
 }

--- a/src/test/ui/async-await/async-await.rs
+++ b/src/test/ui/async-await/async-await.rs
@@ -70,13 +70,6 @@ fn async_nonmove_block(x: u8) -> impl Future<Output = u8> {
     }
 }
 
-fn async_closure(x: u8) -> impl Future<Output = u8> {
-    (async move |x: u8| -> u8 {
-        wake_and_yield_once().await;
-        x
-    })(x)
-}
-
 async fn async_fn(x: u8) -> u8 {
     wake_and_yield_once().await;
     x
@@ -180,7 +173,6 @@ fn main() {
     test! {
         async_block,
         async_nonmove_block,
-        async_closure,
         async_fn,
         generic_async_fn,
         async_fn_with_internal_borrow,

--- a/src/test/ui/async-await/async-closure-matches-expr.rs
+++ b/src/test/ui/async-await/async-closure-matches-expr.rs
@@ -1,0 +1,12 @@
+// compile-pass
+// edition:2018
+
+#![feature(async_await, async_closure)]
+
+macro_rules! match_expr {
+    ($x:expr) => {}
+}
+
+fn main() {
+    match_expr!(async || {});
+}

--- a/src/test/ui/async-await/async-closure-matches-expr.rs
+++ b/src/test/ui/async-await/async-closure-matches-expr.rs
@@ -1,12 +1,12 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 
 macro_rules! match_expr {
     ($x:expr) => {}
 }
 
 fn main() {
-    match_expr!(async {});
+    match_expr!(async || {});
 }

--- a/src/test/ui/async-await/async-closure.rs
+++ b/src/test/ui/async-await/async-closure.rs
@@ -1,0 +1,81 @@
+// run-pass
+
+// edition:2018
+// aux-build:arc_wake.rs
+
+#![feature(async_await, async_closure)]
+
+extern crate arc_wake;
+
+use std::pin::Pin;
+use std::future::Future;
+use std::sync::{
+    Arc,
+    atomic::{self, AtomicUsize},
+};
+use std::task::{Context, Poll};
+use arc_wake::ArcWake;
+
+struct Counter {
+    wakes: AtomicUsize,
+}
+
+impl ArcWake for Counter {
+    fn wake(self: Arc<Self>) {
+        Self::wake_by_ref(&self)
+    }
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.wakes.fetch_add(1, atomic::Ordering::SeqCst);
+    }
+}
+
+struct WakeOnceThenComplete(bool);
+
+fn wake_and_yield_once() -> WakeOnceThenComplete { WakeOnceThenComplete(false) }
+
+impl Future for WakeOnceThenComplete {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.0 {
+            Poll::Ready(())
+        } else {
+            cx.waker().wake_by_ref();
+            self.0 = true;
+            Poll::Pending
+        }
+    }
+}
+
+fn async_closure(x: u8) -> impl Future<Output = u8> {
+    (async move |x: u8| -> u8 {
+        wake_and_yield_once().await;
+        x
+    })(x)
+}
+
+fn test_future_yields_once_then_returns<F, Fut>(f: F)
+where
+    F: FnOnce(u8) -> Fut,
+    Fut: Future<Output = u8>,
+{
+    let mut fut = Box::pin(f(9));
+    let counter = Arc::new(Counter { wakes: AtomicUsize::new(0) });
+    let waker = ArcWake::into_waker(counter.clone());
+    let mut cx = Context::from_waker(&waker);
+    assert_eq!(0, counter.wakes.load(atomic::Ordering::SeqCst));
+    assert_eq!(Poll::Pending, fut.as_mut().poll(&mut cx));
+    assert_eq!(1, counter.wakes.load(atomic::Ordering::SeqCst));
+    assert_eq!(Poll::Ready(9), fut.as_mut().poll(&mut cx));
+}
+
+fn main() {
+    macro_rules! test {
+        ($($fn_name:expr,)*) => { $(
+            test_future_yields_once_then_returns($fn_name);
+        )* }
+    }
+
+    test! {
+        async_closure,
+    }
+}

--- a/src/test/ui/async-await/async-fn-path-elision.rs
+++ b/src/test/ui/async-await/async-fn-path-elision.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 #![allow(dead_code)]
 
 struct HasLifetime<'a>(&'a bool);

--- a/src/test/ui/async-await/async-matches-expr.rs
+++ b/src/test/ui/async-await/async-matches-expr.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 macro_rules! match_expr {
     ($x:expr) => {}
@@ -9,5 +9,4 @@ macro_rules! match_expr {
 
 fn main() {
     match_expr!(async {});
-    match_expr!(async || {});
 }

--- a/src/test/ui/async-await/async-with-closure.rs
+++ b/src/test/ui/async-await/async-with-closure.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 trait MyClosure {
     type Args;
@@ -20,7 +20,7 @@ async fn get_future<C: ?Sized + MyClosure>(_stream: MyStream<C>) {}
 
 async fn f() {
     let messages: MyStream<dyn FnMut()> = unimplemented!();
-    await!(get_future(messages));
+    get_future(messages).await;
 }
 
 fn main() {}

--- a/src/test/ui/async-await/async-with-closure.rs
+++ b/src/test/ui/async-await/async-with-closure.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 trait MyClosure {
     type Args;
@@ -20,7 +20,7 @@ async fn get_future<C: ?Sized + MyClosure>(_stream: MyStream<C>) {}
 
 async fn f() {
     let messages: MyStream<dyn FnMut()> = unimplemented!();
-    await!(get_future(messages));
+    get_future(messages).await;
 }
 
 fn main() {}

--- a/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.rs
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.rs
@@ -1,7 +1,7 @@
 // edition:2018
 
 #![allow(non_camel_case_types)]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 mod outer_mod {
     pub mod await { //~ ERROR expected identifier, found reserved keyword `await`

--- a/src/test/ui/async-await/await-macro.rs
+++ b/src/test/ui/async-await/await-macro.rs
@@ -3,7 +3,7 @@
 // edition:2018
 // aux-build:arc_wake.rs
 
-#![feature(async_await, await_macro)]
+#![feature(async_await, async_closure, await_macro)]
 
 extern crate arc_wake;
 

--- a/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters-by-ref-binding.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters-by-ref-binding.rs
@@ -3,7 +3,7 @@
 // run-pass
 
 #![allow(unused_variables)]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 // Test that the drop order for parameters in a fn and async fn matches up. Also test that
 // parameters (used or unused) are not dropped until the async fn completes execution.

--- a/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-for-async-fn-parameters.rs
@@ -3,7 +3,7 @@
 // run-pass
 
 #![allow(unused_variables)]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 // Test that the drop order for parameters in a fn and async fn matches up. Also test that
 // parameters (used or unused) are not dropped until the async fn completes execution.

--- a/src/test/ui/async-await/feature-async-closure.rs
+++ b/src/test/ui/async-await/feature-async-closure.rs
@@ -1,0 +1,8 @@
+// edition:2018
+// gate-test-async_closure
+
+fn f() {
+    let _ = async || {}; //~ ERROR async closures are unstable
+}
+
+fn main() {}

--- a/src/test/ui/async-await/feature-async-closure.stderr
+++ b/src/test/ui/async-await/feature-async-closure.stderr
@@ -1,0 +1,12 @@
+error[E0658]: async closures are unstable
+  --> $DIR/feature-async-closure.rs:5:13
+   |
+LL |     let _ = async || {};
+   |             ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/62290
+   = help: add #![feature(async_closure)] to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/async-await/issues/issue-53249.rs
+++ b/src/test/ui/async-await/issues/issue-53249.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(arbitrary_self_types, async_await, await_macro)]
+#![feature(arbitrary_self_types, async_await)]
 
 use std::task::{self, Poll};
 use std::future::Future;
@@ -37,11 +37,11 @@ impl<R, F> Future for Lazy<F>
 async fn __receive<WantFn, Fut>(want: WantFn) -> ()
     where Fut: Future<Output = ()>, WantFn: Fn(&Box<dyn Send + 'static>) -> Fut,
 {
-    await!(lazy(|_| ()));
+    lazy(|_| ()).await;
 }
 
 pub fn basic_spawn_receive() {
-    async { await!(__receive(|_| async { () })) };
+    async { __receive(|_| async { () }).await };
 }
 
 fn main() {}

--- a/src/test/ui/async-await/issues/issue-53249.rs
+++ b/src/test/ui/async-await/issues/issue-53249.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(arbitrary_self_types, async_await, await_macro)]
+#![feature(arbitrary_self_types, async_await)]
 
 use std::task::{self, Poll};
 use std::future::Future;
@@ -37,11 +37,11 @@ impl<R, F> Future for Lazy<F>
 async fn __receive<WantFn, Fut>(want: WantFn) -> ()
     where Fut: Future<Output = ()>, WantFn: Fn(&Box<dyn Send + 'static>) -> Fut,
 {
-    await!(lazy(|_| ()));
+    lazy(|_| ()).await;
 }
 
 pub fn basic_spawn_receive() {
-    async { await!(__receive(|_| async { () })) };
+    async { __receive(|_| async { () }).await };
 }
 
 fn main() {}

--- a/src/test/ui/async-await/issues/issue-54974.rs
+++ b/src/test/ui/async-await/issues/issue-54974.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::sync::Arc;
 

--- a/src/test/ui/async-await/issues/issue-54974.rs
+++ b/src/test/ui/async-await/issues/issue-54974.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::sync::Arc;
 

--- a/src/test/ui/async-await/issues/issue-55324.rs
+++ b/src/test/ui/async-await/issues/issue-55324.rs
@@ -1,13 +1,13 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::future::Future;
 
 #[allow(unused)]
 async fn foo<F: Future<Output = i32>>(x: &i32, future: F) -> i32 {
-    let y = await!(future);
+    let y = future.await;
     *x + y
 }
 

--- a/src/test/ui/async-await/issues/issue-55324.rs
+++ b/src/test/ui/async-await/issues/issue-55324.rs
@@ -1,13 +1,13 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::future::Future;
 
 #[allow(unused)]
 async fn foo<F: Future<Output = i32>>(x: &i32, future: F) -> i32 {
-    let y = await!(future);
+    let y = future.await;
     *x + y
 }
 

--- a/src/test/ui/async-await/issues/issue-58885.rs
+++ b/src/test/ui/async-await/issues/issue-58885.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 struct Xyz {
     a: u64,

--- a/src/test/ui/async-await/issues/issue-58885.rs
+++ b/src/test/ui/async-await/issues/issue-58885.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 struct Xyz {
     a: u64,

--- a/src/test/ui/async-await/issues/issue-59001.rs
+++ b/src/test/ui/async-await/issues/issue-59001.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::future::Future;
 

--- a/src/test/ui/async-await/issues/issue-59001.rs
+++ b/src/test/ui/async-await/issues/issue-59001.rs
@@ -1,7 +1,7 @@
 // compile-pass
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use std::future::Future;
 

--- a/src/test/ui/async-await/issues/issue-59972.rs
+++ b/src/test/ui/async-await/issues/issue-59972.rs
@@ -2,7 +2,7 @@
 
 // compile-flags: --edition=2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 pub enum Uninhabited { }
 
@@ -15,7 +15,7 @@ async fn noop() { }
 #[allow(unused)]
 async fn contains_never() {
     let error = uninhabited_async();
-    await!(noop());
+    noop().await;
     let error2 = error;
 }
 

--- a/src/test/ui/async-await/issues/issue-62009-1.rs
+++ b/src/test/ui/async-await/issues/issue-62009-1.rs
@@ -11,8 +11,6 @@ fn main() {
     //~^ ERROR `await` is only allowed inside `async` functions and blocks
         let task1 = print_dur().await;
     }.await;
-    (async || 2333)().await;
-    //~^ ERROR `await` is only allowed inside `async` functions and blocks
     (|_| 2333).await;
     //~^ ERROR `await` is only allowed inside `async` functions and blocks
     //~^^ ERROR

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -1,5 +1,5 @@
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009.rs:8:5
+  --> $DIR/issue-62009-1.rs:8:5
    |
 LL | fn main() {
    |    ---- this is not `async`
@@ -7,7 +7,7 @@ LL |     async { let (); }.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009.rs:10:5
+  --> $DIR/issue-62009-1.rs:10:5
    |
 LL |   fn main() {
    |      ---- this is not `async`
@@ -19,16 +19,7 @@ LL | |     }.await;
    | |___________^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009.rs:14:5
-   |
-LL | fn main() {
-   |    ---- this is not `async`
-...
-LL |     (async || 2333)().await;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
-
-error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009.rs:16:5
+  --> $DIR/issue-62009-1.rs:14:5
    |
 LL | fn main() {
    |    ---- this is not `async`
@@ -36,14 +27,14 @@ LL | fn main() {
 LL |     (|_| 2333).await;
    |     ^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
-error[E0277]: the trait bound `[closure@$DIR/issue-62009.rs:16:5: 16:15]: std::future::Future` is not satisfied
-  --> $DIR/issue-62009.rs:16:5
+error[E0277]: the trait bound `[closure@$DIR/issue-62009-1.rs:14:5: 14:15]: std::future::Future` is not satisfied
+  --> $DIR/issue-62009-1.rs:14:5
    |
 LL |     (|_| 2333).await;
-   |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009.rs:16:5: 16:15]`
+   |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:14:5: 14:15]`
    |
    = note: required by `std::future::poll_with_tls_context`
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/issues/issue-62009-2.rs
+++ b/src/test/ui/async-await/issues/issue-62009-2.rs
@@ -1,0 +1,10 @@
+// edition:2018
+
+#![feature(async_await, async_closure)]
+
+async fn print_dur() {}
+
+fn main() {
+    (async || 2333)().await;
+    //~^ ERROR `await` is only allowed inside `async` functions and blocks
+}

--- a/src/test/ui/async-await/issues/issue-62009-2.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-2.stderr
@@ -1,0 +1,10 @@
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-62009-2.rs:8:5
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+LL |     (async || 2333)().await;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error: aborting due to previous error
+

--- a/src/test/ui/async-await/multiple-lifetimes/hrtb.rs
+++ b/src/test/ui/async-await/multiple-lifetimes/hrtb.rs
@@ -3,7 +3,7 @@
 
 // Test that we can use async fns with multiple arbitrary lifetimes.
 
-#![feature(arbitrary_self_types, async_await, await_macro)]
+#![feature(async_await)]
 #![allow(dead_code)]
 
 use std::ops::Add;

--- a/src/test/ui/async-await/no-args-non-move-async-closure.rs
+++ b/src/test/ui/async-await/no-args-non-move-async-closure.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(async_await, async_closure, await_macro)]
+#![feature(async_await, async_closure)]
 
 fn main() {
     let _ = async |x: u8| {};

--- a/src/test/ui/async-await/no-args-non-move-async-closure.rs
+++ b/src/test/ui/async-await/no-args-non-move-async-closure.rs
@@ -1,6 +1,6 @@
 // edition:2018
 
-#![feature(async_await, await_macro)]
+#![feature(async_await, async_closure, await_macro)]
 
 fn main() {
     let _ = async |x: u8| {};

--- a/src/test/ui/async-await/recursive-async-impl-trait-type.rs
+++ b/src/test/ui/async-await/recursive-async-impl-trait-type.rs
@@ -2,10 +2,10 @@
 // Test that impl trait does not allow creating recursive types that are
 // otherwise forbidden when using `async` and `await`.
 
-#![feature(await_macro, async_await, generators)]
+#![feature(async_await)]
 
 async fn recursive_async_function() -> () { //~ ERROR
-    await!(recursive_async_function());
+    recursive_async_function().await;
 }
 
 fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await-closure.fixed
+++ b/src/test/ui/async-await/suggest-missing-await-closure.fixed
@@ -1,0 +1,23 @@
+// edition:2018
+// run-rustfix
+
+#![feature(async_await, async_closure)]
+
+fn take_u32(_x: u32) {}
+
+async fn make_u32() -> u32 {
+    22
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_closure() {
+    async || {
+        let x = make_u32();
+        take_u32(x.await)
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP consider using `.await` here
+        //~| SUGGESTION x.await
+    };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await-closure.rs
+++ b/src/test/ui/async-await/suggest-missing-await-closure.rs
@@ -1,0 +1,23 @@
+// edition:2018
+// run-rustfix
+
+#![feature(async_await, async_closure)]
+
+fn take_u32(_x: u32) {}
+
+async fn make_u32() -> u32 {
+    22
+}
+
+#[allow(unused)]
+async fn suggest_await_in_async_closure() {
+    async || {
+        let x = make_u32();
+        take_u32(x)
+        //~^ ERROR mismatched types [E0308]
+        //~| HELP consider using `.await` here
+        //~| SUGGESTION x.await
+    };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await-closure.stderr
+++ b/src/test/ui/async-await/suggest-missing-await-closure.stderr
@@ -1,0 +1,15 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-missing-await-closure.rs:16:18
+   |
+LL |         take_u32(x)
+   |                  ^
+   |                  |
+   |                  expected u32, found opaque type
+   |                  help: consider using `.await` here: `x.await`
+   |
+   = note: expected type `u32`
+              found type `impl std::future::Future`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/async-await/suggest-missing-await.fixed
+++ b/src/test/ui/async-await/suggest-missing-await.fixed
@@ -18,15 +18,4 @@ async fn suggest_await_in_async_fn() {
     //~| SUGGESTION x.await
 }
 
-#[allow(unused)]
-async fn suggest_await_in_async_closure() {
-    async || {
-        let x = make_u32();
-        take_u32(x.await)
-        //~^ ERROR mismatched types [E0308]
-        //~| HELP consider using `.await` here
-        //~| SUGGESTION x.await
-    };
-}
-
 fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await.rs
+++ b/src/test/ui/async-await/suggest-missing-await.rs
@@ -18,15 +18,4 @@ async fn suggest_await_in_async_fn() {
     //~| SUGGESTION x.await
 }
 
-#[allow(unused)]
-async fn suggest_await_in_async_closure() {
-    async || {
-        let x = make_u32();
-        take_u32(x)
-        //~^ ERROR mismatched types [E0308]
-        //~| HELP consider using `.await` here
-        //~| SUGGESTION x.await
-    };
-}
-
 fn main() {}

--- a/src/test/ui/async-await/suggest-missing-await.stderr
+++ b/src/test/ui/async-await/suggest-missing-await.stderr
@@ -10,18 +10,6 @@ LL |     take_u32(x)
    = note: expected type `u32`
               found type `impl std::future::Future`
 
-error[E0308]: mismatched types
-  --> $DIR/suggest-missing-await.rs:25:18
-   |
-LL |         take_u32(x)
-   |                  ^
-   |                  |
-   |                  expected u32, found opaque type
-   |                  help: consider using `.await` here: `x.await`
-   |
-   = note: expected type `u32`
-              found type `impl std::future::Future`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/feature-gates/feature-gate-async-await.rs
+++ b/src/test/ui/feature-gates/feature-gate-async-await.rs
@@ -15,5 +15,4 @@ async fn foo() {} //~ ERROR async fn is unstable
 
 fn main() {
     let _ = async {}; //~ ERROR async blocks are unstable
-    let _ = async || {}; //~ ERROR async closures are unstable
 }

--- a/src/test/ui/feature-gates/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await.stderr
@@ -40,15 +40,6 @@ LL |     let _ = async {};
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
    = help: add #![feature(async_await)] to the crate attributes to enable
 
-error[E0658]: async closures are unstable
-  --> $DIR/feature-gate-async-await.rs:18:13
-   |
-LL |     let _ = async || {};
-   |             ^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #61392 (Use a single CtxtInterners)
 - #62103 (Add debug assertions to write_bytes and copy*)
 - #62292 (Move `async || ...` closures into `#![feature(async_closure)]`)
 - #62324 (Reduce reliance on `await!(...)` macro)

Failed merges:


r? @ghost