### PR TITLE
Remove `compile-pass` from compiletest

### DIFF
--- a/src/librustc_mir/error_codes.rs
+++ b/src/librustc_mir/error_codes.rs
@@ -331,7 +331,7 @@ An if-let pattern attempts to match the pattern, and enters the body if the
 match was successful. If the match is irrefutable (when it cannot fail to
 match), use a regular `let`-binding instead. For instance:
 
-```compile_pass
+```
 struct Irrefutable(i32);
 let irr = Irrefutable(0);
 
@@ -360,7 +360,7 @@ A while-let pattern attempts to match the pattern, and enters the body if the
 match was successful. If the match is irrefutable (when it cannot fail to
 match), use a regular `let`-binding inside a `loop` instead. For instance:
 
-```compile_pass,no_run
+```no_run
 struct Irrefutable(i32);
 let irr = Irrefutable(0);
 

--- a/src/test/ui/async-await/async-closure-matches-expr.rs
+++ b/src/test/ui/async-await/async-closure-matches-expr.rs
@@ -1,4 +1,4 @@
-// compile-pass
+// build-pass
 // edition:2018
 
 #![feature(async_await, async_closure)]

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original-elided.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original-elided.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-pass
+// build-pass (FIXME(62277): could be check-pass?)
 // revisions: migrate mir
 //[mir]compile-flags: -Z borrowck=mir
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original-existential.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original-existential.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-pass
+// build-pass (FIXME(62277): could be check-pass?)
 // revisions: migrate mir
 //[mir]compile-flags: -Z borrowck=mir
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-original.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-pass
+// build-pass (FIXME(62277): could be check-pass?)
 // revisions: migrate mir
 //[mir]compile-flags: -Z borrowck=mir
 

--- a/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-other.rs
+++ b/src/test/ui/impl-trait/multiple-lifetimes/ordinary-bounds-pick-other.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// compile-pass
+// build-pass (FIXME(62277): could be check-pass?)
 // revisions: migrate mir
 //[mir]compile-flags: -Z borrowck=mir
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -591,9 +591,6 @@ impl TestProps {
         } else if config.parse_name_directive(ln, "build-pass") {
             check_no_run("build-pass");
             Some(PassMode::Build)
-        } else if config.parse_name_directive(ln, "compile-pass") /* compatibility */ {
-            check_no_run("compile-pass");
-            Some(PassMode::Build)
         } else if config.parse_name_directive(ln, "run-pass") {
             if config.mode != Mode::Ui && config.mode != Mode::RunPass /* compatibility */ {
                 panic!("`run-pass` header is only supported in UI tests")


### PR DESCRIPTION
This is a part of #62277.
Removes `compile-pass` from compiletest (and modify some tests' annotations).

r? @Centril 