### PR TITLE
Improve error span for async type inference error

### DIFF
--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -75,7 +75,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                 // If unresolved type isn't a ty_var then unresolved_type_span is None
                 self.fcx.need_type_info_err_in_generator(
                     self.kind,
-                    unresolved_type_span.unwrap_or(yield_data.span),
+                    unresolved_type_span.unwrap_or(source_span),
                     unresolved_type,
                 )
                     .span_note(yield_data.span, &*note)

--- a/src/test/ui/async-await/async-error-span.rs
+++ b/src/test/ui/async-await/async-error-span.rs
@@ -1,0 +1,17 @@
+// edition:2018
+#![feature(async_await)]
+
+// Regression test for issue #62382
+
+use std::future::Future;
+
+fn get_future() -> impl Future<Output = ()> {
+    panic!()
+}
+
+async fn foo() {
+    let a; //~ ERROR type inside `async` object must be known in this context
+    get_future().await;
+}
+
+fn main() {}

--- a/src/test/ui/async-await/async-error-span.stderr
+++ b/src/test/ui/async-await/async-error-span.stderr
@@ -1,0 +1,15 @@
+error[E0698]: type inside `async` object must be known in this context
+  --> $DIR/async-error-span.rs:13:9
+   |
+LL |     let a;
+   |         ^ cannot infer type
+   |
+note: the type is part of the `async` object because of this `await`
+  --> $DIR/async-error-span.rs:14:5
+   |
+LL |     get_future().await;
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0698`.


### PR DESCRIPTION
Fixes #62382

Previously, we would point at the spawn of the 'await' expression,
instead of the actual expression with an unknown type.