### PR TITLE
suggest return type for main()

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -521,7 +521,7 @@ pub enum FnDeclType {
     /// A return type can be suggested if the expected type implements
     /// `std::process::Termination`.
     MainItem,
-    /// A return type should not be suggested for ImplItems
+    /// A return type should not be suggested for `ImplItem`s.
     ImplItem,
 }
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3934,7 +3934,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 true
             }
             (&hir::FunctionRetTy::DefaultReturn(span), _, FnDeclType::ImplItem, true) => {
-                // do not suggest changing return type for trait impls
+                // Do not suggest changing return type for trait impls.
                 err.span_label(span, "expected `()` because of default return type");
                 true
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -515,7 +515,7 @@ impl<'tcx> EnclosingBreakables<'tcx> {
 /// This is returned by `get_node_fn_decl` to decide whether to suggest
 /// a return type.
 pub enum FnDeclType {
-    /// A return type can always be suggested, for all Items or TraitItems
+    /// A return type can always be suggested, for all `Item`s or `TraitItem`s
     /// but the program entry point.
     Item,
     /// A return type can be suggested if the expected type implements

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3741,8 +3741,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     /// Given a function `Node`, return its `FnDecl` if it exists, or `None` otherwise.
-    fn get_node_fn_decl(&self, node: Node<'tcx>)
-    -> Option<(&'tcx hir::FnDecl, ast::Ident, FnDeclType)> {
+    fn get_node_fn_decl(
+        &self,
+        node: Node<'tcx>
+    ) -> Option<(&'tcx hir::FnDecl, ast::Ident, FnDeclType)> {
         match node {
             Node::Item(&hir::Item {
                 ident, node: hir::ItemKind::Fn(ref decl, ..), ..

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -516,7 +516,7 @@ impl<'tcx> EnclosingBreakables<'tcx> {
 /// a return type.
 pub enum FnDeclType {
     /// A return type can always be suggested, for all Items or TraitItems
-    /// but the program entry point
+    /// but the program entry point.
     Item,
     /// A return type can be suggested if the expected type implements
     /// `std::process::Termination`

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3939,7 +3939,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 true
             }
             (&hir::FunctionRetTy::DefaultReturn(span), _, FnDeclType::MainItem, true) => {
-                // in main(), we can only return types that implement `std::process::Termination`
+                // In `fn main()`, we can only return types that implement `std::process::Termination`.
                 let ret_ty = self.resolve_type_vars_with_obligations(found);
                 let is_term = if let Some(term_id) = self.infcx.tcx.lang_items().termination() {
                     self.infcx.predicate_must_hold_modulo_regions(

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3961,7 +3961,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         format!("-> {} ", ret_ty),
                         Applicability::MachineApplicable);
                 } else {
-                    // `fn main()` must return `()`, do not suggest changing return type
+                    // `fn main()` must return `()`, so do not suggest changing return type.
                     err.span_label(span, "expected `()` because of default return type");
                 }
                 true

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -513,7 +513,7 @@ impl<'tcx> EnclosingBreakables<'tcx> {
 }
 
 /// This is returned by `get_node_fn_decl` to decide whether to suggest
-/// a return type
+/// a return type.
 pub enum FnDeclType {
     /// A return type can always be suggested, for all Items or TraitItems
     /// but the program entry point

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -519,7 +519,7 @@ pub enum FnDeclType {
     /// but the program entry point.
     Item,
     /// A return type can be suggested if the expected type implements
-    /// `std::process::Termination`
+    /// `std::process::Termination`.
     MainItem,
     /// A return type should not be suggested for ImplItems
     ImplItem,

--- a/src/test/ui/suggestions/missing_return_type.rs
+++ b/src/test/ui/suggestions/missing_return_type.rs
@@ -1,0 +1,7 @@
+use std::io::Write;
+
+fn main() {
+    let mut w = Vec::new();
+    write!(&mut w, "test")?;
+    Ok(())
+}

--- a/src/test/ui/suggestions/missing_return_type.stderr
+++ b/src/test/ui/suggestions/missing_return_type.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
+  --> $DIR/missing_return_type.rs:5:5
+   |
+LL |     write!(&mut w, "test")?;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::from_error`
+
+error[E0308]: mismatched types
+  --> $DIR/missing_return_type.rs:6:5
+   |
+LL | fn main() {
+   |           - expected `()` because of default return type
+...
+LL |     Ok(())
+   |     ^^^^^^- help: try adding a semicolon: `;`
+   |     |
+   |     expected (), found enum `std::result::Result`
+   |
+   = note: expected type `()`
+              found type `std::result::Result<(), _>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
This adds a suggestion for `main()` methods with default `()` return if the resulting expression has a type that implements `std::process::Termination`.

This fixes #61277.

r? @estebank 