### PR TITLE
Break out of the correct number of scopes in loops

### DIFF
--- a/src/test/ui/async-await/await-unsize.rs
+++ b/src/test/ui/async-await/await-unsize.rs
@@ -1,0 +1,16 @@
+// Regression test for #62312
+
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+async fn make_boxed_object() -> Box<dyn Send> {
+    Box::new(()) as _
+}
+
+async fn await_object() {
+    let _ = make_boxed_object().await;
+}
+
+fn main() {}

--- a/src/test/ui/loops/loop-break-unsize.rs
+++ b/src/test/ui/loops/loop-break-unsize.rs
@@ -1,0 +1,8 @@
+// Regression test for #62312
+// check-pass
+
+fn main() {
+    let _ = loop {
+        break Box::new(()) as Box<dyn Send>;
+    };
+}


### PR DESCRIPTION
We were incorrectly breaking out of one too many drop scopes when
generating MIR for loops and breakable blocks, resulting in use after
free and associated borrow checker warnings.

This wasn't noticed because the scope that we're breaking out of twice
is only used for temporaries that are created for adjustments applied to
the loop. Since loops generally propagate coercions to the `break`
expressions, the only case we see this is when the type of the loop is a
smart pointer to a trait object.

Closes #62312