### PR TITLE
Update minifier-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.0.30"
+version = "0.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "macro-utils 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3195,7 +3195,7 @@ dependencies = [
 name = "rustdoc"
 version = "0.0.0"
 dependencies = [
- "minifier 0.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "minifier 0.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-rayon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4442,7 +4442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
-"checksum minifier 0.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "4c909e78edf61f3aa0dd2086da168cdf304329044bbf248768ca3d20253ec8c0"
+"checksum minifier 0.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "70bf0db2475f5e627787da77ca52fe33c294063f49f4134b8bc662eedb5e7332"
 "checksum miniz-sys 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0300eafb20369952951699b68243ab4334f4b10a88f411c221d444b36c40e649"
 "checksum miniz_oxide 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ad30a47319c16cde58d0314f5d98202a80c9083b5f61178457403dfb14e509c"
 "checksum miniz_oxide_c_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28edaef377517fd9fe3e085c37d892ce7acd1fbeab9239c5a36eec352d8a8b7e"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 
 [dependencies]
 pulldown-cmark = { version = "0.5.3", default-features = false }
-minifier = "0.0.30"
+minifier = "0.0.33"
 rayon = { version = "0.2.0", package = "rustc-rayon" }
 tempfile = "3"
 parking_lot = "0.7"

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1322,13 +1322,13 @@ fn write_minify_replacer<W: Write>(
                  {
                     let tokens: Tokens<'_> = simple_minify(contents)
                         .into_iter()
-                        .filter(|f| {
+                        .filter(|(f, next)| {
                             // We keep backlines.
-                            minifier::js::clean_token_except(f, &|c: &Token<'_>| {
+                            minifier::js::clean_token_except(f, next, &|c: &Token<'_>| {
                                 c.get_char() != Some(ReservedChar::Backline)
                             })
                         })
-                        .map(|f| {
+                        .map(|(f, _)| {
                             minifier::js::replace_token_with(f, &|t: &Token<'_>| {
                                 match *t {
                                     Token::Keyword(Keyword::Null) => Some(Token::Other("N")),
@@ -1363,7 +1363,7 @@ fn write_minify_replacer<W: Write>(
                             // shouldn't be aggregated.
                             |tokens, pos| {
                                 pos < 2 ||
-                                !tokens[pos - 1].is_char(ReservedChar::OpenBracket) ||
+                                !tokens[pos - 1].eq_char(ReservedChar::OpenBracket) ||
                                 tokens[pos - 2].get_other() != Some("searchIndex")
                             }
                         )


### PR DESCRIPTION
The `main.js` file size goes from 52868 to 50134. A few fixes have been included as well (no more eluded parts of js files).

r? @QuietMisdreavus 