### PR TITLE
Fix pretty-printing of `$crate` (take 4)

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -758,7 +758,10 @@ impl<'a> Resolver<'a> {
     }
 
     pub fn macro_def_scope(&mut self, expansion: Mark) -> Module<'a> {
-        let def_id = self.macro_defs[&expansion];
+        let def_id = match self.macro_defs.get(&expansion) {
+            Some(def_id) => *def_id,
+            None => return self.graph_root,
+        };
         if let Some(id) = self.definitions.as_local_node_id(def_id) {
             self.local_macro_def_scopes[&id]
         } else if def_id.krate == CrateNum::BuiltinMacros {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -701,7 +701,7 @@ pub trait Resolver {
 
     fn get_module_scope(&mut self, id: ast::NodeId) -> Mark;
 
-    fn resolve_dollar_crates(&mut self, fragment: &AstFragment);
+    fn resolve_dollar_crates(&mut self);
     fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,
                                             derives: &[Mark]);
     fn add_builtin(&mut self, ident: ast::Ident, ext: Lrc<SyntaxExtension>);

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -429,7 +429,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     fn collect_invocations(&mut self, mut fragment: AstFragment, derives: &[Mark])
                            -> (AstFragment, Vec<Invocation>) {
         // Resolve `$crate`s in the fragment for pretty-printing.
-        self.cx.resolver.resolve_dollar_crates(&fragment);
+        self.cx.resolver.resolve_dollar_crates();
 
         let invocations = {
             let mut collector = InvocationCollector {

--- a/src/test/ui/proc-macro/auxiliary/dollar-crate-external.rs
+++ b/src/test/ui/proc-macro/auxiliary/dollar-crate-external.rs
@@ -14,3 +14,9 @@ macro_rules! external {
         struct D($crate::S);
     };
 }
+
+#[macro_export]
+macro_rules! issue_62325 { () => {
+    #[print_attr]
+    struct B(identity!($crate::S));
+}}

--- a/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( crate :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( crate :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
@@ -1,6 +1,7 @@
 // check-pass
 // edition:2018
 // aux-build:test-macros.rs
+// aux-build:dollar-crate-external.rs
 
 // Anonymize unstable non-dummy spans while still showing dummy spans `0..0`.
 // normalize-stdout-test "bytes\([^0]\w*\.\.(\w+)\)" -> "bytes(LO..$1)"
@@ -10,6 +11,7 @@
 
 #[macro_use]
 extern crate test_macros;
+extern crate dollar_crate_external;
 
 type S = u8;
 
@@ -19,5 +21,7 @@ macro_rules! m { () => {
 }}
 
 m!();
+
+dollar_crate_external::issue_62325!();
 
 fn main() {}

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
@@ -1,5 +1,4 @@
-//~ ERROR expected type, found `$`
-
+// check-pass
 // edition:2018
 // aux-build:test-macros.rs
 

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.rs
@@ -1,0 +1,24 @@
+//~ ERROR expected type, found `$`
+
+// edition:2018
+// aux-build:test-macros.rs
+
+// Anonymize unstable non-dummy spans while still showing dummy spans `0..0`.
+// normalize-stdout-test "bytes\([^0]\w*\.\.(\w+)\)" -> "bytes(LO..$1)"
+// normalize-stdout-test "bytes\((\w+)\.\.[^0]\w*\)" -> "bytes($1..HI)"
+
+#![feature(proc_macro_hygiene)]
+
+#[macro_use]
+extern crate test_macros;
+
+type S = u8;
+
+macro_rules! m { () => {
+    #[print_attr]
+    struct A(identity!($crate::S));
+}}
+
+m!();
+
+fn main() {}

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stderr
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stderr
@@ -1,4 +1,0 @@
-error: expected type, found `$`
-
-error: aborting due to previous error
-

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stderr
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stderr
@@ -1,0 +1,4 @@
+error: expected type, found `$`
+
+error: aborting due to previous error
+

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -1,61 +1,56 @@
-PRINT-ATTR INPUT (DISPLAY): struct A(identity!($crate :: S));
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( $ crate :: S ) ) ;
+PRINT-ATTR INPUT (DISPLAY): struct A(identity!(crate :: S));
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( crate :: S ) ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
-        span: #0 bytes(0..0),
+        span: #2 bytes(LO..HI),
     },
     Ident {
         ident: "A",
-        span: #0 bytes(0..0),
+        span: #2 bytes(LO..HI),
     },
     Group {
         delimiter: Parenthesis,
         stream: TokenStream [
             Ident {
                 ident: "identity",
-                span: #0 bytes(0..0),
+                span: #2 bytes(LO..HI),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: #0 bytes(0..0),
+                span: #2 bytes(LO..HI),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
-                    Punct {
-                        ch: '$',
-                        spacing: Alone,
-                        span: #0 bytes(0..0),
-                    },
                     Ident {
-                        ident: "crate",
-                        span: #0 bytes(0..0),
+                        ident: "$crate",
+                        span: #2 bytes(LO..HI),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: #0 bytes(0..0),
+                        span: #2 bytes(LO..HI),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: #0 bytes(0..0),
+                        span: #2 bytes(LO..HI),
                     },
                     Ident {
                         ident: "S",
-                        span: #0 bytes(0..0),
+                        span: #2 bytes(LO..HI),
                     },
                 ],
-                span: #0 bytes(0..0),
+                span: #2 bytes(LO..HI),
             },
         ],
-        span: #0 bytes(0..0),
+        span: #2 bytes(LO..HI),
     },
     Punct {
         ch: ';',
         spacing: Alone,
-        span: #0 bytes(0..0),
+        span: #2 bytes(LO..HI),
     },
 ]

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -54,3 +54,59 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         span: #2 bytes(LO..HI),
     },
 ]
+PRINT-ATTR INPUT (DISPLAY): struct B(identity!(::dollar_crate_external :: S));
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct B ( identity ! ( ::dollar_crate_external :: S ) ) ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: #7 bytes(LO..HI),
+    },
+    Ident {
+        ident: "B",
+        span: #7 bytes(LO..HI),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Ident {
+                ident: "identity",
+                span: #7 bytes(LO..HI),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: #7 bytes(LO..HI),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Ident {
+                        ident: "$crate",
+                        span: #7 bytes(LO..HI),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Joint,
+                        span: #7 bytes(LO..HI),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Alone,
+                        span: #7 bytes(LO..HI),
+                    },
+                    Ident {
+                        ident: "S",
+                        span: #7 bytes(LO..HI),
+                    },
+                ],
+                span: #7 bytes(LO..HI),
+            },
+        ],
+        span: #7 bytes(LO..HI),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: #7 bytes(LO..HI),
+    },
+]

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -1,0 +1,61 @@
+PRINT-ATTR INPUT (DISPLAY): struct A(identity!($crate :: S));
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( $ crate :: S ) ) ;
+PRINT-ATTR INPUT (DEBUG): TokenStream [
+    Ident {
+        ident: "struct",
+        span: #0 bytes(0..0),
+    },
+    Ident {
+        ident: "A",
+        span: #0 bytes(0..0),
+    },
+    Group {
+        delimiter: Parenthesis,
+        stream: TokenStream [
+            Ident {
+                ident: "identity",
+                span: #0 bytes(0..0),
+            },
+            Punct {
+                ch: '!',
+                spacing: Alone,
+                span: #0 bytes(0..0),
+            },
+            Group {
+                delimiter: Parenthesis,
+                stream: TokenStream [
+                    Punct {
+                        ch: '$',
+                        spacing: Alone,
+                        span: #0 bytes(0..0),
+                    },
+                    Ident {
+                        ident: "crate",
+                        span: #0 bytes(0..0),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Joint,
+                        span: #0 bytes(0..0),
+                    },
+                    Punct {
+                        ch: ':',
+                        spacing: Alone,
+                        span: #0 bytes(0..0),
+                    },
+                    Ident {
+                        ident: "S",
+                        span: #0 bytes(0..0),
+                    },
+                ],
+                span: #0 bytes(0..0),
+            },
+        ],
+        span: #0 bytes(0..0),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: #0 bytes(0..0),
+    },
+]

--- a/src/test/ui/proc-macro/dollar-crate.stdout
+++ b/src/test/ui/proc-macro/dollar-crate.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( crate :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( crate :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -80,7 +80,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(crate::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( crate :: S ) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -120,7 +120,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #2 bytes(LO..HI),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( ::dollar_crate_external :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -161,7 +161,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(::dollar_crate_external::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( ::dollar_crate_external :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -202,7 +202,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(::dollar_crate_external::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( ::dollar_crate_external :: S ) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",


### PR DESCRIPTION
Pretty-print `$crate` as `crate` or `crate_name` in unstructured tokens like `a $crate c` in `foo!(a $crate c)`, but only if those tokens are printed as a part of AST pretty-printing, rather than as a standalone token stream.

Fixes https://github.com/rust-lang/rust/issues/62325
Previous iterations - https://github.com/rust-lang/rust/pull/56647, https://github.com/rust-lang/rust/pull/57155, https://github.com/rust-lang/rust/pull/57915.