### PR TITLE
remove Scalar::is_null_ptr

### DIFF
--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -276,17 +276,6 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     #[inline]
-    pub fn is_null_ptr(self, cx: &impl HasDataLayout) -> bool {
-        match self {
-            Scalar::Raw { data, size } => {
-                assert_eq!(size as u64, cx.data_layout().pointer_size.bytes());
-                data == 0
-            },
-            Scalar::Ptr(_) => false,
-        }
-    }
-
-    #[inline]
     pub fn from_bool(b: bool) -> Self {
         Scalar::Raw { data: b as u128, size: 1 }
     }


### PR DESCRIPTION
Comparing pointers should be done more carefully than that. With https://github.com/rust-lang/miri/pull/825, Miri does not need it any more and it is otherwise unused.