### PR TITLE
Remove never_type feature requirement for exhaustive patterns

### DIFF
--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -161,7 +161,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             PatternKind::Variant { adt_def, substs, variant_index, ref subpatterns } => {
                 let irrefutable = adt_def.variants.iter_enumerated().all(|(i, v)| {
                     i == variant_index || {
-                        self.hir.tcx().features().never_type &&
                         self.hir.tcx().features().exhaustive_patterns &&
                         !v.uninhabited_from(self.hir.tcx(), substs, adt_def.adt_kind()).is_empty()
                     }

--- a/src/test/ui/uninhabited/exhaustive-wo-nevertype-issue-51221.rs
+++ b/src/test/ui/uninhabited/exhaustive-wo-nevertype-issue-51221.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(exhaustive_patterns)]
+
+enum Void {}
+fn main() {
+    let a: Option<Void> = None;
+    let None = a;
+}


### PR DESCRIPTION
I **think** this resolves #51221
At least for me, it doesn't ICE anymore and all tests are still passing, so LGTM 