### PR TITLE
Fix build with llvm-libunwind

### DIFF
--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -4,11 +4,13 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
 
-    if cfg!(feature = "llvm-libunwind") &&
+    // FIXME: the not(bootstrap) part is needed because of the issue addressed by #62286,
+    // and could be removed once that change is in beta.
+    if cfg!(all(not(bootstrap), feature = "llvm-libunwind")) &&
         (target.contains("linux") ||
          target.contains("fuchsia")) {
         // Build the unwinding from libunwind C/C++ source code.
-        #[cfg(feature = "llvm-libunwind")]
+        #[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
         llvm_libunwind::compile();
     } else if target.contains("linux") {
         if target.contains("musl") {
@@ -42,7 +44,7 @@ fn main() {
     }
 }
 
-#[cfg(feature = "llvm-libunwind")]
+#[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
 mod llvm_libunwind {
     use std::env;
     use std::path::Path;

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -67,7 +67,7 @@ pub enum _Unwind_Context {}
 
 pub type _Unwind_Exception_Cleanup_Fn = extern "C" fn(unwind_code: _Unwind_Reason_Code,
                                                       exception: *mut _Unwind_Exception);
-#[cfg_attr(feature = "llvm-libunwind",
+#[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
            link(name = "unwind", kind = "static"))]
 extern "C" {
     #[unwind(allowed)]
@@ -93,7 +93,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     }
     pub use _Unwind_Action::*;
 
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;
@@ -148,7 +148,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;
 
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         fn _Unwind_VRS_Get(ctx: *mut _Unwind_Context,
@@ -212,7 +212,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
 cfg_if::cfg_if! {
 if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     // Not 32-bit iOS
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]
@@ -223,7 +223,7 @@ if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     }
 } else {
     // 32-bit iOS uses SjLj and does not provide _Unwind_Backtrace()
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind"),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]


### PR DESCRIPTION
This was broken by #62376
Since #62286 is not in beta yet, we cannot remove those not(bootstrap)