### PR TITLE
normalize use of backticks/lowercase in compiler messages for librustc_mir

### DIFF
--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1465,7 +1465,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .map(|b| GuardFrameLocal::new(b.var_id, b.binding_mode))
                     .collect(),
             };
-            debug!("Entering guard building context: {:?}", guard_frame);
+            debug!("entering guard building context: {:?}", guard_frame);
             self.guard_context.push(guard_frame);
 
             let re_erased = tcx.lifetimes.re_erased;

--- a/src/librustc_mir/hair/pattern/check_match.rs
+++ b/src/librustc_mir/hair/pattern/check_match.rs
@@ -577,7 +577,7 @@ fn check_legality_of_move_bindings(
                                            "cannot bind by-move into a pattern guard");
             err.span_label(p.span, "moves value into pattern guard");
             if cx.tcx.sess.opts.unstable_features.is_nightly_build() {
-                err.help("add #![feature(bind_by_move_pattern_guards)] to the \
+                err.help("add `#![feature(bind_by_move_pattern_guards)]` to the \
                           crate attributes to enable");
             }
             err.emit();
@@ -664,7 +664,7 @@ impl<'a, 'tcx> Delegate<'tcx> for MutationChecker<'a, 'tcx> {
                           "cannot mutably borrow in a pattern guard");
                 err.span_label(span, "borrowed mutably in pattern guard");
                 if self.cx.tcx.sess.opts.unstable_features.is_nightly_build() {
-                    err.help("add #![feature(bind_by_move_pattern_guards)] to the \
+                    err.help("add `#![feature(bind_by_move_pattern_guards)]` to the \
                               crate attributes to enable");
                 }
                 err.emit();

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -351,7 +351,7 @@ where
                 if field >= len {
                     // This can be violated because this runs during promotion on code where the
                     // type system has not yet ensured that such things don't happen.
-                    debug!("Tried to access element {} of array/slice with length {}", field, len);
+                    debug!("tried to access element {} of array/slice with length {}", field, len);
                     return err!(BoundsCheck { len, index: field });
                 }
                 stride * field

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -289,7 +289,7 @@ pub fn collect_crate_mono_items(
         collect_roots(tcx, mode)
     });
 
-    debug!("Building mono item graph, beginning at roots");
+    debug!("building mono item graph, beginning at roots");
 
     let mut visited = MTLock::new(FxHashSet::default());
     let mut inlining_map = MTLock::new(InliningMap::new());
@@ -316,7 +316,7 @@ pub fn collect_crate_mono_items(
 // Find all non-generic items by walking the HIR. These items serve as roots to
 // start monomorphizing from.
 fn collect_roots(tcx: TyCtxt<'_>, mode: MonoItemCollectionMode) -> Vec<MonoItem<'_>> {
-    debug!("Collecting roots");
+    debug!("collecting roots");
     let mut roots = Vec::new();
 
     {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -552,10 +552,10 @@ fn unsafe_derive_on_repr_packed(tcx: TyCtxt<'_>, def_id: DefId) {
     // FIXME: when we make this a hard error, this should have its
     // own error code.
     let message = if tcx.generics_of(def_id).own_requires_monomorphization() {
-        "#[derive] can't be used on a #[repr(packed)] struct with \
+        "`#[derive]` can't be used on a `#[repr(packed)]` struct with \
          type or const parameters (error E0133)".to_string()
     } else {
-        "#[derive] can't be used on a #[repr(packed)] struct that \
+        "`#[derive]` can't be used on a `#[repr(packed)]` struct that \
          does not derive Copy (error E0133)".to_string()
     };
     tcx.lint_hir(SAFE_PACKED_BORROWS,

--- a/src/librustc_mir/transform/copy_prop.rs
+++ b/src/librustc_mir/transform/copy_prop.rs
@@ -47,7 +47,7 @@ impl MirPass for CopyPropagation {
 
             let mut changed = false;
             for dest_local in body.local_decls.indices() {
-                debug!("Considering destination local: {:?}", dest_local);
+                debug!("considering destination local: {:?}", dest_local);
 
                 let action;
                 let location;
@@ -159,7 +159,7 @@ fn eliminate_self_assignments(
             } else {
                 continue;
             }
-            debug!("Deleting a self-assignment for {:?}", dest_local);
+            debug!("deleting a self-assignment for {:?}", dest_local);
             body.make_statement_nop(location);
             changed = true;
         }

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -159,7 +159,7 @@ impl Inliner<'tcx> {
 
         // Simplify if we inlined anything.
         if changed {
-            debug!("Running simplify cfg on {:?}", self.source);
+            debug!("running simplify cfg on {:?}", self.source);
             CfgSimplifier::new(caller_body).simplify();
             remove_dead_blocks(caller_body);
         }
@@ -247,7 +247,7 @@ impl Inliner<'tcx> {
             // need to check for first.
             attr::InlineAttr::Always => true,
             attr::InlineAttr::Never => {
-                debug!("#[inline(never)] present - not inlining");
+                debug!("`#[inline(never)]` present - not inlining");
                 return false
             }
             attr::InlineAttr::Hint => true,
@@ -397,7 +397,7 @@ impl Inliner<'tcx> {
         match terminator.kind {
             // FIXME: Handle inlining of diverging calls
             TerminatorKind::Call { args, destination: Some(destination), cleanup, .. } => {
-                debug!("Inlined {:?} into {:?}", callsite.callee, self.source);
+                debug!("inlined {:?} into {:?}", callsite.callee, self.source);
 
                 let mut local_map = IndexVec::with_capacity(callee_body.local_decls.len());
                 let mut scope_map = IndexVec::with_capacity(callee_body.source_scopes.len());
@@ -456,7 +456,7 @@ impl Inliner<'tcx> {
                 }
 
                 let dest = if dest_needs_borrow(&destination.0) {
-                    debug!("Creating temp for return destination");
+                    debug!("creating temp for return destination");
                     let dest = Rvalue::Ref(
                         self.tcx.lifetimes.re_erased,
                         BorrowKind::Mut { allow_two_phase_borrow: false },
@@ -610,7 +610,7 @@ impl Inliner<'tcx> {
             }
         }
 
-        debug!("Creating temp for argument {:?}", arg);
+        debug!("creating temp for argument {:?}", arg);
         // Otherwise, create a temporary for the arg
         let arg = Rvalue::Use(arg);
 
@@ -659,7 +659,7 @@ struct Integrator<'a, 'tcx> {
 impl<'a, 'tcx> Integrator<'a, 'tcx> {
     fn update_target(&self, tgt: BasicBlock) -> BasicBlock {
         let new = BasicBlock::new(tgt.index() + self.block_idx);
-        debug!("Updating target `{:?}`, new: `{:?}`", tgt, new);
+        debug!("updating target `{:?}`, new: `{:?}`", tgt, new);
         new
     }
 }

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -39,7 +39,7 @@ pub struct InstCombineVisitor<'tcx> {
 impl<'tcx> MutVisitor<'tcx> for InstCombineVisitor<'tcx> {
     fn visit_rvalue(&mut self, rvalue: &mut Rvalue<'tcx>, location: Location) {
         if self.optimizations.and_stars.remove(&location) {
-            debug!("Replacing `&*`: {:?}", rvalue);
+            debug!("replacing `&*`: {:?}", rvalue);
             let new_place = match *rvalue {
                 Rvalue::Ref(_, _, Place::Projection(ref mut projection)) => {
                     // Replace with dummy
@@ -51,7 +51,7 @@ impl<'tcx> MutVisitor<'tcx> for InstCombineVisitor<'tcx> {
         }
 
         if let Some(constant) = self.optimizations.arrays_lengths.remove(&location) {
-            debug!("Replacing `Len([_; N])`: {:?}", rvalue);
+            debug!("replacing `Len([_; N])`: {:?}", rvalue);
             *rvalue = Rvalue::Use(Operand::Constant(box constant));
         }
 

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1545,7 +1545,7 @@ impl MirPass for QualifyAndPromoteConstants {
                             diag.note("for more information, see issue \
                                        https://github.com/rust-lang/rust/issues/57563");
                             diag.help(
-                                "add #![feature(const_fn)] to the crate attributes to enable",
+                                "add `#![feature(const_fn)]` to the crate attributes to enable",
                             );
                             diag.emit();
                         } else {

--- a/src/test/ui/bind-by-move/bind-by-move-no-guards.stderr
+++ b/src/test/ui/bind-by-move/bind-by-move-no-guards.stderr
@@ -4,7 +4,7 @@ error[E0008]: cannot bind by-move into a pattern guard
 LL |         Some(z) if z.recv().unwrap() => { panic!() },
    |              ^ moves value into pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-mutate-in-guard.nll.stderr
+++ b/src/test/ui/borrowck/borrowck-mutate-in-guard.nll.stderr
@@ -10,7 +10,7 @@ error[E0301]: cannot mutably borrow in a pattern guard
 LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
    |                                      ^ borrowed mutably in pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error[E0302]: cannot assign in a pattern guard
   --> $DIR/borrowck-mutate-in-guard.rs:15:41

--- a/src/test/ui/borrowck/borrowck-mutate-in-guard.stderr
+++ b/src/test/ui/borrowck/borrowck-mutate-in-guard.stderr
@@ -10,7 +10,7 @@ error[E0301]: cannot mutably borrow in a pattern guard
 LL |         Enum::A(_) if { let y = &mut x; *y = Enum::B(false); false } => 1,
    |                                      ^ borrowed mutably in pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error[E0302]: cannot assign in a pattern guard
   --> $DIR/borrowck-mutate-in-guard.rs:15:41

--- a/src/test/ui/consts/const_let_refutable.nll.stderr
+++ b/src/test/ui/consts/const_let_refutable.nll.stderr
@@ -11,7 +11,7 @@ LL |     a + b
    |     ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0381]: use of possibly uninitialized variable: `a`
   --> $DIR/const_let_refutable.rs:4:5

--- a/src/test/ui/consts/const_let_refutable.stderr
+++ b/src/test/ui/consts/const_let_refutable.stderr
@@ -11,7 +11,7 @@ LL |     a + b
    |     ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 warning[E0381]: use of possibly uninitialized variable: `a`
   --> $DIR/const_let_refutable.rs:4:5

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -5,7 +5,7 @@ LL | const fn error(_: fn()) {}
    |                ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -5,7 +5,7 @@ LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/consts/min_const_fn/cast_errors.stderr
+++ b/src/test/ui/consts/min_const_fn/cast_errors.stderr
@@ -5,7 +5,7 @@ LL | const fn unsize(x: &[u8; 3]) -> &[u8] { x }
    |                                         ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:5:23
@@ -14,7 +14,7 @@ LL | const fn closure() -> fn() { || {} }
    |                       ^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:8:5
@@ -23,7 +23,7 @@ LL |     (|| {}) as fn();
    |     ^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:11:28
@@ -32,7 +32,7 @@ LL | const fn reify(f: fn()) -> unsafe fn() { f }
    |                            ^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/cast_errors.rs:13:21
@@ -41,7 +41,7 @@ LL | const fn reify2() { main as unsafe fn(); }
    |                     ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
+++ b/src/test/ui/consts/min_const_fn/cmp_fn_pointers.stderr
@@ -5,7 +5,7 @@ LL | const fn cmp(x: fn(), y: fn()) -> bool {
    |              ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/min_const_fn/loop_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/loop_ice.stderr
@@ -5,7 +5,7 @@ LL |     loop {}
    |     ^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.nll.stderr
@@ -11,7 +11,7 @@ LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -26,7 +26,7 @@ LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -41,7 +41,7 @@ LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:58:39
@@ -50,7 +50,7 @@ LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:76:16
@@ -59,7 +59,7 @@ LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:78:18
@@ -68,7 +68,7 @@ LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:80:33
@@ -77,7 +77,7 @@ LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:82:35
@@ -86,7 +86,7 @@ LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int and `bool` operations are stable in const fn
   --> $DIR/min_const_fn.rs:84:35
@@ -95,7 +95,7 @@ LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:86:43
@@ -104,7 +104,7 @@ LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:90:27
@@ -113,7 +113,7 @@ LL | const fn foo25() -> u32 { BAR }
    |                           ^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:91:36
@@ -122,7 +122,7 @@ LL | const fn foo26() -> &'static u32 { &BAR }
    |                                    ^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:92:42
@@ -131,7 +131,7 @@ LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:94:63
@@ -140,7 +140,7 @@ LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } 
    |                                                               ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:96:42
@@ -149,7 +149,7 @@ LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:98:63
@@ -158,7 +158,7 @@ LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } 
    |                                                               ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:100:38
@@ -167,7 +167,7 @@ LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops are not allowed in const fn
   --> $DIR/min_const_fn.rs:102:29
@@ -176,7 +176,7 @@ LL | const fn foo30_5(b: bool) { while b { } }
    |                             ^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:105:44
@@ -185,7 +185,7 @@ LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:107:44
@@ -194,7 +194,7 @@ LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:109:14
@@ -203,7 +203,7 @@ LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:114:6
@@ -212,7 +212,7 @@ LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:119:6
@@ -221,7 +221,7 @@ LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:124:6
@@ -230,7 +230,7 @@ LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:130:24
@@ -239,7 +239,7 @@ LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:132:34
@@ -248,7 +248,7 @@ LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:134:22
@@ -257,7 +257,7 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:135:23
@@ -266,7 +266,7 @@ LL | const fn no_rpit() -> impl std::fmt::Debug {}
    |                       ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:136:23
@@ -275,7 +275,7 @@ LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:137:32
@@ -284,7 +284,7 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0515]: cannot return reference to temporary value
   --> $DIR/min_const_fn.rs:137:63
@@ -302,7 +302,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:148:21
@@ -311,7 +311,7 @@ LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:150:27
@@ -320,7 +320,7 @@ LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 37 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -11,7 +11,7 @@ LL |     const fn get_mut(&mut self) -> &mut T { &mut self.0 }
    |                                    ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:44:28
@@ -26,7 +26,7 @@ LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
    |                                          ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:51:27
@@ -41,7 +41,7 @@ LL |     const fn get_mut_s(&mut self) -> &mut T { &mut self.0 }
    |                                      ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:58:39
@@ -50,7 +50,7 @@ LL |     const fn get_mut_sq(&mut self) -> &mut T { &mut self.0 }
    |                                       ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:76:16
@@ -59,7 +59,7 @@ LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:78:18
@@ -68,7 +68,7 @@ LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:80:33
@@ -77,7 +77,7 @@ LL | const fn foo19(f: f32) -> f32 { f * 2.0 }
    |                                 ^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:82:35
@@ -86,7 +86,7 @@ LL | const fn foo19_2(f: f32) -> f32 { 2.0 - f }
    |                                   ^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int and `bool` operations are stable in const fn
   --> $DIR/min_const_fn.rs:84:35
@@ -95,7 +95,7 @@ LL | const fn foo19_3(f: f32) -> f32 { -f }
    |                                   ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn.rs:86:43
@@ -104,7 +104,7 @@ LL | const fn foo19_4(f: f32, g: f32) -> f32 { f / g }
    |                                           ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:90:27
@@ -113,7 +113,7 @@ LL | const fn foo25() -> u32 { BAR }
    |                           ^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: cannot access `static` items in const fn
   --> $DIR/min_const_fn.rs:91:36
@@ -122,7 +122,7 @@ LL | const fn foo26() -> &'static u32 { &BAR }
    |                                    ^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:92:42
@@ -131,7 +131,7 @@ LL | const fn foo30(x: *const u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:94:63
@@ -140,7 +140,7 @@ LL | const fn foo30_with_unsafe(x: *const u32) -> usize { unsafe { x as usize } 
    |                                                               ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:96:42
@@ -149,7 +149,7 @@ LL | const fn foo30_2(x: *mut u32) -> usize { x as usize }
    |                                          ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: casting pointers to ints is unstable in const fn
   --> $DIR/min_const_fn.rs:98:63
@@ -158,7 +158,7 @@ LL | const fn foo30_2_with_unsafe(x: *mut u32) -> usize { unsafe { x as usize } 
    |                                                               ^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:100:38
@@ -167,7 +167,7 @@ LL | const fn foo30_4(b: bool) -> usize { if b { 1 } else { 42 } }
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops are not allowed in const fn
   --> $DIR/min_const_fn.rs:102:29
@@ -176,7 +176,7 @@ LL | const fn foo30_5(b: bool) { while b { } }
    |                             ^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:105:44
@@ -185,7 +185,7 @@ LL | const fn foo36(a: bool, b: bool) -> bool { a && b }
    |                                            ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: loops and conditional expressions are not stable in const fn
   --> $DIR/min_const_fn.rs:107:44
@@ -194,7 +194,7 @@ LL | const fn foo37(a: bool, b: bool) -> bool { a || b }
    |                                            ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/min_const_fn.rs:109:14
@@ -203,7 +203,7 @@ LL | const fn inc(x: &mut i32) { *x += 1 }
    |              ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:114:6
@@ -212,7 +212,7 @@ LL | impl<T: std::fmt::Debug> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:119:6
@@ -221,7 +221,7 @@ LL | impl<T: std::fmt::Debug + Sized> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:124:6
@@ -230,7 +230,7 @@ LL | impl<T: Sync + Sized> Foo<T> {
    |      ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:130:24
@@ -239,7 +239,7 @@ LL | const fn no_rpit2() -> AlanTuring<impl std::fmt::Debug> { AlanTuring(0) }
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:132:34
@@ -248,7 +248,7 @@ LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:134:22
@@ -257,7 +257,7 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: `impl Trait` in const fn is unstable
   --> $DIR/min_const_fn.rs:135:23
@@ -266,7 +266,7 @@ LL | const fn no_rpit() -> impl std::fmt::Debug {}
    |                       ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:136:23
@@ -275,7 +275,7 @@ LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn.rs:137:32
@@ -284,7 +284,7 @@ LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 warning[E0515]: cannot return reference to temporary value
   --> $DIR/min_const_fn.rs:137:63
@@ -306,7 +306,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:148:21
@@ -315,7 +315,7 @@ LL | const fn no_fn_ptrs(_x: fn()) {}
    |                     ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn.rs:150:27
@@ -324,7 +324,7 @@ LL | const fn no_fn_ptrs2() -> fn() { fn foo() {} foo }
    |                           ^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 36 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.nll.stderr
@@ -5,7 +5,7 @@ LL |     x.0.field;
    |     ^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn_dyn.rs:12:66
@@ -14,7 +14,7 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/min_const_fn_dyn.rs:12:67

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -5,7 +5,7 @@ LL |     x.0.field;
    |     ^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: trait bounds other than `Sized` on const fn parameters are unstable
   --> $DIR/min_const_fn_dyn.rs:12:66
@@ -14,7 +14,7 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    |                                                                  ^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 warning[E0716]: temporary value dropped while borrowed
   --> $DIR/min_const_fn_dyn.rs:12:67

--- a/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_fn_ptr.stderr
@@ -5,7 +5,7 @@ LL |     x.0.field;
    |     ^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: function pointers in const fn are unstable
   --> $DIR/min_const_fn_fn_ptr.rs:14:59
@@ -14,7 +14,7 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasPtr { field }) }
    |                                                           ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -5,7 +5,7 @@ LL | const fn bar() -> u32 { foo() }
    |                         ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_fn_libstd_stability.rs:22:26
@@ -14,7 +14,7 @@ LL | const fn bar2() -> u32 { foo2() }
    |                          ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_fn_libstd_stability.rs:26:26
@@ -23,7 +23,7 @@ LL | const fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                          ^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_fn_libstd_stability.rs:34:32
@@ -32,7 +32,7 @@ LL | const fn bar2_gated() -> u32 { foo2_gated() }
    |                                ^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.stderr
@@ -5,7 +5,7 @@ LL | const unsafe fn bar() -> u32 { unsafe { foo() } }
    |                                         ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:22:42
@@ -14,7 +14,7 @@ LL | const unsafe fn bar2() -> u32 { unsafe { foo2() } }
    |                                          ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: only int, `bool` and `char` operations are stable in const fn
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:26:33
@@ -23,7 +23,7 @@ LL | const unsafe fn bar3() -> u32 { (5f32 + 6f32) as u32 }
    |                                 ^^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability.rs:34:48
@@ -32,7 +32,7 @@ LL | const unsafe fn bar2_gated() -> u32 { unsafe { foo2_gated() } }
    |                                                ^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.stderr
@@ -5,7 +5,7 @@ LL | const unsafe fn bar() -> u32 { foo() }
    |                                ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:22:33
@@ -14,7 +14,7 @@ LL | const unsafe fn bar2() -> u32 { foo2() }
    |                                 ^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: can only call other `const fn` within a `const fn`, but `const foo2_gated` is not stable as `const fn`
   --> $DIR/min_const_unsafe_fn_libstd_stability2.rs:30:39
@@ -23,7 +23,7 @@ LL | const unsafe fn bar2_gated() -> u32 { foo2_gated() }
    |                                       ^^^^^^^^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
+++ b/src/test/ui/consts/min_const_fn/mutable_borrow.stderr
@@ -5,7 +5,7 @@ LL |     let b = &mut a;
    |         ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/mutable_borrow.rs:12:13
@@ -14,7 +14,7 @@ LL |         let b = &mut a;
    |             ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/single_variant_match_ice.stderr
+++ b/src/test/ui/consts/single_variant_match_ice.stderr
@@ -17,7 +17,7 @@ LL |         match *self {
    |               ^^^^^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/derives/deriving-with-repr-packed.rs
+++ b/src/test/ui/derives/deriving-with-repr-packed.rs
@@ -6,15 +6,15 @@
 // not be aligned.
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-//~^ ERROR #[derive] can't be used
+//~^ ERROR `#[derive]` can't be used
 //~| hard error
-//~^^^ ERROR #[derive] can't be used
+//~^^^ ERROR `#[derive]` can't be used
 //~| hard error
 #[repr(packed)]
 pub struct Foo<T>(T, T, T);
 
 #[derive(PartialEq, Eq)]
-//~^ ERROR #[derive] can't be used
+//~^ ERROR `#[derive]` can't be used
 //~| hard error
 #[repr(packed)]
 pub struct Bar(u32, u32, u32);
@@ -23,7 +23,7 @@ pub struct Bar(u32, u32, u32);
 struct Y(usize);
 
 #[derive(PartialEq)]
-//~^ ERROR #[derive] can't be used
+//~^ ERROR `#[derive]` can't be used
 //~| hard error
 #[repr(packed)]
 struct X(Y);

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -1,4 +1,4 @@
-error: #[derive] can't be used on a #[repr(packed)] struct with type or const parameters (error E0133)
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or const parameters (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:8:16
    |
 LL | #[derive(Copy, Clone, PartialEq, Eq)]
@@ -12,7 +12,7 @@ LL | #![deny(safe_packed_borrows)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
-error: #[derive] can't be used on a #[repr(packed)] struct with type or const parameters (error E0133)
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or const parameters (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:8:23
    |
 LL | #[derive(Copy, Clone, PartialEq, Eq)]
@@ -21,7 +21,7 @@ LL | #[derive(Copy, Clone, PartialEq, Eq)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
-error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:16:10
    |
 LL | #[derive(PartialEq, Eq)]
@@ -30,7 +30,7 @@ LL | #[derive(PartialEq, Eq)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 
-error: #[derive] can't be used on a #[repr(packed)] struct that does not derive Copy (error E0133)
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
   --> $DIR/deriving-with-repr-packed.rs:25:10
    |
 LL | #[derive(PartialEq)]

--- a/src/test/ui/error-codes/E0008.stderr
+++ b/src/test/ui/error-codes/E0008.stderr
@@ -4,7 +4,7 @@ error[E0008]: cannot bind by-move into a pattern guard
 LL |         Some(s) if s.len() == 0 => {},
    |              ^ moves value into pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0301.stderr
+++ b/src/test/ui/error-codes/E0301.stderr
@@ -4,7 +4,7 @@ error[E0301]: cannot mutably borrow in a pattern guard
 LL |         option if option.take().is_none() => {},
    |                   ^^^^^^ borrowed mutably in pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error[E0596]: cannot borrow `option` as mutable, as it is immutable for the pattern guard
   --> $DIR/E0301.rs:4:19

--- a/src/test/ui/issues/issue-37550.stderr
+++ b/src/test/ui/issues/issue-37550.stderr
@@ -5,7 +5,7 @@ LL |     let x = || t;
    |         ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-0107-bind-by-move-pattern-guards/feature-gate.no_gate.stderr
+++ b/src/test/ui/rfc-0107-bind-by-move-pattern-guards/feature-gate.no_gate.stderr
@@ -4,7 +4,7 @@ error[E0008]: cannot bind by-move into a pattern guard
 LL |         A { a: v } if *v == 42 => v,
    |                ^ moves value into pattern guard
    |
-   = help: add #![feature(bind_by_move_pattern_guards)] to the crate attributes to enable
+   = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsafe/ranged_ints2_const.stderr
+++ b/src/test/ui/unsafe/ranged_ints2_const.stderr
@@ -5,7 +5,7 @@ LL |     let y = &mut x.0;
    |         ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0723]: mutable references in const fn are unstable
   --> $DIR/ranged_ints2_const.rs:18:9
@@ -14,7 +14,7 @@ LL |     let y = unsafe { &mut x.0 };
    |         ^
    |
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0133]: mutation of layout constrained field is unsafe and requires unsafe function or block
   --> $DIR/ranged_ints2_const.rs:11:13


### PR DESCRIPTION
normalize use of backticks/lowercase in compiler messages for librustc_mir

https://github.com/rust-lang/rust/issues/60532

r? @alexreg