### PR TITLE
rustbuild: Cleanup global lint settings

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -91,17 +91,16 @@ fn main() {
     cmd.args(&args)
         .env(bootstrap::util::dylib_path_var(),
              env::join_paths(&dylib_path).unwrap());
-    let mut maybe_crate = None;
 
     // Get the name of the crate we're compiling, if any.
-    let maybe_crate_name = args.windows(2)
-        .find(|a| &*a[0] == "--crate-name")
-        .map(|crate_name| &*crate_name[1]);
+    let crate_name = args.windows(2)
+        .find(|args| args[0] == "--crate-name")
+        .and_then(|args| args[1].to_str());
 
-    if let Some(current_crate) = maybe_crate_name {
+    if let Some(crate_name) = crate_name {
         if let Some(target) = env::var_os("RUSTC_TIME") {
             if target == "all" ||
-               target.into_string().unwrap().split(",").any(|c| c.trim() == current_crate)
+               target.into_string().unwrap().split(",").any(|c| c.trim() == crate_name)
             {
                 cmd.arg("-Ztime");
             }
@@ -123,6 +122,17 @@ fn main() {
 
     if let Ok(debuginfo_level) = env::var("RUSTC_DEBUGINFO_LEVEL") {
         cmd.arg(format!("-Cdebuginfo={}", debuginfo_level));
+    }
+
+    if env::var_os("RUSTC_DENY_WARNINGS").is_some() &&
+       env::var_os("RUSTC_EXTERNAL_TOOL").is_none() {
+        cmd.arg("-Dwarnings");
+        cmd.arg("-Drust_2018_idioms");
+        if stage != "0" && crate_name != Some("rustc_version") && // cfg(not(bootstrap))
+           use_internal_lints(crate_name) {
+            cmd.arg("-Zunstable-options");
+            cmd.arg("-Drustc::internal");
+        }
     }
 
     if let Some(target) = target {
@@ -167,9 +177,6 @@ fn main() {
             cmd.arg(format!("-Clinker={}", target_linker));
         }
 
-        let crate_name = maybe_crate_name.unwrap();
-        maybe_crate = Some(crate_name);
-
         // If we're compiling specifically the `panic_abort` crate then we pass
         // the `-C panic=abort` option. Note that we do not do this for any
         // other crate intentionally as this is the only crate for now that we
@@ -182,8 +189,8 @@ fn main() {
         // `compiler_builtins` are unconditionally compiled with panic=abort to
         // workaround undefined references to `rust_eh_unwind_resume` generated
         // otherwise, see issue https://github.com/rust-lang/rust/issues/43095.
-        if crate_name == "panic_abort" ||
-           crate_name == "compiler_builtins" && stage != "0" {
+        if crate_name == Some("panic_abort") ||
+           crate_name == Some("compiler_builtins") && stage != "0" {
             cmd.arg("-C").arg("panic=abort");
         }
 
@@ -196,7 +203,7 @@ fn main() {
 
         // The compiler builtins are pretty sensitive to symbols referenced in
         // libcore and such, so we never compile them with debug assertions.
-        if crate_name == "compiler_builtins" {
+        if crate_name == Some("compiler_builtins") {
             cmd.arg("-C").arg("debug-assertions=no");
         } else {
             cmd.arg("-C").arg(format!("debug-assertions={}", debug_assertions));
@@ -305,22 +312,6 @@ fn main() {
         }
     }
 
-    // This is required for internal lints.
-    if let Some(crate_name) = args.windows(2).find(|a| &*a[0] == "--crate-name") {
-        let crate_name = crate_name[1].to_string_lossy();
-        if crate_name != "rustc_version"
-            && (crate_name.starts_with("rustc")
-                || crate_name.starts_with("syntax")
-                || crate_name == "arena"
-                || crate_name == "fmt_macros")
-        {
-            cmd.arg("-Zunstable-options");
-            if stage != "0" {
-                cmd.arg("-Wrustc::internal");
-            }
-        }
-    }
-
     // Force all crates compiled by this compiler to (a) be unstable and (b)
     // allow the `rustc_private` feature to link to other unstable crates
     // also in the sysroot. We also do this for host crates, since those
@@ -331,13 +322,6 @@ fn main() {
 
     if env::var_os("RUSTC_PARALLEL_COMPILER").is_some() {
         cmd.arg("--cfg").arg("parallel_compiler");
-    }
-
-    if env::var_os("RUSTC_DENY_WARNINGS").is_some() && env::var_os("RUSTC_EXTERNAL_TOOL").is_none()
-    {
-        cmd.arg("-Dwarnings");
-        cmd.arg("-Dbare_trait_objects");
-        cmd.arg("-Drust_2018_idioms");
     }
 
     if verbose > 1 {
@@ -362,7 +346,7 @@ fn main() {
     }
 
     if env::var_os("RUSTC_PRINT_STEP_TIMINGS").is_some() {
-        if let Some(krate) = maybe_crate {
+        if let Some(crate_name) = crate_name {
             let start = Instant::now();
             let status = cmd
                 .status()
@@ -371,7 +355,7 @@ fn main() {
 
             let is_test = args.iter().any(|a| a == "--test");
             eprintln!("[RUSTC-TIMING] {} test:{} {}.{:03}",
-                      krate.to_string_lossy(),
+                      crate_name,
                       is_test,
                       dur.as_secs(),
                       dur.subsec_nanos() / 1_000_000);
@@ -388,6 +372,14 @@ fn main() {
 
     let code = exec_cmd(&mut cmd).unwrap_or_else(|_| panic!("\n\n failed to run {:?}", cmd));
     std::process::exit(code);
+}
+
+// Rustc crates for which internal lints are in effect.
+fn use_internal_lints(crate_name: Option<&str>) -> bool {
+    crate_name.map_or(false, |crate_name| {
+        crate_name.starts_with("rustc") || crate_name.starts_with("syntax") ||
+        ["arena", "fmt_macros"].contains(&crate_name)
+    })
 }
 
 #[cfg(unix)]

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -128,8 +128,10 @@ fn main() {
        env::var_os("RUSTC_EXTERNAL_TOOL").is_none() {
         cmd.arg("-Dwarnings");
         cmd.arg("-Drust_2018_idioms");
-        if stage != "0" && crate_name != Some("rustc_version") && // cfg(not(bootstrap))
-           use_internal_lints(crate_name) {
+        // cfg(not(bootstrap)): Remove this during the next stage 0 compiler update.
+        // `-Drustc::internal` is a new feature and `rustc_version` mis-reports the `stage`.
+        let cfg_not_bootstrap = stage != "0" && crate_name != Some("rustc_version");
+        if cfg_not_bootstrap && use_internal_lints(crate_name) {
             cmd.arg("-Zunstable-options");
             cmd.arg("-Drustc::internal");
         }


### PR DESCRIPTION
Lint settings do not depend on `if let Some(target) = target` in any way, so they are moved out of that clause.

Internal lints now respect `RUSTC_DENY_WARNINGS`.

Crate name treatment is cleaned up a bit.

cc https://github.com/rust-lang/rust/pull/61545 @flip1995 
r? @Mark-Simulacrum 