### PR TITLE
Add APIs for uninitialized Box, Rc, and Arc. (Plus get_mut_unchecked)

### DIFF
--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -200,6 +200,8 @@ impl<T> Box<mem::MaybeUninit<T>> {
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
     ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
+    ///
     /// # Examples
     ///
     /// ```
@@ -233,6 +235,8 @@ impl<T> Box<[mem::MaybeUninit<T>]> {
     /// really are in an initialized state.
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
+    ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
     ///
     /// # Examples
     ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -123,7 +123,7 @@ impl<T> Box<T> {
         box x
     }
 
-    /// Construct a new box with uninitialized contents.
+    /// Constructs a new box with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -161,7 +161,7 @@ impl<T> Box<T> {
 }
 
 impl<T> Box<[T]> {
-    /// Construct a new boxed slice with uninitialized contents.
+    /// Constructs a new boxed slice with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -192,7 +192,7 @@ impl<T> Box<[T]> {
 }
 
 impl<T> Box<mem::MaybeUninit<T>> {
-    /// Convert to `Box<T>`.
+    /// Converts to `Box<T>`.
     ///
     /// # Safety
     ///
@@ -228,7 +228,7 @@ impl<T> Box<mem::MaybeUninit<T>> {
 }
 
 impl<T> Box<[mem::MaybeUninit<T>]> {
-    /// Convert to `Box<[T]>`.
+    /// Converts to `Box<[T]>`.
     ///
     /// # Safety
     ///

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -149,6 +149,16 @@ impl<T> Box<T> {
         Box(unique.cast())
     }
 
+    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
+    /// `x` will be pinned in memory and unable to be moved.
+    #[stable(feature = "pin", since = "1.33.0")]
+    #[inline(always)]
+    pub fn pin(x: T) -> Pin<Box<T>> {
+        (box x).into()
+    }
+}
+
+impl<T> Box<[T]> {
     /// Construct a new boxed slice with uninitialized contents.
     ///
     /// # Examples
@@ -156,7 +166,7 @@ impl<T> Box<T> {
     /// ```
     /// #![feature(new_uninit)]
     ///
-    /// let mut values = Box::<u32>::new_uninit_slice(3);
+    /// let mut values = Box::<[u32]>::new_uninit_slice(3);
     ///
     /// let values = unsafe {
     ///     // Deferred initialization:
@@ -176,14 +186,6 @@ impl<T> Box<T> {
         let unique = Unique::new(ptr).unwrap_or_else(|| alloc::handle_alloc_error(layout));
         let slice = unsafe { slice::from_raw_parts_mut(unique.cast().as_ptr(), len) };
         Box(Unique::from(slice))
-    }
-
-    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
-    /// `x` will be pinned in memory and unable to be moved.
-    #[stable(feature = "pin", since = "1.33.0")]
-    #[inline(always)]
-    pub fn pin(x: T) -> Pin<Box<T>> {
-        (box x).into()
     }
 }
 
@@ -237,7 +239,7 @@ impl<T> Box<[mem::MaybeUninit<T>]> {
     /// ```
     /// #![feature(new_uninit)]
     ///
-    /// let mut values = Box::<u32>::new_uninit_slice(3);
+    /// let mut values = Box::<[u32]>::new_uninit_slice(3);
     ///
     /// let values = unsafe {
     ///     // Deferred initialization:

--- a/src/liballoc/boxed.rs
+++ b/src/liballoc/boxed.rs
@@ -141,7 +141,7 @@ impl<T> Box<T> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit() -> Box<mem::MaybeUninit<T>> {
         let layout = alloc::Layout::new::<mem::MaybeUninit<T>>();
         let ptr = unsafe {
@@ -181,7 +181,7 @@ impl<T> Box<[T]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit_slice(len: usize) -> Box<[mem::MaybeUninit<T>]> {
         let layout = alloc::Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
         let ptr = unsafe { alloc::alloc(layout) };
@@ -220,7 +220,7 @@ impl<T> Box<mem::MaybeUninit<T>> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Box<T> {
         Box(Box::into_unique(self).cast())
@@ -258,7 +258,7 @@ impl<T> Box<[mem::MaybeUninit<T>]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Box<[T]> {
         Box(Unique::new_unchecked(Box::into_raw(self) as _))

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -441,6 +441,8 @@ impl<T> Rc<[T]> {
     #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit_slice(len: usize) -> Rc<[mem::MaybeUninit<T>]> {
         let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
+        // This relies on `value` being the last field of `RcBox` in memory,
+        // so that the layout of `RcBox<T>` is the same as that of `RcBox<()>` followed by `T`.
         let (layout, offset) = Layout::new::<RcBox<()>>().extend(data_layout).unwrap();
         unsafe {
             let allocated_ptr = Global.alloc(layout)

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -719,8 +719,10 @@ impl<T: ?Sized> Rc<T> {
     ///
     /// # Safety
     ///
-    /// There must be no other `Rc` or [`Weak`] pointers to the same value.
-    /// This is the case for example immediately after `Rc::new`.
+    /// Any other `Rc` or [`Weak`] pointers to the same value must not be dereferenced
+    /// for the duration of the returned borrow.
+    /// This is trivially the case if no such pointer exist,
+    /// for example immediately after `Rc::new`.
     ///
     /// # Examples
     ///

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -327,7 +327,7 @@ impl<T> Rc<T> {
         }))
     }
 
-    /// Construct a new Rc with uninitialized contents.
+    /// Constructs a new `Rc` with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -409,7 +409,7 @@ impl<T> Rc<T> {
 }
 
 impl<T> Rc<[T]> {
-    /// Construct a new reference-counted slice with uninitialized contents.
+    /// Constructs a new reference-counted slice with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -441,7 +441,7 @@ impl<T> Rc<[T]> {
 }
 
 impl<T> Rc<mem::MaybeUninit<T>> {
-    /// Convert to `Rc<T>`.
+    /// Converts to `Rc<T>`.
     ///
     /// # Safety
     ///
@@ -480,7 +480,7 @@ impl<T> Rc<mem::MaybeUninit<T>> {
 }
 
 impl<T> Rc<[mem::MaybeUninit<T>]> {
-    /// Convert to `Rc<[T]>`.
+    /// Converts to `Rc<[T]>`.
     ///
     /// # Safety
     ///
@@ -721,7 +721,7 @@ impl<T: ?Sized> Rc<T> {
     ///
     /// Any other `Rc` or [`Weak`] pointers to the same value must not be dereferenced
     /// for the duration of the returned borrow.
-    /// This is trivially the case if no such pointer exist,
+    /// This is trivially the case if no such pointers exist,
     /// for example immediately after `Rc::new`.
     ///
     /// # Examples

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -364,50 +364,6 @@ impl<T> Rc<T> {
         }
     }
 
-    /// Construct a new reference-counted slice with uninitialized contents.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(new_uninit)]
-    /// #![feature(get_mut_unchecked)]
-    ///
-    /// use std::rc::Rc;
-    ///
-    /// let mut values = Rc::<u32>::new_uninit_slice(3);
-    ///
-    /// let values = unsafe {
-    ///     // Deferred initialization:
-    ///     Rc::get_mut_unchecked(&mut values)[0].as_mut_ptr().write(1);
-    ///     Rc::get_mut_unchecked(&mut values)[1].as_mut_ptr().write(2);
-    ///     Rc::get_mut_unchecked(&mut values)[2].as_mut_ptr().write(3);
-    ///
-    ///     values.assume_init()
-    /// };
-    ///
-    /// assert_eq!(*values, [1, 2, 3])
-    /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
-    pub fn new_uninit_slice(len: usize) -> Rc<[mem::MaybeUninit<T>]> {
-        let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
-        let (layout, offset) = Layout::new::<RcBox<()>>().extend(data_layout).unwrap();
-        unsafe {
-            let allocated_ptr = Global.alloc(layout)
-                .unwrap_or_else(|_| handle_alloc_error(layout))
-                .as_ptr();
-            let data_ptr = allocated_ptr.add(offset) as *mut mem::MaybeUninit<T>;
-            let slice: *mut [mem::MaybeUninit<T>] = from_raw_parts_mut(data_ptr, len);
-            let wide_ptr = slice as *mut RcBox<[mem::MaybeUninit<T>]>;
-            let wide_ptr = set_data_ptr(wide_ptr, allocated_ptr);
-            ptr::write(&mut (*wide_ptr).strong, Cell::new(1));
-            ptr::write(&mut (*wide_ptr).weak, Cell::new(1));
-            Rc {
-                ptr: NonNull::new_unchecked(wide_ptr),
-                phantom: PhantomData,
-            }
-        }
-    }
-
     /// Constructs a new `Pin<Rc<T>>`. If `T` does not implement `Unpin`, then
     /// `value` will be pinned in memory and unable to be moved.
     #[stable(feature = "pin", since = "1.33.0")]
@@ -454,6 +410,52 @@ impl<T> Rc<T> {
             }
         } else {
             Err(this)
+        }
+    }
+}
+
+impl<T> Rc<[T]> {
+    /// Construct a new reference-counted slice with uninitialized contents.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(new_uninit)]
+    /// #![feature(get_mut_unchecked)]
+    ///
+    /// use std::rc::Rc;
+    ///
+    /// let mut values = Rc::<[u32]>::new_uninit_slice(3);
+    ///
+    /// let values = unsafe {
+    ///     // Deferred initialization:
+    ///     Rc::get_mut_unchecked(&mut values)[0].as_mut_ptr().write(1);
+    ///     Rc::get_mut_unchecked(&mut values)[1].as_mut_ptr().write(2);
+    ///     Rc::get_mut_unchecked(&mut values)[2].as_mut_ptr().write(3);
+    ///
+    ///     values.assume_init()
+    /// };
+    ///
+    /// assert_eq!(*values, [1, 2, 3])
+    /// ```
+    #[unstable(feature = "new_uninit", issue = "0")]
+    pub fn new_uninit_slice(len: usize) -> Rc<[mem::MaybeUninit<T>]> {
+        let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
+        let (layout, offset) = Layout::new::<RcBox<()>>().extend(data_layout).unwrap();
+        unsafe {
+            let allocated_ptr = Global.alloc(layout)
+                .unwrap_or_else(|_| handle_alloc_error(layout))
+                .as_ptr();
+            let data_ptr = allocated_ptr.add(offset) as *mut mem::MaybeUninit<T>;
+            let slice: *mut [mem::MaybeUninit<T>] = from_raw_parts_mut(data_ptr, len);
+            let wide_ptr = slice as *mut RcBox<[mem::MaybeUninit<T>]>;
+            let wide_ptr = set_data_ptr(wide_ptr, allocated_ptr);
+            ptr::write(&mut (*wide_ptr).strong, Cell::new(1));
+            ptr::write(&mut (*wide_ptr).weak, Cell::new(1));
+            Rc {
+                ptr: NonNull::new_unchecked(wide_ptr),
+                phantom: PhantomData,
+            }
         }
     }
 }
@@ -519,7 +521,7 @@ impl<T> Rc<[mem::MaybeUninit<T>]> {
     ///
     /// use std::rc::Rc;
     ///
-    /// let mut values = Rc::<u32>::new_uninit_slice(3);
+    /// let mut values = Rc::<[u32]>::new_uninit_slice(3);
     ///
     /// let values = unsafe {
     ///     // Deferred initialization:

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -348,7 +348,7 @@ impl<T> Rc<T> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit() -> Rc<mem::MaybeUninit<T>> {
         let layout = Layout::new::<RcBox<mem::MaybeUninit<T>>>();
         unsafe {
@@ -438,7 +438,7 @@ impl<T> Rc<[T]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit_slice(len: usize) -> Rc<[mem::MaybeUninit<T>]> {
         let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
         let (layout, offset) = Layout::new::<RcBox<()>>().extend(data_layout).unwrap();
@@ -492,7 +492,7 @@ impl<T> Rc<mem::MaybeUninit<T>> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Rc<T> {
         Rc {
@@ -536,7 +536,7 @@ impl<T> Rc<[mem::MaybeUninit<T>]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Rc<[T]> {
         Rc {
@@ -762,7 +762,7 @@ impl<T: ?Sized> Rc<T> {
     /// assert_eq!(*x, "foo");
     /// ```
     #[inline]
-    #[unstable(feature = "get_mut_unchecked", issue = "0")]
+    #[unstable(feature = "get_mut_unchecked", issue = "63292")]
     pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {
         &mut this.ptr.as_mut().value
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -560,11 +560,40 @@ impl<T: ?Sized> Rc<T> {
     pub fn get_mut(this: &mut Self) -> Option<&mut T> {
         if Rc::is_unique(this) {
             unsafe {
-                Some(&mut this.ptr.as_mut().value)
+                Some(Rc::get_mut_unchecked(this))
             }
         } else {
             None
         }
+    }
+
+    /// Returns a mutable reference to the inner value,
+    /// without any check.
+    ///
+    /// See also [`get_mut`], which is safe and does appropriate checks.
+    ///
+    /// [`get_mut`]: struct.Rc.html#method.get_mut
+    ///
+    /// # Safety
+    ///
+    /// There must be no other `Rc` or [`Weak`][weak] pointers to the same value.
+    /// This is the case for example immediately after `Rc::new`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::rc::Rc;
+    ///
+    /// let mut x = Rc::new(String::new());
+    /// unsafe {
+    ///     Rc::get_mut_unchecked(&mut x).push_str("foo")
+    /// }
+    /// assert_eq!(*x, "foo");
+    /// ```
+    #[inline]
+    #[unstable(feature = "get_mut_unchecked", issue = "0")]
+    pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {
+        &mut this.ptr.as_mut().value
     }
 
     #[inline]

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -495,10 +495,8 @@ impl<T> Rc<mem::MaybeUninit<T>> {
     #[unstable(feature = "new_uninit", issue = "0")]
     #[inline]
     pub unsafe fn assume_init(self) -> Rc<T> {
-        let ptr = self.ptr.cast();
-        mem::forget(self);
         Rc {
-            ptr,
+            ptr: mem::ManuallyDrop::new(self).ptr.cast(),
             phantom: PhantomData,
         }
     }
@@ -541,10 +539,8 @@ impl<T> Rc<[mem::MaybeUninit<T>]> {
     #[unstable(feature = "new_uninit", issue = "0")]
     #[inline]
     pub unsafe fn assume_init(self) -> Rc<[T]> {
-        let ptr = NonNull::new_unchecked(self.ptr.as_ptr() as _);
-        mem::forget(self);
         Rc {
-            ptr,
+            ptr: NonNull::new_unchecked(mem::ManuallyDrop::new(self).ptr.as_ptr() as _),
             phantom: PhantomData,
         }
     }

--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -471,6 +471,8 @@ impl<T> Rc<mem::MaybeUninit<T>> {
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
     ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
+    ///
     /// # Examples
     ///
     /// ```
@@ -512,6 +514,8 @@ impl<T> Rc<[mem::MaybeUninit<T>]> {
     /// really is in an initialized state.
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
+    ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
     ///
     /// # Examples
     ///
@@ -745,7 +749,7 @@ impl<T: ?Sized> Rc<T> {
     ///
     /// # Safety
     ///
-    /// There must be no other `Rc` or [`Weak`][weak] pointers to the same value.
+    /// There must be no other `Rc` or [`Weak`] pointers to the same value.
     /// This is the case for example immediately after `Rc::new`.
     ///
     /// # Examples

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -479,10 +479,8 @@ impl<T> Arc<mem::MaybeUninit<T>> {
     #[unstable(feature = "new_uninit", issue = "0")]
     #[inline]
     pub unsafe fn assume_init(self) -> Arc<T> {
-        let ptr = self.ptr.cast();
-        mem::forget(self);
         Arc {
-            ptr,
+            ptr: mem::ManuallyDrop::new(self).ptr.cast(),
             phantom: PhantomData,
         }
     }
@@ -525,10 +523,8 @@ impl<T> Arc<[mem::MaybeUninit<T>]> {
     #[unstable(feature = "new_uninit", issue = "0")]
     #[inline]
     pub unsafe fn assume_init(self) -> Arc<[T]> {
-        let ptr = NonNull::new_unchecked(self.ptr.as_ptr() as _);
-        mem::forget(self);
         Arc {
-            ptr,
+            ptr: NonNull::new_unchecked(mem::ManuallyDrop::new(self).ptr.as_ptr() as _),
             phantom: PhantomData,
         }
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -945,11 +945,40 @@ impl<T: ?Sized> Arc<T> {
             // the Arc itself to be `mut`, so we're returning the only possible
             // reference to the inner data.
             unsafe {
-                Some(&mut this.ptr.as_mut().data)
+                Some(Arc::get_mut_unchecked(this))
             }
         } else {
             None
         }
+    }
+
+    /// Returns a mutable reference to the inner value,
+    /// without any check.
+    ///
+    /// See also [`get_mut`], which is safe and does appropriate checks.
+    ///
+    /// [`get_mut`]: struct.Arc.html#method.get_mut
+    ///
+    /// # Safety
+    ///
+    /// There must be no other `Arc` or [`Weak`][weak] pointers to the same value.
+    /// This is the case for example immediately after `Rc::new`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    ///
+    /// let mut x = Arc::new(String::new());
+    /// unsafe {
+    ///     Arc::get_mut_unchecked(&mut x).push_str("foo")
+    /// }
+    /// assert_eq!(*x, "foo");
+    /// ```
+    #[inline]
+    #[unstable(feature = "get_mut_unchecked", issue = "0")]
+    pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {
+        &mut this.ptr.as_mut().data
     }
 
     /// Determine whether this is the unique reference (including weak refs) to

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -455,6 +455,8 @@ impl<T> Arc<mem::MaybeUninit<T>> {
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
     ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
+    ///
     /// # Examples
     ///
     /// ```
@@ -496,6 +498,8 @@ impl<T> Arc<[mem::MaybeUninit<T>]> {
     /// really is in an initialized state.
     /// Calling this when the content is not yet fully initialized
     /// causes immediate undefined behavior.
+    ///
+    /// [`MaybeUninit::assume_init`]: ../../std/mem/union.MaybeUninit.html#method.assume_init
     ///
     /// # Examples
     ///
@@ -1130,7 +1134,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// # Safety
     ///
-    /// There must be no other `Arc` or [`Weak`][weak] pointers to the same value.
+    /// There must be no other `Arc` or [`Weak`] pointers to the same value.
     /// This is the case for example immediately after `Rc::new`.
     ///
     /// # Examples

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -425,6 +425,8 @@ impl<T> Arc<[T]> {
     #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit_slice(len: usize) -> Arc<[mem::MaybeUninit<T>]> {
         let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
+        // This relies on `value` being the last field of `RcBox` in memory,
+        // so that the layout of `RcBox<T>` is the same as that of `RcBox<()>` followed by `T`.
         let (layout, offset) = Layout::new::<ArcInner<()>>().extend(data_layout).unwrap();
         unsafe {
             let allocated_ptr = Global.alloc(layout)

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -1104,8 +1104,10 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// # Safety
     ///
-    /// There must be no other `Arc` or [`Weak`] pointers to the same value.
-    /// This is the case for example immediately after `Rc::new`.
+    /// Any other `Arc` or [`Weak`] pointers to the same value must not be dereferenced
+    /// for the duration of the returned borrow.
+    /// This is trivially the case if no such pointer exist,
+    /// for example immediately after `Arc::new`.
     ///
     /// # Examples
     ///

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -332,7 +332,7 @@ impl<T> Arc<T> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit() -> Arc<mem::MaybeUninit<T>> {
         let layout = Layout::new::<ArcInner<mem::MaybeUninit<T>>>();
         unsafe {
@@ -422,7 +422,7 @@ impl<T> Arc<[T]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     pub fn new_uninit_slice(len: usize) -> Arc<[mem::MaybeUninit<T>]> {
         let data_layout = Layout::array::<mem::MaybeUninit<T>>(len).unwrap();
         let (layout, offset) = Layout::new::<ArcInner<()>>().extend(data_layout).unwrap();
@@ -476,7 +476,7 @@ impl<T> Arc<mem::MaybeUninit<T>> {
     ///
     /// assert_eq!(*five, 5)
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Arc<T> {
         Arc {
@@ -520,7 +520,7 @@ impl<T> Arc<[mem::MaybeUninit<T>]> {
     ///
     /// assert_eq!(*values, [1, 2, 3])
     /// ```
-    #[unstable(feature = "new_uninit", issue = "0")]
+    #[unstable(feature = "new_uninit", issue = "63291")]
     #[inline]
     pub unsafe fn assume_init(self) -> Arc<[T]> {
         Arc {
@@ -1147,7 +1147,7 @@ impl<T: ?Sized> Arc<T> {
     /// assert_eq!(*x, "foo");
     /// ```
     #[inline]
-    #[unstable(feature = "get_mut_unchecked", issue = "0")]
+    #[unstable(feature = "get_mut_unchecked", issue = "63292")]
     pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {
         &mut this.ptr.as_mut().data
     }

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -311,7 +311,7 @@ impl<T> Arc<T> {
         Self::from_inner(Box::into_raw_non_null(x))
     }
 
-    /// Construct a Arc box with uninitialized contents.
+    /// Constructs a new `Arc` with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -393,7 +393,7 @@ impl<T> Arc<T> {
 }
 
 impl<T> Arc<[T]> {
-    /// Construct a new reference-counted slice with uninitialized contents.
+    /// Constructs a new reference-counted slice with uninitialized contents.
     ///
     /// # Examples
     ///
@@ -425,7 +425,7 @@ impl<T> Arc<[T]> {
 }
 
 impl<T> Arc<mem::MaybeUninit<T>> {
-    /// Convert to `Arc<T>`.
+    /// Converts to `Arc<T>`.
     ///
     /// # Safety
     ///
@@ -464,7 +464,7 @@ impl<T> Arc<mem::MaybeUninit<T>> {
 }
 
 impl<T> Arc<[mem::MaybeUninit<T>]> {
-    /// Convert to `Arc<[T]>`.
+    /// Converts to `Arc<[T]>`.
     ///
     /// # Safety
     ///
@@ -1106,7 +1106,7 @@ impl<T: ?Sized> Arc<T> {
     ///
     /// Any other `Arc` or [`Weak`] pointers to the same value must not be dereferenced
     /// for the duration of the returned borrow.
-    /// This is trivially the case if no such pointer exist,
+    /// This is trivially the case if no such pointers exist,
     /// for example immediately after `Arc::new`.
     ///
     /// # Examples

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -123,7 +123,7 @@ impl<T: ?Sized> Unique<T> {
         &mut *self.as_ptr()
     }
 
-    /// Cast to a pointer of another type
+    /// Casts to a pointer of another type
     #[inline]
     pub const fn cast<U>(self) -> Unique<U> {
         unsafe {

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -122,6 +122,14 @@ impl<T: ?Sized> Unique<T> {
     pub unsafe fn as_mut(&mut self) -> &mut T {
         &mut *self.as_ptr()
     }
+
+    /// Cast to a pointer of another type
+    #[inline]
+    pub const fn cast<U>(self) -> Unique<U> {
+        unsafe {
+            Unique::new_unchecked(self.as_ptr() as *mut U)
+        }
+    }
 }
 
 #[unstable(feature = "ptr_internals", issue = "0")]

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -123,7 +123,7 @@ impl<T: ?Sized> Unique<T> {
         &mut *self.as_ptr()
     }
 
-    /// Casts to a pointer of another type
+    /// Casts to a pointer of another type.
     #[inline]
     pub const fn cast<U>(self) -> Unique<U> {
         unsafe {


### PR DESCRIPTION
Assigning `MaybeUninit::<Foo>::uninit()` to a local variable is usually free, even when `size_of::<Foo>()` is large. However, passing it for example to `Arc::new` [causes at least one copy](https://youtu.be/F1AquroPfcI?t=4116) (from the stack to the newly allocated heap memory) even though there is no meaningful data. It is theoretically possible that a Sufficiently Advanced Compiler could optimize this copy away, but this is [reportedly unlikely to happen soon in LLVM](https://youtu.be/F1AquroPfcI?t=5431).

This PR proposes two sets of features:

* Constructors for containers (`Box`, `Rc`, `Arc`) of `MaybeUninit<T>` or `[MaybeUninit<T>]` that do not initialized the data, and unsafe conversions to the known-initialized types (without `MaybeUninit`). The constructors are guaranteed not to make unnecessary copies.

* On `Rc` and `Arc`, an unsafe `get_mut_unchecked` method that provides `&mut T` access without checking the reference count. `Arc::get_mut` involves multiple atomic operations whose cost can be non-trivial. `Rc::get_mut` is less costly, but we add `Rc::get_mut_unchecked` anyway for symmetry with `Arc`.

  These can be useful independently, but they will presumably be typical when the new constructors of `Rc` and `Arc` are used.

  An alternative with a safe API would be to introduce `UniqueRc` and `UniqueArc` types that have the same memory layout as `Rc` and `Arc` (and so zero-cost conversion to them) but are guaranteed to have only one reference. But introducing entire new types feels “heavier” than new constructors on existing types, and initialization of `MaybeUninit<T>` typically requires unsafe code anyway.

Summary of new APIs (all unstable in this PR):

```rust
impl<T> Box<T> { pub fn new_uninit() -> Box<MaybeUninit<T>> {…} }
impl<T> Box<MaybeUninit<T>> { pub unsafe fn assume_init(self) -> Box<T> {…} }
impl<T> Box<[T]> { pub fn new_uninit_slice(len: usize) -> Box<[MaybeUninit<T>]> {…} }
impl<T> Box<[MaybeUninit<T>]> { pub unsafe fn assume_init(self) -> Box<[T]> {…} }

impl<T> Rc<T> { pub fn new_uninit() -> Rc<MaybeUninit<T>> {…} }
impl<T> Rc<MaybeUninit<T>> { pub unsafe fn assume_init(self) -> Rc<T> {…} }
impl<T> Rc<[T]> { pub fn new_uninit_slice(len: usize) -> Rc<[MaybeUninit<T>]> {…} }
impl<T> Rc<[MaybeUninit<T>]> { pub unsafe fn assume_init(self) -> Rc<[T]> {…} }

impl<T> Arc<T> { pub fn new_uninit() -> Arc<MaybeUninit<T>> {…} }
impl<T> Arc<MaybeUninit<T>> { pub unsafe fn assume_init(self) -> Arc<T> {…} }
impl<T> Arc<[T]> { pub fn new_uninit_slice(len: usize) -> Arc<[MaybeUninit<T>]> {…} }
impl<T> Arc<[MaybeUninit<T>]> { pub unsafe fn assume_init(self) -> Arc<[T]> {…} }

impl<T: ?Sized> Rc<T> { pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {…} }
impl<T: ?Sized> Arc<T> { pub unsafe fn get_mut_unchecked(this: &mut Self) -> &mut T {…} }
```