### PR TITLE
name the trait in ambiguous-associated-items fully qualified suggestion

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1709,8 +1709,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             err.span_suggestion(
                 span,
                 "use fully-qualified syntax",
-                format!("<{} as {}>::{}", qself_ty, "Trait", assoc_ident),
-                Applicability::HasPlaceholders,
+                format!("<{} as {}>::{}", qself_ty, tcx.item_name(trait_did), assoc_ident),
+                Applicability::MachineApplicable,
             ).emit();
         }
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-priority-lint-ambiguous_associated_items.stderr
@@ -2,7 +2,7 @@ error: ambiguous associated item
   --> $DIR/enum-variant-priority-lint-ambiguous_associated_items.rs:32:15
    |
 LL |     fn f() -> Self::V { 0 }
-   |               ^^^^^^^ help: use fully-qualified syntax: `<E as Trait>::V`
+   |               ^^^^^^^ help: use fully-qualified syntax: `<E as Tr>::V`
    |
    = note: #[deny(ambiguous_associated_items)] on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!


### PR DESCRIPTION
We have the trait at this point, so we can name it in the error message, rather than using "Trait" as a (potentially confusing) placeholder.

Thanks to Yuki "@JohnTitor" Okushi for pointing out where to look (in the same file) for a closely related issue for ambiguous associated types (as opposed to items; that was #59225, except that one won't be
quite as easy to resolve, because we actually don't have the trait `DefId` at that point).

r? @petrochenkov 