### PR TITLE
 Handle null from LLVMRustGetSectionName 

### DIFF
--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1736,7 +1736,9 @@ extern "C" {
     pub fn LLVMRustArchiveIteratorFree(AIR: &'a mut ArchiveIterator<'a>);
     pub fn LLVMRustDestroyArchive(AR: &'static mut Archive);
 
-    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>, data: &mut *const c_char) -> size_t;
+    #[allow(improper_ctypes)]
+    pub fn LLVMRustGetSectionName(SI: &SectionIterator<'_>,
+                                  data: &mut Option<std::ptr::NonNull<c_char>>) -> size_t;
 
     #[allow(improper_ctypes)]
     pub fn LLVMRustWriteTwineToString(T: &Twine, s: &RustString);

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -8,7 +8,6 @@ use rustc_data_structures::owning_ref::OwningRef;
 use rustc_codegen_ssa::METADATA_FILENAME;
 
 use std::path::Path;
-use std::ptr;
 use std::slice;
 use rustc_fs_util::path_to_c_string;
 
@@ -67,10 +66,14 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
     unsafe {
         let si = mk_section_iter(of.llof);
         while llvm::LLVMIsSectionIteratorAtEnd(of.llof, si.llsi) == False {
-            let mut name_buf = ptr::null();
+            let mut name_buf = None;
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
-            let name = slice::from_raw_parts(name_buf as *const u8, name_len as usize).to_vec();
-            let name = String::from_utf8(name).unwrap();
+            let name = name_buf.map_or(
+                "".to_string(),
+                |buf| String::from_utf8(
+                    slice::from_raw_parts(buf.as_ptr() as *const u8,
+                                          name_len as usize)
+                    .to_vec()).unwrap());
             debug!("get_metadata_section: name {}", name);
             if read_metadata_section_name(target) == name {
                 let cbuf = llvm::LLVMGetSectionContents(si.llsi);

--- a/src/librustc_codegen_llvm/metadata.rs
+++ b/src/librustc_codegen_llvm/metadata.rs
@@ -69,11 +69,13 @@ fn search_meta_section<'a>(of: &'a ObjectFile,
             let mut name_buf = None;
             let name_len = llvm::LLVMRustGetSectionName(si.llsi, &mut name_buf);
             let name = name_buf.map_or(
-                "".to_string(),
+                String::new(), // We got a NULL ptr, ignore `name_len`.
                 |buf| String::from_utf8(
                     slice::from_raw_parts(buf.as_ptr() as *const u8,
                                           name_len as usize)
-                    .to_vec()).unwrap());
+                    .to_vec()
+                ).unwrap()
+            );
             debug!("get_metadata_section: name {}", name);
             if read_metadata_section_name(target) == name {
                 let cbuf = llvm::LLVMGetSectionContents(si.llsi);


### PR DESCRIPTION
As part of https://github.com/rust-lang/rust/pull/58783 and https://github.com/rust-lang/rust/pull/62103, this incorrect use of a NULL pointer was found in the interface to LLVM. That PR is stuck with some linker issues, but there is no reason the soundness fix should have to wait for that.