### PR TITLE
Prevent shrinking of "crate select" element on Firefox

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -639,6 +639,7 @@ a {
 	margin-top: 5px;
 	padding: 6px;
 	padding-right: 19px;
+	flex: none;
 	border: 0;
 	border-right: 0;
 	border-radius: 4px 0 0 4px;


### PR DESCRIPTION
This fixes #60368