### PR TITLE
Normalize use of backticks in compiler messages p2

### DIFF
--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -459,7 +459,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         let (unsize_did, coerce_unsized_did) = if let (Some(u), Some(cu)) = traits {
             (u, cu)
         } else {
-            debug!("Missing Unsize or CoerceUnsized traits");
+            debug!("missing Unsize or CoerceUnsized traits");
             return Err(TypeError::Mismatch);
         };
 

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -130,7 +130,7 @@ pub fn resolve_interior<'a, 'tcx>(
     // if a Sync generator contains an &'α T, we need to check whether &'α T: Sync),
     // so knowledge of the exact relationships between them isn't particularly important.
 
-    debug!("Types in generator {:?}, span = {:?}", type_list, body.value.span);
+    debug!("types in generator {:?}, span = {:?}", type_list, body.value.span);
 
     // Replace all regions inside the generator interior with late bound regions
     // Note that each region slot in the types gets a new fresh late bound region,
@@ -144,7 +144,7 @@ pub fn resolve_interior<'a, 'tcx>(
 
     let witness = fcx.tcx.mk_generator_witness(ty::Binder::bind(type_list));
 
-    debug!("Types in generator after region replacement {:?}, span = {:?}",
+    debug!("types in generator after region replacement {:?}, span = {:?}",
             witness, body.value.span);
 
     // Unify the type variable inside the generator with the new witness

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1230,7 +1230,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if nightly_options::is_nightly_build() {
             for (candidate, feature) in unstable_candidates {
                 diag.help(&format!(
-                    "add #![feature({})] to the crate attributes to enable `{}`",
+                    "add `#![feature({})]` to the crate attributes to enable `{}`",
                     feature,
                     self.tcx.def_path_str(candidate.item.def_id),
                 ));
@@ -1432,7 +1432,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// candidate method where the method name may have been misspelt. Similarly to other
     /// Levenshtein based suggestions, we provide at most one such suggestion.
     fn probe_for_lev_candidate(&mut self) -> Result<Option<ty::AssocItem>, MethodError<'tcx>> {
-        debug!("Probing for method names similar to {:?}",
+        debug!("probing for method names similar to {:?}",
                self.method_name);
 
         let steps = self.steps.clone();

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -983,7 +983,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
         };
         self.assign(local.span, local.hir_id, local_ty);
 
-        debug!("Local variable {:?} is assigned type {}",
+        debug!("local variable {:?} is assigned type {}",
                local.pat,
                self.fcx.ty_to_string(
                    self.fcx.locals.borrow().get(&local.hir_id).unwrap().clone().decl_ty));
@@ -1000,7 +1000,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                                                traits::VariableType(p.hir_id));
             }
 
-            debug!("Pattern binding {} is assigned to {} with type {:?}",
+            debug!("pattern binding {} is assigned to {} with type {:?}",
                    ident,
                    self.fcx.ty_to_string(
                        self.fcx.locals.borrow().get(&p.hir_id).unwrap().clone().decl_ty),
@@ -4462,7 +4462,7 @@ pub fn check_bounds_are_used<'tcx>(tcx: TyCtxt<'tcx>, generics: &ty::Generics, t
 
     for leaf_ty in ty.walk() {
         if let ty::Param(ty::ParamTy { index, .. }) = leaf_ty.sty {
-            debug!("Found use of ty param num {}", index);
+            debug!("found use of ty param num {}", index);
             types_used[index as usize - own_counts.lifetimes] = true;
         } else if let ty::Error = leaf_ty.sty {
             // If there is already another error, do not emit

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -799,7 +799,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         debug!("callee_region={:?}", callee_region);
 
         for arg_expr in arg_exprs {
-            debug!("Argument: {:?}", arg_expr);
+            debug!("argument: {:?}", arg_expr);
 
             // ensure that any regions appearing in the argument type are
             // valid for at least the lifetime of the function:

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -646,7 +646,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         let n_ty = self.fcx.node_ty(hir_id);
         let n_ty = self.resolve(&n_ty, &span);
         self.write_ty_to_tables(hir_id, n_ty);
-        debug!("Node {:?} has type {:?}", hir_id, n_ty);
+        debug!("node {:?} has type {:?}", hir_id, n_ty);
 
         // Resolve any substitutions
         if let Some(substs) = self.fcx.tables.borrow().node_substs_opt(hir_id) {
@@ -665,13 +665,13 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             .remove(hir_id);
         match adjustment {
             None => {
-                debug!("No adjustments for node {:?}", hir_id);
+                debug!("no adjustments for node {:?}", hir_id);
             }
 
             Some(adjustment) => {
                 let resolved_adjustment = self.resolve(&adjustment, &span);
                 debug!(
-                    "Adjustments for node {:?}: {:?}",
+                    "adjustments for node {:?}: {:?}",
                     hir_id, resolved_adjustment
                 );
                 self.tables
@@ -689,7 +689,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             .remove(hir_id);
         match adjustment {
             None => {
-                debug!("No pat_adjustments for node {:?}", hir_id);
+                debug!("no pat_adjustments for node {:?}", hir_id);
             }
 
             Some(adjustment) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2256,7 +2256,7 @@ fn compute_sig_of_foreign_fn_decl<'tcx>(
                            tcx.hir().hir_to_pretty_string(ast_ty.hir_id)
                        ),
                    )
-                   .help("add #![feature(simd_ffi)] to the crate attributes to enable")
+                   .help("add `#![feature(simd_ffi)]` to the crate attributes to enable")
                    .emit();
             }
         };
@@ -2479,7 +2479,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             }
         } else if attr.check_name(sym::target_feature) {
             if tcx.fn_sig(id).unsafety() == Unsafety::Normal {
-                let msg = "#[target_feature(..)] can only be applied to `unsafe` functions";
+                let msg = "`#[target_feature(..)]` can only be applied to `unsafe` functions";
                 tcx.sess.struct_span_err(attr.span, msg)
                     .span_label(attr.span, "can only be applied to `unsafe` functions")
                     .span_label(tcx.def_span(id), "not an `unsafe` function")
@@ -2593,8 +2593,8 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             if let Some(span) = inline_span {
                 tcx.sess.span_err(
                     span,
-                    "cannot use #[inline(always)] with \
-                     #[target_feature]",
+                    "cannot use `#[inline(always)]` with \
+                     `#[target_feature]`",
                 );
             }
         }

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4848,6 +4848,6 @@ register_diagnostics! {
     E0641, // cannot cast to/from a pointer with an unknown kind
     E0645, // trait aliases not finished
     E0719, // duplicate values for associated type binding
-    E0722, // Malformed #[optimize] attribute
+    E0722, // Malformed `#[optimize]` attribute
     E0724, // `#[ffi_returns_twice]` is only allowed in foreign functions
 }

--- a/src/librustc_typeck/variance/solve.rs
+++ b/src/librustc_typeck/variance/solve.rs
@@ -64,7 +64,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
                 let old_value = self.solutions[inferred];
                 let new_value = glb(variance, old_value);
                 if old_value != new_value {
-                    debug!("Updating inferred {} \
+                    debug!("updating inferred {} \
                             from {:?} to {:?} due to {:?}",
                            inferred,
                            old_value,

--- a/src/test/ui/feature-gates/feature-gate-simd-ffi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-simd-ffi.stderr
@@ -4,7 +4,7 @@ error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result
 LL |     fn baz() -> LocalSimd;
    |                 ^^^^^^^^^
    |
-   = help: add #![feature(simd_ffi)] to the crate attributes to enable
+   = help: add `#![feature(simd_ffi)]` to the crate attributes to enable
 
 error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result in invalid code
   --> $DIR/feature-gate-simd-ffi.rs:10:15
@@ -12,7 +12,7 @@ error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result
 LL |     fn qux(x: LocalSimd);
    |               ^^^^^^^^^
    |
-   = help: add #![feature(simd_ffi)] to the crate attributes to enable
+   = help: add `#![feature(simd_ffi)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/inference_unstable.stderr
+++ b/src/test/ui/inference/inference_unstable.stderr
@@ -8,5 +8,5 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    = warning: once this method is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
-   = help: add #![feature(ipu_flatten)] to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
+   = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
 

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -25,7 +25,7 @@
 unsafe fn foo() {}
 
 #[target_feature(enable = "sse2")]
-//~^ ERROR #[target_feature(..)] can only be applied to `unsafe` functions
+//~^ ERROR `#[target_feature(..)]` can only be applied to `unsafe` functions
 //~| NOTE can only be applied to `unsafe` functions
 fn bar() {}
 //~^ NOTE not an `unsafe` function
@@ -36,7 +36,7 @@ mod another {}
 //~^ NOTE not a function
 
 #[inline(always)]
-//~^ ERROR: cannot use #[inline(always)]
+//~^ ERROR: cannot use `#[inline(always)]`
 #[target_feature(enable = "sse2")]
 unsafe fn test() {}
 

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -22,7 +22,7 @@ error: malformed `target_feature` attribute input
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^ help: must be of the form: `enable = ".."`
 
-error: #[target_feature(..)] can only be applied to `unsafe` functions
+error: `#[target_feature(..)]` can only be applied to `unsafe` functions
   --> $DIR/target-feature-wrong.rs:27:1
    |
 LL | #[target_feature(enable = "sse2")]
@@ -40,7 +40,7 @@ LL |
 LL | mod another {}
    | -------------- not a function
 
-error: cannot use #[inline(always)] with #[target_feature]
+error: cannot use `#[inline(always)]` with `#[target_feature]`
   --> $DIR/target-feature-wrong.rs:38:1
    |
 LL | #[inline(always)]


### PR DESCRIPTION
normalize use of backticks in compiler messages for librustc_typecheck

https://github.com/rust-lang/rust/issues/60532