### PR TITLE
Delegate Iterator::try_fold for Iterators taken by reference

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2719,7 +2719,7 @@ impl<I: Iterator> Iterator for &mut I {
         (**self).nth(n)
     }
     fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R where
-        I: Sized, F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
+        F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
     {
         (**self).try_fold(init, f)
     }

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2708,6 +2708,16 @@ impl<I: Iterator + ?Sized> Iterator for &mut I {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<I: Iterator> Iterator for &mut I {
+    type Item = I::Item;
+    fn next(&mut self) -> Option<I::Item> { (**self).next() }
+    fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        (**self).nth(n)
+    }
     fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R where
         I: Sized, F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
     {

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2717,7 +2717,7 @@ impl<I: Iterator + Sized> Iterator for &mut I {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
-    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R where
+    fn try_fold<B, F, R>(&mut self, init: B, f: F) -> R where
         F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
     {
         (**self).try_fold(init, f)

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2703,16 +2703,15 @@ fn select_fold1<I, F>(mut it: I, mut f: F) -> Option<I::Item>
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<I: Iterator + ?Sized> Iterator for &mut I {
     type Item = I::Item;
-    fn next(&mut self) -> Option<I::Item> { (**self).next() }
-    fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+    default fn next(&mut self) -> Option<I::Item> { (**self).next() }
+    default fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
+    default fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<I: Iterator> Iterator for &mut I {
-    type Item = I::Item;
+impl<I: Iterator + Sized> Iterator for &mut I {
     fn next(&mut self) -> Option<I::Item> { (**self).next() }
     fn size_hint(&self) -> (usize, Option<usize>) { (**self).size_hint() }
     fn nth(&mut self, n: usize) -> Option<Self::Item> {

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2708,4 +2708,9 @@ impl<I: Iterator + ?Sized> Iterator for &mut I {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         (**self).nth(n)
     }
+    fn try_fold<B, F, R>(&mut self, init: B, mut f: F) -> R where
+        I: Sized, F: FnMut(B, Self::Item) -> R, R: Try<Ok=B>
+    {
+        (**self).try_fold(init, f)
+    }
 }

--- a/src/test/ui/issues/issue-31173.stderr
+++ b/src/test/ui/issues/issue-31173.stderr
@@ -14,7 +14,6 @@ LL |         .collect();
    |          ^^^^^^^
    |
    = note: the method `collect` exists but the following trait bounds were not satisfied:
-           `&mut std::iter::Cloned<std::iter::TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6 found_e:_]>> : std::iter::Iterator`
            `std::iter::Cloned<std::iter::TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6 found_e:_]>> : std::iter::Iterator`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -34,8 +34,6 @@ LL | pub struct Foo;
 LL |      .take()
    |       ^^^^
    |
-   = note: the method `take` exists but the following trait bounds were not satisfied:
-           `&mut Foo : std::iter::Iterator`
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `take`, perhaps you need to implement one of them:
            candidate #1: `std::io::Read`

--- a/src/test/ui/mismatched_types/issue-36053-2.stderr
+++ b/src/test/ui/mismatched_types/issue-36053-2.stderr
@@ -5,7 +5,6 @@ LL |     once::<&str>("str").fuse().filter(|a: &str| true).count();
    |                                                       ^^^^^
    |
    = note: the method `count` exists but the following trait bounds were not satisfied:
-           `&mut std::iter::Filter<std::iter::Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]> : std::iter::Iterator`
            `std::iter::Filter<std::iter::Fuse<std::iter::Once<&str>>, [closure@$DIR/issue-36053-2.rs:7:39: 7:53]> : std::iter::Iterator`
 
 error[E0631]: type mismatch in closure arguments


### PR DESCRIPTION
`try_fold` is the most important method to delegate because all the others delegate to it when possible.  (ie `any` and the like)