### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -208,6 +208,32 @@ impl<T> Option<T> {
         !self.is_some()
     }
 
+    /// Returns `true` if the option is a [`Some`] value containing the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_result_contains)]
+    ///
+    /// let x: Option<u32> = Some(2);
+    /// assert_eq!(x.contains(&2), true);
+    ///
+    /// let x: Option<u32> = Some(3);
+    /// assert_eq!(x.contains(&2), false);
+    ///
+    /// let x: Option<u32> = None;
+    /// assert_eq!(x.contains(&2), false);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "option_result_contains", issue = "62358")]
+    pub fn contains<U>(&self, x: &U) -> bool where U: PartialEq<T> {
+        match self {
+            Some(y) => x == y,
+            None => false,
+        }
+    }
+
     /////////////////////////////////////////////////////////////////////////
     // Adapter for working with references
     /////////////////////////////////////////////////////////////////////////

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -309,6 +309,58 @@ impl<T, E> Result<T, E> {
         !self.is_ok()
     }
 
+    /// Returns `true` if the result is an [`Ok`] value containing the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(option_result_contains)]
+    ///
+    /// let x: Result<u32, &str> = Ok(2);
+    /// assert_eq!(x.contains(&2), true);
+    ///
+    /// let x: Result<u32, &str> = Ok(3);
+    /// assert_eq!(x.contains(&2), false);
+    ///
+    /// let x: Result<u32, &str> = Err("Some error message");
+    /// assert_eq!(x.contains(&2), false);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "option_result_contains", issue = "62358")]
+    pub fn contains<U>(&self, x: &U) -> bool where U: PartialEq<T> {
+        match self {
+            Ok(y) => x == y,
+            Err(_) => false
+        }
+    }
+
+    /// Returns `true` if the result is an [`Err`] value containing the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_contains_err)]
+    ///
+    /// let x: Result<u32, &str> = Ok(2);
+    /// assert_eq!(x.contains_err(&"Some error message"), false);
+    ///
+    /// let x: Result<u32, &str> = Err("Some error message");
+    /// assert_eq!(x.contains_err(&"Some error message"), true);
+    ///
+    /// let x: Result<u32, &str> = Err("Some other error message");
+    /// assert_eq!(x.contains_err(&"Some error message"), false);
+    /// ```
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "result_contains_err", issue = "62358")]
+    pub fn contains_err<F>(&self, f: &F) -> bool where F: PartialEq<E> {
+        match self {
+            Ok(_) => false,
+            Err(e) => f == e
+        }
+    }
+
     /////////////////////////////////////////////////////////////////////////
     // Adapter for each variant
     /////////////////////////////////////////////////////////////////////////

--- a/src/librustc_codegen_llvm/asm.rs
+++ b/src/librustc_codegen_llvm/asm.rs
@@ -146,7 +146,7 @@ fn inline_asm_call(
     unsafe {
         // Ask LLVM to verify that the constraints are well-formed.
         let constraints_ok = llvm::LLVMRustInlineAsmVerify(fty, cons.as_ptr());
-        debug!("Constraint verification result: {:?}", constraints_ok);
+        debug!("constraint verification result: {:?}", constraints_ok);
         if constraints_ok {
             let v = llvm::LLVMRustInlineAsm(
                 fty,

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -215,7 +215,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         funclet: Option<&Funclet<'ll>>,
     ) -> &'ll Value {
 
-        debug!("Invoke {:?} with args ({:?})",
+        debug!("invoke {:?} with args ({:?})",
                llfn,
                args);
 
@@ -1035,7 +1035,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         funclet: Option<&Funclet<'ll>>,
     ) -> &'ll Value {
 
-        debug!("Call {:?} with args ({:?})",
+        debug!("call {:?} with args ({:?})",
                llfn,
                args);
 
@@ -1238,7 +1238,7 @@ impl Builder<'a, 'll, 'tcx> {
         if dest_ptr_ty == stored_ptr_ty {
             ptr
         } else {
-            debug!("Type mismatch in store. \
+            debug!("type mismatch in store. \
                     Expected {:?}, got {:?}; inserting bitcast",
                    dest_ptr_ty, stored_ptr_ty);
             self.bitcast(ptr, stored_ptr_ty)
@@ -1274,7 +1274,7 @@ impl Builder<'a, 'll, 'tcx> {
             .map(|(i, (expected_ty, &actual_val))| {
                 let actual_ty = self.val_ty(actual_val);
                 if expected_ty != actual_ty {
-                    debug!("Type mismatch in function call of {:?}. \
+                    debug!("type mismatch in function call of {:?}. \
                             Expected {:?} for param {}, got {:?}; injecting bitcast",
                            llfn, expected_ty, i, actual_ty);
                     self.bitcast(actual_val, expected_ty)

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -433,7 +433,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(cx: &'
         if cx.get_defined_value("main").is_some() {
             // FIXME: We should be smart and show a better diagnostic here.
             cx.sess().struct_span_err(sp, "entry symbol `main` defined multiple times")
-                     .help("did you use #[no_mangle] on `fn main`? Use #[start] instead")
+                     .help("did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead")
                      .emit();
             cx.sess().abort_if_errors();
             bug!();

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -138,7 +138,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
         //   * packed struct - there is no alignment padding
         match field.ty.sty {
             _ if self.llextra.is_none() => {
-                debug!("Unsized field `{}`, of `{:?}` has no metadata for adjustment",
+                debug!("unsized field `{}`, of `{:?}` has no metadata for adjustment",
                     ix, self.llval);
                 return simple();
             }

--- a/src/librustc_codegen_utils/link.rs
+++ b/src/librustc_codegen_utils/link.rs
@@ -57,7 +57,7 @@ pub fn find_crate_name(sess: Option<&Session>,
         if let Some(ref s) = sess.opts.crate_name {
             if let Some((attr, name)) = attr_crate_name {
                 if name.as_str() != *s {
-                    let msg = format!("--crate-name and #[crate_name] are \
+                    let msg = format!("`--crate-name` and `#[crate_name]` are \
                                        required to match, but `{}` != `{}`",
                                       s, name);
                     sess.span_err(attr.span, &msg);

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -459,7 +459,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
         let (unsize_did, coerce_unsized_did) = if let (Some(u), Some(cu)) = traits {
             (u, cu)
         } else {
-            debug!("Missing Unsize or CoerceUnsized traits");
+            debug!("missing Unsize or CoerceUnsized traits");
             return Err(TypeError::Mismatch);
         };
 

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -130,7 +130,7 @@ pub fn resolve_interior<'a, 'tcx>(
     // if a Sync generator contains an &'α T, we need to check whether &'α T: Sync),
     // so knowledge of the exact relationships between them isn't particularly important.
 
-    debug!("Types in generator {:?}, span = {:?}", type_list, body.value.span);
+    debug!("types in generator {:?}, span = {:?}", type_list, body.value.span);
 
     // Replace all regions inside the generator interior with late bound regions
     // Note that each region slot in the types gets a new fresh late bound region,
@@ -144,7 +144,7 @@ pub fn resolve_interior<'a, 'tcx>(
 
     let witness = fcx.tcx.mk_generator_witness(ty::Binder::bind(type_list));
 
-    debug!("Types in generator after region replacement {:?}, span = {:?}",
+    debug!("types in generator after region replacement {:?}, span = {:?}",
             witness, body.value.span);
 
     // Unify the type variable inside the generator with the new witness

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1230,7 +1230,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if nightly_options::is_nightly_build() {
             for (candidate, feature) in unstable_candidates {
                 diag.help(&format!(
-                    "add #![feature({})] to the crate attributes to enable `{}`",
+                    "add `#![feature({})]` to the crate attributes to enable `{}`",
                     feature,
                     self.tcx.def_path_str(candidate.item.def_id),
                 ));
@@ -1432,7 +1432,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
     /// candidate method where the method name may have been misspelt. Similarly to other
     /// Levenshtein based suggestions, we provide at most one such suggestion.
     fn probe_for_lev_candidate(&mut self) -> Result<Option<ty::AssocItem>, MethodError<'tcx>> {
-        debug!("Probing for method names similar to {:?}",
+        debug!("probing for method names similar to {:?}",
                self.method_name);
 
         let steps = self.steps.clone();

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -983,7 +983,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
         };
         self.assign(local.span, local.hir_id, local_ty);
 
-        debug!("Local variable {:?} is assigned type {}",
+        debug!("local variable {:?} is assigned type {}",
                local.pat,
                self.fcx.ty_to_string(
                    self.fcx.locals.borrow().get(&local.hir_id).unwrap().clone().decl_ty));
@@ -1000,7 +1000,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                                                traits::VariableType(p.hir_id));
             }
 
-            debug!("Pattern binding {} is assigned to {} with type {:?}",
+            debug!("pattern binding {} is assigned to {} with type {:?}",
                    ident,
                    self.fcx.ty_to_string(
                        self.fcx.locals.borrow().get(&p.hir_id).unwrap().clone().decl_ty),
@@ -4462,7 +4462,7 @@ pub fn check_bounds_are_used<'tcx>(tcx: TyCtxt<'tcx>, generics: &ty::Generics, t
 
     for leaf_ty in ty.walk() {
         if let ty::Param(ty::ParamTy { index, .. }) = leaf_ty.sty {
-            debug!("Found use of ty param num {}", index);
+            debug!("found use of ty param num {}", index);
             types_used[index as usize - own_counts.lifetimes] = true;
         } else if let ty::Error = leaf_ty.sty {
             // If there is already another error, do not emit

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -799,7 +799,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         debug!("callee_region={:?}", callee_region);
 
         for arg_expr in arg_exprs {
-            debug!("Argument: {:?}", arg_expr);
+            debug!("argument: {:?}", arg_expr);
 
             // ensure that any regions appearing in the argument type are
             // valid for at least the lifetime of the function:

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -646,7 +646,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         let n_ty = self.fcx.node_ty(hir_id);
         let n_ty = self.resolve(&n_ty, &span);
         self.write_ty_to_tables(hir_id, n_ty);
-        debug!("Node {:?} has type {:?}", hir_id, n_ty);
+        debug!("node {:?} has type {:?}", hir_id, n_ty);
 
         // Resolve any substitutions
         if let Some(substs) = self.fcx.tables.borrow().node_substs_opt(hir_id) {
@@ -665,13 +665,13 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             .remove(hir_id);
         match adjustment {
             None => {
-                debug!("No adjustments for node {:?}", hir_id);
+                debug!("no adjustments for node {:?}", hir_id);
             }
 
             Some(adjustment) => {
                 let resolved_adjustment = self.resolve(&adjustment, &span);
                 debug!(
-                    "Adjustments for node {:?}: {:?}",
+                    "adjustments for node {:?}: {:?}",
                     hir_id, resolved_adjustment
                 );
                 self.tables
@@ -689,7 +689,7 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             .remove(hir_id);
         match adjustment {
             None => {
-                debug!("No pat_adjustments for node {:?}", hir_id);
+                debug!("no pat_adjustments for node {:?}", hir_id);
             }
 
             Some(adjustment) => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2256,7 +2256,7 @@ fn compute_sig_of_foreign_fn_decl<'tcx>(
                            tcx.hir().hir_to_pretty_string(ast_ty.hir_id)
                        ),
                    )
-                   .help("add #![feature(simd_ffi)] to the crate attributes to enable")
+                   .help("add `#![feature(simd_ffi)]` to the crate attributes to enable")
                    .emit();
             }
         };
@@ -2479,7 +2479,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             }
         } else if attr.check_name(sym::target_feature) {
             if tcx.fn_sig(id).unsafety() == Unsafety::Normal {
-                let msg = "#[target_feature(..)] can only be applied to `unsafe` functions";
+                let msg = "`#[target_feature(..)]` can only be applied to `unsafe` functions";
                 tcx.sess.struct_span_err(attr.span, msg)
                     .span_label(attr.span, "can only be applied to `unsafe` functions")
                     .span_label(tcx.def_span(id), "not an `unsafe` function")
@@ -2593,8 +2593,8 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             if let Some(span) = inline_span {
                 tcx.sess.span_err(
                     span,
-                    "cannot use #[inline(always)] with \
-                     #[target_feature]",
+                    "cannot use `#[inline(always)]` with \
+                     `#[target_feature]`",
                 );
             }
         }

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4848,6 +4848,6 @@ register_diagnostics! {
     E0641, // cannot cast to/from a pointer with an unknown kind
     E0645, // trait aliases not finished
     E0719, // duplicate values for associated type binding
-    E0722, // Malformed #[optimize] attribute
+    E0722, // Malformed `#[optimize]` attribute
     E0724, // `#[ffi_returns_twice]` is only allowed in foreign functions
 }

--- a/src/librustc_typeck/variance/solve.rs
+++ b/src/librustc_typeck/variance/solve.rs
@@ -64,7 +64,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
                 let old_value = self.solutions[inferred];
                 let new_value = glb(variance, old_value);
                 if old_value != new_value {
-                    debug!("Updating inferred {} \
+                    debug!("updating inferred {} \
                             from {:?} to {:?} due to {:?}",
                            inferred,
                            old_value,

--- a/src/libstd/keyword_docs.rs
+++ b/src/libstd/keyword_docs.rs
@@ -608,6 +608,62 @@ mod in_keyword { }
 /// [Reference]: ../reference/statements.html#let-statements
 mod let_keyword { }
 
+#[doc(keyword = "while")]
+//
+/// Loop while a condition is upheld.
+///
+/// A `while` expression is used for predicate loops. The `while` expression runs the conditional
+/// expression before running the loop body, then runs the loop body if the conditional
+/// expression evaluates to `true`, or exits the loop otherwise.
+///
+/// ```rust
+/// let mut counter = 0;
+///
+/// while counter < 10 {
+///     println!("{}", counter);
+///     counter += 1;
+/// }
+/// ```
+///
+/// Like the [`for`] expression, we can use `break` and `continue`. A `while` expression
+/// cannot break with a value and always evaluates to `()` unlike [`loop`].
+///
+/// ```rust
+/// let mut i = 1;
+///
+/// while i < 100 {
+///     i *= 2;
+///     if i == 64 {
+///         break; // Exit when `i` is 64.
+///     }
+/// }
+/// ```
+///
+/// As `if` expressions have their pattern matching variant in `if let`, so too do `while`
+/// expressions with `while let`. The `while let` expression matches the pattern against the
+/// expression, then runs the loop body if pattern matching succeeds, or exits the loop otherwise.
+/// We can use `break` and `continue` in `while let` expressions just like in `while`.
+///
+/// ```rust
+/// let mut counter = Some(0);
+///
+/// while let Some(i) = counter {
+///     if i == 10 {
+///         counter = None;
+///     } else {
+///         println!("{}", i);
+///         counter = Some (i + 1);
+///     }
+/// }
+/// ```
+///
+/// For more information on `while` and loops in general, see the [reference].
+///
+/// [`for`]: keyword.for.html
+/// [`loop`]: keyword.loop.html
+/// [reference]: ../reference/expressions/loop-expr.html#predicate-loops
+mod while_keyword { }
+
 #[doc(keyword = "loop")]
 //
 /// Loop indefinitely.
@@ -921,15 +977,6 @@ mod use_keyword { }
 ///
 /// [not yet complete]: https://github.com/rust-lang/rust/issues/34601
 mod where_keyword { }
-
-#[doc(keyword = "while")]
-//
-/// Loop while a condition is upheld.
-///
-/// The documentation for this keyword is [not yet complete]. Pull requests welcome!
-///
-/// [not yet complete]: https://github.com/rust-lang/rust/issues/34601
-mod while_keyword { }
 
 // 2018 Edition keywords
 

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -4,11 +4,13 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
 
-    if cfg!(feature = "llvm-libunwind") &&
+    // FIXME: the not(bootstrap) part is needed because of the issue addressed by #62286,
+    // and could be removed once that change is in beta.
+    if cfg!(all(not(bootstrap), feature = "llvm-libunwind")) &&
         (target.contains("linux") ||
          target.contains("fuchsia")) {
         // Build the unwinding from libunwind C/C++ source code.
-        #[cfg(feature = "llvm-libunwind")]
+        #[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
         llvm_libunwind::compile();
     } else if target.contains("linux") {
         if target.contains("musl") {
@@ -42,7 +44,7 @@ fn main() {
     }
 }
 
-#[cfg(feature = "llvm-libunwind")]
+#[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
 mod llvm_libunwind {
     use std::env;
     use std::path::Path;

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -67,7 +67,8 @@ pub enum _Unwind_Context {}
 
 pub type _Unwind_Exception_Cleanup_Fn = extern "C" fn(unwind_code: _Unwind_Reason_Code,
                                                       exception: *mut _Unwind_Exception);
-#[cfg_attr(feature = "llvm-libunwind",
+#[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+               any(target_os = "fuchsia", target_os = "linux")),
            link(name = "unwind", kind = "static"))]
 extern "C" {
     #[unwind(allowed)]
@@ -93,7 +94,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     }
     pub use _Unwind_Action::*;
 
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+                   any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         pub fn _Unwind_GetGR(ctx: *mut _Unwind_Context, reg_index: c_int) -> _Unwind_Word;
@@ -148,7 +150,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;
 
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+                   any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         fn _Unwind_VRS_Get(ctx: *mut _Unwind_Context,
@@ -212,7 +215,8 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
 cfg_if::cfg_if! {
 if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     // Not 32-bit iOS
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+                   any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]
@@ -223,7 +227,8 @@ if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     }
 } else {
     // 32-bit iOS uses SjLj and does not provide _Unwind_Backtrace()
-    #[cfg_attr(feature = "llvm-libunwind",
+    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+                   any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
         #[unwind(allowed)]

--- a/src/test/ui/crate-name-mismatch.rs
+++ b/src/test/ui/crate-name-mismatch.rs
@@ -1,6 +1,6 @@
 // compile-flags: --crate-name foo
 
 #![crate_name = "bar"]
-//~^ ERROR: --crate-name and #[crate_name] are required to match, but `foo` != `bar`
+//~^ ERROR: `--crate-name` and `#[crate_name]` are required to match, but `foo` != `bar`
 
 fn main() {}

--- a/src/test/ui/crate-name-mismatch.stderr
+++ b/src/test/ui/crate-name-mismatch.stderr
@@ -1,4 +1,4 @@
-error: --crate-name and #[crate_name] are required to match, but `foo` != `bar`
+error: `--crate-name` and `#[crate_name]` are required to match, but `foo` != `bar`
   --> $DIR/crate-name-mismatch.rs:3:1
    |
 LL | #![crate_name = "bar"]

--- a/src/test/ui/duplicate/dupe-symbols-7.stderr
+++ b/src/test/ui/duplicate/dupe-symbols-7.stderr
@@ -4,7 +4,7 @@ error: entry symbol `main` defined multiple times
 LL | fn main(){}
    | ^^^^^^^^^^^
    |
-   = help: did you use #[no_mangle] on `fn main`? Use #[start] instead
+   = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-simd-ffi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-simd-ffi.stderr
@@ -4,7 +4,7 @@ error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result
 LL |     fn baz() -> LocalSimd;
    |                 ^^^^^^^^^
    |
-   = help: add #![feature(simd_ffi)] to the crate attributes to enable
+   = help: add `#![feature(simd_ffi)]` to the crate attributes to enable
 
 error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result in invalid code
   --> $DIR/feature-gate-simd-ffi.rs:10:15
@@ -12,7 +12,7 @@ error: use of SIMD type `LocalSimd` in FFI is highly experimental and may result
 LL |     fn qux(x: LocalSimd);
    |               ^^^^^^^^^
    |
-   = help: add #![feature(simd_ffi)] to the crate attributes to enable
+   = help: add `#![feature(simd_ffi)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/inference_unstable.stderr
+++ b/src/test/ui/inference/inference_unstable.stderr
@@ -8,5 +8,5 @@ LL |     assert_eq!('x'.ipu_flatten(), 1);
    = warning: once this method is added to the standard library, the ambiguity may cause an error or change in behavior!
    = note: for more information, see issue #48919 <https://github.com/rust-lang/rust/issues/48919>
    = help: call with fully qualified syntax `inference_unstable_itertools::IpuItertools::ipu_flatten(...)` to keep using the current method
-   = help: add #![feature(ipu_flatten)] to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
+   = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable `inference_unstable_iterator::IpuIterator::ipu_flatten`
 

--- a/src/test/ui/target-feature-wrong.rs
+++ b/src/test/ui/target-feature-wrong.rs
@@ -25,7 +25,7 @@
 unsafe fn foo() {}
 
 #[target_feature(enable = "sse2")]
-//~^ ERROR #[target_feature(..)] can only be applied to `unsafe` functions
+//~^ ERROR `#[target_feature(..)]` can only be applied to `unsafe` functions
 //~| NOTE can only be applied to `unsafe` functions
 fn bar() {}
 //~^ NOTE not an `unsafe` function
@@ -36,7 +36,7 @@ mod another {}
 //~^ NOTE not a function
 
 #[inline(always)]
-//~^ ERROR: cannot use #[inline(always)]
+//~^ ERROR: cannot use `#[inline(always)]`
 #[target_feature(enable = "sse2")]
 unsafe fn test() {}
 

--- a/src/test/ui/target-feature-wrong.stderr
+++ b/src/test/ui/target-feature-wrong.stderr
@@ -22,7 +22,7 @@ error: malformed `target_feature` attribute input
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^ help: must be of the form: `enable = ".."`
 
-error: #[target_feature(..)] can only be applied to `unsafe` functions
+error: `#[target_feature(..)]` can only be applied to `unsafe` functions
   --> $DIR/target-feature-wrong.rs:27:1
    |
 LL | #[target_feature(enable = "sse2")]
@@ -40,7 +40,7 @@ LL |
 LL | mod another {}
    | -------------- not a function
 
-error: cannot use #[inline(always)] with #[target_feature]
+error: cannot use `#[inline(always)]` with `#[target_feature]`
   --> $DIR/target-feature-wrong.rs:38:1
    |
 LL | #[inline(always)]


### PR DESCRIPTION
Successful merges:

 - #62356 (Implement Option::contains and Result::contains)
 - #62462 (Document `while` keyword)
 - #62472 (Normalize use of backticks in compiler messages p2)
 - #62477 (Re-add bootstrap attribute to libunwind for llvm-libunwind feature)
 - #62478 (normalize use of backticks for compiler messages in librustc_codegen)

Failed merges:


r? @ghost