### PR TITLE
Fix Pin urls in Option documentation

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -290,6 +290,8 @@ impl<T> Option<T> {
 
 
     /// Converts from [`Pin`]`<&Option<T>>` to `Option<`[`Pin`]`<&T>>`.
+    ///
+    /// [`Pin`]: ../pin/struct.Pin.html
     #[inline]
     #[stable(feature = "pin", since = "1.33.0")]
     pub fn as_pin_ref<'a>(self: Pin<&'a Option<T>>) -> Option<Pin<&'a T>> {
@@ -299,6 +301,8 @@ impl<T> Option<T> {
     }
 
     /// Converts from [`Pin`]`<&mut Option<T>>` to `Option<`[`Pin`]`<&mut T>>`.
+    ///
+    /// [`Pin`]: ../pin/struct.Pin.html
     #[inline]
     #[stable(feature = "pin", since = "1.33.0")]
     pub fn as_pin_mut<'a>(self: Pin<&'a mut Option<T>>) -> Option<Pin<&'a mut T>> {


### PR DESCRIPTION
Fixes the following situation:

![Screenshot from 2019-07-08 13-24-59](https://user-images.githubusercontent.com/3050060/60806822-55dfdc00-a184-11e9-9ee3-279e82fc92bd.png)

r? @QuietMisdreavus 