### PR TITLE
Regression test for issue 42574.

### DIFF
--- a/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.rs
+++ b/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.rs
@@ -1,0 +1,13 @@
+// This test illustrates a case where full NLL (enabled by the feature
+// switch below) produces superior diagnostics to the NLL-migrate
+// mode.
+
+#![feature(nll)]
+
+fn doit(data: &'static mut ()) {
+    || doit(data);
+    //~^ ERROR lifetime may not live long enough
+    //~| ERROR `data` does not live long enough
+}
+
+fn main() { }

--- a/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
+++ b/src/test/ui/nll/issue-42574-diagnostic-in-nested-closure.stderr
@@ -1,0 +1,26 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-42574-diagnostic-in-nested-closure.rs:8:8
+   |
+LL |     || doit(data);
+   |     -- ^^^^^^^^^^ argument requires that `'1` must outlive `'static`
+   |     |
+   |     lifetime `'1` represents this closure's body
+   |
+   = note: closure implements `FnMut`, so references to captured variables can't escape the closure
+
+error[E0597]: `data` does not live long enough
+  --> $DIR/issue-42574-diagnostic-in-nested-closure.rs:8:13
+   |
+LL |     || doit(data);
+   |     -- -----^^^^-
+   |     |  |    |
+   |     |  |    borrowed value does not live long enough
+   |     |  argument requires that `data` is borrowed for `'static`
+   |     value captured here
+...
+LL | }
+   |  - `data` dropped here while still borrowed
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Cc #42574.

I'm not going to say this *closes* that issue yet, for two reasons:

 1. I am still confused about some aspects of the behavior we are observing that bug

 2. The "fix" to the diagnostic relies on full NLL (`#![feature(nll)]`); migration mode still has a subpar diagnostic.