### PR TITLE
normalize use of backticks in compiler messages for libsyntax/feature_gate.rs

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1465,7 +1465,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         cfg_fn!(dropck_eyepatch))),
     (sym::unwind, Whitelisted, template!(List: "allowed|aborts"), Gated(Stability::Unstable,
                                 sym::unwind_attributes,
-                                "#[unwind] is experimental",
+                                "`#[unwind]` is experimental",
                                 cfg_fn!(unwind_attributes))),
     (sym::used, Whitelisted, template!(Word), Ungated),
 
@@ -1551,13 +1551,13 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     (sym::alloc_error_handler, Normal, template!(Word), Gated(Stability::Unstable,
                         sym::alloc_error_handler,
-                        "#[alloc_error_handler] is an unstable feature",
+                        "`#[alloc_error_handler]` is an unstable feature",
                         cfg_fn!(alloc_error_handler))),
 
     // RFC 2412
     (sym::optimize, Whitelisted, template!(List: "size|speed"), Gated(Stability::Unstable,
                             sym::optimize_attribute,
-                            "#[optimize] attribute is an unstable feature",
+                            "`#[optimize]` attribute is an unstable feature",
                             cfg_fn!(optimize_attribute))),
 
     // Crate level attributes
@@ -1674,7 +1674,7 @@ impl<'a> Context<'a> {
                 if let Some(content) = attr.meta_item_list() {
                     if content.iter().any(|c| c.check_name(sym::include)) {
                         gate_feature!(self, external_doc, attr.span,
-                            "#[doc(include = \"...\")] is experimental"
+                            "`#[doc(include = \"...\")]` is experimental"
                         );
                     }
                 }
@@ -1803,7 +1803,7 @@ fn leveled_feature_err<'a, S: Into<MultiSpan>>(
 
     // #23973: do not suggest `#![feature(...)]` if we are in beta/stable
     if sess.unstable_features.is_nightly_build() {
-        err.help(&format!("add #![feature({})] to the crate attributes to enable", feature));
+        err.help(&format!("add `#![feature({})]` to the crate attributes to enable", feature));
     }
 
     // If we're on stable and only emitting a "soft" warning, add a note to
@@ -1985,23 +1985,23 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             if let Some(content) = attr.meta_item_list() {
                 if content.len() == 1 && content[0].check_name(sym::cfg) {
                     gate_feature_post!(&self, doc_cfg, attr.span,
-                        "#[doc(cfg(...))] is experimental"
+                        "`#[doc(cfg(...))]` is experimental"
                     );
                 } else if content.iter().any(|c| c.check_name(sym::masked)) {
                     gate_feature_post!(&self, doc_masked, attr.span,
-                        "#[doc(masked)] is experimental"
+                        "`#[doc(masked)]` is experimental"
                     );
                 } else if content.iter().any(|c| c.check_name(sym::spotlight)) {
                     gate_feature_post!(&self, doc_spotlight, attr.span,
-                        "#[doc(spotlight)] is experimental"
+                        "`#[doc(spotlight)]` is experimental"
                     );
                 } else if content.iter().any(|c| c.check_name(sym::alias)) {
                     gate_feature_post!(&self, doc_alias, attr.span,
-                        "#[doc(alias = \"...\")] is experimental"
+                        "`#[doc(alias = \"...\")]` is experimental"
                     );
                 } else if content.iter().any(|c| c.check_name(sym::keyword)) {
                     gate_feature_post!(&self, doc_keyword, attr.span,
-                        "#[doc(keyword = \"...\")] is experimental"
+                        "`#[doc(keyword = \"...\")]` is experimental"
                     );
                 }
             }
@@ -2044,13 +2044,13 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
                 if attr::contains_name(&i.attrs[..], sym::start) {
                     gate_feature_post!(&self, start, i.span,
-                                      "a #[start] function is an experimental \
+                                      "a `#[start]` function is an experimental \
                                        feature whose signature may change \
                                        over time");
                 }
                 if attr::contains_name(&i.attrs[..], sym::main) {
                     gate_feature_post!(&self, main, i.span,
-                                       "declaration of a nonstandard #[main] \
+                                       "declaration of a non-standard `#[main]` \
                                         function may change over time, for now \
                                         a top-level `fn main()` is required");
                 }
@@ -2638,7 +2638,7 @@ fn maybe_stage_features(span_handler: &Handler, krate: &ast::Crate,
             if attr.check_name(sym::feature) {
                 let release_channel = option_env!("CFG_RELEASE_CHANNEL").unwrap_or("(unknown)");
                 span_err!(span_handler, attr.span, E0554,
-                          "#![feature] may not be used on the {} release channel",
+                          "`#![feature]` may not be used on the {} release channel",
                           release_channel);
             }
         }

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -5,7 +5,7 @@ LL | #![plugin(attr_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
-   = help: add #![feature(plugin)] to the crate attributes to enable
+   = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/src/test/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -9,7 +9,7 @@ LL | extern crate rustc_data_structures;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:5:1
@@ -18,7 +18,7 @@ LL | extern crate rustc;
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:7:1
@@ -27,7 +27,7 @@ LL | extern crate rustc_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:10:5
@@ -36,7 +36,7 @@ LL | use rustc_macros::HashStable;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:13:10
@@ -45,7 +45,7 @@ LL | #[derive(HashStable)]
    |          ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/async-await/feature-async-closure.stderr
+++ b/src/test/ui/async-await/feature-async-closure.stderr
@@ -5,7 +5,7 @@ LL |     let _ = async || {};
    |             ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62290
-   = help: add #![feature(async_closure)] to the crate attributes to enable
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/attributes/obsolete-attr.stderr
+++ b/src/test/ui/attributes/obsolete-attr.stderr
@@ -5,7 +5,7 @@ LL | #[fixed_stack_segment] fn f() {}
    |   ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ab_isize` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/obsolete-attr.rs:3:3
@@ -14,7 +14,7 @@ LL | #[ab_isize="stdcall"] extern {}
    |   ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/attributes/unknown-attr.stderr
+++ b/src/test/ui/attributes/unknown-attr.stderr
@@ -5,7 +5,7 @@ LL | #![mutable_doc]
    |    ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `dance` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/unknown-attr.rs:7:3
@@ -14,7 +14,7 @@ LL | #[dance] mod a {}
    |   ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `dance` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/unknown-attr.rs:9:3
@@ -23,7 +23,7 @@ LL | #[dance] fn main() {}
    |   ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/cast/cast-ptr-to-int-const.stderr
+++ b/src/test/ui/cast/cast-ptr-to-int-const.stderr
@@ -5,7 +5,7 @@ LL |         main as u32
    |         ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0658]: casting pointers to integers in constants is unstable
   --> $DIR/cast-ptr-to-int-const.rs:9:9
@@ -14,7 +14,7 @@ LL |         &Y as *const u32 as u32
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/conditional-compilation/cfg-attr-crate-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-crate-2.stderr
@@ -5,7 +5,7 @@ LL | #![cfg_attr(broken, no_core)]
    |                     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29639
-   = help: add #![feature(no_core)] to the crate attributes to enable
+   = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-1.stderr
@@ -5,7 +5,7 @@ LL | #![cfg_attr(broken, no_core, no_std)]
    |                     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29639
-   = help: add #![feature(no_core)] to the crate attributes to enable
+   = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-invalid-2.stderr
@@ -5,7 +5,7 @@ LL | #![cfg_attr(broken, no_std, no_core)]
    |                             ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29639
-   = help: add #![feature(no_core)] to the crate attributes to enable
+   = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
@@ -8,7 +8,7 @@ LL | foo!();
    | ------- in this macro invocation
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-generic-params.stderr
+++ b/src/test/ui/conditional-compilation/cfg-generic-params.stderr
@@ -23,7 +23,7 @@ LL | fn f_lt_yes<#[cfg_attr(yes, unknown)] 'a>() {}
    |                             ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `unknown` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/cfg-generic-params.rs:21:29
@@ -32,7 +32,7 @@ LL | fn f_ty_yes<#[cfg_attr(yes, unknown)] T>() {}
    |                             ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `unknown` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/cfg-generic-params.rs:24:34
@@ -41,7 +41,7 @@ LL | type FnYes = for<#[cfg_attr(yes, unknown)] 'a> fn();
    |                                  ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `unknown` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/cfg-generic-params.rs:28:40
@@ -50,7 +50,7 @@ LL | type PolyYes = dyn for<#[cfg_attr(yes, unknown)] 'a> Copy;
    |                                        ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `unknown` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/cfg-generic-params.rs:32:43
@@ -59,7 +59,7 @@ LL | struct WhereYes where for<#[cfg_attr(yes, unknown)] 'a> u8: Copy;
    |                                           ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
@@ -5,7 +5,7 @@ LL | trait Trait<const T: ()> {}
    |                   ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add #![feature(const_generics)] to the crate attributes to enable
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -11,7 +11,7 @@ LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    |                   ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add #![feature(const_generics)] to the crate attributes to enable
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/issue-60263.stderr
+++ b/src/test/ui/const-generics/issue-60263.stderr
@@ -5,7 +5,7 @@ LL | struct B<const I: u8>;
    |                ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add #![feature(const_generics)] to the crate attributes to enable
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-deref-ptr.stderr
+++ b/src/test/ui/consts/const-deref-ptr.stderr
@@ -5,7 +5,7 @@ LL |     static C: u64 = unsafe {*(0xdeadbeef as *const u64)};
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/feature-gate-const_fn_union.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_fn_union.stderr
@@ -5,7 +5,7 @@ LL |     Foo { u }.i
    |     ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51909
-   = help: add #![feature(const_fn_union)] to the crate attributes to enable
+   = help: add `#![feature(const_fn_union)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
+++ b/src/test/ui/consts/const-eval/feature-gate-const_panic.stderr
@@ -5,7 +5,7 @@ LL | const Z: () = panic!("cheese");
    |               ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51999
-   = help: add #![feature(const_panic)] to the crate attributes to enable
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0658]: panicking in constants is unstable
@@ -15,7 +15,7 @@ LL | const X: () = unimplemented!();
    |               ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51999
-   = help: add #![feature(const_panic)] to the crate attributes to enable
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0658]: panicking in constants is unstable
@@ -25,7 +25,7 @@ LL | const Y: () = unreachable!();
    |               ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51999
-   = help: add #![feature(const_panic)] to the crate attributes to enable
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -5,7 +5,7 @@ LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
   --> $DIR/match-test-ptr-null.rs:6:15

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr_feature_gate.stderr
@@ -5,7 +5,7 @@ LL | #[rustc_allow_const_fn_ptr]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/min_const_fn/min_const_fn_unsafe.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_unsafe.stderr
@@ -5,7 +5,7 @@ LL | const fn bad_const_fn_deref_raw(x: *mut usize) -> &'static usize { unsafe {
    |                                                                             ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw pointers in constant functions is unstable
   --> $DIR/min_const_fn_unsafe.rs:53:70
@@ -14,7 +14,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw(x: *mut usize) -> usize { *x }
    |                                                                      ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0658]: dereferencing raw pointers in constant functions is unstable
   --> $DIR/min_const_fn_unsafe.rs:56:83
@@ -23,7 +23,7 @@ LL | const unsafe fn bad_const_unsafe_deref_raw_ref(x: *mut usize) -> &'static u
    |                                                                                   ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error[E0658]: unions in const fn are unstable
   --> $DIR/min_const_fn_unsafe.rs:63:5
@@ -32,7 +32,7 @@ LL |     Foo { x: () }.y
    |     ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51909
-   = help: add #![feature(const_fn_union)] to the crate attributes to enable
+   = help: add `#![feature(const_fn_union)]` to the crate attributes to enable
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
   --> $DIR/min_const_fn_unsafe.rs:50:77

--- a/src/test/ui/consts/projection_qualif.stderr
+++ b/src/test/ui/consts/projection_qualif.stderr
@@ -17,7 +17,7 @@ LL |         unsafe { *b = 5; }
    |                  ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/custom_attribute.stderr
+++ b/src/test/ui/custom_attribute.stderr
@@ -5,7 +5,7 @@ LL | #[foo]
    |   ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/custom_attribute.rs:5:7
@@ -14,7 +14,7 @@ LL |     #[foo]
    |       ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/custom_attribute.rs:7:7
@@ -23,7 +23,7 @@ LL |     #[foo]
    |       ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
+++ b/src/test/ui/enum-discriminant/feature-gate-arbitrary_enum_discriminant.stderr
@@ -5,7 +5,7 @@ LL |   Tuple() = 2,
    |             ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60553
-   = help: add #![feature(arbitrary_enum_discriminant)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error[E0658]: discriminants on non-unit variants are experimental
   --> $DIR/feature-gate-arbitrary_enum_discriminant.rs:8:14
@@ -14,7 +14,7 @@ LL |   Struct{} = 3,
    |              ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60553
-   = help: add #![feature(arbitrary_enum_discriminant)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error[E0658]: custom discriminant values are not allowed in enums with tuple or struct variants
   --> $DIR/feature-gate-arbitrary_enum_discriminant.rs:4:10
@@ -29,7 +29,7 @@ LL |   Struct{} = 3,
    |   ------------ struct variant defined here
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60553
-   = help: add #![feature(arbitrary_enum_discriminant)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0395.stderr
+++ b/src/test/ui/error-codes/E0395.stderr
@@ -5,7 +5,7 @@ LL | static BAZ: bool = unsafe { (&FOO as *const i32) == (&BAR as *const i32) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53020
-   = help: add #![feature(const_compare_raw_pointers)] to the crate attributes to enable
+   = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0396.stderr
+++ b/src/test/ui/error-codes/E0396.stderr
@@ -5,7 +5,7 @@ LL | const VALUE: u8 = unsafe { *REG_ADDR };
    |                            ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51911
-   = help: add #![feature(const_raw_ptr_deref)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_deref)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0658.stderr
+++ b/src/test/ui/error-codes/E0658.stderr
@@ -7,7 +7,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35118
-   = help: add #![feature(repr128)] to the crate attributes to enable
+   = help: add `#![feature(repr128)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/existential-type/issue-60371.stderr
+++ b/src/test/ui/existential-type/issue-60371.stderr
@@ -5,7 +5,7 @@ LL |     existential type Item: Bug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/34511
-   = help: add #![feature(existential_type)] to the crate attributes to enable
+   = help: add `#![feature(existential_type)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `(): Bug` is not satisfied
   --> $DIR/issue-60371.rs:8:5

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -5,7 +5,7 @@ LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_un
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:30:5
@@ -14,7 +14,7 @@ LL |     r.a_unstable_undeclared_pub;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `b_crate` of struct `pub_and_stability::Record` is private
   --> $DIR/explore-issue-38412.rs:31:5
@@ -41,7 +41,7 @@ LL |     t.2;
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `3` of struct `pub_and_stability::Tuple` is private
   --> $DIR/explore-issue-38412.rs:38:5
@@ -68,7 +68,7 @@ LL |     r.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:48:7
@@ -77,7 +77,7 @@ LL |     r.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:50:7
@@ -104,7 +104,7 @@ LL |     t.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
   --> $DIR/explore-issue-38412.rs:61:7
@@ -113,7 +113,7 @@ LL |     t.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38412
-   = help: add #![feature(unstable_undeclared)] to the crate attributes to enable
+   = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: method `pub_crate` is private
   --> $DIR/explore-issue-38412.rs:63:7

--- a/src/test/ui/feature-gate-optimize_attribute.rs
+++ b/src/test/ui/feature-gate-optimize_attribute.rs
@@ -1,17 +1,17 @@
 #![crate_type="rlib"]
-#![optimize(speed)] //~ ERROR #[optimize] attribute is an unstable feature
+#![optimize(speed)] //~ ERROR `#[optimize]` attribute is an unstable feature
 
-#[optimize(size)] //~ ERROR #[optimize] attribute is an unstable feature
+#[optimize(size)] //~ ERROR `#[optimize]` attribute is an unstable feature
 mod module {
 
-#[optimize(size)] //~ ERROR #[optimize] attribute is an unstable feature
+#[optimize(size)] //~ ERROR `#[optimize]` attribute is an unstable feature
 fn size() {}
 
-#[optimize(speed)] //~ ERROR #[optimize] attribute is an unstable feature
+#[optimize(speed)] //~ ERROR `#[optimize]` attribute is an unstable feature
 fn speed() {}
 
 #[optimize(banana)]
-//~^ ERROR #[optimize] attribute is an unstable feature
+//~^ ERROR `#[optimize]` attribute is an unstable feature
 //~| ERROR E0722
 fn not_known() {}
 

--- a/src/test/ui/feature-gate-optimize_attribute.stderr
+++ b/src/test/ui/feature-gate-optimize_attribute.stderr
@@ -1,47 +1,47 @@
-error[E0658]: #[optimize] attribute is an unstable feature
+error[E0658]: `#[optimize]` attribute is an unstable feature
   --> $DIR/feature-gate-optimize_attribute.rs:7:1
    |
 LL | #[optimize(size)]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54882
-   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+   = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
-error[E0658]: #[optimize] attribute is an unstable feature
+error[E0658]: `#[optimize]` attribute is an unstable feature
   --> $DIR/feature-gate-optimize_attribute.rs:10:1
    |
 LL | #[optimize(speed)]
    | ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54882
-   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+   = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
-error[E0658]: #[optimize] attribute is an unstable feature
+error[E0658]: `#[optimize]` attribute is an unstable feature
   --> $DIR/feature-gate-optimize_attribute.rs:13:1
    |
 LL | #[optimize(banana)]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54882
-   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+   = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
-error[E0658]: #[optimize] attribute is an unstable feature
+error[E0658]: `#[optimize]` attribute is an unstable feature
   --> $DIR/feature-gate-optimize_attribute.rs:4:1
    |
 LL | #[optimize(size)]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54882
-   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+   = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
-error[E0658]: #[optimize] attribute is an unstable feature
+error[E0658]: `#[optimize]` attribute is an unstable feature
   --> $DIR/feature-gate-optimize_attribute.rs:2:1
    |
 LL | #![optimize(speed)]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54882
-   = help: add #![feature(optimize_attribute)] to the crate attributes to enable
+   = help: add `#![feature(optimize_attribute)]` to the crate attributes to enable
 
 error[E0722]: invalid argument
   --> $DIR/feature-gate-optimize_attribute.rs:13:12

--- a/src/test/ui/feature-gate/await-macro.stderr
+++ b/src/test/ui/feature-gate/await-macro.stderr
@@ -5,7 +5,7 @@ LL |     await!(bar());
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(await_macro)] to the crate attributes to enable
+   = help: add `#![feature(await_macro)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
+++ b/src/test/ui/feature-gate/feature-gate-c_variadic.stderr
@@ -5,7 +5,7 @@ LL | pub unsafe extern "C" fn test(_: i32, ap: ...) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44930
-   = help: add #![feature(c_variadic)] to the crate attributes to enable
+   = help: add `#![feature(c_variadic)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/feature-gate-cfg_doctest.stderr
+++ b/src/test/ui/feature-gate/feature-gate-cfg_doctest.stderr
@@ -5,7 +5,7 @@ LL | #[cfg(doctest)]
    |       ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62210
-   = help: add #![feature(cfg_doctest)] to the crate attributes to enable
+   = help: add `#![feature(cfg_doctest)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
+++ b/src/test/ui/feature-gate/feature-gate-static-nobundle-2.stderr
@@ -1,7 +1,7 @@
 error[E0658]: kind="static-nobundle" is feature gated
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37403
-   = help: add #![feature(static_nobundle)] to the crate attributes to enable
+   = help: add `#![feature(static_nobundle)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gate/issue-49983-see-issue-0.stderr
+++ b/src/test/ui/feature-gate/issue-49983-see-issue-0.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'ptr_internals': use NonNull inste
 LL | #[allow(unused_imports)] use core::ptr::Unique;
    |                              ^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(ptr_internals)] to the crate attributes to enable
+   = help: add `#![feature(ptr_internals)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gated-feature-in-macro-arg.stderr
+++ b/src/test/ui/feature-gated-feature-in-macro-arg.stderr
@@ -6,7 +6,7 @@ LL | |             fn atomic_fence();
 LL | |         }
    | |_________^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi-msp430-interrupt.stderr
@@ -5,7 +5,7 @@ LL | extern "msp430-interrupt" fn foo() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi.stderr
@@ -4,7 +4,7 @@ error[E0658]: intrinsics are subject to change
 LL | extern "rust-intrinsic" fn f1() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:13:1
@@ -13,7 +13,7 @@ LL | extern "platform-intrinsic" fn f2() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:14:1
@@ -21,7 +21,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | extern "vectorcall" fn f3() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:15:1
@@ -30,7 +30,7 @@ LL | extern "rust-call" fn f4() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:16:1
@@ -39,7 +39,7 @@ LL | extern "msp430-interrupt" fn f5() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:17:1
@@ -48,7 +48,7 @@ LL | extern "ptx-kernel" fn f6() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:18:1
@@ -57,7 +57,7 @@ LL | extern "x86-interrupt" fn f7() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:19:1
@@ -65,7 +65,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL | extern "thiscall" fn f8() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:20:1
@@ -74,7 +74,7 @@ LL | extern "amdgpu-kernel" fn f9() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:24:5
@@ -82,7 +82,7 @@ error[E0658]: intrinsics are subject to change
 LL |     extern "rust-intrinsic" fn m1();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:25:5
@@ -91,7 +91,7 @@ LL |     extern "platform-intrinsic" fn m2();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:26:5
@@ -99,7 +99,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn m3();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:27:5
@@ -108,7 +108,7 @@ LL |     extern "rust-call" fn m4();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:28:5
@@ -117,7 +117,7 @@ LL |     extern "msp430-interrupt" fn m5();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:29:5
@@ -126,7 +126,7 @@ LL |     extern "ptx-kernel" fn m6();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:30:5
@@ -135,7 +135,7 @@ LL |     extern "x86-interrupt" fn m7();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:31:5
@@ -143,7 +143,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL |     extern "thiscall" fn m8();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:32:5
@@ -152,7 +152,7 @@ LL |     extern "amdgpu-kernel" fn m9();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:34:5
@@ -160,7 +160,7 @@ error[E0658]: intrinsics are subject to change
 LL |     extern "rust-intrinsic" fn dm1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:35:5
@@ -169,7 +169,7 @@ LL |     extern "platform-intrinsic" fn dm2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:36:5
@@ -177,7 +177,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn dm3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:37:5
@@ -186,7 +186,7 @@ LL |     extern "rust-call" fn dm4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:38:5
@@ -195,7 +195,7 @@ LL |     extern "msp430-interrupt" fn dm5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:39:5
@@ -204,7 +204,7 @@ LL |     extern "ptx-kernel" fn dm6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:40:5
@@ -213,7 +213,7 @@ LL |     extern "x86-interrupt" fn dm7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:41:5
@@ -221,7 +221,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL |     extern "thiscall" fn dm8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:42:5
@@ -230,7 +230,7 @@ LL |     extern "amdgpu-kernel" fn dm9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:49:5
@@ -238,7 +238,7 @@ error[E0658]: intrinsics are subject to change
 LL |     extern "rust-intrinsic" fn m1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:50:5
@@ -247,7 +247,7 @@ LL |     extern "platform-intrinsic" fn m2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:51:5
@@ -255,7 +255,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn m3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:52:5
@@ -264,7 +264,7 @@ LL |     extern "rust-call" fn m4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:53:5
@@ -273,7 +273,7 @@ LL |     extern "msp430-interrupt" fn m5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:54:5
@@ -282,7 +282,7 @@ LL |     extern "ptx-kernel" fn m6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:55:5
@@ -291,7 +291,7 @@ LL |     extern "x86-interrupt" fn m7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:56:5
@@ -299,7 +299,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL |     extern "thiscall" fn m8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:57:5
@@ -308,7 +308,7 @@ LL |     extern "amdgpu-kernel" fn m9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:62:5
@@ -316,7 +316,7 @@ error[E0658]: intrinsics are subject to change
 LL |     extern "rust-intrinsic" fn im1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:63:5
@@ -325,7 +325,7 @@ LL |     extern "platform-intrinsic" fn im2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:64:5
@@ -333,7 +333,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL |     extern "vectorcall" fn im3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:65:5
@@ -342,7 +342,7 @@ LL |     extern "rust-call" fn im4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:66:5
@@ -351,7 +351,7 @@ LL |     extern "msp430-interrupt" fn im5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:67:5
@@ -360,7 +360,7 @@ LL |     extern "ptx-kernel" fn im6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:68:5
@@ -369,7 +369,7 @@ LL |     extern "x86-interrupt" fn im7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:69:5
@@ -377,7 +377,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL |     extern "thiscall" fn im8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:70:5
@@ -386,7 +386,7 @@ LL |     extern "amdgpu-kernel" fn im9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:74:11
@@ -394,7 +394,7 @@ error[E0658]: intrinsics are subject to change
 LL | type A1 = extern "rust-intrinsic" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:75:11
@@ -403,7 +403,7 @@ LL | type A2 = extern "platform-intrinsic" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:76:11
@@ -411,7 +411,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | type A3 = extern "vectorcall" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:77:11
@@ -420,7 +420,7 @@ LL | type A4 = extern "rust-call" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:78:11
@@ -429,7 +429,7 @@ LL | type A5 = extern "msp430-interrupt" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:79:11
@@ -438,7 +438,7 @@ LL | type A6 = extern "ptx-kernel" fn ();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:80:11
@@ -447,7 +447,7 @@ LL | type A7 = extern "x86-interrupt" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:81:11
@@ -455,7 +455,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL | type A8 = extern "thiscall" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:82:11
@@ -464,7 +464,7 @@ LL | type A9 = extern "amdgpu-kernel" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-abi.rs:85:1
@@ -472,7 +472,7 @@ error[E0658]: intrinsics are subject to change
 LL | extern "rust-intrinsic" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
   --> $DIR/feature-gate-abi.rs:86:1
@@ -481,7 +481,7 @@ LL | extern "platform-intrinsic" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(platform_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:87:1
@@ -489,7 +489,7 @@ error[E0658]: vectorcall is experimental and subject to change
 LL | extern "vectorcall" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_vectorcall)] to the crate attributes to enable
+   = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-abi.rs:88:1
@@ -498,7 +498,7 @@ LL | extern "rust-call" {}
    | ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:89:1
@@ -507,7 +507,7 @@ LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38487
-   = help: add #![feature(abi_msp430_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
   --> $DIR/feature-gate-abi.rs:90:1
@@ -516,7 +516,7 @@ LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/38788
-   = help: add #![feature(abi_ptx)] to the crate attributes to enable
+   = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:91:1
@@ -525,7 +525,7 @@ LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/40180
-   = help: add #![feature(abi_x86_interrupt)] to the crate attributes to enable
+   = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:92:1
@@ -533,7 +533,7 @@ error[E0658]: thiscall is experimental and subject to change
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(abi_thiscall)] to the crate attributes to enable
+   = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:93:1
@@ -542,7 +542,7 @@ LL | extern "amdgpu-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
-   = help: add #![feature(abi_amdgpu_kernel)] to the crate attributes to enable
+   = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
 error: aborting due to 63 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-abi_unadjusted.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi_unadjusted.stderr
@@ -6,7 +6,7 @@ LL | |
 LL | | }
    | |_^
    |
-   = help: add #![feature(abi_unadjusted)] to the crate attributes to enable
+   = help: add `#![feature(abi_unadjusted)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
+++ b/src/test/ui/feature-gates/feature-gate-alloc-error-handler.rs
@@ -5,7 +5,7 @@
 
 use core::alloc::Layout;
 
-#[alloc_error_handler] //~ ERROR #[alloc_error_handler] is an unstable feature
+#[alloc_error_handler] //~ ERROR `#[alloc_error_handler]` is an unstable feature
 fn oom(info: Layout) -> ! {
     loop {}
 }

--- a/src/test/ui/feature-gates/feature-gate-alloc-error-handler.stderr
+++ b/src/test/ui/feature-gates/feature-gate-alloc-error-handler.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[alloc_error_handler] is an unstable feature
+error[E0658]: `#[alloc_error_handler]` is an unstable feature
   --> $DIR/feature-gate-alloc-error-handler.rs:8:1
    |
 LL | #[alloc_error_handler]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51540
-   = help: add #![feature(alloc_error_handler)] to the crate attributes to enable
+   = help: add `#![feature(alloc_error_handler)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allocator_internals.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allocator_internals.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[default_lib_allocator]` attribute is an experimental featur
 LL | #![default_lib_allocator]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(allocator_internals)] to the crate attributes to enable
+   = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unsafe-nested-macro.stderr
@@ -7,7 +7,7 @@ LL |         #[allow_internal_unsafe]
 LL | bar!();
    | ------- in this macro invocation
    |
-   = help: add #![feature(allow_internal_unsafe)] to the crate attributes to enable
+   = help: add `#![feature(allow_internal_unsafe)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-nested-macro.stderr
@@ -7,7 +7,7 @@ LL |         #[allow_internal_unstable()]
 LL | bar!();
    | ------- in this macro invocation
    |
-   = help: add #![feature(allow_internal_unstable)] to the crate attributes to enable
+   = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable-struct.stderr
@@ -4,7 +4,7 @@ error[E0658]: allow_internal_unstable side-steps feature gating and stability ch
 LL | #[allow_internal_unstable()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(allow_internal_unstable)] to the crate attributes to enable
+   = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow-internal-unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: allow_internal_unstable side-steps feature gating and stability ch
 LL | #[allow_internal_unstable()]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(allow_internal_unstable)] to the crate attributes to enable
+   = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-allow_fail.stderr
+++ b/src/test/ui/feature-gates/feature-gate-allow_fail.stderr
@@ -5,7 +5,7 @@ LL | #[allow_fail]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/46488
-   = help: add #![feature(allow_fail)] to the crate attributes to enable
+   = help: add `#![feature(allow_fail)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary-self-types.stderr
@@ -5,7 +5,7 @@ LL |     fn foo(self: Ptr<Self>);
    |                  ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error[E0658]: `Ptr<Bar>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -15,7 +15,7 @@ LL |     fn foo(self: Ptr<Self>) {}
    |                  ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error[E0658]: `std::boxed::Box<Ptr<Bar>>` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -25,7 +25,7 @@ LL |     fn bar(self: Box<Ptr<Self>>) {}
    |                  ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
+++ b/src/test/ui/feature-gates/feature-gate-arbitrary_self_types-raw-pointer.stderr
@@ -5,7 +5,7 @@ LL |     fn bar(self: *const Self);
    |                  ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error[E0658]: `*const Foo` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -15,7 +15,7 @@ LL |     fn foo(self: *const Self) {}
    |                  ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error[E0658]: `*const ()` cannot be used as the type of `self` without the `arbitrary_self_types` feature
@@ -25,7 +25,7 @@ LL |     fn bar(self: *const Self) {}
    |                  ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44874
-   = help: add #![feature(arbitrary_self_types)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_self_types)]` to the crate attributes to enable
    = help: consider changing to `self`, `&self`, `&mut self`, or `self: Box<Self>`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/feature-gates/feature-gate-asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm.stderr
@@ -5,7 +5,7 @@ LL |         asm!("");
    |         ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29722
-   = help: add #![feature(asm)] to the crate attributes to enable
+   = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-asm2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm2.stderr
@@ -5,7 +5,7 @@ LL |         println!("{:?}", asm!(""));
    |                          ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29722
-   = help: add #![feature(asm)] to the crate attributes to enable
+   = help: add `#![feature(asm)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
+++ b/src/test/ui/feature-gates/feature-gate-assoc-type-defaults.stderr
@@ -5,7 +5,7 @@ LL |     type Bar = u8;
    |     ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29661
-   = help: add #![feature(associated_type_defaults)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_defaults)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -5,7 +5,7 @@ LL |     type A: Iterator<Item: Copy>;
    |                      ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:15:22
@@ -14,7 +14,7 @@ LL |     type B: Iterator<Item: 'static>;
    |                      ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:19:20
@@ -23,7 +23,7 @@ LL | struct _St1<T: Tr1<As1: Tr2>> {
    |                    ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:26:18
@@ -32,7 +32,7 @@ LL | enum _En1<T: Tr1<As1: Tr2>> {
    |                  ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:33:19
@@ -41,7 +41,7 @@ LL | union _Un1<T: Tr1<As1: Tr2>> {
    |                   ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:40:37
@@ -50,7 +50,7 @@ LL | type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
    |                                     ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:43:22
@@ -59,7 +59,7 @@ LL | fn _apit(_: impl Tr1<As1: Copy>) {}
    |                      ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:45:26
@@ -68,7 +68,7 @@ LL | fn _apit_dyn(_: &dyn Tr1<As1: Copy>) {}
    |                          ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:48:24
@@ -77,7 +77,7 @@ LL | fn _rpit() -> impl Tr1<As1: Copy> { S1 }
    |                        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:51:31
@@ -86,7 +86,7 @@ LL | fn _rpit_dyn() -> Box<dyn Tr1<As1: Copy>> { Box::new(S1) }
    |                               ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:54:23
@@ -95,7 +95,7 @@ LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |                       ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:60:24
@@ -104,7 +104,7 @@ LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |                        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0658]: associated type bounds are unstable
   --> $DIR/feature-gate-associated_type_bounds.rs:67:21
@@ -113,7 +113,7 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    |                     ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add #![feature(associated_type_bounds)] to the crate attributes to enable
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/feature-gate-associated_type_bounds.rs:54:14

--- a/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await-2015-edition.stderr
@@ -23,7 +23,7 @@ LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
+   = help: add `#![feature(async_await)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-async-await.stderr
+++ b/src/test/ui/feature-gates/feature-gate-async-await.stderr
@@ -11,7 +11,7 @@ LL |     async fn foo() {}
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
+   = help: add `#![feature(async_await)]` to the crate attributes to enable
 
 error[E0658]: async fn is unstable
   --> $DIR/feature-gate-async-await.rs:10:5
@@ -20,7 +20,7 @@ LL |     async fn foo();
    |     ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
+   = help: add `#![feature(async_await)]` to the crate attributes to enable
 
 error[E0658]: async fn is unstable
   --> $DIR/feature-gate-async-await.rs:14:1
@@ -29,7 +29,7 @@ LL | async fn foo() {}
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
+   = help: add `#![feature(async_await)]` to the crate attributes to enable
 
 error[E0658]: async blocks are unstable
   --> $DIR/feature-gate-async-await.rs:17:13
@@ -38,7 +38,7 @@ LL |     let _ = async {};
    |             ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50547
-   = help: add #![feature(async_await)] to the crate attributes to enable
+   = help: add `#![feature(async_await)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-box-expr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box-expr.stderr
@@ -5,7 +5,7 @@ LL |     let x = box 'c';
    |             ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49733
-   = help: add #![feature(box_syntax)] to the crate attributes to enable
+   = help: add `#![feature(box_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
@@ -5,7 +5,7 @@ LL |     let box x = Box::new('c');
    |         ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29641
-   = help: add #![feature(box_patterns)] to the crate attributes to enable
+   = help: add `#![feature(box_patterns)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
@@ -5,7 +5,7 @@ LL |     let x = box 3;
    |             ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49733
-   = help: add #![feature(box_syntax)] to the crate attributes to enable
+   = help: add `#![feature(box_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -5,7 +5,7 @@ LL | #[cfg(target_has_atomic = "8")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:21:7
@@ -14,7 +14,7 @@ LL | #[cfg(target_has_atomic = "8")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:26:7
@@ -23,7 +23,7 @@ LL | #[cfg(target_has_atomic = "16")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:31:7
@@ -32,7 +32,7 @@ LL | #[cfg(target_has_atomic = "16")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:36:7
@@ -41,7 +41,7 @@ LL | #[cfg(target_has_atomic = "32")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:41:7
@@ -50,7 +50,7 @@ LL | #[cfg(target_has_atomic = "32")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:46:7
@@ -59,7 +59,7 @@ LL | #[cfg(target_has_atomic = "64")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:51:7
@@ -68,7 +68,7 @@ LL | #[cfg(target_has_atomic = "64")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:56:7
@@ -77,7 +77,7 @@ LL | #[cfg(target_has_atomic = "128")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:61:7
@@ -86,7 +86,7 @@ LL | #[cfg(target_has_atomic = "128")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:66:7
@@ -95,7 +95,7 @@ LL | #[cfg(target_has_atomic = "ptr")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:71:7
@@ -104,7 +104,7 @@ LL | #[cfg(target_has_atomic = "ptr")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:78:10
@@ -113,7 +113,7 @@ LL |     cfg!(target_has_atomic = "8");
    |          ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:80:10
@@ -122,7 +122,7 @@ LL |     cfg!(target_has_atomic = "16");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:82:10
@@ -131,7 +131,7 @@ LL |     cfg!(target_has_atomic = "32");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:84:10
@@ -140,7 +140,7 @@ LL |     cfg!(target_has_atomic = "64");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:86:10
@@ -149,7 +149,7 @@ LL |     cfg!(target_has_atomic = "128");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error[E0658]: `cfg(target_has_atomic)` is experimental and subject to change
   --> $DIR/feature-gate-cfg-target-has-atomic.rs:88:10
@@ -158,7 +158,7 @@ LL |     cfg!(target_has_atomic = "ptr");
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32976
-   = help: add #![feature(cfg_target_has_atomic)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-thread-local.stderr
@@ -5,7 +5,7 @@ LL |     #[cfg_attr(target_thread_local, thread_local)]
    |                ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29594
-   = help: add #![feature(cfg_target_thread_local)] to the crate attributes to enable
+   = help: add `#![feature(cfg_target_thread_local)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-compiler-builtins.stderr
+++ b/src/test/ui/feature-gates/feature-gate-compiler-builtins.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[compiler_builtins]` attribute is used to identify the `comp
 LL | #![compiler_builtins]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(compiler_builtins)] to the crate attributes to enable
+   = help: add `#![feature(compiler_builtins)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-concat_idents.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents.stderr
@@ -5,7 +5,7 @@ LL |     let a = concat_idents!(X, Y_1);
    |             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29599
-   = help: add #![feature(concat_idents)] to the crate attributes to enable
+   = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents.rs:6:13
@@ -14,7 +14,7 @@ LL |     let b = concat_idents!(X, Y_2);
    |             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29599
-   = help: add #![feature(concat_idents)] to the crate attributes to enable
+   = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -5,7 +5,7 @@ LL |     concat_idents!(a, b);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29599
-   = help: add #![feature(concat_idents)] to the crate attributes to enable
+   = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0425]: cannot find value `ab` in this scope
   --> $DIR/feature-gate-concat_idents2.rs:4:5

--- a/src/test/ui/feature-gates/feature-gate-concat_idents3.stderr
+++ b/src/test/ui/feature-gates/feature-gate-concat_idents3.stderr
@@ -5,7 +5,7 @@ LL |     assert_eq!(10, concat_idents!(X, Y_1));
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29599
-   = help: add #![feature(concat_idents)] to the crate attributes to enable
+   = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents3.rs:8:20
@@ -14,7 +14,7 @@ LL |     assert_eq!(20, concat_idents!(X, Y_2));
    |                    ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29599
-   = help: add #![feature(concat_idents)] to the crate attributes to enable
+   = help: add `#![feature(concat_idents)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_fn.stderr
@@ -23,7 +23,7 @@ LL |     const fn foo() -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0658]: const fn is unstable
   --> $DIR/feature-gate-const_fn.rs:8:5
@@ -32,7 +32,7 @@ LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-const_generics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.stderr
@@ -5,7 +5,7 @@ LL | fn foo<const X: ()>() {}
    |              ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add #![feature(const_generics)] to the crate attributes to enable
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: const generics are unstable
   --> $DIR/feature-gate-const_generics.rs:3:18
@@ -14,7 +14,7 @@ LL | struct Foo<const X: usize>([(); X]);
    |                  ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add #![feature(const_generics)] to the crate attributes to enable
+   = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-const_transmute.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_transmute.stderr
@@ -5,7 +5,7 @@ LL | const TRANSMUTED_U32: u32 = unsafe { mem::transmute(Foo(3)) };
    |                                      ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53605
-   = help: add #![feature(const_transmute)] to the crate attributes to enable
+   = help: add `#![feature(const_transmute)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
+++ b/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
@@ -5,7 +5,7 @@ LL | crate struct Bender {
    | ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53120
-   = help: add #![feature(crate_visibility_modifier)] to the crate attributes to enable
+   = help: add `#![feature(crate_visibility_modifier)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute.stderr
@@ -5,7 +5,7 @@ LL | #[fake_attr]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:8:3
@@ -14,7 +14,7 @@ LL | #[fake_attr(100)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:9:3
@@ -23,7 +23,7 @@ LL | #[fake_attr(1, 2, 3)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:10:3
@@ -32,7 +32,7 @@ LL | #[fake_attr("hello")]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:11:3
@@ -41,7 +41,7 @@ LL | #[fake_attr(name = "hello")]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:12:3
@@ -50,7 +50,7 @@ LL | #[fake_attr(1, "hi", key = 12, true, false)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:13:3
@@ -59,7 +59,7 @@ LL | #[fake_attr(key = "hello", val = 10)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:14:3
@@ -68,7 +68,7 @@ LL | #[fake_attr(key("hello"), val(10))]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:15:3
@@ -77,7 +77,7 @@ LL | #[fake_attr(enabled = true, disabled = false)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:16:3
@@ -86,7 +86,7 @@ LL | #[fake_attr(true)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:17:3
@@ -95,7 +95,7 @@ LL | #[fake_attr(pi = 3.14159)]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:18:3
@@ -104,7 +104,7 @@ LL | #[fake_attr(b"hi")]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `fake_doc` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute.rs:19:3
@@ -113,7 +113,7 @@ LL | #[fake_doc(r"doc")]
    |   ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 13 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute2.stderr
@@ -5,7 +5,7 @@ LL | struct StLt<#[lt_struct] 'a>(&'a u32);
    |             ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_struct` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:8:13
@@ -14,7 +14,7 @@ LL | struct StTy<#[ty_struct] I>(I);
    |             ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_enum` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:11:11
@@ -23,7 +23,7 @@ LL | enum EnLt<#[lt_enum] 'b> { A(&'b u32), B }
    |           ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_enum` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:13:11
@@ -32,7 +32,7 @@ LL | enum EnTy<#[ty_enum] J> { A(J), B }
    |           ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_trait` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:16:12
@@ -41,7 +41,7 @@ LL | trait TrLt<#[lt_trait] 'c> { fn foo(&self, _: &'c [u32]) -> &'c u32; }
    |            ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_trait` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:18:12
@@ -50,7 +50,7 @@ LL | trait TrTy<#[ty_trait] K> { fn foo(&self, _: K); }
    |            ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_type` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:21:11
@@ -59,7 +59,7 @@ LL | type TyLt<#[lt_type] 'd> = &'d u32;
    |           ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_type` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:23:11
@@ -68,7 +68,7 @@ LL | type TyTy<#[ty_type] L> = (L, );
    |           ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_inherent` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:26:6
@@ -77,7 +77,7 @@ LL | impl<#[lt_inherent] 'e> StLt<'e> { }
    |      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_inherent` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:28:6
@@ -86,7 +86,7 @@ LL | impl<#[ty_inherent] M> StTy<M> { }
    |      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_impl_for` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:31:6
@@ -95,7 +95,7 @@ LL | impl<#[lt_impl_for] 'f> TrLt<'f> for StLt<'f> {
    |      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_impl_for` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:35:6
@@ -104,7 +104,7 @@ LL | impl<#[ty_impl_for] N> TrTy<N> for StTy<N> {
    |      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_fn` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:40:9
@@ -113,7 +113,7 @@ LL | fn f_lt<#[lt_fn] 'g>(_: &'g [u32]) -> &'g u32 { loop { } }
    |         ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_fn` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:42:9
@@ -122,7 +122,7 @@ LL | fn f_ty<#[ty_fn] O>(_: O) { }
    |         ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_meth` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:46:13
@@ -131,7 +131,7 @@ LL |     fn m_lt<#[lt_meth] 'h>(_: &'h [u32]) -> &'h u32 { loop { } }
    |             ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `ty_meth` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:48:13
@@ -140,7 +140,7 @@ LL |     fn m_ty<#[ty_meth] P>(_: P) { }
    |             ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `lt_hof` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-custom_attribute2.rs:53:19
@@ -149,7 +149,7 @@ LL |     where Q: for <#[lt_hof] 'i> Fn(&'i [u32]) -> &'i u32
    |                   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -5,7 +5,7 @@ LL | #[test_case]
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50297
-   = help: add #![feature(custom_test_frameworks)] to the crate attributes to enable
+   = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
 
 error[E0658]: custom test frameworks are an unstable feature
   --> $DIR/feature-gate-custom_test_frameworks.rs:1:1
@@ -14,7 +14,7 @@ LL | #![test_runner(main)]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50297
-   = help: add #![feature(custom_test_frameworks)] to the crate attributes to enable
+   = help: add `#![feature(custom_test_frameworks)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
@@ -5,7 +5,7 @@ LL | macro m() {}
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/39412
-   = help: add #![feature(decl_macro)] to the crate attributes to enable
+   = help: add `#![feature(decl_macro)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_alias.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_alias.rs
@@ -1,4 +1,4 @@
-#[doc(alias = "foo")] //~ ERROR: #[doc(alias = "...")] is experimental
+#[doc(alias = "foo")] //~ ERROR: `#[doc(alias = "...")]` is experimental
 pub struct Foo;
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_alias.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_alias.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(alias = "...")] is experimental
+error[E0658]: `#[doc(alias = "...")]` is experimental
   --> $DIR/feature-gate-doc_alias.rs:1:1
    |
 LL | #[doc(alias = "foo")]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/50146
-   = help: add #![feature(doc_alias)] to the crate attributes to enable
+   = help: add `#![feature(doc_alias)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
@@ -5,7 +5,7 @@ LL | #[cfg(rustdoc)]
    |       ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43781
-   = help: add #![feature(doc_cfg)] to the crate attributes to enable
+   = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg.rs
@@ -1,2 +1,2 @@
-#[doc(cfg(unix))] //~ ERROR: #[doc(cfg(...))] is experimental
+#[doc(cfg(unix))] //~ ERROR: `#[doc(cfg(...))]` is experimental
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(cfg(...))] is experimental
+error[E0658]: `#[doc(cfg(...))]` is experimental
   --> $DIR/feature-gate-doc_cfg.rs:1:1
    |
 LL | #[doc(cfg(unix))]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43781
-   = help: add #![feature(doc_cfg)] to the crate attributes to enable
+   = help: add `#![feature(doc_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_keyword.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_keyword.rs
@@ -1,4 +1,4 @@
-#[doc(keyword = "match")] //~ ERROR: #[doc(keyword = "...")] is experimental
+#[doc(keyword = "match")] //~ ERROR: `#[doc(keyword = "...")]` is experimental
 /// wonderful
 mod foo{}
 

--- a/src/test/ui/feature-gates/feature-gate-doc_keyword.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_keyword.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(keyword = "...")] is experimental
+error[E0658]: `#[doc(keyword = "...")]` is experimental
   --> $DIR/feature-gate-doc_keyword.rs:1:1
    |
 LL | #[doc(keyword = "match")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51315
-   = help: add #![feature(doc_keyword)] to the crate attributes to enable
+   = help: add `#![feature(doc_keyword)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_masked.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_masked.rs
@@ -1,4 +1,4 @@
-#[doc(masked)] //~ ERROR: #[doc(masked)] is experimental
+#[doc(masked)] //~ ERROR: `#[doc(masked)]` is experimental
 extern crate std as realstd;
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_masked.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_masked.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(masked)] is experimental
+error[E0658]: `#[doc(masked)]` is experimental
   --> $DIR/feature-gate-doc_masked.rs:1:1
    |
 LL | #[doc(masked)]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44027
-   = help: add #![feature(doc_masked)] to the crate attributes to enable
+   = help: add `#![feature(doc_masked)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-doc_spotlight.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_spotlight.rs
@@ -1,4 +1,4 @@
-#[doc(spotlight)] //~ ERROR: #[doc(spotlight)] is experimental
+#[doc(spotlight)] //~ ERROR: `#[doc(spotlight)]` is experimental
 trait SomeTrait {}
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_spotlight.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_spotlight.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(spotlight)] is experimental
+error[E0658]: `#[doc(spotlight)]` is experimental
   --> $DIR/feature-gate-doc_spotlight.rs:1:1
    |
 LL | #[doc(spotlight)]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/45040
-   = help: add #![feature(doc_spotlight)] to the crate attributes to enable
+   = help: add `#![feature(doc_spotlight)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-dropck-ugeh.stderr
+++ b/src/test/ui/feature-gates/feature-gate-dropck-ugeh.stderr
@@ -5,7 +5,7 @@ LL |     #[unsafe_destructor_blind_to_params] // This is the UGEH attribute
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/28498
-   = help: add #![feature(dropck_parametricity)] to the crate attributes to enable
+   = help: add `#![feature(dropck_parametricity)]` to the crate attributes to enable
 
 warning: use of deprecated attribute `dropck_parametricity`: unsafe_destructor_blind_to_params has been replaced by may_dangle and will be removed in the future. See https://github.com/rust-lang/rust/issues/34761
   --> $DIR/feature-gate-dropck-ugeh.rs:16:5

--- a/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
@@ -5,7 +5,7 @@ LL |         0 .. 3 => {}
    |         ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37854
-   = help: add #![feature(exclusive_range_pattern)] to the crate attributes to enable
+   = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-existential-type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-existential-type.stderr
@@ -5,7 +5,7 @@ LL | existential type Foo: std::fmt::Debug;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/34511
-   = help: add #![feature(existential_type)] to the crate attributes to enable
+   = help: add `#![feature(existential_type)]` to the crate attributes to enable
 
 error[E0658]: existential types are unstable
   --> $DIR/feature-gate-existential-type.rs:11:5
@@ -14,7 +14,7 @@ LL |     existential type Baa: std::fmt::Debug;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/34511
-   = help: add #![feature(existential_type)] to the crate attributes to enable
+   = help: add `#![feature(existential_type)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-extern_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-extern_types.stderr
@@ -5,7 +5,7 @@ LL |     type T;
    |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43467
-   = help: add #![feature(extern_types)] to the crate attributes to enable
+   = help: add `#![feature(extern_types)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-external_doc.rs
+++ b/src/test/ui/feature-gates/feature-gate-external_doc.rs
@@ -1,2 +1,2 @@
-#[doc(include="asdf.md")] //~ ERROR: #[doc(include = "...")] is experimental
+#[doc(include="asdf.md")] //~ ERROR: `#[doc(include = "...")]` is experimental
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-external_doc.stderr
+++ b/src/test/ui/feature-gates/feature-gate-external_doc.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[doc(include = "...")] is experimental
+error[E0658]: `#[doc(include = "...")]` is experimental
   --> $DIR/feature-gate-external_doc.rs:1:1
    |
 LL | #[doc(include="asdf.md")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44732
-   = help: add #![feature(external_doc)] to the crate attributes to enable
+   = help: add `#![feature(external_doc)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
+++ b/src/test/ui/feature-gates/feature-gate-ffi_returns_twice.stderr
@@ -5,7 +5,7 @@ LL |     #[ffi_returns_twice]
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/58314
-   = help: add #![feature(ffi_returns_twice)] to the crate attributes to enable
+   = help: add `#![feature(ffi_returns_twice)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-format_args_nl.stderr
+++ b/src/test/ui/feature-gates/feature-gate-format_args_nl.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'format_args_nl': `format_args_nl`
 LL |     format_args_nl!("");
    |     ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(format_args_nl)] to the crate attributes to enable
+   = help: add `#![feature(format_args_nl)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-fundamental.stderr
+++ b/src/test/ui/feature-gates/feature-gate-fundamental.stderr
@@ -5,7 +5,7 @@ LL | #[fundamental]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29635
-   = help: add #![feature(fundamental)] to the crate attributes to enable
+   = help: add `#![feature(fundamental)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-generators.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generators.stderr
@@ -5,7 +5,7 @@ LL |     yield true;
    |     ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43122
-   = help: add #![feature(generators)] to the crate attributes to enable
+   = help: add `#![feature(generators)]` to the crate attributes to enable
 
 error[E0627]: yield statement outside of generator literal
   --> $DIR/feature-gate-generators.rs:2:5

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -5,7 +5,7 @@ LL |     type Pointer<T>: Deref<Target = T>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:6:5
@@ -14,7 +14,7 @@ LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:6:5
@@ -23,7 +23,7 @@ LL |     type Pointer2<T>: Deref<Target = T> where T: Clone, U: Clone;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:14:5
@@ -32,7 +32,7 @@ LL |     type Pointer<Usize> = Box<Usize>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: generic associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:16:5
@@ -41,7 +41,7 @@ LL |     type Pointer2<U32> = Box<U32>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:21:5
@@ -50,7 +50,7 @@ LL |     type Assoc where Self: Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0658]: where clauses on associated types are unstable
   --> $DIR/feature-gate-generic_associated_types.rs:26:5
@@ -59,7 +59,7 @@ LL |     type Assoc where Self: Sized = Foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-global_asm.stderr
+++ b/src/test/ui/feature-gates/feature-gate-global_asm.stderr
@@ -5,7 +5,7 @@ LL | global_asm!("");
    | ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35119
-   = help: add #![feature(global_asm)] to the crate attributes to enable
+   = help: add `#![feature(global_asm)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-intrinsics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-intrinsics.stderr
@@ -6,7 +6,7 @@ LL | |     fn bar();
 LL | | }
    | |_^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
   --> $DIR/feature-gate-intrinsics.rs:5:1
@@ -14,7 +14,7 @@ error[E0658]: intrinsics are subject to change
 LL | extern "rust-intrinsic" fn baz() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0093]: unrecognized intrinsic function: `bar`
   --> $DIR/feature-gate-intrinsics.rs:2:5

--- a/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
+++ b/src/test/ui/feature-gates/feature-gate-is_sorted.stderr
@@ -5,7 +5,7 @@ LL |     assert!([1, 2, 2, 9].iter().is_sorted());
    |                                 ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53485
-   = help: add #![feature(is_sorted)] to the crate attributes to enable
+   = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:5:39
@@ -14,7 +14,7 @@ LL |     assert!(![-2i32, -1, 0, 3].iter().is_sorted_by_key(|n| n.abs()));
    |                                       ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53485
-   = help: add #![feature(is_sorted)] to the crate attributes to enable
+   = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:9:26
@@ -23,7 +23,7 @@ LL |     assert!([1, 2, 2, 9].is_sorted());
    |                          ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53485
-   = help: add #![feature(is_sorted)] to the crate attributes to enable
+   = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'is_sorted': new API
   --> $DIR/feature-gate-is_sorted.rs:11:32
@@ -32,7 +32,7 @@ LL |     assert!(![-2i32, -1, 0, 3].is_sorted_by_key(|n| n.abs()));
    |                                ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53485
-   = help: add #![feature(is_sorted)] to the crate attributes to enable
+   = help: add `#![feature(is_sorted)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
+++ b/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
@@ -5,7 +5,7 @@ LL |     'a: {
    |     ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/48594
-   = help: add #![feature(label_break_value)] to the crate attributes to enable
+   = help: add `#![feature(label_break_value)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-lang-items.stderr
+++ b/src/test/ui/feature-gates/feature-gate-lang-items.stderr
@@ -4,7 +4,7 @@ error[E0658]: language items are subject to change
 LL | #[lang = "foo"]
    | ^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(lang_items)] to the crate attributes to enable
+   = help: add `#![feature(lang_items)]` to the crate attributes to enable
 
 error[E0522]: definition of an unknown language item: `foo`
   --> $DIR/feature-gate-lang-items.rs:1:1

--- a/src/test/ui/feature-gates/feature-gate-link_args.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_args.stderr
@@ -5,7 +5,7 @@ LL | #[link_args = "-l expected_use_case"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29596
-   = help: add #![feature(link_args)] to the crate attributes to enable
+   = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
   --> $DIR/feature-gate-link_args.rs:16:1
@@ -14,7 +14,7 @@ LL | #[link_args = "-l unexected_use_on_non_extern_item"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29596
-   = help: add #![feature(link_args)] to the crate attributes to enable
+   = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error[E0658]: the `link_args` attribute is experimental and not portable across platforms, it is recommended to use `#[link(name = "foo")] instead
   --> $DIR/feature-gate-link_args.rs:9:1
@@ -23,7 +23,7 @@ LL | #![link_args = "-l unexpected_use_as_inner_attr_on_mod"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29596
-   = help: add #![feature(link_args)] to the crate attributes to enable
+   = help: add `#![feature(link_args)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_cfg.stderr
@@ -5,7 +5,7 @@ LL | #[link(name = "foo", cfg(foo))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37406
-   = help: add #![feature(link_cfg)] to the crate attributes to enable
+   = help: add `#![feature(link_cfg)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
@@ -5,7 +5,7 @@ LL |     fn sqrt(x: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29602
-   = help: add #![feature(link_llvm_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-linkage.stderr
+++ b/src/test/ui/feature-gates/feature-gate-linkage.stderr
@@ -5,7 +5,7 @@ LL |     #[linkage = "extern_weak"] static foo: isize;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29603
-   = help: add #![feature(linkage)] to the crate attributes to enable
+   = help: add `#![feature(linkage)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-lint-reasons.stderr
+++ b/src/test/ui/feature-gates/feature-gate-lint-reasons.stderr
@@ -5,7 +5,7 @@ LL | #![warn(nonstandard_style, reason = "the standard should be respected")]
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54503
-   = help: add #![feature(lint_reasons)] to the crate attributes to enable
+   = help: add `#![feature(lint_reasons)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-log_syntax.stderr
+++ b/src/test/ui/feature-gates/feature-gate-log_syntax.stderr
@@ -5,7 +5,7 @@ LL |     log_syntax!()
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(log_syntax)] to the crate attributes to enable
+   = help: add `#![feature(log_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-log_syntax2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-log_syntax2.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", log_syntax!());
    |                      ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(log_syntax)] to the crate attributes to enable
+   = help: add `#![feature(log_syntax)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-macros_in_extern.stderr
+++ b/src/test/ui/feature-gates/feature-gate-macros_in_extern.stderr
@@ -5,7 +5,7 @@ LL |     returns_isize!(rust_get_test_int);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/feature-gate-macros_in_extern.rs:21:5
@@ -14,7 +14,7 @@ LL |     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/feature-gate-macros_in_extern.rs:23:5
@@ -23,7 +23,7 @@ LL |     emits_nothing!();
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-main.rs
+++ b/src/test/ui/feature-gates/feature-gate-main.rs
@@ -1,2 +1,2 @@
 #[main]
-fn foo() {} //~ ERROR: declaration of a nonstandard #[main] function may change over time
+fn foo() {} //~ ERROR: declaration of a non-standard `#[main]` function may change over time

--- a/src/test/ui/feature-gates/feature-gate-main.stderr
+++ b/src/test/ui/feature-gates/feature-gate-main.stderr
@@ -1,11 +1,11 @@
-error[E0658]: declaration of a nonstandard #[main] function may change over time, for now a top-level `fn main()` is required
+error[E0658]: declaration of a non-standard `#[main]` function may change over time, for now a top-level `fn main()` is required
   --> $DIR/feature-gate-main.rs:2:1
    |
 LL | fn foo() {}
    | ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29634
-   = help: add #![feature(main)] to the crate attributes to enable
+   = help: add `#![feature(main)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-marker_trait_attr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-marker_trait_attr.stderr
@@ -5,7 +5,7 @@ LL | #[marker] trait ExplicitMarker {}
    | ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29864
-   = help: add #![feature(marker_trait_attr)] to the crate attributes to enable
+   = help: add `#![feature(marker_trait_attr)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-may-dangle.stderr
@@ -5,7 +5,7 @@ LL | unsafe impl<#[may_dangle] A> Drop for Pt<A> {
    |             ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/34761
-   = help: add #![feature(dropck_eyepatch)] to the crate attributes to enable
+   = help: add `#![feature(dropck_eyepatch)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
+++ b/src/test/ui/feature-gates/feature-gate-min_const_fn.stderr
@@ -23,7 +23,7 @@ LL |     const fn foo() -> u32;
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error[E0658]: const fn is unstable
   --> $DIR/feature-gate-min_const_fn.rs:8:5
@@ -32,7 +32,7 @@ LL |     const fn bar() -> u32 { 0 }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/57563
-   = help: add #![feature(const_fn)] to the crate attributes to enable
+   = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -5,7 +5,7 @@ LL | #[naked]
    | ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32408
-   = help: add #![feature(naked_functions)] to the crate attributes to enable
+   = help: add `#![feature(naked_functions)]` to the crate attributes to enable
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
   --> $DIR/feature-gate-naked_functions.rs:5:1
@@ -14,7 +14,7 @@ LL | #[naked]
    | ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32408
-   = help: add #![feature(naked_functions)] to the crate attributes to enable
+   = help: add `#![feature(naked_functions)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-needs-allocator.stderr
+++ b/src/test/ui/feature-gates/feature-gate-needs-allocator.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[needs_allocator]` attribute is an experimental feature
 LL | #![needs_allocator]
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(allocator_internals)] to the crate attributes to enable
+   = help: add `#![feature(allocator_internals)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-never_type.stderr
+++ b/src/test/ui/feature-gates/feature-gate-never_type.stderr
@@ -5,7 +5,7 @@ LL | type Ma = (u32, !, i32);
    |                 ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
-   = help: add #![feature(never_type)] to the crate attributes to enable
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:8:20
@@ -14,7 +14,7 @@ LL | type Meeshka = Vec<!>;
    |                    ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
-   = help: add #![feature(never_type)] to the crate attributes to enable
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:9:24
@@ -23,7 +23,7 @@ LL | type Mow = &'static fn(!) -> !;
    |                        ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
-   = help: add #![feature(never_type)] to the crate attributes to enable
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:10:27
@@ -32,7 +32,7 @@ LL | type Skwoz = &'static mut !;
    |                           ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
-   = help: add #![feature(never_type)] to the crate attributes to enable
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error[E0658]: The `!` type is experimental
   --> $DIR/feature-gate-never_type.rs:13:16
@@ -41,7 +41,7 @@ LL |     type Wub = !;
    |                ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35121
-   = help: add #![feature(never_type)] to the crate attributes to enable
+   = help: add `#![feature(never_type)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-no-debug.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no-debug.stderr
@@ -5,7 +5,7 @@ LL | #[no_debug]
    | ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29721
-   = help: add #![feature(no_debug)] to the crate attributes to enable
+   = help: add `#![feature(no_debug)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-no_core.stderr
+++ b/src/test/ui/feature-gates/feature-gate-no_core.stderr
@@ -5,7 +5,7 @@ LL | #![no_core]
    | ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29639
-   = help: add #![feature(no_core)] to the crate attributes to enable
+   = help: add `#![feature(no_core)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
+++ b/src/test/ui/feature-gates/feature-gate-non_ascii_idents.stderr
@@ -5,7 +5,7 @@ LL | extern crate core as bäz;
    |                      ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:3:5
@@ -14,7 +14,7 @@ LL | use föö::bar;
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:5:5
@@ -23,7 +23,7 @@ LL | mod föö {
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:9:4
@@ -32,7 +32,7 @@ LL | fn bär(
    |    ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:10:5
@@ -41,7 +41,7 @@ LL |     bäz: isize
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:12:9
@@ -50,7 +50,7 @@ LL |     let _ö: isize;
    |         ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:15:10
@@ -59,7 +59,7 @@ LL |         (_ä, _) => {}
    |          ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:19:8
@@ -68,7 +68,7 @@ LL | struct Föö {
    |        ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:20:5
@@ -77,7 +77,7 @@ LL |     föö: isize
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:23:6
@@ -86,7 +86,7 @@ LL | enum Bär {
    |      ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:24:5
@@ -95,7 +95,7 @@ LL |     Bäz {
    |     ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:25:9
@@ -104,7 +104,7 @@ LL |         qüx: isize
    |         ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/feature-gate-non_ascii_idents.rs:30:8
@@ -113,7 +113,7 @@ LL |     fn qüx();
    |        ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error: aborting due to 13 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-non_exhaustive.stderr
+++ b/src/test/ui/feature-gates/feature-gate-non_exhaustive.stderr
@@ -5,7 +5,7 @@ LL | #[non_exhaustive]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44109
-   = help: add #![feature(non_exhaustive)] to the crate attributes to enable
+   = help: add `#![feature(non_exhaustive)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-omit-gdb-pretty-printer-section.stderr
+++ b/src/test/ui/feature-gates/feature-gate-omit-gdb-pretty-printer-section.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[omit_gdb_pretty_printer_section]` attribute is just used fo
 LL | #[omit_gdb_pretty_printer_section]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(omit_gdb_pretty_printer_section)] to the crate attributes to enable
+   = help: add `#![feature(omit_gdb_pretty_printer_section)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-on-unimplemented.stderr
+++ b/src/test/ui/feature-gates/feature-gate-on-unimplemented.stderr
@@ -5,7 +5,7 @@ LL | #[rustc_on_unimplemented = "test error `{Self}` with `{Bar}`"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29628
-   = help: add #![feature(on_unimplemented)] to the crate attributes to enable
+   = help: add `#![feature(on_unimplemented)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
+++ b/src/test/ui/feature-gates/feature-gate-optin-builtin-traits.stderr
@@ -5,7 +5,7 @@ LL | auto trait AutoDummyTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/13231
-   = help: add #![feature(optin_builtin_traits)] to the crate attributes to enable
+   = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error[E0658]: negative trait bounds are not yet fully implemented; use marker types for now
   --> $DIR/feature-gate-optin-builtin-traits.rs:9:1
@@ -14,7 +14,7 @@ LL | impl !AutoDummyTrait for DummyStruct {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/13231
-   = help: add #![feature(optin_builtin_traits)] to the crate attributes to enable
+   = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-plugin.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin.stderr
@@ -5,7 +5,7 @@ LL | #![plugin(foo)]
    | ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
-   = help: add #![feature(plugin)] to the crate attributes to enable
+   = help: add `#![feature(plugin)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
@@ -5,7 +5,7 @@ LL | pub fn registrar() {}
    | ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
-   = help: add #![feature(plugin_registrar)] to the crate attributes to enable
+   = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-prelude_import.stderr
+++ b/src/test/ui/feature-gates/feature-gate-prelude_import.stderr
@@ -4,7 +4,7 @@ error[E0658]: `#[prelude_import]` is for use by rustc only
 LL | #[prelude_import]
    | ^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(prelude_import)] to the crate attributes to enable
+   = help: add `#![feature(prelude_import)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-profiler-runtime.stderr
+++ b/src/test/ui/feature-gates/feature-gate-profiler-runtime.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[profiler_runtime]` attribute is used to identify the `profi
 LL | #![profiler_runtime]
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(profiler_runtime)] to the crate attributes to enable
+   = help: add `#![feature(profiler_runtime)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr-simd.stderr
@@ -5,7 +5,7 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(repr_simd)] to the crate attributes to enable
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error[E0658]: SIMD types are experimental and possibly buggy
   --> $DIR/feature-gate-repr-simd.rs:5:1
@@ -14,7 +14,7 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(repr_simd)] to the crate attributes to enable
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 warning[E0566]: conflicting representation hints
   --> $DIR/feature-gate-repr-simd.rs:4:8

--- a/src/test/ui/feature-gates/feature-gate-repr128.stderr
+++ b/src/test/ui/feature-gates/feature-gate-repr128.stderr
@@ -7,7 +7,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/35118
-   = help: add #![feature(repr128)] to the crate attributes to enable
+   = help: add `#![feature(repr128)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs-1.stderr
@@ -5,7 +5,7 @@ LL | #[rustc_variance]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_error]` attribute is just used for rustc unit tests and will never be stable
   --> $DIR/feature-gate-rustc-attrs-1.rs:6:1
@@ -14,7 +14,7 @@ LL | #[rustc_error]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: the `#[rustc_nonnull_optimization_guaranteed]` attribute is just used to enable niche optimizations in libcore and will never be stable
   --> $DIR/feature-gate-rustc-attrs-1.rs:7:1
@@ -23,7 +23,7 @@ LL | #[rustc_nonnull_optimization_guaranteed]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -5,7 +5,7 @@ LL | #[rustc::unknown]
    |   ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: macro `rustc::unknown` may not be used in attributes
   --> $DIR/feature-gate-rustc-attrs.rs:8:1
@@ -20,7 +20,7 @@ LL | #[unknown::rustc]
    |            ^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: macro `unknown::rustc` may not be used in attributes
   --> $DIR/feature-gate-rustc-attrs.rs:13:1
@@ -35,7 +35,7 @@ LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: The attribute `rustc_unknown` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/feature-gate-rustc-attrs.rs:20:3
@@ -44,7 +44,7 @@ LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: used by the test suite
   --> $DIR/feature-gate-rustc-attrs.rs:18:1
@@ -53,7 +53,7 @@ LL | #[rustc_dummy]
    | ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc_const_unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[rustc_const_unstable]` attribute is an internal feature
 LL | #[rustc_const_unstable(feature="fzzzzzt")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(rustc_const_unstable)] to the crate attributes to enable
+   = help: add `#![feature(rustc_const_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-sanitizer-runtime.stderr
+++ b/src/test/ui/feature-gates/feature-gate-sanitizer-runtime.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[sanitizer_runtime]` attribute is used to identify crates th
 LL | #![sanitizer_runtime]
    | ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(sanitizer_runtime)] to the crate attributes to enable
+   = help: add `#![feature(sanitizer_runtime)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-simd.stderr
+++ b/src/test/ui/feature-gates/feature-gate-simd.stderr
@@ -5,7 +5,7 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(repr_simd)] to the crate attributes to enable
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-slice-patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-slice-patterns.stderr
@@ -5,7 +5,7 @@ LL |         [1, 2, ..] => {}
    |                ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
   --> $DIR/feature-gate-slice-patterns.rs:7:13
@@ -14,7 +14,7 @@ LL |         [1, .., 5] => {}
    |             ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
   --> $DIR/feature-gate-slice-patterns.rs:8:10
@@ -23,7 +23,7 @@ LL |         [.., 4, 5] => {}
    |          ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
   --> $DIR/feature-gate-slice-patterns.rs:13:11
@@ -32,7 +32,7 @@ LL |         [ xs.., 4, 5 ] => {}
    |           ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
   --> $DIR/feature-gate-slice-patterns.rs:14:14
@@ -41,7 +41,7 @@ LL |         [ 1, xs.., 5 ] => {}
    |              ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error[E0658]: syntax for subslices in slice patterns is not yet stabilized
   --> $DIR/feature-gate-slice-patterns.rs:15:17
@@ -50,7 +50,7 @@ LL |         [ 1, 2, xs.. ] => {}
    |                 ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/62254
-   = help: add #![feature(slice_patterns)] to the crate attributes to enable
+   = help: add `#![feature(slice_patterns)]` to the crate attributes to enable
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-start.rs
+++ b/src/test/ui/feature-gates/feature-gate-start.rs
@@ -1,3 +1,3 @@
 #[start]
 fn foo(_: isize, _: *const *const u8) -> isize { 0 }
-//~^ ERROR a #[start] function is an experimental feature
+//~^ ERROR a `#[start]` function is an experimental feature

--- a/src/test/ui/feature-gates/feature-gate-start.stderr
+++ b/src/test/ui/feature-gates/feature-gate-start.stderr
@@ -1,11 +1,11 @@
-error[E0658]: a #[start] function is an experimental feature whose signature may change over time
+error[E0658]: a `#[start]` function is an experimental feature whose signature may change over time
   --> $DIR/feature-gate-start.rs:2:1
    |
 LL | fn foo(_: isize, _: *const *const u8) -> isize { 0 }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29633
-   = help: add #![feature(start)] to the crate attributes to enable
+   = help: add `#![feature(start)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
+++ b/src/test/ui/feature-gates/feature-gate-static-nobundle.stderr
@@ -5,7 +5,7 @@ LL | #[link(name="foo", kind="static-nobundle")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37403
-   = help: add #![feature(static_nobundle)] to the crate attributes to enable
+   = help: add `#![feature(static_nobundle)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-stmt_expr_attributes.stderr
@@ -5,7 +5,7 @@ LL | const X: i32 = #[allow(dead_code)] 8;
    |                ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-thread_local.stderr
+++ b/src/test/ui/feature-gates/feature-gate-thread_local.stderr
@@ -5,7 +5,7 @@ LL | #[thread_local]
    | ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29594
-   = help: add #![feature(thread_local)] to the crate attributes to enable
+   = help: add `#![feature(thread_local)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-trace_macros.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trace_macros.stderr
@@ -5,7 +5,7 @@ LL |     trace_macros!(true);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(trace_macros)] to the crate attributes to enable
+   = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
@@ -5,7 +5,7 @@ LL | trait Foo = Default;
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/41517
-   = help: add #![feature(trait_alias)] to the crate attributes to enable
+   = help: add `#![feature(trait_alias)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-transparent_enums.stderr
+++ b/src/test/ui/feature-gates/feature-gate-transparent_enums.stderr
@@ -5,7 +5,7 @@ LL | enum OkButUnstableEnum {
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60405
-   = help: add #![feature(transparent_enums)] to the crate attributes to enable
+   = help: add `#![feature(transparent_enums)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-transparent_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-transparent_unions.stderr
@@ -5,7 +5,7 @@ LL | union OkButUnstableUnion {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60405
-   = help: add #![feature(transparent_unions)] to the crate attributes to enable
+   = help: add `#![feature(transparent_unions)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
+++ b/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
@@ -9,7 +9,7 @@ LL | |     };
    | |_____^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31436
-   = help: add #![feature(try_blocks)] to the crate attributes to enable
+   = help: add `#![feature(try_blocks)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-try_reserve.stderr
+++ b/src/test/ui/feature-gates/feature-gate-try_reserve.stderr
@@ -5,7 +5,7 @@ LL |     v.try_reserve(10);
    |       ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/48043
-   = help: add #![feature(try_reserve)] to the crate attributes to enable
+   = help: add `#![feature(try_reserve)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
@@ -5,7 +5,7 @@ LL |     let a = 10: u8;
    |             ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/23416
-   = help: add #![feature(type_ascription)] to the crate attributes to enable
+   = help: add `#![feature(type_ascription)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -5,7 +5,7 @@ LL |     extern "rust-call" fn call(self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:17:5
@@ -14,7 +14,7 @@ LL |     extern "rust-call" fn call_once(self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:5
@@ -23,7 +23,7 @@ LL |     extern "rust-call" fn call_mut(&self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:29:5
@@ -32,7 +32,7 @@ LL |     extern "rust-call" fn call_once(&self, args: ()) -> () {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
@@ -41,7 +41,7 @@ LL | impl Fn<()> for Foo {
    |      ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:12
@@ -56,7 +56,7 @@ LL | impl FnMut<()> for Bar {
    |      ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:27:6
@@ -65,7 +65,7 @@ LL | impl FnOnce<()> for Baz {
    |      ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
@@ -5,7 +5,7 @@ LL |     f.call(());
    |       ^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:5:7
@@ -14,7 +14,7 @@ LL |     f.call_mut(());
    |       ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:6:7
@@ -23,7 +23,7 @@ LL |     f.call_once(());
    |       ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
@@ -5,7 +5,7 @@ LL |     Fn::call(&f, ());
    |     ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:5:5
@@ -14,7 +14,7 @@ LL |     FnMut::call_mut(&mut f, ());
    |     ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'fn_traits'
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:6:5
@@ -23,7 +23,7 @@ LL |     FnOnce::call_once(f, ());
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(fn_traits)] to the crate attributes to enable
+   = help: add `#![feature(fn_traits)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -7,7 +7,7 @@ LL | |     }
    | |_____^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
   --> $DIR/feature-gate-unboxed-closures.rs:5:6
@@ -16,7 +16,7 @@ LL | impl FnOnce<(u32, u32)> for Test {
    |      ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unsized_tuple_coercion.stderr
@@ -5,7 +5,7 @@ LL |     let _ : &(dyn Send,) = &((),);
    |                            ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/42877
-   = help: add #![feature(unsized_tuple_coercion)] to the crate attributes to enable
+   = help: add `#![feature(unsized_tuple_coercion)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -7,7 +7,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32836
-   = help: add #![feature(untagged_unions)] to the crate attributes to enable
+   = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with non-`Copy` fields are unstable
   --> $DIR/feature-gate-untagged_unions.rs:13:1
@@ -18,7 +18,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32836
-   = help: add #![feature(untagged_unions)] to the crate attributes to enable
+   = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with `Drop` implementations are unstable
   --> $DIR/feature-gate-untagged_unions.rs:17:1
@@ -29,7 +29,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32836
-   = help: add #![feature(untagged_unions)] to the crate attributes to enable
+   = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-unwind-attributes.rs
+++ b/src/test/ui/feature-gates/feature-gate-unwind-attributes.rs
@@ -8,7 +8,7 @@ extern {
     fn extern_fn();
 // CHECK-NOT: Function Attrs: nounwind
 // CHECK: declare void @unwinding_extern_fn
-    #[unwind(allowed)] //~ ERROR #[unwind] is experimental
+    #[unwind(allowed)] //~ ERROR `#[unwind]` is experimental
     fn unwinding_extern_fn();
 }
 

--- a/src/test/ui/feature-gates/feature-gate-unwind-attributes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unwind-attributes.stderr
@@ -1,11 +1,11 @@
-error[E0658]: #[unwind] is experimental
+error[E0658]: `#[unwind]` is experimental
   --> $DIR/feature-gate-unwind-attributes.rs:11:5
    |
 LL |     #[unwind(allowed)]
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/58760
-   = help: add #![feature(unwind_attributes)] to the crate attributes to enable
+   = help: add `#![feature(unwind_attributes)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-2.stderr
@@ -8,7 +8,7 @@ LL |                 () => ( struct Б; )
    |                                ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/local-modularized-tricky-fail-2.rs:36:24
@@ -20,7 +20,7 @@ LL |         () => ( struct Г; )
    |                        ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/local-modularized-tricky-fail-2.rs:46:24
@@ -32,7 +32,7 @@ LL |         () => ( struct Д; )
    |                        ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/inference/inference_unstable_forced.stderr
+++ b/src/test/ui/inference/inference_unstable_forced.stderr
@@ -5,7 +5,7 @@ LL |     assert_eq!('x'.ipu_flatten(), 0);
    |                    ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/99999
-   = help: add #![feature(ipu_flatten)] to the crate attributes to enable
+   = help: add `#![feature(ipu_flatten)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/internal/internal-unstable-noallow.stderr
+++ b/src/test/ui/internal/internal-unstable-noallow.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'function'
 LL |     call_unstable_noallow!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct_field'
@@ -13,7 +13,7 @@ error[E0658]: use of unstable library feature 'struct_field'
 LL |     construct_unstable_noallow!(0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(struct_field)] to the crate attributes to enable
+   = help: add `#![feature(struct_field)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'method'
@@ -22,7 +22,7 @@ error[E0658]: use of unstable library feature 'method'
 LL |     |x: internal_unstable::Foo| { call_method_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(method)] to the crate attributes to enable
+   = help: add `#![feature(method)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0658]: use of unstable library feature 'struct2_field'
@@ -31,7 +31,7 @@ error[E0658]: use of unstable library feature 'struct2_field'
 LL |     |x: internal_unstable::Bar| { access_field_noallow!(x) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(struct2_field)] to the crate attributes to enable
+   = help: add `#![feature(struct2_field)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/internal/internal-unstable-thread-local.stderr
+++ b/src/test/ui/internal/internal-unstable-thread-local.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'function'
 LL | thread_local!(static BAR: () = internal_unstable::unstable());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/internal/internal-unstable.stderr
+++ b/src/test/ui/internal/internal-unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'function'
 LL |     pass_through_allow!(internal_unstable::unstable());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:35:27
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'function'
 LL |     pass_through_noallow!(internal_unstable::unstable());
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:39:22
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'function'
 LL |     println!("{:?}", internal_unstable::unstable());
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:41:10
@@ -28,7 +28,7 @@ error[E0658]: use of unstable library feature 'function'
 LL |     bar!(internal_unstable::unstable());
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'function'
   --> $DIR/internal-unstable.rs:12:9
@@ -39,7 +39,7 @@ LL |         internal_unstable::unstable();
 LL |     bar!(internal_unstable::unstable());
    |     ------------------------------------ in this macro invocation
    |
-   = help: add #![feature(function)] to the crate attributes to enable
+   = help: add `#![feature(function)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/intrinsics/unchecked_math_unstable.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are 
 LL |         let add = std::intrinsics::unchecked_add(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(core_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:5:19
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are 
 LL |         let sub = std::intrinsics::unchecked_sub(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(core_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:6:19
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are 
 LL |         let mul = std::intrinsics::unchecked_mul(x, y);
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(core_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-17458.stderr
+++ b/src/test/ui/issues/issue-17458.stderr
@@ -5,7 +5,7 @@ LL | static X: usize = unsafe { core::ptr::null::<usize>() as usize };
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-18294.stderr
+++ b/src/test/ui/issues/issue-18294.stderr
@@ -5,7 +5,7 @@ LL |     const Y: usize = unsafe { &X as *const u32 as usize };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20313.stderr
+++ b/src/test/ui/issues/issue-20313.stderr
@@ -5,7 +5,7 @@ LL |     fn sqrt(x: f32) -> f32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29602
-   = help: add #![feature(link_llvm_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(link_llvm_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23024.stderr
+++ b/src/test/ui/issues/issue-23024.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}",(vfnfer[0] as dyn Fn)(3));
    |                                       ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/issue-23024.rs:9:39

--- a/src/test/ui/issues/issue-25826.stderr
+++ b/src/test/ui/issues/issue-25826.stderr
@@ -5,7 +5,7 @@ LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const ()
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53020
-   = help: add #![feature(const_compare_raw_pointers)] to the crate attributes to enable
+   = help: add `#![feature(const_compare_raw_pointers)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28075.stderr
+++ b/src/test/ui/issues/issue-28075.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL | use lint_stability::{unstable, deprecated};
    |                      ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28388-3.stderr
+++ b/src/test/ui/issues/issue-28388-3.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL | use lint_stability::UnstableEnum::{};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32655.stderr
+++ b/src/test/ui/issues/issue-32655.stderr
@@ -8,7 +8,7 @@ LL | foo!();
    | ------- in this macro invocation
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `derive_Clone` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/issue-32655.rs:18:7
@@ -17,7 +17,7 @@ LL |     #[derive_Clone]
    |       ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-32782.stderr
+++ b/src/test/ui/issues/issue-32782.stderr
@@ -7,7 +7,7 @@ LL |         #[allow_internal_unstable]
 LL | foo!();
    | ------- in this macro invocation
    |
-   = help: add #![feature(allow_internal_unstable)] to the crate attributes to enable
+   = help: add `#![feature(allow_internal_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32829.stderr
+++ b/src/test/ui/issues/issue-32829.stderr
@@ -5,7 +5,7 @@ LL | static S : u64 = { { panic!("foo"); 0 } };
    |                      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51999
-   = help: add #![feature(const_panic)] to the crate attributes to enable
+   = help: add `#![feature(const_panic)]` to the crate attributes to enable
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-37887.stderr
+++ b/src/test/ui/issues/issue-37887.stderr
@@ -11,7 +11,7 @@ LL |     extern crate libc;
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27812
-   = help: add #![feature(rustc_private)] to the crate attributes to enable
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-49074.stderr
+++ b/src/test/ui/issues/issue-49074.stderr
@@ -5,7 +5,7 @@ LL | #[marco_use] // typo
    |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_use`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: cannot find macro `bar!` in this scope
   --> $DIR/issue-49074.rs:12:4

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -5,7 +5,7 @@ LL |     let _ = [0; (&0 as *const i32) as usize];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
-   = help: add #![feature(const_raw_ptr_to_usize_cast)] to the crate attributes to enable
+   = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/issue-52023-array-size-pointer-cast.rs:2:17

--- a/src/test/ui/issues/issue-52489.stderr
+++ b/src/test/ui/issues/issue-52489.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'issue_52489_unstable'
 LL | use issue_52489;
    |     ^^^^^^^^^^^
    |
-   = help: add #![feature(issue_52489_unstable)] to the crate attributes to enable
+   = help: add `#![feature(issue_52489_unstable)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/linkage-attr/linkage4.stderr
+++ b/src/test/ui/linkage-attr/linkage4.stderr
@@ -5,7 +5,7 @@ LL | #[linkage = "external"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29603
-   = help: add #![feature(linkage)] to the crate attributes to enable
+   = help: add `#![feature(linkage)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-output-format.stderr
+++ b/src/test/ui/lint/lint-output-format.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL | extern crate lint_output_format;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:7:31
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL | use lint_output_format::{foo, bar};
    |                               ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-output-format.rs:11:14
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     let _y = bar();
    |              ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/lint-stability-2.stderr
+++ b/src/test/ui/lint/lint-stability-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.method_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:42:9
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Foo::method_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:44:9
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::method_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:46:13
@@ -28,7 +28,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:48:9
@@ -36,7 +36,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:51:13
@@ -44,7 +44,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.method_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:53:9
@@ -52,7 +52,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Foo::method_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:55:9
@@ -60,7 +60,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::method_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:57:13
@@ -68,7 +68,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:59:9
@@ -76,7 +76,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:62:13
@@ -84,7 +84,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.method_unstable();
    |             ^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:63:9
@@ -92,7 +92,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Foo::method_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:64:9
@@ -100,7 +100,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::method_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:65:13
@@ -108,7 +108,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:66:9
@@ -116,7 +116,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:68:13
@@ -124,7 +124,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         foo.method_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:70:9
@@ -132,7 +132,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         Foo::method_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:72:9
@@ -140,7 +140,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         <Foo>::method_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:74:13
@@ -148,7 +148,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:76:9
@@ -156,7 +156,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         <Foo>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:131:13
@@ -164,7 +164,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:133:9
@@ -172,7 +172,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:135:13
@@ -180,7 +180,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:137:9
@@ -188,7 +188,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:139:13
@@ -196,7 +196,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:140:9
@@ -204,7 +204,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:141:13
@@ -212,7 +212,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:143:9
@@ -220,7 +220,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         <Foo>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:154:13
@@ -228,7 +228,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:156:13
@@ -236,7 +236,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_deprecated_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-2.rs:158:13
@@ -244,7 +244,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         foo.trait_unstable();
    |             ^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability-2.rs:159:13
@@ -252,7 +252,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         foo.trait_unstable_text();
    |             ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 32 previous errors
 

--- a/src/test/ui/lint/lint-stability-fields.stderr
+++ b/src/test/ui/lint/lint-stability-fields.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let x = Unstable {
    |                 ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:61:13
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Unstable {
    |             ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:67:13
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Unstable
    |             ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:72:17
@@ -28,7 +28,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let x = reexport::Unstable2(1, 2, 3);
    |                 ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:74:17
@@ -36,7 +36,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let x = Unstable2(1, 2, 3);
    |                 ^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:80:13
@@ -44,7 +44,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Unstable2
    |             ^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:85:13
@@ -52,7 +52,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Unstable2
    |             ^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:90:17
@@ -60,7 +60,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let x = Deprecated {
    |                 ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:100:13
@@ -68,7 +68,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Deprecated {
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:106:13
@@ -76,7 +76,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Deprecated
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:110:17
@@ -84,7 +84,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:116:13
@@ -92,7 +92,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:121:13
@@ -100,7 +100,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:21:13
@@ -108,7 +108,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override1: 2,
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:22:13
@@ -116,7 +116,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:26:17
@@ -124,7 +124,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.override1;
    |                 ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:27:17
@@ -132,7 +132,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:31:13
@@ -140,7 +140,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override1: _,
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:32:13
@@ -148,7 +148,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: _
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:40:17
@@ -156,7 +156,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.1;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:41:17
@@ -164,7 +164,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.2;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:44:20
@@ -172,7 +172,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |                    _,
    |                    ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:45:20
@@ -180,7 +180,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |                    _)
    |                    ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:52:13
@@ -188,7 +188,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             inherit: 1,
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:54:13
@@ -196,7 +196,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:57:17
@@ -204,7 +204,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:59:17
@@ -212,7 +212,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:62:13
@@ -220,7 +220,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             inherit: _,
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:64:13
@@ -228,7 +228,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: _
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:76:17
@@ -236,7 +236,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.0;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:78:17
@@ -244,7 +244,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.2;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:81:14
@@ -252,7 +252,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             (_,
    |              ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:83:14
@@ -260,7 +260,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |              _)
    |              ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:91:13
@@ -268,7 +268,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             inherit: 1,
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:93:13
@@ -276,7 +276,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: 3,
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:96:17
@@ -284,7 +284,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.inherit;
    |                 ^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:98:17
@@ -292,7 +292,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.override2;
    |                 ^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:101:13
@@ -300,7 +300,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             inherit: _,
    |             ^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:103:13
@@ -308,7 +308,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             override2: _
    |             ^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:112:17
@@ -316,7 +316,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.0;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:114:17
@@ -324,7 +324,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = x.2;
    |                 ^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:117:14
@@ -332,7 +332,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             (_,
    |              ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability-fields.rs:119:14
@@ -340,7 +340,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |              _)
    |              ^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 43 previous errors
 

--- a/src/test/ui/lint/lint-stability.stderr
+++ b/src/test/ui/lint/lint-stability.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     extern crate stability_cfg2;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:45:9
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         deprecated_unstable();
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:47:9
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:49:9
@@ -28,7 +28,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:52:9
@@ -36,7 +36,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         deprecated_unstable_text();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:54:9
@@ -44,7 +44,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:56:9
@@ -52,7 +52,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:59:9
@@ -60,7 +60,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         unstable();
    |         ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:60:9
@@ -68,7 +68,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:61:9
@@ -76,7 +76,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:63:9
@@ -84,7 +84,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         unstable_text();
    |         ^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:65:9
@@ -92,7 +92,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:67:9
@@ -100,7 +100,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:99:17
@@ -108,7 +108,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:103:17
@@ -116,7 +116,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = UnstableStruct { i: 0 };
    |                 ^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:107:17
@@ -124,7 +124,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:109:17
@@ -132,7 +132,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = UnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:113:17
@@ -140,7 +140,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:115:17
@@ -148,7 +148,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = Enum::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:119:17
@@ -156,7 +156,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = DeprecatedUnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:121:17
@@ -164,7 +164,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = UnstableTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:130:25
@@ -172,7 +172,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         macro_test_arg!(deprecated_unstable_text());
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:144:9
@@ -180,7 +180,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:146:9
@@ -188,7 +188,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:148:9
@@ -196,7 +196,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:150:9
@@ -204,7 +204,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:152:9
@@ -212,7 +212,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         Trait::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:153:9
@@ -220,7 +220,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         <Foo as Trait>::trait_unstable(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:154:9
@@ -228,7 +228,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         Trait::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': text
   --> $DIR/lint-stability.rs:156:9
@@ -236,7 +236,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature': text
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:172:10
@@ -244,7 +244,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     impl UnstableTrait for S { }
    |          ^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:174:24
@@ -252,7 +252,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     trait LocalTrait : UnstableTrait { }
    |                        ^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:179:9
@@ -260,7 +260,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         fn trait_unstable(&self) {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:184:5
@@ -268,7 +268,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     extern crate inherited_stability;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:185:9
@@ -276,7 +276,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |     use self::inherited_stability::*;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:188:9
@@ -284,7 +284,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         unstable();
    |         ^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:191:9
@@ -292,7 +292,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         stable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:195:9
@@ -300,7 +300,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         unstable_mod::unstable();
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:197:17
@@ -308,7 +308,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         let _ = Unstable::UnstableVariant;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:88:48
@@ -316,7 +316,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
    |                                                ^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature'
   --> $DIR/lint-stability.rs:92:13
@@ -324,7 +324,7 @@ error[E0658]: use of unstable library feature 'unstable_test_feature'
 LL |             TypeUnstable = u8,
    |             ^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 41 previous errors
 

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -17,7 +17,7 @@ LL | #[macro_reexport(macro_one)]
    |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-stability.stderr
+++ b/src/test/ui/macros/macro-stability.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'local_unstable'
 LL |     local_unstable!();
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(local_unstable)] to the crate attributes to enable
+   = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'local_unstable'
   --> $DIR/macro-stability.rs:20:5
@@ -12,7 +12,7 @@ error[E0658]: use of unstable library feature 'local_unstable'
 LL |     local_unstable_modern!();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(local_unstable)] to the crate attributes to enable
+   = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_macros'
   --> $DIR/macro-stability.rs:21:5
@@ -20,7 +20,7 @@ error[E0658]: use of unstable library feature 'unstable_macros'
 LL |     unstable_macro!();
    |     ^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(unstable_macros)] to the crate attributes to enable
+   = help: add `#![feature(unstable_macros)]` to the crate attributes to enable
 
 warning: use of deprecated item 'deprecated_macro': deprecation reason
   --> $DIR/macro-stability.rs:24:5

--- a/src/test/ui/macros/macros-in-extern.stderr
+++ b/src/test/ui/macros/macros-in-extern.stderr
@@ -5,7 +5,7 @@ LL |     returns_isize!(rust_get_test_int);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/macros-in-extern.rs:28:5
@@ -14,7 +14,7 @@ LL |     takes_u32_returns_u32!(rust_dbg_extern_identity_u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/macros-in-extern.rs:30:5
@@ -23,7 +23,7 @@ LL |     emits_nothing!();
    |     ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/panic-runtime/needs-gate.stderr
+++ b/src/test/ui/panic-runtime/needs-gate.stderr
@@ -5,7 +5,7 @@ LL | #![panic_runtime]
    | ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32837
-   = help: add #![feature(panic_runtime)] to the crate attributes to enable
+   = help: add `#![feature(panic_runtime)]` to the crate attributes to enable
 
 error[E0658]: the `#[needs_panic_runtime]` attribute is an experimental feature
   --> $DIR/needs-gate.rs:5:1
@@ -14,7 +14,7 @@ LL | #![needs_panic_runtime]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/32837
-   = help: add #![feature(needs_panic_runtime)] to the crate attributes to enable
+   = help: add `#![feature(needs_panic_runtime)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/fn-arg-doc-comment.stderr
+++ b/src/test/ui/parser/fn-arg-doc-comment.stderr
@@ -23,7 +23,7 @@ LL |     /// Comment
    |     ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60406
-   = help: add #![feature(param_attrs)] to the crate attributes to enable
+   = help: add `#![feature(param_attrs)]` to the crate attributes to enable
 
 error[E0658]: attributes on function parameters are unstable
   --> $DIR/fn-arg-doc-comment.rs:8:5
@@ -32,7 +32,7 @@ LL |     /// Other
    |     ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60406
-   = help: add #![feature(param_attrs)] to the crate attributes to enable
+   = help: add `#![feature(param_attrs)]` to the crate attributes to enable
 
 error[E0308]: mismatched types
   --> $DIR/fn-arg-doc-comment.rs:22:7

--- a/src/test/ui/parser/issue-17383.stderr
+++ b/src/test/ui/parser/issue-17383.stderr
@@ -8,7 +8,7 @@ LL |     B(usize)
    |     -------- tuple variant defined here
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60553
-   = help: add #![feature(arbitrary_enum_discriminant)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
+++ b/src/test/ui/parser/tag-variant-disr-non-nullary.stderr
@@ -18,7 +18,7 @@ LL |     Other2(usize, usize),
    |     -------------------- tuple variant defined here
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60553
-   = help: add #![feature(arbitrary_enum_discriminant)] to the crate attributes to enable
+   = help: add `#![feature(arbitrary_enum_discriminant)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/attr-stmt-expr.rs
+++ b/src/test/ui/proc-macro/attr-stmt-expr.rs
@@ -9,7 +9,7 @@ fn print_str(string: &'static str) {
     // macros are handled a bit differently
     #[expect_print_expr]
     //~^ ERROR attributes on expressions are experimental
-    //~| HELP add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+    //~| HELP add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
     println!("{}", string)
 }
 
@@ -22,6 +22,6 @@ fn main() {
 
     #[expect_expr]
     //~^ ERROR attributes on expressions are experimental
-    //~| HELP add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+    //~| HELP add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
     print_str("string")
 }

--- a/src/test/ui/proc-macro/attr-stmt-expr.stderr
+++ b/src/test/ui/proc-macro/attr-stmt-expr.stderr
@@ -5,7 +5,7 @@ LL |     #[expect_print_expr]
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/attr-stmt-expr.rs:23:5
@@ -14,7 +14,7 @@ LL |     #[expect_expr]
    |     ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -5,7 +5,7 @@ LL |             #[empty_helper]
    |               ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
   --> $DIR/derive-helper-shadowing.rs:8:3

--- a/src/test/ui/proc-macro/derive-still-gated.stderr
+++ b/src/test/ui/proc-macro/derive-still-gated.stderr
@@ -5,7 +5,7 @@ LL | #[derive_Empty]
    |   ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -5,7 +5,7 @@ LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: The attribute `rustc_foo` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/expand-to-unstable-2.rs:6:10
@@ -14,7 +14,7 @@ LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/expand-to-unstable.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are 
 LL | #[derive(Unstable)]
    |          ^^^^^^^^
    |
-   = help: add #![feature(core_intrinsics)] to the crate attributes to enable
+   = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/proc-macro/issue-41211.stderr
+++ b/src/test/ui/proc-macro/issue-41211.stderr
@@ -5,7 +5,7 @@ LL | #![identity_attr]
    |    ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: inconsistent resolution for a macro: first custom attribute, then attribute macro
   --> $DIR/issue-41211.rs:8:4

--- a/src/test/ui/proc-macro/macros-in-extern.stderr
+++ b/src/test/ui/proc-macro/macros-in-extern.stderr
@@ -5,7 +5,7 @@ LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/macros-in-extern.rs:18:5
@@ -14,7 +14,7 @@ LL |     #[identity_attr]
    |     ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error[E0658]: macro invocations in `extern {}` blocks are experimental
   --> $DIR/macros-in-extern.rs:22:5
@@ -23,7 +23,7 @@ LL |     identity!(fn rust_dbg_extern_identity_u32(arg: u32) -> u32;);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/49476
-   = help: add #![feature(macros_in_extern)] to the crate attributes to enable
+   = help: add `#![feature(macros_in_extern)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/proc-macro/more-gates.stderr
+++ b/src/test/ui/proc-macro/more-gates.stderr
@@ -5,7 +5,7 @@ LL | #[attr2mac1]
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot expand to macro definitions
   --> $DIR/more-gates.rs:12:1
@@ -14,7 +14,7 @@ LL | #[attr2mac2]
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot expand to macro definitions
   --> $DIR/more-gates.rs:16:1
@@ -23,7 +23,7 @@ LL | mac2mac1!();
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot expand to macro definitions
   --> $DIR/more-gates.rs:17:1
@@ -32,7 +32,7 @@ LL | mac2mac2!();
    | ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot expand to macro definitions
   --> $DIR/more-gates.rs:19:1
@@ -41,7 +41,7 @@ LL | tricky!();
    | ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/proc-macro/proc-macro-attributes.stderr
+++ b/src/test/ui/proc-macro/proc-macro-attributes.stderr
@@ -5,7 +5,7 @@ LL | #[C]
    |   ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
   --> $DIR/proc-macro-attributes.rs:6:3

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -5,7 +5,7 @@ LL |     #![empty_attr]
    |     ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54726
-   = help: add #![feature(custom_inner_attributes)] to the crate attributes to enable
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error[E0658]: non-builtin inner attributes are unstable
   --> $DIR/proc-macro-gates.rs:17:5
@@ -14,7 +14,7 @@ LL |     #![empty_attr]
    |     ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54726
-   = help: add #![feature(custom_inner_attributes)] to the crate attributes to enable
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to modules
   --> $DIR/proc-macro-gates.rs:13:1
@@ -23,7 +23,7 @@ LL | #[empty_attr]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to modules
   --> $DIR/proc-macro-gates.rs:17:5
@@ -32,7 +32,7 @@ LL |     #![empty_attr]
    |     ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error: custom attribute invocations must be of the form #[foo] or #[foo(..)], the macro name must only be followed by a delimiter token
   --> $DIR/proc-macro-gates.rs:21:1
@@ -47,7 +47,7 @@ LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to statements
   --> $DIR/proc-macro-gates.rs:34:5
@@ -56,7 +56,7 @@ LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to statements
   --> $DIR/proc-macro-gates.rs:38:5
@@ -65,7 +65,7 @@ LL |     #[empty_attr]
    |     ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:42:14
@@ -74,7 +74,7 @@ LL |     let _x = #[identity_attr] 2;
    |              ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:45:15
@@ -83,7 +83,7 @@ LL |     let _x = [#[identity_attr] 2];
    |               ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: custom attributes cannot be applied to expressions
   --> $DIR/proc-macro-gates.rs:48:14
@@ -92,7 +92,7 @@ LL |     let _x = #[identity_attr] println!();
    |              ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to types
   --> $DIR/proc-macro-gates.rs:53:13
@@ -101,7 +101,7 @@ LL |     let _x: identity!(u32) = 3;
    |             ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to patterns
   --> $DIR/proc-macro-gates.rs:54:12
@@ -110,7 +110,7 @@ LL |     if let identity!(Some(_x)) = Some(3) {}
    |            ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to statements
   --> $DIR/proc-macro-gates.rs:57:5
@@ -119,7 +119,7 @@ LL |     empty!(struct S;);
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to statements
   --> $DIR/proc-macro-gates.rs:58:5
@@ -128,7 +128,7 @@ LL |     empty!(let _x = 3;);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to expressions
   --> $DIR/proc-macro-gates.rs:60:14
@@ -137,7 +137,7 @@ LL |     let _x = identity!(3);
    |              ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error[E0658]: procedural macros cannot be expanded to expressions
   --> $DIR/proc-macro-gates.rs:61:15
@@ -146,7 +146,7 @@ LL |     let _x = [empty!(3)];
    |               ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
-   = help: add #![feature(proc_macro_hygiene)] to the crate attributes to enable
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/proc-macro/proc-macro-gates2.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates2.stderr
@@ -5,7 +5,7 @@ LL | fn _test6<#[empty_attr] T>() {}
    |           ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `empty_attr` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/proc-macro-gates2.rs:17:9
@@ -14,7 +14,7 @@ LL |         #[empty_attr]
    |         ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -5,7 +5,7 @@ LL | #[attr_proc_macra]
    |   ^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `FooWithLongNan` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/resolve-error.rs:31:3
@@ -14,7 +14,7 @@ LL | #[FooWithLongNan]
    |   ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: cannot find derive macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:22:10

--- a/src/test/ui/reserved/reserved-attr-on-macro.stderr
+++ b/src/test/ui/reserved/reserved-attr-on-macro.stderr
@@ -5,7 +5,7 @@ LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: The attribute `rustc_attribute_should_be_reserved` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/reserved-attr-on-macro.rs:1:3
@@ -14,7 +14,7 @@ LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: cannot determine resolution for the macro `foo`
   --> $DIR/reserved-attr-on-macro.rs:10:5

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate.stderr
@@ -14,7 +14,7 @@ LL |     if (let 0 = 1) {}
    |         ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:18:11
@@ -23,7 +23,7 @@ LL |     if (((let 0 = 1))) {}
    |           ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:22:16
@@ -32,7 +32,7 @@ LL |     if true && let 0 = 1 {}
    |                ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:26:8
@@ -41,7 +41,7 @@ LL |     if let 0 = 1 && true {}
    |        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:30:9
@@ -50,7 +50,7 @@ LL |     if (let 0 = 1) && true {}
    |         ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:34:17
@@ -59,7 +59,7 @@ LL |     if true && (let 0 = 1) {}
    |                 ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:38:9
@@ -68,7 +68,7 @@ LL |     if (let 0 = 1) && (let 0 = 1) {}
    |         ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:38:24
@@ -77,7 +77,7 @@ LL |     if (let 0 = 1) && (let 0 = 1) {}
    |                        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:44:8
@@ -86,7 +86,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:44:21
@@ -95,7 +95,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                     ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:44:35
@@ -104,7 +104,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:44:48
@@ -113,7 +113,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:44:61
@@ -122,7 +122,7 @@ LL |     if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {}
    |                                                             ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:56:8
@@ -131,7 +131,7 @@ LL |     if let Range { start: _, end: _ } = (true..true) && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:64:12
@@ -140,7 +140,7 @@ LL |     while (let 0 = 1) {}
    |            ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:68:14
@@ -149,7 +149,7 @@ LL |     while (((let 0 = 1))) {}
    |              ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:72:19
@@ -158,7 +158,7 @@ LL |     while true && let 0 = 1 {}
    |                   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:76:11
@@ -167,7 +167,7 @@ LL |     while let 0 = 1 && true {}
    |           ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:80:12
@@ -176,7 +176,7 @@ LL |     while (let 0 = 1) && true {}
    |            ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:84:20
@@ -185,7 +185,7 @@ LL |     while true && (let 0 = 1) {}
    |                    ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:88:12
@@ -194,7 +194,7 @@ LL |     while (let 0 = 1) && (let 0 = 1) {}
    |            ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:88:27
@@ -203,7 +203,7 @@ LL |     while (let 0 = 1) && (let 0 = 1) {}
    |                           ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:94:11
@@ -212,7 +212,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    |           ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:94:24
@@ -221,7 +221,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    |                        ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:94:38
@@ -230,7 +230,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    |                                      ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:94:51
@@ -239,7 +239,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    |                                                   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:94:64
@@ -248,7 +248,7 @@ LL |     while let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) {
    |                                                                ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:106:11
@@ -257,7 +257,7 @@ LL |     while let Range { start: _, end: _ } = (true..true) && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:129:20
@@ -266,7 +266,7 @@ LL |     #[cfg(FALSE)] (let 0 = 1);
    |                    ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:114:17
@@ -275,7 +275,7 @@ LL |     noop_expr!((let 0 = 1));
    |                 ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:123:16
@@ -284,7 +284,7 @@ LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error[E0658]: `let` expressions in this position are experimental
   --> $DIR/feature-gate.rs:126:16
@@ -293,7 +293,7 @@ LL |     use_expr!((let 0 = 1));
    |                ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/53667
-   = help: add #![feature(let_chains)] to the crate attributes to enable
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
 
 error: `let` expressions are not supported here
   --> $DIR/feature-gate.rs:14:9

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-builtin-attrs.stderr
@@ -269,7 +269,7 @@ LL |         #[test] a: i32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:23:5
@@ -278,7 +278,7 @@ LL |     #[test] a: u32,
    |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:38:5
@@ -287,7 +287,7 @@ LL |     #[test] a: u32,
    |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:58:9
@@ -296,7 +296,7 @@ LL |         #[test] a: i32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:79:9
@@ -305,7 +305,7 @@ LL |         #[test] a: i32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:98:9
@@ -314,7 +314,7 @@ LL |         #[test] a: i32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:117:9
@@ -323,7 +323,7 @@ LL |         #[test] a: i32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `test` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/param-attrs-builtin-attrs.rs:134:9
@@ -332,7 +332,7 @@ LL |         #[test] a: u32,
    |         ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 52 previous errors
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-feature-gate.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-feature-gate.stderr
@@ -11,7 +11,7 @@ LL |     /// Foo
    |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60406
-   = help: add #![feature(param_attrs)] to the crate attributes to enable
+   = help: add `#![feature(param_attrs)]` to the crate attributes to enable
 
 error[E0658]: attributes on function parameters are unstable
   --> $DIR/param-attrs-feature-gate.rs:9:5
@@ -20,7 +20,7 @@ LL |     #[allow(C)] a: u8
    |     ^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/60406
-   = help: add #![feature(param_attrs)] to the crate attributes to enable
+   = help: add `#![feature(param_attrs)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc1445/feature-gate.no_gate.stderr
+++ b/src/test/ui/rfc1445/feature-gate.no_gate.stderr
@@ -5,7 +5,7 @@ LL | #[structural_match]
    | ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31434
-   = help: add #![feature(structural_match)] to the crate attributes to enable
+   = help: add `#![feature(structural_match)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc1598-generic-associated-types/gat-dont-ice-on-absent-feature.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/gat-dont-ice-on-absent-feature.stderr
@@ -5,7 +5,7 @@ LL |     type Item<'b> = &'b Foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44265
-   = help: add #![feature(generic_associated_types)] to the crate attributes to enable
+   = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-unstable-column-gated.stderr
+++ b/src/test/ui/rust-unstable-column-gated.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature '__rust_unstable_column': internal
 LL |     println!("{}", __rust_unstable_column!());
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(__rust_unstable_column)] to the crate attributes to enable
+   = help: add `#![feature(__rust_unstable_column)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/gated-features-attr-spans.stderr
+++ b/src/test/ui/span/gated-features-attr-spans.stderr
@@ -5,7 +5,7 @@ LL | #[repr(simd)]
    | ^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/27731
-   = help: add #![feature(repr_simd)] to the crate attributes to enable
+   = help: add `#![feature(repr_simd)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -5,7 +5,7 @@ LL | #[foo]
    |   ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: non-builtin inner attributes are unstable
   --> $DIR/issue-36530.rs:5:5
@@ -14,7 +14,7 @@ LL |     #![foo]
    |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/54726
-   = help: add #![feature(custom_inner_attributes)] to the crate attributes to enable
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
 error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/issue-36530.rs:5:8
@@ -23,7 +23,7 @@ LL |     #![foo]
    |        ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
@@ -7,7 +7,7 @@ LL | | }
    | |_^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31844
-   = help: add #![feature(specialization)] to the crate attributes to enable
+   = help: add `#![feature(specialization)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/specialization/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/specialization-feature-gate-default.stderr
@@ -5,7 +5,7 @@ LL |     default fn foo(&self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31844
-   = help: add #![feature(specialization)] to the crate attributes to enable
+   = help: add `#![feature(specialization)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/stability-attribute/stability-attribute-issue.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-issue.stderr
@@ -5,7 +5,7 @@ LL |     unstable();
    |     ^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/1
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_test_feature': message
   --> $DIR/stability-attribute-issue.rs:10:5
@@ -14,7 +14,7 @@ LL |     unstable_msg();
    |     ^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/2
-   = help: add #![feature(unstable_test_feature)] to the crate attributes to enable
+   = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/stmt_expr_attrs_no_feature.stderr
+++ b/src/test/ui/stmt_expr_attrs_no_feature.stderr
@@ -5,7 +5,7 @@ LL |     #[rustfmt::skip]
    |     ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:95:18
@@ -14,7 +14,7 @@ LL |     fn y(a: [u8; #[rustc_dummy] 5]);
    |                  ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:102:19
@@ -23,7 +23,7 @@ LL |     const Y: u8 = #[rustc_dummy] 5;
    |                   ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:108:19
@@ -32,7 +32,7 @@ LL |     const Y: [u8; #[rustc_dummy] 5];
    |                   ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:114:18
@@ -41,7 +41,7 @@ LL |     field2: [u8; #[rustc_dummy] 5]
    |                  ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:119:10
@@ -50,7 +50,7 @@ LL |     [u8; #[rustc_dummy] 5]
    |          ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:125:14
@@ -59,7 +59,7 @@ LL |         [u8; #[rustc_dummy] 5]
    |              ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:130:22
@@ -68,7 +68,7 @@ LL |         field2: [u8; #[rustc_dummy] 5]
    |                      ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error[E0658]: attributes on expressions are experimental
   --> $DIR/stmt_expr_attrs_no_feature.rs:138:14
@@ -77,7 +77,7 @@ LL |         6 => #[rustc_dummy] (),
    |              ^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/15701
-   = help: add #![feature(stmt_expr_attributes)] to the crate attributes to enable
+   = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -5,7 +5,7 @@ LL | #[rustc_err]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(rustc_attrs)] to the crate attributes to enable
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
 error[E0658]: The attribute `rustc_err` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/attribute-typos.rs:7:3
@@ -14,7 +14,7 @@ LL | #[rustc_err]
    |   ^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `tests` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/attribute-typos.rs:4:3
@@ -23,7 +23,7 @@ LL | #[tests]
    |   ^^^^^ help: a built-in attribute with a similar name exists: `test`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: The attribute `deprcated` is currently unknown to the compiler and may have meaning added to it in the future
   --> $DIR/attribute-typos.rs:1:3
@@ -32,7 +32,7 @@ LL | #[deprcated]
    |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `deprecated`
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/syntax-trait-polarity-feature-gate.stderr
+++ b/src/test/ui/syntax-trait-polarity-feature-gate.stderr
@@ -5,7 +5,7 @@ LL | impl !Send for TestType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/13231
-   = help: add #![feature(optin_builtin_traits)] to the crate attributes to enable
+   = help: add `#![feature(optin_builtin_traits)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/target-feature-gate.stderr
+++ b/src/test/ui/target-feature-gate.stderr
@@ -5,7 +5,7 @@ LL | #[target_feature(enable = "avx512bw")]
    |                  ^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44839
-   = help: add #![feature(avx512_target_feature)] to the crate attributes to enable
+   = help: add `#![feature(avx512_target_feature)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/tool-attributes/tool-attributes-misplaced-1.stderr
+++ b/src/test/ui/tool-attributes/tool-attributes-misplaced-1.stderr
@@ -5,7 +5,7 @@ LL | #[rustfmt]
    |   ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add #![feature(custom_attribute)] to the crate attributes to enable
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: cannot find derive macro `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:4:10

--- a/src/test/ui/trace_macros-gate.stderr
+++ b/src/test/ui/trace_macros-gate.stderr
@@ -5,7 +5,7 @@ LL |     trace_macros!();
    |     ^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(trace_macros)] to the crate attributes to enable
+   = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error: trace_macros! accepts only `true` or `false`
   --> $DIR/trace_macros-gate.rs:4:5
@@ -20,7 +20,7 @@ LL |     trace_macros!(true);
    |     ^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(trace_macros)] to the crate attributes to enable
+   = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:7:5
@@ -29,7 +29,7 @@ LL |     trace_macros!(false);
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(trace_macros)] to the crate attributes to enable
+   = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:10:26
@@ -41,7 +41,7 @@ LL |     expando!(true);
    |     --------------- in this macro invocation
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29598
-   = help: add #![feature(trace_macros)] to the crate attributes to enable
+   = help: add `#![feature(trace_macros)]` to the crate attributes to enable
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-feature-gate.stderr
@@ -5,7 +5,7 @@ LL |     let x: Box<dyn Foo(isize)>;
    |                    ^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-not-used-on-fn.stderr
@@ -5,7 +5,7 @@ LL | fn bar1(x: &dyn Fn<(), Output=()>) {
    |                 ^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
   --> $DIR/unboxed-closure-sugar-not-used-on-fn.rs:7:28
@@ -14,7 +14,7 @@ LL | fn bar2<T>(x: &T) where T: Fn<()> {
    |                            ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29625
-   = help: add #![feature(unboxed_closures)] to the crate attributes to enable
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/utf8_idents.stderr
+++ b/src/test/ui/utf8_idents.stderr
@@ -5,7 +5,7 @@ LL |     'β,
    |     ^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/utf8_idents.rs:3:5
@@ -14,7 +14,7 @@ LL |     γ
    |     ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/utf8_idents.rs:8:5
@@ -23,7 +23,7 @@ LL |     δ: usize
    |     ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 error[E0658]: non-ascii idents are not fully supported
   --> $DIR/utf8_idents.rs:12:9
@@ -32,7 +32,7 @@ LL |     let α = 0.00001f64;
    |         ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/55467
-   = help: add #![feature(non_ascii_idents)] to the crate attributes to enable
+   = help: add `#![feature(non_ascii_idents)]` to the crate attributes to enable
 
 warning: type parameter `γ` should have an upper camel case name
   --> $DIR/utf8_idents.rs:3:5


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532