### PR TITLE
Add a crt-debug target feature

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -678,6 +678,13 @@ impl Session {
         }
     }
 
+    pub fn crt_debug_feature(&self) -> bool {
+        // Since the debug crt is opt-in only, checking for the negative feature
+        // does not make sense.
+        let requested_features = self.opts.cg.target_feature.split(',');
+        requested_features.clone().any(|r| r == "+crt-debug")
+    }
+
     pub fn must_not_eliminate_frame_pointers(&self) -> bool {
         // "mcount" function relies on stack pointer.
         // See https://sourceware.org/binutils/docs/gprof/Implementation.html

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -80,6 +80,10 @@ pub fn add_configuration(
     if sess.crt_static_feature() {
         cfg.insert((tf, Some(Symbol::intern("crt-static"))));
     }
+
+    if sess.crt_debug_feature() {
+        cfg.insert((tf, Some(Symbol::intern("crt-debug"))));
+    }
 }
 
 pub fn create_session(


### PR DESCRIPTION
This feature is designed to address https://github.com/rust-lang/rust/issues/39016 but it has the curious property that it does not actually affect the behaviour of rustc's linking at all. Ultimately it's used to modify which CRT is linked by libc, much like the crt-static target feature.