### PR TITLE
ci: Configure $CI_JOB_NAME correctly

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -100,7 +100,9 @@ steps:
 
 # Configure our CI_JOB_NAME variable which log analyzers can use for the main
 # step to see what's going on.
-- bash: echo "##vso[task.setvariable variable=CI_JOB_NAME]$SYSTEM_JOBNAME"
+- bash: |
+    builder=$(echo $AGENT_JOBNAME | cut -d ' ' -f 2)
+    echo "##vso[task.setvariable variable=CI_JOB_NAME]$builder"
   displayName: Configure Job Name
 
 # As a quick smoke check on the otherwise very fast mingw-check linux builder


### PR DESCRIPTION
Looks like some env vars were tweaked on Azure's side of things, so
update how we configure `CI_JOB_NAME`.