### PR TITLE
Add a Use-Definition Chain implementation for the MIR.

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1927,11 +1927,11 @@ impl<'tcx> Place<'tcx> {
         place_projection: &Option<Box<Projection<'tcx>>>,
         op: impl FnOnce(&'a PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
     ) -> R {
-        fn iterate_over2<'tcx, R>(
-            place_base: &PlaceBase<'tcx>,
+        fn iterate_over2<'a, 'tcx, R: 'a>(
+            place_base: &'a PlaceBase<'tcx>,
             place_projection: &Option<Box<Projection<'tcx>>>,
             next: &Projections<'_, 'tcx>,
-            op: impl FnOnce(&PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
+            op: impl FnOnce(&'a PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
         ) -> R {
             match place_projection {
                 None => {
@@ -2240,6 +2240,13 @@ impl<'tcx> Operand<'tcx> {
         match *self {
             Operand::Copy(_) | Operand::Constant(_) => self.clone(),
             Operand::Move(ref place) => Operand::Copy(place.clone()),
+        }
+    }
+
+    pub fn place(&self) -> Option<&Place<'tcx>> {
+        match self {
+            Operand::Copy(place) | Operand::Move(place) => Some(place),
+            Operand::Constant(_) => None,
         }
     }
 }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1915,17 +1915,17 @@ impl<'tcx> Place<'tcx> {
 
     /// Recursively "iterates" over place components, generating a `PlaceBase` and
     /// `Projections` list and invoking `op` with a `ProjectionsIter`.
-    pub fn iterate<R>(
-        &self,
-        op: impl FnOnce(&PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
+    pub fn iterate<'a, R: 'a>(
+        &'a self,
+        op: impl FnOnce(&'a PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
     ) -> R {
         Place::iterate_over(&self.base, &self.projection, op)
     }
 
-    pub fn iterate_over<R>(
-        place_base: &PlaceBase<'tcx>,
+    pub fn iterate_over<'a, R: 'a>(
+        place_base: &'a PlaceBase<'tcx>,
         place_projection: &Option<Box<Projection<'tcx>>>,
-        op: impl FnOnce(&PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
+        op: impl FnOnce(&'a PlaceBase<'tcx>, ProjectionsIter<'_, 'tcx>) -> R,
     ) -> R {
         fn iterate_over2<'tcx, R>(
             place_base: &PlaceBase<'tcx>,

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -18,6 +18,12 @@ use super::drop_flag_effects_for_function_entry;
 use super::drop_flag_effects_for_location;
 use super::on_lookup_result_bits;
 
+mod reaching_defs;
+mod use_def_chain;
+
+pub use self::reaching_defs::ReachingDefinitions;
+pub use self::use_def_chain::UseDefChain;
+
 mod storage_liveness;
 
 pub use self::storage_liveness::*;

--- a/src/librustc_mir/dataflow/impls/reaching_defs.rs
+++ b/src/librustc_mir/dataflow/impls/reaching_defs.rs
@@ -1,0 +1,414 @@
+use rustc::mir::visit::{PlaceContext, Visitor};
+use rustc::mir::visit::{MutatingUseContext, NonMutatingUseContext, NonUseContext};
+use rustc::mir::{self, Local, Location, Place, PlaceBase};
+use rustc_data_structures::bit_set::BitSet;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+use smallvec::SmallVec;
+
+use super::{BitDenotation, GenKillSet, BottomValue};
+
+newtype_index! {
+    /// A linear index for each definition in the program.
+    ///
+    /// This must be linear since it will be used to index a bit vector containing the set of
+    /// reaching definitions during dataflow analysis.
+    pub struct DefIndex {
+        DEBUG_FORMAT = "def{}",
+    }
+}
+
+/// A dataflow analysis which tracks whether an assignment to a variable might still constitute the
+/// value of that variable at a given point in the program.
+///
+/// Reaching definitions uses the term "definition" to refer to places in a program where a
+/// variable's value may change. Most definitions are writes to a variable (e.g. via
+/// `StatementKind::Assign`). However, a variable can also be implicitly defined by calling code if
+/// it is a function parameter or defined to be uninitialized via a call to
+/// `MaybeUninit::uninitialized`.
+///
+/// An example, using parentheses to denote each definition.
+///
+/// ```rust,no_run
+/// fn collatz_step(mut n: i32) -> i32 { // (1) Implicit definiton of function param
+///     if n % 2 == 0 {
+///         n /= 2                       // (2)
+///     } else {
+///         n = 3*n + 1                  // (3)
+///     }
+///
+///     // Only definitions (2) and (3) could possibly constitute the value of `n` at function exit.
+///     // (1), the `n` which was passed into the function, is killed by either (2) or (3)
+///     // along all paths to this point.
+///     n
+/// }
+/// ```
+///
+/// Not all programs are so simple; some care is required to handle projections. For field and
+/// array index projections, we cannot kill all previous definitions of the same variable, since
+/// only part of the variable was defined. If we encounter a deref projection on the left-hand side
+/// of an assignment, we don't even know *which* variable is being defined, since the pointer being
+/// dereferenced may be pointing anywhere. Such definitions are never killed. Finally, we must
+/// treat function calls as opaque: We can't know (without MIR inlining or explicit annotation)
+/// whether a callee mutates data behind a pointer. If the address of one of our locals is
+/// observable, it may be the target of such a mutation. A type-based analysis (e.g. does this
+/// function take any type containing a mutable reference as a parameter?) is insufficient, since
+/// raw pointers can be laundered through any integral type.
+///
+/// At the moment, the possible targets of a definition are tracked at the granularity of a
+/// `Local`, not a `MovePath` as is done in the initialized places analysis. That means that a
+/// definition like `x.y = 1` does not kill a previous assignment of `x.y`. This could be made more
+/// precise with more work; it is not a fundamental limitation of the analysis.
+///
+/// Most passes will want to know which definitions of a **specific** local reach a given point in
+/// the program. `ReachingDefinitions` does not provide this information; it can only provide all
+/// definitions of **any** local. However, a `ReachingDefinitions` analysis can be used to build a
+/// `UseDefChain`, which does provide this information.
+pub struct ReachingDefinitions {
+    all: IndexVec<DefIndex, Definition>,
+
+    /// All (direct) definitions of a local in the program.
+    for_local_direct: IndexVec<Local, Vec<DefIndex>>,
+
+    /// All definitions at the given location in the program.
+    at_location: FxHashMap<Location, SmallVec<[DefIndex; 4]>>,
+}
+
+fn is_call_with_side_effects(terminator: &mir::Terminator<'tcx>) -> bool {
+    if let mir::TerminatorKind::Call { .. } = terminator.kind {
+        true
+    } else {
+        false
+    }
+}
+
+impl ReachingDefinitions {
+    pub fn new(body: &mir::Body<'_>) -> Self {
+        let mut ret = ReachingDefinitions {
+            all: IndexVec::new(),
+            for_local_direct: IndexVec::from_elem(Vec::new(), &body.local_decls),
+            at_location: Default::default(),
+        };
+
+        let mut builder = DefBuilder { defs: &mut ret };
+        for arg in body.args_iter() {
+            builder.add_arg_def(arg);
+        }
+
+        DefVisitor(|place: &Place<'_>, loc| builder.visit_def(place, loc))
+            .visit_body(body);
+
+        // Add all function calls as indirect definitions.
+        let blocks_with_side_effects = body
+            .basic_blocks()
+            .iter_enumerated()
+            .filter(|(_, data)| is_call_with_side_effects(data.terminator()));
+
+        for (block, data) in blocks_with_side_effects {
+            let term_loc = Location { block, statement_index: data.statements.len() };
+            builder.add_def(term_loc, DefKind::Indirect);
+        }
+
+        ret
+    }
+
+    pub fn len(&self) -> usize {
+        self.all.len()
+    }
+
+    pub fn get(&self, idx: DefIndex) -> &Definition {
+        &self.all[idx]
+    }
+
+    /// Iterates over all definitions which go through a layer of indirection (e.g. `(*_1) = ...`).
+    pub fn indirect(&self) -> impl Iterator<Item = DefIndex> + '_ {
+        self.all
+            .iter_enumerated()
+            .filter(|(_, def)| def.is_indirect())
+            .map(|(id, _)| id)
+    }
+
+    pub fn for_local_direct(&self, local: Local) -> impl Iterator<Item = DefIndex> + '_ {
+        self.for_local_direct[local].iter().cloned()
+    }
+
+    pub fn at_location(&self, location: Location) -> impl Iterator<Item = DefIndex> + '_ {
+        self.at_location
+            .get(&location)
+            .into_iter()
+            .flat_map(|v| v.iter().cloned())
+    }
+
+    pub fn for_args(&self) -> impl Iterator<Item = DefIndex> + '_ {
+        self.all
+            .iter_enumerated()
+            .take_while(|(_, def)| def.location.is_none())
+            .map(|(def, _)| def)
+    }
+
+    fn update_trans(&self, trans: &mut GenKillSet<DefIndex>, location: Location) {
+        for def in self.at_location(location) {
+            trans.gen(def);
+
+            // If we assign directly to a local (e.g. `_1 = ...`), we can kill all other
+            // direct definitions of that local. We must not kill indirect definitions, since
+            // they may define locals other than the one currently being assigned to.
+            //
+            // FIXME: If we assign to a field of a local `_1.x = ...`, we could kill all other
+            // definitions of any part of that field (e.g. `_1.x.y = ...`). This would require
+            // tracking `MovePath`s instead of `Local`s.
+            if let DefKind::DirectWhole(local) = self.get(def).kind {
+                let other_direct_defs = self
+                    .for_local_direct(local)
+                    .filter(|&d| d != def);
+
+                trans.kill_all(other_direct_defs);
+            }
+        }
+    }
+}
+
+impl<'tcx> BitDenotation<'tcx> for ReachingDefinitions {
+    type Idx = DefIndex;
+    fn name() -> &'static str { "reaching_definitions" }
+
+    fn bits_per_block(&self) -> usize {
+        self.len()
+    }
+
+    fn start_block_effect(&self, entry_set: &mut BitSet<Self::Idx>) {
+        // Our parameters were defined by the caller at function entry.
+        for def in self.for_args() {
+            entry_set.insert(def);
+        }
+    }
+
+    fn statement_effect(
+        &self,
+        trans: &mut GenKillSet<Self::Idx>,
+        location: Location,
+    ) {
+        self.update_trans(trans, location);
+    }
+
+    fn terminator_effect(
+        &self,
+        trans: &mut GenKillSet<Self::Idx>,
+        location: Location,
+    ) {
+        self.update_trans(trans, location);
+    }
+
+    fn propagate_call_return(
+        &self,
+        _in_out: &mut BitSet<Self::Idx>,
+        _call_bb: mir::BasicBlock,
+        _dest_bb: mir::BasicBlock,
+        _dest_place: &mir::Place<'tcx>,
+    ) {
+        // FIXME: RETURN_PLACE should only be defined when a call returns successfully.
+    }
+}
+
+impl BottomValue for ReachingDefinitions {
+    /// bottom = definition not reachable
+    const BOTTOM_VALUE: bool = false;
+}
+
+struct DefBuilder<'a> {
+    defs: &'a mut ReachingDefinitions,
+}
+
+impl DefBuilder<'_> {
+    fn add_arg_def(&mut self, arg: Local) -> DefIndex {
+        let def = Definition { kind: DefKind::DirectWhole(arg), location: None };
+        let idx = self.defs.all.push(def);
+
+        self.defs.for_local_direct[arg].push(idx);
+        idx
+    }
+
+    fn add_def(&mut self, location: Location, kind: DefKind<Local>) -> DefIndex {
+        let def = Definition { kind, location: Some(location) };
+        let idx = self.defs.all.push(def);
+
+        if let Some(local) = kind.direct() {
+            self.defs.for_local_direct[local].push(idx);
+        }
+
+        self.defs.at_location.entry(location).or_default().push(idx);
+        idx
+    }
+
+    fn visit_def(&mut self, place: &mir::Place<'tcx>, location: Location) {
+        // We don't track reaching defs for statics.
+        let def_for_local = DefKind::of_place(place)
+            .map(PlaceBase::local)
+            .transpose();
+
+        if let Some(def) = def_for_local {
+            self.add_def(location, def);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Definition {
+    pub kind: DefKind<Local>,
+
+    /// The `Location` at which this definition occurs, or `None` if it occurs before the
+    /// `mir::Body` is entered (e.g. the value of an argument).
+    pub location: Option<Location>,
+}
+
+impl Definition {
+    fn is_indirect(&self) -> bool {
+        self.kind == DefKind::Indirect
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefKind<T> {
+    /// An entire variable is defined directly, e.g. `_1 = ...`.
+    DirectWhole(T),
+
+    /// Some part of a variable (a field or an array offset) is defined directly, e.g. `_1.field =
+    /// ...` or `_1[2] = ...`.
+    DirectPart(T),
+
+    /// An unknown variable is defined through a pointer, e.g. `(*_1) = ...`.
+    ///
+    /// In general, we cannot know where `_1` is pointing: it may reference any local in the
+    /// current `Body` (whose address has been observed) or somewhere else entirely (e.g. a static,
+    /// the heap, or a local further down the stack).
+    Indirect,
+}
+
+impl<T> DefKind<T> {
+    /// Returns `Some(T)` if the `DefKind` is direct or `None` if it is indirect.
+    pub fn direct(self) -> Option<T> {
+        match self {
+            DefKind::DirectWhole(x) | DefKind::DirectPart(x) => Some(x),
+            DefKind::Indirect => None,
+        }
+    }
+
+    /// Converts a `DefKind<T>` to a `DefKind<U>` by applying a function to the value contained in
+    /// either `DirectWhole` or `DirectPart`.
+    fn map<U>(self, f: impl FnOnce(T) -> U) -> DefKind<U> {
+        match self {
+            DefKind::DirectWhole(x) => DefKind::DirectWhole(f(x)),
+            DefKind::DirectPart(x) => DefKind::DirectPart(f(x)),
+            DefKind::Indirect => DefKind::Indirect,
+        }
+    }
+}
+
+impl<T> DefKind<Option<T>> {
+    /// Converts a `DefKind` of an `Option` into an `Option` of a `DefKind`.
+    ///
+    /// The result is `None` if either direct variant contains `None`. Otherwise, the result is
+    /// `Some(self.map(Option::unwrap))`.
+    fn transpose(self) -> Option<DefKind<T>> {
+        match self {
+            DefKind::DirectWhole(Some(x)) => Some(DefKind::DirectWhole(x)),
+            DefKind::DirectPart(Some(x)) => Some(DefKind::DirectPart(x)),
+            DefKind::Indirect => Some(DefKind::Indirect),
+
+            DefKind::DirectWhole(None) | DefKind::DirectPart(None) => None,
+        }
+    }
+}
+
+impl<'a, 'tcx> DefKind<&'a mir::PlaceBase<'tcx>> {
+    fn of_place(place: &'a mir::Place<'tcx>) -> Self {
+        place.iterate(|base, projections| {
+            let mut is_whole = true;
+            for proj in projections {
+                is_whole = false;
+                if proj.elem == mir::ProjectionElem::Deref {
+                    return DefKind::Indirect;
+                }
+            }
+
+            if is_whole {
+                DefKind::DirectWhole(base)
+            } else {
+                DefKind::DirectPart(base)
+            }
+        })
+    }
+}
+
+pub struct DefVisitor<F>(pub F);
+
+impl<'tcx, F> Visitor<'tcx> for DefVisitor<F>
+    where F: FnMut(&Place<'tcx>, Location)
+{
+    fn visit_place(&mut self,
+                   place: &Place<'tcx>,
+                   context: PlaceContext,
+                   location: Location) {
+        self.super_place(place, context, location);
+
+        match context {
+            // DEFS
+            | PlaceContext::MutatingUse(MutatingUseContext::AsmOutput)
+            | PlaceContext::MutatingUse(MutatingUseContext::Call)
+            | PlaceContext::MutatingUse(MutatingUseContext::Store)
+            => self.0(place, location),
+
+            | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
+            | PlaceContext::MutatingUse(MutatingUseContext::Drop)
+            | PlaceContext::MutatingUse(MutatingUseContext::Projection)
+            | PlaceContext::MutatingUse(MutatingUseContext::Retag)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow)
+            | PlaceContext::NonUse(NonUseContext::AscribeUserTy)
+            | PlaceContext::NonUse(NonUseContext::StorageDead)
+            | PlaceContext::NonUse(NonUseContext::StorageLive)
+            => (),
+        }
+    }
+}
+
+pub struct UseVisitor<F>(pub F);
+
+impl<'tcx, F> Visitor<'tcx> for UseVisitor<F>
+    where F: FnMut(&Place<'tcx>, Location)
+{
+    fn visit_place(&mut self,
+                   place: &Place<'tcx>,
+                   context: PlaceContext,
+                   location: Location) {
+        self.super_place(place, context, location);
+
+        match context {
+            | PlaceContext::MutatingUse(MutatingUseContext::AsmOutput)
+            | PlaceContext::MutatingUse(MutatingUseContext::Borrow)
+            | PlaceContext::MutatingUse(MutatingUseContext::Drop)
+            | PlaceContext::MutatingUse(MutatingUseContext::Projection)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Copy)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::Projection)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::ShallowBorrow)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::SharedBorrow)
+            | PlaceContext::NonMutatingUse(NonMutatingUseContext::UniqueBorrow)
+            => self.0(place, location),
+
+            | PlaceContext::MutatingUse(MutatingUseContext::Call)
+            | PlaceContext::MutatingUse(MutatingUseContext::Retag)
+            | PlaceContext::MutatingUse(MutatingUseContext::Store)
+            | PlaceContext::NonUse(NonUseContext::AscribeUserTy)
+            | PlaceContext::NonUse(NonUseContext::StorageDead)
+            | PlaceContext::NonUse(NonUseContext::StorageLive)
+            => (),
+        }
+    }
+}

--- a/src/librustc_mir/dataflow/impls/use_def_chain.rs
+++ b/src/librustc_mir/dataflow/impls/use_def_chain.rs
@@ -1,0 +1,302 @@
+use std::collections::BTreeMap;
+use std::ops;
+
+use rustc::mir::{self, BasicBlock, Local, Location, Place};
+use rustc::mir::visit::{Visitor, MirVisitable};
+use rustc::util::captures::Captures;
+use rustc_data_structures::bit_set::BitSet;
+use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::indexed_vec::{Idx, IndexVec};
+
+use crate::dataflow::{
+    DataflowResults, DataflowResultsCursor,
+    impls::HaveBeenBorrowedLocals,
+    impls::reaching_defs::{DefIndex, DefKind, Definition, ReachingDefinitions, UseVisitor},
+};
+
+type LocationMap<T> = FxHashMap<Location, T>;
+type DefsForLocalDense = IndexVec<Local, BitSet<DefIndex>>;
+type DefsForLocalSparse = BTreeMap<Local, BitSet<DefIndex>>;
+type DefsForUseAtLocation = LocationMap<DefsForLocalSparse>;
+
+/// A data structure, built using the results of a `ReachingDefinitions` analysis, that maps each
+/// use of a variable to the definitions of that variable that could reach it.
+///
+/// While `ReachingDefinitions` maps each point in the program to every definition which reaches
+/// that point, a `UseDefChain` maps each use of a variable to every definition which could define
+/// that variable. See below for an example where this distinction is meaningful.
+///
+/// ```rust,no_run
+/// fn five() -> i32 {
+///     let mut x = 0;  // (1)
+///
+///     let p = &mut x; // (2)
+///     *p = 1;         // (3)
+///
+///     x = 2;          // (4)
+///
+///     x + 3
+///     // At this point, a `UseDefChain` knows that (4) is the only possible definition of `x`,
+///     // even though (2), (3) and (4) reach here. A reaching definitions analysis can kill (1)
+///     // since it is superseded by (4), but it cannot kill (3) since `p` may be pointing
+///     // to a local besides `x`. However, a `UseDefChain` is only interested in definitions of
+///     // `x`, so it can kill *all* other definitions when (4) is encountered.
+/// }
+/// ```
+///
+/// This precision comes at the cost of increased memory usage; A `UseDefChain` stores a `BitSet`
+/// for every use in the program. This allows consumers to traverse the graph of data dependencies
+/// efficiently. For example, a `UseDefChain` could be used for const-propagation by iterating over
+/// the definitions which could possibly reach `y` at the exit of the following function and
+/// realizing that all of them are the constant `6`.
+///
+/// ```rust,no_run
+/// fn six(condition: bool) -> i32 {
+///     let mut y;
+///     let a = 2 * 3;
+///     let b = 10 - 4;
+///
+///     if condition {
+///         y = a;
+///     } else {
+///         y = b;
+///     }
+///
+///     y
+/// }
+/// ```
+pub struct UseDefChain<'me, 'tcx> {
+    reaching_defs: &'me DataflowResults<'tcx, ReachingDefinitions>,
+
+    /// Maps each local that is used at a given location to the set of definitions which can reach
+    /// it.
+    defs_for_use: DefsForUseAtLocation,
+}
+
+impl<'me, 'tcx> UseDefChain<'me, 'tcx> {
+    pub fn new(
+        body: &'me mir::Body<'tcx>,
+        reaching_defs: &'me DataflowResults<'tcx, ReachingDefinitions>,
+        observed_addresses: &DataflowResults<'tcx, HaveBeenBorrowedLocals<'_, 'tcx>>,
+    ) -> Self {
+        let defs = reaching_defs.operator();
+        let all_defs_for_local = all_defs_for_local(body, defs, &observed_addresses);
+        let locals_used_in_block = LocalsUsedInBlock::new(body);
+        let curr_defs_for_local =
+            IndexVec::from_elem(BitSet::new_empty(defs.len()), &body.local_decls);
+
+        let mut defs_for_use = DefsForUseAtLocation::default();
+
+        {
+            let mut builder = UseDefBuilder {
+                body,
+                ud_chain: &mut defs_for_use,
+                reaching_defs,
+                locals_used_in_block,
+                curr_defs_for_local,
+                all_defs_for_local,
+            };
+
+            builder.visit_body(body);
+        }
+
+        UseDefChain {
+            defs_for_use,
+            reaching_defs,
+        }
+    }
+
+    pub fn defs_for_use(
+        &self,
+        local: Local,
+        location: Location,
+    ) -> impl Iterator<Item = &'_ Definition> + Captures<'tcx> + '_ {
+        let UseDefChain { defs_for_use, reaching_defs, .. } = self;
+
+        defs_for_use
+            .get(&location)
+            .and_then(|for_local| for_local.get(&local))
+            .into_iter()
+            .flat_map(|defs| defs.iter())
+            .map(move |def| reaching_defs.operator().get(def))
+    }
+}
+
+struct UseDefBuilder<'a, 'me, 'tcx> {
+    ud_chain: &'a mut DefsForUseAtLocation,
+
+    body: &'me mir::Body<'tcx>,
+
+    reaching_defs: &'me DataflowResults<'tcx, ReachingDefinitions>,
+
+    /// It's expensive to clone the entry set at the start of each block for every local and apply
+    /// the appropriate mask. However, we only need to keep `curr_defs_for_local` up-to-date for
+    /// the `Local`s which are actually used in a given `BasicBlock`.
+    locals_used_in_block: LocalsUsedInBlock,
+
+    /// The set of definitions which could have reached a given local at the program point we are
+    /// currently processing.
+    curr_defs_for_local: DefsForLocalDense,
+
+    /// The set of all definitions which *might* define the given local. These definitions may or
+    /// may not be live at the current program point.
+    all_defs_for_local: DefsForLocalDense,
+}
+
+impl<'me, 'tcx> UseDefBuilder<'_, 'me, 'tcx> {
+    fn visit_location(&mut self, location: Location, stmt_or_term: &impl MirVisitable<'tcx>) {
+        let UseDefBuilder {
+            all_defs_for_local,
+            curr_defs_for_local,
+            locals_used_in_block,
+            reaching_defs,
+            ud_chain,
+            ..
+        } = self;
+
+        // If this is the start of a `BasicBlock`, reset `curr_defs_for_local` for each (tracked)
+        // local to the set of definitions which reach the start of this block and can modify that
+        // local.
+        if location.statement_index == 0 {
+            for local in locals_used_in_block[location.block].iter() {
+                let entry_set = &reaching_defs.sets().entry_set_for(location.block.index());
+                curr_defs_for_local[local].overwrite(entry_set);
+                curr_defs_for_local[local].intersect(&all_defs_for_local[local]);
+            }
+        }
+
+        // Save the current set of reaching definitions for any local which is used at this
+        // location.
+        let record_use = |place: &Place<'tcx>, location| {
+            if let Some(local) = place.base_local() {
+                ud_chain.entry(location)
+                    .or_default()
+                    .entry(local)
+                    .or_insert_with(|| {
+                        debug_assert!(locals_used_in_block[location.block].contains(local));
+                        curr_defs_for_local[local].clone()
+                    });
+            }
+        };
+
+        stmt_or_term.apply(location, &mut UseVisitor(record_use));
+
+        // Update `curr_defs_for_local` with any new definitions from this location.
+        //
+        // This needs to take place after processing uses, otherwise a def like `x =
+        // x+1` will be marked as reaching its right hand side.
+        let reaching_defs = reaching_defs.operator();
+        let tracked_in_block = &locals_used_in_block[location.block];
+        for def in reaching_defs.at_location(location) {
+            match reaching_defs.get(def).kind {
+                // No need to process defs for a local that is untracked
+                DefKind::DirectWhole(local) | DefKind::DirectPart(local)
+                    if !tracked_in_block.contains(local)
+                    => continue,
+
+                DefKind::DirectWhole(local) => {
+                    let defs = &mut curr_defs_for_local[local];
+                    defs.clear();
+                    defs.insert(def);
+                }
+
+                DefKind::DirectPart(local) => {
+                    curr_defs_for_local[local].insert(def);
+                }
+
+                DefKind::Indirect => {
+                    self.body
+                        .local_decls
+                        .indices()
+                        .filter(|&local| all_defs_for_local[local].contains(def))
+                        .for_each(|local| { curr_defs_for_local[local].insert(def); });
+                }
+            }
+        }
+    }
+}
+
+impl<'tcx> Visitor<'tcx> for UseDefBuilder<'_, '_, 'tcx> {
+    fn visit_statement(&mut self, statement: &mir::Statement<'tcx>, location: Location) {
+        // Don't recurse: We only care about statements and terminators
+        // self.super_statement(statement, location);
+
+        self.visit_location(location, statement)
+    }
+
+    fn visit_terminator(&mut self,
+                        terminator: &mir::Terminator<'tcx>,
+                        location: Location) {
+        // Don't recurse: We only care about statements and terminators
+        // self.super_terminator(terminator, location);
+
+        self.visit_location(location, terminator)
+    }
+}
+
+/// The set of `Local`s which are used at least once in each basic block.
+struct LocalsUsedInBlock(IndexVec<BasicBlock, BitSet<Local>>);
+
+impl LocalsUsedInBlock {
+    fn new(body: &mir::Body<'_>) -> Self {
+        let each_block =
+            IndexVec::from_elem(BitSet::new_empty(body.local_decls.len()), body.basic_blocks());
+        let mut ret = LocalsUsedInBlock(each_block);
+
+        UseVisitor(|place: &Place<'_>, loc| ret.visit_use(place, loc))
+            .visit_body(body);
+
+        ret
+    }
+
+    fn visit_use(&mut self, place: &mir::Place<'tcx>, loc: Location) {
+        if let Some(local) = place.base_local() {
+            self.0[loc.block].insert(local);
+        }
+    }
+}
+
+impl ops::Deref for LocalsUsedInBlock {
+    type Target = IndexVec<BasicBlock, BitSet<Local>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// `BitSet` cannot efficiently `FromIterator` since it needs to know its size ahead of time.
+fn bitset_from_iter<I: Idx>(size: usize, it: impl IntoIterator<Item = I>) -> BitSet<I> {
+    let mut ret = BitSet::new_empty(size);
+    for item in it {
+        ret.insert(item);
+    }
+
+    ret
+}
+
+fn all_defs_for_local<'tcx>(
+    body: &mir::Body<'tcx>,
+    defs: &ReachingDefinitions,
+    observed_addresses: &DataflowResults<'tcx, HaveBeenBorrowedLocals<'_, 'tcx>>,
+) -> DefsForLocalDense {
+    // Initialize the return value with the direct definitions of each local.
+    let mut defs_for_local: DefsForLocalDense = body
+        .local_decls
+        .iter_enumerated()
+        .map(|(local, _)| bitset_from_iter(defs.len(), defs.for_local_direct(local)))
+        .collect();
+
+    // Add each indirect definition to the set of definitions for each local whose address has been
+    // observed at that point.
+    let mut observed_addresses = DataflowResultsCursor::new(observed_addresses, body);
+    for def_id in defs.indirect() {
+        let def = defs.get(def_id);
+        observed_addresses.seek(def.location.expect("Indirect def without location"));
+
+        for local in observed_addresses.get().iter() {
+            defs_for_local[local].insert(def_id);
+        }
+    }
+
+    defs_for_local
+}

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -19,6 +19,7 @@ use std::usize;
 
 pub use self::impls::{MaybeStorageLive, RequiresStorage};
 pub use self::impls::{MaybeInitializedPlaces, MaybeUninitializedPlaces};
+pub use self::impls::{ReachingDefinitions, UseDefChain};
 pub use self::impls::DefinitelyInitializedPlaces;
 pub use self::impls::EverInitializedPlaces;
 pub use self::impls::borrows::Borrows;

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -441,6 +441,10 @@ where
         self.curr_loc = Some(loc);
     }
 
+    pub fn get(&self) -> &BitSet<BD::Idx> {
+        self.flow_state.as_dense()
+    }
+
     /// Return whether the current state contains bit `x`.
     pub fn contains(&self, x: BD::Idx) -> bool {
         self.flow_state.contains(x)

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -59,7 +59,7 @@ impl MirPass for SanityCheck {
                         |_bd, i| DebugFormatted::new(&i));
         let flow_reaching_defs =
             do_dataflow(tcx, body, def_id, &attributes, &dead_unwinds,
-                        ReachingDefinitions::new(body),
+                        ReachingDefinitions::new(tcx, body, tcx.param_env(def_id)),
                         |bd, i| DebugFormatted::new(&bd.get(i).location));
         let flow_use_def_chain =
             UseDefChain::new(body, &flow_reaching_defs, &flow_borrowed_locals);

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -593,6 +593,7 @@ symbols! {
         rustc_peek_definite_init,
         rustc_peek_maybe_init,
         rustc_peek_maybe_uninit,
+        rustc_peek_use_def_chain,
         rustc_private,
         rustc_proc_macro_decls,
         rustc_promotable,

--- a/src/test/ui/mir-dataflow/reaching-defs-1.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-1.rs
@@ -22,7 +22,7 @@ fn foo(test: bool) -> (i32, i32) {
     }
 
     unsafe { rustc_peek(&x); }
-    //~^ ERROR rustc_peek: [16: "x=2", 17: "rustc_peek(&x)", 20: "x=3"]
+    //~^ ERROR rustc_peek: [16: "x=2", 20: "x=3"]
 
     unsafe { rustc_peek(&y); }
     //~^ ERROR rustc_peek: [13: "y=1", 21: "y=4"]

--- a/src/test/ui/mir-dataflow/reaching-defs-1.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-1.rs
@@ -1,0 +1,36 @@
+// General test of reaching_defs state computed by MIR dataflow.
+
+#![feature(core_intrinsics, rustc_attrs)]
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_use_def_chain, stop_after_dataflow, borrowck_graphviz_postflow="flow.dot")]
+fn foo(test: bool) -> (i32, i32) {
+    // Splitting declarations and assignment gives us nicer spans
+    let mut x;
+    let mut y;
+
+    x=0;
+    y=1;
+
+    if test {
+        x=2;
+        unsafe { rustc_peek(&x); }
+        //~^ ERROR rustc_peek: [16: "x=2"]
+    } else {
+        x=3;
+        y=4;
+    }
+
+    unsafe { rustc_peek(&x); }
+    //~^ ERROR rustc_peek: [16: "x=2", 17: "rustc_peek(&x)", 20: "x=3"]
+
+    unsafe { rustc_peek(&y); }
+    //~^ ERROR rustc_peek: [13: "y=1", 21: "y=4"]
+
+    (x, y)
+}
+
+fn main() {
+    foo(true);
+    foo(false);
+}

--- a/src/test/ui/mir-dataflow/reaching-defs-1.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-1.stderr
@@ -1,0 +1,22 @@
+error: rustc_peek: [16: "x=2"]
+  --> $DIR/reaching-defs-1.rs:17:18
+   |
+LL |         unsafe { rustc_peek(&x); }
+   |                  ^^^^^^^^^^^^^^
+
+error: rustc_peek: [16: "x=2", 17: "rustc_peek(&x)", 20: "x=3"]
+  --> $DIR/reaching-defs-1.rs:24:14
+   |
+LL |     unsafe { rustc_peek(&x); }
+   |              ^^^^^^^^^^^^^^
+
+error: rustc_peek: [13: "y=1", 21: "y=4"]
+  --> $DIR/reaching-defs-1.rs:27:14
+   |
+LL |     unsafe { rustc_peek(&y); }
+   |              ^^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/mir-dataflow/reaching-defs-1.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-1.stderr
@@ -4,7 +4,7 @@ error: rustc_peek: [16: "x=2"]
 LL |         unsafe { rustc_peek(&x); }
    |                  ^^^^^^^^^^^^^^
 
-error: rustc_peek: [16: "x=2", 17: "rustc_peek(&x)", 20: "x=3"]
+error: rustc_peek: [16: "x=2", 20: "x=3"]
   --> $DIR/reaching-defs-1.rs:24:14
    |
 LL |     unsafe { rustc_peek(&x); }

--- a/src/test/ui/mir-dataflow/reaching-defs-2.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-2.rs
@@ -1,0 +1,15 @@
+#![feature(core_intrinsics, rustc_attrs)]
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_use_def_chain, stop_after_dataflow, borrowck_graphviz_postflow="flow.dot")]
+fn main() {
+    let mut x;
+    x=0;
+
+    while x != 10 {
+        x+=1;
+    }
+
+    unsafe { rustc_peek(x); }
+    //~^ ERROR rustc_peek: [7: "x=0", 10: "x+=1"]
+}

--- a/src/test/ui/mir-dataflow/reaching-defs-2.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-2.stderr
@@ -1,0 +1,10 @@
+error: rustc_peek: [7: "x=0", 10: "x+=1"]
+  --> $DIR/reaching-defs-2.rs:13:14
+   |
+LL |     unsafe { rustc_peek(x); }
+   |              ^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mir-dataflow/reaching-defs-arg.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-arg.rs
@@ -1,0 +1,19 @@
+#![feature(core_intrinsics, rustc_attrs)]
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_use_def_chain, stop_after_dataflow, borrowck_graphviz_postflow="flow.dot")]
+fn foo(test: bool, mut x: i32) -> i32 {
+    if test {
+        x=42;
+    }
+
+    unsafe { rustc_peek(&x); }
+    //~^ ERROR rustc_peek: [5: "mut x", 7: "x=42"]
+
+    x
+}
+
+fn main() {
+    foo(true, 32);
+    foo(false, 56);
+}

--- a/src/test/ui/mir-dataflow/reaching-defs-arg.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-arg.stderr
@@ -1,0 +1,10 @@
+error: rustc_peek: [5: "mut x", 7: "x=42"]
+  --> $DIR/reaching-defs-arg.rs:10:14
+   |
+LL |     unsafe { rustc_peek(&x); }
+   |              ^^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mir-dataflow/reaching-defs-drop.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-drop.rs
@@ -1,0 +1,26 @@
+#![feature(core_intrinsics, rustc_attrs)]
+use std::intrinsics::rustc_peek;
+
+struct NoSideEffectsInDrop<'a>(&'a mut u32);
+struct SideEffectsInDrop<'a>(&'a mut u32);
+
+impl Drop for SideEffectsInDrop<'_> {
+    fn drop(&mut self) {
+        *self.0 = 42
+    }
+}
+
+#[rustc_mir(rustc_peek_use_def_chain, stop_after_dataflow, borrowck_graphviz_postflow="flow.dot")]
+fn main() {
+    let mut x;
+    x=0;
+
+    NoSideEffectsInDrop(&mut x);
+    SideEffectsInDrop(&mut x);
+
+    // The ";" on line 19 is the point at which `SideEffectsInDrop` is dropped.
+    unsafe { rustc_peek(x); }
+    //~^ ERROR rustc_peek: [16: "x=0", 19: ";"]
+
+    assert_eq!(x, 42);
+}

--- a/src/test/ui/mir-dataflow/reaching-defs-drop.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-drop.stderr
@@ -1,0 +1,10 @@
+error: rustc_peek: [16: "x=0", 19: ";"]
+  --> $DIR/reaching-defs-drop.rs:22:14
+   |
+LL |     unsafe { rustc_peek(x); }
+   |              ^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mir-dataflow/reaching-defs-indirect-1.rs
+++ b/src/test/ui/mir-dataflow/reaching-defs-indirect-1.rs
@@ -1,0 +1,33 @@
+#![feature(core_intrinsics, rustc_attrs)]
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_use_def_chain, stop_after_dataflow, borrowck_graphviz_postflow="flow.dot")]
+fn foo(test: bool) -> (i32, i32) {
+    let mut x;
+    let mut y;
+    let mut p;
+
+    x=0;
+    y=1;
+
+    unsafe { rustc_peek(x); }
+    //~^ ERROR rustc_peek: [10: "x=0"]
+
+    if test {
+        p = &mut x;
+    } else {
+        p = &mut y;
+    }
+
+    *p=2;
+
+    unsafe { rustc_peek(x); }
+    //~^ ERROR rustc_peek: [10: "x=0", 22: "*p=2"]
+
+    (x, y)
+}
+
+fn main() {
+    foo(true);
+    foo(false);
+}

--- a/src/test/ui/mir-dataflow/reaching-defs-indirect-1.stderr
+++ b/src/test/ui/mir-dataflow/reaching-defs-indirect-1.stderr
@@ -1,0 +1,16 @@
+error: rustc_peek: [10: "x=0"]
+  --> $DIR/reaching-defs-indirect-1.rs:13:14
+   |
+LL |     unsafe { rustc_peek(x); }
+   |              ^^^^^^^^^^^^^
+
+error: rustc_peek: [10: "x=0", 22: "*p=2"]
+  --> $DIR/reaching-defs-indirect-1.rs:24:14
+   |
+LL |     unsafe { rustc_peek(x); }
+   |              ^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This work began from [a discussion](https://rust-lang.zulipchat.com/#narrow/stream/146212-t-compiler.2Fconst-eval/topic/dataflow-based.20const.20qualification.20MVP) about extending const-qualification to work on arbitrary CFGs (currently it does not support conditional jumps). @eddyb was not convinced that this was the right approach, so I stopped working on it for a while. I picked it up again since it was almost complete, and it might also be useful for MIR optimization. I'm opening this PR so there's a place to discuss possible use cases, but it's very much a work in progress. 

You can see an example of this analysis [here](https://github.com/ecstatic-morse/rust/blob/ud-chain/src/test/ui/mir-dataflow/reaching-defs-1.rs). The `ERROR` lines contain the possible definitions of the given variable at that point in the program prefixed by their line number. ~~Note the presence of `rustc_peek(&x)` in the possible definitions on [line 25](https://github.com/ecstatic-morse/rust/blob/e9812eb386aef82c923673c6cb1b1394aced7db8/src/test/ui/mir-dataflow/reaching-defs-1.rs#L25). This is because function calls may mutate locals higher up the call stack via a pointer, so any local which has had its address taken at that point in the CFG could be modified when calling an arbitrary function (obviously `rustc_peek` does not actually mutate its environment).~~ The fact that `rustc_peek` does not mutate its environment has been [special-cased in the analysis](https://github.com/rust-lang/rust/pull/62547/files#diff-f7260434bc49a5d0402c7cf7f08ea77cR89) (this could be extended to other intrinsics). 