### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,16 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytesize 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-test-macro 0.1.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crates-io 0.26.0",
+ "crates-io 0.27.0",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-hash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -578,7 +577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "crates-io"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "curl 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2563,7 +2562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rls"
 version = "1.37.0"
 dependencies = [
- "cargo 0.38.0",
+ "cargo 0.39.0",
  "cargo_metadata 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.212",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Update cargo

12 commits in 4c1fa54d10f58d69ac9ff55be68e1b1c25ecb816..677a180f4c8ca1dcef594f68dd0e63e4f08621f5
2019-06-24 11:24:18 +0000 to 2019-07-08 13:43:02 +0000
- Update dependencies (rust-lang/cargo#7106)
- Fix overwriting .d file for binary with dSYM on apple targets. (rust-lang/cargo#7057)
- Update changelog. (rust-lang/cargo#7102)
- Revert "Fix 'getting started' internal links" (rust-lang/cargo#7099)
- Bump to 0.39.0 (rust-lang/cargo#7100)
- Update dependency.rs (rust-lang/cargo#7098)
- Typo (rust-lang/cargo#7097)
- Fix 'getting started' internal links (rust-lang/cargo#7093)
- Fix misleading comment in testsuite (rust-lang/cargo#7090)
- improve uncommitted changes cargo-package message (rust-lang/cargo#7083)
- Clean environment when git-fetch-with-cli is used. (rust-lang/cargo#7082)
- Fix exponentiality in depend_on_deps_of_deps. (rust-lang/cargo#7062)