### PR TITLE
pretty-print: Do not lose the `$crate` printing flag in `print_tt`

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -689,7 +689,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
             TokenTree::Delimited(_, delim, tts) => {
                 self.word(token_kind_to_string(&token::OpenDelim(delim)));
                 self.space();
-                self.print_tts(tts);
+                self.print_tts(tts, convert_dollar_crate);
                 self.space();
                 self.word(token_kind_to_string(&token::CloseDelim(delim)))
             },

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -187,8 +187,9 @@ pub fn literal_to_string(lit: token::Lit) -> String {
     out
 }
 
-fn ident_to_string(ident: ast::Ident, is_raw: bool) -> String {
-    ident_to_string_ext(ident.name, is_raw, Some(ident.span))
+/// Print an ident from AST, `$crate` is converted into its respective crate name.
+fn ast_ident_to_string(ident: ast::Ident, is_raw: bool) -> String {
+    ident_to_string(ident.name, is_raw, Some(ident.span))
 }
 
 // AST pretty-printer is used as a fallback for turning AST structures into token streams for
@@ -202,9 +203,7 @@ fn ident_to_string(ident: ast::Ident, is_raw: bool) -> String {
 // but not otherwise. Pretty-printing is the only way for proc macros to discover token contents,
 // so we should not perform this lossy conversion if the top level call to the pretty-printer was
 // done for a token stream or a single token.
-fn ident_to_string_ext(
-    name: ast::Name, is_raw: bool, convert_dollar_crate: Option<Span>
-) -> String {
+fn ident_to_string(name: ast::Name, is_raw: bool, convert_dollar_crate: Option<Span>) -> String {
     if is_raw {
         format!("r#{}", name)
     } else {
@@ -222,6 +221,7 @@ fn ident_to_string_ext(
     }
 }
 
+/// Print the token kind precisely, without converting `$crate` into its respective crate name.
 pub fn token_kind_to_string(tok: &TokenKind) -> String {
     token_kind_to_string_ext(tok, None)
 }
@@ -272,7 +272,7 @@ fn token_kind_to_string_ext(tok: &TokenKind, convert_dollar_crate: Option<Span>)
         token::Literal(lit) => literal_to_string(lit),
 
         /* Name components */
-        token::Ident(s, is_raw)     => ident_to_string_ext(s, is_raw, convert_dollar_crate),
+        token::Ident(s, is_raw)     => ident_to_string(s, is_raw, convert_dollar_crate),
         token::Lifetime(s)          => s.to_string(),
 
         /* Other */
@@ -286,6 +286,7 @@ fn token_kind_to_string_ext(tok: &TokenKind, convert_dollar_crate: Option<Span>)
     }
 }
 
+/// Print the token precisely, without converting `$crate` into its respective crate name.
 pub fn token_to_string(token: &Token) -> String {
     token_to_string_ext(token, false)
 }
@@ -305,7 +306,7 @@ crate fn nonterminal_to_string(nt: &Nonterminal) -> String {
         token::NtBlock(ref e)       => block_to_string(e),
         token::NtStmt(ref e)        => stmt_to_string(e),
         token::NtPat(ref e)         => pat_to_string(e),
-        token::NtIdent(e, is_raw)   => ident_to_string(e, is_raw),
+        token::NtIdent(e, is_raw)   => ast_ident_to_string(e, is_raw),
         token::NtLifetime(e)        => e.to_string(),
         token::NtLiteral(ref e)     => expr_to_string(e),
         token::NtTT(ref tree)       => tt_to_string(tree.clone()),
@@ -601,7 +602,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
                 self.word("::");
             }
             if segment.ident.name != kw::PathRoot {
-                self.word(ident_to_string(segment.ident, segment.ident.is_raw_guess()));
+                self.word(ast_ident_to_string(segment.ident, segment.ident.is_raw_guess()));
             }
         }
     }
@@ -2205,7 +2206,7 @@ impl<'a> State<'a> {
     }
 
     crate fn print_ident(&mut self, ident: ast::Ident) {
-        self.s.word(ident_to_string(ident, ident.is_raw_guess()));
+        self.s.word(ast_ident_to_string(ident, ident.is_raw_guess()));
         self.ann.post(self, AnnNode::Ident(&ident))
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -341,7 +341,7 @@ pub fn tts_to_string(tts: &[tokenstream::TokenTree]) -> String {
 }
 
 pub fn tokens_to_string(tokens: TokenStream) -> String {
-    to_string(|s| s.print_tts_ext(tokens, false))
+    to_string(|s| s.print_tts(tokens, false))
 }
 
 pub fn stmt_to_string(stmt: &ast::Stmt) -> String {
@@ -629,7 +629,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
             } else {
                 self.print_attribute_path(&attr.path);
                 self.space();
-                self.print_tts(attr.tokens.clone());
+                self.print_tts(attr.tokens.clone(), true);
             }
             self.word("]");
         }
@@ -696,11 +696,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
         }
     }
 
-    fn print_tts(&mut self, tts: tokenstream::TokenStream) {
-        self.print_tts_ext(tts, true)
-    }
-
-    fn print_tts_ext(&mut self, tts: tokenstream::TokenStream, convert_dollar_crate: bool) {
+    fn print_tts(&mut self, tts: tokenstream::TokenStream, convert_dollar_crate: bool) {
         self.ibox(0);
         for (i, tt) in tts.into_trees().enumerate() {
             if i != 0 {
@@ -1247,7 +1243,7 @@ impl<'a> State<'a> {
                     self.print_ident(item.ident);
                     self.cbox(INDENT_UNIT);
                     self.popen();
-                    self.print_tts(mac.node.stream());
+                    self.print_tts(mac.node.stream(), true);
                     self.pclose();
                     self.s.word(";");
                     self.end();
@@ -1258,7 +1254,7 @@ impl<'a> State<'a> {
                 self.print_ident(item.ident);
                 self.cbox(INDENT_UNIT);
                 self.popen();
-                self.print_tts(tts.stream());
+                self.print_tts(tts.stream(), true);
                 self.pclose();
                 self.s.word(";");
                 self.end();
@@ -1659,7 +1655,7 @@ impl<'a> State<'a> {
                 self.bopen();
             }
         }
-        self.print_tts(m.node.stream());
+        self.print_tts(m.node.stream(), true);
         match m.node.delim {
             MacDelimiter::Parenthesis => self.pclose(),
             MacDelimiter::Bracket => self.s.word("]"),

--- a/src/test/ui/macros/auxiliary/dollar-crate-nested-encoding.rs
+++ b/src/test/ui/macros/auxiliary/dollar-crate-nested-encoding.rs
@@ -1,0 +1,10 @@
+pub type S = u8;
+
+macro_rules! generate_exported { () => {
+    #[macro_export]
+    macro_rules! exported {
+        () => ($crate::S)
+    }
+}}
+
+generate_exported!();

--- a/src/test/ui/macros/dollar-crate-nested-encoding.rs
+++ b/src/test/ui/macros/dollar-crate-nested-encoding.rs
@@ -1,0 +1,8 @@
+// check-pass
+// aux-build:dollar-crate-nested-encoding.rs
+
+extern crate dollar_crate_nested_encoding;
+
+type A = dollar_crate_nested_encoding::exported!();
+
+fn main() {}

--- a/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -1,5 +1,5 @@
 PRINT-ATTR INPUT (DISPLAY): struct A(identity!(crate :: S));
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( crate :: S ) ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( $crate :: S ) ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -55,7 +55,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct B(identity!(::dollar_crate_external :: S));
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct B ( identity ! ( ::dollar_crate_external :: S ) ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct B ( identity ! ( $crate :: S ) ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/src/test/ui/proc-macro/dollar-crate.stdout
+++ b/src/test/ui/proc-macro/dollar-crate.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -80,7 +80,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(crate::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( crate :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -120,7 +120,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #2 bytes(LO..HI),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): struct M ( ::dollar_crate_external :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -161,7 +161,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(::dollar_crate_external::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( ::dollar_crate_external :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -202,7 +202,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(::dollar_crate_external::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( ::dollar_crate_external :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/62393 had this accidental mistake.

Fixes https://github.com/rust-lang/rust/issues/62562
r? @Mark-Simulacrum 