### PR TITLE
Add serde to the `cargotest` test suite

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -65,6 +65,13 @@ const TEST_REPOS: &'static [Test] = &[
         lock: None,
         packages: &[],
     },
+    Test {
+        name: "serde",
+        repo: "https://github.com/serde-rs/serde",
+        sha: "ce89adecc12b909e32548b1b929d443d62647029",
+        lock: None,
+        packages: &[],
+    },
 ];
 
 fn main() {


### PR DESCRIPTION
This branch is based before https://github.com/rust-lang/rust/pull/62574, so that https://github.com/rust-lang/rust/issues/62562 can be reproduced. This should succeed when merged into `master`.