### PR TITLE
move mem::uninitialized deprecation back by 1 release, to 1.39

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -62,7 +62,7 @@ Misc
 Compatibility Notes
 -------------------
 - With the stabilisation of `mem::MaybeUninit`, `mem::uninitialized` use is no
-  longer recommended, and will be deprecated in 1.38.0.
+  longer recommended, and will be deprecated in 1.39.0.
 
 [60318]: https://github.com/rust-lang/rust/pull/60318/
 [60364]: https://github.com/rust-lang/rust/pull/60364/

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -472,7 +472,7 @@ pub unsafe fn zeroed<T>() -> T {
 /// [`MaybeUninit<T>`]: union.MaybeUninit.html
 /// [inv]: union.MaybeUninit.html#initialization-invariant
 #[inline]
-#[rustc_deprecated(since = "1.38.0", reason = "use `mem::MaybeUninit` instead")]
+#[rustc_deprecated(since = "1.39.0", reason = "use `mem::MaybeUninit` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub unsafe fn uninitialized<T>() -> T {
     MaybeUninit::uninit().assume_init()


### PR DESCRIPTION
As per discussion at https://github.com/rust-lang/rust/issues/53491#issuecomment-509271182. Three releases also agrees with the precedent from `trim_left/right`. Three releases means that even nightly users (including rustc itself) get a full cycle from when the announcement is made in the stable release to when nightly starts to warn.