### PR TITLE
downgrade indirect_structural_match lint to allow

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -350,7 +350,8 @@ declare_lint! {
 
 declare_lint! {
     pub INDIRECT_STRUCTURAL_MATCH,
-    Warn,
+    // defaulting to allow until rust-lang/rust#62614 is fixed.
+    Allow,
     "pattern with const indirectly referencing non-`#[structural_match]` type"
 }
 
@@ -451,6 +452,7 @@ declare_lint_pass! {
         AMBIGUOUS_ASSOCIATED_ITEMS,
         NESTED_IMPL_TRAIT,
         MUTABLE_BORROW_RESERVATION_CONFLICT,
+        INDIRECT_STRUCTURAL_MATCH,
     ]
 }
 

--- a/src/test/ui/issues/issue-55511.rs
+++ b/src/test/ui/issues/issue-55511.rs
@@ -1,5 +1,5 @@
+#![warn(indirect_structural_match)]
 use std::cell::Cell;
-
 trait Foo<'a> {
     const C: Option<Cell<&'a u32>>;
 }

--- a/src/test/ui/issues/issue-55511.stderr
+++ b/src/test/ui/issues/issue-55511.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `std::cell::Cell` in a pattern, `std::cell::C
 LL |         <() as Foo<'static>>::C => { }
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/issue-55511.rs:1:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 

--- a/src/test/ui/rfc1445/allow-use-behind-cousin-variant.rs
+++ b/src/test/ui/rfc1445/allow-use-behind-cousin-variant.rs
@@ -1,0 +1,59 @@
+// rust-lang/rust#62614: we want to allow matching on constants of types that
+// have non-structural-match variants, *if* the constant itself does not use
+// any such variant.
+
+// NOTE: for now, deliberately leaving the lint `indirect_structural_match` set
+// to its default, so that we will not issue a diangostic even if
+// rust-lang/rust#62614 remains an open issue.
+
+// run-pass
+
+struct Sum(u32, u32);
+
+impl PartialEq for Sum {
+    fn eq(&self, other: &Self) -> bool { self.0 + self.1 == other.0 + other.1 }
+}
+
+impl Eq for Sum { }
+
+#[derive(PartialEq, Eq)]
+enum Eek {
+    TheConst,
+    UnusedByTheConst(Sum)
+}
+
+const THE_CONST: Eek = Eek::TheConst;
+const SUM_THREE: Eek = Eek::UnusedByTheConst(Sum(3,0));
+
+const EEK_ZERO: &[Eek] = &[];
+const EEK_ONE: &[Eek] = &[THE_CONST];
+
+pub fn main() {
+    match Eek::UnusedByTheConst(Sum(1,2)) {
+        ref sum if sum == &SUM_THREE => { println!("Hello 0"); }
+        _ => { println!("Gbye"); }
+    }
+
+    match Eek::TheConst {
+        THE_CONST => { println!("Hello 1"); }
+        _ => { println!("Gbye"); }
+    }
+
+
+    match & &Eek::TheConst {
+        & & THE_CONST => { println!("Hello 2"); }
+        _ => { println!("Gbye"); }
+    }
+
+    match & & &[][..] {
+        & & EEK_ZERO => { println!("Hello 3"); }
+        & & EEK_ONE => { println!("Gbye"); }
+        _ => { println!("Gbye"); }
+    }
+
+    match & & &[Eek::TheConst][..] {
+        & & EEK_ZERO => { println!("Gby"); }
+        & & EEK_ONE => { println!("Hello 4"); }
+        _ => { println!("Gbye"); }
+    }
+}

--- a/src/test/ui/rfc1445/cant-hide-behind-direct-struct-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-direct-struct-param.rs
@@ -4,7 +4,7 @@
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
-
+#![warn(indirect_structural_match)]
 struct NoDerive(i32);
 
 // This impl makes NoDerive irreflexive.

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.rs
@@ -4,7 +4,7 @@
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
-
+#![warn(indirect_structural_match)]
 // run-pass
 
 struct NoDerive(i32);

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-embedded.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_DOUBLY_INDIRECT_INLINE => { panic!("WRAP_DOUBLY_INDIRECT_INLINE matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/cant-hide-behind-doubly-indirect-embedded.rs:7:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.rs
@@ -4,7 +4,7 @@
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
-
+#![warn(indirect_structural_match)]
 // run-pass
 
 struct NoDerive(i32);

--- a/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-doubly-indirect-param.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_DOUBLY_INDIRECT_PARAM => { panic!("WRAP_DOUBLY_INDIRECT_PARAM matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/cant-hide-behind-doubly-indirect-param.rs:7:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.rs
@@ -4,7 +4,7 @@
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
-
+#![warn(indirect_structural_match)]
 // run-pass
 
 struct NoDerive(i32);

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-embedded.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_INDIRECT_INLINE => { panic!("WRAP_INDIRECT_INLINE matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/cant-hide-behind-indirect-struct-embedded.rs:7:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.rs
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.rs
@@ -4,7 +4,7 @@
 // through that we had intended to reject.
 //
 // See discussion on rust-lang/rust#62307 and rust-lang/rust#62339
-
+#![warn(indirect_structural_match)]
 // run-pass
 
 struct NoDerive(i32);

--- a/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
+++ b/src/test/ui/rfc1445/cant-hide-behind-indirect-struct-param.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `NoDerive` in a pattern, `NoDerive` must be a
 LL |         WRAP_INDIRECT_PARAM => { panic!("WRAP_INDIRECT_PARAM matched itself"); }
    |         ^^^^^^^^^^^^^^^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/cant-hide-behind-indirect-struct-param.rs:7:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 

--- a/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.rs
+++ b/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.rs
@@ -10,7 +10,7 @@
 
 // Issue 62307 pointed out a case where the checking for
 // `#[structural_match]` was too shallow.
-
+#![warn(indirect_structural_match)]
 // run-pass
 
 #[derive(Debug)]

--- a/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
+++ b/src/test/ui/rfc1445/issue-62307-match-ref-ref-forbidden-without-eq.stderr
@@ -4,7 +4,11 @@ warning: to use a constant of type `B` in a pattern, `B` must be annotated with 
 LL |         RR_B1 => { println!("CLAIM RR0: {:?} matches {:?}", RR_B1, RR_B0); }
    |         ^^^^^
    |
-   = note: #[warn(indirect_structural_match)] on by default
+note: lint level defined here
+  --> $DIR/issue-62307-match-ref-ref-forbidden-without-eq.rs:13:9
+   |
+LL | #![warn(indirect_structural_match)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #62411 <https://github.com/rust-lang/rust/issues/62411>
 


### PR DESCRIPTION
This is a short-term band-aid for the regression aspect of #62614.

