### PR TITLE
Cleanup borrowck errors

### DIFF
--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -22,7 +22,7 @@ use super::{InitializationRequiringAction, PrefixSet};
 use super::error_reporting::{IncludingDowncast, UseSpans};
 use crate::dataflow::drop_flag_effects;
 use crate::dataflow::indexes::{MovePathIndex, MoveOutIndex};
-use crate::util::borrowck_errors::BorrowckErrors;
+use crate::util::borrowck_errors;
 
 #[derive(Debug)]
 struct MoveSite {
@@ -89,7 +89,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 Some(name) => format!("`{}`", name),
                 None => "value".to_owned(),
             };
-            let mut err = self.infcx.tcx.cannot_act_on_uninitialized_variable(
+            let mut err = self.cannot_act_on_uninitialized_variable(
                 span,
                 desired_action.as_noun(),
                 &self.describe_place_with_options(moved_place, IncludingDowncast(true))
@@ -119,7 +119,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             let msg = ""; //FIXME: add "partially " or "collaterally "
 
-            let mut err = self.infcx.tcx.cannot_act_on_moved_value(
+            let mut err = self.cannot_act_on_moved_value(
                 span,
                 desired_action.as_noun(),
                 msg,
@@ -265,7 +265,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             "report_move_out_while_borrowed: location={:?} place={:?} span={:?} borrow={:?}",
             location, place, span, borrow
         );
-        let tcx = self.infcx.tcx;
         let value_msg = match self.describe_place(place) {
             Some(name) => format!("`{}`", name),
             None => "value".to_owned(),
@@ -281,7 +280,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let move_spans = self.move_spans(place, location);
         let span = move_spans.args_or_use();
 
-        let mut err = tcx.cannot_move_when_borrowed(
+        let mut err = self.cannot_move_when_borrowed(
             span,
             &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
         );
@@ -312,8 +311,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         (place, _span): (&Place<'tcx>, Span),
         borrow: &BorrowData<'tcx>,
     ) -> DiagnosticBuilder<'cx> {
-        let tcx = self.infcx.tcx;
-
         let borrow_spans = self.retrieve_borrow_spans(borrow);
         let borrow_span = borrow_spans.args_or_use();
 
@@ -322,7 +319,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let use_spans = self.move_spans(place, location);
         let span = use_spans.var_or_use();
 
-        let mut err = tcx.cannot_use_when_mutably_borrowed(
+        let mut err = self.cannot_use_when_mutably_borrowed(
             span,
             &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
             borrow_span,
@@ -372,7 +369,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         };
 
         // FIXME: supply non-"" `opt_via` when appropriate
-        let tcx = self.infcx.tcx;
         let first_borrow_desc;
         let mut err = match (
             gen_borrow_kind,
@@ -384,7 +380,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         ) {
             (BorrowKind::Shared, lft, _, BorrowKind::Mut { .. }, _, rgt) => {
                 first_borrow_desc = "mutable ";
-                tcx.cannot_reborrow_already_borrowed(
+                self.cannot_reborrow_already_borrowed(
                     span,
                     &desc_place,
                     &msg_place,
@@ -398,7 +394,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
             (BorrowKind::Mut { .. }, _, lft, BorrowKind::Shared, rgt, _) => {
                 first_borrow_desc = "immutable ";
-                tcx.cannot_reborrow_already_borrowed(
+                self.cannot_reborrow_already_borrowed(
                     span,
                     &desc_place,
                     &msg_place,
@@ -413,7 +409,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Mut { .. }, _, _, BorrowKind::Mut { .. }, _, _) => {
                 first_borrow_desc = "first ";
-                tcx.cannot_mutably_borrow_multiply(
+                self.cannot_mutably_borrow_multiply(
                     span,
                     &desc_place,
                     &msg_place,
@@ -425,7 +421,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Unique, _, _, BorrowKind::Unique, _, _) => {
                 first_borrow_desc = "first ";
-                tcx.cannot_uniquely_borrow_by_two_closures(
+                self.cannot_uniquely_borrow_by_two_closures(
                     span,
                     &desc_place,
                     issued_span,
@@ -435,7 +431,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Mut { .. }, _, _, BorrowKind::Shallow, _, _)
             | (BorrowKind::Unique, _, _, BorrowKind::Shallow, _, _) => {
-                let mut err = tcx.cannot_mutate_in_match_guard(
+                let mut err = self.cannot_mutate_in_match_guard(
                     span,
                     issued_span,
                     &desc_place,
@@ -453,7 +449,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Unique, _, _, _, _, _) => {
                 first_borrow_desc = "first ";
-                tcx.cannot_uniquely_borrow_by_one_closure(
+                self.cannot_uniquely_borrow_by_one_closure(
                     span,
                     container_name,
                     &desc_place,
@@ -467,7 +463,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Shared, lft, _, BorrowKind::Unique, _, _) => {
                 first_borrow_desc = "first ";
-                tcx.cannot_reborrow_already_uniquely_borrowed(
+                self.cannot_reborrow_already_uniquely_borrowed(
                     span,
                     container_name,
                     &desc_place,
@@ -482,7 +478,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             (BorrowKind::Mut { .. }, _, lft, BorrowKind::Unique, _, _) => {
                 first_borrow_desc = "first ";
-                tcx.cannot_reborrow_already_uniquely_borrowed(
+                self.cannot_reborrow_already_uniquely_borrowed(
                     span,
                     container_name,
                     &desc_place,
@@ -821,7 +817,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
         }
 
-        let mut err = self.infcx.tcx.path_does_not_live_long_enough(
+        let mut err = self.path_does_not_live_long_enough(
             borrow_span,
             &format!("`{}`", name),
         );
@@ -912,9 +908,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let borrow_spans = self.retrieve_borrow_spans(borrow);
         let borrow_span = borrow_spans.var_or_use();
 
-        let mut err = self.infcx
-            .tcx
-            .cannot_borrow_across_destructor(borrow_span);
+        let mut err = self.cannot_borrow_across_destructor(borrow_span);
 
         let what_was_dropped = match self.describe_place(place) {
             Some(name) => format!("`{}`", name.as_str()),
@@ -965,9 +959,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             drop_span, borrow_span
         );
 
-        let mut err = self.infcx
-            .tcx
-            .thread_local_value_does_not_live_long_enough(borrow_span);
+        let mut err = self.thread_local_value_does_not_live_long_enough(borrow_span);
 
         err.span_label(
             borrow_span,
@@ -1011,8 +1003,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
         }
 
-        let tcx = self.infcx.tcx;
-        let mut err = tcx.temporary_value_borrowed_for_too_long(proper_span);
+        let mut err = self.temporary_value_borrowed_for_too_long(proper_span);
         err.span_label(
             proper_span,
             "creates a temporary which is freed while still in use",
@@ -1055,8 +1046,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         category: ConstraintCategory,
         opt_place_desc: Option<&String>,
     ) -> Option<DiagnosticBuilder<'cx>> {
-        let tcx = self.infcx.tcx;
-
         let return_kind = match category {
             ConstraintCategory::Return => "return",
             ConstraintCategory::Yield => "yield",
@@ -1119,7 +1108,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
         };
 
-        let mut err = tcx.cannot_return_reference_to_local(
+        let mut err = self.cannot_return_reference_to_local(
             return_span,
             return_kind,
             reference_desc,
@@ -1144,7 +1133,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
     ) -> DiagnosticBuilder<'cx> {
         let tcx = self.infcx.tcx;
 
-        let mut err = tcx.cannot_capture_in_long_lived_closure(
+        let mut err = self.cannot_capture_in_long_lived_closure(
             args_span,
             captured_var,
             var_span,
@@ -1203,7 +1192,11 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             "function"
         };
 
-        let mut err = tcx.borrowed_data_escapes_closure(escape_span, escapes_from);
+        let mut err = borrowck_errors::borrowed_data_escapes_closure(
+            tcx,
+            escape_span,
+            escapes_from,
+        );
 
         err.span_label(
             upvar_span,
@@ -1345,9 +1338,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let loan_spans = self.retrieve_borrow_spans(loan);
         let loan_span = loan_spans.args_or_use();
 
-        let tcx = self.infcx.tcx;
         if loan.kind == BorrowKind::Shallow {
-            let mut err = tcx.cannot_mutate_in_match_guard(
+            let mut err = self.cannot_mutate_in_match_guard(
                 span,
                 loan_span,
                 &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
@@ -1363,7 +1355,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             return;
         }
 
-        let mut err = tcx.cannot_assign_to_borrowed(
+        let mut err = self.cannot_assign_to_borrowed(
             span,
             loan_span,
             &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
@@ -1427,7 +1419,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             Some(decl) => (self.describe_place(err_place), decl.source_info.span),
         };
 
-        let mut err = self.infcx.tcx.cannot_reassign_immutable(
+        let mut err = self.cannot_reassign_immutable(
             span,
             place_description.as_ref().map(AsRef::as_ref).unwrap_or("_"),
             from_arg,

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -22,7 +22,7 @@ use super::{InitializationRequiringAction, PrefixSet};
 use super::error_reporting::{IncludingDowncast, UseSpans};
 use crate::dataflow::drop_flag_effects;
 use crate::dataflow::indexes::{MovePathIndex, MoveOutIndex};
-use crate::util::borrowck_errors::{BorrowckErrors, Origin};
+use crate::util::borrowck_errors::BorrowckErrors;
 
 #[derive(Debug)]
 struct MoveSite {
@@ -94,7 +94,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 desired_action.as_noun(),
                 &self.describe_place_with_options(moved_place, IncludingDowncast(true))
                     .unwrap_or_else(|| "_".to_owned()),
-                Origin::Mir,
             );
             err.span_label(span, format!("use of possibly uninitialized {}", item_msg));
 
@@ -125,7 +124,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 desired_action.as_noun(),
                 msg,
                 self.describe_place_with_options(&moved_place, IncludingDowncast(true)),
-                Origin::Mir,
             );
 
             self.add_moved_or_invoked_closure_note(
@@ -286,7 +284,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = tcx.cannot_move_when_borrowed(
             span,
             &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
-            Origin::Mir,
         );
         err.span_label(borrow_span, format!("borrow of {} occurs here", borrow_msg));
         err.span_label(span, format!("move out of {} occurs here", value_msg));
@@ -331,7 +328,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             borrow_span,
             &self.describe_place(&borrow.borrowed_place)
                 .unwrap_or_else(|| "_".to_owned()),
-            Origin::Mir,
         );
 
         borrow_spans.var_span_label(&mut err, {
@@ -398,7 +394,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     rgt,
                     &msg_borrow,
                     None,
-                    Origin::Mir,
                 )
             }
             (BorrowKind::Mut { .. }, _, lft, BorrowKind::Shared, rgt, _) => {
@@ -413,7 +408,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     rgt,
                     &msg_borrow,
                     None,
-                    Origin::Mir,
                 )
             }
 
@@ -426,7 +420,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     issued_span,
                     &msg_borrow,
                     None,
-                    Origin::Mir,
                 )
             }
 
@@ -437,7 +430,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     &desc_place,
                     issued_span,
                     None,
-                    Origin::Mir,
                 )
             }
 
@@ -448,7 +440,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     issued_span,
                     &desc_place,
                     "mutably borrow",
-                    Origin::Mir,
                 );
                 borrow_spans.var_span_label(
                     &mut err,
@@ -471,7 +462,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     "it",
                     "",
                     None,
-                    Origin::Mir,
                 )
             },
 
@@ -487,7 +477,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     "",
                     None,
                     second_borrow_desc,
-                    Origin::Mir,
                 )
             }
 
@@ -503,7 +492,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     "",
                     None,
                     second_borrow_desc,
-                    Origin::Mir,
                 )
             }
 
@@ -836,7 +824,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let mut err = self.infcx.tcx.path_does_not_live_long_enough(
             borrow_span,
             &format!("`{}`", name),
-            Origin::Mir,
         );
 
         if let Some(annotation) = self.annotate_argument_and_return_for_borrow(borrow) {
@@ -927,7 +914,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         let mut err = self.infcx
             .tcx
-            .cannot_borrow_across_destructor(borrow_span, Origin::Mir);
+            .cannot_borrow_across_destructor(borrow_span);
 
         let what_was_dropped = match self.describe_place(place) {
             Some(name) => format!("`{}`", name.as_str()),
@@ -980,7 +967,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
         let mut err = self.infcx
             .tcx
-            .thread_local_value_does_not_live_long_enough(borrow_span, Origin::Mir);
+            .thread_local_value_does_not_live_long_enough(borrow_span);
 
         err.span_label(
             borrow_span,
@@ -1025,7 +1012,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         }
 
         let tcx = self.infcx.tcx;
-        let mut err = tcx.temporary_value_borrowed_for_too_long(proper_span, Origin::Mir);
+        let mut err = tcx.temporary_value_borrowed_for_too_long(proper_span);
         err.span_label(
             proper_span,
             "creates a temporary which is freed while still in use",
@@ -1137,7 +1124,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             return_kind,
             reference_desc,
             &place_desc,
-            Origin::Mir,
         );
 
         if return_span != borrow_span {
@@ -1162,7 +1148,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             args_span,
             captured_var,
             var_span,
-          Origin::Mir,
         );
 
         let suggestion = match tcx.sess.source_map().span_to_snippet(args_span) {
@@ -1218,7 +1203,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             "function"
         };
 
-        let mut err = tcx.borrowed_data_escapes_closure(escape_span, escapes_from, Origin::Mir);
+        let mut err = tcx.borrowed_data_escapes_closure(escape_span, escapes_from);
 
         err.span_label(
             upvar_span,
@@ -1367,7 +1352,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 loan_span,
                 &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
                 "assign",
-                Origin::Mir,
             );
             loan_spans.var_span_label(
                 &mut err,
@@ -1383,7 +1367,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             span,
             loan_span,
             &self.describe_place(place).unwrap_or_else(|| "_".to_owned()),
-            Origin::Mir,
         );
 
         loan_spans.var_span_label(
@@ -1448,7 +1431,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             span,
             place_description.as_ref().map(AsRef::as_ref).unwrap_or("_"),
             from_arg,
-            Origin::Mir,
         );
         let msg = if from_arg {
             "cannot assign to immutable argument"

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -41,7 +41,6 @@ use crate::dataflow::MoveDataParamEnv;
 use crate::dataflow::{do_dataflow, DebugFormatted};
 use crate::dataflow::EverInitializedPlaces;
 use crate::dataflow::{MaybeInitializedPlaces, MaybeUninitializedPlaces};
-use crate::util::borrowck_errors::BorrowckErrors;
 
 use self::borrow_set::{BorrowData, BorrowSet};
 use self::flows::Flows;
@@ -423,7 +422,7 @@ fn downgrade_if_error(diag: &mut Diagnostic) {
 }
 
 pub struct MirBorrowckCtxt<'cx, 'tcx> {
-    infcx: &'cx InferCtxt<'cx, 'tcx>,
+    pub(crate) infcx: &'cx InferCtxt<'cx, 'tcx>,
     body: &'cx Body<'tcx>,
     mir_def_id: DefId,
     move_data: &'cx MoveData<'tcx>,
@@ -1499,8 +1498,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         debug!("check_for_local_borrow({:?})", borrow);
 
         if borrow_of_local_data(&borrow.borrowed_place) {
-            let err = self.infcx.tcx
-                .cannot_borrow_across_generator_yield(
+            let err = self.cannot_borrow_across_generator_yield(
                     self.retrieve_borrow_spans(borrow).var_or_use(),
                     yield_span,
                 );

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -421,8 +421,8 @@ fn downgrade_if_error(diag: &mut Diagnostic) {
     }
 }
 
-pub struct MirBorrowckCtxt<'cx, 'tcx> {
-    pub(crate) infcx: &'cx InferCtxt<'cx, 'tcx>,
+crate struct MirBorrowckCtxt<'cx, 'tcx> {
+    crate infcx: &'cx InferCtxt<'cx, 'tcx>,
     body: &'cx Body<'tcx>,
     mir_def_id: DefId,
     move_data: &'cx MoveData<'tcx>,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -41,7 +41,7 @@ use crate::dataflow::MoveDataParamEnv;
 use crate::dataflow::{do_dataflow, DebugFormatted};
 use crate::dataflow::EverInitializedPlaces;
 use crate::dataflow::{MaybeInitializedPlaces, MaybeUninitializedPlaces};
-use crate::util::borrowck_errors::{BorrowckErrors, Origin};
+use crate::util::borrowck_errors::BorrowckErrors;
 
 use self::borrow_set::{BorrowData, BorrowSet};
 use self::flows::Flows;
@@ -1503,7 +1503,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 .cannot_borrow_across_generator_yield(
                     self.retrieve_borrow_spans(borrow).var_or_use(),
                     yield_span,
-                    Origin::Mir,
                 );
 
             err.buffer(&mut self.errors_buffer);

--- a/src/librustc_mir/borrow_check/move_errors.rs
+++ b/src/librustc_mir/borrow_check/move_errors.rs
@@ -12,7 +12,6 @@ use crate::dataflow::move_paths::{
     IllegalMoveOrigin, IllegalMoveOriginKind,
     LookupResult, MoveError, MovePathIndex,
 };
-use crate::util::borrowck_errors::BorrowckErrors;
 
 // Often when desugaring a pattern match we may have many individual moves in
 // MIR that are all part of one operation from the user's point-of-view. For
@@ -254,11 +253,10 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                         )
                     }
                     IllegalMoveOriginKind::InteriorOfTypeWithDestructor { container_ty: ty } => {
-                        self.infcx.tcx
-                            .cannot_move_out_of_interior_of_drop(span, ty)
+                        self.cannot_move_out_of_interior_of_drop(span, ty)
                     }
                     IllegalMoveOriginKind::InteriorOfSliceOrArray { ty, is_index } =>
-                        self.infcx.tcx.cannot_move_out_of_interior_noncopy(
+                        self.cannot_move_out_of_interior_noncopy(
                             span, ty, Some(*is_index),
                         ),
                 },
@@ -293,7 +291,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             )
         };
 
-        self.infcx.tcx.cannot_move_out_of(span, &description)
+        self.cannot_move_out_of(span, &description)
     }
 
     fn report_cannot_move_from_borrowed_content(
@@ -317,7 +315,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         if let Place::Base(PlaceBase::Local(local)) = *deref_base {
             let decl = &self.body.local_decls[local];
             if decl.is_ref_for_guard() {
-                let mut err = self.infcx.tcx.cannot_move_out_of(
+                let mut err = self.cannot_move_out_of(
                     span,
                     &format!("`{}` in pattern guard", decl.name.unwrap()),
                 );
@@ -331,7 +329,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
         debug!("report: ty={:?}", ty);
         let mut err = match ty.sty {
             ty::Array(..) | ty::Slice(..) =>
-                self.infcx.tcx.cannot_move_out_of_interior_noncopy(span, ty, None),
+                self.cannot_move_out_of_interior_noncopy(span, ty, None),
             ty::Closure(def_id, closure_substs)
                 if def_id == self.mir_def_id && upvar_field.is_some()
             => {
@@ -373,7 +371,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     closure_kind_ty, closure_kind, place_description,
                 );
 
-                let mut diag = self.infcx.tcx.cannot_move_out_of(span, &place_description);
+                let mut diag = self.cannot_move_out_of(span, &place_description);
 
                 diag.span_label(upvar_span, "captured outer variable");
 
@@ -383,13 +381,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let source = self.borrowed_content_source(deref_base);
                 match (self.describe_place(move_place), source.describe_for_named_place()) {
                     (Some(place_desc), Some(source_desc)) => {
-                        self.infcx.tcx.cannot_move_out_of(
+                        self.cannot_move_out_of(
                             span,
                             &format!("`{}` which is behind a {}", place_desc, source_desc),
                         )
                     }
                     (_, _) => {
-                        self.infcx.tcx.cannot_move_out_of(
+                        self.cannot_move_out_of(
                             span,
                             &source.describe_for_unnamed_place(),
                         )

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -9,7 +9,6 @@ use syntax_pos::symbol::kw;
 
 use crate::borrow_check::MirBorrowckCtxt;
 use crate::borrow_check::error_reporting::BorrowedContentSource;
-use crate::util::borrowck_errors::BorrowckErrors;
 use crate::util::collect_writes::FindAssignments;
 use crate::util::suggest_ref_mut;
 use rustc_errors::Applicability;
@@ -161,13 +160,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
         let span = match error_access {
             AccessKind::Move => {
-                err = self.infcx.tcx.cannot_move_out_of(span, &(item_msg + &reason));
+                err = self.cannot_move_out_of(span, &(item_msg + &reason));
                 err.span_label(span, "cannot move");
                 err.buffer(&mut self.errors_buffer);
                 return;
             }
             AccessKind::Mutate => {
-                err = self.infcx.tcx.cannot_assign(span, &(item_msg + &reason));
+                err = self.cannot_assign(span, &(item_msg + &reason));
                 act = "assign";
                 acted_on = "written";
                 span
@@ -178,7 +177,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
                 let borrow_spans = self.borrow_spans(span, location);
                 let borrow_span = borrow_spans.args_or_use();
-                err = self.infcx.tcx.cannot_borrow_path_as_mutable_because(
+                err = self.cannot_borrow_path_as_mutable_because(
                     borrow_span,
                     &item_msg,
                     &reason,

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -9,7 +9,7 @@ use syntax_pos::symbol::kw;
 
 use crate::borrow_check::MirBorrowckCtxt;
 use crate::borrow_check::error_reporting::BorrowedContentSource;
-use crate::util::borrowck_errors::{BorrowckErrors, Origin};
+use crate::util::borrowck_errors::BorrowckErrors;
 use crate::util::collect_writes::FindAssignments;
 use crate::util::suggest_ref_mut;
 use rustc_errors::Applicability;
@@ -161,15 +161,13 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
         let span = match error_access {
             AccessKind::Move => {
-                err = self.infcx.tcx
-                    .cannot_move_out_of(span, &(item_msg + &reason), Origin::Mir);
+                err = self.infcx.tcx.cannot_move_out_of(span, &(item_msg + &reason));
                 err.span_label(span, "cannot move");
                 err.buffer(&mut self.errors_buffer);
                 return;
             }
             AccessKind::Mutate => {
-                err = self.infcx.tcx
-                    .cannot_assign(span, &(item_msg + &reason), Origin::Mir);
+                err = self.infcx.tcx.cannot_assign(span, &(item_msg + &reason));
                 act = "assign";
                 acted_on = "written";
                 span
@@ -184,7 +182,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     borrow_span,
                     &item_msg,
                     &reason,
-                    Origin::Mir,
                 );
                 borrow_spans.var_span_label(
                     &mut err,

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -4,7 +4,7 @@ use crate::borrow_check::nll::region_infer::RegionInferenceContext;
 use crate::borrow_check::nll::type_check::Locations;
 use crate::borrow_check::nll::universal_regions::DefiningTy;
 use crate::borrow_check::nll::ConstraintDescription;
-use crate::util::borrowck_errors::{BorrowckErrors, Origin};
+use crate::util::borrowck_errors::BorrowckErrors;
 use crate::borrow_check::Upvar;
 use rustc::hir::def_id::DefId;
 use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
@@ -489,7 +489,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let mut diag = infcx
             .tcx
-            .borrowed_data_escapes_closure(span, escapes_from, Origin::Mir);
+            .borrowed_data_escapes_closure(span, escapes_from);
 
         if let Some((Some(outlived_fr_name), outlived_fr_span)) = outlived_fr_name_and_span {
             diag.span_label(

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -4,8 +4,8 @@ use crate::borrow_check::nll::region_infer::RegionInferenceContext;
 use crate::borrow_check::nll::type_check::Locations;
 use crate::borrow_check::nll::universal_regions::DefiningTy;
 use crate::borrow_check::nll::ConstraintDescription;
-use crate::util::borrowck_errors::BorrowckErrors;
 use crate::borrow_check::Upvar;
+use crate::util::borrowck_errors;
 use rustc::hir::def_id::DefId;
 use rustc::infer::error_reporting::nice_region_error::NiceRegionError;
 use rustc::infer::InferCtxt;
@@ -487,9 +487,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             );
         }
 
-        let mut diag = infcx
-            .tcx
-            .borrowed_data_escapes_closure(span, escapes_from);
+        let mut diag = borrowck_errors::borrowed_data_escapes_closure(
+            infcx.tcx,
+            span,
+            escapes_from,
+        );
 
         if let Some((Some(outlived_fr_name), outlived_fr_span)) = outlived_fr_name_and_span {
             diag.span_label(

--- a/src/librustc_mir/error_codes.rs
+++ b/src/librustc_mir/error_codes.rs
@@ -2462,12 +2462,12 @@ register_diagnostics! {
 //  E0298, // cannot compare constants
 //  E0299, // mismatched types between arms
 //  E0471, // constant evaluation error (in pattern)
-//    E0385, // {} in an aliasable location
+//  E0385, // {} in an aliasable location
     E0493, // destructors cannot be evaluated at compile-time
-    E0521,  // borrowed data escapes outside of closure
+    E0521, // borrowed data escapes outside of closure
     E0524, // two closures require unique access to `..` at the same time
     E0526, // shuffle indices are not constant
     E0594, // cannot assign to {}
-    E0598, // lifetime of {} is too short to guarantee its contents can be...
+//  E0598, // lifetime of {} is too short to guarantee its contents can be...
     E0625, // thread-local statics cannot be accessed at compile-time
 }

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -2,18 +2,9 @@ use rustc::ty::{self, Ty, TyCtxt};
 use rustc_errors::{DiagnosticBuilder, DiagnosticId};
 use syntax_pos::{MultiSpan, Span};
 
-pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
-    fn struct_span_err_with_code<S: Into<MultiSpan>>(
-        self,
-        sp: S,
-        msg: &str,
-        code: DiagnosticId,
-    ) -> DiagnosticBuilder<'cx>;
-
-    fn struct_span_err<S: Into<MultiSpan>>(self, sp: S, msg: &str) -> DiagnosticBuilder<'cx>;
-
-    fn cannot_move_when_borrowed(
-        self,
+impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
+    pub(crate) fn cannot_move_when_borrowed(
+        &self,
         span: Span,
         desc: &str,
     ) -> DiagnosticBuilder<'cx> {
@@ -26,8 +17,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_use_when_mutably_borrowed(
-        self,
+    pub(crate) fn cannot_use_when_mutably_borrowed(
+        &self,
         span: Span,
         desc: &str,
         borrow_span: Span,
@@ -49,8 +40,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_act_on_uninitialized_variable(
-        self,
+    pub(crate) fn cannot_act_on_uninitialized_variable(
+        &self,
         span: Span,
         verb: &str,
         desc: &str,
@@ -65,8 +56,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_mutably_borrow_multiply(
-        self,
+    pub(crate) fn cannot_mutably_borrow_multiply(
+        &self,
         new_loan_span: Span,
         desc: &str,
         opt_via: &str,
@@ -114,8 +105,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_uniquely_borrow_by_two_closures(
-        self,
+    pub(crate) fn cannot_uniquely_borrow_by_two_closures(
+        &self,
         new_loan_span: Span,
         desc: &str,
         old_loan_span: Span,
@@ -143,8 +134,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_uniquely_borrow_by_one_closure(
-        self,
+    pub(crate) fn cannot_uniquely_borrow_by_one_closure(
+        &self,
         new_loan_span: Span,
         container_name: &str,
         desc_new: &str,
@@ -174,8 +165,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_reborrow_already_uniquely_borrowed(
-        self,
+    pub(crate) fn cannot_reborrow_already_uniquely_borrowed(
+        &self,
         new_loan_span: Span,
         container_name: &str,
         desc_new: &str,
@@ -210,8 +201,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_reborrow_already_borrowed(
-        self,
+    pub(crate) fn cannot_reborrow_already_borrowed(
+        &self,
         span: Span,
         desc_new: &str,
         msg_new: &str,
@@ -263,8 +254,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_assign_to_borrowed(
-        self,
+    pub(crate) fn cannot_assign_to_borrowed(
+        &self,
         span: Span,
         borrow_span: Span,
         desc: &str,
@@ -285,8 +276,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_reassign_immutable(
-        self,
+    pub(crate) fn cannot_reassign_immutable(
+        &self,
         span: Span,
         desc: &str,
         is_arg: bool,
@@ -306,12 +297,12 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_assign(self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
+    pub(crate) fn cannot_assign(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
     }
 
-    fn cannot_move_out_of(
-        self,
+    pub(crate) fn cannot_move_out_of(
+        &self,
         move_from_span: Span,
         move_from_desc: &str,
     ) -> DiagnosticBuilder<'cx> {
@@ -327,8 +318,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
     /// Signal an error due to an attempt to move out of the interior
     /// of an array or slice. `is_index` is None when error origin
     /// didn't capture whether there was an indexing operation or not.
-    fn cannot_move_out_of_interior_noncopy(
-        self,
+    pub(crate) fn cannot_move_out_of_interior_noncopy(
+        &self,
         move_from_span: Span,
         ty: Ty<'_>,
         is_index: Option<bool>,
@@ -350,8 +341,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_move_out_of_interior_of_drop(
-        self,
+    pub(crate) fn cannot_move_out_of_interior_of_drop(
+        &self,
         move_from_span: Span,
         container_ty: Ty<'_>,
     ) -> DiagnosticBuilder<'cx> {
@@ -366,8 +357,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_act_on_moved_value(
-        self,
+    pub(crate) fn cannot_act_on_moved_value(
+        &self,
         use_span: Span,
         verb: &str,
         optional_adverb_for_moved: &str,
@@ -388,8 +379,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_borrow_path_as_mutable_because(
-        self,
+    pub(crate) fn cannot_borrow_path_as_mutable_because(
+        &self,
         span: Span,
         path: &str,
         reason: &str,
@@ -404,8 +395,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_mutate_in_match_guard(
-        self,
+    pub(crate) fn cannot_mutate_in_match_guard(
+        &self,
         mutate_span: Span,
         match_span: Span,
         match_place: &str,
@@ -424,8 +415,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_borrow_across_generator_yield(
-        self,
+    pub(crate) fn cannot_borrow_across_generator_yield(
+        &self,
         span: Span,
         yield_span: Span,
     ) -> DiagnosticBuilder<'cx> {
@@ -439,8 +430,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_borrow_across_destructor(
-        self,
+    pub(crate) fn cannot_borrow_across_destructor(
+        &self,
         borrow_span: Span,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
@@ -451,8 +442,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn path_does_not_live_long_enough(
-        self,
+    pub(crate) fn path_does_not_live_long_enough(
+        &self,
         span: Span,
         path: &str,
     ) -> DiagnosticBuilder<'cx> {
@@ -465,8 +456,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_return_reference_to_local(
-        self,
+    pub(crate) fn cannot_return_reference_to_local(
+        &self,
         span: Span,
         return_kind: &str,
         reference_desc: &str,
@@ -490,8 +481,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_capture_in_long_lived_closure(
-        self,
+    pub(crate) fn cannot_capture_in_long_lived_closure(
+        &self,
         closure_span: Span,
         borrowed_path: &str,
         capture_span: Span,
@@ -513,22 +504,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn borrowed_data_escapes_closure(
-        self,
-        escape_span: Span,
-        escapes_from: &str,
-    ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(
-            self,
-            escape_span,
-            E0521,
-            "borrowed data escapes outside of {}",
-            escapes_from,
-        )
-    }
-
-    fn thread_local_value_does_not_live_long_enough(
-        self,
+    pub(crate) fn thread_local_value_does_not_live_long_enough(
+        &self,
         span: Span,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
@@ -539,8 +516,8 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn temporary_value_borrowed_for_too_long(
-        self,
+    pub(crate) fn temporary_value_borrowed_for_too_long(
+        &self,
         span: Span,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
@@ -550,19 +527,27 @@ pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
             "temporary value dropped while borrowed",
         )
     }
-}
 
-impl BorrowckErrors<'tcx> for TyCtxt<'tcx> {
     fn struct_span_err_with_code<S: Into<MultiSpan>>(
-        self,
+        &self,
         sp: S,
         msg: &str,
         code: DiagnosticId,
     ) -> DiagnosticBuilder<'tcx> {
-        self.sess.struct_span_err_with_code(sp, msg, code)
+        self.infcx.tcx.sess.struct_span_err_with_code(sp, msg, code)
     }
+}
 
-    fn struct_span_err<S: Into<MultiSpan>>(self, sp: S, msg: &str) -> DiagnosticBuilder<'tcx> {
-        self.sess.struct_span_err(sp, msg)
-    }
+pub(crate) fn borrowed_data_escapes_closure<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    escape_span: Span,
+    escapes_from: &str,
+) -> DiagnosticBuilder<'tcx> {
+    struct_span_err!(
+        tcx.sess,
+        escape_span,
+        E0521,
+        "borrowed data escapes outside of {}",
+        escapes_from,
+    )
 }

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -3,7 +3,7 @@ use rustc_errors::{DiagnosticBuilder, DiagnosticId};
 use syntax_pos::{MultiSpan, Span};
 
 impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
-    pub(crate) fn cannot_move_when_borrowed(
+    crate fn cannot_move_when_borrowed(
         &self,
         span: Span,
         desc: &str,
@@ -17,7 +17,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_use_when_mutably_borrowed(
+    crate fn cannot_use_when_mutably_borrowed(
         &self,
         span: Span,
         desc: &str,
@@ -40,7 +40,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_act_on_uninitialized_variable(
+    crate fn cannot_act_on_uninitialized_variable(
         &self,
         span: Span,
         verb: &str,
@@ -56,7 +56,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_mutably_borrow_multiply(
+    crate fn cannot_mutably_borrow_multiply(
         &self,
         new_loan_span: Span,
         desc: &str,
@@ -105,7 +105,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_uniquely_borrow_by_two_closures(
+    crate fn cannot_uniquely_borrow_by_two_closures(
         &self,
         new_loan_span: Span,
         desc: &str,
@@ -134,7 +134,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_uniquely_borrow_by_one_closure(
+    crate fn cannot_uniquely_borrow_by_one_closure(
         &self,
         new_loan_span: Span,
         container_name: &str,
@@ -165,7 +165,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_reborrow_already_uniquely_borrowed(
+    crate fn cannot_reborrow_already_uniquely_borrowed(
         &self,
         new_loan_span: Span,
         container_name: &str,
@@ -201,7 +201,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_reborrow_already_borrowed(
+    crate fn cannot_reborrow_already_borrowed(
         &self,
         span: Span,
         desc_new: &str,
@@ -254,7 +254,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_assign_to_borrowed(
+    crate fn cannot_assign_to_borrowed(
         &self,
         span: Span,
         borrow_span: Span,
@@ -276,7 +276,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_reassign_immutable(
+    crate fn cannot_reassign_immutable(
         &self,
         span: Span,
         desc: &str,
@@ -297,11 +297,11 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_assign(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
+    crate fn cannot_assign(&self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
     }
 
-    pub(crate) fn cannot_move_out_of(
+    crate fn cannot_move_out_of(
         &self,
         move_from_span: Span,
         move_from_desc: &str,
@@ -318,7 +318,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     /// Signal an error due to an attempt to move out of the interior
     /// of an array or slice. `is_index` is None when error origin
     /// didn't capture whether there was an indexing operation or not.
-    pub(crate) fn cannot_move_out_of_interior_noncopy(
+    crate fn cannot_move_out_of_interior_noncopy(
         &self,
         move_from_span: Span,
         ty: Ty<'_>,
@@ -341,7 +341,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_move_out_of_interior_of_drop(
+    crate fn cannot_move_out_of_interior_of_drop(
         &self,
         move_from_span: Span,
         container_ty: Ty<'_>,
@@ -357,7 +357,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_act_on_moved_value(
+    crate fn cannot_act_on_moved_value(
         &self,
         use_span: Span,
         verb: &str,
@@ -379,7 +379,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_borrow_path_as_mutable_because(
+    crate fn cannot_borrow_path_as_mutable_because(
         &self,
         span: Span,
         path: &str,
@@ -395,7 +395,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_mutate_in_match_guard(
+    crate fn cannot_mutate_in_match_guard(
         &self,
         mutate_span: Span,
         match_span: Span,
@@ -415,7 +415,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_borrow_across_generator_yield(
+    crate fn cannot_borrow_across_generator_yield(
         &self,
         span: Span,
         yield_span: Span,
@@ -430,7 +430,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_borrow_across_destructor(
+    crate fn cannot_borrow_across_destructor(
         &self,
         borrow_span: Span,
     ) -> DiagnosticBuilder<'cx> {
@@ -442,7 +442,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn path_does_not_live_long_enough(
+    crate fn path_does_not_live_long_enough(
         &self,
         span: Span,
         path: &str,
@@ -456,7 +456,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn cannot_return_reference_to_local(
+    crate fn cannot_return_reference_to_local(
         &self,
         span: Span,
         return_kind: &str,
@@ -481,7 +481,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn cannot_capture_in_long_lived_closure(
+    crate fn cannot_capture_in_long_lived_closure(
         &self,
         closure_span: Span,
         borrowed_path: &str,
@@ -504,7 +504,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         err
     }
 
-    pub(crate) fn thread_local_value_does_not_live_long_enough(
+    crate fn thread_local_value_does_not_live_long_enough(
         &self,
         span: Span,
     ) -> DiagnosticBuilder<'cx> {
@@ -516,7 +516,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
         )
     }
 
-    pub(crate) fn temporary_value_borrowed_for_too_long(
+    crate fn temporary_value_borrowed_for_too_long(
         &self,
         span: Span,
     ) -> DiagnosticBuilder<'cx> {
@@ -538,7 +538,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
     }
 }
 
-pub(crate) fn borrowed_data_escapes_closure<'tcx>(
+crate fn borrowed_data_escapes_closure<'tcx>(
     tcx: TyCtxt<'tcx>,
     escape_span: Span,
     escapes_from: &str,

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -2,13 +2,7 @@ use rustc::ty::{self, Ty, TyCtxt};
 use rustc_errors::{DiagnosticBuilder, DiagnosticId};
 use syntax_pos::{MultiSpan, Span};
 
-// FIXME(chrisvittal) remove Origin entirely
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub enum Origin {
-    Mir,
-}
-
-pub trait BorrowckErrors<'cx>: Sized + Copy {
+pub(crate) trait BorrowckErrors<'cx>: Sized + Copy {
     fn struct_span_err_with_code<S: Into<MultiSpan>>(
         self,
         sp: S,
@@ -22,7 +16,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         span: Span,
         desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -39,7 +32,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         desc: &str,
         borrow_span: Span,
         borrow_desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -62,7 +54,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         span: Span,
         verb: &str,
         desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -82,7 +73,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         old_loan_span: Span,
         old_opt_via: &str,
         old_load_end_span: Option<Span>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let via = |msg: &str|
             if msg.is_empty() { msg.to_string() } else { format!(" (via `{}`)", msg) };
@@ -130,7 +120,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         desc: &str,
         old_loan_span: Span,
         old_load_end_span: Option<Span>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -164,7 +153,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         noun_old: &str,
         old_opt_via: &str,
         previous_end_span: Option<Span>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -197,7 +185,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         old_opt_via: &str,
         previous_end_span: Option<Span>,
         second_borrow_desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -234,7 +221,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         kind_old: &str,
         msg_old: &str,
         old_load_end_span: Option<Span>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let via = |msg: &str|
             if msg.is_empty() { msg.to_string() } else { format!(" (via `{}`)", msg) };
@@ -282,7 +268,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         span: Span,
         borrow_span: Span,
         desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -305,7 +290,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         span: Span,
         desc: &str,
         is_arg: bool,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let msg = if is_arg {
             "to immutable argument"
@@ -322,7 +306,7 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_assign(self, span: Span, desc: &str, _: Origin) -> DiagnosticBuilder<'cx> {
+    fn cannot_assign(self, span: Span, desc: &str) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
     }
 
@@ -330,7 +314,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         move_from_span: Span,
         move_from_desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -349,7 +332,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         move_from_span: Span,
         ty: Ty<'_>,
         is_index: Option<bool>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let type_name = match (&ty.sty, is_index) {
             (&ty::Array(_, _), Some(true)) | (&ty::Array(_, _), None) => "array",
@@ -372,7 +354,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         move_from_span: Span,
         container_ty: Ty<'_>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -391,7 +372,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         verb: &str,
         optional_adverb_for_moved: &str,
         moved_path: Option<String>,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let moved_path = moved_path
             .map(|mp| format!(": `{}`", mp))
@@ -413,7 +393,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         span: Span,
         path: &str,
         reason: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -431,7 +410,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         match_span: Span,
         match_place: &str,
         action: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -450,7 +428,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         span: Span,
         yield_span: Span,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -465,7 +442,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     fn cannot_borrow_across_destructor(
         self,
         borrow_span: Span,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -479,7 +455,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         span: Span,
         path: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -496,7 +471,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         return_kind: &str,
         reference_desc: &str,
         path_desc: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -521,7 +495,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         closure_span: Span,
         borrowed_path: &str,
         capture_span: Span,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         let mut err = struct_span_err!(
             self,
@@ -544,7 +517,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         self,
         escape_span: Span,
         escapes_from: &str,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -558,7 +530,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     fn thread_local_value_does_not_live_long_enough(
         self,
         span: Span,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,
@@ -571,7 +542,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
     fn temporary_value_borrowed_for_too_long(
         self,
         span: Span,
-        _: Origin,
     ) -> DiagnosticBuilder<'cx> {
         struct_span_err!(
             self,

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -300,16 +300,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         err
     }
 
-    fn cannot_move_into_closure(self, span: Span, desc: &str, _: Origin) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(
-            self,
-            span,
-            E0504,
-            "cannot move `{}` into closure because it is borrowed",
-            desc,
-        )
-    }
-
     fn cannot_reassign_immutable(
         self,
         span: Span,
@@ -334,10 +324,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
 
     fn cannot_assign(self, span: Span, desc: &str, _: Origin) -> DiagnosticBuilder<'cx> {
         struct_span_err!(self, span, E0594, "cannot assign to {}", desc)
-    }
-
-    fn cannot_assign_static(self, span: Span, desc: &str, o: Origin) -> DiagnosticBuilder<'cx> {
-        self.cannot_assign(span, &format!("immutable static item `{}`", desc), o)
     }
 
     fn cannot_move_out_of(
@@ -422,36 +408,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
         )
     }
 
-    fn cannot_partially_reinit_an_uninit_struct(
-        self,
-        span: Span,
-        uninit_path: &str,
-        _: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(
-            self,
-            span,
-            E0383,
-            "partial reinitialization of uninitialized structure `{}`",
-            uninit_path,
-        )
-    }
-
-    fn closure_cannot_assign_to_borrowed(
-        self,
-        span: Span,
-        descr: &str,
-        _: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(
-            self,
-            span,
-            E0595,
-            "closure cannot assign to {}",
-            descr,
-        )
-    }
-
     fn cannot_borrow_path_as_mutable_because(
         self,
         span: Span,
@@ -467,15 +423,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
             path,
             reason,
         )
-    }
-
-    fn cannot_borrow_path_as_mutable(
-        self,
-        span: Span,
-        path: &str,
-        o: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        self.cannot_borrow_path_as_mutable_because(span, path, "", o)
     }
 
     fn cannot_mutate_in_match_guard(
@@ -566,58 +513,6 @@ pub trait BorrowckErrors<'cx>: Sized + Copy {
             format!("{}s a {} data owned by the current function", return_kind, reference_desc),
         );
 
-        err
-    }
-
-    fn lifetime_too_short_for_reborrow(
-        self,
-        span: Span,
-        path: &str,
-        _: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        struct_span_err!(
-            self,
-            span,
-            E0598,
-            "lifetime of {} is too short to guarantee \
-             its contents can be safely reborrowed",
-            path,
-        )
-    }
-
-    fn cannot_act_on_capture_in_sharable_fn(
-        self,
-        span: Span,
-        bad_thing: &str,
-        help: (Span, &str),
-        _: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        let (help_span, help_msg) = help;
-        let mut err = struct_span_err!(
-            self,
-            span,
-            E0387,
-            "{} in a captured outer variable in an `Fn` closure",
-            bad_thing,
-        );
-        err.span_help(help_span, help_msg);
-        err
-    }
-
-    fn cannot_assign_into_immutable_reference(
-        self,
-        span: Span,
-        bad_thing: &str,
-        _: Origin,
-    ) -> DiagnosticBuilder<'cx> {
-        let mut err = struct_span_err!(
-            self,
-            span,
-            E0389,
-            "{} in a `&` reference",
-            bad_thing,
-        );
-        err.span_label(span, "assignment into an immutable reference");
         err
     }
 

--- a/src/librustc_mir/util/mod.rs
+++ b/src/librustc_mir/util/mod.rs
@@ -1,7 +1,3 @@
-use core::unicode::property::Pattern_White_Space;
-use rustc::ty::TyCtxt;
-use syntax_pos::Span;
-
 pub mod aggregate;
 pub mod borrowck_errors;
 pub mod elaborate_drops;
@@ -19,16 +15,3 @@ pub use self::alignment::is_disaligned;
 pub use self::pretty::{dump_enabled, dump_mir, write_mir_pretty, PassWhere};
 pub use self::graphviz::{graphviz_safe_def_name, write_mir_graphviz};
 pub use self::graphviz::write_node_label as write_graphviz_node_label;
-
-/// If possible, suggest replacing `ref` with `ref mut`.
-pub fn suggest_ref_mut(tcx: TyCtxt<'_>, binding_span: Span) -> Option<(String)> {
-    let hi_src = tcx.sess.source_map().span_to_snippet(binding_span).unwrap();
-    if hi_src.starts_with("ref")
-        && hi_src["ref".len()..].starts_with(Pattern_White_Space)
-    {
-        let replacement = format!("ref mut{}", &hi_src["ref".len()..]);
-        Some(replacement)
-    } else {
-        None
-    }
-}


### PR DESCRIPTION
This removes some of the unnecessary code that allowed sharing error reporting between two borrow checkers.

closes #59193