### PR TITLE
Do not emit type errors after parse error in last statement of block

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -4678,6 +4678,9 @@ impl<'a> Parser<'a> {
                     {
                         e.emit();
                         self.recover_stmt();
+                        // Don't complain about type errors in body tail after parse error (#57383).
+                        let sp = expr.span.to(self.prev_span);
+                        stmt.node = StmtKind::Expr(DummyResult::raw_expr(sp, true));
                     }
                 }
             }
@@ -4695,8 +4698,7 @@ impl<'a> Parser<'a> {
         if self.eat(&token::Semi) {
             stmt = stmt.add_trailing_semicolon();
         }
-
-        stmt.span = stmt.span.with_hi(self.prev_span.hi());
+        stmt.span = stmt.span.to(self.prev_span);
         Ok(Some(stmt))
     }
 

--- a/src/test/ui/obsolete-in-place/bad.rs
+++ b/src/test/ui/obsolete-in-place/bad.rs
@@ -3,7 +3,6 @@
 fn foo() {
     let (x, y) = (0, 0);
     x <- y; //~ ERROR expected one of
-    //~^ ERROR mismatched types
 }
 
 fn main() {

--- a/src/test/ui/obsolete-in-place/bad.stderr
+++ b/src/test/ui/obsolete-in-place/bad.stderr
@@ -5,23 +5,10 @@ LL |     x <- y;
    |       ^^ expected one of 8 possible tokens here
 
 error: expected expression, found keyword `in`
-  --> $DIR/bad.rs:11:5
+  --> $DIR/bad.rs:10:5
    |
 LL |     in(foo) { bar };
    |     ^^ expected expression
 
-error[E0308]: mismatched types
-  --> $DIR/bad.rs:5:5
-   |
-LL | fn foo() {
-   |          - possibly return type missing here?
-LL |     let (x, y) = (0, 0);
-LL |     x <- y;
-   |     ^ expected (), found integer
-   |
-   = note: expected type `()`
-              found type `{integer}`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/issue-19096.rs
+++ b/src/test/ui/parser/issue-19096.rs
@@ -1,5 +1,10 @@
-fn main() {
+fn main() { // we don't complain about the return type being `{integer}`
     let t = (42, 42);
     t.0::<isize>; //~ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `::`
-                  //~| ERROR mismatched types
+}
+
+fn foo() -> usize { // we don't complain about the return type being unit
+    let t = (42, 42);
+    t.0::<isize>; //~ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `::`
+    42;
 }

--- a/src/test/ui/parser/issue-19096.stderr
+++ b/src/test/ui/parser/issue-19096.stderr
@@ -4,18 +4,11 @@ error: expected one of `.`, `;`, `?`, `}`, or an operator, found `::`
 LL |     t.0::<isize>;
    |        ^^ expected one of `.`, `;`, `?`, `}`, or an operator here
 
-error[E0308]: mismatched types
-  --> $DIR/issue-19096.rs:3:5
+error: expected one of `.`, `;`, `?`, `}`, or an operator, found `::`
+  --> $DIR/issue-19096.rs:8:8
    |
-LL | fn main() {
-   |           - expected `()` because of default return type
-LL |     let t = (42, 42);
 LL |     t.0::<isize>;
-   |     ^^^ expected (), found integer
-   |
-   = note: expected type `()`
-              found type `{integer}`
+   |        ^^ expected one of `.`, `;`, `?`, `}`, or an operator here
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/raw/raw-literal-keywords.rs
+++ b/src/test/ui/parser/raw/raw-literal-keywords.rs
@@ -1,16 +1,25 @@
 fn test_if() {
     r#if true { } //~ ERROR found `true`
-                  //~| ERROR cannot find value `if` in this scope
 }
 
 fn test_struct() {
     r#struct Test; //~ ERROR found `Test`
-                   //~| ERROR cannot find value `struct` in this scope
 }
 
 fn test_union() {
     r#union Test; //~ ERROR found `Test`
-                  //~| ERROR cannot find value `union` in this scope
+}
+
+fn test_if_2() {
+    let _ = r#if; //~ ERROR cannot find value `if` in this scope
+}
+
+fn test_struct_2() {
+    let _ = r#struct; //~ ERROR cannot find value `struct` in this scope
+}
+
+fn test_union_2() {
+    let _ = r#union; //~ ERROR cannot find value `union` in this scope
 }
 
 fn main() {}

--- a/src/test/ui/parser/raw/raw-literal-keywords.stderr
+++ b/src/test/ui/parser/raw/raw-literal-keywords.stderr
@@ -5,34 +5,34 @@ LL |     r#if true { }
    |          ^^^^ expected one of 8 possible tokens here
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `Test`
-  --> $DIR/raw-literal-keywords.rs:7:14
+  --> $DIR/raw-literal-keywords.rs:6:14
    |
 LL |     r#struct Test;
    |              ^^^^ expected one of 8 possible tokens here
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `Test`
-  --> $DIR/raw-literal-keywords.rs:12:13
+  --> $DIR/raw-literal-keywords.rs:10:13
    |
 LL |     r#union Test;
    |             ^^^^ expected one of 8 possible tokens here
 
 error[E0425]: cannot find value `if` in this scope
-  --> $DIR/raw-literal-keywords.rs:2:5
+  --> $DIR/raw-literal-keywords.rs:14:13
    |
-LL |     r#if true { }
-   |     ^^^^ not found in this scope
+LL |     let _ = r#if;
+   |             ^^^^ not found in this scope
 
 error[E0425]: cannot find value `struct` in this scope
-  --> $DIR/raw-literal-keywords.rs:7:5
+  --> $DIR/raw-literal-keywords.rs:18:13
    |
-LL |     r#struct Test;
-   |     ^^^^^^^^ not found in this scope
+LL |     let _ = r#struct;
+   |             ^^^^^^^^ not found in this scope
 
 error[E0425]: cannot find value `union` in this scope
-  --> $DIR/raw-literal-keywords.rs:12:5
+  --> $DIR/raw-literal-keywords.rs:22:13
    |
-LL |     r#union Test;
-   |     ^^^^^^^ not found in this scope
+LL |     let _ = r#union;
+   |             ^^^^^^^ not found in this scope
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/resolve/token-error-correct-3.rs
+++ b/src/test/ui/resolve/token-error-correct-3.rs
@@ -15,7 +15,6 @@ pub mod raw {
             callback(path.as_ref();
             //~^ ERROR expected one of
             fs::create_dir_all(path.as_ref()).map(|()| true)
-            //~^ ERROR mismatched types
         } else {
             //~^ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
             Ok(false);

--- a/src/test/ui/resolve/token-error-correct-3.stderr
+++ b/src/test/ui/resolve/token-error-correct-3.stderr
@@ -7,11 +7,10 @@ LL |             callback(path.as_ref();
    |                     unclosed delimiter
 
 error: expected one of `.`, `;`, `?`, `}`, or an operator, found `)`
-  --> $DIR/token-error-correct-3.rs:19:9
+  --> $DIR/token-error-correct-3.rs:18:9
    |
 LL |             fs::create_dir_all(path.as_ref()).map(|()| true)
    |                                                             - expected one of `.`, `;`, `?`, `}`, or an operator here
-LL |
 LL |         } else {
    |         ^ unexpected token
 
@@ -21,18 +20,6 @@ error[E0425]: cannot find function `is_directory` in this scope
 LL |         if !is_directory(path.as_ref()) {
    |             ^^^^^^^^^^^^ not found in this scope
 
-error[E0308]: mismatched types
-  --> $DIR/token-error-correct-3.rs:17:13
-   |
-LL |             fs::create_dir_all(path.as_ref()).map(|()| true)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^- help: try adding a semicolon: `;`
-   |             |
-   |             expected (), found enum `std::result::Result`
-   |
-   = note: expected type `()`
-              found type `std::result::Result<bool, std::io::Error>`
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0308, E0425.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
When recovering from a parse error inside a block, do not emit type
errors generating on that block's recovered return expression.

Fix #57383.