### PR TITLE
simplify std::io::Write::write rustdoc

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -1105,7 +1105,7 @@ pub trait Write {
     /// an [`Err`] variant.
     ///
     /// If the return value is [`Ok(n)`] then it must be guaranteed that
-    /// `0 <= n <= buf.len()`. A return value of `0` typically means that the
+    /// `n <= buf.len()`. A return value of `0` typically means that the
     /// underlying object is no longer able to accept bytes and will likely not
     /// be able to in the future as well, or that the buffer provided is empty.
     ///


### PR DESCRIPTION
The std::io::Write::write method currensly suggests consumers guaranteed
that `0 <= n <= buf.len()`, for `Ok(n)`, however `n` is of type `usize`
causing the compiler to emit a warning:
```
warning: comparison is useless due to type limits
 --> lib.rs:6:18
  |
6 |         Ok(n) => 0 <= n && n <= output.len(),
  |                  ^^^^^^
  |
  = note: #[warn(unused_comparisons)] on by default
```

This PR removes the suggestion to check `0 <= n` since it is moot.

r? @steveklabnik