### PR TITLE
Avoid copying some undef memory in MIR

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -695,6 +695,12 @@ impl<Tag, Extra> Allocation<Tag, Extra> {
     }
 }
 
+impl AllocationDefinedness {
+    pub fn all_bytes_undef(&self) -> bool {
+        self.initial == false && self.ranges.len() == 1
+    }
+}
+
 /// Relocations.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 pub struct Relocations<Tag = (), Id = AllocId>(SortedMap<Size, (Tag, Id)>);

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -924,7 +924,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     }
 }
 
-/// Undefined bytes
+/// Machine pointer introspection.
 impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     pub fn force_ptr(
         &self,


### PR DESCRIPTION
Copying memory between allocations in MIR is not required to preserve the current representation of undef bytes. When the complete source of a copy is in undef state then there are no bytes that need to be copied and the function can return nearly immediately. In some cases this completely avoids writing to the allocation's memory with should have various benefits.

This for example reduces required physical memory when interpreting `const fn` involving large uninitialized values, such as `MaybeUninit::uninit()`.

(*This description has been changed from the original one after parts have been integrated into #63561 *)