### PR TITLE
Removing use of mem::uninitialized from std::io::util

### DIFF
--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -2,7 +2,6 @@
 
 use crate::fmt;
 use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoSlice, IoSliceMut};
-use crate::mem;
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -43,11 +42,8 @@ use crate::mem;
 pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64>
     where R: Read, W: Write
 {
-    let mut buf = unsafe {
-        let mut buf: [u8; super::DEFAULT_BUF_SIZE] = mem::MaybeUninit::uninit().assume_init();
-        reader.initializer().initialize(&mut buf);
-        buf
-    };
+
+    let mut buf: [u8; super::DEFAULT_BUF_SIZE] = [0; super::DEFAULT_BUF_SIZE];
 
     let mut written = 0;
     loop {

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -44,8 +44,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
     where R: Read, W: Write
 {
     let mut buf = unsafe {
-        #[allow(deprecated)]
-        let mut buf: [u8; super::DEFAULT_BUF_SIZE] = mem::uninitialized();
+        let mut buf: [u8; super::DEFAULT_BUF_SIZE] = mem::MaybeUninit::uninit().assume_init();
         reader.initializer().initialize(&mut buf);
         buf
     };

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // mem::uninitialized
+
 use crate::io::ErrorKind;
 use crate::mem;
 
@@ -59,7 +61,7 @@ pub use libc::strlen;
 
 pub fn hashmap_random_keys() -> (u64, u64) {
     unsafe {
-        let mut v = mem::MaybeUninit::uninit().assume_init();
+        let mut v = mem::uninitialized();
         libc::arc4random_buf(&mut v as *mut _ as *mut libc::c_void, mem::size_of_val(&v));
         v
     }

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)] // mem::uninitialized
-
 use crate::io::ErrorKind;
 use crate::mem;
 
@@ -61,7 +59,7 @@ pub use libc::strlen;
 
 pub fn hashmap_random_keys() -> (u64, u64) {
     unsafe {
-        let mut v = mem::uninitialized();
+        let mut v = mem::MaybeUninit::uninit().assume_init();
         libc::arc4random_buf(&mut v as *mut _ as *mut libc::c_void, mem::size_of_val(&v));
         v
     }


### PR DESCRIPTION
Removing use of the deprecated `mem::uninitialized` from `CloudABI` and `std::io::util`. Replaced by usage of `mem::MaybeUninit::uninit().assume_init()`

Fixes #62397