### PR TITLE
pprust: Improve pretty-printing of delimited token groups

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -4,7 +4,7 @@ use syntax::source_map::{SourceMap, Spanned};
 use syntax::parse::ParseSess;
 use syntax::print::pp::{self, Breaks};
 use syntax::print::pp::Breaks::{Consistent, Inconsistent};
-use syntax::print::pprust::{Comments, PrintState};
+use syntax::print::pprust::{self, Comments, PrintState};
 use syntax::symbol::kw;
 use syntax::util::parser::{self, AssocOp, Fixity};
 use syntax_pos::{self, BytePos, FileName};
@@ -89,6 +89,15 @@ impl std::ops::DerefMut for State<'_> {
 impl<'a> PrintState<'a> for State<'a> {
     fn comments(&mut self) -> &mut Option<Comments<'a>> {
         &mut self.comments
+    }
+
+    fn print_ident(&mut self, ident: ast::Ident) {
+        self.s.word(pprust::ast_ident_to_string(ident, ident.is_raw_guess()));
+        self.ann.post(self, AnnNode::Name(&ident.name))
+    }
+
+    fn print_generic_args(&mut self, args: &ast::GenericArgs, _colons_before_params: bool) {
+        span_bug!(args.span(), "AST generic args printed by HIR pretty-printer");
     }
 }
 
@@ -1440,15 +1449,6 @@ impl<'a> State<'a> {
 
     pub fn print_usize(&mut self, i: usize) {
         self.s.word(i.to_string())
-    }
-
-    pub fn print_ident(&mut self, ident: ast::Ident) {
-        if ident.is_raw_guess() {
-            self.s.word(format!("r#{}", ident.name));
-        } else {
-            self.s.word(ident.as_str().to_string());
-        }
-        self.ann.post(self, AnnNode::Name(&ident.name))
     }
 
     pub fn print_name(&mut self, name: ast::Name) {

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -6,7 +6,7 @@ pub use crate::symbol::{Ident, Symbol as Name};
 pub use crate::util::parser::ExprPrecedence;
 
 use crate::ext::hygiene::{Mark, SyntaxContext};
-use crate::parse::token;
+use crate::parse::token::{self, DelimToken};
 use crate::print::pprust;
 use crate::ptr::P;
 use crate::source_map::{dummy_spanned, respan, Spanned};
@@ -1295,6 +1295,16 @@ pub enum MacDelimiter {
 impl Mac_ {
     pub fn stream(&self) -> TokenStream {
         self.tts.clone()
+    }
+}
+
+impl MacDelimiter {
+    crate fn to_token(self) -> DelimToken {
+        match self {
+            MacDelimiter::Parenthesis => DelimToken::Paren,
+            MacDelimiter::Bracket => DelimToken::Bracket,
+            MacDelimiter::Brace => DelimToken::Brace,
+        }
     }
 }
 

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -1328,7 +1328,7 @@ mod tests {
                 matches_codepattern,
                 "matches_codepattern",
                 pprust::to_string(|s| fake_print_crate(s, &krate)),
-                "macro_rules! zz((zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+)));".to_string());
+                "macro_rules! zz{(zz$zz:zz$(zz $zz:zz)zz+=>(zz$(zz$zz$zz)+))}".to_string());
         })
     }
 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -714,6 +714,9 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
         convert_dollar_crate: bool,
         span: Span,
     ) {
+        if delim == DelimToken::Brace {
+            self.cbox(INDENT_UNIT);
+        }
         if let Some(path) = path {
             self.print_path(path, false, 0);
         }
@@ -721,27 +724,27 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
             self.word("!");
         }
         if let Some(ident) = ident {
-            self.space();
+            self.nbsp();
             self.print_ident(ident);
-            self.space();
         }
         match delim {
-            DelimToken::Paren => self.popen(),
-            DelimToken::Bracket => self.word("["),
-            DelimToken::NoDelim => self.word(" "),
             DelimToken::Brace => {
-                self.head("");
-                self.bopen();
+                if path.is_some() || has_bang || ident.is_some() {
+                    self.nbsp();
+                }
+                self.word("{");
+                if !tts.is_empty() {
+                    self.space();
+                }
             }
+            _ => self.word(token_kind_to_string(&token::OpenDelim(delim))),
         }
         self.ibox(0);
         self.print_tts(tts, convert_dollar_crate);
         self.end();
         match delim {
-            DelimToken::Paren => self.pclose(),
-            DelimToken::Bracket => self.word("]"),
-            DelimToken::NoDelim => self.word(" "),
             DelimToken::Brace => self.bclose(span),
+            _ => self.word(token_kind_to_string(&token::CloseDelim(delim))),
         }
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -617,21 +617,17 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
                 ast::AttrStyle::Outer => self.word("#["),
             }
             self.ibox(0);
-            if let Some(mi) = attr.meta() {
-                self.print_meta_item(&mi);
-            } else {
-                match attr.tokens.trees().next() {
-                    Some(TokenTree::Delimited(_, delim, tts)) => {
-                        self.print_mac_common(
-                            Some(&attr.path), false, None, delim, tts, true, attr.span
-                        );
-                    }
-                    tree => {
-                        self.print_path(&attr.path, false, 0);
-                        if tree.is_some() {
-                            self.space();
-                            self.print_tts(attr.tokens.clone(), true);
-                        }
+            match attr.tokens.trees().next() {
+                Some(TokenTree::Delimited(_, delim, tts)) => {
+                    self.print_mac_common(
+                        Some(&attr.path), false, None, delim, tts, true, attr.span
+                    );
+                }
+                tree => {
+                    self.print_path(&attr.path, false, 0);
+                    if tree.is_some() {
+                        self.space();
+                        self.print_tts(attr.tokens.clone(), true);
                     }
                 }
             }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -616,6 +616,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
                 ast::AttrStyle::Inner => self.word("#!["),
                 ast::AttrStyle::Outer => self.word("#["),
             }
+            self.ibox(0);
             if let Some(mi) = attr.meta() {
                 self.print_meta_item(&mi);
             } else {
@@ -634,6 +635,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
                     }
                 }
             }
+            self.end();
             self.word("]");
         }
     }
@@ -698,14 +700,12 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
     }
 
     fn print_tts(&mut self, tts: tokenstream::TokenStream, convert_dollar_crate: bool) {
-        self.ibox(0);
         for (i, tt) in tts.into_trees().enumerate() {
             if i != 0 {
                 self.space();
             }
             self.print_tt(tt, convert_dollar_crate);
         }
-        self.end();
     }
 
     fn print_mac_common(
@@ -738,7 +738,9 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
                 self.bopen();
             }
         }
+        self.ibox(0);
         self.print_tts(tts, convert_dollar_crate);
+        self.end();
         match delim {
             DelimToken::Paren => self.pclose(),
             DelimToken::Bracket => self.word("]"),

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -188,7 +188,7 @@ pub fn literal_to_string(lit: token::Lit) -> String {
 }
 
 /// Print an ident from AST, `$crate` is converted into its respective crate name.
-fn ast_ident_to_string(ident: ast::Ident, is_raw: bool) -> String {
+pub fn ast_ident_to_string(ident: ast::Ident, is_raw: bool) -> String {
     ident_to_string(ident.name, is_raw, Some(ident.span))
 }
 
@@ -446,6 +446,8 @@ impl std::ops::DerefMut for State<'_> {
 
 pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefMut {
     fn comments(&mut self) -> &mut Option<Comments<'a>>;
+    fn print_ident(&mut self, ident: ast::Ident);
+    fn print_generic_args(&mut self, args: &ast::GenericArgs, colons_before_params: bool);
 
     fn commasep<T, F>(&mut self, b: Breaks, elts: &[T], mut op: F)
         where F: FnMut(&mut Self, &T),
@@ -596,17 +598,6 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
         }
     }
 
-    fn print_attribute_path(&mut self, path: &ast::Path) {
-        for (i, segment) in path.segments.iter().enumerate() {
-            if i > 0 {
-                self.word("::");
-            }
-            if segment.ident.name != kw::PathRoot {
-                self.word(ast_ident_to_string(segment.ident, segment.ident.is_raw_guess()));
-            }
-        }
-    }
-
     fn print_attribute(&mut self, attr: &ast::Attribute) {
         self.print_attribute_inline(attr, false)
     }
@@ -628,7 +619,7 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
             if let Some(mi) = attr.meta() {
                 self.print_meta_item(&mi);
             } else {
-                self.print_attribute_path(&attr.path);
+                self.print_path(&attr.path, false, 0);
                 self.space();
                 self.print_tts(attr.tokens.clone(), true);
             }
@@ -650,15 +641,15 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
     fn print_meta_item(&mut self, item: &ast::MetaItem) {
         self.ibox(INDENT_UNIT);
         match item.node {
-            ast::MetaItemKind::Word => self.print_attribute_path(&item.path),
+            ast::MetaItemKind::Word => self.print_path(&item.path, false, 0),
             ast::MetaItemKind::NameValue(ref value) => {
-                self.print_attribute_path(&item.path);
+                self.print_path(&item.path, false, 0);
                 self.space();
                 self.word_space("=");
                 self.print_literal(value);
             }
             ast::MetaItemKind::List(ref items) => {
-                self.print_attribute_path(&item.path);
+                self.print_path(&item.path, false, 0);
                 self.popen();
                 self.commasep(Consistent,
                               &items[..],
@@ -707,16 +698,56 @@ pub trait PrintState<'a>: std::ops::Deref<Target=pp::Printer> + std::ops::DerefM
         }
         self.end();
     }
-}
 
-impl<'a> PrintState<'a> for State<'a> {
-    fn comments(&mut self) -> &mut Option<Comments<'a>> {
-        &mut self.comments
+    fn print_mac_common(
+        &mut self,
+        path: &ast::Path,
+        has_bang: bool,
+        tts: TokenStream,
+        delim: MacDelimiter,
+        span: Span,
+    ) {
+        self.print_path(path, false, 0);
+        if has_bang {
+            self.word("!");
+        }
+        match delim {
+            MacDelimiter::Parenthesis => self.popen(),
+            MacDelimiter::Bracket => self.word("["),
+            MacDelimiter::Brace => {
+                self.head("");
+                self.bopen();
+            }
+        }
+        self.print_tts(tts, true);
+        match delim {
+            MacDelimiter::Parenthesis => self.pclose(),
+            MacDelimiter::Bracket => self.word("]"),
+            MacDelimiter::Brace => self.bclose(span),
+        }
     }
-}
 
-impl<'a> State<'a> {
-    crate fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) {
+    fn print_path(&mut self, path: &ast::Path, colons_before_params: bool, depth: usize) {
+        self.maybe_print_comment(path.span.lo());
+
+        for (i, segment) in path.segments[..path.segments.len() - depth].iter().enumerate() {
+            if i > 0 {
+                self.word("::")
+            }
+            self.print_path_segment(segment, colons_before_params);
+        }
+    }
+
+    fn print_path_segment(&mut self, segment: &ast::PathSegment, colons_before_params: bool) {
+        if segment.ident.name != kw::PathRoot {
+            self.print_ident(segment.ident);
+            if let Some(ref args) = segment.args {
+                self.print_generic_args(args, colons_before_params);
+            }
+        }
+    }
+
+    fn head<S: Into<Cow<'static, str>>>(&mut self, w: S) {
         let w = w.into();
         // outer-box is consistent
         self.cbox(INDENT_UNIT);
@@ -728,36 +759,103 @@ impl<'a> State<'a> {
         }
     }
 
-    crate fn bopen(&mut self) {
-        self.s.word("{");
+    fn bopen(&mut self) {
+        self.word("{");
         self.end(); // close the head-box
     }
 
-    crate fn bclose_maybe_open(&mut self, span: syntax_pos::Span, close_box: bool) {
+    fn bclose_maybe_open(&mut self, span: syntax_pos::Span, close_box: bool) {
         self.maybe_print_comment(span.hi());
         self.break_offset_if_not_bol(1, -(INDENT_UNIT as isize));
-        self.s.word("}");
+        self.word("}");
         if close_box {
             self.end(); // close the outer-box
         }
     }
-    crate fn bclose(&mut self, span: syntax_pos::Span) {
+
+    fn bclose(&mut self, span: syntax_pos::Span) {
         self.bclose_maybe_open(span, true)
     }
 
-    crate fn break_offset_if_not_bol(&mut self, n: usize, off: isize) {
-        if !self.s.is_beginning_of_line() {
-            self.s.break_offset(n, off)
+    fn break_offset_if_not_bol(&mut self, n: usize, off: isize) {
+        if !self.is_beginning_of_line() {
+            self.break_offset(n, off)
         } else {
-            if off != 0 && self.s.last_token().is_hardbreak_tok() {
+            if off != 0 && self.last_token().is_hardbreak_tok() {
                 // We do something pretty sketchy here: tuck the nonzero
                 // offset-adjustment we were going to deposit along with the
                 // break into the previous hardbreak.
-                self.s.replace_last_token(pp::Printer::hardbreak_tok_offset(off));
+                self.replace_last_token(pp::Printer::hardbreak_tok_offset(off));
             }
         }
     }
+}
 
+impl<'a> PrintState<'a> for State<'a> {
+    fn comments(&mut self) -> &mut Option<Comments<'a>> {
+        &mut self.comments
+    }
+
+    fn print_ident(&mut self, ident: ast::Ident) {
+        self.s.word(ast_ident_to_string(ident, ident.is_raw_guess()));
+        self.ann.post(self, AnnNode::Ident(&ident))
+    }
+
+    fn print_generic_args(&mut self, args: &ast::GenericArgs, colons_before_params: bool) {
+        if colons_before_params {
+            self.s.word("::")
+        }
+
+        match *args {
+            ast::GenericArgs::AngleBracketed(ref data) => {
+                self.s.word("<");
+
+                self.commasep(Inconsistent, &data.args, |s, generic_arg| {
+                    s.print_generic_arg(generic_arg)
+                });
+
+                let mut comma = data.args.len() != 0;
+
+                for constraint in data.constraints.iter() {
+                    if comma {
+                        self.word_space(",")
+                    }
+                    self.print_ident(constraint.ident);
+                    self.s.space();
+                    match constraint.kind {
+                        ast::AssocTyConstraintKind::Equality { ref ty } => {
+                            self.word_space("=");
+                            self.print_type(ty);
+                        }
+                        ast::AssocTyConstraintKind::Bound { ref bounds } => {
+                            self.print_type_bounds(":", &*bounds);
+                        }
+                    }
+                    comma = true;
+                }
+
+                self.s.word(">")
+            }
+
+            ast::GenericArgs::Parenthesized(ref data) => {
+                self.s.word("(");
+                self.commasep(
+                    Inconsistent,
+                    &data.inputs,
+                    |s, ty| s.print_type(ty));
+                self.s.word(")");
+
+                if let Some(ref ty) = data.output {
+                    self.space_if_not_bol();
+                    self.word_space("->");
+                    self.print_type(ty);
+                }
+            }
+        }
+    }
+}
+
+impl<'a> State<'a> {
     // Synthesizes a comment that was not textually present in the original source
     // file.
     pub fn synth_comment(&mut self, text: String) {
@@ -1645,22 +1743,7 @@ impl<'a> State<'a> {
     }
 
     crate fn print_mac(&mut self, m: &ast::Mac) {
-        self.print_path(&m.node.path, false, 0);
-        self.s.word("!");
-        match m.node.delim {
-            MacDelimiter::Parenthesis => self.popen(),
-            MacDelimiter::Bracket => self.s.word("["),
-            MacDelimiter::Brace => {
-                self.head("");
-                self.bopen();
-            }
-        }
-        self.print_tts(m.node.stream(), true);
-        match m.node.delim {
-            MacDelimiter::Parenthesis => self.pclose(),
-            MacDelimiter::Bracket => self.s.word("]"),
-            MacDelimiter::Brace => self.bclose(m.span),
-        }
+        self.print_mac_common(&m.node.path, true, m.node.stream(), m.node.delim, m.span);
     }
 
 
@@ -2204,11 +2287,6 @@ impl<'a> State<'a> {
         }
     }
 
-    crate fn print_ident(&mut self, ident: ast::Ident) {
-        self.s.word(ast_ident_to_string(ident, ident.is_raw_guess()));
-        self.ann.post(self, AnnNode::Ident(&ident))
-    }
-
     crate fn print_usize(&mut self, i: usize) {
         self.s.word(i.to_string())
     }
@@ -2216,31 +2294,6 @@ impl<'a> State<'a> {
     crate fn print_name(&mut self, name: ast::Name) {
         self.s.word(name.as_str().to_string());
         self.ann.post(self, AnnNode::Name(&name))
-    }
-
-    fn print_path(&mut self,
-                  path: &ast::Path,
-                  colons_before_params: bool,
-                  depth: usize) {
-        self.maybe_print_comment(path.span.lo());
-
-        for (i, segment) in path.segments[..path.segments.len() - depth].iter().enumerate() {
-            if i > 0 {
-                self.s.word("::")
-            }
-            self.print_path_segment(segment, colons_before_params);
-        }
-    }
-
-    fn print_path_segment(&mut self,
-                          segment: &ast::PathSegment,
-                          colons_before_params: bool) {
-        if segment.ident.name != kw::PathRoot {
-            self.print_ident(segment.ident);
-            if let Some(ref args) = segment.args {
-                self.print_generic_args(args, colons_before_params);
-            }
-        }
     }
 
     fn print_qpath(&mut self,
@@ -2263,62 +2316,6 @@ impl<'a> State<'a> {
         match item_segment.args {
             Some(ref args) => self.print_generic_args(args, colons_before_params),
             None => {},
-        }
-    }
-
-    fn print_generic_args(&mut self,
-                          args: &ast::GenericArgs,
-                          colons_before_params: bool)
-    {
-        if colons_before_params {
-            self.s.word("::")
-        }
-
-        match *args {
-            ast::GenericArgs::AngleBracketed(ref data) => {
-                self.s.word("<");
-
-                self.commasep(Inconsistent, &data.args, |s, generic_arg| {
-                    s.print_generic_arg(generic_arg)
-                });
-
-                let mut comma = data.args.len() != 0;
-
-                for constraint in data.constraints.iter() {
-                    if comma {
-                        self.word_space(",")
-                    }
-                    self.print_ident(constraint.ident);
-                    self.s.space();
-                    match constraint.kind {
-                        ast::AssocTyConstraintKind::Equality { ref ty } => {
-                            self.word_space("=");
-                            self.print_type(ty);
-                        }
-                        ast::AssocTyConstraintKind::Bound { ref bounds } => {
-                            self.print_type_bounds(":", &*bounds);
-                        }
-                    }
-                    comma = true;
-                }
-
-                self.s.word(">")
-            }
-
-            ast::GenericArgs::Parenthesized(ref data) => {
-                self.s.word("(");
-                self.commasep(
-                    Inconsistent,
-                    &data.inputs,
-                    |s, ty| s.print_type(ty));
-                self.s.word(")");
-
-                if let Some(ref ty) = data.output {
-                    self.space_if_not_bol();
-                    self.word_space("->");
-                    self.print_type(ty);
-                }
-            }
         }
     }
 

--- a/src/test/pretty/attr-literals.rs
+++ b/src/test/pretty/attr-literals.rs
@@ -5,10 +5,10 @@
 #![feature(rustc_attrs)]
 
 fn main() {
-    #![rustc_dummy("hi", 1, 2, 1.012, pi = 3.14, bye, name("John"))]
+    #![rustc_dummy("hi" , 1 , 2 , 1.012 , pi = 3.14 , bye , name ("John"))]
     #[rustc_dummy = 8]
     fn f() { }
 
-    #[rustc_dummy(1, 2, 3)]
+    #[rustc_dummy(1 , 2 , 3)]
     fn g() { }
 }

--- a/src/test/pretty/attr-tokens-raw-ident.rs
+++ b/src/test/pretty/attr-tokens-raw-ident.rs
@@ -1,0 +1,7 @@
+// Keywords in attribute paths are printed as raw idents,
+// but keywords in attribute arguments are not.
+
+// pp-exact
+
+#[rustfmt::r#final(final)]
+fn main() { }

--- a/src/test/pretty/cast-lt.pp
+++ b/src/test/pretty/cast-lt.pp
@@ -8,6 +8,6 @@ extern crate std;
 // pretty-mode:expanded
 // pp-exact:cast-lt.pp
 
-macro_rules! negative {($ e : expr) => {$ e < 0 } }
+macro_rules! negative { ($ e : expr) => { $ e < 0 } }
 
 fn main() { (1 as i32) < 0; }

--- a/src/test/pretty/cast-lt.pp
+++ b/src/test/pretty/cast-lt.pp
@@ -8,6 +8,6 @@ extern crate std;
 // pretty-mode:expanded
 // pp-exact:cast-lt.pp
 
-macro_rules! negative(( $ e : expr ) => { $ e < 0 });
+macro_rules! negative {( $ e : expr ) => { $ e < 0 } }
 
 fn main() { (1 as i32) < 0; }

--- a/src/test/pretty/cast-lt.pp
+++ b/src/test/pretty/cast-lt.pp
@@ -8,6 +8,6 @@ extern crate std;
 // pretty-mode:expanded
 // pp-exact:cast-lt.pp
 
-macro_rules! negative {( $ e : expr ) => { $ e < 0 } }
+macro_rules! negative {($ e : expr) => {$ e < 0 } }
 
 fn main() { (1 as i32) < 0; }

--- a/src/test/pretty/delimited-token-groups.rs
+++ b/src/test/pretty/delimited-token-groups.rs
@@ -1,0 +1,49 @@
+// pp-exact
+
+#![feature(rustc_attrs)]
+
+macro_rules! mac { ($ ($ tt : tt) *) => () }
+
+mac! {
+    struct S { field1 : u8 , field2 : u16 , } impl Clone for S
+    {
+        fn clone () -> S
+        {
+            panic ! () ;
+
+        }
+    }
+}
+
+mac! {
+    a
+    (aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+     aaaaaaaa aaaaaaaa) a
+    [aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+     aaaaaaaa aaaaaaaa] a
+    {
+        aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+        aaaaaaaa aaaaaaaa aaaaaaaa
+    } a
+}
+
+mac!(aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+     aaaaaaaa aaaaaaaa);
+mac![aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+     aaaaaaaa aaaaaaaa];
+mac! {
+    aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+    aaaaaaaa aaaaaaaa
+}
+
+#[rustc_dummy(aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+              aaaaaaaa aaaaaaaa aaaaaaaa)]
+#[rustc_dummy[aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+              aaaaaaaa aaaaaaaa aaaaaaaa]]
+#[rustc_dummy {
+      aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa
+      aaaaaaaa aaaaaaaa
+  }]
+#[rustc_dummy =
+  "aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa"]
+fn main() { }

--- a/src/test/pretty/issue-30731.rs
+++ b/src/test/pretty/issue-30731.rs
@@ -5,4 +5,4 @@
 // pretty-compare-only
 // pp-exact
 
-fn main() { b!{ } c }
+fn main() { b! { } c }

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -29,8 +29,8 @@ pub fn bar() ({
 
 
 
-                  (($crate::fmt::format as
-                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<$crate::fmt::Arguments>::new_v1
+                  ((::alloc::fmt::format as
+                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::std::fmt::Arguments>::new_v1
                                                                                                            as
                                                                                                            fn(&[&str], &[std::fmt::ArgumentV1<'_>]) -> std::fmt::Arguments<'_> {std::fmt::Arguments::<'_>::new_v1})((&([("test"
                                                                                                                                                                                                                             as

--- a/src/test/pretty/macro.rs
+++ b/src/test/pretty/macro.rs
@@ -1,0 +1,7 @@
+// pp-exact
+
+#![feature(decl_macro)]
+
+macro mac { ($ arg : expr) => { $ arg + $ arg } }
+
+fn main() { }

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -111,7 +111,9 @@ fn _8() {
 }
 
 fn _9() {
-    macro_rules! stmt_mac((  ) => { let _ = (  ) ; });
+    macro_rules!
+    stmt_mac
+    {(  ) => { let _ = (  ) ; } }
 
     #[rustc_dummy]
     stmt_mac!();
@@ -128,7 +130,7 @@ fn _9() {
     let _ = ();
 }
 
-macro_rules! expr_mac((  ) => { (  ) });
+macro_rules! expr_mac {(  ) => { (  ) } }
 
 fn _10() {
     let _ = #[rustc_dummy] expr_mac!();

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -111,31 +111,29 @@ fn _8() {
 }
 
 fn _9() {
-    macro_rules!
-    stmt_mac
-    {() => {let _ = () ; } }
+    macro_rules! stmt_mac { () => { let _ = () ; } }
 
     #[rustc_dummy]
     stmt_mac!();
 
     #[rustc_dummy]
-    stmt_mac!{ };
+    stmt_mac! { };
 
     #[rustc_dummy]
     stmt_mac![];
 
     #[rustc_dummy]
-    stmt_mac!{ }
+    stmt_mac! { }
 
     let _ = ();
 }
 
-macro_rules! expr_mac {() => {() } }
+macro_rules! expr_mac { () => { () } }
 
 fn _10() {
     let _ = #[rustc_dummy] expr_mac!();
     let _ = #[rustc_dummy] expr_mac![];
-    let _ = #[rustc_dummy] expr_mac!{ };
+    let _ = #[rustc_dummy] expr_mac! { };
 }
 
 fn _11() {
@@ -238,7 +236,7 @@ fn _11() {
     || #[rustc_dummy] return;
     let _ = #[rustc_dummy] expr_mac!();
     let _ = #[rustc_dummy] expr_mac![];
-    let _ = #[rustc_dummy] expr_mac!{ };
+    let _ = #[rustc_dummy] expr_mac! { };
     let _ = #[rustc_dummy] Foo{#![rustc_dummy] data: (),};
     let _ = #[rustc_dummy] Foo{#![rustc_dummy] ..s};
     let _ = #[rustc_dummy] Foo{#![rustc_dummy] data: (), ..s};

--- a/src/test/pretty/stmt_expr_attributes.rs
+++ b/src/test/pretty/stmt_expr_attributes.rs
@@ -113,7 +113,7 @@ fn _8() {
 fn _9() {
     macro_rules!
     stmt_mac
-    {(  ) => { let _ = (  ) ; } }
+    {() => {let _ = () ; } }
 
     #[rustc_dummy]
     stmt_mac!();
@@ -130,7 +130,7 @@ fn _9() {
     let _ = ();
 }
 
-macro_rules! expr_mac {(  ) => { (  ) } }
+macro_rules! expr_mac {() => {() } }
 
 fn _10() {
     let _ = #[rustc_dummy] expr_mac!();

--- a/src/test/run-make-fulldeps/pretty-expanded-hygiene/input.pp.rs
+++ b/src/test/run-make-fulldeps/pretty-expanded-hygiene/input.pp.rs
@@ -2,7 +2,7 @@
 #![feature /* 0#0 */(no_core)]
 #![no_core /* 0#0 */]
 
-macro_rules /* 0#0 */! foo /* 0#0 */ { ($ x : ident) => { y + $ x } }
+macro_rules! foo /* 0#0 */ { ($ x : ident) => { y + $ x } }
 
 fn bar /* 0#0 */() { let x /* 0#0 */ = 1; y /* 0#1 */ + x /* 0#0 */ }
 

--- a/src/test/run-make-fulldeps/pretty-expanded-hygiene/input.pp.rs
+++ b/src/test/run-make-fulldeps/pretty-expanded-hygiene/input.pp.rs
@@ -1,9 +1,9 @@
 // minimal junk
-#![feature(no_core)]
-#![no_core]
+#![feature /* 0#0 */(no_core)]
+#![no_core /* 0#0 */]
 
-macro_rules! foo /* 60#0 */(( $ x : ident ) => { y + $ x });
+macro_rules /* 0#0 */! foo /* 0#0 */ { ($ x : ident) => { y + $ x } }
 
-fn bar /* 62#0 */() { let x /* 59#2 */ = 1; y /* 61#4 */ + x /* 59#5 */ }
+fn bar /* 0#0 */() { let x /* 0#0 */ = 1; y /* 0#1 */ + x /* 0#0 */ }
 
-fn y /* 61#0 */() { }
+fn y /* 0#0 */() { }

--- a/src/test/run-pass/macros/syntax-extension-source-utils.rs
+++ b/src/test/run-pass/macros/syntax-extension-source-utils.rs
@@ -18,7 +18,7 @@ pub fn main() {
     assert_eq!(column!(), 16);
     assert_eq!(indirect_line!(), 19);
     assert!((file!().ends_with("syntax-extension-source-utils.rs")));
-    assert_eq!(stringify!((2*3) + 5).to_string(), "( 2 * 3 ) + 5".to_string());
+    assert_eq!(stringify!((2*3) + 5).to_string(), "(2 * 3) + 5".to_string());
     assert!(include!("syntax-extension-source-utils-files/includeme.\
                       fragment").to_string()
            == "victory robot 6".to_string());
@@ -33,5 +33,5 @@ pub fn main() {
     // The Windows tests are wrapped in an extra module for some reason
     assert!((m1::m2::where_am_i().ends_with("m1::m2")));
 
-    assert_eq!((36, "( 2 * 3 ) + 5"), (line!(), stringify!((2*3) + 5)));
+    assert_eq!((36, "(2 * 3) + 5"), (line!(), stringify!((2*3) + 5)));
 }

--- a/src/test/run-pass/proc-macro/auxiliary/derive-b.rs
+++ b/src/test/run-pass/proc-macro/auxiliary/derive-b.rs
@@ -10,7 +10,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(B, attributes(B, C))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = input.to_string();
-    assert!(input.contains("#[B [ arbitrary tokens ]]"));
+    assert!(input.contains("#[B[arbitrary tokens]]"));
     assert!(input.contains("struct B {"));
     assert!(input.contains("#[C]"));
     "".parse().unwrap()

--- a/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
@@ -7,8 +7,8 @@ LL |     produces_async! {}
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers
    |
-LL | (  ) => ( pub fn r#async (  ) {  } )
-   |                  ^^^^^^^
+LL | () => (pub fn r#async () { })
+   |               ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -31,10 +31,10 @@ LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
 
 error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
-  --> <::edition_kw_macro_2015::passes_ident macros>:1:25
+  --> <::edition_kw_macro_2015::passes_ident macros>:1:22
    |
-LL | ( $ i : ident ) => ( $ i )
-   |                         ^ expected one of `move`, `|`, or `||` here
+LL | ($ i : ident) => ($ i)
+   |                      ^ expected one of `move`, `|`, or `||` here
    | 
   ::: $DIR/edition-keywords-2018-2015-parsing.rs:16:8
    |

--- a/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
@@ -7,8 +7,8 @@ LL |     produces_async! {}
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers
    |
-LL | (  ) => ( pub fn r#async (  ) {  } )
-   |                  ^^^^^^^
+LL | () => (pub fn r#async () { })
+   |               ^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -31,10 +31,10 @@ LL |     r#async = consumes_async_raw!(async);
    |                                   ^^^^^ no rules expected this token in macro call
 
 error: macro expansion ends with an incomplete expression: expected one of `move`, `|`, or `||`
-  --> <::edition_kw_macro_2018::passes_ident macros>:1:25
+  --> <::edition_kw_macro_2018::passes_ident macros>:1:22
    |
-LL | ( $ i : ident ) => ( $ i )
-   |                         ^ expected one of `move`, `|`, or `||` here
+LL | ($ i : ident) => ($ i)
+   |                      ^ expected one of `move`, `|`, or `||` here
    | 
   ::: $DIR/edition-keywords-2018-2018-parsing.rs:16:8
    |

--- a/src/test/ui/macro_backtrace/main.stderr
+++ b/src/test/ui/macro_backtrace/main.stderr
@@ -24,10 +24,10 @@ LL |       ping!();
    | 
   ::: <::ping::ping macros>:1:1
    |
-LL |   (  ) => { pong ! (  ) ; }
-   |   -------------------------
-   |   |         |
-   |   |         in this macro invocation
+LL |   () => {pong ! () ; }
+   |   --------------------
+   |   |      |
+   |   |      in this macro invocation
    |   in this expansion of `ping!`
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
@@ -44,34 +44,34 @@ LL |       deep!();
    | 
   ::: <::ping::deep macros>:1:1
    |
-LL |   (  ) => { foo ! (  ) ; }
-   |   ------------------------
-   |   |         |
-   |   |         in this macro invocation (#2)
+LL |   () => {foo ! () ; }
+   |   -------------------
+   |   |      |
+   |   |      in this macro invocation (#2)
    |   in this expansion of `deep!` (#1)
    | 
   ::: <::ping::foo macros>:1:1
    |
-LL |   (  ) => { bar ! (  ) ; }
-   |   ------------------------
-   |   |         |
-   |   |         in this macro invocation (#3)
+LL |   () => {bar ! () ; }
+   |   -------------------
+   |   |      |
+   |   |      in this macro invocation (#3)
    |   in this expansion of `foo!` (#2)
    | 
   ::: <::ping::bar macros>:1:1
    |
-LL |   (  ) => { ping ! (  ) ; }
-   |   -------------------------
-   |   |         |
-   |   |         in this macro invocation (#4)
+LL |   () => {ping ! () ; }
+   |   --------------------
+   |   |      |
+   |   |      in this macro invocation (#4)
    |   in this expansion of `bar!` (#3)
    | 
   ::: <::ping::ping macros>:1:1
    |
-LL |   (  ) => { pong ! (  ) ; }
-   |   -------------------------
-   |   |         |
-   |   |         in this macro invocation (#5)
+LL |   () => {pong ! () ; }
+   |   --------------------
+   |   |      |
+   |   |      in this macro invocation (#5)
    |   in this expansion of `ping!` (#4)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/macro_backtrace/main.stderr
+++ b/src/test/ui/macro_backtrace/main.stderr
@@ -24,10 +24,10 @@ LL |       ping!();
    | 
   ::: <::ping::ping macros>:1:1
    |
-LL |   () => {pong ! () ; }
-   |   --------------------
-   |   |      |
-   |   |      in this macro invocation
+LL |   () => { pong ! () ; }
+   |   ---------------------
+   |   |       |
+   |   |       in this macro invocation
    |   in this expansion of `ping!`
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `error`
@@ -44,34 +44,34 @@ LL |       deep!();
    | 
   ::: <::ping::deep macros>:1:1
    |
-LL |   () => {foo ! () ; }
-   |   -------------------
-   |   |      |
-   |   |      in this macro invocation (#2)
+LL |   () => { foo ! () ; }
+   |   --------------------
+   |   |       |
+   |   |       in this macro invocation (#2)
    |   in this expansion of `deep!` (#1)
    | 
   ::: <::ping::foo macros>:1:1
    |
-LL |   () => {bar ! () ; }
-   |   -------------------
-   |   |      |
-   |   |      in this macro invocation (#3)
+LL |   () => { bar ! () ; }
+   |   --------------------
+   |   |       |
+   |   |       in this macro invocation (#3)
    |   in this expansion of `foo!` (#2)
    | 
   ::: <::ping::bar macros>:1:1
    |
-LL |   () => {ping ! () ; }
-   |   --------------------
-   |   |      |
-   |   |      in this macro invocation (#4)
+LL |   () => { ping ! () ; }
+   |   ---------------------
+   |   |       |
+   |   |       in this macro invocation (#4)
    |   in this expansion of `bar!` (#3)
    | 
   ::: <::ping::ping macros>:1:1
    |
-LL |   () => {pong ! () ; }
-   |   --------------------
-   |   |      |
-   |   |      in this macro invocation (#5)
+LL |   () => { pong ! () ; }
+   |   ---------------------
+   |   |       |
+   |   |       in this macro invocation (#5)
    |   in this expansion of `ping!` (#4)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/macros/trace-macro.stderr
+++ b/src/test/ui/macros/trace-macro.stderr
@@ -5,5 +5,5 @@ LL |     println!("Hello, World!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `println! { "Hello, World!" }`
-   = note: to `{$crate :: io :: _print (format_args_nl ! ("Hello, World!")) ; }`
+   = note: to `{ $crate :: io :: _print (format_args_nl ! ("Hello, World!")) ; }`
 

--- a/src/test/ui/macros/trace-macro.stderr
+++ b/src/test/ui/macros/trace-macro.stderr
@@ -5,5 +5,5 @@ LL |     println!("Hello, World!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `println! { "Hello, World!" }`
-   = note: to `{ $crate :: io :: _print ( format_args_nl ! ( "Hello, World!" ) ) ; }`
+   = note: to `{$crate :: io :: _print (format_args_nl ! ("Hello, World!")) ; }`
 

--- a/src/test/ui/macros/trace_faulty_macros.stderr
+++ b/src/test/ui/macros/trace_faulty_macros.stderr
@@ -17,7 +17,7 @@ LL |     my_faulty_macro!();
    |     ^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_faulty_macro! {  }`
-   = note: to `my_faulty_macro ! ( bcd ) ;`
+   = note: to `my_faulty_macro ! (bcd) ;`
    = note: expanding `my_faulty_macro! { bcd }`
 
 error: recursion limit reached while expanding the macro `my_recursive_macro`
@@ -38,13 +38,13 @@ LL |     my_recursive_macro!();
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro ! (  ) ;`
+   = note: to `my_recursive_macro ! () ;`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro ! (  ) ;`
+   = note: to `my_recursive_macro ! () ;`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro ! (  ) ;`
+   = note: to `my_recursive_macro ! () ;`
    = note: expanding `my_recursive_macro! {  }`
-   = note: to `my_recursive_macro ! (  ) ;`
+   = note: to `my_recursive_macro ! () ;`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/attribute-spans-preserved.stdout
+++ b/src/test/ui/proc-macro/attribute-spans-preserved.stdout
@@ -1,1 +1,1 @@
-fn main () {let y : u32 = "z" ; {let x : u32 = "y" ; } }
+fn main () { let y : u32 = "z" ; { let x : u32 = "y" ; } }

--- a/src/test/ui/proc-macro/attribute-spans-preserved.stdout
+++ b/src/test/ui/proc-macro/attribute-spans-preserved.stdout
@@ -1,1 +1,1 @@
-fn main (  ) { let y : u32 = "z" ; { let x : u32 = "y" ; } }
+fn main () {let y : u32 = "z" ; {let x : u32 = "y" ; } }

--- a/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-57089.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
+++ b/src/test/ui/proc-macro/dollar-crate-issue-62325.stdout
@@ -1,5 +1,5 @@
 PRINT-ATTR INPUT (DISPLAY): struct A(identity!(crate :: S));
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( identity ! ( $crate :: S ) ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A (identity ! ($crate :: S)) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -55,7 +55,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct B(identity!(::dollar_crate_external :: S));
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct B ( identity ! ( $crate :: S ) ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct B (identity ! ($crate :: S)) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",

--- a/src/test/ui/proc-macro/dollar-crate.stdout
+++ b/src/test/ui/proc-macro/dollar-crate.stdout
@@ -1,4 +1,4 @@
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -39,7 +39,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(crate::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -80,7 +80,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(crate::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ($crate :: S) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -120,7 +120,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: #2 bytes(LO..HI),
     },
 ]
-PRINT-BANG INPUT (DISPLAY): struct M ( $crate :: S ) ;
+PRINT-BANG INPUT (DISPLAY): struct M ($crate :: S) ;
 PRINT-BANG INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -161,7 +161,7 @@ PRINT-BANG INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct A(::dollar_crate_external::S);
-PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ( $crate :: S ) ;
+PRINT-ATTR RE-COLLECTED (DISPLAY): struct A ($crate :: S) ;
 PRINT-ATTR INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -202,7 +202,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     },
 ]
 PRINT-DERIVE INPUT (DISPLAY): struct D(::dollar_crate_external::S);
-PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ( $crate :: S ) ;
+PRINT-DERIVE RE-COLLECTED (DISPLAY): struct D ($crate :: S) ;
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",


### PR DESCRIPTION
The commit "Do not convert attributes into `MetaItem`s for printing" fixes https://github.com/rust-lang/rust/issues/62628.

Other commits fix regressions from abandoning `MetaItem`s, and make formatting for attributes, macro calls, macro definitions and other delimited token groups better and more consistent.

r? @Mark-Simulacrum 