### PR TITLE
Suggest assoc type on type not found in trait method definition

### DIFF
--- a/src/test/ui/suggestions/assoc-type-in-method-return.rs
+++ b/src/test/ui/suggestions/assoc-type-in-method-return.rs
@@ -1,0 +1,7 @@
+trait A {
+    type Bla;
+    fn to_bla(&self) -> Bla;
+    //~^ ERROR cannot find type `Bla` in this scope
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/assoc-type-in-method-return.stderr
+++ b/src/test/ui/suggestions/assoc-type-in-method-return.stderr
@@ -1,0 +1,9 @@
+error[E0412]: cannot find type `Bla` in this scope
+  --> $DIR/assoc-type-in-method-return.rs:3:25
+   |
+LL |     fn to_bla(&self) -> Bla;
+   |                         ^^^ help: try: `Self::Bla`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Given

```
trait A {
    type Bla;
    fn to_bla(&self) -> Bla;
}
```
suggest using `Self::Bla`:

```
error[E0412]: cannot find type `Bla` in this scope
  --> file.rs:3:25
   |
LL |     fn to_bla(&self) -> Bla;
   |                         ^^^ help: try: `Self::Bla`
```

Fix #62650.