### PR TITLE
Deprecate `try!` macro

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -300,6 +300,7 @@ macro_rules! debug_assert_ne {
 ///     Ok(())
 /// }
 /// ```
+#[rustc_deprecated(since = "1.38.0", reason = "use the `?` operator instead")]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(alias = "?")]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -300,9 +300,9 @@ macro_rules! debug_assert_ne {
 ///     Ok(())
 /// }
 /// ```
-#[rustc_deprecated(since = "1.38.0", reason = "use the `?` operator instead")]
 #[macro_export]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[rustc_deprecated(since = "1.39.0", reason = "use the `?` operator instead")]
 #[doc(alias = "?")]
 macro_rules! r#try {
     ($expr:expr) => (match $expr {

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -330,7 +330,10 @@ use prelude::v1::*;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::{assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne};
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use core::{unreachable, unimplemented, write, writeln, r#try, todo};
+pub use core::{unreachable, unimplemented, write, writeln, todo};
+#[allow(deprecated)]
+#[stable(feature = "rust1", since = "1.0.0")]
+pub use core::r#try;
 
 #[allow(unused_imports)] // macros from `alloc` are not used on all platforms
 #[macro_use]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -331,7 +331,8 @@ use prelude::v1::*;
 pub use core::{assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::{unreachable, unimplemented, write, writeln, todo};
-#[allow(deprecated)]
+// FIXME: change this to `#[allow(deprecated)]` when we update nightly compiler.
+#[allow(deprecated_in_future)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::r#try;
 

--- a/src/test/ui/associated-types/cache/chrono-scan.rs
+++ b/src/test/ui/associated-types/cache/chrono-scan.rs
@@ -18,7 +18,7 @@ pub fn timezone_offset_zulu<F>(s: &str, colon: F) -> ParseResult<(&str, i32)>
 pub fn parse<'a, I>(mut s: &str, items: I) -> ParseResult<()>
         where I: Iterator<Item=Item<'a>> {
     macro_rules! try_consume {
-        ($e:expr) => ({ let (s_, v) = try!($e); s = s_; v })
+        ($e:expr) => ({ let (s_, v) = $e?; s = s_; v })
     }
     let offset = try_consume!(timezone_offset_zulu(s.trim_start(), colon_or_space));
     let offset = try_consume!(timezone_offset_zulu(s.trim_start(), colon_or_space));

--- a/src/test/ui/associated-types/cache/chrono-scan.rs
+++ b/src/test/ui/associated-types/cache/chrono-scan.rs
@@ -1,5 +1,7 @@
 // check-pass
 
+#![allow(deprecated)]
+
 pub type ParseResult<T> = Result<T, ()>;
 
 pub enum Item<'a> {
@@ -18,7 +20,7 @@ pub fn timezone_offset_zulu<F>(s: &str, colon: F) -> ParseResult<(&str, i32)>
 pub fn parse<'a, I>(mut s: &str, items: I) -> ParseResult<()>
         where I: Iterator<Item=Item<'a>> {
     macro_rules! try_consume {
-        ($e:expr) => ({ let (s_, v) = $e?; s = s_; v })
+        ($e:expr) => ({ let (s_, v) = try!($e); s = s_; v })
     }
     let offset = try_consume!(timezone_offset_zulu(s.trim_start(), colon_or_space));
     let offset = try_consume!(timezone_offset_zulu(s.trim_start(), colon_or_space));

--- a/src/test/ui/derived-errors/issue-31997.rs
+++ b/src/test/ui/derived-errors/issue-31997.rs
@@ -1,5 +1,6 @@
 // Test that the resolve failure does not lead to downstream type errors.
 // See issue #31997.
+#![allow(deprecated)]
 
 trait TheTrait { }
 
@@ -10,7 +11,7 @@ fn closure<F, T>(x: F) -> Result<T, ()>
 }
 
 fn foo() -> Result<(), ()> {
-    closure(|| bar(core::ptr::null_mut()))?; //~ ERROR cannot find function `bar` in this scope
+    try!(closure(|| bar(core::ptr::null_mut()))); //~ ERROR cannot find function `bar` in this scope
     Ok(())
 }
 

--- a/src/test/ui/derived-errors/issue-31997.rs
+++ b/src/test/ui/derived-errors/issue-31997.rs
@@ -10,7 +10,7 @@ fn closure<F, T>(x: F) -> Result<T, ()>
 }
 
 fn foo() -> Result<(), ()> {
-    try!(closure(|| bar(core::ptr::null_mut()))); //~ ERROR cannot find function `bar` in this scope
+    closure(|| bar(core::ptr::null_mut()))?; //~ ERROR cannot find function `bar` in this scope
     Ok(())
 }
 

--- a/src/test/ui/derived-errors/issue-31997.stderr
+++ b/src/test/ui/derived-errors/issue-31997.stderr
@@ -1,8 +1,8 @@
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/issue-31997.rs:13:21
+  --> $DIR/issue-31997.rs:13:16
    |
-LL |     try!(closure(|| bar(core::ptr::null_mut())));
-   |                     ^^^ not found in this scope
+LL |     closure(|| bar(core::ptr::null_mut()))?;
+   |                ^^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/src/test/ui/derived-errors/issue-31997.stderr
+++ b/src/test/ui/derived-errors/issue-31997.stderr
@@ -1,8 +1,8 @@
 error[E0425]: cannot find function `bar` in this scope
-  --> $DIR/issue-31997.rs:13:16
+  --> $DIR/issue-31997.rs:14:21
    |
-LL |     closure(|| bar(core::ptr::null_mut()))?;
-   |                ^^^ not found in this scope
+LL |     try!(closure(|| bar(core::ptr::null_mut())));
+   |                     ^^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-qualification.rs
+++ b/src/test/ui/lint/lint-qualification.rs
@@ -9,7 +9,7 @@ fn main() {
     foo::bar(); //~ ERROR: unnecessary qualification
     bar();
 
-    let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
+    let _ = || -> Result<(), ()> { Ok(())?; Ok(()) }; // issue #37345
 
     macro_rules! m { () => {
         $crate::foo::bar(); // issue #37357

--- a/src/test/ui/lint/lint-qualification.rs
+++ b/src/test/ui/lint/lint-qualification.rs
@@ -1,4 +1,5 @@
 #![deny(unused_qualifications)]
+#[allow(deprecated)]
 
 mod foo {
     pub fn bar() {}
@@ -9,7 +10,7 @@ fn main() {
     foo::bar(); //~ ERROR: unnecessary qualification
     bar();
 
-    let _ = || -> Result<(), ()> { Ok(())?; Ok(()) }; // issue #37345
+    let _ = || -> Result<(), ()> { try!(Ok(())); Ok(()) }; // issue #37345
 
     macro_rules! m { () => {
         $crate::foo::bar(); // issue #37357

--- a/src/test/ui/lint/lint-qualification.stderr
+++ b/src/test/ui/lint/lint-qualification.stderr
@@ -1,5 +1,5 @@
 error: unnecessary qualification
-  --> $DIR/lint-qualification.rs:9:5
+  --> $DIR/lint-qualification.rs:10:5
    |
 LL |     foo::bar();
    |     ^^^^^^^^

--- a/src/test/ui/macros/macro-comma-support-rpass.rs
+++ b/src/test/ui/macros/macro-comma-support-rpass.rs
@@ -261,7 +261,9 @@ fn thread_local() {
 #[test]
 fn try() {
     fn inner() -> Result<(), ()> {
+        #[allow(deprecated)]
         try!(Ok(()));
+        #[allow(deprecated)]
         try!(Ok(()),);
         Ok(())
     }

--- a/src/test/ui/macros/macro-comma-support-rpass.rs
+++ b/src/test/ui/macros/macro-comma-support-rpass.rs
@@ -15,6 +15,7 @@
 
 #![cfg_attr(core, no_std)]
 
+#![allow(deprecated)] // for deprecated `try!()` macro
 #![feature(concat_idents)]
 
 #[cfg(std)] use std::fmt;
@@ -261,9 +262,7 @@ fn thread_local() {
 #[test]
 fn try() {
     fn inner() -> Result<(), ()> {
-        #[allow(deprecated)]
         try!(Ok(()));
-        #[allow(deprecated)]
         try!(Ok(()),);
         Ok(())
     }

--- a/src/test/ui/macros/try-macro.rs
+++ b/src/test/ui/macros/try-macro.rs
@@ -1,5 +1,5 @@
 // run-pass
-#[allow(deprecated)]
+#![allow(deprecated)] // for deprecated `try!()` macro
 use std::num::{ParseFloatError, ParseIntError};
 
 fn main() {

--- a/src/test/ui/macros/try-macro.rs
+++ b/src/test/ui/macros/try-macro.rs
@@ -1,4 +1,5 @@
 // run-pass
+#[allow(deprecated)]
 use std::num::{ParseFloatError, ParseIntError};
 
 fn main() {

--- a/src/test/ui/rust-2018/try-macro.fixed
+++ b/src/test/ui/rust-2018/try-macro.fixed
@@ -6,6 +6,7 @@
 #![warn(rust_2018_compatibility)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 
 fn foo() -> Result<usize, ()> {
     let x: Result<usize, ()> = Ok(22);

--- a/src/test/ui/rust-2018/try-macro.rs
+++ b/src/test/ui/rust-2018/try-macro.rs
@@ -6,6 +6,7 @@
 #![warn(rust_2018_compatibility)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
+#![allow(deprecated)]
 
 fn foo() -> Result<usize, ()> {
     let x: Result<usize, ()> = Ok(22);

--- a/src/test/ui/rust-2018/try-macro.stderr
+++ b/src/test/ui/rust-2018/try-macro.stderr
@@ -1,5 +1,5 @@
 warning: `try` is a keyword in the 2018 edition
-  --> $DIR/try-macro.rs:12:5
+  --> $DIR/try-macro.rs:13:5
    |
 LL |     try!(x);
    |     ^^^ help: you can use a raw identifier to stay compatible: `r#try`


### PR DESCRIPTION
Replaces #62077

Fixes rust-lang/rust-clippy#1361
Fixes #61000