### PR TITLE
Add an `after_expansion` callback in the driver

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -105,17 +105,20 @@ pub fn abort_on_err<T>(result: Result<T, ErrorReported>, sess: &Session) -> T {
 pub trait Callbacks {
     /// Called before creating the compiler instance
     fn config(&mut self, _config: &mut interface::Config) {}
-    /// Called after parsing and returns true to continue execution
-    fn after_parsing(&mut self, _compiler: &interface::Compiler) -> bool {
-        true
+    /// Called after parsing. Return value instructs the compiler whether to
+    /// continue the compilation afterwards (defaults to `Compilation::Continue`)
+    fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {
+        Compilation::Continue
     }
-    /// Called after expansion and returns true to continue execution
-    fn after_expansion(&mut self, _compiler: &interface::Compiler) -> bool {
-        true
+    /// Called after expansion. Return value instructs the compiler whether to
+    /// continue the compilation afterwards (defaults to `Compilation::Continue`)
+    fn after_expansion(&mut self, _compiler: &interface::Compiler) -> Compilation {
+        Compilation::Continue
     }
-    /// Called after analysis and returns true to continue execution
-    fn after_analysis(&mut self, _compiler: &interface::Compiler) -> bool {
-        true
+    /// Called after analysis. Return value instructs the compiler whether to
+    /// continue the compilation afterwards (defaults to `Compilation::Continue`)
+    fn after_analysis(&mut self, _compiler: &interface::Compiler) -> Compilation {
+        Compilation::Continue
     }
 }
 
@@ -298,7 +301,7 @@ pub fn run_compiler(
             }
         }
 
-        if !callbacks.after_parsing(compiler) {
+        if callbacks.after_parsing(compiler) == Compilation::Stop {
             return sess.compile_status();
         }
 
@@ -317,7 +320,7 @@ pub fn run_compiler(
         }
 
         compiler.expansion()?;
-        if !callbacks.after_expansion(compiler) {
+        if callbacks.after_expansion(compiler) == Compilation::Stop {
             return sess.compile_status();
         }
 
@@ -364,7 +367,7 @@ pub fn run_compiler(
 
         compiler.global_ctxt()?.peek_mut().enter(|tcx| tcx.analysis(LOCAL_CRATE))?;
 
-        if !callbacks.after_analysis(compiler) {
+        if callbacks.after_analysis(compiler) == Compilation::Stop {
             return sess.compile_status();
         }
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -109,6 +109,10 @@ pub trait Callbacks {
     fn after_parsing(&mut self, _compiler: &interface::Compiler) -> bool {
         true
     }
+    /// Called after expansion and returns true to continue execution
+    fn after_expansion(&mut self, _compiler: &interface::Compiler) -> bool {
+        true
+    }
     /// Called after analysis and returns true to continue execution
     fn after_analysis(&mut self, _compiler: &interface::Compiler) -> bool {
         true
@@ -309,6 +313,11 @@ pub fn run_compiler(
         // Lint plugins are registered; now we can process command line flags.
         if sess.opts.describe_lints {
             describe_lints(&sess, &sess.lint_store.borrow(), true);
+            return sess.compile_status();
+        }
+
+        compiler.expansion()?;
+        if !callbacks.after_expansion(compiler) {
             return sess.compile_status();
         }
 


### PR DESCRIPTION
To format a given file RLS needs to know the Rust edition associated with it. It's not enough to look at the `edition` key in Cargo.toml - each crate target can have a different edition associated with it so the sure way to fetch a correct edition is to scan the input files used to compile a given crate target.

Right now this was done in the `after_analysis` callback of our shim, however this leads to other problems - if a crate cannot be successfully compiled (e.g. it has a type error) then a callback would not be invoked meaning we can't populate the files -> edition mapping.

However, doing this only after parsing is not enough, since expansion can pull in additional source files (e.g. by invoking `macro_rules! include_my_mod { () => { mod some_mod; }; }`).

Without copy-pasting the entire driver setup it's also not possible to expand the crate ourselves in the `after_parsing` callback - to expand crate we'd need to register plugins and initialize session ourselves. However, this is done normally after executing the callback itself, thus triggering the `Once::set` assertions in `Session::init_features`.

r? @Zoxc 

cc @RalfJung @oli-obk this affects public driver interface used by Miri and Clippy