### PR TITLE
Actually call `visit_block_entry` in `DataflowResultsConsumer`

### DIFF
--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -333,6 +333,8 @@ pub(crate) trait DataflowResultsConsumer<'a, 'tcx: 'a> {
     }
 
     fn process_basic_block(&mut self, bb: BasicBlock, flow_state: &mut Self::FlowState) {
+        self.visit_block_entry(bb, flow_state);
+
         let BasicBlockData { ref statements, ref terminator, is_cleanup: _ } =
             self.body()[bb];
         let mut location = Location { block: bb, statement_index: 0 };


### PR DESCRIPTION
This fixes a trivial bug in `DataflowResultsConsumer`: `visit_block_entry` is never called when visiting dataflow results.

A previous version of #62547 used this API and included this fix, but it has since switched to `DataflowResultsCursor` making this commit irrelevant.