### PR TITLE
resolve: Improve candidate search for unresolved macro suggestions

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -398,4 +398,12 @@ impl<Id> Res<Id> {
             Res::Err => Res::Err,
         }
     }
+
+    pub fn macro_kind(self) -> Option<MacroKind> {
+        match self {
+            Res::Def(DefKind::Macro(kind), _) => Some(kind),
+            Res::NonMacroAttr(..) => Some(MacroKind::Attr),
+            _ => None,
+        }
+    }
 }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -3,11 +3,11 @@
 //! Here we build the "reduced graph": the graph of the module tree without
 //! any imports resolved.
 
-use crate::macros::{InvocationData, ParentScope, LegacyScope};
+use crate::macros::{InvocationData, LegacyScope};
 use crate::resolve_imports::ImportDirective;
 use crate::resolve_imports::ImportDirectiveSubclass::{self, GlobImport, SingleImport};
 use crate::{Module, ModuleData, ModuleKind, NameBinding, NameBindingKind, Segment, ToNameBinding};
-use crate::{ModuleOrUniformRoot, PerNS, Resolver, ResolverArenas, ExternPreludeEntry};
+use crate::{ModuleOrUniformRoot, ParentScope, PerNS, Resolver, ResolverArenas, ExternPreludeEntry};
 use crate::Namespace::{self, TypeNS, ValueNS, MacroNS};
 use crate::{resolve_error, resolve_struct_error, ResolutionError, Determinacy};
 

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -574,7 +574,7 @@ impl<'a> Resolver<'a> {
                         for derive in &parent_scope.derives {
                             let parent_scope = ParentScope { derives: Vec::new(), ..*parent_scope };
                             if let Ok((Some(ext), _)) = this.resolve_macro_path(
-                                derive, MacroKind::Derive, &parent_scope, false, false
+                                derive, Some(MacroKind::Derive), &parent_scope, false, false
                             ) {
                                 suggestions.extend(ext.helper_attrs.iter().map(|name| {
                                     TypoSuggestion::from_res(*name, res)

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -414,7 +414,7 @@ impl<'a> Resolver<'a> {
         };
 
         match (res, source) {
-            (Res::Def(DefKind::Macro(..), _), _) => {
+            (Res::Def(DefKind::Macro(MacroKind::Bang), _), _) => {
                 err.span_suggestion(
                     span,
                     "use `!` to invoke the macro",
@@ -574,7 +574,7 @@ impl<'a> Resolver<'a> {
                         for derive in &parent_scope.derives {
                             let parent_scope = ParentScope { derives: Vec::new(), ..*parent_scope };
                             if let Ok((Some(ext), _)) = this.resolve_macro_path(
-                                derive, MacroKind::Derive, &parent_scope, true, true
+                                derive, MacroKind::Derive, &parent_scope, false, false
                             ) {
                                 suggestions.extend(ext.helper_attrs.iter().map(|name| {
                                     TypoSuggestion::from_res(*name, res)

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -16,11 +16,10 @@ use syntax::symbol::{Symbol, kw};
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax_pos::{BytePos, Span};
 
-use crate::macros::ParentScope;
 use crate::resolve_imports::{ImportDirective, ImportDirectiveSubclass, ImportResolver};
 use crate::{is_self_type, is_self_value, path_names_to_string};
 use crate::{CrateLint, Module, ModuleKind, ModuleOrUniformRoot};
-use crate::{PathResult, PathSource, Resolver, RibKind, Segment};
+use crate::{PathResult, PathSource, ParentScope, Resolver, RibKind, Segment};
 
 type Res = def::Res<ast::NodeId>;
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -31,7 +31,7 @@ use rustc::hir::def::{
 use rustc::hir::def::Namespace::*;
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
 use rustc::hir::{TraitCandidate, TraitMap, GlobMap};
-use rustc::ty::{self, DefIdTree};
+use rustc::ty;
 use rustc::util::nodemap::{NodeMap, NodeSet, FxHashMap, FxHashSet, DefIdMap};
 use rustc::{bug, span_bug};
 
@@ -69,6 +69,7 @@ use rustc_data_structures::ptr_key::PtrKey;
 use rustc_data_structures::sync::Lrc;
 use smallvec::SmallVec;
 
+use diagnostics::{Suggestion, ImportSuggestion};
 use diagnostics::{find_span_of_binding_until_next_binding, extend_span_to_previous_binding};
 use resolve_imports::{ImportDirective, ImportDirectiveSubclass, NameResolution, ImportResolver};
 use macros::{InvocationData, LegacyBinding, ParentScope};
@@ -112,34 +113,11 @@ enum ScopeSet {
     Module,
 }
 
-/// A free importable items suggested in case of resolution failure.
-struct ImportSuggestion {
-    did: Option<DefId>,
-    path: Path,
-}
-
-/// A field or associated item from self type suggested in case of resolution failure.
-enum AssocSuggestion {
-    Field,
-    MethodWithSelf,
-    AssocItem,
-}
-
 #[derive(Eq)]
 struct BindingError {
     name: Name,
     origin: BTreeSet<Span>,
     target: BTreeSet<Span>,
-}
-
-struct TypoSuggestion {
-    candidate: Symbol,
-
-    /// The kind of the binding ("crate", "module", etc.)
-    kind: &'static str,
-
-    /// An appropriate article to refer to the binding ("a", "an", etc.)
-    article: &'static str,
 }
 
 impl PartialOrd for BindingError {
@@ -159,9 +137,6 @@ impl Ord for BindingError {
         self.name.cmp(&other.name)
     }
 }
-
-/// A vector of spans and replacements, a message and applicability.
-type Suggestion = (Vec<(Span, String)>, String, Applicability);
 
 enum ResolutionError<'a> {
     /// Error E0401: can't use type or const parameters from outer function.
@@ -4124,195 +4099,6 @@ impl<'a> Resolver<'a> {
         res
     }
 
-    fn lookup_assoc_candidate<FilterFn: Fn(Res) -> bool>(
-        &mut self,
-        ident: Ident,
-        ns: Namespace,
-        filter_fn: FilterFn,
-    ) -> Option<AssocSuggestion> {
-        fn extract_node_id(t: &Ty) -> Option<NodeId> {
-            match t.node {
-                TyKind::Path(None, _) => Some(t.id),
-                TyKind::Rptr(_, ref mut_ty) => extract_node_id(&mut_ty.ty),
-                // This doesn't handle the remaining `Ty` variants as they are not
-                // that commonly the self_type, it might be interesting to provide
-                // support for those in future.
-                _ => None,
-            }
-        }
-
-        // Fields are generally expected in the same contexts as locals.
-        if filter_fn(Res::Local(ast::DUMMY_NODE_ID)) {
-            if let Some(node_id) = self.current_self_type.as_ref().and_then(extract_node_id) {
-                // Look for a field with the same name in the current self_type.
-                if let Some(resolution) = self.partial_res_map.get(&node_id) {
-                    match resolution.base_res() {
-                        Res::Def(DefKind::Struct, did) | Res::Def(DefKind::Union, did)
-                                if resolution.unresolved_segments() == 0 => {
-                            if let Some(field_names) = self.field_names.get(&did) {
-                                if field_names.iter().any(|&field_name| ident.name == field_name) {
-                                    return Some(AssocSuggestion::Field);
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
-
-        for assoc_type_ident in &self.current_trait_assoc_types {
-            if *assoc_type_ident == ident {
-                return Some(AssocSuggestion::AssocItem);
-            }
-        }
-
-        // Look for associated items in the current trait.
-        if let Some((module, _)) = self.current_trait_ref {
-            if let Ok(binding) = self.resolve_ident_in_module(
-                    ModuleOrUniformRoot::Module(module),
-                    ident,
-                    ns,
-                    None,
-                    false,
-                    module.span,
-                ) {
-                let res = binding.res();
-                if filter_fn(res) {
-                    debug!("extract_node_id res not filtered");
-                    return Some(if self.has_self.contains(&res.def_id()) {
-                        AssocSuggestion::MethodWithSelf
-                    } else {
-                        AssocSuggestion::AssocItem
-                    });
-                }
-            }
-        }
-
-        None
-    }
-
-    fn lookup_typo_candidate<FilterFn>(
-        &mut self,
-        path: &[Segment],
-        ns: Namespace,
-        filter_fn: FilterFn,
-        span: Span,
-    ) -> Option<TypoSuggestion>
-    where
-        FilterFn: Fn(Res) -> bool,
-    {
-        let add_module_candidates = |module: Module<'_>, names: &mut Vec<TypoSuggestion>| {
-            for (&(ident, _), resolution) in module.resolutions.borrow().iter() {
-                if let Some(binding) = resolution.borrow().binding {
-                    if filter_fn(binding.res()) {
-                        names.push(TypoSuggestion {
-                            candidate: ident.name,
-                            article: binding.res().article(),
-                            kind: binding.res().descr(),
-                        });
-                    }
-                }
-            }
-        };
-
-        let mut names = Vec::new();
-        if path.len() == 1 {
-            // Search in lexical scope.
-            // Walk backwards up the ribs in scope and collect candidates.
-            for rib in self.ribs[ns].iter().rev() {
-                // Locals and type parameters
-                for (ident, &res) in &rib.bindings {
-                    if filter_fn(res) {
-                        names.push(TypoSuggestion {
-                            candidate: ident.name,
-                            article: res.article(),
-                            kind: res.descr(),
-                        });
-                    }
-                }
-                // Items in scope
-                if let ModuleRibKind(module) = rib.kind {
-                    // Items from this module
-                    add_module_candidates(module, &mut names);
-
-                    if let ModuleKind::Block(..) = module.kind {
-                        // We can see through blocks
-                    } else {
-                        // Items from the prelude
-                        if !module.no_implicit_prelude {
-                            names.extend(self.extern_prelude.clone().iter().flat_map(|(ident, _)| {
-                                self.crate_loader
-                                    .maybe_process_path_extern(ident.name, ident.span)
-                                    .and_then(|crate_id| {
-                                        let crate_mod = Res::Def(
-                                            DefKind::Mod,
-                                            DefId {
-                                                krate: crate_id,
-                                                index: CRATE_DEF_INDEX,
-                                            },
-                                        );
-
-                                        if filter_fn(crate_mod) {
-                                            Some(TypoSuggestion {
-                                                candidate: ident.name,
-                                                article: "a",
-                                                kind: "crate",
-                                            })
-                                        } else {
-                                            None
-                                        }
-                                    })
-                            }));
-
-                            if let Some(prelude) = self.prelude {
-                                add_module_candidates(prelude, &mut names);
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-            // Add primitive types to the mix
-            if filter_fn(Res::PrimTy(Bool)) {
-                names.extend(
-                    self.primitive_type_table.primitive_types.iter().map(|(name, _)| {
-                        TypoSuggestion {
-                            candidate: *name,
-                            article: "a",
-                            kind: "primitive type",
-                        }
-                    })
-                )
-            }
-        } else {
-            // Search in module.
-            let mod_path = &path[..path.len() - 1];
-            if let PathResult::Module(module) = self.resolve_path_without_parent_scope(
-                mod_path, Some(TypeNS), false, span, CrateLint::No
-            ) {
-                if let ModuleOrUniformRoot::Module(module) = module {
-                    add_module_candidates(module, &mut names);
-                }
-            }
-        }
-
-        let name = path[path.len() - 1].ident.name;
-        // Make sure error reporting is deterministic.
-        names.sort_by_cached_key(|suggestion| suggestion.candidate.as_str());
-
-        match find_best_match_for_name(
-            names.iter().map(|suggestion| &suggestion.candidate),
-            &name.as_str(),
-            None,
-        ) {
-            Some(found) if found != name => names
-                .into_iter()
-                .find(|suggestion| suggestion.candidate == found),
-            _ => None,
-        }
-    }
-
     fn with_resolved_label<F>(&mut self, label: Option<Label>, id: NodeId, f: F)
         where F: FnOnce(&mut Resolver<'_>)
     {
@@ -4606,193 +4392,6 @@ impl<'a> Resolver<'a> {
         import_ids
     }
 
-    fn lookup_import_candidates_from_module<FilterFn>(&mut self,
-                                          lookup_ident: Ident,
-                                          namespace: Namespace,
-                                          start_module: &'a ModuleData<'a>,
-                                          crate_name: Ident,
-                                          filter_fn: FilterFn)
-                                          -> Vec<ImportSuggestion>
-        where FilterFn: Fn(Res) -> bool
-    {
-        let mut candidates = Vec::new();
-        let mut seen_modules = FxHashSet::default();
-        let not_local_module = crate_name.name != kw::Crate;
-        let mut worklist = vec![(start_module, Vec::<ast::PathSegment>::new(), not_local_module)];
-
-        while let Some((in_module,
-                        path_segments,
-                        in_module_is_extern)) = worklist.pop() {
-            self.populate_module_if_necessary(in_module);
-
-            // We have to visit module children in deterministic order to avoid
-            // instabilities in reported imports (#43552).
-            in_module.for_each_child_stable(|ident, ns, name_binding| {
-                // avoid imports entirely
-                if name_binding.is_import() && !name_binding.is_extern_crate() { return; }
-                // avoid non-importable candidates as well
-                if !name_binding.is_importable() { return; }
-
-                // collect results based on the filter function
-                if ident.name == lookup_ident.name && ns == namespace {
-                    let res = name_binding.res();
-                    if filter_fn(res) {
-                        // create the path
-                        let mut segms = path_segments.clone();
-                        if lookup_ident.span.rust_2018() {
-                            // crate-local absolute paths start with `crate::` in edition 2018
-                            // FIXME: may also be stabilized for Rust 2015 (Issues #45477, #44660)
-                            segms.insert(
-                                0, ast::PathSegment::from_ident(crate_name)
-                            );
-                        }
-
-                        segms.push(ast::PathSegment::from_ident(ident));
-                        let path = Path {
-                            span: name_binding.span,
-                            segments: segms,
-                        };
-                        // the entity is accessible in the following cases:
-                        // 1. if it's defined in the same crate, it's always
-                        // accessible (since private entities can be made public)
-                        // 2. if it's defined in another crate, it's accessible
-                        // only if both the module is public and the entity is
-                        // declared as public (due to pruning, we don't explore
-                        // outside crate private modules => no need to check this)
-                        if !in_module_is_extern || name_binding.vis == ty::Visibility::Public {
-                            let did = match res {
-                                Res::Def(DefKind::Ctor(..), did) => self.parent(did),
-                                _ => res.opt_def_id(),
-                            };
-                            candidates.push(ImportSuggestion { did, path });
-                        }
-                    }
-                }
-
-                // collect submodules to explore
-                if let Some(module) = name_binding.module() {
-                    // form the path
-                    let mut path_segments = path_segments.clone();
-                    path_segments.push(ast::PathSegment::from_ident(ident));
-
-                    let is_extern_crate_that_also_appears_in_prelude =
-                        name_binding.is_extern_crate() &&
-                        lookup_ident.span.rust_2018();
-
-                    let is_visible_to_user =
-                        !in_module_is_extern || name_binding.vis == ty::Visibility::Public;
-
-                    if !is_extern_crate_that_also_appears_in_prelude && is_visible_to_user {
-                        // add the module to the lookup
-                        let is_extern = in_module_is_extern || name_binding.is_extern_crate();
-                        if seen_modules.insert(module.def_id().unwrap()) {
-                            worklist.push((module, path_segments, is_extern));
-                        }
-                    }
-                }
-            })
-        }
-
-        candidates
-    }
-
-    /// When name resolution fails, this method can be used to look up candidate
-    /// entities with the expected name. It allows filtering them using the
-    /// supplied predicate (which should be used to only accept the types of
-    /// definitions expected, e.g., traits). The lookup spans across all crates.
-    ///
-    /// N.B., the method does not look into imports, but this is not a problem,
-    /// since we report the definitions (thus, the de-aliased imports).
-    fn lookup_import_candidates<FilterFn>(&mut self,
-                                          lookup_ident: Ident,
-                                          namespace: Namespace,
-                                          filter_fn: FilterFn)
-                                          -> Vec<ImportSuggestion>
-        where FilterFn: Fn(Res) -> bool
-    {
-        let mut suggestions = self.lookup_import_candidates_from_module(
-            lookup_ident, namespace, self.graph_root, Ident::with_empty_ctxt(kw::Crate), &filter_fn
-        );
-
-        if lookup_ident.span.rust_2018() {
-            let extern_prelude_names = self.extern_prelude.clone();
-            for (ident, _) in extern_prelude_names.into_iter() {
-                if let Some(crate_id) = self.crate_loader.maybe_process_path_extern(ident.name,
-                                                                                    ident.span) {
-                    let crate_root = self.get_module(DefId {
-                        krate: crate_id,
-                        index: CRATE_DEF_INDEX,
-                    });
-                    self.populate_module_if_necessary(&crate_root);
-
-                    suggestions.extend(self.lookup_import_candidates_from_module(
-                        lookup_ident, namespace, crate_root, ident, &filter_fn));
-                }
-            }
-        }
-
-        suggestions
-    }
-
-    fn find_module(&mut self, def_id: DefId) -> Option<(Module<'a>, ImportSuggestion)> {
-        let mut result = None;
-        let mut seen_modules = FxHashSet::default();
-        let mut worklist = vec![(self.graph_root, Vec::new())];
-
-        while let Some((in_module, path_segments)) = worklist.pop() {
-            // abort if the module is already found
-            if result.is_some() { break; }
-
-            self.populate_module_if_necessary(in_module);
-
-            in_module.for_each_child_stable(|ident, _, name_binding| {
-                // abort if the module is already found or if name_binding is private external
-                if result.is_some() || !name_binding.vis.is_visible_locally() {
-                    return
-                }
-                if let Some(module) = name_binding.module() {
-                    // form the path
-                    let mut path_segments = path_segments.clone();
-                    path_segments.push(ast::PathSegment::from_ident(ident));
-                    let module_def_id = module.def_id().unwrap();
-                    if module_def_id == def_id {
-                        let path = Path {
-                            span: name_binding.span,
-                            segments: path_segments,
-                        };
-                        result = Some((module, ImportSuggestion { did: Some(def_id), path }));
-                    } else {
-                        // add the module to the lookup
-                        if seen_modules.insert(module_def_id) {
-                            worklist.push((module, path_segments));
-                        }
-                    }
-                }
-            });
-        }
-
-        result
-    }
-
-    fn collect_enum_variants(&mut self, def_id: DefId) -> Option<Vec<Path>> {
-        self.find_module(def_id).map(|(enum_module, enum_import_suggestion)| {
-            self.populate_module_if_necessary(enum_module);
-
-            let mut variants = Vec::new();
-            enum_module.for_each_child_stable(|ident, _, name_binding| {
-                if let Res::Def(DefKind::Variant, _) = name_binding.res() {
-                    let mut segms = enum_import_suggestion.path.segments.clone();
-                    segms.push(ast::PathSegment::from_ident(ident));
-                    variants.push(Path {
-                        span: name_binding.span,
-                        segments: segms,
-                    });
-                }
-            });
-            variants
-        })
-    }
-
     fn record_partial_res(&mut self, node_id: NodeId, resolution: PartialRes) {
         debug!("(recording res) recording {:?} for {}", resolution, node_id);
         if let Some(prev_res) = self.partial_res_map.insert(node_id, resolution) {
@@ -5010,7 +4609,7 @@ impl<'a> Resolver<'a> {
         for UseError { mut err, candidates, node_id, better } in self.use_injections.drain(..) {
             let (span, found_use) = UsePlacementFinder::check(krate, node_id);
             if !candidates.is_empty() {
-                show_candidates(&mut err, span, &candidates, better, found_use);
+                diagnostics::show_candidates(&mut err, span, &candidates, better, found_use);
             }
             err.emit();
         }
@@ -5324,72 +4923,6 @@ fn path_names_to_string(path: &Path) -> String {
     names_to_string(&path.segments.iter()
                         .map(|seg| seg.ident)
                         .collect::<Vec<_>>())
-}
-
-/// Gets the stringified path for an enum from an `ImportSuggestion` for an enum variant.
-fn import_candidate_to_enum_paths(suggestion: &ImportSuggestion) -> (String, String) {
-    let variant_path = &suggestion.path;
-    let variant_path_string = path_names_to_string(variant_path);
-
-    let path_len = suggestion.path.segments.len();
-    let enum_path = ast::Path {
-        span: suggestion.path.span,
-        segments: suggestion.path.segments[0..path_len - 1].to_vec(),
-    };
-    let enum_path_string = path_names_to_string(&enum_path);
-
-    (variant_path_string, enum_path_string)
-}
-
-/// When an entity with a given name is not available in scope, we search for
-/// entities with that name in all crates. This method allows outputting the
-/// results of this search in a programmer-friendly way
-fn show_candidates(err: &mut DiagnosticBuilder<'_>,
-                   // This is `None` if all placement locations are inside expansions
-                   span: Option<Span>,
-                   candidates: &[ImportSuggestion],
-                   better: bool,
-                   found_use: bool) {
-
-    // we want consistent results across executions, but candidates are produced
-    // by iterating through a hash map, so make sure they are ordered:
-    let mut path_strings: Vec<_> =
-        candidates.into_iter().map(|c| path_names_to_string(&c.path)).collect();
-    path_strings.sort();
-
-    let better = if better { "better " } else { "" };
-    let msg_diff = match path_strings.len() {
-        1 => " is found in another module, you can import it",
-        _ => "s are found in other modules, you can import them",
-    };
-    let msg = format!("possible {}candidate{} into scope", better, msg_diff);
-
-    if let Some(span) = span {
-        for candidate in &mut path_strings {
-            // produce an additional newline to separate the new use statement
-            // from the directly following item.
-            let additional_newline = if found_use {
-                ""
-            } else {
-                "\n"
-            };
-            *candidate = format!("use {};\n{}", candidate, additional_newline);
-        }
-
-        err.span_suggestions(
-            span,
-            &msg,
-            path_strings.into_iter(),
-            Applicability::Unspecified,
-        );
-    } else {
-        let mut msg = msg;
-        msg.push(':');
-        for candidate in path_strings {
-            msg.push('\n');
-            msg.push_str(&candidate);
-        }
-    }
 }
 
 /// A somewhat inefficient routine to obtain the name of a module.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -85,9 +85,7 @@ mod check_unused;
 mod build_reduced_graph;
 mod resolve_imports;
 
-fn is_known_tool(name: Name) -> bool {
-    ["clippy", "rustfmt"].contains(&&*name.as_str())
-}
+const KNOWN_TOOLS: &[Name] = &[sym::clippy, sym::rustfmt];
 
 enum Weak {
     Yes,
@@ -1498,11 +1496,7 @@ impl<'a> NameBinding<'a> {
     }
 
     fn macro_kind(&self) -> Option<MacroKind> {
-        match self.res() {
-            Res::Def(DefKind::Macro(kind), _) => Some(kind),
-            Res::NonMacroAttr(..) => Some(MacroKind::Attr),
-            _ => None,
-        }
+        self.res().macro_kind()
     }
 
     fn descr(&self) -> &'static str {
@@ -2390,7 +2384,7 @@ impl<'a> Resolver<'a> {
                     return Some(LexicalScopeBinding::Item(binding));
                 }
             }
-            if ns == TypeNS && is_known_tool(ident.name) {
+            if ns == TypeNS && KNOWN_TOOLS.contains(&ident.name) {
                 let binding = (Res::ToolMod, ty::Visibility::Public,
                                DUMMY_SP, Mark::root()).to_name_binding(self.arenas);
                 return Some(LexicalScopeBinding::Item(binding));

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -3684,11 +3684,9 @@ impl<'a> Resolver<'a> {
             let path = Path { segments: path.iter().map(path_seg).collect(), span };
             let parent_scope =
                 ParentScope { module: self.current_module, ..self.dummy_parent_scope() };
-            for macro_kind in &[MacroKind::Bang, MacroKind::Attr, MacroKind::Derive] {
-                if let Ok((_, res)) = self.resolve_macro_path(&path, *macro_kind,
-                                                              &parent_scope, false, false) {
-                    return Some(PartialRes::new(res));
-                }
+            if let Ok((_, res)) =
+                    self.resolve_macro_path(&path, None, &parent_scope, false, false) {
+                return Some(PartialRes::new(res));
             }
         }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -312,23 +312,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
             }
-            Res::NonMacroAttr(attr_kind) => {
-                if attr_kind == NonMacroAttrKind::Custom {
-                    assert!(path.segments.len() == 1);
-                    if !features.custom_attribute {
-                        let msg = format!("The attribute `{}` is currently unknown to the \
-                                            compiler and may have meaning added to it in the \
-                                            future", path);
-                        self.report_unknown_attribute(
-                            path.span,
-                            &path.segments[0].ident.as_str(),
-                            &msg,
-                            sym::custom_attribute,
-                        );
-                    }
-                }
-            }
-            Res::Err => {}
+            Res::NonMacroAttr(..) | Res::Err => {}
             _ => panic!("expected `DefKind::Macro` or `Res::NonMacroAttr`"),
         };
 
@@ -721,7 +705,8 @@ impl<'a> Resolver<'a> {
         }
 
         let determinacy = Determinacy::determined(determinacy == Determinacy::Determined || force);
-        if determinacy == Determinacy::Determined && macro_kind == Some(MacroKind::Attr) {
+        if determinacy == Determinacy::Determined && macro_kind == Some(MacroKind::Attr) &&
+           self.session.features_untracked().custom_attribute {
             // For single-segment attributes interpret determinate "no resolution" as a custom
             // attribute. (Lexical resolution implies the first segment and attr kind should imply
             // the last segment, so we are certainly working with a single-segment attribute here.)

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -7,8 +7,9 @@ use crate::Namespace::{self, TypeNS, MacroNS};
 use crate::{NameBinding, NameBindingKind, ToNameBinding, PathResult, PrivacyError};
 use crate::{Resolver, Segment};
 use crate::{names_to_string, module_to_string};
-use crate::{resolve_error, ResolutionError, Suggestion};
+use crate::{resolve_error, ResolutionError};
 use crate::ModuleKind;
+use crate::diagnostics::Suggestion;
 use crate::macros::ParentScope;
 
 use errors::Applicability;

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -1,7 +1,7 @@
 use ImportDirectiveSubclass::*;
 
 use crate::{AmbiguityError, AmbiguityKind, AmbiguityErrorMisc};
-use crate::{CrateLint, Module, ModuleOrUniformRoot, PerNS, ScopeSet, Weak};
+use crate::{CrateLint, Module, ModuleOrUniformRoot, PerNS, ScopeSet, ParentScope, Weak};
 use crate::Determinacy::{self, *};
 use crate::Namespace::{self, TypeNS, MacroNS};
 use crate::{NameBinding, NameBindingKind, ToNameBinding, PathResult, PrivacyError};
@@ -10,7 +10,6 @@ use crate::{names_to_string, module_to_string};
 use crate::{resolve_error, ResolutionError};
 use crate::ModuleKind;
 use crate::diagnostics::Suggestion;
-use crate::macros::ParentScope;
 
 use errors::Applicability;
 

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -6,6 +6,7 @@ use rustc::lint as lint;
 use rustc::ty;
 use syntax;
 use syntax::ast::{self, Ident};
+use syntax::ext::base::SyntaxExtensionKind;
 use syntax::feature_gate::UnstableFeatures;
 use syntax::symbol::Symbol;
 use syntax_pos::DUMMY_SP;
@@ -425,12 +426,10 @@ impl<'a, 'tcx> DocFolder for LinkCollector<'a, 'tcx> {
 
 /// Resolves a string as a macro.
 fn macro_resolve(cx: &DocContext<'_>, path_str: &str) -> Option<Res> {
-    use syntax::ext::base::{MacroKind, SyntaxExtensionKind};
-    let segment = ast::PathSegment::from_ident(Ident::from_str(path_str));
-    let path = ast::Path { segments: vec![segment], span: DUMMY_SP };
+    let path = ast::Path::from_ident(Ident::from_str(path_str));
     cx.enter_resolver(|resolver| {
         if let Ok((Some(ext), res)) = resolver.resolve_macro_path(
-            &path, MacroKind::Bang, &resolver.dummy_parent_scope(), false, false
+            &path, None, &resolver.dummy_parent_scope(), false, false
         ) {
             if let SyntaxExtensionKind::LegacyBang { .. } = ext.kind {
                 return Some(res.map_id(|_| panic!("unexpected id")));

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -603,6 +603,7 @@ symbols! {
         rustc_then_this_would_need,
         rustc_variance,
         rustdoc,
+        rustfmt,
         rust_eh_personality,
         rust_eh_unwind_resume,
         rust_oom,

--- a/src/test/ui/attributes/obsolete-attr.rs
+++ b/src/test/ui/attributes/obsolete-attr.rs
@@ -1,7 +1,9 @@
 // Obsolete attributes fall back to feature gated custom attributes.
 
-#[ab_isize="stdcall"] extern {} //~ ERROR attribute `ab_isize` is currently unknown
+#[ab_isize="stdcall"] extern {}
+//~^ ERROR cannot find attribute macro `ab_isize` in this scope
 
-#[fixed_stack_segment] fn f() {} //~ ERROR attribute `fixed_stack_segment` is currently unknown
+#[fixed_stack_segment] fn f() {}
+//~^ ERROR cannot find attribute macro `fixed_stack_segment` in this scope
 
 fn main() {}

--- a/src/test/ui/attributes/obsolete-attr.stderr
+++ b/src/test/ui/attributes/obsolete-attr.stderr
@@ -1,21 +1,14 @@
-error[E0658]: The attribute `fixed_stack_segment` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/obsolete-attr.rs:5:3
+error: cannot find attribute macro `fixed_stack_segment` in this scope
+  --> $DIR/obsolete-attr.rs:6:3
    |
 LL | #[fixed_stack_segment] fn f() {}
    |   ^^^^^^^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `ab_isize` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `ab_isize` in this scope
   --> $DIR/obsolete-attr.rs:3:3
    |
 LL | #[ab_isize="stdcall"] extern {}
    |   ^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/attributes/unknown-attr.rs
+++ b/src/test/ui/attributes/unknown-attr.rs
@@ -2,8 +2,11 @@
 
 #![feature(custom_inner_attributes)]
 
-#![mutable_doc] //~ ERROR attribute `mutable_doc` is currently unknown
+#![mutable_doc]
+//~^ ERROR cannot find attribute macro `mutable_doc` in this scope
 
-#[dance] mod a {} //~ ERROR attribute `dance` is currently unknown
+#[dance] mod a {}
+//~^ ERROR cannot find attribute macro `dance` in this scope
 
-#[dance] fn main() {} //~ ERROR attribute `dance` is currently unknown
+#[dance] fn main() {}
+//~^ ERROR cannot find attribute macro `dance` in this scope

--- a/src/test/ui/attributes/unknown-attr.stderr
+++ b/src/test/ui/attributes/unknown-attr.stderr
@@ -1,30 +1,20 @@
-error[E0658]: The attribute `mutable_doc` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `mutable_doc` in this scope
   --> $DIR/unknown-attr.rs:5:4
    |
 LL | #![mutable_doc]
    |    ^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `dance` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/unknown-attr.rs:7:3
+error: cannot find attribute macro `dance` in this scope
+  --> $DIR/unknown-attr.rs:8:3
    |
 LL | #[dance] mod a {}
    |   ^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `dance` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/unknown-attr.rs:9:3
+error: cannot find attribute macro `dance` in this scope
+  --> $DIR/unknown-attr.rs:11:3
    |
 LL | #[dance] fn main() {}
    |   ^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.rs
@@ -1,6 +1,7 @@
 macro_rules! foo {
     () => {
-        #[cfg_attr(all(), unknown)] //~ ERROR `unknown` is currently unknown
+        #[cfg_attr(all(), unknown)]
+        //~^ ERROR cannot find attribute macro `unknown` in this scope
         fn foo() {}
     }
 }

--- a/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-unknown-attribute-macro-expansion.stderr
@@ -1,4 +1,4 @@
-error[E0658]: The attribute `unknown` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `unknown` in this scope
   --> $DIR/cfg-attr-unknown-attribute-macro-expansion.rs:3:27
    |
 LL |         #[cfg_attr(all(), unknown)]
@@ -6,10 +6,6 @@ LL |         #[cfg_attr(all(), unknown)]
 ...
 LL | foo!();
    | ------- in this macro invocation
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/custom_attribute.rs
+++ b/src/test/ui/custom_attribute.rs
@@ -1,9 +1,9 @@
 #![feature(stmt_expr_attributes)]
 
-#[foo] //~ ERROR The attribute `foo`
+#[foo] //~ ERROR cannot find attribute macro `foo` in this scope
 fn main() {
-    #[foo] //~ ERROR The attribute `foo`
+    #[foo] //~ ERROR cannot find attribute macro `foo` in this scope
     let x = ();
-    #[foo] //~ ERROR The attribute `foo`
+    #[foo] //~ ERROR cannot find attribute macro `foo` in this scope
     x
 }

--- a/src/test/ui/custom_attribute.stderr
+++ b/src/test/ui/custom_attribute.stderr
@@ -1,30 +1,20 @@
-error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `foo` in this scope
   --> $DIR/custom_attribute.rs:3:3
    |
 LL | #[foo]
    |   ^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `foo` in this scope
   --> $DIR/custom_attribute.rs:5:7
    |
 LL |     #[foo]
    |       ^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `foo` in this scope
   --> $DIR/custom_attribute.rs:7:7
    |
 LL |     #[foo]
    |       ^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/derives/deriving-meta-unknown-trait.stderr
+++ b/src/test/ui/derives/deriving-meta-unknown-trait.stderr
@@ -2,7 +2,7 @@ error: cannot find derive macro `Eqr` in this scope
   --> $DIR/deriving-meta-unknown-trait.rs:1:10
    |
 LL | #[derive(Eqr)]
-   |          ^^^ help: try: `Eq`
+   |          ^^^ help: a derive macro with a similar name exists: `Eq`
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute.rs
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute.rs
@@ -1,23 +1,18 @@
 // Check that literals in attributes parse just fine.
 
+#[fake_attr] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(100)] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(1, 2, 3)] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr("hello")] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(name = "hello")] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(1, "hi", key = 12, true, false)] //~ ERROR cannot find attribute macro `fake_attr` in th
+#[fake_attr(key = "hello", val = 10)] //~ ERROR cannot find attribute macro `fake_attr` in this scop
+#[fake_attr(key("hello"), val(10))] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(enabled = true, disabled = false)] //~ ERROR cannot find attribute macro `fake_attr` in
+#[fake_attr(true)] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(pi = 3.14159)] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_attr(b"hi")] //~ ERROR cannot find attribute macro `fake_attr` in this scope
+#[fake_doc(r"doc")] //~ ERROR cannot find attribute macro `fake_doc` in this scope
+struct Q {}
 
-#![allow(dead_code)]
-#![allow(unused_variables)]
-
-#[fake_attr] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(100)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(1, 2, 3)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr("hello")] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(name = "hello")] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(1, "hi", key = 12, true, false)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(key = "hello", val = 10)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(key("hello"), val(10))] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(enabled = true, disabled = false)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(true)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(pi = 3.14159)] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_attr(b"hi")] //~ ERROR attribute `fake_attr` is currently unknown
-#[fake_doc(r"doc")] //~ ERROR attribute `fake_doc` is currently unknown
-struct Q {  }
-
-
-fn main() { }
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute.stderr
@@ -1,120 +1,80 @@
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:7:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:3:3
    |
 LL | #[fake_attr]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:8:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:4:3
    |
 LL | #[fake_attr(100)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:9:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:5:3
    |
 LL | #[fake_attr(1, 2, 3)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:10:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:6:3
    |
 LL | #[fake_attr("hello")]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:11:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:7:3
    |
 LL | #[fake_attr(name = "hello")]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:12:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:8:3
    |
 LL | #[fake_attr(1, "hi", key = 12, true, false)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:13:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:9:3
    |
 LL | #[fake_attr(key = "hello", val = 10)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:14:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:10:3
    |
 LL | #[fake_attr(key("hello"), val(10))]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:15:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:11:3
    |
 LL | #[fake_attr(enabled = true, disabled = false)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:16:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:12:3
    |
 LL | #[fake_attr(true)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:17:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:13:3
    |
 LL | #[fake_attr(pi = 3.14159)]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:18:3
+error: cannot find attribute macro `fake_attr` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:14:3
    |
 LL | #[fake_attr(b"hi")]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `fake_doc` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/feature-gate-custom_attribute.rs:19:3
+error: cannot find attribute macro `fake_doc` in this scope
+  --> $DIR/feature-gate-custom_attribute.rs:15:3
    |
 LL | #[fake_doc(r"doc")]
    |   ^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 13 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs.rs
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs.rs
@@ -19,5 +19,5 @@ fn g() {}
 //~^ ERROR used by the test suite
 #[rustc_unknown]
 //~^ ERROR attributes starting with `rustc` are reserved for use by the `rustc` compiler
-//~| ERROR attribute `rustc_unknown` is currently unknown
+//~| ERROR cannot find attribute macro `rustc_unknown` in this scope
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
+++ b/src/test/ui/feature-gates/feature-gate-rustc-attrs.stderr
@@ -37,14 +37,11 @@ LL | #[rustc_unknown]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
-error[E0658]: The attribute `rustc_unknown` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `rustc_unknown` in this scope
   --> $DIR/feature-gate-rustc-attrs.rs:20:3
    |
 LL | #[rustc_unknown]
    |   ^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0658]: used by the test suite
   --> $DIR/feature-gate-rustc-attrs.rs:18:1

--- a/src/test/ui/hygiene/no_implicit_prelude-2018.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude-2018.stderr
@@ -3,8 +3,6 @@ error: cannot find macro `print!` in this scope
    |
 LL |         print!();
    |         ^^^^^
-   |
-   = help: have you added the `#[macro_use]` on the module/import?
 
 error: aborting due to previous error
 

--- a/src/test/ui/hygiene/no_implicit_prelude.stderr
+++ b/src/test/ui/hygiene/no_implicit_prelude.stderr
@@ -13,7 +13,6 @@ error: cannot find macro `panic!` in this scope
 LL |         assert_eq!(0, 0);
    |         ^^^^^^^^^^^^^^^^^
    |
-   = help: have you added the `#[macro_use]` on the module/import?
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0599]: no method named `clone` found for type `()` in the current scope

--- a/src/test/ui/hygiene/rustc-macro-transparency.rs
+++ b/src/test/ui/hygiene/rustc-macro-transparency.rs
@@ -26,6 +26,6 @@ fn main() {
     Opaque; //~ ERROR cannot find value `Opaque` in this scope
 
     transparent; // OK
-    semitransparent; //~ ERROR cannot find value `semitransparent` in this scope
-    opaque; //~ ERROR cannot find value `opaque` in this scope
+    semitransparent; //~ ERROR expected value, found macro `semitransparent`
+    opaque; //~ ERROR expected value, found macro `opaque`
 }

--- a/src/test/ui/hygiene/rustc-macro-transparency.stderr
+++ b/src/test/ui/hygiene/rustc-macro-transparency.stderr
@@ -4,18 +4,19 @@ error[E0425]: cannot find value `Opaque` in this scope
 LL |     Opaque;
    |     ^^^^^^ help: a local variable with a similar name exists: `opaque`
 
-error[E0425]: cannot find value `semitransparent` in this scope
+error[E0423]: expected value, found macro `semitransparent`
   --> $DIR/rustc-macro-transparency.rs:29:5
    |
 LL |     semitransparent;
-   |     ^^^^^^^^^^^^^^^ not found in this scope
+   |     ^^^^^^^^^^^^^^^ help: use `!` to invoke the macro: `semitransparent!`
 
-error[E0425]: cannot find value `opaque` in this scope
+error[E0423]: expected value, found macro `opaque`
   --> $DIR/rustc-macro-transparency.rs:30:5
    |
 LL |     opaque;
-   |     ^^^^^^ not found in this scope
+   |     ^^^^^^ help: use `!` to invoke the macro: `opaque!`
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0425`.
+Some errors have detailed explanations: E0423, E0425.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/impl-trait/universal_wrong_bounds.rs
+++ b/src/test/ui/impl-trait/universal_wrong_bounds.rs
@@ -6,9 +6,8 @@ fn foo(f: impl Display + Clone) -> String {
     wants_clone(f);
 }
 
-fn wants_debug(g: impl Debug) { } //~ ERROR cannot find
-fn wants_display(g: impl Debug) { } //~ ERROR cannot find
+fn wants_debug(g: impl Debug) { } //~ ERROR expected trait, found derive macro `Debug`
+fn wants_display(g: impl Debug) { } //~ ERROR expected trait, found derive macro `Debug`
 fn wants_clone(g: impl Clone) { }
 
-fn main() {
-}
+fn main() {}

--- a/src/test/ui/impl-trait/universal_wrong_bounds.stderr
+++ b/src/test/ui/impl-trait/universal_wrong_bounds.stderr
@@ -1,23 +1,23 @@
-error[E0405]: cannot find trait `Debug` in this scope
+error[E0404]: expected trait, found derive macro `Debug`
   --> $DIR/universal_wrong_bounds.rs:9:24
    |
 LL | fn wants_debug(g: impl Debug) { }
-   |                        ^^^^^ not found in this scope
-help: possible candidate is found in another module, you can import it into scope
+   |                        ^^^^^ not a trait
+help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::fmt::Debug;
    |
 
-error[E0405]: cannot find trait `Debug` in this scope
+error[E0404]: expected trait, found derive macro `Debug`
   --> $DIR/universal_wrong_bounds.rs:10:26
    |
 LL | fn wants_display(g: impl Debug) { }
-   |                          ^^^^^ not found in this scope
-help: possible candidate is found in another module, you can import it into scope
+   |                          ^^^^^ not a trait
+help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::fmt::Debug;
    |
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0405`.
+For more information about this error, try `rustc --explain E0404`.

--- a/src/test/ui/issues/issue-32655.rs
+++ b/src/test/ui/issues/issue-32655.rs
@@ -1,9 +1,6 @@
-#![allow(dead_code)]
-#![feature(rustc_attrs)]
-
 macro_rules! foo (
     () => (
-        #[derive_Clone] //~ ERROR attribute `derive_Clone` is currently unknown
+        #[derive_Clone] //~ ERROR cannot find attribute macro `derive_Clone` in this scope
         struct T;
     );
 );
@@ -15,7 +12,7 @@ macro_rules! bar (
 foo!();
 
 bar!(
-    #[derive_Clone] //~ ERROR attribute `derive_Clone` is currently unknown
+    #[derive_Clone] //~ ERROR cannot find attribute macro `derive_Clone` in this scope
     struct S;
 );
 

--- a/src/test/ui/issues/issue-32655.stderr
+++ b/src/test/ui/issues/issue-32655.stderr
@@ -1,24 +1,17 @@
-error[E0658]: The attribute `derive_Clone` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/issue-32655.rs:6:11
+error: cannot find attribute macro `derive_Clone` in this scope
+  --> $DIR/issue-32655.rs:3:11
    |
 LL |         #[derive_Clone]
    |           ^^^^^^^^^^^^
 ...
 LL | foo!();
    | ------- in this macro invocation
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `derive_Clone` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/issue-32655.rs:18:7
+error: cannot find attribute macro `derive_Clone` in this scope
+  --> $DIR/issue-32655.rs:15:7
    |
 LL |     #[derive_Clone]
    |       ^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/issues/issue-37534.rs
+++ b/src/test/ui/issues/issue-37534.rs
@@ -1,5 +1,5 @@
 struct Foo<T: ?Hash> { }
-//~^ ERROR cannot find trait `Hash` in this scope
+//~^ ERROR expected trait, found derive macro `Hash`
 //~^^ ERROR parameter `T` is never used
 //~^^^ WARN default bound relaxed for a type parameter, but this does nothing
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -1,9 +1,9 @@
-error[E0405]: cannot find trait `Hash` in this scope
+error[E0404]: expected trait, found derive macro `Hash`
   --> $DIR/issue-37534.rs:1:16
    |
 LL | struct Foo<T: ?Hash> { }
-   |                ^^^^ not found in this scope
-help: possible candidate is found in another module, you can import it into scope
+   |                ^^^^ not a trait
+help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::hash::Hash;
    |
@@ -24,5 +24,5 @@ LL | struct Foo<T: ?Hash> { }
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0392, E0405.
+Some errors have detailed explanations: E0392, E0404.
 For more information about an error, try `rustc --explain E0392`.

--- a/src/test/ui/issues/issue-49074.rs
+++ b/src/test/ui/issues/issue-49074.rs
@@ -1,7 +1,7 @@
 // Check that unknown attribute error is shown even if there are unresolved macros.
 
 #[marco_use] // typo
-//~^ ERROR The attribute `marco_use` is currently unknown to the compiler
+//~^ ERROR cannot find attribute macro `marco_use` in this scope
 mod foo {
     macro_rules! bar {
         () => ();

--- a/src/test/ui/issues/issue-49074.stderr
+++ b/src/test/ui/issues/issue-49074.stderr
@@ -2,7 +2,7 @@ error: cannot find attribute macro `marco_use` in this scope
   --> $DIR/issue-49074.rs:3:3
    |
 LL | #[marco_use] // typo
-   |   ^^^^^^^^^
+   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_use`
 
 error: cannot find macro `bar!` in this scope
   --> $DIR/issue-49074.rs:12:4

--- a/src/test/ui/issues/issue-49074.stderr
+++ b/src/test/ui/issues/issue-49074.stderr
@@ -1,11 +1,8 @@
-error[E0658]: The attribute `marco_use` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `marco_use` in this scope
   --> $DIR/issue-49074.rs:3:3
    |
 LL | #[marco_use] // typo
-   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_use`
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+   |   ^^^^^^^^^
 
 error: cannot find macro `bar!` in this scope
   --> $DIR/issue-49074.rs:12:4
@@ -17,4 +14,3 @@ LL |    bar!();
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/macros/macro-name-typo.stderr
+++ b/src/test/ui/macros/macro-name-typo.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `printlx!` in this scope
   --> $DIR/macro-name-typo.rs:2:5
    |
 LL |     printlx!("oh noes!");
-   |     ^^^^^^^ help: you could try the macro: `println`
+   |     ^^^^^^^ help: a macro with a similar name exists: `println`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-path-prelude-fail-3.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-3.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `inline!` in this scope
   --> $DIR/macro-path-prelude-fail-3.rs:2:5
    |
 LL |     inline!();
-   |     ^^^^^^ help: you could try the macro: `line`
+   |     ^^^^^^ help: a macro with a similar name exists: `line`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro-reexport-removed.rs
+++ b/src/test/ui/macros/macro-reexport-removed.rs
@@ -2,7 +2,7 @@
 
 #![feature(macro_reexport)] //~ ERROR feature has been removed
 
-#[macro_reexport(macro_one)] //~ ERROR attribute `macro_reexport` is currently unknown
+#[macro_reexport(macro_one)] //~ ERROR cannot find attribute macro `macro_reexport` in this scope
 extern crate two_macros;
 
 fn main() {}

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -14,7 +14,7 @@ error: cannot find attribute macro `macro_reexport` in this scope
   --> $DIR/macro-reexport-removed.rs:5:3
    |
 LL | #[macro_reexport(macro_one)]
-   |   ^^^^^^^^^^^^^^
+   |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/macro-reexport-removed.stderr
+++ b/src/test/ui/macros/macro-reexport-removed.stderr
@@ -10,16 +10,12 @@ note: subsumed by `pub use`
 LL | #![feature(macro_reexport)]
    |            ^^^^^^^^^^^^^^
 
-error[E0658]: The attribute `macro_reexport` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `macro_reexport` in this scope
   --> $DIR/macro-reexport-removed.rs:5:3
    |
 LL | #[macro_reexport(macro_one)]
-   |   ^^^^^^^^^^^^^^ help: a built-in attribute with a similar name exists: `macro_export`
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+   |   ^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0557, E0658.
-For more information about an error, try `rustc --explain E0557`.
+For more information about this error, try `rustc --explain E0557`.

--- a/src/test/ui/macros/macro-use-wrong-name.stderr
+++ b/src/test/ui/macros/macro-use-wrong-name.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `macro_two!` in this scope
   --> $DIR/macro-use-wrong-name.rs:7:5
    |
 LL |     macro_two!();
-   |     ^^^^^^^^^ help: you could try the macro: `macro_one`
+   |     ^^^^^^^^^ help: a macro with a similar name exists: `macro_one`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/macro_undefined.stderr
+++ b/src/test/ui/macros/macro_undefined.stderr
@@ -2,7 +2,7 @@ error: cannot find macro `k!` in this scope
   --> $DIR/macro_undefined.rs:11:5
    |
 LL |     k!();
-   |     ^ help: you could try the macro: `kl`
+   |     ^ help: a macro with a similar name exists: `kl`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no-implicit-prelude-nested.rs
+++ b/src/test/ui/no-implicit-prelude-nested.rs
@@ -9,7 +9,7 @@ mod foo {
     mod baz {
         struct Test;
         impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+        impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
         impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
         impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
         impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
@@ -21,7 +21,7 @@ mod foo {
 
     struct Test;
     impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-    impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+    impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
     impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
     impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
     impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope
@@ -36,7 +36,7 @@ fn qux() {
     mod qux_inner {
         struct Test;
         impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-        impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+        impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
         impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
         impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
         impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope

--- a/src/test/ui/no-implicit-prelude-nested.stderr
+++ b/src/test/ui/no-implicit-prelude-nested.stderr
@@ -8,12 +8,12 @@ help: possible candidate is found in another module, you can import it into scop
 LL |         use std::ops::Add;
    |
 
-error[E0405]: cannot find trait `Clone` in this scope
+error[E0404]: expected trait, found derive macro `Clone`
   --> $DIR/no-implicit-prelude-nested.rs:12:14
    |
 LL |         impl Clone for Test {}
-   |              ^^^^^ not found in this scope
-help: possible candidates are found in other modules, you can import them into scope
+   |              ^^^^^ not a trait
+help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |         use std::clone::Clone;
    |
@@ -72,12 +72,12 @@ help: possible candidate is found in another module, you can import it into scop
 LL |     use std::ops::Add;
    |
 
-error[E0405]: cannot find trait `Clone` in this scope
+error[E0404]: expected trait, found derive macro `Clone`
   --> $DIR/no-implicit-prelude-nested.rs:24:10
    |
 LL |     impl Clone for Test {}
-   |          ^^^^^ not found in this scope
-help: possible candidates are found in other modules, you can import them into scope
+   |          ^^^^^ not a trait
+help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |     use std::clone::Clone;
    |
@@ -136,12 +136,12 @@ help: possible candidate is found in another module, you can import it into scop
 LL |         use std::ops::Add;
    |
 
-error[E0405]: cannot find trait `Clone` in this scope
+error[E0404]: expected trait, found derive macro `Clone`
   --> $DIR/no-implicit-prelude-nested.rs:39:14
    |
 LL |         impl Clone for Test {}
-   |              ^^^^^ not found in this scope
-help: possible candidates are found in other modules, you can import them into scope
+   |              ^^^^^ not a trait
+help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |         use std::clone::Clone;
    |
@@ -192,5 +192,5 @@ LL |         use std::prelude::v1::drop;
 
 error: aborting due to 18 previous errors
 
-Some errors have detailed explanations: E0405, E0425.
-For more information about an error, try `rustc --explain E0405`.
+Some errors have detailed explanations: E0404, E0405, E0425.
+For more information about an error, try `rustc --explain E0404`.

--- a/src/test/ui/no-implicit-prelude.rs
+++ b/src/test/ui/no-implicit-prelude.rs
@@ -8,7 +8,7 @@
 
 struct Test;
 impl Add for Test {} //~ ERROR cannot find trait `Add` in this scope
-impl Clone for Test {} //~ ERROR cannot find trait `Clone` in this scope
+impl Clone for Test {} //~ ERROR expected trait, found derive macro `Clone`
 impl Iterator for Test {} //~ ERROR cannot find trait `Iterator` in this scope
 impl ToString for Test {} //~ ERROR cannot find trait `ToString` in this scope
 impl Writer for Test {} //~ ERROR cannot find trait `Writer` in this scope

--- a/src/test/ui/no-implicit-prelude.stderr
+++ b/src/test/ui/no-implicit-prelude.stderr
@@ -8,12 +8,12 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use std::ops::Add;
    |
 
-error[E0405]: cannot find trait `Clone` in this scope
+error[E0404]: expected trait, found derive macro `Clone`
   --> $DIR/no-implicit-prelude.rs:11:6
    |
 LL | impl Clone for Test {}
-   |      ^^^^^ not found in this scope
-help: possible candidates are found in other modules, you can import them into scope
+   |      ^^^^^ not a trait
+help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use std::clone::Clone;
    |
@@ -64,5 +64,5 @@ LL | use std::prelude::v1::drop;
 
 error: aborting due to 6 previous errors
 
-Some errors have detailed explanations: E0405, E0425.
-For more information about an error, try `rustc --explain E0405`.
+Some errors have detailed explanations: E0404, E0405, E0425.
+For more information about an error, try `rustc --explain E0404`.

--- a/src/test/ui/proc-macro/derive-helper-shadowing.rs
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.rs
@@ -19,7 +19,7 @@ struct S {
         struct U;
 
         mod inner {
-            #[empty_helper] //~ ERROR attribute `empty_helper` is currently unknown
+            #[empty_helper] //~ ERROR cannot find attribute macro `empty_helper` in this scope
             struct V;
         }
 

--- a/src/test/ui/proc-macro/derive-helper-shadowing.stderr
+++ b/src/test/ui/proc-macro/derive-helper-shadowing.stderr
@@ -1,11 +1,8 @@
-error[E0658]: The attribute `empty_helper` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `empty_helper` in this scope
   --> $DIR/derive-helper-shadowing.rs:22:15
    |
 LL |             #[empty_helper]
    |               ^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0659]: `empty_helper` is ambiguous (derive helper attribute vs any other name)
   --> $DIR/derive-helper-shadowing.rs:8:3
@@ -27,5 +24,4 @@ LL | use test_macros::empty_attr as empty_helper;
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0658, E0659.
-For more information about an error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/proc-macro/derive-still-gated.rs
+++ b/src/test/ui/proc-macro/derive-still-gated.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate test_macros;
 
-#[derive_Empty] //~ ERROR attribute `derive_Empty` is currently unknown
+#[derive_Empty] //~ ERROR cannot find attribute macro `derive_Empty` in this scope
 struct A;
 
 fn main() {}

--- a/src/test/ui/proc-macro/derive-still-gated.stderr
+++ b/src/test/ui/proc-macro/derive-still-gated.stderr
@@ -1,12 +1,8 @@
-error[E0658]: The attribute `derive_Empty` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `derive_Empty` in this scope
   --> $DIR/derive-still-gated.rs:6:3
    |
 LL | #[derive_Empty]
    |   ^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/expand-to-unstable-2.rs
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.rs
@@ -1,11 +1,12 @@
 // aux-build:derive-unstable-2.rs
 
+#![feature(custom_attribute)]
+
 #[macro_use]
 extern crate derive_unstable_2;
 
 #[derive(Unstable)]
 //~^ ERROR attributes starting with `rustc` are reserved for use by the `rustc` compiler
-//~| ERROR attribute `rustc_foo` is currently unknown to the compiler
 
 struct A;
 

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes starting with `rustc` are reserved for use by the `rustc` compiler
-  --> $DIR/expand-to-unstable-2.rs:6:10
+  --> $DIR/expand-to-unstable-2.rs:8:10
    |
 LL | #[derive(Unstable)]
    |          ^^^^^^^^
@@ -7,15 +7,6 @@ LL | #[derive(Unstable)]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
-error[E0658]: The attribute `rustc_foo` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/expand-to-unstable-2.rs:6:10
-   |
-LL | #[derive(Unstable)]
-   |          ^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/issue-41211.rs
+++ b/src/test/ui/proc-macro/issue-41211.rs
@@ -3,11 +3,11 @@
 // FIXME: https://github.com/rust-lang/rust/issues/41430
 // This is a temporary regression test for the ICE reported in #41211
 
+#![feature(custom_attribute)]
 #![feature(custom_inner_attributes)]
 
 #![identity_attr]
-//~^ ERROR attribute `identity_attr` is currently unknown to the compiler
-//~| ERROR inconsistent resolution for a macro: first custom attribute, then attribute macro
+//~^ ERROR inconsistent resolution for a macro: first custom attribute, then attribute macro
 extern crate test_macros;
 use test_macros::identity_attr;
 

--- a/src/test/ui/proc-macro/issue-41211.stderr
+++ b/src/test/ui/proc-macro/issue-41211.stderr
@@ -1,18 +1,8 @@
-error[E0658]: The attribute `identity_attr` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/issue-41211.rs:8:4
-   |
-LL | #![identity_attr]
-   |    ^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
 error: inconsistent resolution for a macro: first custom attribute, then attribute macro
-  --> $DIR/issue-41211.rs:8:4
+  --> $DIR/issue-41211.rs:9:4
    |
 LL | #![identity_attr]
    |    ^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/macro-namespace-reserved-2.rs
+++ b/src/test/ui/proc-macro/macro-namespace-reserved-2.rs
@@ -35,7 +35,7 @@ fn check_bang3() {
                        //~| ERROR expected macro, found derive macro `crate::MyTrait`
 }
 
-#[my_macro] //~ ERROR attribute `my_macro` is currently unknown
+#[my_macro] //~ ERROR cannot find attribute macro `my_macro` in this scope
 #[crate::my_macro] //~ ERROR can't use a procedural macro from the same crate that defines it
                    //~| ERROR expected attribute, found macro `crate::my_macro`
 fn check_attr1() {}

--- a/src/test/ui/proc-macro/macro-namespace-reserved-2.stderr
+++ b/src/test/ui/proc-macro/macro-namespace-reserved-2.stderr
@@ -76,15 +76,6 @@ error: can't use a procedural macro from the same crate that defines it
 LL | #[derive(MyTrait)]
    |          ^^^^^^^
 
-error[E0658]: The attribute `my_macro` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/macro-namespace-reserved-2.rs:38:3
-   |
-LL | #[my_macro]
-   |   ^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
 error: can't use a procedural macro from the same crate that defines it
   --> $DIR/macro-namespace-reserved-2.rs:39:3
    |
@@ -96,6 +87,12 @@ error: expected attribute, found macro `crate::my_macro`
    |
 LL | #[crate::my_macro]
    |   ^^^^^^^^^^^^^^^ not an attribute
+
+error: cannot find attribute macro `my_macro` in this scope
+  --> $DIR/macro-namespace-reserved-2.rs:38:3
+   |
+LL | #[my_macro]
+   |   ^^^^^^^^
 
 error: cannot find derive macro `my_macro` in this scope
   --> $DIR/macro-namespace-reserved-2.rs:48:10
@@ -117,4 +114,3 @@ LL |     MyTrait!();
 
 error: aborting due to 19 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/proc-macro-attributes.rs
+++ b/src/test/ui/proc-macro/proc-macro-attributes.rs
@@ -4,7 +4,7 @@
 extern crate derive_b;
 
 #[B] //~ ERROR `B` is ambiguous
-#[C] //~ ERROR attribute `C` is currently unknown to the compiler
+#[C] //~ ERROR cannot find attribute macro `C` in this scope
 #[B(D)] //~ ERROR `B` is ambiguous
 #[B(E = "foo")] //~ ERROR `B` is ambiguous
 #[B(arbitrary tokens)] //~ ERROR `B` is ambiguous

--- a/src/test/ui/proc-macro/proc-macro-attributes.stderr
+++ b/src/test/ui/proc-macro/proc-macro-attributes.stderr
@@ -2,7 +2,7 @@ error: cannot find attribute macro `C` in this scope
   --> $DIR/proc-macro-attributes.rs:7:3
    |
 LL | #[C]
-   |   ^
+   |   ^ help: a derive helper attribute with a similar name exists: `B`
 
 error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
   --> $DIR/proc-macro-attributes.rs:6:3

--- a/src/test/ui/proc-macro/proc-macro-attributes.stderr
+++ b/src/test/ui/proc-macro/proc-macro-attributes.stderr
@@ -1,11 +1,8 @@
-error[E0658]: The attribute `C` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `C` in this scope
   --> $DIR/proc-macro-attributes.rs:7:3
    |
 LL | #[C]
    |   ^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error[E0659]: `B` is ambiguous (derive helper attribute vs any other name)
   --> $DIR/proc-macro-attributes.rs:6:3
@@ -77,5 +74,4 @@ LL | #[macro_use]
 
 error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0658, E0659.
-For more information about an error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/proc-macro/resolve-error.rs
+++ b/src/test/ui/proc-macro/resolve-error.rs
@@ -24,11 +24,11 @@ macro_rules! attr_proc_mac {
 struct Foo;
 
 // Interpreted as a feature gated custom attribute
-#[attr_proc_macra] //~ ERROR attribute `attr_proc_macra` is currently unknown
+#[attr_proc_macra] //~ ERROR cannot find attribute macro `attr_proc_macra` in this scope
 struct Bar;
 
 // Interpreted as a feature gated custom attribute
-#[FooWithLongNan] //~ ERROR attribute `FooWithLongNan` is currently unknown
+#[FooWithLongNan] //~ ERROR cannot find attribute macro `FooWithLongNan` in this scope
 struct Asdf;
 
 #[derive(Dlone)]

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -2,13 +2,13 @@ error: cannot find derive macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:22:10
    |
 LL | #[derive(FooWithLongNan)]
-   |          ^^^^^^^^^^^^^^ help: try: `FooWithLongName`
+   |          ^^^^^^^^^^^^^^ help: a derive macro with a similar name exists: `FooWithLongName`
 
 error: cannot find attribute macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:27:3
    |
 LL | #[attr_proc_macra]
-   |   ^^^^^^^^^^^^^^^ help: try: `attr_proc_macro`
+   |   ^^^^^^^^^^^^^^^ help: an attribute macro with a similar name exists: `attr_proc_macro`
 
 error: cannot find attribute macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:31:3
@@ -20,13 +20,13 @@ error: cannot find derive macro `Dlone` in this scope
   --> $DIR/resolve-error.rs:34:10
    |
 LL | #[derive(Dlone)]
-   |          ^^^^^ help: try: `Clone`
+   |          ^^^^^ help: a derive macro with a similar name exists: `Clone`
 
 error: cannot find derive macro `Dlona` in this scope
   --> $DIR/resolve-error.rs:38:10
    |
 LL | #[derive(Dlona)]
-   |          ^^^^^ help: try: `Clona`
+   |          ^^^^^ help: a derive macro with a similar name exists: `Clona`
 
 error: cannot find derive macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:42:10
@@ -38,13 +38,13 @@ error: cannot find macro `FooWithLongNama!` in this scope
   --> $DIR/resolve-error.rs:47:5
    |
 LL |     FooWithLongNama!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `FooWithLongNam`
+   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `FooWithLongNam`
 
 error: cannot find macro `attr_proc_macra!` in this scope
   --> $DIR/resolve-error.rs:50:5
    |
 LL |     attr_proc_macra!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `attr_proc_mac`
+   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `attr_proc_mac`
 
 error: cannot find macro `Dlona!` in this scope
   --> $DIR/resolve-error.rs:53:5
@@ -56,7 +56,7 @@ error: cannot find macro `bang_proc_macrp!` in this scope
   --> $DIR/resolve-error.rs:56:5
    |
 LL |     bang_proc_macrp!();
-   |     ^^^^^^^^^^^^^^^ help: you could try the macro: `bang_proc_macro`
+   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `bang_proc_macro`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -1,26 +1,20 @@
-error[E0658]: The attribute `attr_proc_macra` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/resolve-error.rs:27:3
-   |
-LL | #[attr_proc_macra]
-   |   ^^^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
-error[E0658]: The attribute `FooWithLongNan` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/resolve-error.rs:31:3
-   |
-LL | #[FooWithLongNan]
-   |   ^^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
 error: cannot find derive macro `FooWithLongNan` in this scope
   --> $DIR/resolve-error.rs:22:10
    |
 LL | #[derive(FooWithLongNan)]
    |          ^^^^^^^^^^^^^^ help: try: `FooWithLongName`
+
+error: cannot find attribute macro `attr_proc_macra` in this scope
+  --> $DIR/resolve-error.rs:27:3
+   |
+LL | #[attr_proc_macra]
+   |   ^^^^^^^^^^^^^^^ help: try: `attr_proc_macro`
+
+error: cannot find attribute macro `FooWithLongNan` in this scope
+  --> $DIR/resolve-error.rs:31:3
+   |
+LL | #[FooWithLongNan]
+   |   ^^^^^^^^^^^^^^
 
 error: cannot find derive macro `Dlone` in this scope
   --> $DIR/resolve-error.rs:34:10
@@ -66,4 +60,3 @@ LL |     bang_proc_macrp!();
 
 error: aborting due to 10 previous errors
 
-For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/reserved/reserved-attr-on-macro.rs
+++ b/src/test/ui/reserved/reserved-attr-on-macro.rs
@@ -1,5 +1,5 @@
 #[rustc_attribute_should_be_reserved]
-//~^ ERROR attribute `rustc_attribute_should_be_reserved` is currently unknown
+//~^ ERROR cannot find attribute macro `rustc_attribute_should_be_reserved` in this scope
 //~| ERROR attributes starting with `rustc` are reserved for use by the `rustc` compiler
 
 macro_rules! foo {

--- a/src/test/ui/reserved/reserved-attr-on-macro.stderr
+++ b/src/test/ui/reserved/reserved-attr-on-macro.stderr
@@ -7,14 +7,11 @@ LL | #[rustc_attribute_should_be_reserved]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
-error[E0658]: The attribute `rustc_attribute_should_be_reserved` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `rustc_attribute_should_be_reserved` in this scope
   --> $DIR/reserved-attr-on-macro.rs:1:3
    |
 LL | #[rustc_attribute_should_be_reserved]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
 error: cannot determine resolution for the macro `foo`
   --> $DIR/reserved-attr-on-macro.rs:10:5

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -2,7 +2,7 @@ error[E0412]: cannot find type `esize` in this scope
   --> $DIR/levenshtein.rs:5:11
    |
 LL | fn foo(c: esize) {} // Misspelled primitive type name.
-   |           ^^^^^ help: a primitive type with a similar name exists: `isize`
+   |           ^^^^^ help: a builtin type with a similar name exists: `isize`
 
 error[E0412]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10

--- a/src/test/ui/span/issue-36530.rs
+++ b/src/test/ui/span/issue-36530.rs
@@ -1,9 +1,10 @@
 // gate-test-custom_inner_attributes
 
-#[foo] //~ ERROR is currently unknown to the compiler
+#![feature(custom_attribute)]
+
+#[foo]
 mod foo {
-    #![foo] //~ ERROR is currently unknown to the compiler
-            //~| ERROR non-builtin inner attributes are unstable
+    #![foo] //~ ERROR non-builtin inner attributes are unstable
 }
 
 fn main() {}

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -1,14 +1,5 @@
-error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/issue-36530.rs:3:3
-   |
-LL | #[foo]
-   |   ^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
 error[E0658]: non-builtin inner attributes are unstable
-  --> $DIR/issue-36530.rs:5:5
+  --> $DIR/issue-36530.rs:7:5
    |
 LL |     #![foo]
    |     ^^^^^^^
@@ -16,15 +7,6 @@ LL |     #![foo]
    = note: for more information, see https://github.com/rust-lang/rust/issues/54726
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
 
-error[E0658]: The attribute `foo` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/issue-36530.rs:5:8
-   |
-LL |     #![foo]
-   |        ^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/suggestions/attribute-typos.rs
+++ b/src/test/ui/suggestions/attribute-typos.rs
@@ -1,11 +1,11 @@
-#[deprcated] //~ ERROR attribute `deprcated` is currently unknown
+#[deprcated] //~ ERROR cannot find attribute macro `deprcated` in this scope
 fn foo() {}
 
-#[tests] //~ ERROR attribute `tests` is currently unknown to the compiler
+#[tests] //~ ERROR cannot find attribute macro `tests` in this scope
 fn bar() {}
 
 #[rustc_err]
-//~^ ERROR attribute `rustc_err` is currently unknown
+//~^ ERROR cannot find attribute macro `rustc_err` in this scope
 //~| ERROR attributes starting with `rustc` are reserved for use by the `rustc` compiler
 
 fn main() {}

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -7,32 +7,23 @@ LL | #[rustc_err]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29642
    = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
 
-error[E0658]: The attribute `rustc_err` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `rustc_err` in this scope
   --> $DIR/attribute-typos.rs:7:3
    |
 LL | #[rustc_err]
    |   ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
 
-error[E0658]: The attribute `tests` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `tests` in this scope
   --> $DIR/attribute-typos.rs:4:3
    |
 LL | #[tests]
-   |   ^^^^^ help: a built-in attribute with a similar name exists: `test`
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+   |   ^^^^^ help: try: `test`
 
-error[E0658]: The attribute `deprcated` is currently unknown to the compiler and may have meaning added to it in the future
+error: cannot find attribute macro `deprcated` in this scope
   --> $DIR/attribute-typos.rs:1:3
    |
 LL | #[deprcated]
-   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `deprecated`
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+   |   ^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/attribute-typos.stderr
+++ b/src/test/ui/suggestions/attribute-typos.stderr
@@ -11,19 +11,19 @@ error: cannot find attribute macro `rustc_err` in this scope
   --> $DIR/attribute-typos.rs:7:3
    |
 LL | #[rustc_err]
-   |   ^^^^^^^^^
+   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `rustc_error`
 
 error: cannot find attribute macro `tests` in this scope
   --> $DIR/attribute-typos.rs:4:3
    |
 LL | #[tests]
-   |   ^^^^^ help: try: `test`
+   |   ^^^^^ help: an attribute macro with a similar name exists: `test`
 
 error: cannot find attribute macro `deprcated` in this scope
   --> $DIR/attribute-typos.rs:1:3
    |
 LL | #[deprcated]
-   |   ^^^^^^^^^
+   |   ^^^^^^^^^ help: a built-in attribute with a similar name exists: `deprecated`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/tool-attributes/tool-attributes-misplaced-1.rs
+++ b/src/test/ui/tool-attributes/tool-attributes-misplaced-1.rs
@@ -5,7 +5,7 @@ type B = rustfmt::skip; //~ ERROR expected type, found tool attribute `rustfmt::
 struct S;
 
 // Interpreted as a feature gated custom attribute
-#[rustfmt] //~ ERROR attribute `rustfmt` is currently unknown
+#[rustfmt] //~ ERROR cannot find attribute macro `rustfmt` in this scope
 fn check() {}
 
 #[rustfmt::skip] // OK

--- a/src/test/ui/tool-attributes/tool-attributes-misplaced-1.stderr
+++ b/src/test/ui/tool-attributes/tool-attributes-misplaced-1.stderr
@@ -1,17 +1,14 @@
-error[E0658]: The attribute `rustfmt` is currently unknown to the compiler and may have meaning added to it in the future
-  --> $DIR/tool-attributes-misplaced-1.rs:8:3
-   |
-LL | #[rustfmt]
-   |   ^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
-   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
-
 error: cannot find derive macro `rustfmt` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:4:10
    |
 LL | #[derive(rustfmt)]
    |          ^^^^^^^
+
+error: cannot find attribute macro `rustfmt` in this scope
+  --> $DIR/tool-attributes-misplaced-1.rs:8:3
+   |
+LL | #[rustfmt]
+   |   ^^^^^^^
 
 error: cannot find macro `rustfmt!` in this scope
   --> $DIR/tool-attributes-misplaced-1.rs:14:5
@@ -45,5 +42,4 @@ LL |     rustfmt::skip;
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0423, E0658.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Use same scope visiting machinery for both collecting suggestion candidates and actually resolving the names.

The PR is better read in per-commit fashion with whitespace changes ignored (the first commit in particular moves some code around).

This should be the last pre-requisite for https://github.com/rust-lang/rust/pull/62086.
r? @davidtwco 