### PR TITLE
normalize use of backticks in compiler messages for libsyntax_ext

### DIFF
--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -73,7 +73,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt<'_>,
             }
         }
 
-        _ => cx.span_bug(span, "#[derive(Clone)] on trait item or impl item"),
+        _ => cx.span_bug(span, "`#[derive(Clone)]` on trait item or impl item"),
     }
 
     let inline = cx.meta_word(span, sym::inline);

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -42,12 +42,12 @@ pub fn expand_test_or_bench(
         if let Annotatable::Item(i) = item { i }
         else {
             cx.parse_sess.span_diagnostic.span_fatal(item.span(),
-                "#[test] attribute is only allowed on non associated functions").raise();
+                "`#[test]` attribute is only allowed on non associated functions").raise();
         };
 
     if let ast::ItemKind::Mac(_) = item.node {
         cx.parse_sess.span_diagnostic.span_warn(item.span,
-            "#[test] attribute should not be used on macros. Use #[cfg(test)] instead.");
+            "`#[test]` attribute should not be used on macros. Use `#[cfg(test)]` instead.");
         return vec![Annotatable::Item(item)];
     }
 
@@ -167,7 +167,7 @@ pub fn expand_test_or_bench(
         ast::ItemKind::ExternCrate(Some(sym::test))
     );
 
-    log::debug!("Synthetic test item:\n{}\n", pprust::item_to_string(&test_const));
+    log::debug!("synthetic test item:\n{}\n", pprust::item_to_string(&test_const));
 
     vec![
         // Access to libtest under a gensymed name

--- a/src/test/ui/test-attr-non-associated-functions.rs
+++ b/src/test/ui/test-attr-non-associated-functions.rs
@@ -6,7 +6,7 @@ struct A {}
 
 impl A {
     #[test]
-    fn new() -> A { //~ ERROR #[test] attribute is only allowed on non associated functions
+    fn new() -> A { //~ ERROR `#[test]` attribute is only allowed on non associated functions
         A {}
     }
 }

--- a/src/test/ui/test-attr-non-associated-functions.stderr
+++ b/src/test/ui/test-attr-non-associated-functions.stderr
@@ -1,4 +1,4 @@
-error: #[test] attribute is only allowed on non associated functions
+error: `#[test]` attribute is only allowed on non associated functions
   --> $DIR/test-attr-non-associated-functions.rs:9:5
    |
 LL | /     fn new() -> A {

--- a/src/test/ui/test-on-macro.stderr
+++ b/src/test/ui/test-on-macro.stderr
@@ -1,4 +1,4 @@
-warning: #[test] attribute should not be used on macros. Use #[cfg(test)] instead.
+warning: `#[test]` attribute should not be used on macros. Use `#[cfg(test)]` instead.
   --> $DIR/test-on-macro.rs:11:1
    |
 LL | foo!();


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532