### PR TITLE
normalize use of backticks in compiler messages for libsyntax/parse

### DIFF
--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -226,7 +226,7 @@ impl<'a> Parser<'a> {
 
     fn parse_unsuffixed_lit(&mut self) -> PResult<'a, ast::Lit> {
         let lit = self.parse_lit()?;
-        debug!("Checking if {:?} is unusuffixed.", lit);
+        debug!("checking if {:?} is unusuffixed", lit);
 
         if !lit.node.is_unsuffixed() {
             let msg = "suffixed literals are not allowed in attributes";

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -919,7 +919,7 @@ impl<'a> Parser<'a> {
                     Applicability::MaybeIncorrect,
                 );
             } else {
-                err.note("#![feature(type_ascription)] lets you annotate an \
+                err.note("`#![feature(type_ascription)]` lets you annotate an \
                           expression with a type: `<expr>: <type>`")
                     .span_note(
                         lhs_span,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -443,7 +443,7 @@ impl<'a> StringReader<'a> {
 
                 let is_beginning_of_file = self.pos == self.source_file.start_pos;
                 if is_beginning_of_file {
-                    debug!("Skipping a shebang");
+                    debug!("skipping a shebang");
                     let start = self.pos;
                     while !self.ch_is('\n') && !self.is_eof() {
                         self.bump();

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -89,7 +89,7 @@ error: expected type, found `4`
 LL |     println!("{}", a: &mut 4);
    |                            ^ expecting a type here because of type ascription
    |
-   = note: #![feature(type_ascription)] lets you annotate an expression with a type: `<expr>: <type>`
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
 note: this expression expects an ascribed type after the colon
   --> $DIR/issue-22644.rs:34:20
    |

--- a/src/test/ui/issues/issue-34255-1.stderr
+++ b/src/test/ui/issues/issue-34255-1.stderr
@@ -4,7 +4,7 @@ error: expected type, found `42`
 LL |     Test::Drill(field: 42);
    |                        ^^ expecting a type here because of type ascription
    |
-   = note: #![feature(type_ascription)] lets you annotate an expression with a type: `<expr>: <type>`
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
 note: this expression expects an ascribed type after the colon
   --> $DIR/issue-34255-1.rs:8:17
    |

--- a/src/test/ui/lifetime_starts_expressions.stderr
+++ b/src/test/ui/lifetime_starts_expressions.stderr
@@ -14,7 +14,7 @@ error: expected type, found keyword `loop`
 LL |     loop { break 'label: loop { break 'label 42; }; }
    |                          ^^^^ expecting a type here because of type ascription
    |
-   = note: #![feature(type_ascription)] lets you annotate an expression with a type: `<expr>: <type>`
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
 note: this expression expects an ascribed type after the colon
   --> $DIR/lifetime_starts_expressions.rs:6:12
    |

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -4,7 +4,7 @@ error: expected type, found `3`
 LL |     let x = Enum::Foo(a: 3, b: 4);
    |                          ^ expecting a type here because of type ascription
    |
-   = note: #![feature(type_ascription)] lets you annotate an expression with a type: `<expr>: <type>`
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
 note: this expression expects an ascribed type after the colon
   --> $DIR/recover-from-bad-variant.rs:7:23
    |

--- a/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
+++ b/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
@@ -12,7 +12,7 @@ error: expected type, found `0`
 LL |     println!("test"): 0;
    |                       ^ expecting a type here because of type ascription
    |
-   = note: #![feature(type_ascription)] lets you annotate an expression with a type: `<expr>: <type>`
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
 note: this expression expects an ascribed type after the colon
   --> $DIR/type-ascription-instead-of-statement-end.rs:9:5
    |


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532