### PR TITLE
libsyntax: Rename `Mark` into `ExpnId`

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -60,7 +60,7 @@ use syntax::attr;
 use syntax::ast;
 use syntax::ast::*;
 use syntax::errors;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::print::pprust;
 use syntax::source_map::{respan, ExpnInfo, ExpnKind, DesugaringKind, Spanned};
 use syntax::std_inject;
@@ -437,7 +437,7 @@ impl<'a> LoweringContext<'a> {
                                 owner,
                                 id,
                                 DefPathData::Misc,
-                                Mark::root(),
+                                ExpnId::root(),
                                 tree.prefix.span,
                             );
                             self.lctx.allocate_hir_id_counter(id);
@@ -875,7 +875,7 @@ impl<'a> LoweringContext<'a> {
         span: Span,
         allow_internal_unstable: Option<Lrc<[Symbol]>>,
     ) -> Span {
-        span.fresh_expansion(Mark::root(), ExpnInfo {
+        span.fresh_expansion(ExpnId::root(), ExpnInfo {
             def_site: span,
             allow_internal_unstable,
             ..ExpnInfo::default(ExpnKind::Desugaring(reason), span, self.sess.edition())
@@ -968,7 +968,7 @@ impl<'a> LoweringContext<'a> {
             parent_index,
             node_id,
             DefPathData::LifetimeNs(str_name),
-            Mark::root(),
+            ExpnId::root(),
             span,
         );
 
@@ -1462,7 +1462,7 @@ impl<'a> LoweringContext<'a> {
                         parent_def_index,
                         impl_trait_node_id,
                         DefPathData::ImplTrait,
-                        Mark::root(),
+                        ExpnId::root(),
                         DUMMY_SP
                     );
 
@@ -1921,7 +1921,7 @@ impl<'a> LoweringContext<'a> {
                         self.parent,
                         def_node_id,
                         DefPathData::LifetimeNs(name.ident().as_interned_str()),
-                        Mark::root(),
+                        ExpnId::root(),
                         lifetime.span);
 
                     let (name, kind) = match name {

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -2,7 +2,7 @@ use crate::hir::map::definitions::*;
 use crate::hir::def_id::DefIndex;
 
 use syntax::ast::*;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::visit;
 use syntax::symbol::{kw, sym};
 use syntax::parse::token::{self, Token};
@@ -12,11 +12,11 @@ use syntax_pos::Span;
 pub struct DefCollector<'a> {
     definitions: &'a mut Definitions,
     parent_def: DefIndex,
-    expansion: Mark,
+    expansion: ExpnId,
 }
 
 impl<'a> DefCollector<'a> {
-    pub fn new(definitions: &'a mut Definitions, expansion: Mark) -> Self {
+    pub fn new(definitions: &'a mut Definitions, expansion: ExpnId) -> Self {
         let parent_def = definitions.invocation_parent(expansion);
         DefCollector { definitions, parent_def, expansion }
     }

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -75,7 +75,7 @@ impl<'a> DefCollector<'a> {
     }
 
     fn visit_macro_invoc(&mut self, id: NodeId) {
-        self.definitions.set_invocation_parent(id.placeholder_to_mark(), self.parent_def);
+        self.definitions.set_invocation_parent(id.placeholder_to_expn_id(), self.parent_def);
     }
 }
 

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -450,7 +450,7 @@ impl Definitions {
                                   parent: DefIndex,
                                   node_id: ast::NodeId,
                                   data: DefPathData,
-                                  expansion: ExpnId,
+                                  expn_id: ExpnId,
                                   span: Span)
                                   -> DefIndex {
         debug!("create_def_with_parent(parent={:?}, node_id={:?}, data={:?})",
@@ -498,8 +498,8 @@ impl Definitions {
             self.node_to_def_index.insert(node_id, index);
         }
 
-        if expansion != ExpnId::root() {
-            self.expansions_that_defined.insert(index, expansion);
+        if expn_id != ExpnId::root() {
+            self.expansions_that_defined.insert(index, expn_id);
         }
 
         // The span is added if it isn't dummy
@@ -523,12 +523,12 @@ impl Definitions {
         self.expansions_that_defined.get(&index).cloned().unwrap_or(ExpnId::root())
     }
 
-    pub fn parent_module_of_macro_def(&self, mark: ExpnId) -> DefId {
-        self.parent_modules_of_macro_defs[&mark]
+    pub fn parent_module_of_macro_def(&self, expn_id: ExpnId) -> DefId {
+        self.parent_modules_of_macro_defs[&expn_id]
     }
 
-    pub fn add_parent_module_of_macro_def(&mut self, mark: ExpnId, module: DefId) {
-        self.parent_modules_of_macro_defs.insert(mark, module);
+    pub fn add_parent_module_of_macro_def(&mut self, expn_id: ExpnId, module: DefId) {
+        self.parent_modules_of_macro_defs.insert(expn_id, module);
     }
 
     pub fn invocation_parent(&self, invoc_id: ExpnId) -> DefIndex {

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -15,7 +15,7 @@ use std::borrow::Borrow;
 use std::fmt::Write;
 use std::hash::Hash;
 use syntax::ast;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::symbol::{Symbol, sym, InternedString};
 use syntax_pos::{Span, DUMMY_SP};
 use crate::util::nodemap::NodeMap;
@@ -93,16 +93,16 @@ pub struct Definitions {
     node_to_def_index: NodeMap<DefIndex>,
     def_index_to_node: Vec<ast::NodeId>,
     pub(super) node_to_hir_id: IndexVec<ast::NodeId, hir::HirId>,
-    /// If `Mark` is an ID of some macro expansion,
+    /// If `ExpnId` is an ID of some macro expansion,
     /// then `DefId` is the normal module (`mod`) in which the expanded macro was defined.
-    parent_modules_of_macro_defs: FxHashMap<Mark, DefId>,
-    /// Item with a given `DefIndex` was defined during macro expansion with ID `Mark`.
-    expansions_that_defined: FxHashMap<DefIndex, Mark>,
+    parent_modules_of_macro_defs: FxHashMap<ExpnId, DefId>,
+    /// Item with a given `DefIndex` was defined during macro expansion with ID `ExpnId`.
+    expansions_that_defined: FxHashMap<DefIndex, ExpnId>,
     next_disambiguator: FxHashMap<(DefIndex, DefPathData), u32>,
     def_index_to_span: FxHashMap<DefIndex, Span>,
-    /// When collecting definitions from an AST fragment produced by a macro invocation `Mark`
+    /// When collecting definitions from an AST fragment produced by a macro invocation `ExpnId`
     /// we know what parent node that fragment should be attached to thanks to this table.
-    invocation_parents: FxHashMap<Mark, DefIndex>,
+    invocation_parents: FxHashMap<ExpnId, DefIndex>,
 }
 
 /// A unique identifier that we can use to lookup a definition
@@ -437,7 +437,7 @@ impl Definitions {
         assert!(self.def_index_to_node.is_empty());
         self.def_index_to_node.push(ast::CRATE_NODE_ID);
         self.node_to_def_index.insert(ast::CRATE_NODE_ID, root_index);
-        self.set_invocation_parent(Mark::root(), root_index);
+        self.set_invocation_parent(ExpnId::root(), root_index);
 
         // Allocate some other DefIndices that always must exist.
         GlobalMetaDataKind::allocate_def_indices(self);
@@ -450,7 +450,7 @@ impl Definitions {
                                   parent: DefIndex,
                                   node_id: ast::NodeId,
                                   data: DefPathData,
-                                  expansion: Mark,
+                                  expansion: ExpnId,
                                   span: Span)
                                   -> DefIndex {
         debug!("create_def_with_parent(parent={:?}, node_id={:?}, data={:?})",
@@ -498,7 +498,7 @@ impl Definitions {
             self.node_to_def_index.insert(node_id, index);
         }
 
-        if expansion != Mark::root() {
+        if expansion != ExpnId::root() {
             self.expansions_that_defined.insert(index, expansion);
         }
 
@@ -519,23 +519,23 @@ impl Definitions {
         self.node_to_hir_id = mapping;
     }
 
-    pub fn expansion_that_defined(&self, index: DefIndex) -> Mark {
-        self.expansions_that_defined.get(&index).cloned().unwrap_or(Mark::root())
+    pub fn expansion_that_defined(&self, index: DefIndex) -> ExpnId {
+        self.expansions_that_defined.get(&index).cloned().unwrap_or(ExpnId::root())
     }
 
-    pub fn parent_module_of_macro_def(&self, mark: Mark) -> DefId {
+    pub fn parent_module_of_macro_def(&self, mark: ExpnId) -> DefId {
         self.parent_modules_of_macro_defs[&mark]
     }
 
-    pub fn add_parent_module_of_macro_def(&mut self, mark: Mark, module: DefId) {
+    pub fn add_parent_module_of_macro_def(&mut self, mark: ExpnId, module: DefId) {
         self.parent_modules_of_macro_defs.insert(mark, module);
     }
 
-    pub fn invocation_parent(&self, invoc_id: Mark) -> DefIndex {
+    pub fn invocation_parent(&self, invoc_id: ExpnId) -> DefIndex {
         self.invocation_parents[&invoc_id]
     }
 
-    pub fn set_invocation_parent(&mut self, invoc_id: Mark, parent: DefIndex) {
+    pub fn set_invocation_parent(&mut self, invoc_id: ExpnId, parent: DefIndex) {
         let old_parent = self.invocation_parents.insert(invoc_id, parent);
         assert!(old_parent.is_none(), "parent def-index is reset for an invocation");
     }
@@ -624,7 +624,7 @@ macro_rules! define_global_metadata_kind {
                         CRATE_DEF_INDEX,
                         ast::DUMMY_NODE_ID,
                         DefPathData::GlobalMetaData(instance.name().as_interned_str()),
-                        Mark::root(),
+                        ExpnId::root(),
                         DUMMY_SP
                     );
 

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -363,17 +363,17 @@ impl<'a> HashStable<StableHashingContext<'a>> for Span {
             }
 
             let sub_hash: u64 = CACHE.with(|cache| {
-                let mark = span.ctxt.outer();
+                let expn_id = span.ctxt.outer_expn();
 
-                if let Some(&sub_hash) = cache.borrow().get(&mark) {
+                if let Some(&sub_hash) = cache.borrow().get(&expn_id) {
                     return sub_hash;
                 }
 
                 let mut hasher = StableHasher::new();
-                mark.expn_info().hash_stable(hcx, &mut hasher);
+                expn_id.expn_info().hash_stable(hcx, &mut hasher);
                 let sub_hash: Fingerprint = hasher.finish();
                 let sub_hash = sub_hash.to_smaller_hash();
-                cache.borrow_mut().insert(mark, sub_hash);
+                cache.borrow_mut().insert(expn_id, sub_hash);
                 sub_hash
             });
 

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -359,7 +359,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for Span {
             // times, we cache a stable hash of it and hash that instead of
             // recursing every time.
             thread_local! {
-                static CACHE: RefCell<FxHashMap<hygiene::Mark, u64>> = Default::default();
+                static CACHE: RefCell<FxHashMap<hygiene::ExpnId, u64>> = Default::default();
             }
 
             let sub_hash: u64 = CACHE.with(|cache| {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -44,7 +44,7 @@ use std::{mem, ptr};
 use std::ops::Range;
 use syntax::ast::{self, Name, Ident, NodeId};
 use syntax::attr;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::symbol::{kw, sym, Symbol, LocalInternedString, InternedString};
 use syntax_pos::Span;
 
@@ -3071,10 +3071,10 @@ impl<'tcx> TyCtxt<'tcx> {
                                          self.expansion_that_defined(def_parent_def_id))
     }
 
-    fn expansion_that_defined(self, scope: DefId) -> Mark {
+    fn expansion_that_defined(self, scope: DefId) -> ExpnId {
         match scope.krate {
             LOCAL_CRATE => self.hir().definitions().expansion_that_defined(scope.index),
-            _ => Mark::root(),
+            _ => ExpnId::root(),
         }
     }
 

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -819,15 +819,15 @@ where
         if span_data.ctxt == SyntaxContext::empty() {
             TAG_NO_EXPANSION_INFO.encode(self)
         } else {
-            let (mark, expn_info) = span_data.ctxt.outer_and_expn_info();
+            let (expn_id, expn_info) = span_data.ctxt.outer_expn_with_info();
             if let Some(expn_info) = expn_info {
-                if let Some(pos) = self.expn_info_shorthands.get(&mark).cloned() {
+                if let Some(pos) = self.expn_info_shorthands.get(&expn_id).cloned() {
                     TAG_EXPANSION_INFO_SHORTHAND.encode(self)?;
                     pos.encode(self)
                 } else {
                     TAG_EXPANSION_INFO_INLINE.encode(self)?;
                     let pos = AbsoluteBytePos::new(self.position());
-                    self.expn_info_shorthands.insert(mark, pos);
+                    self.expn_info_shorthands.insert(expn_id, pos);
                     expn_info.encode(self)
                 }
             } else {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -23,7 +23,7 @@ use std::mem;
 use syntax::ast::NodeId;
 use syntax::source_map::{SourceMap, StableSourceFileId};
 use syntax_pos::{BytePos, Span, DUMMY_SP, SourceFile};
-use syntax_pos::hygiene::{Mark, SyntaxContext, ExpnInfo};
+use syntax_pos::hygiene::{ExpnId, SyntaxContext, ExpnInfo};
 
 const TAG_FILE_FOOTER: u128 = 0xC0FFEE_C0FFEE_C0FFEE_C0FFEE_C0FFEE;
 
@@ -594,7 +594,7 @@ impl<'a, 'tcx> SpecializedDecoder<Span> for CacheDecoder<'a, 'tcx> {
         // as long as incremental compilation does not kick in before that.
         let location = || Span::new(lo, hi, SyntaxContext::empty());
         let recover_from_expn_info = |this: &Self, expn_info, pos| {
-            let span = location().fresh_expansion(Mark::root(), expn_info);
+            let span = location().fresh_expansion(ExpnId::root(), expn_info);
             this.synthetic_expansion_infos.borrow_mut().insert(pos, span.ctxt());
             span
         };
@@ -725,7 +725,7 @@ struct CacheEncoder<'a, 'tcx, E: ty_codec::TyEncoder> {
     encoder: &'a mut E,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::Predicate<'tcx>, usize>,
-    expn_info_shorthands: FxHashMap<Mark, AbsoluteBytePos>,
+    expn_info_shorthands: FxHashMap<ExpnId, AbsoluteBytePos>,
     interpret_allocs: FxHashMap<interpret::AllocId, usize>,
     interpret_allocs_inverse: Vec<interpret::AllocId>,
     source_map: CachingSourceMapView<'tcx>,

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -588,7 +588,7 @@ impl<'a, 'tcx> SpecializedDecoder<Span> for CacheDecoder<'a, 'tcx> {
 
         let expn_info_tag = u8::decode(self)?;
 
-        // FIXME(mw): This method does not restore `MarkData::parent` or
+        // FIXME(mw): This method does not restore `InternalExpnData::parent` or
         // `SyntaxContextData::prev_ctxt` or `SyntaxContextData::opaque`. These things
         // don't seem to be used after HIR lowering, so everything should be fine
         // as long as incremental compilation does not kick in before that.

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -14,7 +14,7 @@ use syntax::{
         base::{ExtCtxt, MacroKind, Resolver},
         build::AstBuilder,
         expand::ExpansionConfig,
-        hygiene::Mark,
+        hygiene::ExpnId,
     },
     mut_visit::{self, MutVisitor},
     parse::ParseSess,
@@ -85,7 +85,7 @@ impl MutVisitor for ExpandAllocatorDirectives<'_> {
         self.found = true;
 
         // Create a new expansion for the generated allocator code.
-        let span = item.span.fresh_expansion(Mark::root(), ExpnInfo::allow_unstable(
+        let span = item.span.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
             ExpnKind::Macro(MacroKind::Attr, sym::global_allocator), item.span, self.sess.edition,
             [sym::rustc_attrs][..].into(),
         ));

--- a/src/librustc_codegen_llvm/asm.rs
+++ b/src/librustc_codegen_llvm/asm.rs
@@ -102,7 +102,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
             let kind = llvm::LLVMGetMDKindIDInContext(self.llcx,
                 key.as_ptr() as *const c_char, key.len() as c_uint);
 
-            let val: &'ll Value = self.const_i32(ia.ctxt.outer().as_u32() as i32);
+            let val: &'ll Value = self.const_i32(ia.ctxt.outer_expn().as_u32() as i32);
 
             llvm::LLVMSetMetadata(r, kind,
                 llvm::LLVMMDNodeInContext(self.llcx, &val, 1));

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -26,7 +26,7 @@ use rustc_errors::{Handler, Level, DiagnosticBuilder, FatalError, DiagnosticId};
 use rustc_errors::emitter::{Emitter};
 use rustc_target::spec::MergeFunctions;
 use syntax::attr;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax_pos::MultiSpan;
 use syntax_pos::symbol::{Symbol, sym};
 use jobserver::{Client, Acquired};
@@ -1775,7 +1775,7 @@ impl SharedEmitterMain {
                     }
                 }
                 Ok(SharedEmitterMessage::InlineAsmError(cookie, msg)) => {
-                    match Mark::from_u32(cookie).expn_info() {
+                    match ExpnId::from_u32(cookie).expn_info() {
                         Some(ei) => sess.span_err(ei.call_site, &msg),
                         None     => sess.err(&msg),
                     }

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -572,7 +572,7 @@ pub fn lower_to_hir(
 
     // Discard hygiene data, which isn't required after lowering to HIR.
     if !sess.opts.debugging_opts.keep_hygiene_data {
-        syntax::ext::hygiene::clear_markings();
+        syntax::ext::hygiene::syntax_context_map();
     }
 
     Ok(hir_forest)

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -572,7 +572,7 @@ pub fn lower_to_hir(
 
     // Discard hygiene data, which isn't required after lowering to HIR.
     if !sess.opts.debugging_opts.keep_hygiene_data {
-        syntax::ext::hygiene::syntax_context_map();
+        syntax::ext::hygiene::clear_syntax_context_map();
     }
 
     Ok(hir_forest)

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -31,7 +31,7 @@ use syntax::ast::{self, Ident};
 use syntax::source_map;
 use syntax::symbol::{Symbol, sym};
 use syntax::ext::base::{MacroKind, SyntaxExtension};
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, NO_EXPANSION};
 use log::debug;
 
@@ -458,7 +458,7 @@ crate fn proc_macro_def_path_table(crate_root: &CrateRoot<'_>,
             crate_root,
             ast::DUMMY_NODE_ID,
             DefPathData::MacroNs(name.as_interned_str()),
-            Mark::root(),
+            ExpnId::root(),
             DUMMY_SP);
         debug!("definition for {:?} is {:?}", name, def_index);
         assert_eq!(def_index, DefIndex::from_proc_macro_index(index));

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -30,7 +30,7 @@ use syntax::attr;
 use syntax::ast::{self, Block, ForeignItem, ForeignItemKind, Item, ItemKind, NodeId};
 use syntax::ast::{MetaItemKind, StmtKind, TraitItem, TraitItemKind, Variant};
 use syntax::ext::base::SyntaxExtension;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::ext::tt::macro_rules;
 use syntax::feature_gate::is_builtin_attr;
 use syntax::parse::token::{self, Token};
@@ -45,7 +45,7 @@ use log::debug;
 
 type Res = def::Res<NodeId>;
 
-impl<'a> ToNameBinding<'a> for (Module<'a>, ty::Visibility, Span, Mark) {
+impl<'a> ToNameBinding<'a> for (Module<'a>, ty::Visibility, Span, ExpnId) {
     fn to_name_binding(self, arenas: &'a ResolverArenas<'a>) -> &'a NameBinding<'a> {
         arenas.alloc_name_binding(NameBinding {
             kind: NameBindingKind::Module(self.0),
@@ -57,7 +57,7 @@ impl<'a> ToNameBinding<'a> for (Module<'a>, ty::Visibility, Span, Mark) {
     }
 }
 
-impl<'a> ToNameBinding<'a> for (Res, ty::Visibility, Span, Mark) {
+impl<'a> ToNameBinding<'a> for (Res, ty::Visibility, Span, ExpnId) {
     fn to_name_binding(self, arenas: &'a ResolverArenas<'a>) -> &'a NameBinding<'a> {
         arenas.alloc_name_binding(NameBinding {
             kind: NameBindingKind::Res(self.0, false),
@@ -71,7 +71,7 @@ impl<'a> ToNameBinding<'a> for (Res, ty::Visibility, Span, Mark) {
 
 pub(crate) struct IsMacroExport;
 
-impl<'a> ToNameBinding<'a> for (Res, ty::Visibility, Span, Mark, IsMacroExport) {
+impl<'a> ToNameBinding<'a> for (Res, ty::Visibility, Span, ExpnId, IsMacroExport) {
     fn to_name_binding(self, arenas: &'a ResolverArenas<'a>) -> &'a NameBinding<'a> {
         arenas.alloc_name_binding(NameBinding {
             kind: NameBindingKind::Res(self.0, true),
@@ -397,7 +397,7 @@ impl<'a> Resolver<'a> {
                 let imported_binding = self.import(binding, directive);
                 if ptr::eq(self.current_module, self.graph_root) {
                     if let Some(entry) = self.extern_prelude.get(&ident.modern()) {
-                        if expansion != Mark::root() && orig_name.is_some() &&
+                        if expansion != ExpnId::root() && orig_name.is_some() &&
                            entry.extern_crate_item.is_none() {
                             self.session.span_err(item.span, "macro-expanded `extern crate` items \
                                                               cannot shadow names passed with \
@@ -571,7 +571,7 @@ impl<'a> Resolver<'a> {
                                        variant: &Variant,
                                        parent: Module<'a>,
                                        vis: ty::Visibility,
-                                       expansion: Mark) {
+                                       expansion: ExpnId) {
         let ident = variant.node.ident;
 
         // Define a name in the type namespace.
@@ -600,7 +600,7 @@ impl<'a> Resolver<'a> {
     }
 
     /// Constructs the reduced graph for one foreign item.
-    fn build_reduced_graph_for_foreign_item(&mut self, item: &ForeignItem, expansion: Mark) {
+    fn build_reduced_graph_for_foreign_item(&mut self, item: &ForeignItem, expansion: ExpnId) {
         let (res, ns) = match item.node {
             ForeignItemKind::Fn(..) => {
                 (Res::Def(DefKind::Fn, self.definitions.local_def_id(item.id)), ValueNS)
@@ -618,7 +618,7 @@ impl<'a> Resolver<'a> {
         self.define(parent, item.ident, ns, (res, vis, item.span, expansion));
     }
 
-    fn build_reduced_graph_for_block(&mut self, block: &Block, expansion: Mark) {
+    fn build_reduced_graph_for_block(&mut self, block: &Block, expansion: ExpnId) {
         let parent = self.current_module;
         if self.block_needs_anonymous_module(block) {
             let module = self.new_module(parent,
@@ -642,7 +642,7 @@ impl<'a> Resolver<'a> {
         // but metadata cannot encode gensyms currently, so we create it here.
         // This is only a guess, two equivalent idents may incorrectly get different gensyms here.
         let ident = ident.gensym_if_underscore();
-        let expansion = Mark::root(); // FIXME(jseyfried) intercrate hygiene
+        let expansion = ExpnId::root(); // FIXME(jseyfried) intercrate hygiene
         match res {
             Res::Def(kind @ DefKind::Mod, def_id)
             | Res::Def(kind @ DefKind::Enum, def_id) => {
@@ -734,13 +734,14 @@ impl<'a> Resolver<'a> {
         };
 
         let kind = ModuleKind::Def(DefKind::Mod, def_id, name.as_symbol());
-        let module =
-            self.arenas.alloc_module(ModuleData::new(parent, kind, def_id, Mark::root(), DUMMY_SP));
+        let module = self.arenas.alloc_module(ModuleData::new(
+            parent, kind, def_id, ExpnId::root(), DUMMY_SP
+        ));
         self.extern_module_map.insert((def_id, macros_only), module);
         module
     }
 
-    pub fn macro_def_scope(&mut self, expansion: Mark) -> Module<'a> {
+    pub fn macro_def_scope(&mut self, expansion: ExpnId) -> Module<'a> {
         let def_id = match self.macro_defs.get(&expansion) {
             Some(def_id) => *def_id,
             None => return self.graph_root,
@@ -858,7 +859,7 @@ impl<'a> Resolver<'a> {
             used: Cell::new(false),
         });
 
-        let allow_shadowing = parent_scope.expansion == Mark::root();
+        let allow_shadowing = parent_scope.expansion == ExpnId::root();
         if let Some(span) = import_all {
             let directive = macro_use_directive(span);
             self.potentially_unused_imports.push(directive);
@@ -918,7 +919,7 @@ impl<'a> Resolver<'a> {
 pub struct BuildReducedGraphVisitor<'a, 'b> {
     pub resolver: &'a mut Resolver<'b>,
     pub current_legacy_scope: LegacyScope<'b>,
-    pub expansion: Mark,
+    pub expansion: ExpnId,
 }
 
 impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2095,10 +2095,10 @@ impl<'a> Resolver<'a> {
         parent: Module<'a>,
         kind: ModuleKind,
         normal_ancestor_id: DefId,
-        expansion: ExpnId,
+        expn_id: ExpnId,
         span: Span,
     ) -> Module<'a> {
-        let module = ModuleData::new(Some(parent), kind, normal_ancestor_id, expansion, span);
+        let module = ModuleData::new(Some(parent), kind, normal_ancestor_id, expn_id, span);
         self.arenas.alloc_module(module)
     }
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -39,7 +39,7 @@ use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
 
 use syntax::source_map::SourceMap;
-use syntax::ext::hygiene::{Mark, Transparency, SyntaxContext};
+use syntax::ext::hygiene::{ExpnId, Transparency, SyntaxContext};
 use syntax::ast::{self, Name, NodeId, Ident, FloatTy, IntTy, UintTy};
 use syntax::ext::base::SyntaxExtension;
 use syntax::ext::base::MacroKind;
@@ -141,7 +141,7 @@ enum ScopeSet {
 #[derive(Clone, Debug)]
 pub struct ParentScope<'a> {
     module: Module<'a>,
-    expansion: Mark,
+    expansion: ExpnId,
     legacy: LegacyScope<'a>,
     derives: Vec<ast::Path>,
 }
@@ -1178,7 +1178,7 @@ pub struct ModuleData<'a> {
     builtin_attrs: RefCell<Vec<(Ident, ParentScope<'a>)>>,
 
     // Macro invocations that can expand into items in this module.
-    unresolved_invocations: RefCell<FxHashSet<Mark>>,
+    unresolved_invocations: RefCell<FxHashSet<ExpnId>>,
 
     no_implicit_prelude: bool,
 
@@ -1196,7 +1196,7 @@ pub struct ModuleData<'a> {
     /// Span of the module itself. Used for error reporting.
     span: Span,
 
-    expansion: Mark,
+    expansion: ExpnId,
 }
 
 type Module<'a> = &'a ModuleData<'a>;
@@ -1205,7 +1205,7 @@ impl<'a> ModuleData<'a> {
     fn new(parent: Option<Module<'a>>,
            kind: ModuleKind,
            normal_ancestor_id: DefId,
-           expansion: Mark,
+           expansion: ExpnId,
            span: Span) -> Self {
         ModuleData {
             parent,
@@ -1304,7 +1304,7 @@ impl<'a> fmt::Debug for ModuleData<'a> {
 pub struct NameBinding<'a> {
     kind: NameBindingKind<'a>,
     ambiguity: Option<(&'a NameBinding<'a>, AmbiguityKind)>,
-    expansion: Mark,
+    expansion: ExpnId,
     span: Span,
     vis: ty::Visibility,
 }
@@ -1513,7 +1513,7 @@ impl<'a> NameBinding<'a> {
     // in some later round and screw up our previously found resolution.
     // See more detailed explanation in
     // https://github.com/rust-lang/rust/pull/53778#issuecomment-419224049
-    fn may_appear_after(&self, invoc_parent_expansion: Mark, binding: &NameBinding<'_>) -> bool {
+    fn may_appear_after(&self, invoc_parent_expansion: ExpnId, binding: &NameBinding<'_>) -> bool {
         // self > max(invoc, binding) => !(self <= invoc || self <= binding)
         // Expansions are partially ordered, so "may appear after" is an inversion of
         // "certainly appears before or simultaneously" and includes unordered cases.
@@ -1686,13 +1686,13 @@ pub struct Resolver<'a> {
     dummy_ext_bang: Lrc<SyntaxExtension>,
     dummy_ext_derive: Lrc<SyntaxExtension>,
     non_macro_attrs: [Lrc<SyntaxExtension>; 2],
-    macro_defs: FxHashMap<Mark, DefId>,
+    macro_defs: FxHashMap<ExpnId, DefId>,
     local_macro_def_scopes: FxHashMap<NodeId, Module<'a>>,
     unused_macros: NodeMap<Span>,
     proc_macro_stubs: NodeSet,
 
-    /// Maps the `Mark` of an expansion to its containing module or block.
-    invocations: FxHashMap<Mark, &'a InvocationData<'a>>,
+    /// Maps the `ExpnId` of an expansion to its containing module or block.
+    invocations: FxHashMap<ExpnId, &'a InvocationData<'a>>,
 
     /// Avoid duplicated errors for "name already defined".
     name_already_seen: FxHashMap<Name, Span>,
@@ -1918,7 +1918,7 @@ impl<'a> Resolver<'a> {
         );
         let graph_root = arenas.alloc_module(ModuleData {
             no_implicit_prelude: attr::contains_name(&krate.attrs, sym::no_implicit_prelude),
-            ..ModuleData::new(None, root_module_kind, root_def_id, Mark::root(), krate.span)
+            ..ModuleData::new(None, root_module_kind, root_def_id, ExpnId::root(), krate.span)
         });
         let mut module_map = FxHashMap::default();
         module_map.insert(DefId::local(CRATE_DEF_INDEX), graph_root);
@@ -1941,11 +1941,11 @@ impl<'a> Resolver<'a> {
         }
 
         let mut invocations = FxHashMap::default();
-        invocations.insert(Mark::root(),
+        invocations.insert(ExpnId::root(),
                            arenas.alloc_invocation_data(InvocationData::root(graph_root)));
 
         let mut macro_defs = FxHashMap::default();
-        macro_defs.insert(Mark::root(), root_def_id);
+        macro_defs.insert(ExpnId::root(), root_def_id);
 
         let features = session.features_untracked();
         let non_macro_attr =
@@ -2014,7 +2014,7 @@ impl<'a> Resolver<'a> {
             dummy_binding: arenas.alloc_name_binding(NameBinding {
                 kind: NameBindingKind::Res(Res::Err, false),
                 ambiguity: None,
-                expansion: Mark::root(),
+                expansion: ExpnId::root(),
                 span: DUMMY_SP,
                 vis: ty::Visibility::Public,
             }),
@@ -2095,7 +2095,7 @@ impl<'a> Resolver<'a> {
         parent: Module<'a>,
         kind: ModuleKind,
         normal_ancestor_id: DefId,
-        expansion: Mark,
+        expansion: ExpnId,
         span: Span,
     ) -> Module<'a> {
         let module = ModuleData::new(Some(parent), kind, normal_ancestor_id, expansion, span);
@@ -2243,7 +2243,7 @@ impl<'a> Resolver<'a> {
                 }
                 Scope::CrateRoot => match ns {
                     TypeNS => {
-                        ident.span.adjust(Mark::root());
+                        ident.span.adjust(ExpnId::root());
                         Scope::ExternPrelude
                     }
                     ValueNS | MacroNS => break,
@@ -2253,7 +2253,7 @@ impl<'a> Resolver<'a> {
                     match self.hygienic_lexical_parent(module, &mut ident.span) {
                         Some(parent_module) => Scope::Module(parent_module),
                         None => {
-                            ident.span.adjust(Mark::root());
+                            ident.span.adjust(ExpnId::root());
                             match ns {
                                 TypeNS => Scope::ExternPrelude,
                                 ValueNS => Scope::StdLibPrelude,
@@ -2399,7 +2399,7 @@ impl<'a> Resolver<'a> {
         }
 
         if !module.no_implicit_prelude {
-            ident.span.adjust(Mark::root());
+            ident.span.adjust(ExpnId::root());
             if ns == TypeNS {
                 if let Some(binding) = self.extern_prelude_get(ident, !record_used) {
                     return Some(LexicalScopeBinding::Item(binding));
@@ -2407,7 +2407,7 @@ impl<'a> Resolver<'a> {
             }
             if ns == TypeNS && KNOWN_TOOLS.contains(&ident.name) {
                 let binding = (Res::ToolMod, ty::Visibility::Public,
-                               DUMMY_SP, Mark::root()).to_name_binding(self.arenas);
+                               DUMMY_SP, ExpnId::root()).to_name_binding(self.arenas);
                 return Some(LexicalScopeBinding::Item(binding));
             }
             if let Some(prelude) = self.prelude {
@@ -2506,7 +2506,7 @@ impl<'a> Resolver<'a> {
                 }
             }
             ModuleOrUniformRoot::ExternPrelude => {
-                ident.span.modernize_and_adjust(Mark::root());
+                ident.span.modernize_and_adjust(ExpnId::root());
             }
             ModuleOrUniformRoot::CrateRootAndExternPrelude |
             ModuleOrUniformRoot::CurrentScope => {
@@ -2552,7 +2552,7 @@ impl<'a> Resolver<'a> {
             result
         } else {
             ctxt = ctxt.modern();
-            ctxt.adjust(Mark::root())
+            ctxt.adjust(ExpnId::root())
         };
         let module = match mark {
             Some(def) => self.macro_def_scope(def),
@@ -5063,7 +5063,7 @@ impl<'a> Resolver<'a> {
                 };
                 let crate_root = self.get_module(DefId { krate: crate_id, index: CRATE_DEF_INDEX });
                 self.populate_module_if_necessary(&crate_root);
-                Some((crate_root, ty::Visibility::Public, DUMMY_SP, Mark::root())
+                Some((crate_root, ty::Visibility::Public, DUMMY_SP, ExpnId::root())
                     .to_name_binding(self.arenas))
             }
         })

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2070,7 +2070,7 @@ impl<'a> Resolver<'a> {
 
     fn macro_def(&self, mut ctxt: SyntaxContext) -> DefId {
         loop {
-            match self.macro_defs.get(&ctxt.outer()) {
+            match self.macro_defs.get(&ctxt.outer_expn()) {
                 Some(&def_id) => return def_id,
                 None => ctxt.remove_mark(),
             };
@@ -2428,7 +2428,7 @@ impl<'a> Resolver<'a> {
 
     fn hygienic_lexical_parent(&mut self, module: Module<'a>, span: &mut Span)
                                -> Option<Module<'a>> {
-        if !module.expansion.outer_is_descendant_of(span.ctxt()) {
+        if !module.expansion.outer_expn_is_descendant_of(span.ctxt()) {
             return Some(self.macro_def_scope(span.remove_mark()));
         }
 
@@ -2464,7 +2464,7 @@ impl<'a> Resolver<'a> {
             module.expansion.is_descendant_of(parent.expansion) {
                 // The macro is a proc macro derive
                 if module.expansion.looks_like_proc_macro_derive() {
-                    if parent.expansion.outer_is_descendant_of(span.ctxt()) {
+                    if parent.expansion.outer_expn_is_descendant_of(span.ctxt()) {
                         *poisoned = Some(node_id);
                         return module.parent;
                     }

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -139,15 +139,15 @@ impl<'a> base::Resolver for Resolver<'a> {
         let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::default(
             ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, self.session.edition()
         ));
-        let mark = span.ctxt().outer();
+        let expn_id = span.ctxt().outer_expn();
         let module = self.module_map[&self.definitions.local_def_id(id)];
-        self.definitions.set_invocation_parent(mark, module.def_id().unwrap().index);
-        self.invocations.insert(mark, self.arenas.alloc_invocation_data(InvocationData {
+        self.definitions.set_invocation_parent(expn_id, module.def_id().unwrap().index);
+        self.invocations.insert(expn_id, self.arenas.alloc_invocation_data(InvocationData {
             module,
             parent_legacy_scope: LegacyScope::Empty,
             output_legacy_scope: Cell::new(None),
         }));
-        mark
+        expn_id
     }
 
     fn resolve_dollar_crates(&mut self) {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -28,7 +28,7 @@ use rustc::util::nodemap::FxHashSet;
 use rustc::{bug, span_bug};
 
 use syntax::ast::{self, Ident, Name, NodeId, CRATE_NODE_ID};
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::symbol::kw;
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax::{struct_span_err, unwrap_or};
@@ -221,7 +221,7 @@ impl<'a> Resolver<'a> {
                         ident.name == kw::DollarCrate {
                         let module = self.resolve_crate_root(ident);
                         let binding = (module, ty::Visibility::Public,
-                                        module.span, Mark::root())
+                                        module.span, ExpnId::root())
                                         .to_name_binding(self.arenas);
                         return Ok(binding);
                     } else if ident.name == kw::Super ||
@@ -246,7 +246,7 @@ impl<'a> Resolver<'a> {
             .map_err(|_| (Determined, Weak::No))?; // This happens when there is a cycle of imports.
 
         if let Some(binding) = resolution.binding {
-            if !restricted_shadowing && binding.expansion != Mark::root() {
+            if !restricted_shadowing && binding.expansion != ExpnId::root() {
                 if let NameBindingKind::Res(_, true) = binding.kind {
                     self.macro_expanded_macro_export_errors.insert((path_span, binding.span));
                 }
@@ -286,7 +286,7 @@ impl<'a> Resolver<'a> {
                     if let Some(shadowed_glob) = resolution.shadowed_glob {
                         // Forbid expanded shadowing to avoid time travel.
                         if restricted_shadowing &&
-                        binding.expansion != Mark::root() &&
+                        binding.expansion != ExpnId::root() &&
                         binding.res() != shadowed_glob.res() {
                             self.ambiguity_errors.push(AmbiguityError {
                                 kind: AmbiguityKind::GlobVsExpanded,
@@ -525,7 +525,7 @@ impl<'a> Resolver<'a> {
                             (binding, old_binding)
                         };
                         if glob_binding.res() != nonglob_binding.res() &&
-                           ns == MacroNS && nonglob_binding.expansion != Mark::root() {
+                           ns == MacroNS && nonglob_binding.expansion != ExpnId::root() {
                             resolution.binding = Some(this.ambiguity(AmbiguityKind::GlobVsExpanded,
                                                                     nonglob_binding, glob_binding));
                         } else {
@@ -1248,7 +1248,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
         target: Ident,
     ) {
         // Skip if the import was produced by a macro.
-        if directive.parent_scope.expansion != Mark::root() {
+        if directive.parent_scope.expansion != ExpnId::root() {
             return;
         }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -5,7 +5,7 @@ pub use UnsafeSource::*;
 pub use crate::symbol::{Ident, Symbol as Name};
 pub use crate::util::parser::ExprPrecedence;
 
-use crate::ext::hygiene::{Mark, SyntaxContext};
+use crate::ext::hygiene::{ExpnId, SyntaxContext};
 use crate::parse::token::{self, DelimToken};
 use crate::print::pprust;
 use crate::ptr::P;
@@ -251,12 +251,12 @@ mod node_id_inner {
 pub use node_id_inner::NodeId;
 
 impl NodeId {
-    pub fn placeholder_from_mark(mark: Mark) -> Self {
+    pub fn placeholder_from_mark(mark: ExpnId) -> Self {
         NodeId::from_u32(mark.as_u32())
     }
 
-    pub fn placeholder_to_mark(self) -> Mark {
-        Mark::from_u32(self.as_u32())
+    pub fn placeholder_to_mark(self) -> ExpnId {
+        ExpnId::from_u32(self.as_u32())
     }
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -251,11 +251,11 @@ mod node_id_inner {
 pub use node_id_inner::NodeId;
 
 impl NodeId {
-    pub fn placeholder_from_mark(mark: ExpnId) -> Self {
-        NodeId::from_u32(mark.as_u32())
+    pub fn placeholder_from_expn_id(expn_id: ExpnId) -> Self {
+        NodeId::from_u32(expn_id.as_u32())
     }
 
-    pub fn placeholder_to_mark(self) -> ExpnId {
+    pub fn placeholder_to_expn_id(self) -> ExpnId {
         ExpnId::from_u32(self.as_u32())
     }
 }

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -3,7 +3,7 @@ use crate::attr::{HasAttrs, Stability, Deprecation};
 use crate::source_map::{SourceMap, Spanned, respan};
 use crate::edition::Edition;
 use crate::ext::expand::{self, AstFragment, Invocation};
-use crate::ext::hygiene::{Mark, SyntaxContext, Transparency};
+use crate::ext::hygiene::{ExpnId, SyntaxContext, Transparency};
 use crate::mut_visit::{self, MutVisitor};
 use crate::parse::{self, parser, DirectoryOwnership};
 use crate::parse::token;
@@ -682,16 +682,16 @@ pub struct Indeterminate;
 pub trait Resolver {
     fn next_node_id(&mut self) -> ast::NodeId;
 
-    fn get_module_scope(&mut self, id: ast::NodeId) -> Mark;
+    fn get_module_scope(&mut self, id: ast::NodeId) -> ExpnId;
 
     fn resolve_dollar_crates(&mut self);
-    fn visit_ast_fragment_with_placeholders(&mut self, mark: Mark, fragment: &AstFragment,
-                                            derives: &[Mark]);
+    fn visit_ast_fragment_with_placeholders(&mut self, mark: ExpnId, fragment: &AstFragment,
+                                            derives: &[ExpnId]);
     fn add_builtin(&mut self, ident: ast::Ident, ext: Lrc<SyntaxExtension>);
 
     fn resolve_imports(&mut self);
 
-    fn resolve_macro_invocation(&mut self, invoc: &Invocation, invoc_id: Mark, force: bool)
+    fn resolve_macro_invocation(&mut self, invoc: &Invocation, invoc_id: ExpnId, force: bool)
                                 -> Result<Option<Lrc<SyntaxExtension>>, Indeterminate>;
 
     fn check_unused_macros(&self);
@@ -705,7 +705,7 @@ pub struct ModuleData {
 
 #[derive(Clone)]
 pub struct ExpansionData {
-    pub mark: Mark,
+    pub mark: ExpnId,
     pub depth: usize,
     pub module: Rc<ModuleData>,
     pub directory_ownership: DirectoryOwnership,
@@ -735,7 +735,7 @@ impl<'a> ExtCtxt<'a> {
             root_path: PathBuf::new(),
             resolver,
             current_expansion: ExpansionData {
-                mark: Mark::root(),
+                mark: ExpnId::root(),
                 depth: 0,
                 module: Rc::new(ModuleData { mod_path: Vec::new(), directory: PathBuf::new() }),
                 directory_ownership: DirectoryOwnership::Owned { relative: None },

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -54,7 +54,7 @@ pub fn add_derived_markers<T>(cx: &mut ExtCtxt<'_>, span: Span, traits: &[ast::P
         names.insert(unwrap_or!(path.segments.get(0), continue).ident.name);
     }
 
-    let span = span.fresh_expansion(cx.current_expansion.mark, ExpnInfo::allow_unstable(
+    let span = span.fresh_expansion(cx.current_expansion.id, ExpnInfo::allow_unstable(
         ExpnKind::Macro(MacroKind::Derive, Symbol::intern(&pretty_name)), span,
         cx.parse_sess.edition, cx.allow_derive_markers.clone(),
     ));

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -88,7 +88,7 @@ impl<'a, 'b> PlaceholderExpander<'a, 'b> {
         fragment.mut_visit_with(self);
         if let AstFragment::Items(mut items) = fragment {
             for derive in derives {
-                match self.remove(NodeId::placeholder_from_mark(derive)) {
+                match self.remove(NodeId::placeholder_from_expn_id(derive)) {
                     AstFragment::Items(derived_items) => items.extend(derived_items),
                     _ => unreachable!(),
                 }

--- a/src/libsyntax/ext/placeholders.rs
+++ b/src/libsyntax/ext/placeholders.rs
@@ -2,7 +2,7 @@ use crate::ast::{self, NodeId};
 use crate::source_map::{DUMMY_SP, dummy_spanned};
 use crate::ext::base::ExtCtxt;
 use crate::ext::expand::{AstFragment, AstFragmentKind};
-use crate::ext::hygiene::Mark;
+use crate::ext::hygiene::ExpnId;
 use crate::tokenstream::TokenStream;
 use crate::mut_visit::*;
 use crate::ptr::P;
@@ -84,7 +84,7 @@ impl<'a, 'b> PlaceholderExpander<'a, 'b> {
         }
     }
 
-    pub fn add(&mut self, id: ast::NodeId, mut fragment: AstFragment, derives: Vec<Mark>) {
+    pub fn add(&mut self, id: ast::NodeId, mut fragment: AstFragment, derives: Vec<ExpnId>) {
         fragment.mut_visit_with(self);
         if let AstFragment::Items(mut items) = fragment {
             for derive in derives {

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -219,7 +219,7 @@ pub fn transcribe(
                         if let NtTT(ref tt) = **nt {
                             result.push(tt.clone().into());
                         } else {
-                            sp = sp.apply_mark(cx.current_expansion.mark);
+                            sp = sp.apply_mark(cx.current_expansion.id);
                             let token = TokenTree::token(token::Interpolated(nt.clone()), sp);
                             result.push(token.into());
                         }
@@ -234,8 +234,8 @@ pub fn transcribe(
                     // If we aren't able to match the meta-var, we push it back into the result but
                     // with modified syntax context. (I believe this supports nested macros).
                     let ident =
-                        Ident::new(ident.name, ident.span.apply_mark(cx.current_expansion.mark));
-                    sp = sp.apply_mark(cx.current_expansion.mark);
+                        Ident::new(ident.name, ident.span.apply_mark(cx.current_expansion.id));
+                    sp = sp.apply_mark(cx.current_expansion.id);
                     result.push(TokenTree::token(token::Dollar, sp).into());
                     result.push(TokenTree::Token(Token::from_ast_ident(ident)).into());
                 }
@@ -247,7 +247,7 @@ pub fn transcribe(
             // jump back out of the Delimited, pop the result_stack and add the new results back to
             // the previous results (from outside the Delimited).
             quoted::TokenTree::Delimited(mut span, delimited) => {
-                span = span.apply_mark(cx.current_expansion.mark);
+                span = span.apply_mark(cx.current_expansion.id);
                 stack.push(Frame::Delimited { forest: delimited, idx: 0, span });
                 result_stack.push(mem::take(&mut result));
             }
@@ -255,7 +255,7 @@ pub fn transcribe(
             // Nothing much to do here. Just push the token to the result, being careful to
             // preserve syntax context.
             quoted::TokenTree::Token(token) => {
-                let mut marker = Marker(cx.current_expansion.mark);
+                let mut marker = Marker(cx.current_expansion.id);
                 let mut tt = TokenTree::Token(token);
                 noop_visit_tt(&mut tt, &mut marker);
                 result.push(tt.into());

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -1,7 +1,7 @@
 use crate::ast;
 use crate::attr;
 use crate::edition::Edition;
-use crate::ext::hygiene::{Mark, MacroKind};
+use crate::ext::hygiene::{ExpnId, MacroKind};
 use crate::symbol::{Ident, Symbol, kw, sym};
 use crate::source_map::{ExpnInfo, ExpnKind, dummy_spanned, respan};
 use crate::ptr::P;
@@ -75,7 +75,7 @@ pub fn maybe_inject_crates_ref(
 
     INJECTED_CRATE_NAME.with(|opt_name| opt_name.set(Some(name)));
 
-    let span = DUMMY_SP.fresh_expansion(Mark::root(), ExpnInfo::allow_unstable(
+    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
         ExpnKind::Macro(MacroKind::Attr, sym::std_inject), DUMMY_SP, edition,
         [sym::prelude_import][..].into(),
     ));

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -21,7 +21,7 @@ use crate::entry::{self, EntryPointType};
 use crate::ext::base::{ExtCtxt, Resolver};
 use crate::ext::build::AstBuilder;
 use crate::ext::expand::ExpansionConfig;
-use crate::ext::hygiene::{self, Mark, SyntaxContext, MacroKind};
+use crate::ext::hygiene::{self, ExpnId, SyntaxContext, MacroKind};
 use crate::mut_visit::{*, ExpectOne};
 use crate::feature_gate::Features;
 use crate::util::map_in_place::MapInPlace;
@@ -303,7 +303,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
     //            #![main]
     //            test::test_main_static(&[..tests]);
     //        }
-    let sp = DUMMY_SP.fresh_expansion(Mark::root(), ExpnInfo::allow_unstable(
+    let sp = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
         ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, cx.ext_cx.parse_sess.edition,
         [sym::main, sym::test, sym::rustc_attrs][..].into(),
     ));

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -232,7 +232,7 @@ fn mk_reexport_mod(cx: &mut TestCtxt<'_>,
 
     let name = Ident::from_str("__test_reexports").gensym();
     let parent = if parent == ast::DUMMY_NODE_ID { ast::CRATE_NODE_ID } else { parent };
-    cx.ext_cx.current_expansion.mark = cx.ext_cx.resolver.get_module_scope(parent);
+    cx.ext_cx.current_expansion.id = cx.ext_cx.resolver.get_module_scope(parent);
     let it = cx.ext_cx.monotonic_expander().flat_map_item(P(ast::Item {
         ident: name,
         attrs: Vec::new(),

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -545,10 +545,10 @@ impl DelimSpan {
         self.open.with_hi(self.close.hi())
     }
 
-    pub fn apply_mark(self, mark: ExpnId) -> Self {
+    pub fn apply_mark(self, expn_id: ExpnId) -> Self {
         DelimSpan {
-            open: self.open.apply_mark(mark),
-            close: self.close.apply_mark(mark),
+            open: self.open.apply_mark(expn_id),
+            close: self.close.apply_mark(expn_id),
         }
     }
 }

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -19,7 +19,7 @@ use crate::parse::Directory;
 use crate::parse::token::{self, DelimToken, Token, TokenKind};
 use crate::print::pprust;
 
-use syntax_pos::{BytePos, Mark, Span, DUMMY_SP};
+use syntax_pos::{BytePos, ExpnId, Span, DUMMY_SP};
 #[cfg(target_arch = "x86_64")]
 use rustc_data_structures::static_assert_size;
 use rustc_data_structures::sync::Lrc;
@@ -545,7 +545,7 @@ impl DelimSpan {
         self.open.with_hi(self.close.hi())
     }
 
-    pub fn apply_mark(self, mark: Mark) -> Self {
+    pub fn apply_mark(self, mark: ExpnId) -> Self {
         DelimSpan {
             open: self.open.apply_mark(mark),
             close: self.close.apply_mark(mark),

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -25,7 +25,7 @@ pub fn expand_assert<'cx>(
         }
     };
 
-    let sp = sp.apply_mark(cx.current_expansion.mark);
+    let sp = sp.apply_mark(cx.current_expansion.id);
     let panic_call = Mac_ {
         path: Path::from_ident(Ident::new(sym::panic, sp)),
         tts: custom_message.unwrap_or_else(|| {

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -17,7 +17,7 @@ pub fn expand_cfg(
     sp: Span,
     tts: &[tokenstream::TokenTree],
 ) -> Box<dyn base::MacResult + 'static> {
-    let sp = sp.apply_mark(cx.current_expansion.mark);
+    let sp = sp.apply_mark(cx.current_expansion.id);
 
     match parse_cfg(cx, sp, tts) {
         Ok(cfg) => {

--- a/src/libsyntax_ext/concat.rs
+++ b/src/libsyntax_ext/concat.rs
@@ -60,6 +60,6 @@ pub fn expand_syntax_ext(
     } else if has_errors {
         return base::DummyResult::expr(sp);
     }
-    let sp = sp.apply_mark(cx.current_expansion.mark);
+    let sp = sp.apply_mark(cx.current_expansion.id);
     base::MacEager::expr(cx.expr_str(sp, Symbol::intern(&accumulator)))
 }

--- a/src/libsyntax_ext/concat_idents.rs
+++ b/src/libsyntax_ext/concat_idents.rs
@@ -39,7 +39,7 @@ pub fn expand_syntax_ext<'cx>(cx: &'cx mut ExtCtxt<'_>,
         }
     }
 
-    let ident = ast::Ident::new(Symbol::intern(&res_str), sp.apply_mark(cx.current_expansion.mark));
+    let ident = ast::Ident::new(Symbol::intern(&res_str), sp.apply_mark(cx.current_expansion.id));
 
     struct ConcatIdentsResult { ident: ast::Ident }
 

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -85,7 +85,7 @@ impl<'a> Path<'a> {
             PathKind::Global => cx.path_all(span, true, idents, params, Vec::new()),
             PathKind::Local => cx.path_all(span, false, idents, params, Vec::new()),
             PathKind::Std => {
-                let def_site = DUMMY_SP.apply_mark(cx.current_expansion.mark);
+                let def_site = DUMMY_SP.apply_mark(cx.current_expansion.id);
                 idents.insert(0, Ident::new(kw::DollarCrate, def_site));
                 cx.path_all(span, false, idents, params, Vec::new())
             }

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -21,7 +21,7 @@ pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
         Some(v) => v,
     };
 
-    let sp = sp.apply_mark(cx.current_expansion.mark);
+    let sp = sp.apply_mark(cx.current_expansion.id);
     let e = match env::var(&*var.as_str()) {
         Err(..) => {
             let lt = cx.lifetime(sp, Ident::with_empty_ctxt(kw::StaticLifetime));

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -575,7 +575,7 @@ impl<'a, 'b> Context<'a, 'b> {
         for (i, e) in self.args.into_iter().enumerate() {
             let name = names_pos[i];
             let span =
-                DUMMY_SP.with_ctxt(e.span.ctxt().apply_mark(self.ecx.current_expansion.mark));
+                DUMMY_SP.with_ctxt(e.span.ctxt().apply_mark(self.ecx.current_expansion.id));
             pats.push(self.ecx.pat_ident(span, name));
             for ref arg_ty in self.arg_unique_types[i].iter() {
                 locals.push(Context::format_arg(self.ecx, self.macsp, e.span, arg_ty, name));
@@ -652,7 +652,7 @@ impl<'a, 'b> Context<'a, 'b> {
                   ty: &ArgumentType,
                   arg: ast::Ident)
                   -> P<ast::Expr> {
-        sp = sp.apply_mark(ecx.current_expansion.mark);
+        sp = sp.apply_mark(ecx.current_expansion.id);
         let arg = ecx.expr_ident(sp, arg);
         let trait_ = match *ty {
             Placeholder(ref tyname) => {
@@ -691,7 +691,7 @@ fn expand_format_args_impl<'cx>(
     tts: &[tokenstream::TokenTree],
     nl: bool,
 ) -> Box<dyn base::MacResult + 'cx> {
-    sp = sp.apply_mark(ecx.current_expansion.mark);
+    sp = sp.apply_mark(ecx.current_expansion.id);
     match parse_args(ecx, sp, tts) {
         Ok((efmt, args, names)) => {
             MacEager::expr(expand_preparsed_format_args(ecx, sp, efmt, args, names, nl))
@@ -734,7 +734,7 @@ pub fn expand_preparsed_format_args(ecx: &mut ExtCtxt<'_>,
     let arg_unique_types: Vec<_> = (0..args.len()).map(|_| Vec::new()).collect();
 
     let mut macsp = ecx.call_site();
-    macsp = macsp.apply_mark(ecx.current_expansion.mark);
+    macsp = macsp.apply_mark(ecx.current_expansion.id);
 
     let msg = "format argument must be a string literal";
     let fmt_sp = efmt.span;

--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -8,7 +8,7 @@ use syntax::source_map::{ExpnInfo, ExpnKind, respan};
 use syntax::ext::base::{ExtCtxt, MacroKind};
 use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
-use syntax::ext::hygiene::Mark;
+use syntax::ext::hygiene::ExpnId;
 use syntax::mut_visit::MutVisitor;
 use syntax::parse::ParseSess;
 use syntax::ptr::P;
@@ -346,7 +346,7 @@ fn mk_decls(
     custom_attrs: &[ProcMacroDef],
     custom_macros: &[ProcMacroDef],
 ) -> P<ast::Item> {
-    let span = DUMMY_SP.fresh_expansion(Mark::root(), ExpnInfo::allow_unstable(
+    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
         ExpnKind::Macro(MacroKind::Attr, sym::proc_macro), DUMMY_SP, cx.parse_sess.edition,
         [sym::rustc_attrs, sym::proc_macro_internals][..].into(),
     ));

--- a/src/libsyntax_ext/proc_macro_server.rs
+++ b/src/libsyntax_ext/proc_macro_server.rs
@@ -364,11 +364,11 @@ pub(crate) struct Rustc<'a> {
 impl<'a> Rustc<'a> {
     pub fn new(cx: &'a ExtCtxt<'_>) -> Self {
         // No way to determine def location for a proc macro right now, so use call location.
-        let location = cx.current_expansion.mark.expn_info().unwrap().call_site;
+        let location = cx.current_expansion.id.expn_info().unwrap().call_site;
         let to_span = |transparency| {
             location.with_ctxt(
                 SyntaxContext::empty()
-                    .apply_mark_with_transparency(cx.current_expansion.mark, transparency),
+                    .apply_mark_with_transparency(cx.current_expansion.id, transparency),
             )
         };
         Rustc {

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -59,7 +59,7 @@ pub fn expand_test_or_bench(
         return vec![Annotatable::Item(item)];
     }
 
-    let ctxt = SyntaxContext::empty().apply_mark(cx.current_expansion.mark);
+    let ctxt = SyntaxContext::empty().apply_mark(cx.current_expansion.id);
     let (sp, attr_sp) = (item.span.with_ctxt(ctxt), attr_sp.with_ctxt(ctxt));
 
     // Gensym "test" so we can extern crate without conflicting with any local names

--- a/src/libsyntax_ext/test_case.rs
+++ b/src/libsyntax_ext/test_case.rs
@@ -25,7 +25,7 @@ pub fn expand(
 ) -> Vec<Annotatable> {
     if !ecx.ecfg.should_test { return vec![]; }
 
-    let sp = attr_sp.with_ctxt(SyntaxContext::empty().apply_mark(ecx.current_expansion.mark));
+    let sp = attr_sp.with_ctxt(SyntaxContext::empty().apply_mark(ecx.current_expansion.id));
     let mut item = anno_item.expect_item();
     item = item.map(|mut item| {
         item.vis = respan(item.vis.span, ast::VisibilityKind::Public);

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -530,34 +530,34 @@ impl Span {
     }
 
     #[inline]
-    pub fn adjust(&mut self, expansion: ExpnId) -> Option<ExpnId> {
+    pub fn adjust(&mut self, expn_id: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
-        let mark = span.ctxt.adjust(expansion);
+        let mark = span.ctxt.adjust(expn_id);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }
 
     #[inline]
-    pub fn modernize_and_adjust(&mut self, expansion: ExpnId) -> Option<ExpnId> {
+    pub fn modernize_and_adjust(&mut self, expn_id: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
-        let mark = span.ctxt.modernize_and_adjust(expansion);
+        let mark = span.ctxt.modernize_and_adjust(expn_id);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }
 
     #[inline]
-    pub fn glob_adjust(&mut self, expansion: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
+    pub fn glob_adjust(&mut self, expn_id: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
         let mut span = self.data();
-        let mark = span.ctxt.glob_adjust(expansion, glob_span);
+        let mark = span.ctxt.glob_adjust(expn_id, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }
 
     #[inline]
-    pub fn reverse_glob_adjust(&mut self, expansion: ExpnId, glob_span: Span)
+    pub fn reverse_glob_adjust(&mut self, expn_id: ExpnId, glob_span: Span)
                                -> Option<Option<ExpnId>> {
         let mut span = self.data();
-        let mark = span.ctxt.reverse_glob_adjust(expansion, glob_span);
+        let mark = span.ctxt.reverse_glob_adjust(expn_id, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);
         mark
     }

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -27,7 +27,7 @@ extern crate serialize as rustc_serialize; // used by deriving
 pub mod edition;
 use edition::Edition;
 pub mod hygiene;
-pub use hygiene::{Mark, SyntaxContext, ExpnInfo, ExpnKind, MacroKind, DesugaringKind};
+pub use hygiene::{ExpnId, SyntaxContext, ExpnInfo, ExpnKind, MacroKind, DesugaringKind};
 
 mod span_encoding;
 pub use span_encoding::{Span, DUMMY_SP};
@@ -516,13 +516,13 @@ impl Span {
     }
 
     #[inline]
-    pub fn apply_mark(self, mark: Mark) -> Span {
+    pub fn apply_mark(self, mark: ExpnId) -> Span {
         let span = self.data();
         span.with_ctxt(span.ctxt.apply_mark(mark))
     }
 
     #[inline]
-    pub fn remove_mark(&mut self) -> Mark {
+    pub fn remove_mark(&mut self) -> ExpnId {
         let mut span = self.data();
         let mark = span.ctxt.remove_mark();
         *self = Span::new(span.lo, span.hi, span.ctxt);
@@ -530,7 +530,7 @@ impl Span {
     }
 
     #[inline]
-    pub fn adjust(&mut self, expansion: Mark) -> Option<Mark> {
+    pub fn adjust(&mut self, expansion: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
         let mark = span.ctxt.adjust(expansion);
         *self = Span::new(span.lo, span.hi, span.ctxt);
@@ -538,7 +538,7 @@ impl Span {
     }
 
     #[inline]
-    pub fn modernize_and_adjust(&mut self, expansion: Mark) -> Option<Mark> {
+    pub fn modernize_and_adjust(&mut self, expansion: ExpnId) -> Option<ExpnId> {
         let mut span = self.data();
         let mark = span.ctxt.modernize_and_adjust(expansion);
         *self = Span::new(span.lo, span.hi, span.ctxt);
@@ -546,7 +546,7 @@ impl Span {
     }
 
     #[inline]
-    pub fn glob_adjust(&mut self, expansion: Mark, glob_span: Span) -> Option<Option<Mark>> {
+    pub fn glob_adjust(&mut self, expansion: ExpnId, glob_span: Span) -> Option<Option<ExpnId>> {
         let mut span = self.data();
         let mark = span.ctxt.glob_adjust(expansion, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);
@@ -554,8 +554,8 @@ impl Span {
     }
 
     #[inline]
-    pub fn reverse_glob_adjust(&mut self, expansion: Mark, glob_span: Span)
-                               -> Option<Option<Mark>> {
+    pub fn reverse_glob_adjust(&mut self, expansion: ExpnId, glob_span: Span)
+                               -> Option<Option<ExpnId>> {
         let mut span = self.data();
         let mark = span.ctxt.reverse_glob_adjust(expansion, glob_span);
         *self = Span::new(span.lo, span.hi, span.ctxt);


### PR DESCRIPTION
"`Mark`" is an ID that identifies both a macro invocation (`foo!()`), and expansion process, and expansion result of that macro invocation.
The problem is that it's pretty hard to infer that from its name.

This PR renames it into `ExpnId` reflecting its meaning in most contexts.
(The contexts where it's meaning is closer to "macro invocation ID" are rarer.)

I've kept "mark" in the names of functions that add or remove marks to/from syntactic contexts, those marks are not just expansion IDs, but something more complex.