### PR TITLE
Specific error for positional args after named args in `format!()`

### DIFF
--- a/src/test/ui/if/ifmt-bad-arg.rs
+++ b/src/test/ui/if/ifmt-bad-arg.rs
@@ -38,7 +38,7 @@ fn main() {
     format!("{} {}", 1, 2, foo=1, bar=2);  //~ ERROR: multiple unused formatting arguments
 
     format!("{foo}", foo=1, foo=2);  //~ ERROR: duplicate argument
-    format!("", foo=1, 2);           //~ ERROR: positional arguments cannot follow
+    format!("{foo} {} {}", foo=1, 2);   //~ ERROR: positional arguments cannot follow
 
     // bad named arguments, #35082
 

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -146,11 +146,13 @@ note: previously here
 LL |     format!("{foo}", foo=1, foo=2);
    |                          ^
 
-error: expected ident, positional arguments cannot follow named arguments
-  --> $DIR/ifmt-bad-arg.rs:41:24
+error: positional arguments cannot follow named arguments
+  --> $DIR/ifmt-bad-arg.rs:41:35
    |
-LL |     format!("", foo=1, 2);
-   |                        ^
+LL |     format!("{foo} {} {}", foo=1, 2);
+   |                                -  ^ positional arguments must be before named arguments
+   |                                |
+   |                                named argument
 
 error: there is no argument named `valueb`
   --> $DIR/ifmt-bad-arg.rs:45:23

--- a/src/test/ui/macros/format-parse-errors.rs
+++ b/src/test/ui/macros/format-parse-errors.rs
@@ -1,9 +1,15 @@
 fn main() {
+    let foo = "";
+    let bar = "";
     format!(); //~ ERROR requires at least a format string argument
     format!(struct); //~ ERROR expected expression
     format!("s", name =); //~ ERROR expected expression
-    format!("s", foo = foo, bar); //~ ERROR expected `=`
-    format!("s", foo = struct); //~ ERROR expected expression
+    format!(
+        "s {foo} {} {}",
+        foo = foo,
+        bar, //~ ERROR positional arguments cannot follow named arguments
+    );
+    format!("s {foo}", foo = struct); //~ ERROR expected expression
     format!("s", struct); //~ ERROR expected expression
 
     // This error should come after parsing errors to ensure they are non-fatal.

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -1,5 +1,5 @@
 error: requires at least a format string argument
-  --> $DIR/format-parse-errors.rs:2:5
+  --> $DIR/format-parse-errors.rs:4:5
    |
 LL |     format!();
    |     ^^^^^^^^^^
@@ -7,37 +7,39 @@ LL |     format!();
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: expected expression, found keyword `struct`
-  --> $DIR/format-parse-errors.rs:3:13
+  --> $DIR/format-parse-errors.rs:5:13
    |
 LL |     format!(struct);
    |             ^^^^^^ expected expression
 
 error: expected expression, found end of macro arguments
-  --> $DIR/format-parse-errors.rs:4:24
+  --> $DIR/format-parse-errors.rs:6:24
    |
 LL |     format!("s", name =);
    |                        ^ expected expression
 
-error: expected `=`, found end of macro arguments
-  --> $DIR/format-parse-errors.rs:5:32
+error: positional arguments cannot follow named arguments
+  --> $DIR/format-parse-errors.rs:10:9
    |
-LL |     format!("s", foo = foo, bar);
-   |                                ^ expected `=`
+LL |         foo = foo,
+   |               --- named argument
+LL |         bar,
+   |         ^^^ positional arguments must be before named arguments
 
 error: expected expression, found keyword `struct`
-  --> $DIR/format-parse-errors.rs:6:24
+  --> $DIR/format-parse-errors.rs:12:30
    |
-LL |     format!("s", foo = struct);
-   |                        ^^^^^^ expected expression
+LL |     format!("s {foo}", foo = struct);
+   |                              ^^^^^^ expected expression
 
 error: expected expression, found keyword `struct`
-  --> $DIR/format-parse-errors.rs:7:18
+  --> $DIR/format-parse-errors.rs:13:18
    |
 LL |     format!("s", struct);
    |                  ^^^^^^ expected expression
 
 error: format argument must be a string literal
-  --> $DIR/format-parse-errors.rs:10:13
+  --> $DIR/format-parse-errors.rs:16:13
    |
 LL |     format!(123);
    |             ^^^


### PR DESCRIPTION
When writing positional arguments after named arguments in the
`format!()` and `println!()` macros, provide a targeted diagnostic.

Follow up to https://github.com/rust-lang/rust/pull/57522/files#r247278885