### PR TITLE
ci: Bump time limit of tools builder on PRs

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -21,6 +21,7 @@ jobs:
         IMAGE: mingw-check
 
 - job: LinuxTools
+  timeoutInMinutes: 600
   pool:
     vmImage: ubuntu-16.04
   steps:


### PR DESCRIPTION
This should give it enough time to finish instead of being killed after
an hour.