### PR TITLE
Deprecate using rustc_plugin without the rustc_driver dylib.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "rustc_interface",
  "rustc_metadata",
  "rustc_mir",
+ "rustc_plugin_impl",
  "rustc_save_analysis",
  "rustc_target",
  "serialize",
@@ -3246,7 +3247,7 @@ dependencies = [
  "rustc_metadata",
  "rustc_mir",
  "rustc_passes",
- "rustc_plugin",
+ "rustc_plugin_impl",
  "rustc_privacy",
  "rustc_resolve",
  "rustc_traits",
@@ -3372,7 +3373,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_plugin"
+name = "rustc_plugin_impl"
 version = "0.0.0"
 dependencies = [
  "rustc",

--- a/src/doc/rustc-ux-guidelines.md
+++ b/src/doc/rustc-ux-guidelines.md
@@ -70,7 +70,7 @@ for details on how to format and write long error codes.
   [librustc_privacy](https://github.com/rust-lang/rust/blob/master/src/librustc_privacy/error_codes.rs),
   [librustc_resolve](https://github.com/rust-lang/rust/blob/master/src/librustc_resolve/error_codes.rs),
   [librustc_codegen_llvm](https://github.com/rust-lang/rust/blob/master/src/librustc_codegen_llvm/error_codes.rs),
-  [librustc_plugin](https://github.com/rust-lang/rust/blob/master/src/librustc_plugin/error_codes.rs),
+  [librustc_plugin_impl](https://github.com/rust-lang/rust/blob/master/src/librustc_plugin/error_codes.rs),
   [librustc_typeck](https://github.com/rust-lang/rust/blob/master/src/librustc_typeck/error_codes.rs).
 * Explanations have full markdown support. Use it, especially to highlight
 code with backticks.

--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -18,7 +18,7 @@ extend the compiler's behavior with new syntax extensions, lint checks, etc.
 A plugin is a dynamic library crate with a designated *registrar* function that
 registers extensions with `rustc`. Other crates can load these extensions using
 the crate attribute `#![plugin(...)]`.  See the
-`rustc_plugin` documentation for more about the
+`rustc_driver::plugin` documentation for more about the
 mechanics of defining and loading a plugin.
 
 If present, arguments passed as `#![plugin(foo(... args ...))]` are not
@@ -54,13 +54,13 @@ that implements Roman numeral integer literals.
 extern crate syntax;
 extern crate syntax_pos;
 extern crate rustc;
-extern crate rustc_plugin;
+extern crate rustc_driver;
 
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
 use syntax_pos::Span;
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         -> Box<dyn MacResult + 'static> {
@@ -180,11 +180,11 @@ extern crate syntax;
 // Load rustc as a plugin to get macros
 #[macro_use]
 extern crate rustc;
-extern crate rustc_plugin;
+extern crate rustc_driver;
 
 use rustc::lint::{EarlyContext, LintContext, LintPass, EarlyLintPass,
                   EarlyLintPassObject, LintArray};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use syntax::ast;
 
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -20,6 +20,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_mir = { path = "../librustc_mir" }
+rustc_plugin_impl = { path = "../librustc_plugin" }
 rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }
 rustc_interface = { path = "../librustc_interface" }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -22,6 +22,8 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 
+pub extern crate rustc_plugin_impl as plugin;
+
 use pretty::{PpMode, UserIdentifiedItem};
 
 //use rustc_resolve as resolve;

--- a/src/librustc_interface/Cargo.toml
+++ b/src/librustc_interface/Cargo.toml
@@ -30,7 +30,7 @@ rustc_passes = { path = "../librustc_passes" }
 rustc_typeck = { path = "../librustc_typeck" }
 rustc_lint = { path = "../librustc_lint" }
 rustc_errors = { path = "../librustc_errors" }
-rustc_plugin = { path = "../librustc_plugin" }
+rustc_plugin = { path = "../librustc_plugin", package = "rustc_plugin_impl" }
 rustc_privacy = { path = "../librustc_privacy" }
 rustc_resolve = { path = "../librustc_resolve" }
 tempfile = "3.0.5"

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -3,7 +3,7 @@
 //! This currently only contains the definitions and implementations
 //! of most of the lints that `rustc` supports directly, it does not
 //! contain the infrastructure for defining/registering lints. That is
-//! available in `rustc::lint` and `rustc_plugin` respectively.
+//! available in `rustc::lint` and `rustc_driver::plugin` respectively.
 //!
 //! ## Note
 //!

--- a/src/librustc_plugin/Cargo.toml
+++ b/src/librustc_plugin/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 authors = ["The Rust Project Developers"]
-name = "rustc_plugin"
+name = "rustc_plugin_impl"
 version = "0.0.0"
 build = false
 edition = "2018"
 
 [lib]
-name = "rustc_plugin"
+name = "rustc_plugin_impl"
 path = "lib.rs"
 doctest = false
 

--- a/src/librustc_plugin/deprecated/Cargo.toml
+++ b/src/librustc_plugin/deprecated/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["The Rust Project Developers"]
+name = "rustc_plugin"
+version = "0.0.0"
+build = false
+edition = "2018"
+
+[lib]
+name = "rustc_plugin"
+path = "lib.rs"
+doctest = false
+
+[dependencies]
+rustc_plugin_impl = { path = ".." }

--- a/src/librustc_plugin/deprecated/lib.rs
+++ b/src/librustc_plugin/deprecated/lib.rs
@@ -1,0 +1,8 @@
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
+#![feature(staged_api)]
+#![unstable(feature = "rustc_plugin", issue = "29597")]
+#![rustc_deprecated(since = "1.38.0", reason = "\
+    import this through `rustc_driver::plugin` instead to make TLS work correctly. \
+    See https://github.com/rust-lang/rust/issues/62717")]
+
+pub use rustc_plugin_impl::*;

--- a/src/librustc_plugin/lib.rs
+++ b/src/librustc_plugin/lib.rs
@@ -16,12 +16,11 @@
 //! #![feature(plugin_registrar)]
 //! #![feature(rustc_private)]
 //!
-//! extern crate rustc_plugin;
 //! extern crate rustc_driver;
 //! extern crate syntax;
 //! extern crate syntax_pos;
 //!
-//! use rustc_plugin::Registry;
+//! use rustc_driver::plugin::Registry;
 //! use syntax::ext::base::{ExtCtxt, MacResult};
 //! use syntax_pos::Span;
 //! use syntax::tokenstream::TokenTree;

--- a/src/test/ui-fulldeps/auxiliary/attr-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/attr-plugin-test.rs
@@ -4,10 +4,9 @@
 #![feature(rustc_private)]
 
 extern crate rustc_driver;
-extern crate rustc_plugin;
 extern crate syntax;
 
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use syntax::ext::base::SyntaxExtension;
 use syntax::feature_gate::AttributeType;
 use syntax::symbol::Symbol;

--- a/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
@@ -3,11 +3,10 @@
 
 #[macro_use]
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 extern crate syntax;
 
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use syntax::attr;
 use syntax::ext::base::*;
 use syntax::feature_gate::AttributeType::Whitelisted;

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate-rpass.rs
@@ -4,12 +4,11 @@
 #![feature(box_syntax)]
 
 #[macro_use] extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 extern crate syntax;
 
 use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LateLintPassObject, LintArray};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use rustc::hir;
 use syntax::attr;
 use syntax::symbol::Symbol;

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
@@ -4,12 +4,11 @@
 #![feature(box_syntax)]
 
 #[macro_use] extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 extern crate syntax;
 
 use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LateLintPassObject, LintArray};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use rustc::hir;
 use syntax::attr;
 use syntax::symbol::Symbol;

--- a/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
@@ -6,12 +6,11 @@
 // Load rustc as a plugin to get macros.
 #[macro_use]
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use rustc::hir;
 use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LateLintPassObject, LintArray};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
 

--- a/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
@@ -8,12 +8,11 @@ extern crate syntax;
 // Load rustc as a plugin to get macros
 #[macro_use]
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use rustc::lint::{EarlyContext, LintContext, LintPass, EarlyLintPass,
                   EarlyLintPassObject, LintArray};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use syntax::ast;
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
 

--- a/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
@@ -6,11 +6,10 @@ extern crate syntax;
 // Load rustc as a plugin to get macros
 #[macro_use]
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 use syntax::ast;
 declare_tool_lint!(pub clippy::TEST_LINT, Warn, "Warn about stuff");
 declare_tool_lint!(

--- a/src/test/ui-fulldeps/auxiliary/llvm-pass-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/llvm-pass-plugin.rs
@@ -4,10 +4,9 @@
 #![feature(rustc_private)]
 
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {

--- a/src/test/ui-fulldeps/auxiliary/lto-syntax-extension-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/lto-syntax-extension-plugin.rs
@@ -4,10 +4,9 @@
 #![feature(rustc_private)]
 
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 #[plugin_registrar]
 pub fn plugin_registrar(_reg: &mut Registry) {}

--- a/src/test/ui-fulldeps/auxiliary/macro-crate-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/macro-crate-test.rs
@@ -6,7 +6,6 @@
 
 extern crate syntax;
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 extern crate syntax_pos;
 extern crate proc_macro;

--- a/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
+++ b/src/test/ui-fulldeps/auxiliary/outlive-expansion-phase.rs
@@ -4,12 +4,11 @@
 #![feature(box_syntax, rustc_private)]
 
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use std::any::Any;
 use std::cell::RefCell;
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 struct Foo {
     foo: isize

--- a/src/test/ui-fulldeps/auxiliary/plugin-args.rs
+++ b/src/test/ui-fulldeps/auxiliary/plugin-args.rs
@@ -6,7 +6,6 @@
 extern crate syntax;
 extern crate syntax_pos;
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use std::borrow::ToOwned;
@@ -17,7 +16,7 @@ use syntax::print::pprust;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;
 use syntax::tokenstream::TokenStream;
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 struct Expander {
     args: Vec<ast::NestedMetaItem>,

--- a/src/test/ui-fulldeps/auxiliary/rlib-crate-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/rlib-crate-test.rs
@@ -4,10 +4,9 @@
 #![feature(plugin_registrar, rustc_private)]
 
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 #[plugin_registrar]
 pub fn plugin_registrar(_: &mut Registry) {}

--- a/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
+++ b/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
@@ -12,14 +12,13 @@
 extern crate syntax;
 extern crate syntax_pos;
 extern crate rustc;
-extern crate rustc_plugin;
 extern crate rustc_driver;
 
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
 use syntax_pos::Span;
-use rustc_plugin::Registry;
+use rustc_driver::plugin::Registry;
 
 fn expand_rn(cx: &mut ExtCtxt, sp: Span, args: &[TokenTree])
         -> Box<dyn MacResult + 'static> {


### PR DESCRIPTION
CC https://github.com/rust-lang/rust/pull/59800, https://github.com/rust-lang/rust/commit/7198687bb2df13a3298ef1e8f594753073d6b9e8

Fix https://github.com/rust-lang/rust/issues/62717