### PR TITLE
Remove uses of mem::uninitialized from std::sys::cloudabi

### DIFF
--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -273,6 +273,7 @@
 #![feature(link_args)]
 #![feature(linkage)]
 #![feature(maybe_uninit_ref)]
+#![feature(maybe_uninit_slice)]
 #![feature(mem_take)]
 #![feature(needs_panic_runtime)]
 #![feature(never_type)]

--- a/src/libstd/sys/cloudabi/abi/cloudabi.rs
+++ b/src/libstd/sys/cloudabi/abi/cloudabi.rs
@@ -1884,7 +1884,7 @@ pub unsafe fn clock_res_get(clock_id_: clockid, resolution_: &mut timestamp) -> 
 /// **time**:
 /// The time value of the clock.
 #[inline]
-pub unsafe fn clock_time_get(clock_id_: clockid, precision_: timestamp, time_: &mut timestamp) -> errno {
+pub unsafe fn clock_time_get(clock_id_: clockid, precision_: timestamp, time_: *mut timestamp) -> errno {
   cloudabi_sys_clock_time_get(clock_id_, precision_, time_)
 }
 
@@ -2643,7 +2643,7 @@ pub unsafe fn mem_unmap(mapping_: &mut [u8]) -> errno {
 /// **nevents**:
 /// The number of events stored.
 #[inline]
-pub unsafe fn poll(in_: *const subscription, out_: *mut event, nsubscriptions_: usize, nevents_: &mut usize) -> errno {
+pub unsafe fn poll(in_: *const subscription, out_: *mut event, nsubscriptions_: usize, nevents_: *mut usize) -> errno {
   cloudabi_sys_poll(in_, out_, nsubscriptions_, nevents_)
 }
 

--- a/src/libstd/sys/cloudabi/condvar.rs
+++ b/src/libstd/sys/cloudabi/condvar.rs
@@ -79,16 +79,21 @@ impl Condvar {
             },
             ..mem::zeroed()
         };
-        let mut event: abi::event = mem::uninitialized();
-        let mut nevents: usize = mem::uninitialized();
-        let ret = abi::poll(&subscription, &mut event, 1, &mut nevents);
+        let mut event: mem::MaybeUninit<abi::event> = mem::MaybeUninit::uninit();
+        let mut nevents: mem::MaybeUninit<usize> = mem::MaybeUninit::uninit();
+        let ret = abi::poll(
+            &subscription,
+            event.as_mut_ptr(),
+            1,
+            nevents.get_mut()
+        );
         assert_eq!(
             ret,
             abi::errno::SUCCESS,
             "Failed to wait on condition variable"
         );
         assert_eq!(
-            event.error,
+            event.assume_init().error,
             abi::errno::SUCCESS,
             "Failed to wait on condition variable"
         );
@@ -131,21 +136,27 @@ impl Condvar {
                 ..mem::zeroed()
             },
         ];
-        let mut events: [abi::event; 2] = mem::uninitialized();
-        let mut nevents: usize = mem::uninitialized();
-        let ret = abi::poll(subscriptions.as_ptr(), events.as_mut_ptr(), 2, &mut nevents);
+        let mut events: [mem::MaybeUninit<abi::event>; 2] = [mem::MaybeUninit::uninit(); 2];
+        let mut nevents: mem::MaybeUninit<usize> = mem::MaybeUninit::uninit();
+        let ret = abi::poll(
+            subscriptions.as_ptr(),
+            mem::MaybeUninit::first_ptr_mut(&mut events),
+            2,
+            nevents.get_mut()
+        );
         assert_eq!(
             ret,
             abi::errno::SUCCESS,
             "Failed to wait on condition variable"
         );
+        let nevents = nevents.assume_init();
         for i in 0..nevents {
             assert_eq!(
-                events[i].error,
+                events[i].assume_init().error,
                 abi::errno::SUCCESS,
                 "Failed to wait on condition variable"
             );
-            if events[i].type_ == abi::eventtype::CONDVAR {
+            if events[i].assume_init().type_ == abi::eventtype::CONDVAR {
                 return true;
             }
         }

--- a/src/libstd/sys/cloudabi/condvar.rs
+++ b/src/libstd/sys/cloudabi/condvar.rs
@@ -85,7 +85,7 @@ impl Condvar {
             &subscription,
             event.as_mut_ptr(),
             1,
-            nevents.get_mut()
+            nevents.as_mut_ptr()
         );
         assert_eq!(
             ret,
@@ -142,7 +142,7 @@ impl Condvar {
             subscriptions.as_ptr(),
             mem::MaybeUninit::first_ptr_mut(&mut events),
             2,
-            nevents.get_mut()
+            nevents.as_mut_ptr()
         );
         assert_eq!(
             ret,

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -64,7 +64,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
         let mut v: mem::MaybeUninit<(u64, u64)> = mem::MaybeUninit::uninit();
         libc::arc4random_buf(
             v.as_mut_ptr() as *mut libc::c_void,
-            mem::size_of_val(v.get_ref())
+            mem::size_of_val(&v)
         );
         v.assume_init()
     }

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -61,8 +61,11 @@ pub use libc::strlen;
 
 pub fn hashmap_random_keys() -> (u64, u64) {
     unsafe {
-        let mut v = mem::uninitialized();
-        libc::arc4random_buf(&mut v as *mut _ as *mut libc::c_void, mem::size_of_val(&v));
-        v
+        let mut v: mem::MaybeUninit<(u64, u64)> = mem::MaybeUninit::uninit();
+        libc::arc4random_buf(
+            v.as_mut_ptr() as *mut libc::c_void,
+            mem::size_of_val(v.get_ref())
+        );
+        v.assume_init()
     }
 }

--- a/src/libstd/sys/cloudabi/time.rs
+++ b/src/libstd/sys/cloudabi/time.rs
@@ -21,7 +21,7 @@ impl Instant {
             let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
             let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, t.get_mut());
             assert_eq!(ret, abi::errno::SUCCESS);
-            Instant { t }
+            Instant { t: t.assume_init() }
         }
     }
 
@@ -62,7 +62,7 @@ impl SystemTime {
             let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
             let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, t.get_mut());
             assert_eq!(ret, abi::errno::SUCCESS);
-            SystemTime { t }
+            SystemTime { t: t.assume_init() }
         }
     }
 

--- a/src/libstd/sys/cloudabi/time.rs
+++ b/src/libstd/sys/cloudabi/time.rs
@@ -18,8 +18,8 @@ pub fn checked_dur2intervals(dur: &Duration) -> Option<abi::timestamp> {
 impl Instant {
     pub fn now() -> Instant {
         unsafe {
-            let mut t = mem::uninitialized();
-            let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, &mut t);
+            let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
+            let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, t.get_mut());
             assert_eq!(ret, abi::errno::SUCCESS);
             Instant { t }
         }
@@ -59,8 +59,8 @@ pub struct SystemTime {
 impl SystemTime {
     pub fn now() -> SystemTime {
         unsafe {
-            let mut t = mem::uninitialized();
-            let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, &mut t);
+            let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
+            let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, t.get_mut());
             assert_eq!(ret, abi::errno::SUCCESS);
             SystemTime { t }
         }

--- a/src/libstd/sys/cloudabi/time.rs
+++ b/src/libstd/sys/cloudabi/time.rs
@@ -19,7 +19,7 @@ impl Instant {
     pub fn now() -> Instant {
         unsafe {
             let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
-            let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, t.get_mut());
+            let ret = abi::clock_time_get(abi::clockid::MONOTONIC, 0, t.as_mut_ptr());
             assert_eq!(ret, abi::errno::SUCCESS);
             Instant { t: t.assume_init() }
         }
@@ -60,7 +60,7 @@ impl SystemTime {
     pub fn now() -> SystemTime {
         unsafe {
             let mut t: mem::MaybeUninit<abi::timestamp> = mem::MaybeUninit::uninit();
-            let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, t.get_mut());
+            let ret = abi::clock_time_get(abi::clockid::REALTIME, 0, t.as_mut_ptr());
             assert_eq!(ret, abi::errno::SUCCESS);
             SystemTime { t: t.assume_init() }
         }


### PR DESCRIPTION
Addresses #62397 for std::sys::cloudabi, excluding the tests within cloudabi, which will be a separate PR