### PR TITLE
Optimize RefCell read borrowing

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1101,13 +1101,13 @@ struct BorrowRef<'b> {
 impl<'b> BorrowRef<'b> {
     #[inline]
     fn new(borrow: &'b Cell<BorrowFlag>) -> Option<BorrowRef<'b>> {
-        let b = borrow.get();
-        if is_writing(b) || b == isize::max_value() {
+        let b = borrow.get().wrapping_add(1);
+        if !is_reading(b) {
             // If there's currently a writing borrow, or if incrementing the
             // refcount would overflow into a writing borrow.
             None
         } else {
-            borrow.set(b + 1);
+            borrow.set(b);
             Some(BorrowRef { borrow })
         }
     }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1113,7 +1113,7 @@ impl<'b> BorrowRef<'b> {
             //    `Ref`s, which is not good practice)
             None
         } else {
-            // Incrementing borrow can result in a reading value (< 0) in these cases:
+            // Incrementing borrow can result in a reading value (> 0) in these cases:
             // 1. It was = 0, i.e. it wasn't borrowed, and we are taking the first read borrow
             // 2. It was > 0 and < isize::max_value(), i.e. there were read borrows, and isize
             //    is large enough to represent having one more read borrow

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1103,10 +1103,20 @@ impl<'b> BorrowRef<'b> {
     fn new(borrow: &'b Cell<BorrowFlag>) -> Option<BorrowRef<'b>> {
         let b = borrow.get().wrapping_add(1);
         if !is_reading(b) {
-            // If there's currently a writing borrow, or if incrementing the
-            // refcount would overflow into a writing borrow.
+            // Incrementing borrow can result in a non-reading value (<= 0) in these cases:
+            // 1. It was < 0, i.e. there are writing borrows, so we can't allow a read borrow
+            //    due to Rust's reference aliasing rules
+            // 2. It was isize::max_value() (the max amount of reading borrows) and it overflowed
+            //    into isize::min_value() (the max amount of writing borrows) so we can't allow
+            //    an additional read borrow because isize can't represent so many read borrows
+            //    (this can only happen if you mem::forget more than a small constant amount of
+            //    `Ref`s, which is not good practice)
             None
         } else {
+            // Incrementing borrow can result in a reading value (< 0) in these cases:
+            // 1. It was = 0, i.e. it wasn't borrowed, and we are taking the first read borrow
+            // 2. It was > 0 and < isize::max_value(), i.e. there were read borrows, and isize
+            //    is large enough to represent having one more read borrow
             borrow.set(b);
             Some(BorrowRef { borrow })
         }


### PR DESCRIPTION
Instead of doing two comparisons we can do only one with a bit of cleverness.

LLVM currently can't do this optimization itself on x86-64.