### PR TITLE
ci: fix LinuxTools PR builder missing environment variables

### DIFF
--- a/.azure-pipelines/pr.yml
+++ b/.azure-pipelines/pr.yml
@@ -6,6 +6,9 @@ trigger: none
 pr:
 - master
 
+variables:
+- group: public-credentials
+
 jobs:
 - job: Linux
   timeoutInMinutes: 600


### PR DESCRIPTION
This PR includes the new `public-credentials` variables group in PR builders, hopefully fixing sccache and toolstate.

~~Do not merge this yet as I want to do a test build first.~~

r? @alexcrichton 
fixes https://github.com/rust-lang/rust/issues/62754 https://github.com/rust-lang/rust/issues/62753