### PR TITLE
Suggest trait bound on type parameter when it is unconstrained

### DIFF
--- a/src/test/ui/issues/issue-39559.stderr
+++ b/src/test/ui/issues/issue-39559.stderr
@@ -4,9 +4,11 @@ error[E0599]: no function or associated item named `dim` found for type `D` in t
 LL |     entries: [T; D::dim()],
    |                     ^^^ function or associated item not found in `D`
    |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `dim`, perhaps you need to implement it:
-           candidate #1: `Dim`
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `dim`, perhaps you need to restrict type parameter `D` with it:
+   |
+LL | pub struct Vector<T, D: Dim + Dim> {
+   |                      ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -61,9 +61,11 @@ note: the candidate is defined in the trait `ManyImplTrait`
 LL |     fn is_str() -> bool {
    |     ^^^^^^^^^^^^^^^^^^^
    = help: to disambiguate the method call, write `ManyImplTrait::is_str(t)` instead
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `is_str`, perhaps you need to implement it:
-           candidate #1: `ManyImplTrait`
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `is_str`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn param_bound<T: ManyImplTrait + ManyImplTrait>(t: T) -> bool {
+   |                ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/issue-21673.rs
+++ b/src/test/ui/suggestions/issue-21673.rs
@@ -1,0 +1,13 @@
+trait Foo {
+    fn method(&self) {}
+}
+
+fn call_method<T: std::fmt::Debug>(x: &T) {
+    x.method() //~ ERROR E0599
+}
+
+fn call_method_2<T>(x: T) {
+    x.method() //~ ERROR E0599
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-21673.stderr
+++ b/src/test/ui/suggestions/issue-21673.stderr
@@ -1,0 +1,27 @@
+error[E0599]: no method named `method` found for type `&T` in the current scope
+  --> $DIR/issue-21673.rs:6:7
+   |
+LL |     x.method()
+   |       ^^^^^^
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn call_method<T: Foo + std::fmt::Debug>(x: &T) {
+   |                ^^^^^^^^
+
+error[E0599]: no method named `method` found for type `T` in the current scope
+  --> $DIR/issue-21673.rs:10:7
+   |
+LL |     x.method()
+   |       ^^^^^^
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn call_method_2<T: Foo>(x: T) {
+   |                  ^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Given

```
trait Foo { fn method(&self) {} }

fn call_method<T>(x: &T) {
    x.method()
}
```

suggest constraining `T` with `Foo`.

Fix #21673, fix #41030.