### PR TITLE
Disable simd_select_bitmask test on big endian

### DIFF
--- a/src/test/run-pass/simd/simd-intrinsic-generic-select.rs
+++ b/src/test/run-pass/simd/simd-intrinsic-generic-select.rs
@@ -2,6 +2,10 @@
 #![allow(non_camel_case_types)]
 
 // ignore-emscripten
+// ignore-mips       behavior of simd_select_bitmask is endian-specific
+// ignore-mips64     behavior of simd_select_bitmask is endian-specific
+// ignore-powerpc    behavior of simd_select_bitmask is endian-specific
+// ignore-powerpc64  behavior of simd_select_bitmask is endian-specific
 
 // Test that the simd_select intrinsics produces correct results.
 


### PR DESCRIPTION
Per #59356 it is expected that the interpretation of the bitmask depends
on target endianness.

Closes #59356