### PR TITLE
Self-referencial type now called a recursive type

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1320,7 +1320,7 @@ fn check_opaque<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, substs: SubstsRef<'tcx>,
             tcx.sess, span, E0720,
             "opaque type expands to a recursive type",
         );
-        err.span_label(span, "expands to self-referential type");
+        err.span_label(span, "expands to a recursive type");
         if let ty::Opaque(..) = partially_expanded_type.sty {
             err.note("type resolves to itself");
         } else {

--- a/src/test/ui/async-await/recursive-async-impl-trait-type.stderr
+++ b/src/test/ui/async-await/recursive-async-impl-trait-type.stderr
@@ -2,7 +2,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-async-impl-trait-type.rs:7:40
    |
 LL | async fn recursive_async_function() -> () {
-   |                                        ^^ expands to self-referential type
+   |                                        ^^ expands to a recursive type
    |
    = note: expanded type is `std::future::GenFuture<[static generator@$DIR/recursive-async-impl-trait-type.rs:7:43: 9:2 {impl std::future::Future, ()}]>`
 

--- a/src/test/ui/generator/issue-62506-two_awaits.rs
+++ b/src/test/ui/generator/issue-62506-two_awaits.rs
@@ -1,0 +1,18 @@
+// Output = String caused an ICE whereas Output = &'static str compiled successfully.
+// Broken MIR: generator contains type std::string::String in MIR,
+// but typeck only knows about {<S as T>::Future, ()}
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+use std::future::Future;
+
+pub trait T {
+    type Future: Future<Output = String>;
+    fn bar() -> Self::Future;
+}
+pub async fn foo<S>() where S: T {
+    S::bar().await;
+    S::bar().await;
+}
+pub fn main() {}

--- a/src/test/ui/impl-trait/issues/infinite-impl-trait-issue-38064.stderr
+++ b/src/test/ui/impl-trait/issues/infinite-impl-trait-issue-38064.stderr
@@ -2,7 +2,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/infinite-impl-trait-issue-38064.rs:8:13
    |
 LL | fn foo() -> impl Quux {
-   |             ^^^^^^^^^ expands to self-referential type
+   |             ^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `foo::Foo<bar::Bar<impl Quux>>`
 
@@ -10,7 +10,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/infinite-impl-trait-issue-38064.rs:14:13
    |
 LL | fn bar() -> impl Quux {
-   |             ^^^^^^^^^ expands to self-referential type
+   |             ^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `bar::Bar<foo::Foo<impl Quux>>`
 

--- a/src/test/ui/impl-trait/recursive-impl-trait-type.stderr
+++ b/src/test/ui/impl-trait/recursive-impl-trait-type.stderr
@@ -2,7 +2,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:6:22
    |
 LL | fn option(i: i32) -> impl Sized {
-   |                      ^^^^^^^^^^ expands to self-referential type
+   |                      ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `std::option::Option<(impl Sized, i32)>`
 
@@ -10,7 +10,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:14:15
    |
 LL | fn tuple() -> impl Sized {
-   |               ^^^^^^^^^^ expands to self-referential type
+   |               ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `(impl Sized,)`
 
@@ -18,7 +18,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:18:15
    |
 LL | fn array() -> impl Sized {
-   |               ^^^^^^^^^^ expands to self-referential type
+   |               ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[impl Sized; 1]`
 
@@ -26,7 +26,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:22:13
    |
 LL | fn ptr() -> impl Sized {
-   |             ^^^^^^^^^^ expands to self-referential type
+   |             ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `*const impl Sized`
 
@@ -34,7 +34,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:26:16
    |
 LL | fn fn_ptr() -> impl Sized {
-   |                ^^^^^^^^^^ expands to self-referential type
+   |                ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `fn() -> impl Sized`
 
@@ -42,7 +42,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:30:25
    |
 LL | fn closure_capture() -> impl Sized {
-   |                         ^^^^^^^^^^ expands to self-referential type
+   |                         ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[closure@$DIR/recursive-impl-trait-type.rs:32:5: 32:19 x:impl Sized]`
 
@@ -50,7 +50,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:35:29
    |
 LL | fn closure_ref_capture() -> impl Sized {
-   |                             ^^^^^^^^^^ expands to self-referential type
+   |                             ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[closure@$DIR/recursive-impl-trait-type.rs:37:5: 37:20 x:impl Sized]`
 
@@ -58,7 +58,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:40:21
    |
 LL | fn closure_sig() -> impl Sized {
-   |                     ^^^^^^^^^^ expands to self-referential type
+   |                     ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[closure@$DIR/recursive-impl-trait-type.rs:41:5: 41:21]`
 
@@ -66,7 +66,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:44:23
    |
 LL | fn generator_sig() -> impl Sized {
-   |                       ^^^^^^^^^^ expands to self-referential type
+   |                       ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[closure@$DIR/recursive-impl-trait-type.rs:45:5: 45:23]`
 
@@ -74,7 +74,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:48:27
    |
 LL | fn generator_capture() -> impl Sized {
-   |                           ^^^^^^^^^^ expands to self-referential type
+   |                           ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[generator@$DIR/recursive-impl-trait-type.rs:50:5: 50:26 x:impl Sized {()}]`
 
@@ -82,7 +82,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:53:26
    |
 LL | fn substs_change<T>() -> impl Sized {
-   |                          ^^^^^^^^^^ expands to self-referential type
+   |                          ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `(impl Sized,)`
 
@@ -90,7 +90,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:57:24
    |
 LL | fn generator_hold() -> impl Sized {
-   |                        ^^^^^^^^^^ expands to self-referential type
+   |                        ^^^^^^^^^^ expands to a recursive type
    |
    = note: expanded type is `[generator@$DIR/recursive-impl-trait-type.rs:58:5: 62:6 {impl Sized, ()}]`
 
@@ -98,7 +98,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:69:26
    |
 LL | fn mutual_recursion() -> impl Sync {
-   |                          ^^^^^^^^^ expands to self-referential type
+   |                          ^^^^^^^^^ expands to a recursive type
    |
    = note: type resolves to itself
 
@@ -106,7 +106,7 @@ error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type.rs:73:28
    |
 LL | fn mutual_recursion_b() -> impl Sized {
-   |                            ^^^^^^^^^^ expands to self-referential type
+   |                            ^^^^^^^^^^ expands to a recursive type
    |
    = note: type resolves to itself
 


### PR DESCRIPTION
As per Boat's suggestion - #62539, this makes the error message clearer.