### PR TITLE
Emit artifact notifications for dependency files

### DIFF
--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -688,12 +688,20 @@ fn write_out_deps(sess: &Session, outputs: &OutputFilenames, out_filenames: &[Pa
         Ok(())
     })();
 
-    if let Err(e) = result {
-        sess.fatal(&format!(
-            "error writing dependencies to `{}`: {}",
-            deps_filename.display(),
-            e
-        ));
+    match result {
+        Ok(_) => {
+            if sess.opts.debugging_opts.emit_artifact_notifications {
+                 sess.parse_sess.span_diagnostic
+                    .emit_artifact_notification(&deps_filename, "dep-info");
+            }
+        },
+        Err(e) => {
+            sess.fatal(&format!(
+                "error writing dependencies to `{}`: {}",
+                deps_filename.display(),
+                e
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
Emit `dep-info` artifact notifications for `.d` files.