### PR TITLE
Always implement Unpin for PhantomData

### DIFF
--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -431,6 +431,9 @@ macro_rules! impls{
                 $t
             }
         }
+
+        #[stable(feature = "pin", since = "1.33.0")]
+        impl<T:?Sized> Unpin for $t<T> { }
         )
 }
 


### PR DESCRIPTION
This PR makes it so that `PhantomData<T>` implements `Unpin` no matter what `T` is.

Interestingly enough, the situation is the same for `Send` and `Sync`. `PhantomData` only implements `Send` if `T: Send` and `Sync` if `T: Sync`. I don't know whether that's on purpose, or if it's an overlook.