### PR TITLE
[beta] Fix #62660

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1498,7 +1498,7 @@ impl<'a> Parser<'a> {
         F: Fn(&token::Token) -> bool
     {
         let attrs = self.parse_arg_attributes()?;
-        if let Ok(Some(mut arg)) = self.parse_self_arg() {
+        if let Some(mut arg) = self.parse_self_arg()? {
             arg.attrs = attrs.into();
             return self.recover_bad_self_arg(arg, is_trait_item);
         }

--- a/src/test/ui/parser/issue-62660.rs
+++ b/src/test/ui/parser/issue-62660.rs
@@ -1,0 +1,11 @@
+// Regression test for issue #62660: if a receiver's type does not
+// successfully parse, emit the correct error instead of ICE-ing the compiler.
+
+struct Foo;
+
+impl Foo {
+    pub fn foo(_: i32, self: Box<Self) {}
+    //~^ ERROR expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `)`
+}
+
+fn main() {}

--- a/src/test/ui/parser/issue-62660.stderr
+++ b/src/test/ui/parser/issue-62660.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `)`
+  --> $DIR/issue-62660.rs:7:38
+   |
+LL |     pub fn foo(_: i32, self: Box<Self) {}
+   |                                      ^ expected one of 7 possible tokens here
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Beta backport of #62668.

If the explicitly given type of a `self` parameter fails to parse correctly,
we need to propagate the error rather than dropping it and causing an ICE.