### PR TITLE
tests: Require run-pass tests without annotations to run successfully again

### DIFF
--- a/src/test/run-pass/backtrace-debuginfo.rs
+++ b/src/test/run-pass/backtrace-debuginfo.rs
@@ -10,8 +10,9 @@
 // ignore-pretty issue #37195
 // ignore-cloudabi spawning processes is not supported
 // ignore-emscripten spawning processes is not supported
-// normalize-stderr-test ".*\n" -> ""
+// ignore-msvc issue #62844
 // ignore-sgx no processes
+// normalize-stderr-test ".*\n" -> ""
 
 // Note that above `-opt-bisect-limit=0` is used to basically disable
 // optimizations. It creates tons of output on stderr, hence we normalize

--- a/src/test/run-pass/backtrace.rs
+++ b/src/test/run-pass/backtrace.rs
@@ -2,6 +2,7 @@
 // ignore-cloudabi spawning processes is not supported
 // ignore-emscripten spawning processes is not supported
 // ignore-openbsd no support for libbacktrace without filename
+// ignore-msvc issue #62844
 // ignore-sgx no processes
 // compile-flags:-g
 

--- a/src/test/run-pass/command-uid-gid.rs
+++ b/src/test/run-pass/command-uid-gid.rs
@@ -1,3 +1,8 @@
+// ignore-android
+// ignore-cloudabi
+// ignore-emscripten
+// ignore-sgx
+
 #![feature(rustc_private)]
 
 fn main() {

--- a/src/test/run-pass/generator/size-moved-locals.rs
+++ b/src/test/run-pass/generator/size-moved-locals.rs
@@ -9,6 +9,7 @@
 // See issue #59123 for a full explanation.
 
 // edition:2018
+// ignore-wasm32 issue #62807
 
 #![feature(generators, generator_trait)]
 

--- a/src/test/ui/issues/issue-58375-monomorphize-default-impls.rs
+++ b/src/test/ui/issues/issue-58375-monomorphize-default-impls.rs
@@ -1,6 +1,8 @@
 // Make sure that the mono-item collector does not crash when trying to
 // instantiate a default impl for DecodeUtf16<<u8 as A>::Item>
 // See https://github.com/rust-lang/rust/issues/58375
+
+// build-pass
 // compile-flags:-C link-dead-code
 
 #![crate_type = "rlib"]
@@ -19,5 +21,4 @@ impl A for u8 {
     type Item = char;
 }
 
-impl Arbitrary for DecodeUtf16<<u8 as A>::Item>  {
-}
+impl Arbitrary for DecodeUtf16<<u8 as A>::Item> {}

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -318,8 +318,10 @@ impl<'test> TestCx<'test> {
     }
 
     fn should_run_successfully(&self) -> bool {
+        let pass_mode = self.pass_mode();
         match self.config.mode {
-            RunPass | Ui => self.pass_mode() == Some(PassMode::Run),
+            Ui => pass_mode == Some(PassMode::Run),
+            RunPass => pass_mode == Some(PassMode::Run) || pass_mode.is_none(),
             mode => panic!("unimplemented for mode {:?}", mode),
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/62775 (regression from https://github.com/rust-lang/rust/pull/61755)