### PR TITLE
use const array repeat expressions for uninit_array

### DIFF
--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -106,8 +106,8 @@ impl<K, V> LeafNode<K, V> {
         LeafNode {
             // As a general policy, we leave fields uninitialized if they can be, as this should
             // be both slightly faster and easier to track in Valgrind.
-            keys: uninitialized_array![_; CAPACITY],
-            vals: uninitialized_array![_; CAPACITY],
+            keys: uninit_array![_; CAPACITY],
+            vals: uninit_array![_; CAPACITY],
             parent: ptr::null(),
             parent_idx: MaybeUninit::uninit(),
             len: 0
@@ -159,7 +159,7 @@ impl<K, V> InternalNode<K, V> {
     unsafe fn new() -> Self {
         InternalNode {
             data: LeafNode::new(),
-            edges: uninitialized_array![_; 2*B],
+            edges: uninit_array![_; 2*B],
         }
     }
 }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -85,6 +85,7 @@
 #![feature(fmt_internals)]
 #![feature(fn_traits)]
 #![feature(fundamental)]
+#![feature(internal_uninit_const)]
 #![feature(lang_items)]
 #![feature(libc)]
 #![feature(nll)]

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -77,6 +77,7 @@
 #![feature(box_syntax)]
 #![feature(cfg_target_has_atomic)]
 #![feature(coerce_unsized)]
+#![cfg_attr(not(bootstrap), feature(const_in_array_repeat_expressions))]
 #![feature(dispatch_from_dyn)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -51,7 +51,7 @@ trait GenericRadix {
         // characters for a base 2 number.
         let zero = T::zero();
         let is_nonnegative = x >= zero;
-        let mut buf = uninit_array![u8; 128];
+        let mut buf = [MaybeUninit::<u8>::uninit(); 128];
         let mut curr = buf.len();
         let base = T::from_u8(Self::BASE);
         if is_nonnegative {
@@ -189,7 +189,7 @@ static DEC_DIGITS_LUT: &[u8; 200] =
 macro_rules! impl_Display {
     ($($t:ident),* as $u:ident via $conv_fn:ident named $name:ident) => {
         fn $name(mut n: $u, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut buf = uninit_array![u8; 39];
+            let mut buf = [MaybeUninit::<u8>::uninit(); 39];
             let mut curr = buf.len() as isize;
             let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();

--- a/src/libcore/fmt/num.rs
+++ b/src/libcore/fmt/num.rs
@@ -51,7 +51,7 @@ trait GenericRadix {
         // characters for a base 2 number.
         let zero = T::zero();
         let is_nonnegative = x >= zero;
-        let mut buf = uninitialized_array![u8; 128];
+        let mut buf = uninit_array![u8; 128];
         let mut curr = buf.len();
         let base = T::from_u8(Self::BASE);
         if is_nonnegative {
@@ -189,7 +189,7 @@ static DEC_DIGITS_LUT: &[u8; 200] =
 macro_rules! impl_Display {
     ($($t:ident),* as $u:ident via $conv_fn:ident named $name:ident) => {
         fn $name(mut n: $u, is_nonnegative: bool, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let mut buf = uninitialized_array![u8; 39];
+            let mut buf = uninit_array![u8; 39];
             let mut curr = buf.len() as isize;
             let buf_ptr = MaybeUninit::first_ptr_mut(&mut buf);
             let lut_ptr = DEC_DIGITS_LUT.as_ptr();

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -75,7 +75,6 @@
 #![feature(const_fn)]
 #![feature(const_fn_union)]
 #![cfg_attr(not(bootstrap), feature(const_generics))]
-#![cfg_attr(not(bootstrap), feature(const_in_array_repeat_expressions))]
 #![feature(custom_inner_attributes)]
 #![feature(decl_macro)]
 #![feature(doc_cfg)]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -75,6 +75,7 @@
 #![feature(const_fn)]
 #![feature(const_fn_union)]
 #![cfg_attr(not(bootstrap), feature(const_generics))]
+#![cfg_attr(not(bootstrap), feature(const_in_array_repeat_expressions))]
 #![feature(custom_inner_attributes)]
 #![feature(decl_macro)]
 #![feature(doc_cfg)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -626,18 +626,35 @@ macro_rules! todo {
 /// Creates an array of [`MaybeUninit`].
 ///
 /// This macro constructs an uninitialized array of the type `[MaybeUninit<K>; N]`.
+/// It exists solely because bootstrap does not yet support const array-init expressions.
 ///
 /// [`MaybeUninit`]: mem/union.MaybeUninit.html
+// FIXME: Remove both versions of this macro once bootstrap is 1.38.
 #[macro_export]
 #[unstable(feature = "maybe_uninit_array", issue = "53491")]
-macro_rules! uninitialized_array {
+#[cfg(bootstrap)]
+macro_rules! uninit_array {
     // This `assume_init` is safe because an array of `MaybeUninit` does not
     // require initialization.
-    // FIXME(#49147): Could be replaced by an array initializer, once those can
-    // be any const expression.
     ($t:ty; $size:expr) => (unsafe {
         MaybeUninit::<[MaybeUninit<$t>; $size]>::uninit().assume_init()
     });
+}
+
+/// Creates an array of [`MaybeUninit`].
+///
+/// This macro constructs an uninitialized array of the type `[MaybeUninit<K>; N]`.
+/// It exists solely because bootstrap does not yet support const array-init expressions.
+///
+/// [`MaybeUninit`]: mem/union.MaybeUninit.html
+// FIXME: Just inline this version of the macro once bootstrap is 1.38.
+#[macro_export]
+#[unstable(feature = "maybe_uninit_array", issue = "53491")]
+#[cfg(not(bootstrap))]
+macro_rules! uninit_array {
+    ($t:ty; $size:expr) => (
+        [MaybeUninit::<$t>::uninit(); $size]
+    );
 }
 
 /// Built-in macros to the compiler itself.

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -653,7 +653,7 @@ macro_rules! uninit_array {
 #[cfg(not(bootstrap))]
 macro_rules! uninit_array {
     ($t:ty; $size:expr) => (
-        [MaybeUninit::<$t>::uninit(); $size]
+        [MaybeUninit::<$t>::UNINIT; $size]
     );
 }
 

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -253,11 +253,8 @@ impl<T> MaybeUninit<T> {
     }
 
     /// A promotable constant, equivalent to `uninit()`.
-    #[unstable(
-        feature = "internal_uninit_const",
-        issue = "0",
-        reason = "hack to work around promotability",
-    )]
+    #[unstable(feature = "internal_uninit_const", issue = "0",
+        reason = "hack to work around promotability")]
     pub const UNINIT: Self = Self::uninit();
 
     /// Creates a new `MaybeUninit<T>` in an uninitialized state, with the memory being

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -248,10 +248,17 @@ impl<T> MaybeUninit<T> {
     /// [type]: union.MaybeUninit.html
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
     #[inline(always)]
-    #[rustc_promotable]
     pub const fn uninit() -> MaybeUninit<T> {
         MaybeUninit { uninit: () }
     }
+
+    /// A promotable constant, equivalent to `uninit()`.
+    #[unstable(
+        feature = "internal_uninit_const",
+        issue = "0",
+        reason = "hack to work around promotability",
+    )]
+    pub const UNINIT: Self = Self::uninit();
 
     /// Creates a new `MaybeUninit<T>` in an uninitialized state, with the memory being
     /// filled with `0` bytes. It depends on `T` whether that already makes for

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -248,6 +248,7 @@ impl<T> MaybeUninit<T> {
     /// [type]: union.MaybeUninit.html
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
     #[inline(always)]
+    #[rustc_promotable]
     pub const fn uninit() -> MaybeUninit<T> {
         MaybeUninit { uninit: () }
     }

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -216,14 +216,14 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
     let mut block_l = BLOCK;
     let mut start_l = ptr::null_mut();
     let mut end_l = ptr::null_mut();
-    let mut offsets_l: [MaybeUninit<u8>; BLOCK] = uninitialized_array![u8; BLOCK];
+    let mut offsets_l: [MaybeUninit<u8>; BLOCK] = uninit_array![u8; BLOCK];
 
     // The current block on the right side (from `r.sub(block_r)` to `r`).
     let mut r = unsafe { l.add(v.len()) };
     let mut block_r = BLOCK;
     let mut start_r = ptr::null_mut();
     let mut end_r = ptr::null_mut();
-    let mut offsets_r: [MaybeUninit<u8>; BLOCK] = uninitialized_array![u8; BLOCK];
+    let mut offsets_r: [MaybeUninit<u8>; BLOCK] = uninit_array![u8; BLOCK];
 
     // FIXME: When we get VLAs, try creating one array of length `min(v.len(), 2 * BLOCK)` rather
     // than two fixed-size arrays of length `BLOCK`. VLAs might be more cache-efficient.

--- a/src/libcore/slice/sort.rs
+++ b/src/libcore/slice/sort.rs
@@ -216,14 +216,14 @@ fn partition_in_blocks<T, F>(v: &mut [T], pivot: &T, is_less: &mut F) -> usize
     let mut block_l = BLOCK;
     let mut start_l = ptr::null_mut();
     let mut end_l = ptr::null_mut();
-    let mut offsets_l: [MaybeUninit<u8>; BLOCK] = uninit_array![u8; BLOCK];
+    let mut offsets_l = [MaybeUninit::<u8>::uninit(); BLOCK];
 
     // The current block on the right side (from `r.sub(block_r)` to `r`).
     let mut r = unsafe { l.add(v.len()) };
     let mut block_r = BLOCK;
     let mut start_r = ptr::null_mut();
     let mut end_r = ptr::null_mut();
-    let mut offsets_r: [MaybeUninit<u8>; BLOCK] = uninit_array![u8; BLOCK];
+    let mut offsets_r = [MaybeUninit::<u8>::uninit(); BLOCK];
 
     // FIXME: When we get VLAs, try creating one array of length `min(v.len(), 2 * BLOCK)` rather
     // than two fixed-size arrays of length `BLOCK`. VLAs might be more cache-efficient.


### PR DESCRIPTION
With a first implementation of https://github.com/rust-lang/rust/issues/49147 having landed, we can make this macro nicer and phase it out with the next bootstrap bump.

However, to make this work, we have to mark `MaybeUninit::uninit()` as promotable. I do feel uneasy about promoting stuff involving uninitialized memory, but OTOH no *operation* on `MaybeUninit` is promotable, so maybe this is okay?

r? @oli-obk @eddyb