### PR TITLE
rustc_typeck: improve diagnostics for _ const/static declarations

### DIFF
--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -11,7 +11,10 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/E0121.rs:3:13
    |
 LL | static BAR: _ = "test";
-   |             ^ not allowed in type signatures
+   |             ^
+   |             |
+   |             not allowed in type signatures
+   |             help: replace `_` with the correct return type: `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -14,7 +14,7 @@ LL | static BAR: _ = "test";
    |             ^
    |             |
    |             not allowed in type signatures
-   |             help: replace `_` with the correct return type: `&'static str`
+   |             help: replace `_` with the correct type: `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -23,13 +23,19 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/typeck_type_placeholder_item.rs:11:15
    |
 LL | static TEST3: _ = "test";
-   |               ^ not allowed in type signatures
+   |               ^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace `_` with the correct type: `&'static str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:14:15
    |
 LL | static TEST4: _ = 145;
-   |               ^ not allowed in type signatures
+   |               ^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:17:16
@@ -122,13 +128,19 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/typeck_type_placeholder_item.rs:64:22
    |
 LL |     static FN_TEST3: _ = "test";
-   |                      ^ not allowed in type signatures
+   |                      ^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace `_` with the correct type: `&'static str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:67:22
    |
 LL |     static FN_TEST4: _ = 145;
-   |                      ^ not allowed in type signatures
+   |                      ^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:70:23

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -4,6 +4,24 @@
 fn test1() -> _ { Some(42) }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
+const TEST2: _ = 42u32;
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+
+const TEST3: _ = Some(42);
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+
+trait Test4 {
+    const TEST4: _ = 42;
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+}
+
+struct Test5;
+
+impl Test5 {
+    const TEST5: _ = 13;
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+}
+
 pub fn main() {
     let _: Option<usize> = test1();
     let _: f64 = test1();

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -7,6 +7,42 @@ LL | fn test1() -> _ { Some(42) }
    |               not allowed in type signatures
    |               help: replace `_` with the correct return type: `std::option::Option<i32>`
 
-error: aborting due to previous error
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:7:14
+   |
+LL | const TEST2: _ = 42u32;
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace `_` with the correct type: `u32`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:10:14
+   |
+LL | const TEST3: _ = Some(42);
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace `_` with the correct type: `std::option::Option<i32>`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:14:18
+   |
+LL |     const TEST4: _ = 42;
+   |                  ^
+   |                  |
+   |                  not allowed in type signatures
+   |                  help: replace `_` with the correct type: `i32`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:21:18
+   |
+LL |     const TEST5: _ = 13;
+   |                  ^
+   |                  |
+   |                  not allowed in type signatures
+   |                  help: replace `_` with the correct type: `i32`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0121`.


### PR DESCRIPTION
This continues https://github.com/rust-lang/rust/pull/62694 and adds type suggestions to const/static declarations with `_` type.

r? @eddyb 