### PR TITLE
Revert "Disable stack probing for gnux32."

### DIFF
--- a/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
@@ -5,8 +5,7 @@ pub fn target() -> TargetResult {
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-mx32".to_string());
-    // BUG: temporarily workaround #59674
-    base.stack_probes = false;
+    base.stack_probes = true;
     base.has_elf_tls = false;
     // BUG(GabrielMajeri): disabling the PLT on x86_64 Linux with x32 ABI
     // breaks code gen. See LLVM bug 36743


### PR DESCRIPTION
This reverts commit 42d652ecd6709b756d95fc42615b166aacd2ea07. (#59686)

Closes #59674.
