### PR TITLE
normalize use of backticks in compiler messages for librustc_lint

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -591,7 +591,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDebugImplementations {
         if !self.impling_types.as_ref().unwrap().contains(&item.hir_id) {
             cx.span_lint(MISSING_DEBUG_IMPLEMENTATIONS,
                          item.span,
-                         "type does not implement `fmt::Debug`; consider adding #[derive(Debug)] \
+                         "type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` \
                           or a manual implementation")
         }
     }
@@ -867,7 +867,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidNoMangleItems {
                 if attr::contains_name(&it.attrs, sym::no_mangle) {
                     // Const items do not refer to a particular location in memory, and therefore
                     // don't have anything to attach a symbol to
-                    let msg = "const items should never be #[no_mangle]";
+                    let msg = "const items should never be `#[no_mangle]`";
                     let mut err = cx.struct_span_lint(NO_MANGLE_CONST_ITEMS, it.span, msg);
 
                     // account for "pub const" (#45562)
@@ -1358,7 +1358,7 @@ impl EarlyLintPass for EllipsisInclusiveRangePatterns {
 declare_lint! {
     UNNAMEABLE_TEST_ITEMS,
     Warn,
-    "detects an item that cannot be named being marked as #[test_case]",
+    "detects an item that cannot be named being marked as `#[test_case]`",
     report_in_external_macro: true
 }
 

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -481,9 +481,9 @@ pub fn register_builtins(store: &mut lint::LintStore, sess: Option<&Session>) {
     store.register_removed("resolve_trait_on_defaulted_unit",
         "converted into hard error, see https://github.com/rust-lang/rust/issues/48950");
     store.register_removed("private_no_mangle_fns",
-        "no longer a warning, #[no_mangle] functions always exported");
+        "no longer a warning, `#[no_mangle]` functions always exported");
     store.register_removed("private_no_mangle_statics",
-        "no longer a warning, #[no_mangle] statics always exported");
+        "no longer a warning, `#[no_mangle]` statics always exported");
     store.register_removed("bad_repr",
         "replaced with a generic attribute input check");
     store.register_removed("duplicate_matcher_binding_name",

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -24,7 +24,7 @@ use log::debug;
 declare_lint! {
     pub UNUSED_MUST_USE,
     Warn,
-    "unused result of a type flagged as #[must_use]",
+    "unused result of a type flagged as `#[must_use]`",
     report_in_external_macro: true
 }
 
@@ -316,7 +316,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
 
         let name = attr.name_or_empty();
         if !attr::is_used(attr) {
-            debug!("Emitting warning for: {:?}", attr);
+            debug!("emitting warning for: {:?}", attr);
             cx.span_lint(UNUSED_ATTRIBUTES, attr.span, "unused attribute");
             // Is it a builtin attribute that must be used at the crate level?
             let known_crate = attr_info.map(|&&(_, ty, ..)| {
@@ -332,7 +332,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
                 let msg = match attr.style {
                     ast::AttrStyle::Outer => {
                         "crate-level attribute should be an inner attribute: add an exclamation \
-                         mark: #![foo]"
+                         mark: `#![foo]`"
                     }
                     ast::AttrStyle::Inner => "crate-level attribute should be in the root module",
                 };
@@ -570,9 +570,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAllocation {
             if let adjustment::Adjust::Borrow(adjustment::AutoBorrow::Ref(_, m)) = adj.kind {
                 let msg = match m {
                     adjustment::AutoBorrowMutability::Immutable =>
-                        "unnecessary allocation, use & instead",
+                        "unnecessary allocation, use `&` instead",
                     adjustment::AutoBorrowMutability::Mutable { .. }=>
-                        "unnecessary allocation, use &mut instead"
+                        "unnecessary allocation, use `&mut` instead"
                 };
                 cx.span_lint(UNUSED_ALLOCATION, e.span, msg);
             }

--- a/src/test/ui-fulldeps/plugin-attr-register-deny.stderr
+++ b/src/test/ui-fulldeps/plugin-attr-register-deny.stderr
@@ -10,7 +10,7 @@ note: lint level defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/plugin-attr-register-deny.rs:14:5
    |
 LL |     #[bar]

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -632,7 +632,7 @@ warning: unused attribute
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:5
    |
 LL |     #[no_std] fn f() { }
@@ -644,7 +644,7 @@ warning: unused attribute
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
    |
 LL |     #[no_std] struct S;
@@ -656,7 +656,7 @@ warning: unused attribute
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
    |
 LL |     #[no_std] type T = S;
@@ -668,7 +668,7 @@ warning: unused attribute
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
    |
 LL |     #[no_std] impl S { }
@@ -680,7 +680,7 @@ warning: unused attribute
 LL | #[no_std]
    | ^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:1
    |
 LL | #[no_std]
@@ -704,7 +704,7 @@ warning: unused attribute
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:638:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
@@ -716,7 +716,7 @@ warning: unused attribute
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
    |
 LL |     #[crate_name = "0900"] struct S;
@@ -728,7 +728,7 @@ warning: unused attribute
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
    |
 LL |     #[crate_name = "0900"] type T = S;
@@ -740,7 +740,7 @@ warning: unused attribute
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:5
    |
 LL |     #[crate_name = "0900"] impl S { }
@@ -752,7 +752,7 @@ warning: unused attribute
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:630:1
    |
 LL | #[crate_name = "0900"]
@@ -776,7 +776,7 @@ warning: unused attribute
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
@@ -788,7 +788,7 @@ warning: unused attribute
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:667:5
    |
 LL |     #[crate_type = "0800"] struct S;
@@ -800,7 +800,7 @@ warning: unused attribute
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:5
    |
 LL |     #[crate_type = "0800"] type T = S;
@@ -812,7 +812,7 @@ warning: unused attribute
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
    |
 LL |     #[crate_type = "0800"] impl S { }
@@ -824,7 +824,7 @@ warning: unused attribute
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:655:1
    |
 LL | #[crate_type = "0800"]
@@ -848,7 +848,7 @@ warning: unused attribute
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:5
    |
 LL |     #[feature(x0600)] fn f() { }
@@ -860,7 +860,7 @@ warning: unused attribute
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:5
    |
 LL |     #[feature(x0600)] struct S;
@@ -872,7 +872,7 @@ warning: unused attribute
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
    |
 LL |     #[feature(x0600)] type T = S;
@@ -884,7 +884,7 @@ warning: unused attribute
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
    |
 LL |     #[feature(x0600)] impl S { }
@@ -896,7 +896,7 @@ warning: unused attribute
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:680:1
    |
 LL | #[feature(x0600)]
@@ -920,7 +920,7 @@ warning: unused attribute
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:714:5
    |
 LL |     #[no_main] fn f() { }
@@ -932,7 +932,7 @@ warning: unused attribute
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
    |
 LL |     #[no_main] struct S;
@@ -944,7 +944,7 @@ warning: unused attribute
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
    |
 LL |     #[no_main] type T = S;
@@ -956,7 +956,7 @@ warning: unused attribute
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
    |
 LL |     #[no_main] impl S { }
@@ -968,7 +968,7 @@ warning: unused attribute
 LL | #[no_main]
    | ^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:1
    |
 LL | #[no_main]
@@ -992,7 +992,7 @@ warning: unused attribute
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:752:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
@@ -1004,7 +1004,7 @@ warning: unused attribute
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
    |
 LL |     #[recursion_limit="0200"] struct S;
@@ -1016,7 +1016,7 @@ warning: unused attribute
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
@@ -1028,7 +1028,7 @@ warning: unused attribute
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
@@ -1040,7 +1040,7 @@ warning: unused attribute
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:744:1
    |
 LL | #[recursion_limit="0200"]
@@ -1064,7 +1064,7 @@ warning: unused attribute
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
@@ -1076,7 +1076,7 @@ warning: unused attribute
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
    |
 LL |     #[type_length_limit="0100"] struct S;
@@ -1088,7 +1088,7 @@ warning: unused attribute
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
@@ -1100,7 +1100,7 @@ warning: unused attribute
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
@@ -1112,7 +1112,7 @@ warning: unused attribute
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:769:1
    |
 LL | #[type_length_limit="0100"]

--- a/src/test/ui/invalid/invalid-plugin-attr.stderr
+++ b/src/test/ui/invalid/invalid-plugin-attr.stderr
@@ -10,7 +10,7 @@ note: lint level defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/invalid-plugin-attr.rs:4:1
    |
 LL | #[plugin(bla)]

--- a/src/test/ui/issues/issue-45562.fixed
+++ b/src/test/ui/issues/issue-45562.fixed
@@ -1,6 +1,6 @@
 // run-rustfix
 
 #[no_mangle] pub static RAH: usize = 5;
-//~^ ERROR const items should never be #[no_mangle]
+//~^ ERROR const items should never be `#[no_mangle]`
 
 fn main() {}

--- a/src/test/ui/issues/issue-45562.rs
+++ b/src/test/ui/issues/issue-45562.rs
@@ -1,6 +1,6 @@
 // run-rustfix
 
 #[no_mangle] pub const RAH: usize = 5;
-//~^ ERROR const items should never be #[no_mangle]
+//~^ ERROR const items should never be `#[no_mangle]`
 
 fn main() {}

--- a/src/test/ui/issues/issue-45562.stderr
+++ b/src/test/ui/issues/issue-45562.stderr
@@ -1,4 +1,4 @@
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/issue-45562.rs:3:14
    |
 LL | #[no_mangle] pub const RAH: usize = 5;

--- a/src/test/ui/lint/lint-misplaced-attr.stderr
+++ b/src/test/ui/lint/lint-misplaced-attr.stderr
@@ -22,7 +22,7 @@ error: unused attribute
 LL | #[crate_type = "bin"] fn main() {}
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: crate-level attribute should be an inner attribute: add an exclamation mark: #![foo]
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
   --> $DIR/lint-misplaced-attr.rs:11:1
    |
 LL | #[crate_type = "bin"] fn main() {}

--- a/src/test/ui/lint/lint-unexported-no-mangle.rs
+++ b/src/test/ui/lint/lint-unexported-no-mangle.rs
@@ -6,10 +6,10 @@ fn foo() {
 
 #[allow(dead_code)]
 #[no_mangle]
-const FOO: u64 = 1; //~ ERROR const items should never be #[no_mangle]
+const FOO: u64 = 1; //~ ERROR const items should never be `#[no_mangle]`
 
 #[no_mangle]
-pub const PUB_FOO: u64 = 1; //~ ERROR const items should never be #[no_mangle]
+pub const PUB_FOO: u64 = 1; //~ ERROR const items should never be `#[no_mangle]`
 
 #[no_mangle]
 pub fn bar()  {

--- a/src/test/ui/lint/lint-unexported-no-mangle.stderr
+++ b/src/test/ui/lint/lint-unexported-no-mangle.stderr
@@ -1,12 +1,12 @@
-warning: lint `private_no_mangle_fns` has been removed: `no longer a warning, #[no_mangle] functions always exported`
+warning: lint `private_no_mangle_fns` has been removed: `no longer a warning, `#[no_mangle]` functions always exported`
    |
    = note: requested on the command line with `-F private_no_mangle_fns`
 
-warning: lint `private_no_mangle_statics` has been removed: `no longer a warning, #[no_mangle] statics always exported`
+warning: lint `private_no_mangle_statics` has been removed: `no longer a warning, `#[no_mangle]` statics always exported`
    |
    = note: requested on the command line with `-F private_no_mangle_statics`
 
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/lint-unexported-no-mangle.rs:9:1
    |
 LL | const FOO: u64 = 1;
@@ -16,7 +16,7 @@ LL | const FOO: u64 = 1;
    |
    = note: requested on the command line with `-F no-mangle-const-items`
 
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/lint-unexported-no-mangle.rs:12:1
    |
 LL | pub const PUB_FOO: u64 = 1;

--- a/src/test/ui/lint/suggestions.rs
+++ b/src/test/ui/lint/suggestions.rs
@@ -4,7 +4,7 @@
 #![feature(no_debug)]
 
 #[no_mangle] const DISCOVERY: usize = 1;
-//~^ ERROR const items should never be #[no_mangle]
+//~^ ERROR const items should never be `#[no_mangle]`
 //~| HELP try a static value
 
 #[no_mangle]
@@ -20,7 +20,7 @@ mod badlands {
     // item is already `pub` (but triggered the lint because, e.g., it's in a
     // private module). (Issue #47383)
     #[no_mangle] pub const DAUNTLESS: bool = true;
-    //~^ ERROR const items should never be #[no_mangle]
+    //~^ ERROR const items should never be `#[no_mangle]`
     //~| HELP try a static value
     #[no_mangle] pub fn val_jean<T>() {}
     //~^ WARN functions generic over types or consts must be mangled
@@ -28,7 +28,7 @@ mod badlands {
 
     // ... but we can suggest just-`pub` instead of restricted
     #[no_mangle] pub(crate) const VETAR: bool = true;
-    //~^ ERROR const items should never be #[no_mangle]
+    //~^ ERROR const items should never be `#[no_mangle]`
     //~| HELP try a static value
     #[no_mangle] pub(crate) fn crossfield<T>() {}
     //~^ WARN functions generic over types or consts must be mangled

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -52,7 +52,7 @@ LL | ||             b = 1;
    |  |____________|
    |               help: remove this `mut`
 
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/suggestions.rs:6:14
    |
 LL | #[no_mangle] const DISCOVERY: usize = 1;
@@ -83,7 +83,7 @@ LL |             Equinox { warp_factor: warp_factor } => {}
    |
    = note: `#[warn(non_shorthand_field_patterns)]` on by default
 
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/suggestions.rs:22:18
    |
 LL |     #[no_mangle] pub const DAUNTLESS: bool = true;
@@ -99,7 +99,7 @@ LL |     #[no_mangle] pub fn val_jean<T>() {}
    |     |
    |     help: remove this attribute
 
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
   --> $DIR/suggestions.rs:30:18
    |
 LL |     #[no_mangle] pub(crate) const VETAR: bool = true;

--- a/src/test/ui/missing_debug_impls.stderr
+++ b/src/test/ui/missing_debug_impls.stderr
@@ -1,4 +1,4 @@
-error: type does not implement `fmt::Debug`; consider adding #[derive(Debug)] or a manual implementation
+error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
   --> $DIR/missing_debug_impls.rs:7:1
    |
 LL | pub enum A {}
@@ -10,7 +10,7 @@ note: lint level defined here
 LL | #![deny(missing_debug_implementations)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: type does not implement `fmt::Debug`; consider adding #[derive(Debug)] or a manual implementation
+error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
   --> $DIR/missing_debug_impls.rs:20:1
    |
 LL | pub struct Foo;


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532