### PR TITLE
rustc: Compile the `fmt_macros` crate as an rlib

### DIFF
--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [lib]
 name = "fmt_macros"
 path = "lib.rs"
-crate-type = ["dylib"]
 
 [dependencies]
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -6,6 +6,7 @@ extern crate rustc_codegen_utils;
 #[macro_use]
 extern crate rustc_data_structures;
 extern crate rustc_target;
+extern crate rustc_driver;
 
 use std::any::Any;
 use std::sync::{Arc, mpsc};


### PR DESCRIPTION
I think this was left out by accident from the "convert everything to
rlibs" commit, there's no need for this to be a dylib just as everything
else doesn't need to be a dylib!