### PR TITLE
Fix theme picker blur handler: always hide instead of switching

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -874,15 +874,23 @@ fn write_shared(
 r#"var themes = document.getElementById("theme-choices");
 var themePicker = document.getElementById("theme-picker");
 
+function showThemeButtonState() {{
+    themes.style.display = "none";
+    themePicker.style.borderBottomRightRadius = "3px";
+    themePicker.style.borderBottomLeftRadius = "3px";
+}}
+
+function hideThemeButtonState() {{
+    themes.style.display = "block";
+    themePicker.style.borderBottomRightRadius = "0";
+    themePicker.style.borderBottomLeftRadius = "0";
+}}
+        
 function switchThemeButtonState() {{
     if (themes.style.display === "block") {{
-        themes.style.display = "none";
-        themePicker.style.borderBottomRightRadius = "3px";
-        themePicker.style.borderBottomLeftRadius = "3px";
+        showThemeButtonState();
     }} else {{
-        themes.style.display = "block";
-        themePicker.style.borderBottomRightRadius = "0";
-        themePicker.style.borderBottomLeftRadius = "0";
+        hideThemeButtonState();
     }}
 }};
 
@@ -895,7 +903,7 @@ function handleThemeButtonsBlur(e) {{
         (!related ||
          (related.id !== "themePicker" &&
           (!related.parentNode || related.parentNode.id !== "theme-choices")))) {{
-        switchThemeButtonState();
+        hideThemeButtonState();
     }}
 }}
 

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -885,7 +885,7 @@ function hideThemeButtonState() {{
     themePicker.style.borderBottomRightRadius = "0";
     themePicker.style.borderBottomLeftRadius = "0";
 }}
-        
+
 function switchThemeButtonState() {{
     if (themes.style.display === "block") {{
         showThemeButtonState();


### PR DESCRIPTION
Fixes a minor bug in UI generated by rustdoc.

For example, this page: https://doc.rust-lang.org/std/

Reproduction steps:
1. Click the theme picker twice
   * The list of themes will be shown and then hidden
2. Click anywhere else
   * The list of themes will be shown again, which is unexpected

The bug was caused by blur event handler toggling the state of the element instead of always hiding it regardless of the current state.