### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/src/libcore/fmt/float.rs
+++ b/src/libcore/fmt/float.rs
@@ -12,10 +12,11 @@ fn float_to_decimal_common_exact<T>(fmt: &mut Formatter<'_>, num: &T,
     unsafe {
         let mut buf = MaybeUninit::<[u8; 1024]>::uninit(); // enough for f32 and f64
         let mut parts = MaybeUninit::<[flt2dec::Part<'_>; 4]>::uninit();
-        // FIXME(#53491): Technically, this is calling `get_mut` on an uninitialized
-        // `MaybeUninit` (here and elsewhere in this file).  Revisit this once
+        // FIXME(#53491): This is calling `get_mut` on an uninitialized
+        // `MaybeUninit` (here and elsewhere in this file). Revisit this once
         // we decided whether that is valid or not.
-        // Using `freeze` is *not enough*; `flt2dec::Part` is an enum!
+        // We can do this only because we are libstd and coupled to the compiler.
+        // (FWIW, using `freeze` would not be enough; `flt2dec::Part` is an enum!)
         let formatted = flt2dec::to_exact_fixed_str(flt2dec::strategy::grisu::format_exact,
                                                     *num, sign, precision,
                                                     false, buf.get_mut(), parts.get_mut());

--- a/src/libcore/ptr/unique.rs
+++ b/src/libcore/ptr/unique.rs
@@ -26,8 +26,8 @@ use crate::ptr::NonNull;
 /// Unlike `*mut T`, `Unique<T>` is covariant over `T`. This should always be correct
 /// for any type which upholds Unique's aliasing requirements.
 #[unstable(feature = "ptr_internals", issue = "0",
-           reason = "use NonNull instead and consider PhantomData<T> \
-                     (if you also use #[may_dangle]), Send, and/or Sync")]
+           reason = "use `NonNull` instead and consider `PhantomData<T>` \
+                     (if you also use `#[may_dangle]`), `Send`, and/or `Sync`")]
 #[doc(hidden)]
 #[repr(transparent)]
 #[rustc_layout_scalar_valid_range_start(1)]

--- a/src/libfmt_macros/Cargo.toml
+++ b/src/libfmt_macros/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [lib]
 name = "fmt_macros"
 path = "lib.rs"
-crate-type = ["dylib"]
 
 [dependencies]
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_incremental/assert_dep_graph.rs
+++ b/src/librustc_incremental/assert_dep_graph.rs
@@ -190,7 +190,7 @@ fn check_paths<'tcx>(tcx: TyCtxt<'tcx>, if_this_changed: &Sources, then_this_wou
         for &(target_span, _, _, _) in then_this_would_need {
             tcx.sess.span_err(
                 target_span,
-                "no #[rustc_if_this_changed] annotation detected");
+                "no `#[rustc_if_this_changed]` annotation detected");
 
         }
         return;

--- a/src/librustc_incremental/persist/dirty_clean.rs
+++ b/src/librustc_incremental/persist/dirty_clean.rs
@@ -610,7 +610,7 @@ impl FindAllAttrs<'tcx> {
         for attr in &self.found_attrs {
             if !checked_attrs.contains(&attr.id) {
                 self.tcx.sess.span_err(attr.span, &format!("found unchecked \
-                    #[rustc_dirty]/#[rustc_clean] attribute"));
+                    `#[rustc_dirty]` / `#[rustc_clean]` attribute"));
             }
         }
     }

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -538,7 +538,7 @@ fn find_source_directory_in_iter<I>(iter: I,
         if source_directories_already_tried.contains(&session_dir) ||
            !is_session_directory(&directory_name) ||
            !is_finalized(&directory_name) {
-            debug!("find_source_directory_in_iter - ignoring.");
+            debug!("find_source_directory_in_iter - ignoring");
             continue
         }
 
@@ -693,7 +693,7 @@ pub fn garbage_collect_session_directories(sess: &Session) -> io::Result<()> {
             let timestamp = match extract_timestamp_from_session_dir(lock_file_name) {
                 Ok(timestamp) => timestamp,
                 Err(()) => {
-                    debug!("Found lock-file with malformed timestamp: {}",
+                    debug!("found lock-file with malformed timestamp: {}",
                         crate_directory.join(&lock_file_name).display());
                     // Ignore it
                     continue
@@ -746,7 +746,7 @@ pub fn garbage_collect_session_directories(sess: &Session) -> io::Result<()> {
         let timestamp = match extract_timestamp_from_session_dir(directory_name) {
             Ok(timestamp) => timestamp,
             Err(()) => {
-                debug!("Found session-dir with malformed timestamp: {}",
+                debug!("found session-dir with malformed timestamp: {}",
                         crate_directory.join(directory_name).display());
                 // Ignore it
                 continue

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -938,14 +938,14 @@ impl<'a> CrateLoader<'a> {
             }
             match global_allocator {
                 Some(Some(other_crate)) => {
-                    self.sess.err(&format!("the #[global_allocator] in {} \
+                    self.sess.err(&format!("the `#[global_allocator]` in {} \
                                             conflicts with this global \
                                             allocator in: {}",
                                            other_crate,
                                            data.root.name));
                 }
                 Some(None) => {
-                    self.sess.err(&format!("the #[global_allocator] in this \
+                    self.sess.err(&format!("the `#[global_allocator]` in this \
                                             crate conflicts with global \
                                             allocator in: {}", data.root.name));
                 }
@@ -971,7 +971,7 @@ impl<'a> CrateLoader<'a> {
         if !has_default {
             self.sess.err("no global memory allocator found but one is \
                            required; link to std or \
-                           add #[global_allocator] to a static item \
+                           add `#[global_allocator]` to a static item \
                            that implements the GlobalAlloc trait.");
         }
         self.sess.allocator_kind.set(Some(AllocatorKind::DefaultLib));

--- a/src/librustc_metadata/error_codes.rs
+++ b/src/librustc_metadata/error_codes.rs
@@ -7,7 +7,8 @@ E0454: r##"
 A link name was given with an empty name. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
-#[link(name = "")] extern {} // error: #[link(name = "")] given with empty name
+#[link(name = "")] extern {}
+// error: `#[link(name = "")]` given with empty name
 ```
 
 The rust compiler cannot link to an external library if you don't give it its
@@ -61,7 +62,7 @@ A link was used without a name parameter. Erroneous code example:
 
 ```ignore (cannot-test-this-because-rustdoc-stops-compile-fail-before-codegen)
 #[link(kind = "dylib")] extern {}
-// error: #[link(...)] specified without `name = "foo"`
+// error: `#[link(...)]` specified without `name = "foo"`
 ```
 
 Please add the name parameter to allow the rust compiler to find the library

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -102,7 +102,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
                     match item.value_str() {
                         Some(s) => lib.wasm_import_module = Some(s),
                         None => {
-                            let msg = "must be of the form #[link(wasm_import_module = \"...\")]";
+                            let msg = "must be of the form `#[link(wasm_import_module = \"...\")]`";
                             self.tcx.sess.span_err(item.span(), msg);
                         }
                     }
@@ -117,7 +117,7 @@ impl ItemLikeVisitor<'tcx> for Collector<'tcx> {
             let requires_name = kind_specified || lib.wasm_import_module.is_none();
             if lib.name.is_none() && requires_name {
                 struct_span_err!(self.tcx.sess, m.span, E0459,
-                                 "#[link(...)] specified without \
+                                 "`#[link(...)]` specified without \
                                   `name = \"foo\"`")
                     .span_label(m.span, "missing `name` argument")
                     .emit();
@@ -136,7 +136,7 @@ impl Collector<'tcx> {
             match span {
                 Some(span) => {
                     struct_span_err!(self.tcx.sess, span, E0454,
-                                     "#[link(name = \"\")] given with empty name")
+                                     "`#[link(name = \"\")]` given with empty name")
                         .span_label(span, "empty name given")
                         .emit();
                 }
@@ -187,7 +187,7 @@ impl Collector<'tcx> {
                         &format!("an empty renaming target was specified for library `{}`",name));
                 } else if !any_duplicate {
                     self.tcx.sess.err(&format!("renaming of the library `{}` was specified, \
-                                                however this crate contains no #[link(...)] \
+                                                however this crate contains no `#[link(...)]` \
                                                 attributes referencing this library.", name));
                 } else if renames.contains(name) {
                     self.tcx.sess.err(&format!("multiple renamings were \

--- a/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
+++ b/src/librustc_target/spec/x86_64_unknown_linux_gnux32.rs
@@ -5,8 +5,7 @@ pub fn target() -> TargetResult {
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
     base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-mx32".to_string());
-    // BUG: temporarily workaround #59674
-    base.stack_probes = false;
+    base.stack_probes = true;
     base.has_elf_tls = false;
     // BUG(GabrielMajeri): disabling the PLT on x86_64 Linux with x32 ABI
     // breaks code gen. See LLVM bug 36743

--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -3138,13 +3138,15 @@ mod test_map {
 
     #[test]
     fn test_from_iter() {
-        let xs = [(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
+        let xs = [(1, 1), (2, 2), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6)];
 
         let map: HashMap<_, _> = xs.iter().cloned().collect();
 
         for &(k, v) in &xs {
             assert_eq!(map.get(&k), Some(&v));
         }
+
+        assert_eq!(map.iter().len(), xs.len() - 1);
     }
 
     #[test]

--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -1782,13 +1782,15 @@ mod test_set {
 
     #[test]
     fn test_from_iter() {
-        let xs = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let xs = [1, 2, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let set: HashSet<_> = xs.iter().cloned().collect();
 
         for x in &xs {
             assert!(set.contains(x));
         }
+
+        assert_eq!(set.iter().len(), xs.len() - 1);
     }
 
     #[test]

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -48,7 +48,7 @@ pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<
     // `MaybeUninit`. Revisit this once we decided whether that is valid or not.
     // This is still technically undefined behavior due to creating a reference
     // to uninitialized data, but within libstd we can rely on more guarantees
-    // than if this code were in an external lib
+    // than if this code were in an external lib.
     unsafe { reader.initializer().initialize(buf.get_mut()); }
 
     let mut written = 0;

--- a/src/libstd/io/util.rs
+++ b/src/libstd/io/util.rs
@@ -2,7 +2,7 @@
 
 use crate::fmt;
 use crate::io::{self, Read, Initializer, Write, ErrorKind, BufRead, IoSlice, IoSliceMut};
-use crate::mem;
+use crate::mem::MaybeUninit;
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -43,27 +43,23 @@ use crate::mem;
 pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64>
     where R: Read, W: Write
 {
-    let mut buf = unsafe {
-        // This is still technically undefined behavior due to creating a reference
-        // to uninitialized data, but within libstd we can rely on more guarantees
-        // than if this code were in an external lib
-
-        // FIXME: This should probably be changed to an array of `MaybeUninit<u8>`
-        // once the `mem::MaybeUninit` slice APIs stabilize
-        let mut buf: mem::MaybeUninit<[u8; super::DEFAULT_BUF_SIZE]> = mem::MaybeUninit::uninit();
-        reader.initializer().initialize(&mut *buf.as_mut_ptr());
-        buf.assume_init()
-    };
+    let mut buf = MaybeUninit::<[u8; super::DEFAULT_BUF_SIZE]>::uninit();
+    // FIXME(#53491): This is calling `get_mut` and `get_ref` on an uninitialized
+    // `MaybeUninit`. Revisit this once we decided whether that is valid or not.
+    // This is still technically undefined behavior due to creating a reference
+    // to uninitialized data, but within libstd we can rely on more guarantees
+    // than if this code were in an external lib
+    unsafe { reader.initializer().initialize(buf.get_mut()); }
 
     let mut written = 0;
     loop {
-        let len = match reader.read(&mut buf) {
+        let len = match reader.read(unsafe { buf.get_mut() }) {
             Ok(0) => return Ok(written),
             Ok(len) => len,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),
         };
-        writer.write_all(&buf[..len])?;
+        writer.write_all(unsafe { &buf.get_ref()[..len] })?;
         written += len as u64;
     }
 }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -205,7 +205,7 @@
 // Don't link to std. We are std.
 #![no_std]
 
-//#![warn(deprecated_in_future)] // FIXME: std still has quite a few uses of `mem::uninitialized`
+#![warn(deprecated_in_future)]
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -272,6 +272,7 @@
 #![feature(libc)]
 #![feature(link_args)]
 #![feature(linkage)]
+#![feature(maybe_uninit_ref)]
 #![feature(mem_take)]
 #![feature(needs_panic_runtime)]
 #![feature(never_type)]

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -422,7 +422,7 @@ impl UdpSocket {
     /// Sets the value of the `IP_MULTICAST_LOOP` option for this socket.
     ///
     /// If enabled, multicast packets will be looped back to the local socket.
-    /// Note that this may not have any affect on IPv6 sockets.
+    /// Note that this may not have any effect on IPv6 sockets.
     ///
     /// # Examples
     ///
@@ -464,7 +464,7 @@ impl UdpSocket {
     /// this socket. The default value is 1 which means that multicast packets
     /// don't leave the local network unless explicitly requested.
     ///
-    /// Note that this may not have any affect on IPv6 sockets.
+    /// Note that this may not have any effect on IPv6 sockets.
     ///
     /// # Examples
     ///

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -163,7 +163,7 @@ pub use self::condvar::{Condvar, WaitTimeoutResult};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated)]
+#[allow(deprecated_in_future)]
 pub use self::once::{Once, OnceState, ONCE_INIT};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use crate::sys_common::poison::{PoisonError, TryLockError, TryLockResult, LockResult};

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -163,7 +163,8 @@ pub use self::condvar::{Condvar, WaitTimeoutResult};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated_in_future)]
+#[cfg_attr(bootstrap, allow(deprecated_in_future))]
+#[allow(deprecated)]
 pub use self::once::{Once, OnceState, ONCE_INIT};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use crate::sys_common::poison::{PoisonError, TryLockError, TryLockResult, LockResult};

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated)] // mem::uninitialized
+#![allow(deprecated_in_future)] // mem::uninitialized; becomes `deprecated` when nightly is 1.39
 
 use crate::io::ErrorKind;
 use crate::mem;

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -327,8 +327,8 @@ impl<'a> Parser<'a> {
             self.token.is_keyword(kw::Return) ||
             self.token.is_keyword(kw::While)
         );
-        let cm = self.sess.source_map();
-        match (cm.lookup_line(self.token.span.lo()), cm.lookup_line(sp.lo())) {
+        let sm = self.sess.source_map();
+        match (sm.lookup_line(self.token.span.lo()), sm.lookup_line(sp.lo())) {
             (Ok(ref a), Ok(ref b)) if a.line != b.line && is_semi_suggestable => {
                 // The spans are in different lines, expected `;` and found `let` or `return`.
                 // High likelihood that it is only a missing `;`.
@@ -376,9 +376,9 @@ impl<'a> Parser<'a> {
         maybe_expected_semicolon: bool,
     ) {
         if let Some((sp, likely_path)) = self.last_type_ascription {
-            let cm = self.sess.source_map();
-            let next_pos = cm.lookup_char_pos(self.token.span.lo());
-            let op_pos = cm.lookup_char_pos(sp.hi());
+            let sm = self.sess.source_map();
+            let next_pos = sm.lookup_char_pos(self.token.span.lo());
+            let op_pos = sm.lookup_char_pos(sp.hi());
 
             if likely_path {
                 err.span_suggestion(
@@ -814,8 +814,8 @@ impl<'a> Parser<'a> {
                 return Ok(recovered);
             }
         }
-        let cm = self.sess.source_map();
-        match (cm.lookup_line(prev_sp.lo()), cm.lookup_line(sp.lo())) {
+        let sm = self.sess.source_map();
+        match (sm.lookup_line(prev_sp.lo()), sm.lookup_line(sp.lo())) {
             (Ok(ref a), Ok(ref b)) if a.line == b.line => {
                 // When the spans are in the same line, it means that the only content
                 // between them is whitespace, point only at the found token.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -239,6 +239,7 @@ pub struct Parser<'a> {
     /// error.
     crate unclosed_delims: Vec<UnmatchedBrace>,
     crate last_unexpected_token_span: Option<Span>,
+    crate last_type_ascription: Option<(Span, bool /* likely path typo */)>,
     /// If present, this `Parser` is not parsing Rust code but rather a macro call.
     crate subparser_name: Option<&'static str>,
 }
@@ -502,6 +503,7 @@ impl<'a> Parser<'a> {
             max_angle_bracket_count: 0,
             unclosed_delims: Vec::new(),
             last_unexpected_token_span: None,
+            last_type_ascription: None,
             subparser_name,
         };
 
@@ -1422,7 +1424,10 @@ impl<'a> Parser<'a> {
             }
         } else {
             let msg = format!("expected type, found {}", self.this_token_descr());
-            return Err(self.fatal(&msg));
+            let mut err = self.fatal(&msg);
+            err.span_label(self.token.span, "expected type");
+            self.maybe_annotate_with_ascription(&mut err, true);
+            return Err(err);
         };
 
         let span = lo.to(self.prev_span);
@@ -2823,10 +2828,11 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses an associative expression with operators of at least `min_prec` precedence.
-    fn parse_assoc_expr_with(&mut self,
-                                 min_prec: usize,
-                                 lhs: LhsExpr)
-                                 -> PResult<'a, P<Expr>> {
+    fn parse_assoc_expr_with(
+        &mut self,
+        min_prec: usize,
+        lhs: LhsExpr,
+    ) -> PResult<'a, P<Expr>> {
         let mut lhs = if let LhsExpr::AlreadyParsed(expr) = lhs {
             expr
         } else {
@@ -2840,9 +2846,13 @@ impl<'a> Parser<'a> {
                 self.parse_prefix_expr(attrs)?
             }
         };
+        let last_type_ascription_set = self.last_type_ascription.is_some();
 
         match (self.expr_is_complete(&lhs), AssocOp::from_token(&self.token)) {
             (true, None) => {
+                if last_type_ascription_set {
+                    self.last_type_ascription = None;
+                }
                 // Semi-statement forms are odd. See https://github.com/rust-lang/rust/issues/29071
                 return Ok(lhs);
             }
@@ -2857,12 +2867,18 @@ impl<'a> Parser<'a> {
             // If the next token is a keyword, then the tokens above *are* unambiguously incorrect:
             // `if x { a } else { b } && if y { c } else { d }`
             if !self.look_ahead(1, |t| t.is_reserved_ident()) => {
+                if last_type_ascription_set {
+                    self.last_type_ascription = None;
+                }
                 // These cases are ambiguous and can't be identified in the parser alone
                 let sp = self.sess.source_map().start_point(self.token.span);
                 self.sess.ambiguous_block_expr_parse.borrow_mut().insert(sp, lhs.span);
                 return Ok(lhs);
             }
             (true, Some(ref op)) if !op.can_continue_expr_unambiguously() => {
+                if last_type_ascription_set {
+                    self.last_type_ascription = None;
+                }
                 return Ok(lhs);
             }
             (true, Some(_)) => {
@@ -2921,21 +2937,9 @@ impl<'a> Parser<'a> {
                 continue
             } else if op == AssocOp::Colon {
                 let maybe_path = self.could_ascription_be_path(&lhs.node);
-                let next_sp = self.token.span;
+                self.last_type_ascription = Some((self.prev_span, maybe_path));
 
-                lhs = match self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Type) {
-                    Ok(lhs) => lhs,
-                    Err(mut err) => {
-                        self.bad_type_ascription(
-                            &mut err,
-                            lhs_span,
-                            cur_op_span,
-                            next_sp,
-                            maybe_path,
-                        );
-                        return Err(err);
-                    }
-                };
+                lhs = self.parse_assoc_op_cast(lhs, lhs_span, ExprKind::Type)?;
                 continue
             } else if op == AssocOp::DotDot || op == AssocOp::DotDotEq {
                 // If we didn’t have to handle `x..`/`x..=`, it would be pretty easy to
@@ -3019,6 +3023,9 @@ impl<'a> Parser<'a> {
             };
 
             if let Fixity::None = fixity { break }
+        }
+        if last_type_ascription_set {
+            self.last_type_ascription = None;
         }
         Ok(lhs)
     }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -2850,9 +2850,7 @@ impl<'a> Parser<'a> {
 
         match (self.expr_is_complete(&lhs), AssocOp::from_token(&self.token)) {
             (true, None) => {
-                if last_type_ascription_set {
-                    self.last_type_ascription = None;
-                }
+                self.last_type_ascription = None;
                 // Semi-statement forms are odd. See https://github.com/rust-lang/rust/issues/29071
                 return Ok(lhs);
             }
@@ -2867,18 +2865,14 @@ impl<'a> Parser<'a> {
             // If the next token is a keyword, then the tokens above *are* unambiguously incorrect:
             // `if x { a } else { b } && if y { c } else { d }`
             if !self.look_ahead(1, |t| t.is_reserved_ident()) => {
-                if last_type_ascription_set {
-                    self.last_type_ascription = None;
-                }
+                self.last_type_ascription = None;
                 // These cases are ambiguous and can't be identified in the parser alone
                 let sp = self.sess.source_map().start_point(self.token.span);
                 self.sess.ambiguous_block_expr_parse.borrow_mut().insert(sp, lhs.span);
                 return Ok(lhs);
             }
             (true, Some(ref op)) if !op.can_continue_expr_unambiguously() => {
-                if last_type_ascription_set {
-                    self.last_type_ascription = None;
-                }
+                self.last_type_ascription = None;
                 return Ok(lhs);
             }
             (true, Some(_)) => {

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -141,7 +141,10 @@ fn parse_args<'a>(
 
     while p.token != token::Eof {
         if !p.eat(&token::Comma) {
-            return Err(ecx.struct_span_err(p.token.span, "expected token: `,`"));
+            let mut err = ecx.struct_span_err(p.token.span, "expected token: `,`");
+            err.span_label(p.token.span, "expected `,`");
+            p.maybe_annotate_with_ascription(&mut err, false);
+            return Err(err);
         }
         if p.token == token::Eof {
             break;

--- a/src/test/incremental/unchecked_dirty_clean.rs
+++ b/src/test/incremental/unchecked_dirty_clean.rs
@@ -11,13 +11,13 @@
 fn main() {
 
     #[rustc_dirty(label="Hir", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked #[rustc_dirty]/#[rustc_clean] attribute
+    //[cfail2]~^ ERROR found unchecked `#[rustc_dirty]` / `#[rustc_clean]` attribute
     {
         // empty block
     }
 
     #[rustc_clean(label="Hir", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked #[rustc_dirty]/#[rustc_clean] attribute
+    //[cfail2]~^ ERROR found unchecked `#[rustc_dirty]` / `#[rustc_clean]` attribute
     {
         // empty block
     }
@@ -25,10 +25,10 @@ fn main() {
 
 struct _Struct {
     #[rustc_dirty(label="Hir", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked #[rustc_dirty]/#[rustc_clean] attribute
+    //[cfail2]~^ ERROR found unchecked `#[rustc_dirty]` / `#[rustc_clean]` attribute
     _field1: i32,
 
     #[rustc_clean(label="Hir", cfg="cfail2")]
-    //[cfail2]~^ ERROR found unchecked #[rustc_dirty]/#[rustc_clean] attribute
+    //[cfail2]~^ ERROR found unchecked `#[rustc_dirty]` / `#[rustc_clean]` attribute
     _field2: i32,
 }

--- a/src/test/ui/allocator/two-allocators2.rs
+++ b/src/test/ui/allocator/two-allocators2.rs
@@ -1,6 +1,6 @@
 // aux-build:system-allocator.rs
 // no-prefer-dynamic
-// error-pattern: the #[global_allocator] in
+// error-pattern: the `#[global_allocator]` in
 
 extern crate system_allocator;
 

--- a/src/test/ui/allocator/two-allocators2.stderr
+++ b/src/test/ui/allocator/two-allocators2.stderr
@@ -1,4 +1,4 @@
-error: the #[global_allocator] in this crate conflicts with global allocator in: system_allocator
+error: the `#[global_allocator]` in this crate conflicts with global allocator in: system_allocator
 
 error: aborting due to previous error
 

--- a/src/test/ui/allocator/two-allocators3.rs
+++ b/src/test/ui/allocator/two-allocators3.rs
@@ -1,7 +1,7 @@
 // aux-build:system-allocator.rs
 // aux-build:system-allocator2.rs
 // no-prefer-dynamic
-// error-pattern: the #[global_allocator] in
+// error-pattern: the `#[global_allocator]` in
 
 
 extern crate system_allocator;

--- a/src/test/ui/allocator/two-allocators3.stderr
+++ b/src/test/ui/allocator/two-allocators3.stderr
@@ -1,4 +1,4 @@
-error: the #[global_allocator] in system_allocator conflicts with this global allocator in: system_allocator2
+error: the `#[global_allocator]` in system_allocator conflicts with this global allocator in: system_allocator2
 
 error: aborting due to previous error
 

--- a/src/test/ui/bad/bad-extern-link-attrs.stderr
+++ b/src/test/ui/bad/bad-extern-link-attrs.stderr
@@ -1,10 +1,10 @@
-error[E0459]: #[link(...)] specified without `name = "foo"`
+error[E0459]: `#[link(...)]` specified without `name = "foo"`
   --> $DIR/bad-extern-link-attrs.rs:1:1
    |
 LL | #[link()]
    | ^^^^^^^^^ missing `name` argument
 
-error[E0454]: #[link(name = "")] given with empty name
+error[E0454]: `#[link(name = "")]` given with empty name
   --> $DIR/bad-extern-link-attrs.rs:2:1
    |
 LL | #[link(name = "")]

--- a/src/test/ui/codemap_tests/bad-format-args.stderr
+++ b/src/test/ui/codemap_tests/bad-format-args.stderr
@@ -10,13 +10,13 @@ error: expected token: `,`
   --> $DIR/bad-format-args.rs:3:16
    |
 LL |     format!("" 1);
-   |                ^
+   |                ^ expected `,`
 
 error: expected token: `,`
   --> $DIR/bad-format-args.rs:4:19
    |
 LL |     format!("", 1 1);
-   |                   ^
+   |                   ^ expected `,`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/empty/empty-linkname.stderr
+++ b/src/test/ui/empty/empty-linkname.stderr
@@ -1,4 +1,4 @@
-error[E0454]: #[link(name = "")] given with empty name
+error[E0454]: `#[link(name = "")]` given with empty name
   --> $DIR/empty-linkname.rs:1:1
    |
 LL | #[link(name = "")]

--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -11,7 +11,10 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/E0121.rs:3:13
    |
 LL | static BAR: _ = "test";
-   |             ^ not allowed in type signatures
+   |             ^
+   |             |
+   |             not allowed in type signatures
+   |             help: replace `_` with the correct return type: `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0121.stderr
+++ b/src/test/ui/error-codes/E0121.stderr
@@ -14,7 +14,7 @@ LL | static BAR: _ = "test";
    |             ^
    |             |
    |             not allowed in type signatures
-   |             help: replace `_` with the correct return type: `&'static str`
+   |             help: replace `_` with the correct type: `&'static str`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0454.stderr
+++ b/src/test/ui/error-codes/E0454.stderr
@@ -1,4 +1,4 @@
-error[E0454]: #[link(name = "")] given with empty name
+error[E0454]: `#[link(name = "")]` given with empty name
   --> $DIR/E0454.rs:1:1
    |
 LL | #[link(name = "")] extern {}

--- a/src/test/ui/error-codes/E0458.stderr
+++ b/src/test/ui/error-codes/E0458.stderr
@@ -6,7 +6,7 @@ LL | #[link(kind = "wonderful_unicorn")] extern {}
    |        |
    |        unknown kind
 
-error[E0459]: #[link(...)] specified without `name = "foo"`
+error[E0459]: `#[link(...)]` specified without `name = "foo"`
   --> $DIR/E0458.rs:1:1
    |
 LL | #[link(kind = "wonderful_unicorn")] extern {}

--- a/src/test/ui/error-codes/E0459.stderr
+++ b/src/test/ui/error-codes/E0459.stderr
@@ -1,4 +1,4 @@
-error[E0459]: #[link(...)] specified without `name = "foo"`
+error[E0459]: `#[link(...)]` specified without `name = "foo"`
   --> $DIR/E0459.rs:1:1
    |
 LL | #[link(kind = "dylib")] extern {}

--- a/src/test/ui/feature-gate/issue-49983-see-issue-0.stderr
+++ b/src/test/ui/feature-gate/issue-49983-see-issue-0.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync
+error[E0658]: use of unstable library feature 'ptr_internals': use `NonNull` instead and consider `PhantomData<T>` (if you also use `#[may_dangle]`), `Send`, and/or `Sync`
   --> $DIR/issue-49983-see-issue-0.rs:4:30
    |
 LL | #[allow(unused_imports)] use core::ptr::Unique;

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -87,15 +87,12 @@ error: expected type, found `4`
   --> $DIR/issue-22644.rs:34:28
    |
 LL |     println!("{}", a: &mut 4);
-   |                            ^ expecting a type here because of type ascription
+   |                     -      ^ expected type
+   |                     |
+   |                     tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-note: this expression expects an ascribed type after the colon
-  --> $DIR/issue-22644.rs:34:20
-   |
-LL |     println!("{}", a: &mut 4);
-   |                    ^
-   = help: this might be indicative of a syntax error elsewhere
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/issues/issue-34255-1.stderr
+++ b/src/test/ui/issues/issue-34255-1.stderr
@@ -2,15 +2,12 @@ error: expected type, found `42`
   --> $DIR/issue-34255-1.rs:8:24
    |
 LL |     Test::Drill(field: 42);
-   |                        ^^ expecting a type here because of type ascription
+   |                      - ^^ expected type
+   |                      |
+   |                      tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-note: this expression expects an ascribed type after the colon
-  --> $DIR/issue-34255-1.rs:8:17
-   |
-LL |     Test::Drill(field: 42);
-   |                 ^^^^^
-   = help: this might be indicative of a syntax error elsewhere
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39559.stderr
+++ b/src/test/ui/issues/issue-39559.stderr
@@ -4,9 +4,11 @@ error[E0599]: no function or associated item named `dim` found for type `D` in t
 LL |     entries: [T; D::dim()],
    |                     ^^^ function or associated item not found in `D`
    |
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `dim`, perhaps you need to implement it:
-           candidate #1: `Dim`
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `dim`, perhaps you need to restrict type parameter `D` with it:
+   |
+LL | pub struct Vector<T, D: Dim + Dim> {
+   |                      ^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39616.stderr
+++ b/src/test/ui/issues/issue-39616.stderr
@@ -2,7 +2,7 @@ error: expected type, found `0`
   --> $DIR/issue-39616.rs:1:12
    |
 LL | fn foo(a: [0; 1]) {}
-   |            ^
+   |            ^ expected type
 
 error: expected one of `)`, `,`, `->`, `where`, or `{`, found `]`
   --> $DIR/issue-39616.rs:1:16

--- a/src/test/ui/issues/issue-44406.stderr
+++ b/src/test/ui/issues/issue-44406.stderr
@@ -15,7 +15,10 @@ LL |         bar(baz: $rest)
    |                - help: try using a semicolon: `;`
 ...
 LL |     foo!(true);
-   |          ^^^^ expecting a type here because of type ascription
+   |          ^^^^ expected type
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lifetime_starts_expressions.stderr
+++ b/src/test/ui/lifetime_starts_expressions.stderr
@@ -12,15 +12,12 @@ error: expected type, found keyword `loop`
   --> $DIR/lifetime_starts_expressions.rs:6:26
    |
 LL |     loop { break 'label: loop { break 'label 42; }; }
-   |                          ^^^^ expecting a type here because of type ascription
+   |                        - ^^^^ expected type
+   |                        |
+   |                        tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-note: this expression expects an ascribed type after the colon
-  --> $DIR/lifetime_starts_expressions.rs:6:12
-   |
-LL |     loop { break 'label: loop { break 'label 42; }; }
-   |            ^^^^^^^^^^^^
-   = help: this might be indicative of a syntax error elsewhere
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/macros/missing-comma.stderr
+++ b/src/test/ui/macros/missing-comma.stderr
@@ -2,7 +2,7 @@ error: expected token: `,`
   --> $DIR/missing-comma.rs:19:19
    |
 LL |     println!("{}" a);
-   |                   ^
+   |                   ^ expected `,`
 
 error: no rules expected the token `b`
   --> $DIR/missing-comma.rs:21:12

--- a/src/test/ui/missing/missing-allocator.stderr
+++ b/src/test/ui/missing/missing-allocator.stderr
@@ -1,4 +1,4 @@
-error: no global memory allocator found but one is required; link to std or add #[global_allocator] to a static item that implements the GlobalAlloc trait.
+error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait.
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issue-33262.stderr
+++ b/src/test/ui/parser/issue-33262.stderr
@@ -2,7 +2,7 @@ error: expected type, found `{`
   --> $DIR/issue-33262.rs:4:22
    |
 LL |     for i in 0..a as { }
-   |                      ^
+   |                      ^ expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
+++ b/src/test/ui/parser/macro/trait-object-macro-matcher.stderr
@@ -2,7 +2,7 @@ error: expected type, found `'static`
   --> $DIR/trait-object-macro-matcher.rs:9:8
    |
 LL |     m!('static);
-   |        ^^^^^^^
+   |        ^^^^^^^ expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/recover-enum2.stderr
+++ b/src/test/ui/parser/recover-enum2.stderr
@@ -2,7 +2,7 @@ error: expected type, found `{`
   --> $DIR/recover-enum2.rs:6:18
    |
 LL |             abc: {},
-   |                  ^
+   |                  ^ expected type
 
 error: expected one of `!`, `(`, `)`, `+`, `,`, `::`, or `<`, found `{`
   --> $DIR/recover-enum2.rs:25:22

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -2,15 +2,12 @@ error: expected type, found `3`
   --> $DIR/recover-from-bad-variant.rs:7:26
    |
 LL |     let x = Enum::Foo(a: 3, b: 4);
-   |                          ^ expecting a type here because of type ascription
+   |                        - ^ expected type
+   |                        |
+   |                        tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-note: this expression expects an ascribed type after the colon
-  --> $DIR/recover-from-bad-variant.rs:7:23
-   |
-LL |     let x = Enum::Foo(a: 3, b: 4);
-   |                       ^
-   = help: this might be indicative of a syntax error elsewhere
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error[E0532]: expected tuple struct/variant, found struct variant `Enum::Foo`
   --> $DIR/recover-from-bad-variant.rs:10:9

--- a/src/test/ui/parser/removed-syntax-mut-vec-ty.stderr
+++ b/src/test/ui/parser/removed-syntax-mut-vec-ty.stderr
@@ -2,7 +2,7 @@ error: expected type, found keyword `mut`
   --> $DIR/removed-syntax-mut-vec-ty.rs:1:11
    |
 LL | type v = [mut isize];
-   |           ^^^
+   |           ^^^ expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/removed-syntax-record.stderr
+++ b/src/test/ui/parser/removed-syntax-record.stderr
@@ -2,7 +2,7 @@ error: expected type, found `{`
   --> $DIR/removed-syntax-record.rs:1:10
    |
 LL | type t = { f: () };
-   |          ^
+   |          ^ expected type
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/trait-object-lifetime-parens.stderr
+++ b/src/test/ui/parser/trait-object-lifetime-parens.stderr
@@ -29,7 +29,7 @@ error: expected type, found `'a`
   --> $DIR/trait-object-lifetime-parens.rs:9:17
    |
 LL |     let _: Box<('a) + Trait>;
-   |         -       ^^
+   |         -       ^^ expected type
    |         |
    |         while parsing the type for `_`
 

--- a/src/test/ui/rfc1717/missing-link-attr.stderr
+++ b/src/test/ui/rfc1717/missing-link-attr.stderr
@@ -1,4 +1,4 @@
-error: renaming of the library `foo` was specified, however this crate contains no #[link(...)] attributes referencing this library.
+error: renaming of the library `foo` was specified, however this crate contains no `#[link(...)]` attributes referencing this library.
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -61,9 +61,11 @@ note: the candidate is defined in the trait `ManyImplTrait`
 LL |     fn is_str() -> bool {
    |     ^^^^^^^^^^^^^^^^^^^
    = help: to disambiguate the method call, write `ManyImplTrait::is_str(t)` instead
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `is_str`, perhaps you need to implement it:
-           candidate #1: `ManyImplTrait`
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `is_str`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn param_bound<T: ManyImplTrait + ManyImplTrait>(t: T) -> bool {
+   |                ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/issue-21673.rs
+++ b/src/test/ui/suggestions/issue-21673.rs
@@ -1,0 +1,13 @@
+trait Foo {
+    fn method(&self) {}
+}
+
+fn call_method<T: std::fmt::Debug>(x: &T) {
+    x.method() //~ ERROR E0599
+}
+
+fn call_method_2<T>(x: T) {
+    x.method() //~ ERROR E0599
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/issue-21673.stderr
+++ b/src/test/ui/suggestions/issue-21673.stderr
@@ -1,0 +1,27 @@
+error[E0599]: no method named `method` found for type `&T` in the current scope
+  --> $DIR/issue-21673.rs:6:7
+   |
+LL |     x.method()
+   |       ^^^^^^
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn call_method<T: Foo + std::fmt::Debug>(x: &T) {
+   |                ^^^^^^^^
+
+error[E0599]: no method named `method` found for type `T` in the current scope
+  --> $DIR/issue-21673.rs:10:7
+   |
+LL |     x.method()
+   |       ^^^^^^
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn call_method_2<T: Foo>(x: T) {
+   |                  ^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/suggestions/type-ascription-instead-of-method.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-method.stderr
@@ -2,9 +2,12 @@ error: expected type, found `"foo"`
   --> $DIR/type-ascription-instead-of-method.rs:2:13
    |
 LL |     Box:new("foo".to_string())
-   |        -    ^^^^^ expecting a type here because of type ascription
+   |        -    ^^^^^ expected type
    |        |
-   |        help: maybe you meant to write a path separator here: `::`
+   |        help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-variant.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-variant.stderr
@@ -2,9 +2,12 @@ error: expected type, found `""`
   --> $DIR/type-ascription-instead-of-variant.rs:2:25
    |
 LL |     let _ = Option:Some("");
-   |                   -     ^^ expecting a type here because of type ascription
+   |                   -     ^^ expected type
    |                   |
-   |                   help: maybe you meant to write a path separator here: `::`
+   |                   help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/ascription/issue-34255-1.rs
+++ b/src/test/ui/type/ascription/issue-34255-1.rs
@@ -1,0 +1,15 @@
+struct Reactor {
+    input_cells: Vec<usize>,
+}
+
+impl Reactor {
+    pub fn new() -> Self {
+        input_cells: Vec::new()
+        //~^ ERROR cannot find value `input_cells` in this scope
+        //~| ERROR parenthesized type parameters may only be used with a `Fn` trait
+        //~| ERROR wrong number of type arguments: expected 1, found 0
+        //~| WARNING this was previously accepted by the compiler but is being phased out
+    }
+}
+
+// This case isn't currently being handled gracefully, including for completeness.

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -1,0 +1,30 @@
+error[E0425]: cannot find value `input_cells` in this scope
+  --> $DIR/issue-34255-1.rs:7:9
+   |
+LL |         input_cells: Vec::new()
+   |         ^^^^^^^^^^^ a field by this name exists in `Self`
+
+error: parenthesized type parameters may only be used with a `Fn` trait
+  --> $DIR/issue-34255-1.rs:7:30
+   |
+LL |         input_cells: Vec::new()
+   |                              ^^
+   |
+   = note: `#[deny(parenthesized_params_in_types_and_modules)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
+
+error[E0601]: `main` function not found in crate `issue_34255_1`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-34255-1.rs`
+
+error[E0107]: wrong number of type arguments: expected 1, found 0
+  --> $DIR/issue-34255-1.rs:7:22
+   |
+LL |         input_cells: Vec::new()
+   |                      ^^^^^^^^^^ expected 1 type argument
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0425, E0601.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/type/ascription/issue-47666.rs
+++ b/src/test/ui/type/ascription/issue-47666.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let _ = Option:Some(vec![0, 1]); //~ ERROR expected type, found
+}
+
+// This case isn't currently being handled gracefully due to the macro invocation.

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -1,0 +1,13 @@
+error: expected type, found reserved keyword `box`
+  --> $DIR/issue-47666.rs:2:25
+   |
+LL |     let _ = Option:Some(vec![0, 1]);
+   |                         ^^^^^^^^^^
+   |                         |
+   |                         expected type
+   |                         in this macro invocation
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/type/ascription/issue-54516.rs
+++ b/src/test/ui/type/ascription/issue-54516.rs
@@ -1,0 +1,6 @@
+use std::collections::BTreeMap;
+
+fn main() {
+    println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
+    //~^ ERROR expected token: `,`
+}

--- a/src/test/ui/type/ascription/issue-54516.stderr
+++ b/src/test/ui/type/ascription/issue-54516.stderr
@@ -1,0 +1,13 @@
+error: expected token: `,`
+  --> $DIR/issue-54516.rs:4:58
+   |
+LL |     println!("{}", std::mem:size_of::<BTreeMap<u32, u32>>());
+   |                            -                             ^ expected `,`
+   |                            |
+   |                            help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+
+error: aborting due to previous error
+

--- a/src/test/ui/type/ascription/issue-60933.rs
+++ b/src/test/ui/type/ascription/issue-60933.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let u: usize = std::mem:size_of::<u32>();
+    //~^ ERROR expected one of
+}

--- a/src/test/ui/type/ascription/issue-60933.stderr
+++ b/src/test/ui/type/ascription/issue-60933.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!`, `::`, or `;`, found `(`
+  --> $DIR/issue-60933.rs:2:43
+   |
+LL |     let u: usize = std::mem:size_of::<u32>();
+   |                            -              ^ expected one of `!`, `::`, or `;` here
+   |                            |
+   |                            help: maybe write a path separator here: `::`
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+
+error: aborting due to previous error
+

--- a/src/test/ui/type/type-ascription-instead-of-initializer.stderr
+++ b/src/test/ui/type/type-ascription-instead-of-initializer.stderr
@@ -2,7 +2,7 @@ error: expected type, found `10`
   --> $DIR/type-ascription-instead-of-initializer.rs:2:31
    |
 LL |     let x: Vec::with_capacity(10, 20);
-   |         --                    ^^
+   |         --                    ^^ expected type
    |         ||
    |         |help: use `=` if you meant to assign
    |         while parsing the type for `x`

--- a/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
+++ b/src/test/ui/type/type-ascription-instead-of-statement-end.stderr
@@ -4,21 +4,21 @@ error: expected type, found `0`
 LL |     println!("test"):
    |                     - help: try using a semicolon: `;`
 LL |     0;
-   |     ^ expecting a type here because of type ascription
+   |     ^ expected type
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: expected type, found `0`
   --> $DIR/type-ascription-instead-of-statement-end.rs:9:23
    |
 LL |     println!("test"): 0;
-   |                       ^ expecting a type here because of type ascription
+   |                     - ^ expected type
+   |                     |
+   |                     tried to parse a type due to this type ascription
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
-note: this expression expects an ascribed type after the colon
-  --> $DIR/type-ascription-instead-of-statement-end.rs:9:5
-   |
-LL |     println!("test"): 0;
-   |     ^^^^^^^^^^^^^^^^
-   = help: this might be indicative of a syntax error elsewhere
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item.stderr
@@ -23,13 +23,19 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/typeck_type_placeholder_item.rs:11:15
    |
 LL | static TEST3: _ = "test";
-   |               ^ not allowed in type signatures
+   |               ^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace `_` with the correct type: `&'static str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:14:15
    |
 LL | static TEST4: _ = 145;
-   |               ^ not allowed in type signatures
+   |               ^
+   |               |
+   |               not allowed in type signatures
+   |               help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:17:16
@@ -122,13 +128,19 @@ error[E0121]: the type placeholder `_` is not allowed within types on item signa
   --> $DIR/typeck_type_placeholder_item.rs:64:22
    |
 LL |     static FN_TEST3: _ = "test";
-   |                      ^ not allowed in type signatures
+   |                      ^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace `_` with the correct type: `&'static str`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:67:22
    |
 LL |     static FN_TEST4: _ = 145;
-   |                      ^ not allowed in type signatures
+   |                      ^
+   |                      |
+   |                      not allowed in type signatures
+   |                      help: replace `_` with the correct type: `i32`
 
 error[E0121]: the type placeholder `_` is not allowed within types on item signatures
   --> $DIR/typeck_type_placeholder_item.rs:70:23

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.rs
@@ -4,6 +4,24 @@
 fn test1() -> _ { Some(42) }
 //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
 
+const TEST2: _ = 42u32;
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+
+const TEST3: _ = Some(42);
+//~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+
+trait Test4 {
+    const TEST4: _ = 42;
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+}
+
+struct Test5;
+
+impl Test5 {
+    const TEST5: _ = 13;
+    //~^ ERROR the type placeholder `_` is not allowed within types on item signatures
+}
+
 pub fn main() {
     let _: Option<usize> = test1();
     let _: f64 = test1();

--- a/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
+++ b/src/test/ui/typeck/typeck_type_placeholder_item_help.stderr
@@ -7,6 +7,42 @@ LL | fn test1() -> _ { Some(42) }
    |               not allowed in type signatures
    |               help: replace `_` with the correct return type: `std::option::Option<i32>`
 
-error: aborting due to previous error
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:7:14
+   |
+LL | const TEST2: _ = 42u32;
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace `_` with the correct type: `u32`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:10:14
+   |
+LL | const TEST3: _ = Some(42);
+   |              ^
+   |              |
+   |              not allowed in type signatures
+   |              help: replace `_` with the correct type: `std::option::Option<i32>`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:14:18
+   |
+LL |     const TEST4: _ = 42;
+   |                  ^
+   |                  |
+   |                  not allowed in type signatures
+   |                  help: replace `_` with the correct type: `i32`
+
+error[E0121]: the type placeholder `_` is not allowed within types on item signatures
+  --> $DIR/typeck_type_placeholder_item_help.rs:21:18
+   |
+LL |     const TEST5: _ = 13;
+   |                  ^
+   |                  |
+   |                  not allowed in type signatures
+   |                  help: replace `_` with the correct type: `i32`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0121`.

--- a/src/test/ui/wasm-import-module.stderr
+++ b/src/test/ui/wasm-import-module.stderr
@@ -1,16 +1,16 @@
-error: must be of the form #[link(wasm_import_module = "...")]
+error: must be of the form `#[link(wasm_import_module = "...")]`
   --> $DIR/wasm-import-module.rs:1:22
    |
 LL | #[link(name = "...", wasm_import_module)]
    |                      ^^^^^^^^^^^^^^^^^^
 
-error: must be of the form #[link(wasm_import_module = "...")]
+error: must be of the form `#[link(wasm_import_module = "...")]`
   --> $DIR/wasm-import-module.rs:4:22
    |
 LL | #[link(name = "...", wasm_import_module(x))]
    |                      ^^^^^^^^^^^^^^^^^^^^^
 
-error: must be of the form #[link(wasm_import_module = "...")]
+error: must be of the form `#[link(wasm_import_module = "...")]`
   --> $DIR/wasm-import-module.rs:7:22
    |
 LL | #[link(name = "...", wasm_import_module())]


### PR DESCRIPTION
Successful merges:

 - #62709 (Test that maplike FromIter satisfies uniqueness)
 - #62746 ( do not use assume_init in std::io)
 - #62772 (Suggest trait bound on type parameter when it is unconstrained)
 - #62787 (Fix typo in src/libstd/net/udp.rs doc comment)
 - #62788 (normalize use of backticks in compiler messages for libcore/ptr)
 - #62791 (Handle more cases of typos misinterpreted as type ascription)
 - #62804 (rustc_typeck: improve diagnostics for _ const/static declarations)
 - #62808 (Revert "Disable stack probing for gnux32.")
 - #62812 (normalize use of backticks in compiler messages for librustc_metadata)
 - #62813 (rustc: Compile the `fmt_macros` crate as an rlib)
 - #62832 (normalize use of backticks in compiler messages for librustc_incremental)

Failed merges:


r? @ghost