### PR TITLE
move unescape module to rustc_lexer

### DIFF
--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(feature = "unicode-xid"), feature(unicode_internals))]
 
 mod cursor;
+pub mod unescape;
 
 use crate::cursor::{Cursor, EOF_CHAR};
 

--- a/src/librustc_lexer/src/unescape.rs
+++ b/src/librustc_lexer/src/unescape.rs
@@ -5,7 +5,7 @@ use std::str::Chars;
 use std::ops::Range;
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum EscapeError {
+pub enum EscapeError {
     ZeroChars,
     MoreThanOneChar,
 
@@ -35,7 +35,7 @@ pub(crate) enum EscapeError {
 
 /// Takes a contents of a char literal (without quotes), and returns an
 /// unescaped char or an error
-pub(crate) fn unescape_char(literal_text: &str) -> Result<char, (usize, EscapeError)> {
+pub fn unescape_char(literal_text: &str) -> Result<char, (usize, EscapeError)> {
     let mut chars = literal_text.chars();
     unescape_char_or_byte(&mut chars, Mode::Char)
         .map_err(|err| (literal_text.len() - chars.as_str().len(), err))
@@ -43,14 +43,14 @@ pub(crate) fn unescape_char(literal_text: &str) -> Result<char, (usize, EscapeEr
 
 /// Takes a contents of a string literal (without quotes) and produces a
 /// sequence of escaped characters or errors.
-pub(crate) fn unescape_str<F>(literal_text: &str, callback: &mut F)
+pub fn unescape_str<F>(literal_text: &str, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<char, EscapeError>),
 {
     unescape_str_or_byte_str(literal_text, Mode::Str, callback)
 }
 
-pub(crate) fn unescape_byte(literal_text: &str) -> Result<u8, (usize, EscapeError)> {
+pub fn unescape_byte(literal_text: &str) -> Result<u8, (usize, EscapeError)> {
     let mut chars = literal_text.chars();
     unescape_char_or_byte(&mut chars, Mode::Byte)
         .map(byte_from_char)
@@ -59,7 +59,7 @@ pub(crate) fn unescape_byte(literal_text: &str) -> Result<u8, (usize, EscapeErro
 
 /// Takes a contents of a string literal (without quotes) and produces a
 /// sequence of escaped characters or errors.
-pub(crate) fn unescape_byte_str<F>(literal_text: &str, callback: &mut F)
+pub fn unescape_byte_str<F>(literal_text: &str, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<u8, EscapeError>),
 {
@@ -72,7 +72,7 @@ where
 /// sequence of characters or errors.
 /// NOTE: Raw strings do not perform any explicit character escaping, here we
 /// only translate CRLF to LF and produce errors on bare CR.
-pub(crate) fn unescape_raw_str<F>(literal_text: &str, callback: &mut F)
+pub fn unescape_raw_str<F>(literal_text: &str, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<char, EscapeError>),
 {
@@ -83,7 +83,7 @@ where
 /// sequence of characters or errors.
 /// NOTE: Raw strings do not perform any explicit character escaping, here we
 /// only translate CRLF to LF and produce errors on bare CR.
-pub(crate) fn unescape_raw_byte_str<F>(literal_text: &str, callback: &mut F)
+pub fn unescape_raw_byte_str<F>(literal_text: &str, callback: &mut F)
 where
     F: FnMut(Range<usize>, Result<u8, EscapeError>),
 {
@@ -93,7 +93,7 @@ where
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum Mode {
+pub enum Mode {
     Char,
     Str,
     Byte,
@@ -101,18 +101,18 @@ pub(crate) enum Mode {
 }
 
 impl Mode {
-    fn in_single_quotes(self) -> bool {
+    pub fn in_single_quotes(self) -> bool {
         match self {
             Mode::Char | Mode::Byte => true,
             Mode::Str | Mode::ByteStr => false,
         }
     }
 
-    pub(crate) fn in_double_quotes(self) -> bool {
+    pub fn in_double_quotes(self) -> bool {
         !self.in_single_quotes()
     }
 
-    pub(crate) fn is_bytes(self) -> bool {
+    pub fn is_bytes(self) -> bool {
         match self {
             Mode::Byte | Mode::ByteStr => true,
             Mode::Char | Mode::Str => false,

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -1,12 +1,12 @@
 use crate::parse::ParseSess;
 use crate::parse::token::{self, Token, TokenKind};
 use crate::symbol::{sym, Symbol};
-use crate::parse::unescape;
 use crate::parse::unescape_error_reporting::{emit_unescape_error, push_escaped_char};
 
 use errors::{FatalError, Diagnostic, DiagnosticBuilder};
 use syntax_pos::{BytePos, Pos, Span, NO_EXPANSION};
 use rustc_lexer::Base;
+use rustc_lexer::unescape;
 
 use std::borrow::Cow;
 use std::char;

--- a/src/libsyntax/parse/literal.rs
+++ b/src/libsyntax/parse/literal.rs
@@ -4,9 +4,6 @@ use crate::ast::{self, Lit, LitKind};
 use crate::parse::parser::Parser;
 use crate::parse::PResult;
 use crate::parse::token::{self, Token, TokenKind};
-use crate::parse::unescape::{unescape_char, unescape_byte};
-use crate::parse::unescape::{unescape_str, unescape_byte_str};
-use crate::parse::unescape::{unescape_raw_str, unescape_raw_byte_str};
 use crate::print::pprust;
 use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{TokenStream, TokenTree};
@@ -15,6 +12,9 @@ use errors::{Applicability, Handler};
 use log::debug;
 use rustc_data_structures::sync::Lrc;
 use syntax_pos::Span;
+use rustc_lexer::unescape::{unescape_char, unescape_byte};
+use rustc_lexer::unescape::{unescape_str, unescape_byte_str};
+use rustc_lexer::unescape::{unescape_raw_str, unescape_raw_byte_str};
 
 use std::ascii;
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -32,7 +32,6 @@ pub mod token;
 crate mod classify;
 crate mod diagnostics;
 crate mod literal;
-crate mod unescape;
 crate mod unescape_error_reporting;
 
 /// Info about a parsing session.

--- a/src/libsyntax/parse/unescape_error_reporting.rs
+++ b/src/libsyntax/parse/unescape_error_reporting.rs
@@ -3,11 +3,10 @@
 use std::ops::Range;
 use std::iter::once;
 
+use rustc_lexer::unescape::{EscapeError, Mode};
 use syntax_pos::{Span, BytePos};
 
 use crate::errors::{Handler, Applicability};
-
-use super::unescape::{EscapeError, Mode};
 
 pub(crate) fn emit_unescape_error(
     handler: &Handler,


### PR DESCRIPTION
It makes sense to keep the definition of escape sequences closer to the lexer itself, and it is also a bit of code that I would like to share with rust-analyzer.

r? @petrochenkov 