### PR TITLE
normalize use of backticks in compiler messages for librustc/hir

### DIFF
--- a/src/librustc/hir/def_id.rs
+++ b/src/librustc/hir/def_id.rs
@@ -69,14 +69,14 @@ impl CrateNum {
     pub fn as_usize(self) -> usize {
         match self {
             CrateNum::Index(id) => id.as_usize(),
-            _ => bug!("tried to get index of nonstandard crate {:?}", self),
+            _ => bug!("tried to get index of non-standard crate {:?}", self),
         }
     }
 
     pub fn as_u32(self) -> u32 {
         match self {
             CrateNum::Index(id) => id.as_u32(),
-            _ => bug!("tried to get index of nonstandard crate {:?}", self),
+            _ => bug!("tried to get index of non-standard crate {:?}", self),
         }
     }
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1693,8 +1693,8 @@ impl<'a> LoweringContext<'a> {
                         if pos == ImplTraitPosition::Binding &&
                             nightly_options::is_nightly_build() {
                             help!(err,
-                                  "add #![feature(impl_trait_in_bindings)] to the crate attributes \
-                                   to enable");
+                                  "add `#![feature(impl_trait_in_bindings)]` to the crate \
+                                   attributes to enable");
                         }
                         err.emit();
                         hir::TyKind::Err

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -121,7 +121,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL | const _cdef: impl Tr1<As1: Copy> = S1;
    |              ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/feature-gate-associated_type_bounds.rs:60:15
@@ -129,7 +129,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL | static _sdef: impl Tr1<As1: Copy> = S1;
    |               ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/feature-gate-associated_type_bounds.rs:67:12
@@ -137,7 +137,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL |     let _: impl Tr1<As1: Copy> = S1;
    |            ^^^^^^^^^^^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-impl_trait_in_bindings.stderr
+++ b/src/test/ui/feature-gates/feature-gate-impl_trait_in_bindings.stderr
@@ -10,7 +10,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL | const FOO: impl Copy = 42;
    |            ^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/feature-gate-impl_trait_in_bindings.rs:4:13
@@ -18,7 +18,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL | static BAR: impl Copy = 42;
    |             ^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -232,7 +232,7 @@ error[E0562]: `impl Trait` not allowed outside of function and inherent method r
 LL |     let _in_local_variable: impl Fn() = || {};
    |                             ^^^^^^^^^
    |
-   = help: add #![feature(impl_trait_in_bindings)] to the crate attributes to enable
+   = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/where-allowed.rs:222:46


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532