### PR TITLE
Fix typo in Unicode character name

### DIFF
--- a/src/libsyntax/parse/lexer/unicode_chars.rs
+++ b/src/libsyntax/parse/lexer/unicode_chars.rs
@@ -50,7 +50,7 @@ const UNICODE_ARRAY: &[(char, &str, char)] = &[
     ('─', "Box Drawings Light Horizontal", '-'),
     ('━', "Box Drawings Heavy Horizontal", '-'),
     ('㇐', "CJK Stroke H", '-'),
-    ('ꟷ', "Latin Epigraphic Letter Dideways", '-'),
+    ('ꟷ', "Latin Epigraphic Letter Sideways I", '-'),
     ('ᅳ', "Hangul Jungseong Eu", '-'),
     ('ㅡ', "Hangul Letter Eu", '-'),
     ('一', "CJK Unified Ideograph-4E00", '-'),


### PR DESCRIPTION
There's a small typo in the Unicode character definitions: "Latin Epigraphic Letter Dideways" should be "Latin Epigraphic Letter Sideways I" (see [here](https://www.compart.com/en/unicode/U+A7F7)).