### PR TITLE
ci: pin awscli dependencies

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -142,11 +142,11 @@ steps:
     set -e
     source src/ci/shared.sh
     sudo apt-get install -y python3-setuptools
-    retry pip3 install awscli --upgrade --user
+    retry pip3 install -r src/ci/awscli-requirements.txt --upgrade --user
     echo "##vso[task.prependpath]$HOME/.local/bin"
   displayName: Install awscli (Linux)
   condition: and(succeeded(), not(variables.SKIP_JOB), eq(variables['Agent.OS'], 'Linux'))
-- script: pip install awscli
+- script: pip install -r src/ci/awscli-requirements.txt
   displayName: Install awscli (non-Linux)
   condition: and(succeeded(), not(variables.SKIP_JOB), ne(variables['Agent.OS'], 'Linux'))
 

--- a/src/ci/awscli-requirements.txt
+++ b/src/ci/awscli-requirements.txt
@@ -1,0 +1,13 @@
+awscli==1.16.201
+botocore==1.12.191
+colorama==0.3.9
+docutils==0.14
+jmespath==0.9.4
+pyasn1==0.4.5
+python-dateutil==2.8.0
+PyYAML==5.1
+rsa==3.4.2
+s3transfer==0.2.1
+six==1.12.0
+urllib3==1.25.3
+futures==3.3.0; python_version < '3.0'


### PR DESCRIPTION
docutils 0.15, a dependency of awscli, broke our CI since it's not compatible with Python 2 due to a bug. This pins all the dependencies of awscli with docutils 0.14, to make sure this kind of regressions doesn't happen again.

r? @Mark-Simulacrum @alexcrichton 