### PR TITLE
[WIP] Lower core::ops::drop directly to MIR drop

### DIFF
--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -693,6 +693,7 @@ pub fn replace<T>(dest: &mut T, mut src: T) -> T {
 /// [`Copy`]: ../../std/marker/trait.Copy.html
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), lang = "drop")]
 pub fn drop<T>(_x: T) { }
 
 /// Interprets `src` as having type `&U`, and then reads `src` without moving

--- a/src/libcore/ops/drop.rs
+++ b/src/libcore/ops/drop.rs
@@ -80,7 +80,8 @@
 ///     let _second = PrintOnDrop("Declared second!");
 /// }
 /// ```
-#[lang = "drop"]
+#[cfg_attr(not(bootstrap), lang = "drop_trait")]
+#[cfg_attr(bootstrap, lang = "drop")]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Drop {
     /// Executes the destructor for this type.

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -279,7 +279,7 @@ language_item_table! {
     SyncTraitLangItem,           "sync",               sync_trait,              Target::Trait;
     FreezeTraitLangItem,         "freeze",             freeze_trait,            Target::Trait;
 
-    DropTraitLangItem,           "drop",               drop_trait,              Target::Trait;
+    DropTraitLangItem,           "drop_trait",         drop_trait,              Target::Trait;
 
     CoerceUnsizedTraitLangItem,  "coerce_unsized",     coerce_unsized_trait,    Target::Trait;
     DispatchFromDynTraitLangItem,"dispatch_from_dyn",  dispatch_from_dyn_trait, Target::Trait;
@@ -349,6 +349,7 @@ language_item_table! {
 
     ExchangeMallocFnLangItem,    "exchange_malloc",    exchange_malloc_fn,      Target::Fn;
     BoxFreeFnLangItem,           "box_free",           box_free_fn,             Target::Fn;
+    DropFnLangItem,              "drop",               drop_fn,                 Target::Fn;
     DropInPlaceFnLangItem,       "drop_in_place",      drop_in_place_fn,        Target::Fn;
     OomLangItem,                 "oom",                oom,                     Target::Fn;
     AllocLayoutLangItem,         "alloc_layout",       alloc_layout,            Target::Struct;

--- a/src/test/mir-opt/box_expr.rs
+++ b/src/test/mir-opt/box_expr.rs
@@ -53,7 +53,7 @@ impl Drop for S {
 //         StorageLive(_3);
 //         StorageLive(_4);
 //         _4 = move _1;
-//         _3 = const std::mem::drop::<std::boxed::Box<S>>(move _4) -> [return: bb5, unwind: bb7];
+//         drop(_4) -> [return: bb5, unwind: bb7];
 //     }
 //
 //     bb5: {

--- a/src/test/mir-opt/issue-49232.rs
+++ b/src/test/mir-opt/issue-49232.rs
@@ -76,7 +76,7 @@ fn main() {
 //         StorageLive(_5);
 //         StorageLive(_6);
 //         _6 = &_2;
-//         _5 = const std::mem::drop::<&i32>(move _6) -> [return: bb13, unwind: bb4];
+//         drop(_6) -> [return: bb13, unwind: bb4];
 //     }
 //     bb13: {
 //         StorageDead(_6);

--- a/src/test/ui/type_length_limit.rs
+++ b/src/test/ui/type_length_limit.rs
@@ -22,6 +22,8 @@ link! { F, G }
 
 pub struct G;
 
+fn take<T>(x: T) {}
+
 fn main() {
-    drop::<Option<A>>(None);
+    take::<Option<A>>(None);
 }

--- a/src/test/ui/type_length_limit.stderr
+++ b/src/test/ui/type_length_limit.stderr
@@ -1,8 +1,8 @@
-error: reached the type-length limit while instantiating `std::mem::drop::<std::option::Op... G), (G, G, G), (G, G, G))))))>>`
-  --> $SRC_DIR/libcore/mem/mod.rs:LL:COL
+error: reached the type-length limit while instantiating `take::<std::option::Option<(((((... G), (G, G, G), (G, G, G))))))>>`
+  --> $DIR/type_length_limit.rs:25:1
    |
-LL | pub fn drop<T>(_x: T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn take<T>(x: T) {}
+   | ^^^^^^^^^^^^^^^^^^^
    |
    = note: consider adding a `#![type_length_limit="1094"]` attribute to your crate
 


### PR DESCRIPTION
This change causes drop() to always drop in-place. This is meant to
allow internal optimizations (see #62508).

This does _not_ change the documented contract for drop(). Only internal
compiler code is allowed to rely on this for now.

This is WIP still because it breaks the optimization implemented in #53080.

Closes #62508.

r? @cramertj 
cc @arielb1 @eddyb 