### PR TITLE
add rustc_private as a proper language feature gate

### DIFF
--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -553,10 +553,12 @@ impl char {
     /// 'XID_Start' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to `ID_Start` but modified for closure under `NFKx`.
-    #[unstable(feature = "rustc_private",
-               reason = "mainly needed for compiler internals",
-               issue = "27812")]
-    #[inline]
+    #[cfg_attr(bootstrap,
+               unstable(feature = "rustc_private",
+                        reason = "mainly needed for compiler internals",
+                        issue = "27812"))]
+    #[cfg_attr(not(bootstrap),
+               unstable(feature = "unicode_internals", issue = "0"))]
     pub fn is_xid_start(self) -> bool {
         derived_property::XID_Start(self)
     }
@@ -567,9 +569,12 @@ impl char {
     /// 'XID_Continue' is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to 'ID_Continue' but modified for closure under NFKx.
-    #[unstable(feature = "rustc_private",
-               reason = "mainly needed for compiler internals",
-               issue = "27812")]
+    #[cfg_attr(bootstrap,
+               unstable(feature = "rustc_private",
+                        reason = "mainly needed for compiler internals",
+                        issue = "27812"))]
+    #[cfg_attr(not(bootstrap),
+               unstable(feature = "unicode_internals", issue = "0"))]
     #[inline]
     pub fn is_xid_continue(self) -> bool {
         derived_property::XID_Continue(self)

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -13,6 +13,7 @@
 
 #![feature(nll)]
 #![feature(rustc_private)]
+#![feature(unicode_internals)]
 
 pub use Piece::*;
 pub use Position::*;

--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -1,5 +1,5 @@
 // We want to be able to build this crate with a stable compiler, so feature
-// flags should optional.
+// flags should be optional.
 #![cfg_attr(not(feature = "unicode-xid"), feature(unicode_internals))]
 
 mod cursor;

--- a/src/librustc_lexer/src/lib.rs
+++ b/src/librustc_lexer/src/lib.rs
@@ -1,6 +1,5 @@
 // We want to be able to build this crate with a stable compiler, so feature
 // flags should optional.
-#![cfg_attr(not(feature = "unicode-xid"), feature(rustc_private))]
 #![cfg_attr(not(feature = "unicode-xid"), feature(unicode_internals))]
 
 mod cursor;

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -21,6 +21,7 @@
 #![feature(inner_deref)]
 #![feature(never_type)]
 #![feature(mem_take)]
+#![feature(unicode_internals)]
 
 #![recursion_limit="256"]
 

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -126,6 +126,9 @@ declare_features! (
 
     // no-tracking-issue-start
 
+    // Allows using compiler's own crates.
+    (active, rustc_private, "1.0.0", Some(27812), None),
+
     // Allows using the `rust-intrinsic`'s "ABI".
     (active, intrinsics, "1.0.0", None, None),
 

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -12,6 +12,7 @@
 #![feature(decl_macro)]
 #![feature(nll)]
 #![feature(rustc_diagnostic_macros)]
+#![feature(unicode_internals)]
 
 #![recursion_limit="256"]
 

--- a/src/test/ui/feature-gate/rustc-private.rs
+++ b/src/test/ui/feature-gate/rustc-private.rs
@@ -1,0 +1,5 @@
+// gate-test-rustc_private
+
+extern crate libc; //~ ERROR  use of unstable library feature 'rustc_private'
+
+fn main() {}

--- a/src/test/ui/feature-gate/rustc-private.stderr
+++ b/src/test/ui/feature-gate/rustc-private.stderr
@@ -1,0 +1,12 @@
+error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+  --> $DIR/rustc-private.rs:3:1
+   |
+LL | extern crate libc;
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27812
+   = help: add `#![feature(rustc_private)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
At the moment, `rustc_private` as a (library) feature exists by
accident: `char::is_xid_start`, `char::is_xid_continue` methods in
libcore define it.

cc https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/How.20to.20declare.20new.20langauge.20feature.3F

I don't know if this is at all reasonable, but at least tests seem to pass locally. That probably means that we can remove/rename to something more resonable the feature in libcore in the next release?