### PR TITLE
normalize use of backticks in compiler messages for librustc_allocator

### DIFF
--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -79,7 +79,7 @@ impl MutVisitor for ExpandAllocatorDirectives<'_> {
 
         if self.found {
             self.handler
-                .span_err(item.span, "cannot define more than one #[global_allocator]");
+                .span_err(item.span, "cannot define more than one `#[global_allocator]`");
             return smallvec![item];
         }
         self.found = true;
@@ -280,7 +280,7 @@ impl AllocFnFactory<'_> {
             AllocatorTy::Unit => (self.cx.ty(self.span, TyKind::Tup(Vec::new())), expr),
 
             AllocatorTy::Layout | AllocatorTy::Usize | AllocatorTy::Ptr => {
-                panic!("can't convert AllocatorTy to an output")
+                panic!("can't convert `AllocatorTy` to an output")
             }
         }
     }

--- a/src/test/ui/allocator/two-allocators.rs
+++ b/src/test/ui/allocator/two-allocators.rs
@@ -4,6 +4,6 @@ use std::alloc::System;
 static A: System = System;
 #[global_allocator]
 static B: System = System;
-//~^ ERROR: cannot define more than one #[global_allocator]
+//~^ ERROR: cannot define more than one `#[global_allocator]`
 
 fn main() {}

--- a/src/test/ui/allocator/two-allocators.stderr
+++ b/src/test/ui/allocator/two-allocators.stderr
@@ -1,4 +1,4 @@
-error: cannot define more than one #[global_allocator]
+error: cannot define more than one `#[global_allocator]`
   --> $DIR/two-allocators.rs:6:1
    |
 LL | static B: System = System;


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532