### PR TITLE
Change "OSX" to "macOS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,11 @@ fetch snapshots, and an OS that can execute the available snapshot binaries.
 
 Snapshot binaries are currently built and tested on several platforms:
 
-| Platform / Architecture  | x86 | x86_64 |
-|--------------------------|-----|--------|
-| Windows (7, 8, 10, ...)  | ✓   | ✓      |
-| Linux (2.6.18 or later)  | ✓   | ✓      |
-| OSX (10.7 Lion or later) | ✓   | ✓      |
+| Platform / Architecture    | x86 | x86_64 |
+|----------------------------|-----|--------|
+| Windows (7, 8, 10, ...)    | ✓   | ✓      |
+| Linux (2.6.18 or later)    | ✓   | ✓      |
+| macOS (10.7 Lion or later) | ✓   | ✓      |
 
 You may find that other platforms work, but these are our officially
 supported build environments that are most likely to work.


### PR DESCRIPTION
Apple no longer uses the OS X branding.