### PR TITLE
Normalize use of backticks in compiler messages for libsyntax/*

### DIFF
--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -30,7 +30,7 @@ use std::iter;
 use std::ops::DerefMut;
 
 pub fn mark_used(attr: &Attribute) {
-    debug!("Marking {:?} as used.", attr);
+    debug!("marking {:?} as used", attr);
     GLOBALS.with(|globals| {
         globals.used_attrs.lock().insert(attr.id);
     });
@@ -43,7 +43,7 @@ pub fn is_used(attr: &Attribute) -> bool {
 }
 
 pub fn mark_known(attr: &Attribute) {
-    debug!("Marking {:?} as known.", attr);
+    debug!("marking {:?} as known", attr);
     GLOBALS.with(|globals| {
         globals.known_attrs.lock().insert(attr.id);
     });

--- a/src/libsyntax/error_codes.rs
+++ b/src/libsyntax/error_codes.rs
@@ -182,7 +182,7 @@ beta compilers will not comply.
 Example of erroneous code (on a stable compiler):
 
 ```ignore (depends on release channel)
-#![feature(non_ascii_idents)] // error: #![feature] may not be used on the
+#![feature(non_ascii_idents)] // error: `#![feature]` may not be used on the
                               //        stable release channel
 ```
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -602,7 +602,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             None => return TokenStream::empty(),
         }
         self.cx.span_err(span, "custom attribute invocations must be \
-            of the form #[foo] or #[foo(..)], the macro name must only be \
+            of the form `#[foo]` or `#[foo(..)]`, the macro name must only be \
             followed by a delimiter token");
         TokenStream::empty()
     }

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -414,7 +414,7 @@ fn get_test_runner(sd: &errors::Handler, krate: &ast::Crate) -> Option<ast::Path
     test_attr.meta_item_list().map(|meta_list| {
         if meta_list.len() != 1 {
             sd.span_fatal(test_attr.span,
-                "#![test_runner(..)] accepts exactly 1 argument").raise()
+                "`#![test_runner(..)]` accepts exactly 1 argument").raise()
         }
         match meta_list[0].meta_item() {
             Some(meta_item) if meta_item.is_word() => meta_item.path.clone(),

--- a/src/test/ui/proc-macro/proc-macro-gates.stderr
+++ b/src/test/ui/proc-macro/proc-macro-gates.stderr
@@ -34,7 +34,7 @@ LL |     #![empty_attr]
    = note: for more information, see https://github.com/rust-lang/rust/issues/54727
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
 
-error: custom attribute invocations must be of the form #[foo] or #[foo(..)], the macro name must only be followed by a delimiter token
+error: custom attribute invocations must be of the form `#[foo]` or `#[foo(..)]`, the macro name must only be followed by a delimiter token
   --> $DIR/proc-macro-gates.rs:21:1
    |
 LL | #[empty_attr = "y"]


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532