### PR TITLE
Share expansion definition data between expansions with the same definition

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -396,15 +396,19 @@ impl_stable_hash_for!(enum ::syntax_pos::hygiene::Transparency {
     Opaque,
 });
 
-impl_stable_hash_for!(struct ::syntax_pos::hygiene::ExpnInfo {
-    call_site,
-    kind,
+impl_stable_hash_for!(struct ::syntax_pos::hygiene::ExpnDef {
     def_site,
     default_transparency,
     allow_internal_unstable,
     allow_internal_unsafe,
     local_inner_macros,
-    edition
+    edition,
+});
+
+impl_stable_hash_for!(struct ::syntax_pos::hygiene::ExpnInfo {
+    call_site,
+    kind,
+    def,
 });
 
 impl_stable_hash_for!(enum ::syntax_pos::hygiene::ExpnKind {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -61,9 +61,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             // We want to ignore desugarings here: spans are equivalent even
             // if one is the result of a desugaring and the other is not.
             let mut span = error.obligation.cause.span;
-            if let Some(ExpnInfo { kind: ExpnKind::Desugaring(_), def_site, .. })
+            if let Some(ExpnInfo { kind: ExpnKind::Desugaring(_), call_site, .. })
                     = span.ctxt().outer_expn_info() {
-                span = def_site;
+                span = call_site;
             }
 
             error_map.entry(span).or_default().push(

--- a/src/librustc_allocator/expand.rs
+++ b/src/librustc_allocator/expand.rs
@@ -14,7 +14,7 @@ use syntax::{
         base::{ExtCtxt, MacroKind, Resolver},
         build::AstBuilder,
         expand::ExpansionConfig,
-        hygiene::ExpnId,
+        hygiene::{ExpnId, ExpnDef},
     },
     mut_visit::{self, MutVisitor},
     parse::ParseSess,
@@ -85,9 +85,9 @@ impl MutVisitor for ExpandAllocatorDirectives<'_> {
         self.found = true;
 
         // Create a new expansion for the generated allocator code.
-        let span = item.span.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
-            ExpnKind::Macro(MacroKind::Attr, sym::global_allocator), item.span, self.sess.edition,
-            [sym::rustc_attrs][..].into(),
+        let expn_def = ExpnDef::allow_unstable(self.sess.edition, &[sym::rustc_attrs]);
+        let span = item.span.fresh_expansion(ExpnId::root(), ExpnInfo::new(
+            ExpnKind::Macro(MacroKind::Attr, sym::global_allocator), item.span, expn_def
         ));
 
         // Create an expansion config

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -431,10 +431,9 @@ impl cstore::CStore {
         } else if data.name == sym::proc_macro && data.item_name(id.index) == sym::quote {
             let client = proc_macro::bridge::client::Client::expand1(proc_macro::quote);
             let kind = SyntaxExtensionKind::Bang(Box::new(BangProcMacro { client }));
-            let ext = SyntaxExtension {
-                allow_internal_unstable: Some([sym::proc_macro_def_site][..].into()),
-                ..SyntaxExtension::default(kind, data.root.edition)
-            };
+            let ext = SyntaxExtension::allow_unstable(
+                kind, data.root.edition, &[sym::proc_macro_def_site]
+            );
             return LoadedMacro::ProcMacro(Lrc::new(ext));
         }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -136,10 +136,10 @@ impl<'a> base::Resolver for Resolver<'a> {
     }
 
     fn get_module_scope(&mut self, id: ast::NodeId) -> ExpnId {
-        let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::default(
-            ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, self.session.edition()
-        ));
-        let expn_id = span.ctxt().outer_expn();
+        let expn_def = self.session.parse_sess.default_expn_def.clone();
+        let expn_id = ExpnId::fresh(ExpnId::root(), Some(ExpnInfo::new(
+            ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, expn_def
+        )));
         let module = self.module_map[&self.definitions.local_def_id(id)];
         self.definitions.set_invocation_parent(expn_id, module.def_id().unwrap().index);
         self.invocations.insert(expn_id, self.arenas.alloc_invocation_data(InvocationData {

--- a/src/libsyntax/ext/derive.rs
+++ b/src/libsyntax/ext/derive.rs
@@ -54,9 +54,9 @@ pub fn add_derived_markers<T>(cx: &mut ExtCtxt<'_>, span: Span, traits: &[ast::P
         names.insert(unwrap_or!(path.segments.get(0), continue).ident.name);
     }
 
-    let span = span.fresh_expansion(cx.current_expansion.id, ExpnInfo::allow_unstable(
-        ExpnKind::Macro(MacroKind::Derive, Symbol::intern(&pretty_name)), span,
-        cx.parse_sess.edition, cx.allow_derive_markers.clone(),
+    let expn_def = cx.parse_sess.allow_derive_markers.clone();
+    let span = span.fresh_expansion(cx.current_expansion.id, ExpnInfo::new(
+        ExpnKind::Macro(MacroKind::Derive, Symbol::intern(&pretty_name)), span, expn_def
     ));
 
     item.visit_attrs(|attrs| {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -815,10 +815,10 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
         // Expansion info for all the collected invocations is set upon their resolution,
         // with exception of the derive container case which is not resolved and can get
         // its expansion info immediately.
+        let expn_def = self.cx.parse_sess.default_expn_def.clone();
         let expn_info = match &kind {
-            InvocationKind::DeriveContainer { item, .. } => Some(ExpnInfo::default(
-                ExpnKind::Macro(MacroKind::Attr, sym::derive),
-                item.span(), self.cx.parse_sess.edition,
+            InvocationKind::DeriveContainer { item, .. } => Some(ExpnInfo::new(
+                ExpnKind::Macro(MacroKind::Attr, sym::derive), item.span(), expn_def
             )),
             _ => None,
         };

--- a/src/libsyntax/std_inject.rs
+++ b/src/libsyntax/std_inject.rs
@@ -10,6 +10,7 @@ use crate::tokenstream::TokenStream;
 use std::cell::Cell;
 use std::iter;
 use syntax_pos::DUMMY_SP;
+use syntax_pos::hygiene::ExpnDef;
 
 pub fn injected_crate_name() -> Option<&'static str> {
     INJECTED_CRATE_NAME.with(|name| name.get())
@@ -75,9 +76,9 @@ pub fn maybe_inject_crates_ref(
 
     INJECTED_CRATE_NAME.with(|opt_name| opt_name.set(Some(name)));
 
-    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
-        ExpnKind::Macro(MacroKind::Attr, sym::std_inject), DUMMY_SP, edition,
-        [sym::prelude_import][..].into(),
+    let expn_def = ExpnDef::allow_unstable(edition, &[sym::prelude_import]);
+    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::new(
+        ExpnKind::Macro(MacroKind::Attr, sym::std_inject), DUMMY_SP, expn_def
     ));
 
     krate.module.items.insert(0, P(ast::Item {

--- a/src/libsyntax/test.rs
+++ b/src/libsyntax/test.rs
@@ -13,6 +13,7 @@ use std::vec;
 use log::debug;
 use smallvec::{smallvec, SmallVec};
 use syntax_pos::{DUMMY_SP, NO_EXPANSION, Span, SourceFile, BytePos};
+use syntax_pos::hygiene::ExpnDef;
 
 use crate::attr::{self, HasAttrs};
 use crate::source_map::{self, SourceMap, ExpnInfo, ExpnKind, dummy_spanned, respan};
@@ -303,9 +304,11 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
     //            #![main]
     //            test::test_main_static(&[..tests]);
     //        }
-    let sp = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
-        ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, cx.ext_cx.parse_sess.edition,
-        [sym::main, sym::test, sym::rustc_attrs][..].into(),
+    let expn_def = ExpnDef::allow_unstable(
+        cx.ext_cx.parse_sess.edition, &[sym::main, sym::test, sym::rustc_attrs]
+    );
+    let sp = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::new(
+        ExpnKind::Macro(MacroKind::Attr, sym::test_case), DUMMY_SP, expn_def
     ));
     let ecx = &cx.ext_cx;
     let test_id = Ident::with_empty_ctxt(sym::test);

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -70,13 +70,13 @@ macro_rules! derive_traits {
         }
 
         pub fn register_builtin_derives(resolver: &mut dyn Resolver, edition: Edition) {
-            let allow_internal_unstable = Some([
+            let allow_derive_internals = &[
                 sym::core_intrinsics,
                 sym::rustc_attrs,
                 Symbol::intern("derive_clone_copy"),
                 Symbol::intern("derive_eq"),
                 Symbol::intern("libstd_sys_internals"), // RustcDeserialize and RustcSerialize
-            ][..].into());
+            ];
 
             $(
                 resolver.add_builtin(
@@ -86,10 +86,10 @@ macro_rules! derive_traits {
                             since: Some(Symbol::intern("1.0.0")),
                             note: Some(Symbol::intern(msg)),
                         }),
-                        allow_internal_unstable: allow_internal_unstable.clone(),
-                        ..SyntaxExtension::default(
+                        ..SyntaxExtension::allow_unstable(
                             SyntaxExtensionKind::LegacyDerive(Box::new(BuiltinDerive($func))),
                             edition,
+                            allow_derive_internals,
                         )
                     }),
                 );

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -126,47 +126,42 @@ pub fn register_builtins(resolver: &mut dyn syntax::ext::base::Resolver,
         trace_macros: trace_macros::expand_trace_macros,
     }
 
-    let allow_internal_unstable = Some([sym::test, sym::rustc_attrs][..].into());
+    let allow_test_internals = &[sym::test, sym::rustc_attrs];
     register(sym::test_case, SyntaxExtension {
         stability: Some(Stability::unstable(
             sym::custom_test_frameworks,
             Some(Symbol::intern(EXPLAIN_CUSTOM_TEST_FRAMEWORKS)),
             50297,
         )),
-        allow_internal_unstable: allow_internal_unstable.clone(),
-        ..SyntaxExtension::default(
-            SyntaxExtensionKind::LegacyAttr(Box::new(test_case::expand)), edition
+        ..SyntaxExtension::allow_unstable(
+            SyntaxExtensionKind::LegacyAttr(Box::new(test_case::expand)),
+            edition,
+            allow_test_internals
         )
     });
-    register(sym::test, SyntaxExtension {
-        allow_internal_unstable: allow_internal_unstable.clone(),
-        ..SyntaxExtension::default(
-            SyntaxExtensionKind::LegacyAttr(Box::new(test::expand_test)), edition
-        )
-    });
-    register(sym::bench, SyntaxExtension {
-        allow_internal_unstable,
-        ..SyntaxExtension::default(
-            SyntaxExtensionKind::LegacyAttr(Box::new(test::expand_bench)), edition
-        )
-    });
+    register(sym::test, SyntaxExtension::allow_unstable(
+        SyntaxExtensionKind::LegacyAttr(Box::new(test::expand_test)), edition, allow_test_internals
+    ));
+    register(sym::bench, SyntaxExtension::allow_unstable(
+        SyntaxExtensionKind::LegacyAttr(Box::new(test::expand_bench)), edition, allow_test_internals
+    ));
 
-    let allow_internal_unstable = Some([sym::fmt_internals][..].into());
-    register(sym::format_args, SyntaxExtension {
-        allow_internal_unstable: allow_internal_unstable.clone(),
-        ..SyntaxExtension::default(
-            SyntaxExtensionKind::LegacyBang(Box::new(format::expand_format_args)), edition
-        )
-    });
+    let allow_fmt_internals = &[sym::fmt_internals];
+    register(sym::format_args, SyntaxExtension::allow_unstable(
+        SyntaxExtensionKind::LegacyBang(Box::new(format::expand_format_args)),
+        edition,
+        allow_fmt_internals,
+    ));
     register(sym::format_args_nl, SyntaxExtension {
         stability: Some(Stability::unstable(
             sym::format_args_nl,
             Some(Symbol::intern(EXPLAIN_FORMAT_ARGS_NL)),
             0,
         )),
-        allow_internal_unstable,
-        ..SyntaxExtension::default(
-            SyntaxExtensionKind::LegacyBang(Box::new(format::expand_format_args_nl)), edition
+        ..SyntaxExtension::allow_unstable(
+            SyntaxExtensionKind::LegacyBang(Box::new(format::expand_format_args_nl)),
+            edition,
+            allow_fmt_internals,
         )
     });
 

--- a/src/libsyntax_ext/proc_macro_decls.rs
+++ b/src/libsyntax_ext/proc_macro_decls.rs
@@ -17,6 +17,7 @@ use syntax::symbol::{kw, sym};
 use syntax::visit::{self, Visitor};
 
 use syntax_pos::{Span, DUMMY_SP};
+use syntax_pos::hygiene::ExpnDef;
 
 const PROC_MACRO_KINDS: [Symbol; 3] = [
     sym::proc_macro_derive,
@@ -346,9 +347,11 @@ fn mk_decls(
     custom_attrs: &[ProcMacroDef],
     custom_macros: &[ProcMacroDef],
 ) -> P<ast::Item> {
-    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::allow_unstable(
-        ExpnKind::Macro(MacroKind::Attr, sym::proc_macro), DUMMY_SP, cx.parse_sess.edition,
-        [sym::rustc_attrs, sym::proc_macro_internals][..].into(),
+    let expn_def = ExpnDef::allow_unstable(
+        cx.parse_sess.edition, &[sym::rustc_attrs, sym::proc_macro_internals]
+    );
+    let span = DUMMY_SP.fresh_expansion(ExpnId::root(), ExpnInfo::new(
+        ExpnKind::Macro(MacroKind::Attr, sym::proc_macro), DUMMY_SP, expn_def
     ));
 
     let hidden = cx.meta_list_item_word(span, sym::hidden);

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -393,11 +393,9 @@ impl Span {
     /// `#[allow_internal_unstable]`).
     pub fn allows_unstable(&self, feature: Symbol) -> bool {
         match self.ctxt().outer_expn_info() {
-            Some(info) => info
-                .allow_internal_unstable
-                .map_or(false, |features| features.iter().any(|&f|
-                    f == feature || f == sym::allow_internal_unstable_backcompat_hack
-                )),
+            Some(info) => info.allow_internal_unstable.iter().any(|&f| {
+                f == feature || f == sym::allow_internal_unstable_backcompat_hack
+            }),
             None => false,
         }
     }


### PR DESCRIPTION
The subset of `SyntaxExtension` fields named `ExpnDef` is now shared through `Lrc` with all expansions (`ExpnInfo`) of that syntax extension.
Some `ExpnDef`s for built-in non-macro expansions/desugarings are shared as well.

r? @eddyb or @matthewjasper 