### PR TITLE
Disable d32 on armv6 hf targets

### DIFF
--- a/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_gnueabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            features: "+strict-align,+v6,+vfp2".to_string(),
+            features: "+strict-align,+v6,+vfp2,-d32".to_string(),
             abi_blacklist: super::arm_base::abi_blacklist(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),
             .. base

--- a/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
+++ b/src/librustc_target/spec/arm_unknown_linux_musleabihf.rs
@@ -5,7 +5,7 @@ pub fn target() -> TargetResult {
 
     // Most of these settings are copied from the arm_unknown_linux_gnueabihf
     // target.
-    base.features = "+strict-align,+v6,+vfp2".to_string();
+    base.features = "+strict-align,+v6,+vfp2,-d32".to_string();
     base.max_atomic_width = Some(64);
     Ok(Target {
         // It's important we use "gnueabihf" and not "musleabihf" here. LLVM

--- a/src/librustc_target/spec/armv6_unknown_freebsd.rs
+++ b/src/librustc_target/spec/armv6_unknown_freebsd.rs
@@ -15,7 +15,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            features: "+v6,+vfp2".to_string(),
+            features: "+v6,+vfp2,-d32".to_string(),
             max_atomic_width: Some(64),
             abi_blacklist: super::arm_base::abi_blacklist(),
             target_mcount: "\u{1}__gnu_mcount_nc".to_string(),

--- a/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
+++ b/src/librustc_target/spec/armv6_unknown_netbsd_eabihf.rs
@@ -16,7 +16,7 @@ pub fn target() -> TargetResult {
         linker_flavor: LinkerFlavor::Gcc,
 
         options: TargetOptions {
-            features: "+v6,+vfp2".to_string(),
+            features: "+v6,+vfp2,-d32".to_string(),
             abi_blacklist: super::arm_base::abi_blacklist(),
             target_mcount: "__mcount".to_string(),
             .. base


### PR DESCRIPTION
We already do this on armv7 targets. It seems that this now gets enabled by default if '+vfp2` is specified, so disable it explicitly.

Hopefully fixes #62841.

r? @alexcrichton 