### PR TITLE
Normalize use of backticks in compiler messages for doc

### DIFF
--- a/src/doc/rustc/src/lints/index.md
+++ b/src/doc/rustc/src/lints/index.md
@@ -19,7 +19,7 @@ warning: unused variable: `x`
 2 |     let x = 5;
   |         ^
   |
-  = note: #[warn(unused_variables)] on by default
+  = note: `#[warn(unused_variables)]` on by default
   = note: to avoid this warning, consider using `_x` instead
 ```
 

--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -53,7 +53,7 @@ warning: unused variable: `x`
 2 |     let x = 5;
   |         ^
   |
-  = note: #[warn(unused_variables)] on by default
+  = note: `#[warn(unused_variables)]` on by default
   = note: to avoid this warning, consider using `_x` instead
 ```
 
@@ -76,7 +76,7 @@ error: bitshift exceeds the type's number of bits
 2 |     100u8 << 10;
   |     ^^^^^^^^^^^
   |
-  = note: #[deny(exceeding_bitshifts)] on by default
+  = note: `#[deny(exceeding_bitshifts)]` on by default
 ```
 
 What's the difference between an error from a lint and a regular old error?
@@ -236,7 +236,7 @@ warning: bitshift exceeds the type's number of bits
 2 |     100u8 << 10;
   |     ^^^^^^^^^^^
   |
-  = note: #[warn(exceeding_bitshifts)] on by default
+  = note: `#[warn(exceeding_bitshifts)]` on by default
 
 warning: this expression will panic at run-time
  --> lib.rs:2:5

--- a/src/doc/rustc/src/lints/listing/allowed-by-default.md
+++ b/src/doc/rustc/src/lints/listing/allowed-by-default.md
@@ -165,7 +165,7 @@ pub struct Foo;
 When set to 'deny', this will produce:
 
 ```text
-error: type does not implement `fmt::Debug`; consider adding #[derive(Debug)] or a manual implementation
+error: type does not implement `fmt::Debug`; consider adding `#[derive(Debug)]` or a manual implementation
  --> src/main.rs:3:1
   |
 3 | pub struct Foo;

--- a/src/doc/rustc/src/lints/listing/deny-by-default.md
+++ b/src/doc/rustc/src/lints/listing/deny-by-default.md
@@ -40,7 +40,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
 4 | fn foo<T=i32>(t: T) {}
   |        ^
   |
-  = note: #[deny(invalid_type_param_default)] on by default
+  = note: `#[deny(invalid_type_param_default)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 ```
@@ -74,7 +74,7 @@ error: private struct constructors are not usable through re-exports in outer mo
 5 |         ::S;
   |         ^^^
   |
-  = note: #[deny(legacy_constructor_visibility)] on by default
+  = note: `#[deny(legacy_constructor_visibility)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #39207 <https://github.com/rust-lang/rust/issues/39207>
 ```
@@ -84,9 +84,9 @@ error: private struct constructors are not usable through re-exports in outer mo
 
 The legacy_directory_ownership warning is issued when
 
-* There is a non-inline module with a #[path] attribute (e.g. #[path = "foo.rs"] mod bar;),
+* There is a non-inline module with a `#[path]` attribute (e.g. `#[path = "foo.rs"] mod bar;`),
 * The module's file ("foo.rs" in the above example) is not named "mod.rs", and
-* The module's file contains a non-inline child module without a #[path] attribute.
+* The module's file contains a non-inline child module without a `#[path]` attribute.
 
 The warning can be fixed by renaming the parent module to "mod.rs" and moving
 it into its own directory if appropriate.
@@ -139,7 +139,7 @@ const FOO: i32 = 5;
 This will produce:
 
 ```text
-error: const items should never be #[no_mangle]
+error: const items should never be `#[no_mangle]`
  --> src/main.rs:3:1
   |
 3 | const FOO: i32 = 5;
@@ -187,7 +187,7 @@ error: parenthesized parameters may only be used with a trait
 2 |   let x = 5 as usize();
   |                     ^^
   |
-  = note: #[deny(parenthesized_params_in_types_and_modules)] on by default
+  = note: `#[deny(parenthesized_params_in_types_and_modules)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 ```

--- a/src/doc/rustc/src/lints/listing/warn-by-default.md
+++ b/src/doc/rustc/src/lints/listing/warn-by-default.md
@@ -90,7 +90,7 @@ warning: floating-point literals cannot be used in patterns
 4 |         5.0 => {},
   |         ^^^
   |
-  = note: #[warn(illegal_floating_point_literal_pattern)] on by default
+  = note: `#[warn(illegal_floating_point_literal_pattern)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #41620 <https://github.com/rust-lang/rust/issues/41620>
 ```
@@ -109,7 +109,7 @@ extern "C" {
 This will produce:
 
 ```text
-warning: found struct without foreign-function-safe representation annotation in foreign module, consider adding a #[repr(C)] attribute to the type
+warning: found struct without foreign-function-safe representation annotation in foreign module, consider adding a `#[repr(C)]` attribute to the type
  --> src/main.rs:2:20
   |
 2 |     static STATIC: String;
@@ -146,7 +146,7 @@ warning: cannot specify lifetime arguments explicitly if late bound lifetime par
 8 |     S.late::<'static>(&0, &0);
   |              ^^^^^^^
   |
-  = note: #[warn(late_bound_lifetime_arguments)] on by default
+  = note: `#[warn(late_bound_lifetime_arguments)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #42868 <https://github.com/rust-lang/rust/issues/42868>
 ```
@@ -327,7 +327,7 @@ warning: patterns aren't allowed in methods without bodies
 2 |     fn foo(mut arg: u8);
   |            ^^^^^^^
   |
-  = note: #[warn(patterns_in_fns_without_body)] on by default
+  = note: `#[warn(patterns_in_fns_without_body)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #35203 <https://github.com/rust-lang/rust/issues/35203>
 ```
@@ -406,7 +406,7 @@ fn foo() {}
 This will produce:
 
 ```text
-warning: function is marked #[no_mangle], but not exported
+warning: function is marked `#[no_mangle]`, but not exported
  --> src/main.rs:2:1
   |
 2 | fn foo() {}
@@ -433,7 +433,7 @@ static X: i32 = 4;
 This will produce:
 
 ```text
-warning: static is marked #[no_mangle], but not exported
+warning: static is marked `#[no_mangle]`, but not exported
  --> src/main.rs:2:1
   |
 2 | static X: i32 = 4;
@@ -496,7 +496,7 @@ warning: borrow of packed field requires unsafe function or block (error E0133)
 11 |     let y = &x.data.0;
    |             ^^^^^^^^^
    |
-   = note: #[warn(safe_packed_borrows)] on by default
+   = note: `#[warn(safe_packed_borrows)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #46043 <https://github.com/rust-lang/rust/issues/46043>
 ```
@@ -542,7 +542,7 @@ warning: bounds on generic parameters are not enforced in type aliases
 2 | type SendVec<T: Send> = Vec<T>;
   |                 ^^^^
   |
-  = note: #[warn(type_alias_bounds)] on by default
+  = note: `#[warn(type_alias_bounds)]` on by default
   = help: the bound will not be checked when the type alias is used, and should be removed
 ```
 
@@ -567,7 +567,7 @@ warning: type annotations needed
 4 |     if data.is_null() {}
   |             ^^^^^^^
   |
-  = note: #[warn(tyvar_behind_raw_pointer)] on by default
+  = note: `#[warn(tyvar_behind_raw_pointer)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2018 edition!
   = note: for more information, see issue #46906 <https://github.com/rust-lang/rust/issues/46906>
 ```
@@ -787,7 +787,7 @@ warning: doc comment not used by rustdoc
 
 ## unused-features
 
-This lint detects unused or unknown features found in crate-level #[feature] directives.
+This lint detects unused or unknown features found in crate-level `#[feature]` directives.
 To fix this, simply remove the feature flag.
 
 ## unused-imports
@@ -839,7 +839,7 @@ warning: unused macro definition
 
 ## unused-must-use
 
-This lint detects unused result of a type flagged as #[must_use]. Some
+This lint detects unused result of a type flagged as `#[must_use]`. Some
 example code that triggers this lint:
 
 ```rust

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1319,7 +1319,7 @@ impl Clean<Option<Lifetime>> for ty::RegionKind {
             ty::ReEmpty |
             ty::ReClosureBound(_) |
             ty::ReErased => {
-                debug!("Cannot clean region {:?}", self);
+                debug!("cannot clean region {:?}", self);
                 None
             }
         }
@@ -4082,7 +4082,7 @@ impl ToSource for syntax_pos::Span {
 
 fn name_from_pat(p: &hir::Pat) -> String {
     use rustc::hir::*;
-    debug!("Trying to get a name from pattern: {:?}", p);
+    debug!("trying to get a name from pattern: {:?}", p);
 
     match p.node {
         PatKind::Wild => "_".to_string(),

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -250,7 +250,7 @@ impl Options {
             None => ColorConfig::Auto,
             Some(arg) => {
                 early_error(ErrorOutputType::default(),
-                            &format!("argument for --color must be `auto`, `always` or `never` \
+                            &format!("argument for `--color` must be `auto`, `always` or `never` \
                                       (instead was `{}`)", arg));
             }
         };
@@ -269,7 +269,7 @@ impl Options {
             Some("short") => ErrorOutputType::HumanReadable(HumanReadableErrorType::Short(color)),
             Some(arg) => {
                 early_error(ErrorOutputType::default(),
-                            &format!("argument for --error-format must be `human`, `json` or \
+                            &format!("argument for `--error-format` must be `human`, `json` or \
                                       `short` (instead was `{}`)", arg));
             }
         };

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -432,7 +432,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
                         },
                         sym::plugins => {
                             report_deprecated_attr("plugins = \"...\"", diag);
-                            eprintln!("WARNING: #![doc(plugins = \"...\")] no longer functions; \
+                            eprintln!("WARNING: `#![doc(plugins = \"...\")]` no longer functions; \
                                       see CVE-2018-1000622");
                             continue
                         },

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -730,7 +730,7 @@ impl Tester for Collector {
         let edition = config.edition.unwrap_or(self.edition);
         let persist_doctests = self.persist_doctests.clone();
 
-        debug!("Creating test {}: {}", name, test);
+        debug!("creating test {}: {}", name, test);
         self.tests.push(testing::TestDescAndFn {
             desc: testing::TestDesc {
                 name: testing::DynTestName(name),

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -96,7 +96,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_variant_data(&mut self, item: &'tcx hir::Item,
                               name: ast::Name, sd: &'tcx hir::VariantData,
                               generics: &'tcx hir::Generics) -> Struct<'tcx> {
-        debug!("Visiting struct");
+        debug!("visiting struct");
         let struct_type = struct_type_from_def(&*sd);
         Struct {
             id: item.hir_id,
@@ -115,7 +115,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_union_data(&mut self, item: &'tcx hir::Item,
                             name: ast::Name, sd: &'tcx hir::VariantData,
                             generics: &'tcx hir::Generics) -> Union<'tcx> {
-        debug!("Visiting union");
+        debug!("visiting union");
         let struct_type = struct_type_from_def(&*sd);
         Union {
             id: item.hir_id,
@@ -134,7 +134,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
     pub fn visit_enum_def(&mut self, it: &'tcx hir::Item,
                           name: ast::Name, def: &'tcx hir::EnumDef,
                           generics: &'tcx hir::Generics) -> Enum<'tcx> {
-        debug!("Visiting enum");
+        debug!("visiting enum");
         Enum {
             name,
             variants: def.variants.iter().map(|v| Variant {
@@ -161,7 +161,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     header: hir::FnHeader,
                     generics: &'tcx hir::Generics,
                     body: hir::BodyId) {
-        debug!("Visiting fn");
+        debug!("visiting fn");
         let macro_kind = item.attrs.iter().filter_map(|a| {
             if a.check_name(sym::proc_macro) {
                 Some(MacroKind::Bang)
@@ -371,7 +371,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
 
     pub fn visit_item(&mut self, item: &'tcx hir::Item,
                       renamed: Option<ast::Ident>, om: &mut Module<'tcx>) {
-        debug!("Visiting item {:?}", item);
+        debug!("visiting item {:?}", item);
         let ident = renamed.unwrap_or(item.ident);
 
         if item.vis.node.is_pub() {


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/60532