### PR TITLE
Miri: dispatch first on the type

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1863,6 +1863,12 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
+    /// Tests if this is any kind of primitive pointer type (reference, raw pointer, fn pointer).
+    #[inline]
+    pub fn is_any_ptr(&self) -> bool {
+        self.is_region_ptr() || self.is_unsafe_ptr() || self.is_fn_ptr()
+    }
+
     /// Returns `true` if this type is an `Arc<T>`.
     #[inline]
     pub fn is_arc(&self) -> bool {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -20,10 +20,10 @@ use rustc_data_structures::fx::FxHashMap;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use crate::interpret::{self,
-    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar,
+    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar, Pointer,
     RawConst, ConstValue,
     InterpResult, InterpErrorInfo, GlobalId, InterpCx, StackPopCleanup,
-    Allocation, AllocId, MemoryKind,
+    Allocation, AllocId, MemoryKind, Memory,
     snapshot, RefTracking, intern_const_alloc_recursive,
 };
 
@@ -394,6 +394,15 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         let intrinsic_name = &ecx.tcx.item_name(instance.def_id()).as_str()[..];
         Err(
             ConstEvalError::NeedsRfc(format!("calling intrinsic `{}`", intrinsic_name)).into()
+        )
+    }
+
+    fn ptr_to_int(
+        _mem: &Memory<'mir, 'tcx, Self>,
+        _ptr: Pointer,
+    ) -> InterpResult<'tcx, u64> {
+        Err(
+            ConstEvalError::NeedsRfc("pointer-to-integer cast".to_string()).into(),
         )
     }
 

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -397,7 +397,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         )
     }
 
-    fn ptr_op(
+    fn binary_ptr_op(
         _ecx: &InterpCx<'mir, 'tcx, Self>,
         _bin_op: mir::BinOp,
         _left: ImmTy<'tcx>,

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -250,12 +250,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             RawPtr(_) => Ok(ptr.into()),
             Int(_) | Uint(_) => {
                 let size = self.memory.pointer_size();
-
-                match self.force_bits(Scalar::Ptr(ptr), size) {
-                    Ok(bits) => self.cast_from_int(bits, src_layout, dest_layout),
-                    Err(_) if dest_layout.size == size => Ok(ptr.into()),
-                    Err(e) => Err(e),
-                }
+                let bits = self.force_bits(Scalar::Ptr(ptr), size)?;
+                self.cast_from_int(bits, src_layout, dest_layout)
             }
             _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -105,8 +105,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 assert!(
                     src.layout.ty.is_bool()       || src.layout.ty.is_char()     ||
                     src.layout.ty.is_enum()       || src.layout.ty.is_integral() ||
-                    src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()   ||
-                    src.layout.ty.is_region_ptr(),
+                    src.layout.ty.is_any_ptr(),
                     "Unexpected cast from type {:?}", src.layout.ty
                 )
         }
@@ -143,8 +142,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         }
 
         // Handle casting any ptr to raw ptr (might be a fat ptr).
-        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()) &&
-            dest_layout.ty.is_unsafe_ptr()
+        if src.layout.ty.is_any_ptr() && dest_layout.ty.is_unsafe_ptr()
         {
             // The only possible size-unequal case was handled above.
             assert_eq!(src.layout.size, dest_layout.size);

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -110,7 +110,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
         }
 
-        // Handle cast from a univariant (ZST) enum
+        // Handle cast from a univariant (ZST) enum.
         match src.layout.variants {
             layout::Variants::Single { index } => {
                 if let Some(discr) =

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -165,11 +165,10 @@ pub trait Machine<'mir, 'tcx>: Sized {
         def_id: DefId,
     ) -> InterpResult<'tcx, Cow<'tcx, Allocation>>;
 
-    /// Called for all binary operations on integer(-like) types when one operand is a pointer
-    /// value, and for the `Offset` operation that is inherently about pointers.
+    /// Called for all binary operations where the LHS has pointer type.
     ///
     /// Returns a (value, overflowed) pair if the operation succeeded
-    fn ptr_op(
+    fn binary_ptr_op(
         ecx: &InterpCx<'mir, 'tcx, Self>,
         bin_op: mir::BinOp,
         left: ImmTy<'tcx, Self::PointerTag>,

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -233,7 +233,6 @@ pub trait Machine<'mir, 'tcx>: Sized {
         extra: Self::FrameExtra,
     ) -> InterpResult<'tcx>;
 
-    #[inline(always)]
     fn int_to_ptr(
         _mem: &Memory<'mir, 'tcx, Self>,
         int: u64,
@@ -245,11 +244,8 @@ pub trait Machine<'mir, 'tcx>: Sized {
         }).into())
     }
 
-    #[inline(always)]
     fn ptr_to_int(
         _mem: &Memory<'mir, 'tcx, Self>,
         _ptr: Pointer<Self::PointerTag>,
-    ) -> InterpResult<'tcx, u64> {
-        throw_unsup!(ReadPointerAsBytes)
-    }
+    ) -> InterpResult<'tcx, u64>;
 }

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -47,11 +47,6 @@ impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
 }
 
 impl<'tcx, Tag> Immediate<Tag> {
-    #[inline]
-    pub fn from_scalar(val: Scalar<Tag>) -> Self {
-        Immediate::Scalar(ScalarMaybeUndef::Scalar(val))
-    }
-
     pub fn new_slice(
         val: Scalar<Tag>,
         len: u64,
@@ -196,7 +191,7 @@ impl<'tcx, Tag: Copy> ImmTy<'tcx, Tag>
 {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>, layout: TyLayout<'tcx>) -> Self {
-        ImmTy { imm: Immediate::from_scalar(val), layout }
+        ImmTy { imm: val.into(), layout }
     }
 
     #[inline]
@@ -254,7 +249,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let ptr = match self.check_mplace_access(mplace, None)? {
             Some(ptr) => ptr,
             None => return Ok(Some(ImmTy { // zero-sized type
-                imm: Immediate::Scalar(Scalar::zst().into()),
+                imm: Scalar::zst().into(),
                 layout: mplace.layout,
             })),
         };
@@ -265,7 +260,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     .get(ptr.alloc_id)?
                     .read_scalar(self, ptr, mplace.layout.size)?;
                 Ok(Some(ImmTy {
-                    imm: Immediate::Scalar(scalar),
+                    imm: scalar.into(),
                     layout: mplace.layout,
                 }))
             }
@@ -368,7 +363,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let field = field.try_into().unwrap();
         let field_layout = op.layout.field(self, field)?;
         if field_layout.is_zst() {
-            let immediate = Immediate::Scalar(Scalar::zst().into());
+            let immediate = Scalar::zst().into();
             return Ok(OpTy { op: Operand::Immediate(immediate), layout: field_layout });
         }
         let offset = op.layout.fields.offset(field);
@@ -378,7 +373,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // extract fields from types with `ScalarPair` ABI
             Immediate::ScalarPair(a, b) => {
                 let val = if offset.bytes() == 0 { a } else { b };
-                Immediate::Scalar(val)
+                Immediate::from(val)
             },
             Immediate::Scalar(val) =>
                 bug!("field access on non aggregate {:#?}, {:#?}", val, op.layout),
@@ -415,7 +410,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Deref => self.deref_operand(base)?.into(),
             Subslice { .. } | ConstantIndex { .. } | Index(_) => if base.layout.is_zst() {
                 OpTy {
-                    op: Operand::Immediate(Immediate::Scalar(Scalar::zst().into())),
+                    op: Operand::Immediate(Scalar::zst().into()),
                     // the actual index doesn't matter, so we just pick a convenient one like 0
                     layout: base.layout.field(self, 0)?,
                 }
@@ -439,7 +434,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let layout = self.layout_of_local(frame, local, layout)?;
         let op = if layout.is_zst() {
             // Do not read from ZST, they might not be initialized
-            Operand::Immediate(Immediate::Scalar(Scalar::zst().into()))
+            Operand::Immediate(Scalar::zst().into())
         } else {
             frame.locals[local].access()?
         };
@@ -570,7 +565,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Operand::Indirect(MemPlace::from_ptr(ptr, align))
             },
             ConstValue::Scalar(x) =>
-                Operand::Immediate(Immediate::Scalar(tag_scalar(x).into())),
+                Operand::Immediate(tag_scalar(x).into()),
             ConstValue::Slice { data, start, end } => {
                 // We rely on mutability being set correctly in `data` to prevent writes
                 // where none should happen.

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -32,6 +32,20 @@ pub enum Immediate<Tag=(), Id=AllocId> {
     ScalarPair(ScalarMaybeUndef<Tag, Id>, ScalarMaybeUndef<Tag, Id>),
 }
 
+impl<Tag> From<ScalarMaybeUndef<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: ScalarMaybeUndef<Tag>) -> Self {
+        Immediate::Scalar(val)
+    }
+}
+
+impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: Scalar<Tag>) -> Self {
+        Immediate::Scalar(val.into())
+    }
+}
+
 impl<'tcx, Tag> Immediate<Tag> {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>) -> Self {

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -302,7 +302,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
-            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+            _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`)
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -290,30 +290,29 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     FloatTy::F64 => self.binary_float_op(bin_op, left.to_f64()?, right.to_f64()?),
                 })
             }
-            _ => {
-                // Must be integer(-like) types.  Don't forget about == on fn pointers.
+            _ if left.layout.ty.is_integral() => {
+                // the RHS type can be different, e.g. for shifts -- but it has to be integral, too
                 assert!(
-                    left.layout.ty.is_integral()   ||
-                    left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr(),
-                    "Unexpected LHS type {:?} for BinOp {:?}", left.layout.ty, bin_op);
-                assert!(
-                    right.layout.ty.is_integral()   ||
-                    right.layout.ty.is_unsafe_ptr() || right.layout.ty.is_fn_ptr(),
-                    "Unexpected RHS type {:?} for BinOp {:?}", right.layout.ty, bin_op);
+                    right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
 
-                // Handle operations that support pointer values
-                if left.to_scalar_ptr()?.is_ptr() ||
-                    right.to_scalar_ptr()?.is_ptr() ||
-                    bin_op == mir::BinOp::Offset
-                {
-                    return M::ptr_op(self, bin_op, left, right);
-                }
-
-                // Everything else only works with "proper" bits
-                let l = left.to_bits().expect("we checked is_ptr");
-                let r = right.to_bits().expect("we checked is_ptr");
+                let l = self.force_bits(left.to_scalar()?, left.layout.size)?;
+                let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
+            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+                // The RHS type must be the same *or an integer type* (for `Offset`)
+                assert!(
+                    right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
+
+                M::binary_ptr_op(self, bin_op, left, right)
+            }
+            _ => bug!("Invalid MIR: bad LHS type for binop: {:?}", left.layout.ty),
         }
     }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -303,7 +303,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
-                // The RHS type must be the same *or an integer type* (for `Offset`)
+                // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -8,7 +8,7 @@ use rustc_target::spec::abi::Abi;
 
 use super::{
     InterpResult, PointerArithmetic, Scalar,
-    InterpCx, Machine, Immediate, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
+    InterpCx, Machine, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
 };
 
 impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
@@ -460,7 +460,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // Adjust receiver argument.
                 args[0] = OpTy::from(ImmTy {
                     layout: this_receiver_ptr,
-                    imm: Immediate::Scalar(receiver_place.ptr.into())
+                    imm: receiver_place.ptr.into()
                 });
                 trace!("Patched self operand to {:#?}", args[0]);
                 // recurse with concrete function

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.rs
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.rs
@@ -19,7 +19,7 @@ fn main() {
 //      _3 = const Scalar(AllocId(1).0x0) : fn();
 //      _2 = move _3 as usize (Misc);
 //      ...
-//      _1 = const Scalar(AllocId(1).0x0) : *const fn();
+//      _1 = move _2 as *const fn() (Misc);
 //      ...
 //  }
 // END rustc.main.ConstProp.after.mir

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
@@ -4,8 +4,8 @@ fn main() {}
 
 // unconst and bad, will thus error in miri
 const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 }; //~ ERROR any use of this
-// unconst and fine
-const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+// unconst and bad, will thus error in miri
+const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 }; //~ ERROR any use of this
 // unconst and fine
 const Y: usize = unsafe { 42usize as *const i32 as usize + 1 };
 // unconst and bad, will thus error in miri

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
@@ -9,12 +9,20 @@ LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
+  --> $DIR/const_raw_ptr_ops.rs:8:27
+   |
+LL | const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+
+error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:12:28
    |
 LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
-   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^-------
    |                            |
-   |                            "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+   |                            "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:16:26
@@ -32,5 +40,5 @@ LL | const Z3: i32 = unsafe { *(44 as *const i32) };
    |                          |
    |                          a memory access tried to interpret some bytes as a pointer
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-52442.rs
+++ b/src/test/ui/consts/const-eval/issue-52442.rs
@@ -1,5 +1,5 @@
 fn main() {
     [();  { &loop { break } as *const _ as usize } ];
     //~^ ERROR casting pointers to integers in constants is unstable
-    //~| ERROR it is undefined behavior to use this value
+    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -7,13 +7,11 @@ LL |     [();  { &loop { break } as *const _ as usize } ];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-52442.rs:2:11
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-52442.rs:2:13
    |
 LL |     [();  { &loop { break } as *const _ as usize } ];
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,3 +1,4 @@
+
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw
@@ -5,11 +6,9 @@ fn main() {
     let _: [u8; 0] = [4; {
         match &1 as *const i32 as usize {
             //~^ ERROR casting pointers to integers in constants
-            //~| NOTE for more information, see
             //~| ERROR constant contains unimplemented expression type
-            0 => 42, //~ ERROR constant contains unimplemented expression type
-            //~^ NOTE "pointer arithmetic or comparison" needs an rfc before being allowed
             //~| ERROR evaluation of constant value failed
+            0 => 42, //~ ERROR constant contains unimplemented expression type
             n => n,
         }
     }];

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,19 +8,19 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:11:13
+  --> $DIR/match-test-ptr-null.rs:10:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,22 +8,22 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:11:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
-LL |             0 => 42,
-   |             ^ "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+LL |         match &1 as *const i32 as usize {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/issue-51559.rs
+++ b/src/test/ui/consts/issue-51559.rs
@@ -2,6 +2,6 @@
 
 const BAR: *mut () = ((|| 3) as fn() -> i32) as *mut ();
 pub const FOO: usize = unsafe { BAR as usize };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR any use of this value will cause an error
 
 fn main() {}

--- a/src/test/ui/consts/issue-51559.stderr
+++ b/src/test/ui/consts/issue-51559.stderr
@@ -1,11 +1,12 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-51559.rs:4:1
+error: any use of this value will cause an error
+  --> $DIR/issue-51559.rs:4:33
    |
 LL | pub const FOO: usize = unsafe { BAR as usize };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
+   | --------------------------------^^^^^^^^^^^^---
+   |                                 |
+   |                                 "pointer-to-integer cast" needs an rfc before being allowed inside constants
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: `#[deny(const_err)]` on by default
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _ = [0; (&0 as *const i32) as usize]; //~ ERROR casting pointers to integers in constants
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 }

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -7,13 +7,11 @@ LL |     let _ = [0; (&0 as *const i32) as usize];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
+error[E0080]: evaluation of constant value failed
   --> $DIR/issue-52023-array-size-pointer-cast.rs:2:17
    |
 LL |     let _ = [0; (&0 as *const i32) as usize];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Based on the fact that Miri now always has intptrcast available, we can change binops and casts to first check the type of the source operand and then decide based on that what to do, instead of considering the value (pointer vs bits) first.