### PR TITLE
rustdoc: general cleanups

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -5,8 +5,6 @@ use rustc::ty::subst::Subst;
 use rustc::infer::InferOk;
 use syntax_pos::DUMMY_SP;
 
-use crate::core::DocAccessLevels;
-
 use super::*;
 
 pub struct BlanketImplFinder<'a, 'tcx> {
@@ -30,7 +28,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
         debug!("get_blanket_impls({:?})", ty);
         let mut impls = Vec::new();
         for &trait_def_id in self.cx.all_traits.iter() {
-            if !self.cx.renderinfo.borrow().access_levels.is_doc_reachable(trait_def_id) ||
+            if !self.cx.renderinfo.borrow().access_levels.is_public(trait_def_id) ||
                self.cx.generated_synthetics
                       .borrow_mut()
                       .get(&(ty, trait_def_id))

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -14,7 +14,7 @@ use rustc_metadata::cstore::LoadedMacro;
 use rustc::ty;
 use rustc::util::nodemap::FxHashSet;
 
-use crate::core::{DocContext, DocAccessLevels};
+use crate::core::DocContext;
 use crate::doctree;
 use crate::clean::{
     self,
@@ -326,7 +326,7 @@ pub fn build_impl(cx: &DocContext<'_>, did: DefId, attrs: Option<Attrs<'_>>,
     // reachable in rustdoc generated documentation
     if !did.is_local() {
         if let Some(traitref) = associated_trait {
-            if !cx.renderinfo.borrow().access_levels.is_doc_reachable(traitref.def_id) {
+            if !cx.renderinfo.borrow().access_levels.is_public(traitref.def_id) {
                 return
             }
         }
@@ -347,7 +347,7 @@ pub fn build_impl(cx: &DocContext<'_>, did: DefId, attrs: Option<Attrs<'_>>,
     // reachable in rustdoc generated documentation
     if !did.is_local() {
         if let Some(did) = for_.def_id() {
-            if !cx.renderinfo.borrow().access_levels.is_doc_reachable(did) {
+            if !cx.renderinfo.borrow().access_levels.is_public(did) {
                 return
             }
         }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -654,7 +654,7 @@ impl Clean<Item> for doctree::Module<'_> {
             attrs,
             source: whence.clean(cx),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.hid).clean(cx),
             deprecation: self.depr.clean(cx),
             def_id: cx.tcx.hir().local_def_id_from_node_id(self.id),
             inner: ModuleItem(Module {
@@ -1940,7 +1940,7 @@ impl Clean<Item> for doctree::Function<'_> {
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             def_id: did,
             inner: FunctionItem(Function {
@@ -2140,7 +2140,7 @@ impl Clean<Item> for doctree::Trait<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: TraitItem(Trait {
                 auto: self.is_auto.clean(cx),
@@ -2170,7 +2170,7 @@ impl Clean<Item> for doctree::TraitAlias<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: TraitAliasItem(TraitAlias {
                 generics: self.generics.clean(cx),
@@ -3244,7 +3244,7 @@ impl Clean<Item> for doctree::Struct<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: StructItem(Struct {
                 struct_type: self.struct_type,
@@ -3264,7 +3264,7 @@ impl Clean<Item> for doctree::Union<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: UnionItem(Union {
                 struct_type: self.struct_type,
@@ -3311,7 +3311,7 @@ impl Clean<Item> for doctree::Enum<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: EnumItem(Enum {
                 variants: self.variants.iter().map(|v| v.clean(cx)).collect(),
@@ -3334,7 +3334,7 @@ impl Clean<Item> for doctree::Variant<'_> {
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
             visibility: None,
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             inner: VariantItem(Variant {
@@ -3639,7 +3639,7 @@ impl Clean<Item> for doctree::Typedef<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: TypedefItem(Typedef {
                 type_: self.ty.clean(cx),
@@ -3663,7 +3663,7 @@ impl Clean<Item> for doctree::OpaqueTy<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: OpaqueTyItem(OpaqueTy {
                 bounds: self.opaque_ty.bounds.clean(cx),
@@ -3714,7 +3714,7 @@ impl Clean<Item> for doctree::Static<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: StaticItem(Static {
                 type_: self.type_.clean(cx),
@@ -3739,7 +3739,7 @@ impl Clean<Item> for doctree::Constant<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: ConstantItem(Constant {
                 type_: self.type_.clean(cx),
@@ -3826,7 +3826,7 @@ impl Clean<Vec<Item>> for doctree::Impl<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner: ImplItem(Impl {
                 unsafety: self.unsafety,
@@ -4065,7 +4065,7 @@ impl Clean<Item> for doctree::ForeignItem<'_> {
             source: self.whence.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             inner,
         }
@@ -4248,7 +4248,7 @@ impl Clean<Item> for doctree::Macro<'_> {
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
             visibility: Some(Public),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.hid).clean(cx),
             deprecation: self.depr.clean(cx),
             def_id: self.def_id,
             inner: MacroItem(Macro {
@@ -4276,7 +4276,7 @@ impl Clean<Item> for doctree::ProcMacro<'_> {
             attrs: self.attrs.clean(cx),
             source: self.whence.clean(cx),
             visibility: Some(Public),
-            stability: self.stab.clean(cx),
+            stability: cx.stability(self.id).clean(cx),
             deprecation: self.depr.clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             inner: ProcMacroItem(ProcMacro {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -138,7 +138,7 @@ pub struct Crate {
     pub masked_crates: FxHashSet<CrateNum>,
 }
 
-impl<'a, 'tcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx> {
+impl<'a, 'tcx> Clean<Crate> for (visit_ast::RustdocVisitor<'a, 'tcx>, doctree::Module<'tcx>) {
     fn clean(&self, cx: &DocContext<'_>) -> Crate {
         use crate::visit_lib::LibEmbargoVisitor;
 
@@ -159,7 +159,7 @@ impl<'a, 'tcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx> {
 
         // Clean the crate, translating the entire libsyntax AST to one that is
         // understood by rustdoc.
-        let mut module = self.module.as_ref().unwrap().clean(cx);
+        let mut module = self.1.clean(cx);
         let mut masked_crates = FxHashSet::default();
 
         match module.inner {
@@ -169,7 +169,7 @@ impl<'a, 'tcx> Clean<Crate> for visit_ast::RustdocVisitor<'a, 'tcx> {
                     // `#[doc(masked)]` to the injected `extern crate` because it's unstable.
                     if it.is_extern_crate()
                         && (it.attrs.has_doc_flag(sym::masked)
-                            || self.cx.tcx.is_compiler_builtins(it.def_id.krate))
+                            || cx.tcx.is_compiler_builtins(it.def_id.krate))
                     {
                         masked_crates.insert(it.def_id.krate);
                     }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -49,7 +49,6 @@ use parking_lot::ReentrantMutex;
 
 use crate::core::{self, DocContext};
 use crate::doctree;
-use crate::visit_ast;
 use crate::html::render::{cache, ExternalLocation};
 use crate::html::item_type::ItemType;
 
@@ -138,7 +137,10 @@ pub struct Crate {
     pub masked_crates: FxHashSet<CrateNum>,
 }
 
-impl<'a, 'tcx> Clean<Crate> for (visit_ast::RustdocVisitor<'a, 'tcx>, doctree::Module<'tcx>) {
+// The `()` here is rather ugly and would be great to remove. Unfortunately, we
+// already have a different Clean impl for `doctree::Module` which makes this
+// the only way to easily disambiguate.
+impl<'tcx> Clean<Crate> for ((), doctree::Module<'tcx>) {
     fn clean(&self, cx: &DocContext<'_>) -> Crate {
         use crate::visit_lib::LibEmbargoVisitor;
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -654,9 +654,9 @@ impl Clean<Item> for doctree::Module<'_> {
             attrs,
             source: whence.clean(cx),
             visibility: self.vis.clean(cx),
-            stability: cx.stability(self.hid).clean(cx),
-            deprecation: cx.deprecation(self.hid).clean(cx),
-            def_id: cx.tcx.hir().local_def_id_from_node_id(self.id),
+            stability: cx.stability(self.id).clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
+            def_id: cx.tcx.hir().local_def_id(self.id),
             inner: ModuleItem(Module {
                is_crate: self.is_crate,
                items,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -655,7 +655,7 @@ impl Clean<Item> for doctree::Module<'_> {
             source: whence.clean(cx),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.hid).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.hid).clean(cx),
             def_id: cx.tcx.hir().local_def_id_from_node_id(self.id),
             inner: ModuleItem(Module {
                is_crate: self.is_crate,
@@ -1941,7 +1941,7 @@ impl Clean<Item> for doctree::Function<'_> {
             source: self.whence.clean(cx),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             def_id: did,
             inner: FunctionItem(Function {
                 decl,
@@ -2141,7 +2141,7 @@ impl Clean<Item> for doctree::Trait<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: TraitItem(Trait {
                 auto: self.is_auto.clean(cx),
                 unsafety: self.unsafety,
@@ -2171,7 +2171,7 @@ impl Clean<Item> for doctree::TraitAlias<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: TraitAliasItem(TraitAlias {
                 generics: self.generics.clean(cx),
                 bounds: self.bounds.clean(cx),
@@ -3245,7 +3245,7 @@ impl Clean<Item> for doctree::Struct<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: StructItem(Struct {
                 struct_type: self.struct_type,
                 generics: self.generics.clean(cx),
@@ -3265,7 +3265,7 @@ impl Clean<Item> for doctree::Union<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: UnionItem(Union {
                 struct_type: self.struct_type,
                 generics: self.generics.clean(cx),
@@ -3312,7 +3312,7 @@ impl Clean<Item> for doctree::Enum<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: EnumItem(Enum {
                 variants: self.variants.iter().map(|v| v.clean(cx)).collect(),
                 generics: self.generics.clean(cx),
@@ -3335,7 +3335,7 @@ impl Clean<Item> for doctree::Variant<'_> {
             source: self.whence.clean(cx),
             visibility: None,
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             inner: VariantItem(Variant {
                 kind: self.def.clean(cx),
@@ -3640,7 +3640,7 @@ impl Clean<Item> for doctree::Typedef<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: TypedefItem(Typedef {
                 type_: self.ty.clean(cx),
                 generics: self.gen.clean(cx),
@@ -3664,7 +3664,7 @@ impl Clean<Item> for doctree::OpaqueTy<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: OpaqueTyItem(OpaqueTy {
                 bounds: self.opaque_ty.bounds.clean(cx),
                 generics: self.opaque_ty.generics.clean(cx),
@@ -3715,7 +3715,7 @@ impl Clean<Item> for doctree::Static<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: StaticItem(Static {
                 type_: self.type_.clean(cx),
                 mutability: self.mutability.clean(cx),
@@ -3740,7 +3740,7 @@ impl Clean<Item> for doctree::Constant<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: ConstantItem(Constant {
                 type_: self.type_.clean(cx),
                 expr: print_const_expr(cx, self.expr),
@@ -3827,7 +3827,7 @@ impl Clean<Vec<Item>> for doctree::Impl<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner: ImplItem(Impl {
                 unsafety: self.unsafety,
                 generics: self.generics.clean(cx),
@@ -4066,7 +4066,7 @@ impl Clean<Item> for doctree::ForeignItem<'_> {
             def_id: cx.tcx.hir().local_def_id(self.id),
             visibility: self.vis.clean(cx),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             inner,
         }
     }
@@ -4249,7 +4249,7 @@ impl Clean<Item> for doctree::Macro<'_> {
             source: self.whence.clean(cx),
             visibility: Some(Public),
             stability: cx.stability(self.hid).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.hid).clean(cx),
             def_id: self.def_id,
             inner: MacroItem(Macro {
                 source: format!("macro_rules! {} {{\n{}}}",
@@ -4277,7 +4277,7 @@ impl Clean<Item> for doctree::ProcMacro<'_> {
             source: self.whence.clean(cx),
             visibility: Some(Public),
             stability: cx.stability(self.id).clean(cx),
-            deprecation: self.depr.clean(cx),
+            deprecation: cx.deprecation(self.id).clean(cx),
             def_id: cx.tcx.hir().local_def_id(self.id),
             inner: ProcMacroItem(ProcMacro {
                 kind: self.kind,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -178,16 +178,6 @@ impl<'tcx> DocContext<'tcx> {
     }
 }
 
-pub trait DocAccessLevels {
-    fn is_doc_reachable(&self, did: DefId) -> bool;
-}
-
-impl DocAccessLevels for AccessLevels<DefId> {
-    fn is_doc_reachable(&self, did: DefId) -> bool {
-        self.is_public(did)
-    }
-}
-
 /// Creates a new diagnostic `Handler` that can be used to emit warnings and errors.
 ///
 /// If the given `error_format` is `ErrorOutputType::Json` and no `SourceMap` is given, a new one

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -395,8 +395,8 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
 
             let mut krate = {
                 let mut v = RustdocVisitor::new(&ctxt);
-                v.visit(tcx.hir().krate());
-                v.clean(&ctxt)
+                let module = v.visit(tcx.hir().krate());
+                (v, module).clean(&ctxt)
             };
 
             fn report_deprecated_attr(name: &str, diag: &errors::Handler) {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -171,6 +171,11 @@ impl<'tcx> DocContext<'tcx> {
         self.tcx.hir().opt_local_def_id(id)
             .and_then(|def_id| self.tcx.lookup_stability(def_id)).cloned()
     }
+
+    pub fn deprecation(&self, id: HirId) -> Option<attr::Deprecation> {
+        self.tcx.hir().opt_local_def_id(id)
+            .and_then(|def_id| self.tcx.lookup_deprecation(def_id))
+    }
 }
 
 pub trait DocAccessLevels {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -16,6 +16,7 @@ use rustc_metadata::cstore::CStore;
 use rustc_target::spec::TargetTriple;
 
 use syntax::source_map;
+use syntax::attr;
 use syntax::feature_gate::UnstableFeatures;
 use syntax::json::JsonEmitter;
 use syntax::symbol::sym;
@@ -164,6 +165,11 @@ impl<'tcx> DocContext<'tcx> {
         } else {
             self.tcx.hir().as_local_hir_id(def_id)
         }
+    }
+
+    pub fn stability(&self, id: HirId) -> Option<attr::Stability> {
+        self.tcx.hir().opt_local_def_id(id)
+            .and_then(|def_id| self.tcx.lookup_stability(def_id)).cloned()
     }
 }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -30,7 +30,6 @@ use rustc_data_structures::sync::{self, Lrc};
 use std::sync::Arc;
 use std::rc::Rc;
 
-use crate::visit_ast::RustdocVisitor;
 use crate::config::{Options as RustdocOptions, RenderOptions};
 use crate::clean;
 use crate::clean::{Clean, MAX_DEF_ID, AttributesExt};
@@ -392,11 +391,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             };
             debug!("crate: {:?}", tcx.hir().krate());
 
-            let mut krate = {
-                let v = RustdocVisitor::new(&ctxt);
-                let module = v.visit(tcx.hir().krate());
-                ((), module).clean(&ctxt)
-            };
+            let mut krate = tcx.hir().krate().clean(&ctxt);
 
             fn report_deprecated_attr(name: &str, diag: &errors::Handler) {
                 let mut msg = diag.struct_warn(&format!("the `#![doc({})]` attribute is \

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -392,9 +392,9 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
             debug!("crate: {:?}", tcx.hir().krate());
 
             let mut krate = {
-                let mut v = RustdocVisitor::new(&ctxt);
+                let v = RustdocVisitor::new(&ctxt);
                 let module = v.visit(tcx.hir().krate());
-                (v, module).clean(&ctxt)
+                ((), module).clean(&ctxt)
             };
 
             fn report_deprecated_attr(name: &str, diag: &errors::Handler) {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -3,7 +3,7 @@
 pub use self::StructType::*;
 
 use syntax::ast;
-use syntax::ast::{Name, NodeId};
+use syntax::ast::Name;
 use syntax::ext::base::MacroKind;
 use syntax_pos::{self, Span};
 
@@ -23,8 +23,7 @@ pub struct Module<'hir> {
     pub enums: Vec<Enum<'hir>>,
     pub fns: Vec<Function<'hir>>,
     pub mods: Vec<Module<'hir>>,
-    pub id: NodeId,
-    pub hid: hir::HirId,
+    pub id: hir::HirId,
     pub typedefs: Vec<Typedef<'hir>>,
     pub opaque_tys: Vec<OpaqueTy<'hir>>,
     pub statics: Vec<Static<'hir>>,
@@ -47,8 +46,7 @@ impl Module<'hir> {
     ) -> Module<'hir> {
         Module {
             name       : name,
-            id: ast::CRATE_NODE_ID,
-            hid: hir::CRATE_HIR_ID,
+            id: hir::CRATE_HIR_ID,
             vis,
             where_outer: syntax_pos::DUMMY_SP,
             where_inner: syntax_pos::DUMMY_SP,

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -4,7 +4,6 @@ pub use self::StructType::*;
 
 use syntax::ast;
 use syntax::ast::{Name, NodeId};
-use syntax::attr;
 use syntax::ext::base::MacroKind;
 use syntax_pos::{self, Span};
 
@@ -32,7 +31,6 @@ pub struct Module<'hir> {
     pub constants: Vec<Constant<'hir>>,
     pub traits: Vec<Trait<'hir>>,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub impls: Vec<Impl<'hir>>,
     pub foreigns: Vec<ForeignItem<'hir>>,
     pub macros: Vec<Macro<'hir>>,
@@ -52,7 +50,6 @@ impl Module<'hir> {
             id: ast::CRATE_NODE_ID,
             hid: hir::CRATE_HIR_ID,
             vis,
-            depr: None,
             where_outer: syntax_pos::DUMMY_SP,
             where_inner: syntax_pos::DUMMY_SP,
             attrs,
@@ -90,7 +87,6 @@ pub enum StructType {
 
 pub struct Struct<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub struct_type: StructType,
     pub name: Name,
@@ -102,7 +98,6 @@ pub struct Struct<'hir> {
 
 pub struct Union<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub struct_type: StructType,
     pub name: Name,
@@ -114,7 +109,6 @@ pub struct Union<'hir> {
 
 pub struct Enum<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub variants: Vec<Variant<'hir>>,
     pub generics: &'hir hir::Generics,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
@@ -128,7 +122,6 @@ pub struct Variant<'hir> {
     pub id: hir::HirId,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub def: &'hir hir::VariantData,
-    pub depr: Option<attr::Deprecation>,
     pub whence: Span,
 }
 
@@ -138,7 +131,6 @@ pub struct Function<'hir> {
     pub id: hir::HirId,
     pub name: Name,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub header: hir::FnHeader,
     pub whence: Span,
     pub generics: &'hir hir::Generics,
@@ -153,7 +145,6 @@ pub struct Typedef<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
 }
 
 pub struct OpaqueTy<'hir> {
@@ -163,7 +154,6 @@ pub struct OpaqueTy<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
 }
 
 #[derive(Debug)]
@@ -174,7 +164,6 @@ pub struct Static<'hir> {
     pub name: Name,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub whence: Span,
 }
@@ -185,7 +174,6 @@ pub struct Constant<'hir> {
     pub name: Name,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub whence: Span,
 }
@@ -201,7 +189,6 @@ pub struct Trait<'hir> {
     pub id: hir::HirId,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
 }
 
 pub struct TraitAlias<'hir> {
@@ -212,7 +199,6 @@ pub struct TraitAlias<'hir> {
     pub id: hir::HirId,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
 }
 
 #[derive(Debug)]
@@ -227,13 +213,11 @@ pub struct Impl<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
 }
 
 pub struct ForeignItem<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub name: Name,
     pub kind: &'hir hir::ForeignItemKind,
@@ -250,7 +234,6 @@ pub struct Macro<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub matchers: hir::HirVec<Span>,
-    pub depr: Option<attr::Deprecation>,
     pub imported_from: Option<Name>,
 }
 
@@ -280,7 +263,6 @@ pub struct ProcMacro<'hir> {
     pub helpers: Vec<Name>,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
-    pub depr: Option<attr::Deprecation>,
 }
 
 pub fn struct_type_from_def(vdata: &hir::VariantData) -> StructType {

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -25,13 +25,13 @@ pub struct Module<'hir> {
     pub fns: Vec<Function<'hir>>,
     pub mods: Vec<Module<'hir>>,
     pub id: NodeId,
+    pub hid: hir::HirId,
     pub typedefs: Vec<Typedef<'hir>>,
     pub opaque_tys: Vec<OpaqueTy<'hir>>,
     pub statics: Vec<Static<'hir>>,
     pub constants: Vec<Constant<'hir>>,
     pub traits: Vec<Trait<'hir>>,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub impls: Vec<Impl<'hir>>,
     pub foreigns: Vec<ForeignItem<'hir>>,
@@ -50,8 +50,8 @@ impl Module<'hir> {
         Module {
             name       : name,
             id: ast::CRATE_NODE_ID,
+            hid: hir::CRATE_HIR_ID,
             vis,
-            stab: None,
             depr: None,
             where_outer: syntax_pos::DUMMY_SP,
             where_inner: syntax_pos::DUMMY_SP,
@@ -90,7 +90,6 @@ pub enum StructType {
 
 pub struct Struct<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub struct_type: StructType,
@@ -103,7 +102,6 @@ pub struct Struct<'hir> {
 
 pub struct Union<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub struct_type: StructType,
@@ -116,7 +114,6 @@ pub struct Union<'hir> {
 
 pub struct Enum<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub variants: Vec<Variant<'hir>>,
     pub generics: &'hir hir::Generics,
@@ -131,7 +128,6 @@ pub struct Variant<'hir> {
     pub id: hir::HirId,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub def: &'hir hir::VariantData,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub whence: Span,
 }
@@ -142,7 +138,6 @@ pub struct Function<'hir> {
     pub id: hir::HirId,
     pub name: Name,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub header: hir::FnHeader,
     pub whence: Span,
@@ -158,7 +153,6 @@ pub struct Typedef<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
 }
 
@@ -169,7 +163,6 @@ pub struct OpaqueTy<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
 }
 
@@ -181,7 +174,6 @@ pub struct Static<'hir> {
     pub name: Name,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub whence: Span,
@@ -193,7 +185,6 @@ pub struct Constant<'hir> {
     pub name: Name,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub whence: Span,
@@ -210,7 +201,6 @@ pub struct Trait<'hir> {
     pub id: hir::HirId,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
 }
 
@@ -222,7 +212,6 @@ pub struct TraitAlias<'hir> {
     pub id: hir::HirId,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
 }
 
@@ -238,14 +227,12 @@ pub struct Impl<'hir> {
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
 }
 
 pub struct ForeignItem<'hir> {
     pub vis: &'hir hir::Visibility,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub id: hir::HirId,
     pub name: Name,
@@ -258,11 +245,11 @@ pub struct ForeignItem<'hir> {
 // these imported macro_rules (which only have a DUMMY_NODE_ID).
 pub struct Macro<'hir> {
     pub name: Name,
+    pub hid: hir::HirId,
     pub def_id: hir::def_id::DefId,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
     pub matchers: hir::HirVec<Span>,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
     pub imported_from: Option<Name>,
 }
@@ -293,7 +280,6 @@ pub struct ProcMacro<'hir> {
     pub helpers: Vec<Name>,
     pub attrs: &'hir hir::HirVec<ast::Attribute>,
     pub whence: Span,
-    pub stab: Option<attr::Stability>,
     pub depr: Option<attr::Deprecation>,
 }
 

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -14,7 +14,6 @@ use rustc_target::spec::abi::Abi;
 use rustc::hir;
 
 use crate::clean::{self, PrimitiveType};
-use crate::core::DocAccessLevels;
 use crate::html::item_type::ItemType;
 use crate::html::render::{self, cache, CURRENT_LOCATION_KEY};
 
@@ -404,7 +403,7 @@ impl fmt::Display for clean::Path {
 
 pub fn href(did: DefId) -> Option<(String, ItemType, Vec<String>)> {
     let cache = cache();
-    if !did.is_local() && !cache.access_levels.is_doc_reachable(did) {
+    if !did.is_local() && !cache.access_levels.is_public(did) {
         return None
     }
 

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -10,7 +10,7 @@ use syntax_pos::{DUMMY_SP, InnerSpan, Span};
 use std::ops::Range;
 
 use crate::clean::{self, GetDefId, Item};
-use crate::core::{DocContext, DocAccessLevels};
+use crate::core::DocContext;
 use crate::fold::{DocFolder, StripItem};
 use crate::html::markdown::{find_testable_code, ErrorCodes, LangString};
 
@@ -347,7 +347,7 @@ pub fn look_for_tests<'tcx>(
         diag.emit();
     } else if check_missing_code == false &&
               tests.found_tests > 0 &&
-              !cx.renderinfo.borrow().access_levels.is_doc_reachable(item.def_id) {
+              !cx.renderinfo.borrow().access_levels.is_public(item.def_id) {
         let mut diag = cx.tcx.struct_span_lint_hir(
             lint::builtin::PRIVATE_DOC_TESTS,
             hir_id,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -68,7 +68,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             .and_then(|def_id| self.cx.tcx.lookup_deprecation(def_id))
     }
 
-    pub fn visit(&mut self, krate: &'tcx hir::Crate) -> Module<'tcx> {
+    pub fn visit(mut self, krate: &'tcx hir::Crate) -> Module<'tcx> {
         let mut module = self.visit_mod_contents(krate.span,
                                               &krate.attrs,
                                               &Spanned { span: syntax_pos::DUMMY_SP,

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -7,7 +7,6 @@ use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::middle::privacy::AccessLevel;
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
 use syntax::ast;
-use syntax::attr;
 use syntax::ext::base::MacroKind;
 use syntax::source_map::Spanned;
 use syntax::symbol::sym;
@@ -57,11 +56,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         }
     }
 
-    fn deprecation(&self, id: hir::HirId) -> Option<attr::Deprecation> {
-        self.cx.tcx.hir().opt_local_def_id(id)
-            .and_then(|def_id| self.cx.tcx.lookup_deprecation(def_id))
-    }
-
     pub fn visit(mut self, krate: &'tcx hir::Crate) -> Module<'tcx> {
         let mut module = self.visit_mod_contents(krate.span,
                                               &krate.attrs,
@@ -91,7 +85,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             struct_type,
             name,
             vis: &item.vis,
-            depr: self.deprecation(item.hir_id),
             attrs: &item.attrs,
             generics,
             fields: sd.fields(),
@@ -109,7 +102,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             struct_type,
             name,
             vis: &item.vis,
-            depr: self.deprecation(item.hir_id),
             attrs: &item.attrs,
             generics,
             fields: sd.fields(),
@@ -127,12 +119,10 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 name: v.node.ident.name,
                 id: v.node.id,
                 attrs: &v.node.attrs,
-                depr: self.deprecation(v.node.id),
                 def: &v.node.data,
                 whence: v.span,
             }).collect(),
             vis: &it.vis,
-            depr: self.deprecation(it.hir_id),
             generics,
             attrs: &it.attrs,
             id: it.hir_id,
@@ -191,14 +181,12 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     helpers,
                     attrs: &item.attrs,
                     whence: item.span,
-                    depr: self.deprecation(item.hir_id),
                 });
             }
             None => {
                 om.fns.push(Function {
                     id: item.hir_id,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                     attrs: &item.attrs,
                     decl,
                     name,
@@ -218,7 +206,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         let mut om = Module::new(name, attrs, vis);
         om.where_outer = span;
         om.where_inner = m.inner;
-        om.depr = self.deprecation(id);
         om.hid = id;
         om.id = self.cx.tcx.hir().hir_to_node_id(id);
         // Keep track of if there were any private modules in the path.
@@ -449,7 +436,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.typedefs.push(t);
             },
@@ -461,7 +447,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.opaque_tys.push(t);
             },
@@ -475,7 +460,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.statics.push(s);
             },
@@ -488,7 +472,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.constants.push(s);
             },
@@ -507,7 +490,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.traits.push(t);
             },
@@ -520,7 +502,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                     attrs: &item.attrs,
                     whence: item.span,
                     vis: &item.vis,
-                    depr: self.deprecation(item.hir_id),
                 };
                 om.trait_aliases.push(t);
             },
@@ -550,7 +531,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                         id: item.hir_id,
                         whence: item.span,
                         vis: &item.vis,
-                        depr: self.deprecation(item.hir_id),
                     };
                     om.impls.push(i);
                 }
@@ -570,7 +550,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             name: renamed.unwrap_or(item.ident).name,
             kind: &item.node,
             vis: &item.vis,
-            depr: self.deprecation(item.hir_id),
             attrs: &item.attrs,
             whence: item.span
         });
@@ -594,7 +573,6 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
             name: renamed.unwrap_or(def.name),
             whence: def.span,
             matchers,
-            depr: self.deprecation(def.hir_id),
             imported_from: None,
         }
     }

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -206,8 +206,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
         let mut om = Module::new(name, attrs, vis);
         om.where_outer = span;
         om.where_inner = m.inner;
-        om.hid = id;
-        om.id = self.cx.tcx.hir().hir_to_node_id(id);
+        om.id = id;
         // Keep track of if there were any private modules in the path.
         let orig_inside_public_path = self.inside_public_path;
         self.inside_public_path &= vis.node.is_pub();


### PR DESCRIPTION
This is purely a refactoring, mostly just simplifying some of the code. Commits are best reviewed individually.

