### PR TITLE
clarify and unify some type test names

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1847,7 +1847,7 @@ impl<'tcx> TyS<'tcx> {
     }
 
     #[inline]
-    pub fn is_mutable_pointer(&self) -> bool {
+    pub fn is_mutable_ptr(&self) -> bool {
         match self.sty {
             RawPtr(TypeAndMut { mutbl: hir::Mutability::MutMutable, .. }) |
             Ref(_, _, hir::Mutability::MutMutable) => true,
@@ -2002,7 +2002,7 @@ impl<'tcx> TyS<'tcx> {
     }
 
     #[inline]
-    pub fn is_pointer_sized(&self) -> bool {
+    pub fn is_ptr_sized_integral(&self) -> bool {
         match self.sty {
             Int(ast::IntTy::Isize) | Uint(ast::UintTy::Usize) => true,
             _ => false,

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -536,7 +536,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         let base_ty = Place::ty_from(deref_base.base, deref_base.projection, self.body, tcx).ty;
         if base_ty.is_unsafe_ptr() {
             BorrowedContentSource::DerefRawPointer
-        } else if base_ty.is_mutable_pointer() {
+        } else if base_ty.is_mutable_ptr() {
             BorrowedContentSource::DerefMutableRef
         } else {
             BorrowedContentSource::DerefSharedRef

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -1329,7 +1329,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 base: PlaceBase::Local(local),
                 projection: None,
             }) if self.body.local_decls[local].is_user_variable.is_none() => {
-                if self.body.local_decls[local].ty.is_mutable_pointer() {
+                if self.body.local_decls[local].ty.is_mutable_ptr() {
                     // The variable will be marked as mutable by the borrow.
                     return;
                 }

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -1171,7 +1171,7 @@ pub fn is_useful<'p, 'a, 'tcx>(
         // For privately empty and non-exhaustive enums, we work as if there were an "extra"
         // `_` constructor for the type, so we can never match over all constructors.
         let is_non_exhaustive = is_privately_empty || is_declared_nonexhaustive ||
-            (pcx.ty.is_pointer_sized() && !cx.tcx.features().precise_pointer_size_matching);
+            (pcx.ty.is_ptr_sized_integral() && !cx.tcx.features().precise_pointer_size_matching);
 
         if cheap_missing_ctors == MissingCtors::Empty && !is_non_exhaustive {
             split_grouped_constructors(cx.tcx, all_ctors, matrix, pcx.ty).into_iter().map(|c| {
@@ -1488,7 +1488,7 @@ fn should_treat_range_exhaustively(tcx: TyCtxt<'tcx>, ctor: &Constructor<'tcx>) 
         _ => return false,
     };
     if let ty::Char | ty::Int(_) | ty::Uint(_) = ty.sty {
-        !ty.is_pointer_sized() || tcx.features().precise_pointer_size_matching
+        !ty.is_ptr_sized_integral() || tcx.features().precise_pointer_size_matching
     } else {
         false
     }

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 trait_name,
                 item_name,
                 if rcvr_ty.is_region_ptr() && args.is_some() {
-                    if rcvr_ty.is_mutable_pointer() {
+                    if rcvr_ty.is_mutable_ptr() {
                         "&mut "
                     } else {
                         "&"


### PR DESCRIPTION
* `is_mutable_pointer`: use `ptr` suffix for consistency with `is_region_ptr`, `is_fn_ptr`, `is_unsafe_ptr`.
* `is_pointer_sized`: the name is misleading as this only tests for pointer-sized *integers*, so rename to `is_ptr_sized_integral`.