### PR TITLE
ci: gate toolstate repo pushes on the TOOLSTATE_PUBLISH envvar

### DIFF
--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -112,7 +112,7 @@ $COMMIT\t$(cat "$TOOLSTATE_FILE")
 }
 
 if [ "$RUST_RELEASE_CHANNEL" = nightly ]; then
-    if [ -n "${TOOLSTATE_REPO_ACCESS_TOKEN+is_set}" ]; then
+    if [ -n "${TOOLSTATE_PUBLISH+is_set}" ]; then
         . "$(dirname $0)/repo.sh"
         MESSAGE_FILE=$(mktemp -t msg.XXXXXX)
         echo "($OS CI update)" > "$MESSAGE_FILE"


### PR DESCRIPTION
This PR fixes toolstate failing to push on the LinuxTools PR builder by gating the pushes on the new `TOOLSTATE_PUBLISH` environment variable, which is set on prod credentials but not on the PR ones. The old code checked whether the access token was set, but that doesn't work due to an Azure quirk.

For a bit of background, secret environment variables are not available by default, but each step needs to explicitly declare which secret vars to load:

```yaml
- bash: echo foo
  env:
    SECRET_VAR: $(SECRET_VAR)
```

This works fine when the variable is present but when it's missing, instead of setting `SECRET_VAR` to an empty string or just not setting it at all, Azure Pipelines puts the literal `$(SECRET_VAR)` as the content, which completly breaks the old check we had. I tried almost every thing to make this work in a sensible way, and the only conclusion I reached is to set the variable at the top level with the runtime expression evaluation syntax, which sets the variable to an empty string if missing:

```yaml
# At the top:
variables:
  - name: MAYBE_SECRET_VAR
    value: $[ variables.MAYBE_SECRET_VAR ]

# In the step:
- bash: echo foo
  env:
    SECRET_VAR: $(MAYBE_SECRET_VAR)
```

While that *could've worked* it was ugly and messy, so I just opted to add yet another non-secret variable.

r? @alexcrichton
fixes #62811 