### PR TITLE
Almost fully deprecate hir::map::Map.hir_to_node_id

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -97,7 +97,7 @@ pub struct LoweringContext<'a> {
 
     trait_impls: BTreeMap<DefId, Vec<hir::HirId>>,
 
-    modules: BTreeMap<NodeId, hir::ModuleItems>,
+    modules: BTreeMap<hir::HirId, hir::ModuleItems>,
 
     generator_kind: Option<hir::GeneratorKind>,
 
@@ -141,7 +141,7 @@ pub struct LoweringContext<'a> {
     /// vector.
     in_scope_lifetimes: Vec<ParamName>,
 
-    current_module: NodeId,
+    current_module: hir::HirId,
 
     type_def_lifetime_params: DefIdMap<usize>,
 
@@ -262,7 +262,7 @@ pub fn lower_crate(
         is_in_dyn_type: false,
         anonymous_lifetime_mode: AnonymousLifetimeMode::PassThrough,
         type_def_lifetime_params: Default::default(),
-        current_module: CRATE_NODE_ID,
+        current_module: hir::CRATE_HIR_ID,
         current_hir_id_owner: vec![(CRATE_DEF_INDEX, 0)],
         item_local_id_counters: Default::default(),
         node_id_to_hir_id: IndexVec::new(),

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -45,14 +45,16 @@ impl<'tcx, 'interner> ItemLowerer<'tcx, 'interner> {
 
 impl<'tcx, 'interner> Visitor<'tcx> for ItemLowerer<'tcx, 'interner> {
     fn visit_mod(&mut self, m: &'tcx Mod, _s: Span, _attrs: &[Attribute], n: NodeId) {
-        self.lctx.modules.insert(n, hir::ModuleItems {
+        let hir_id = self.lctx.lower_node_id(n);
+
+        self.lctx.modules.insert(hir_id, hir::ModuleItems {
             items: BTreeSet::new(),
             trait_items: BTreeSet::new(),
             impl_items: BTreeSet::new(),
         });
 
         let old = self.lctx.current_module;
-        self.lctx.current_module = n;
+        self.lctx.current_module = hir_id;
         visit::walk_mod(self, m);
         self.lctx.current_module = old;
     }

--- a/src/librustc/hir/map/hir_id_validator.rs
+++ b/src/librustc/hir/map/hir_id_validator.rs
@@ -10,7 +10,7 @@ pub fn check_crate(hir_map: &hir::map::Map<'_>) {
     let errors = Lock::new(Vec::new());
 
     par_iter(&hir_map.krate().modules).for_each(|(module_id, _)| {
-        let local_def_id = hir_map.local_def_id_from_node_id(*module_id);
+        let local_def_id = hir_map.local_def_id(*module_id);
         hir_map.visit_item_likes_in_module(local_def_id, &mut OuterVisitor {
             hir_map,
             errors: &errors,

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -539,9 +539,7 @@ impl<'hir> Map<'hir> {
         // in the expect_* calls the loops below
         self.read(hir_id);
 
-        let node_id = self.hir_to_node_id[&hir_id];
-
-        let module = &self.forest.krate.modules[&node_id];
+        let module = &self.forest.krate.modules[&hir_id];
 
         for id in &module.items {
             visitor.visit_item(self.expect_item(*id));

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -767,7 +767,7 @@ pub struct Crate {
 
     /// A list of modules written out in the order in which they
     /// appear in the crate. This includes the main crate module.
-    pub modules: BTreeMap<NodeId, ModuleItems>,
+    pub modules: BTreeMap<HirId, ModuleItems>,
 }
 
 impl Crate {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -1515,7 +1515,7 @@ pub fn check_crate<'tcx, T: for<'a> LateLintPass<'a, 'tcx>>(
         time(tcx.sess, "module lints", || {
             // Run per-module lints
             par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
-                tcx.ensure().lint_mod(tcx.hir().local_def_id_from_node_id(module));
+                tcx.ensure().lint_mod(tcx.hir().local_def_id(module));
             });
         });
     });

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -913,10 +913,10 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
             });
         }, {
             par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
-                tcx.ensure().check_mod_loops(tcx.hir().local_def_id_from_node_id(module));
-                tcx.ensure().check_mod_attrs(tcx.hir().local_def_id_from_node_id(module));
-                tcx.ensure().check_mod_unstable_api_usage(
-                    tcx.hir().local_def_id_from_node_id(module));
+                let local_def_id = tcx.hir().local_def_id(module);
+                tcx.ensure().check_mod_loops(local_def_id);
+                tcx.ensure().check_mod_attrs(local_def_id);
+                tcx.ensure().check_mod_unstable_api_usage(local_def_id);
             });
         });
     });
@@ -939,9 +939,10 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
                     // "not all control paths return a value" is reported here.
                     //
                     // maybe move the check to a MIR pass?
-                    tcx.ensure().check_mod_liveness(tcx.hir().local_def_id_from_node_id(module));
+                    let local_def_id = tcx.hir().local_def_id(module);
 
-                    tcx.ensure().check_mod_intrinsics(tcx.hir().local_def_id_from_node_id(module));
+                    tcx.ensure().check_mod_liveness(local_def_id);
+                    tcx.ensure().check_mod_intrinsics(local_def_id);
                 });
             });
         });
@@ -1001,7 +1002,7 @@ fn analysis(tcx: TyCtxt<'_>, cnum: CrateNum) -> Result<()> {
         }, {
             time(sess, "privacy checking modules", || {
                 par_iter(&tcx.hir().krate().modules).for_each(|(&module, _)| {
-                    tcx.ensure().check_mod_privacy(tcx.hir().local_def_id_from_node_id(module));
+                    tcx.ensure().check_mod_privacy(tcx.hir().local_def_id(module));
                 });
             });
         });

--- a/src/librustc_typeck/impl_wf_check.rs
+++ b/src/librustc_typeck/impl_wf_check.rs
@@ -54,7 +54,7 @@ pub fn impl_wf_check(tcx: TyCtxt<'_>) {
     // but it's one that we must perform earlier than the rest of
     // WfCheck.
     for &module in tcx.hir().krate().modules.keys() {
-        tcx.ensure().check_mod_impl_wf(tcx.hir().local_def_id_from_node_id(module));
+        tcx.ensure().check_mod_impl_wf(tcx.hir().local_def_id(module));
     }
 }
 

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -306,7 +306,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorReported> {
     tcx.sess.track_errors(|| {
         time(tcx.sess, "type collecting", || {
             for &module in tcx.hir().krate().modules.keys() {
-                tcx.ensure().collect_mod_item_types(tcx.hir().local_def_id_from_node_id(module));
+                tcx.ensure().collect_mod_item_types(tcx.hir().local_def_id(module));
             }
         });
     })?;
@@ -341,7 +341,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) -> Result<(), ErrorReported> {
 
     time(tcx.sess, "item-types checking", || {
         for &module in tcx.hir().krate().modules.keys() {
-            tcx.ensure().check_mod_item_types(tcx.hir().local_def_id_from_node_id(module));
+            tcx.ensure().check_mod_item_types(tcx.hir().local_def_id(module));
         }
     });
 


### PR DESCRIPTION
- HirIdify `doctree::Module.id`
- HirIdify `hir::Crate.modules`
- introduce a `HirId` to `DefIndex` map in `map::Definitions`

The only last uses of `hir::map::Map.hir_to_node_id` in the compiler are:
- for the purposes of `driver::pretty` (in `map::nodes_matching_suffix`), but I don't know if we can remove `NodeId`s in there (I think when I attempted it previously there was some issue due to `HirId` not being representable with an integer)
- in `ty::query::on_disk_cache` (not sure about the purpose of this one)
- in `mir::transform::check_unsafety` (only important for error message order)

Any suggestions how to kill these off?

r? @Zoxc 