### PR TITLE
Remove `cfg(bootstrap)` code for array implementations

### DIFF
--- a/src/libcore/array.rs
+++ b/src/libcore/array.rs
@@ -81,487 +81,296 @@ impl From<Infallible> for TryFromSliceError {
     }
 }
 
-#[cfg(bootstrap)]
-macro_rules! __impl_slice_eq1 {
-    ($Lhs: ty, $Rhs: ty) => {
-        __impl_slice_eq1! { $Lhs, $Rhs, Sized }
-    };
-    ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, 'b, A: $Bound, B> PartialEq<$Rhs> for $Lhs where A: PartialEq<B> {
-            #[inline]
-            fn eq(&self, other: &$Rhs) -> bool { self[..] == other[..] }
-            #[inline]
-            fn ne(&self, other: &$Rhs) -> bool { self[..] != other[..] }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T, const N: usize> AsRef<[T]> for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    #[inline]
+    fn as_ref(&self) -> &[T] {
+        &self[..]
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T, const N: usize> AsMut<[T]> for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut [T] {
+        &mut self[..]
+    }
+}
+
+#[stable(feature = "array_borrow", since = "1.4.0")]
+impl<T, const N: usize> Borrow<[T]> for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    fn borrow(&self) -> &[T] {
+        self
+    }
+}
+
+#[stable(feature = "array_borrow", since = "1.4.0")]
+impl<T, const N: usize> BorrowMut<[T]> for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self
+    }
+}
+
+#[stable(feature = "try_from", since = "1.34.0")]
+impl<T, const N: usize> TryFrom<&[T]> for [T; N]
+where
+    T: Copy,
+    [T; N]: LengthAtMost32,
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(slice: &[T]) -> Result<[T; N], TryFromSliceError> {
+        <&Self>::try_from(slice).map(|r| *r)
+    }
+}
+
+#[stable(feature = "try_from", since = "1.34.0")]
+impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    type Error = TryFromSliceError;
+
+    fn try_from(slice: &[T]) -> Result<&[T; N], TryFromSliceError> {
+        if slice.len() == N {
+            let ptr = slice.as_ptr() as *const [T; N];
+            unsafe { Ok(&*ptr) }
+        } else {
+            Err(TryFromSliceError(()))
         }
     }
 }
 
-#[cfg(bootstrap)]
-macro_rules! __impl_slice_eq2 {
-    ($Lhs: ty, $Rhs: ty) => {
-        __impl_slice_eq2! { $Lhs, $Rhs, Sized }
-    };
-    ($Lhs: ty, $Rhs: ty, $Bound: ident) => {
-        __impl_slice_eq1!($Lhs, $Rhs, $Bound);
+#[stable(feature = "try_from", since = "1.34.0")]
+impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    type Error = TryFromSliceError;
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl<'a, 'b, A: $Bound, B> PartialEq<$Lhs> for $Rhs where B: PartialEq<A> {
-            #[inline]
-            fn eq(&self, other: &$Lhs) -> bool { self[..] == other[..] }
-            #[inline]
-            fn ne(&self, other: &$Lhs) -> bool { self[..] != other[..] }
+    fn try_from(slice: &mut [T]) -> Result<&mut [T; N], TryFromSliceError> {
+        if slice.len() == N {
+            let ptr = slice.as_mut_ptr() as *mut [T; N];
+            unsafe { Ok(&mut *ptr) }
+        } else {
+            Err(TryFromSliceError(()))
         }
     }
 }
 
-// macro for implementing n-element array functions and operations
-#[cfg(bootstrap)]
-macro_rules! array_impls {
-    ($($N:expr)+) => {
-        $(
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T> AsRef<[T]> for [T; $N] {
-                #[inline]
-                fn as_ref(&self) -> &[T] {
-                    &self[..]
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T> AsMut<[T]> for [T; $N] {
-                #[inline]
-                fn as_mut(&mut self) -> &mut [T] {
-                    &mut self[..]
-                }
-            }
-
-            #[stable(feature = "array_borrow", since = "1.4.0")]
-            impl<T> Borrow<[T]> for [T; $N] {
-                fn borrow(&self) -> &[T] {
-                    self
-                }
-            }
-
-            #[stable(feature = "array_borrow", since = "1.4.0")]
-            impl<T> BorrowMut<[T]> for [T; $N] {
-                fn borrow_mut(&mut self) -> &mut [T] {
-                    self
-                }
-            }
-
-            #[stable(feature = "try_from", since = "1.34.0")]
-            impl<T> TryFrom<&[T]> for [T; $N] where T: Copy {
-                type Error = TryFromSliceError;
-
-                fn try_from(slice: &[T]) -> Result<[T; $N], TryFromSliceError> {
-                    <&Self>::try_from(slice).map(|r| *r)
-                }
-            }
-
-            #[stable(feature = "try_from", since = "1.34.0")]
-            impl<'a, T> TryFrom<&'a [T]> for &'a [T; $N] {
-                type Error = TryFromSliceError;
-
-                fn try_from(slice: &[T]) -> Result<&[T; $N], TryFromSliceError> {
-                    if slice.len() == $N {
-                        let ptr = slice.as_ptr() as *const [T; $N];
-                        unsafe { Ok(&*ptr) }
-                    } else {
-                        Err(TryFromSliceError(()))
-                    }
-                }
-            }
-
-            #[stable(feature = "try_from", since = "1.34.0")]
-            impl<'a, T> TryFrom<&'a mut [T]> for &'a mut [T; $N] {
-                type Error = TryFromSliceError;
-
-                fn try_from(slice: &mut [T]) -> Result<&mut [T; $N], TryFromSliceError> {
-                    if slice.len() == $N {
-                        let ptr = slice.as_mut_ptr() as *mut [T; $N];
-                        unsafe { Ok(&mut *ptr) }
-                    } else {
-                        Err(TryFromSliceError(()))
-                    }
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T: Hash> Hash for [T; $N] {
-                fn hash<H: hash::Hasher>(&self, state: &mut H) {
-                    Hash::hash(&self[..], state)
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T: fmt::Debug> fmt::Debug for [T; $N] {
-                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                    fmt::Debug::fmt(&&self[..], f)
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<'a, T> IntoIterator for &'a [T; $N] {
-                type Item = &'a T;
-                type IntoIter = Iter<'a, T>;
-
-                fn into_iter(self) -> Iter<'a, T> {
-                    self.iter()
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<'a, T> IntoIterator for &'a mut [T; $N] {
-                type Item = &'a mut T;
-                type IntoIter = IterMut<'a, T>;
-
-                fn into_iter(self) -> IterMut<'a, T> {
-                    self.iter_mut()
-                }
-            }
-
-            // NOTE: some less important impls are omitted to reduce code bloat
-            __impl_slice_eq1! { [A; $N], [B; $N] }
-            __impl_slice_eq2! { [A; $N], [B] }
-            __impl_slice_eq2! { [A; $N], &'b [B] }
-            __impl_slice_eq2! { [A; $N], &'b mut [B] }
-            // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
-            // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T:Eq> Eq for [T; $N] { }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T:PartialOrd> PartialOrd for [T; $N] {
-                #[inline]
-                fn partial_cmp(&self, other: &[T; $N]) -> Option<Ordering> {
-                    PartialOrd::partial_cmp(&&self[..], &&other[..])
-                }
-                #[inline]
-                fn lt(&self, other: &[T; $N]) -> bool {
-                    PartialOrd::lt(&&self[..], &&other[..])
-                }
-                #[inline]
-                fn le(&self, other: &[T; $N]) -> bool {
-                    PartialOrd::le(&&self[..], &&other[..])
-                }
-                #[inline]
-                fn ge(&self, other: &[T; $N]) -> bool {
-                    PartialOrd::ge(&&self[..], &&other[..])
-                }
-                #[inline]
-                fn gt(&self, other: &[T; $N]) -> bool {
-                    PartialOrd::gt(&&self[..], &&other[..])
-                }
-            }
-
-            #[stable(feature = "rust1", since = "1.0.0")]
-            impl<T:Ord> Ord for [T; $N] {
-                #[inline]
-                fn cmp(&self, other: &[T; $N]) -> Ordering {
-                    Ord::cmp(&&self[..], &&other[..])
-                }
-            }
-        )+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Hash, const N: usize> Hash for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        Hash::hash(&self[..], state)
     }
 }
 
-#[cfg(not(bootstrap))]
-mod impls_using_const_generics {
-    use super::*;
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T, const N: usize> AsRef<[T]> for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn as_ref(&self) -> &[T] {
-            &self[..]
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: fmt::Debug, const N: usize> fmt::Debug for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&&self[..], f)
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T, const N: usize> AsMut<[T]> for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn as_mut(&mut self) -> &mut [T] {
-            &mut self[..]
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, T, const N: usize> IntoIterator for &'a [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    type Item = &'a T;
+    type IntoIter = Iter<'a, T>;
+
+    fn into_iter(self) -> Iter<'a, T> {
+        self.iter()
     }
+}
 
-    #[stable(feature = "array_borrow", since = "1.4.0")]
-    impl<T, const N: usize> Borrow<[T]> for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        fn borrow(&self) -> &[T] {
-            self
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, T, const N: usize> IntoIterator for &'a mut [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    type Item = &'a mut T;
+    type IntoIter = IterMut<'a, T>;
+
+    fn into_iter(self) -> IterMut<'a, T> {
+        self.iter_mut()
     }
+}
 
-    #[stable(feature = "array_borrow", since = "1.4.0")]
-    impl<T, const N: usize> BorrowMut<[T]> for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        fn borrow_mut(&mut self) -> &mut [T] {
-            self
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<[B; N]> for [A; N]
+where
+    A: PartialEq<B>,
+    [A; N]: LengthAtMost32,
+    [B; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &[B; N]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "try_from", since = "1.34.0")]
-    impl<T, const N: usize> TryFrom<&[T]> for [T; N]
-    where
-        T: Copy,
-        [T; N]: LengthAtMost32,
-    {
-        type Error = TryFromSliceError;
-
-        fn try_from(slice: &[T]) -> Result<[T; N], TryFromSliceError> {
-            <&Self>::try_from(slice).map(|r| *r)
-        }
+    #[inline]
+    fn ne(&self, other: &[B; N]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "try_from", since = "1.34.0")]
-    impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        type Error = TryFromSliceError;
-
-        fn try_from(slice: &[T]) -> Result<&[T; N], TryFromSliceError> {
-            if slice.len() == N {
-                let ptr = slice.as_ptr() as *const [T; N];
-                unsafe { Ok(&*ptr) }
-            } else {
-                Err(TryFromSliceError(()))
-            }
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<[B]> for [A; N]
+where
+    A: PartialEq<B>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &[B]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "try_from", since = "1.34.0")]
-    impl<'a, T, const N: usize> TryFrom<&'a mut [T]> for &'a mut [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        type Error = TryFromSliceError;
-
-        fn try_from(slice: &mut [T]) -> Result<&mut [T; N], TryFromSliceError> {
-            if slice.len() == N {
-                let ptr = slice.as_mut_ptr() as *mut [T; N];
-                unsafe { Ok(&mut *ptr) }
-            } else {
-                Err(TryFromSliceError(()))
-            }
-        }
+    #[inline]
+    fn ne(&self, other: &[B]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: Hash, const N: usize> Hash for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        fn hash<H: hash::Hasher>(&self, state: &mut H) {
-            Hash::hash(&self[..], state)
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for [B]
+where
+    B: PartialEq<A>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: fmt::Debug, const N: usize> fmt::Debug for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            fmt::Debug::fmt(&&self[..], f)
-        }
+    #[inline]
+    fn ne(&self, other: &[A; N]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, T, const N: usize> IntoIterator for &'a [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        type Item = &'a T;
-        type IntoIter = Iter<'a, T>;
-
-        fn into_iter(self) -> Iter<'a, T> {
-            self.iter()
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<&'b [B]> for [A; N]
+where
+    A: PartialEq<B>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &&'b [B]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, T, const N: usize> IntoIterator for &'a mut [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        type Item = &'a mut T;
-        type IntoIter = IterMut<'a, T>;
-
-        fn into_iter(self) -> IterMut<'a, T> {
-            self.iter_mut()
-        }
+    #[inline]
+    fn ne(&self, other: &&'b [B]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<[B; N]> for [A; N]
-    where
-        A: PartialEq<B>,
-        [A; N]: LengthAtMost32,
-        [B; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &[B; N]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &[B; N]) -> bool {
-            self[..] != other[..]
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for &'b [B]
+where
+    B: PartialEq<A>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<[B]> for [A; N]
-    where
-        A: PartialEq<B>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &[B]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &[B]) -> bool {
-            self[..] != other[..]
-        }
+    #[inline]
+    fn ne(&self, other: &[A; N]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for [B]
-    where
-        B: PartialEq<A>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &[A; N]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &[A; N]) -> bool {
-            self[..] != other[..]
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<&'b mut [B]> for [A; N]
+where
+    A: PartialEq<B>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &&'b mut [B]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<&'b [B]> for [A; N]
-    where
-        A: PartialEq<B>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &&'b [B]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &&'b [B]) -> bool {
-            self[..] != other[..]
-        }
+    #[inline]
+    fn ne(&self, other: &&'b mut [B]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for &'b [B]
-    where
-        B: PartialEq<A>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &[A; N]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &[A; N]) -> bool {
-            self[..] != other[..]
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for &'b mut [B]
+where
+    B: PartialEq<A>,
+    [A; N]: LengthAtMost32,
+{
+    #[inline]
+    fn eq(&self, other: &[A; N]) -> bool {
+        self[..] == other[..]
     }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<&'b mut [B]> for [A; N]
-    where
-        A: PartialEq<B>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &&'b mut [B]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &&'b mut [B]) -> bool {
-            self[..] != other[..]
-        }
+    #[inline]
+    fn ne(&self, other: &[A; N]) -> bool {
+        self[..] != other[..]
     }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<'a, 'b, A, B, const N: usize> PartialEq<[A; N]> for &'b mut [B]
-    where
-        B: PartialEq<A>,
-        [A; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn eq(&self, other: &[A; N]) -> bool {
-            self[..] == other[..]
-        }
-        #[inline]
-        fn ne(&self, other: &[A; N]) -> bool {
-            self[..] != other[..]
-        }
+// NOTE: some less important impls are omitted to reduce code bloat
+// __impl_slice_eq2! { [A; $N], &'b [B; $N] }
+// __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Eq, const N: usize> Eq for [T; N] where [T; N]: LengthAtMost32 {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: PartialOrd, const N: usize> PartialOrd for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    #[inline]
+    fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
+        PartialOrd::partial_cmp(&&self[..], &&other[..])
     }
-
-    // NOTE: some less important impls are omitted to reduce code bloat
-    // __impl_slice_eq2! { [A; $N], &'b [B; $N] }
-    // __impl_slice_eq2! { [A; $N], &'b mut [B; $N] }
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: Eq, const N: usize> Eq for [T; N] where [T; N]: LengthAtMost32 {}
-
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: PartialOrd, const N: usize> PartialOrd for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn partial_cmp(&self, other: &[T; N]) -> Option<Ordering> {
-            PartialOrd::partial_cmp(&&self[..], &&other[..])
-        }
-        #[inline]
-        fn lt(&self, other: &[T; N]) -> bool {
-            PartialOrd::lt(&&self[..], &&other[..])
-        }
-        #[inline]
-        fn le(&self, other: &[T; N]) -> bool {
-            PartialOrd::le(&&self[..], &&other[..])
-        }
-        #[inline]
-        fn ge(&self, other: &[T; N]) -> bool {
-            PartialOrd::ge(&&self[..], &&other[..])
-        }
-        #[inline]
-        fn gt(&self, other: &[T; N]) -> bool {
-            PartialOrd::gt(&&self[..], &&other[..])
-        }
+    #[inline]
+    fn lt(&self, other: &[T; N]) -> bool {
+        PartialOrd::lt(&&self[..], &&other[..])
     }
+    #[inline]
+    fn le(&self, other: &[T; N]) -> bool {
+        PartialOrd::le(&&self[..], &&other[..])
+    }
+    #[inline]
+    fn ge(&self, other: &[T; N]) -> bool {
+        PartialOrd::ge(&&self[..], &&other[..])
+    }
+    #[inline]
+    fn gt(&self, other: &[T; N]) -> bool {
+        PartialOrd::gt(&&self[..], &&other[..])
+    }
+}
 
-    #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: Ord, const N: usize> Ord for [T; N]
-    where
-        [T; N]: LengthAtMost32,
-    {
-        #[inline]
-        fn cmp(&self, other: &[T; N]) -> Ordering {
-            Ord::cmp(&&self[..], &&other[..])
-        }
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Ord, const N: usize> Ord for [T; N]
+where
+    [T; N]: LengthAtMost32,
+{
+    #[inline]
+    fn cmp(&self, other: &[T; N]) -> Ordering {
+        Ord::cmp(&&self[..], &&other[..])
     }
 }
 
@@ -571,10 +380,8 @@ mod impls_using_const_generics {
 )]
 #[unstable(feature = "const_generic_impls_guard", issue = "0",
     reason = "will never be stable, just a temporary step until const generics are stable")]
-#[cfg(not(bootstrap))]
 pub trait LengthAtMost32 {}
 
-#[cfg(not(bootstrap))]
 macro_rules! array_impls {
     ($($N:literal)+) => {
         $(

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -74,7 +74,7 @@
 #![feature(concat_idents)]
 #![feature(const_fn)]
 #![feature(const_fn_union)]
-#![cfg_attr(not(bootstrap), feature(const_generics))]
+#![feature(const_generics)]
 #![feature(custom_inner_attributes)]
 #![feature(decl_macro)]
 #![feature(doc_cfg)]


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/62435 ("Use const generics for array impls [part 1]") the old macro-based implementations were not removed but still used with `cfg(bootstrap)` since the bootstrap compiler had some problems with const generics at the time. This does not seem to be the case anymore, so there is no reason to keep the old code.

Unfortunately, the diff is pretty ugly because much of the code was indented by one level before. The change is pretty trivial, though.

PS: I did not run the full test suite locally. There are 40°C outside and 31°C inside my room. I don't want my notebook to melt. I hope that CI is green. 

r? @scottmcm

