### PR TITLE
Add lint for excess trailing semicolons

### DIFF
--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -24,6 +24,7 @@ extern crate rustc;
 
 mod error_codes;
 mod nonstandard_style;
+mod redundant_semicolon;
 pub mod builtin;
 mod types;
 mod unused;
@@ -55,6 +56,7 @@ use session::Session;
 use lint::LintId;
 use lint::FutureIncompatibleInfo;
 
+use redundant_semicolon::*;
 use nonstandard_style::*;
 use builtin::*;
 use types::*;
@@ -98,6 +100,7 @@ macro_rules! early_lint_passes {
             WhileTrue: WhileTrue,
             NonAsciiIdents: NonAsciiIdents,
             IncompleteFeatures: IncompleteFeatures,
+            RedundantSemicolon: RedundantSemicolon,
         ]);
     )
 }

--- a/src/test/ui/block-expr-precedence.stderr
+++ b/src/test/ui/block-expr-precedence.stderr
@@ -1,0 +1,8 @@
+warning: unnecessary trailing semicolons
+  --> $DIR/block-expr-precedence.rs:60:21
+   |
+LL |   if (true) { 12; };;; -num;
+   |                     ^^ help: remove these semicolons
+   |
+   = note: `#[warn(redundant_semicolon)]` on by default
+

--- a/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
+++ b/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
@@ -28,7 +28,10 @@ error: expected `{`, found `;`
 LL |     if not  // lack of braces is [sic]
    |     -- this `if` statement has a condition, but no block
 LL |         println!("Then when?");
-   |                               ^ expected `{`
+   |                               ^
+   |                               |
+   |                               expected `{`
+   |                               help: try placing this code inside a block: `{ ; }`
 
 error: unexpected `2` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:26:24

--- a/src/test/ui/parser/doc-before-semi.rs
+++ b/src/test/ui/parser/doc-before-semi.rs
@@ -3,4 +3,6 @@ fn main() {
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
     ;
+    //~^ WARNING unnecessary trailing semicolon
+    //~| HELP remove this semicolon
 }

--- a/src/test/ui/parser/doc-before-semi.stderr
+++ b/src/test/ui/parser/doc-before-semi.stderr
@@ -6,6 +6,14 @@ LL |     /// hi
    |
    = help: doc comments must come before what they document, maybe a comment was intended with `//`?
 
+warning: unnecessary trailing semicolon
+  --> $DIR/doc-before-semi.rs:5:5
+   |
+LL |     ;
+   |     ^ help: remove this semicolon
+   |
+   = note: `#[warn(redundant_semicolon)]` on by default
+
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0585`.

--- a/src/test/ui/proc-macro/span-preservation.rs
+++ b/src/test/ui/proc-macro/span-preservation.rs
@@ -9,7 +9,7 @@ extern crate test_macros;
 
 #[recollect_attr]
 fn a() {
-    let x: usize = "hello";;;;; //~ ERROR mismatched types
+    let x: usize = "hello"; //~ ERROR mismatched types
 }
 
 #[recollect_attr]

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -6,7 +6,7 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:12:20
    |
-LL |     let x: usize = "hello";;;;;
+LL |     let x: usize = "hello";
    |                    ^^^^^^^ expected usize, found reference
    |
    = note: expected type `usize`


### PR DESCRIPTION
Closes #60876. 
A caveat (not necessarily a negative, but something to consider) with this implementation is that excess semicolons after return/continue/break now also cause an 'unreachable statement' warning.

For the following example:
```
fn main() {
    extra_semis();
}
fn extra_semis() -> i32 {
    let mut sum = 0;;;
    for i in 0..10 {
        if i == 5 {
            continue;;
        } else if i == 9 {
            break;;
        } else {
            sum += i;;
        }
    }
    return sum;;
}
```
The output is:
```
warning: unnecessary trailing semicolons
 --> src/main.rs:5:21
  |
5 |     let mut sum = 0;;;
  |                     ^^ help: remove these semicolons
  |
  = note: `#[warn(redundant_semicolon)]` on by default

warning: unnecessary trailing semicolon
 --> src/main.rs:8:22
  |
8 |             continue;;
  |                      ^ help: remove this semicolon

warning: unnecessary trailing semicolon
  --> src/main.rs:10:19
   |
10 |             break;;
   |                   ^ help: remove this semicolon

warning: unnecessary trailing semicolon
  --> src/main.rs:12:22
   |
12 |             sum += i;;
   |                      ^ help: remove this semicolon

warning: unnecessary trailing semicolon
  --> src/main.rs:15:16
   |
15 |     return sum;;
   |                ^ help: remove this semicolon

warning: unreachable statement
 --> src/main.rs:8:22
  |
8 |             continue;;
  |                      ^
  |
  = note: `#[warn(unreachable_code)]` on by default

warning: unreachable statement
  --> src/main.rs:10:19
   |
10 |             break;;
   |                   ^

warning: unreachable statement
  --> src/main.rs:15:16
   |
15 |     return sum;;
   |                ^

```