### PR TITLE
librustc_errors: Support ui-testing flag in annotate-snippet emitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,7 +3078,7 @@ dependencies = [
 name = "rustc_errors"
 version = "0.0.0"
 dependencies = [
- "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_data_structures 0.0.0",
@@ -4492,6 +4497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ammonia 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8b93ecb80665873703bf3b0a77f369c96b183d8e0afaf30a3ff5ff07dfc6409"
 "checksum ammonia 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c799ecf1ad77acb48b643e2f45b12d60ee41576287fc575031aa020de88b8f45"
 "checksum annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e"
+"checksum annotate-snippets 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7021ce4924a3f25f802b2cccd1af585e39ea1a363a1aa2e72afe54b67a3a7a7"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"

--- a/src/librustc_errors/Cargo.toml
+++ b/src/librustc_errors/Cargo.toml
@@ -17,4 +17,4 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 unicode-width = "0.1.4"
 atty = "0.2"
 termcolor = "1.0"
-annotate-snippets = "0.5.0"
+annotate-snippets = "0.6.1"

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -23,7 +23,7 @@ pub struct AnnotateSnippetEmitterWriter {
     source_map: Option<Lrc<SourceMapperDyn>>,
     /// If true, hides the longer explanation text
     short_message: bool,
-    /// If true, will normalize line numbers with LL to prevent noise in UI test diffs.
+    /// If true, will normalize line numbers with `LL` to prevent noise in UI test diffs.
     ui_testing: bool,
 }
 
@@ -173,10 +173,6 @@ impl AnnotateSnippetEmitterWriter {
     /// Allows to modify `Self` to enable or disable the `ui_testing` flag.
     ///
     /// If this is set to true, line numbers will be normalized as `LL` in the output.
-    // FIXME(#59346): This method is used via the public interface, but setting the `ui_testing`
-    // flag currently does not anonymize line numbers. We would have to add the `maybe_anonymized`
-    // method from `emitter.rs` and implement rust-lang/annotate-snippets-rs#2 in order to
-    // anonymize line numbers.
     pub fn ui_testing(mut self, ui_testing: bool) -> Self {
         self.ui_testing = ui_testing;
         self
@@ -202,7 +198,7 @@ impl AnnotateSnippetEmitterWriter {
         };
         if let Some(snippet) = converter.to_annotation_snippet() {
             let dl = DisplayList::from(snippet);
-            let dlf = DisplayListFormatter::new(true);
+            let dlf = DisplayListFormatter::new(true, self.ui_testing);
             // FIXME(#59346): Figure out if we can _always_ print to stderr or not.
             // `emitter.rs` has the `Destination` enum that lists various possible output
             // destinations.

--- a/src/test/ui/annotate-snippet/missing-type.stderr
+++ b/src/test/ui/annotate-snippet/missing-type.stderr
@@ -1,6 +1,6 @@
 error[E0412]: cannot find type `Iter` in this scope
- --> $DIR/missing-type.rs:4:11
-  |
-4 |     let x: Iter;
-  |            ^^^^ not found in this scope
-  |
+  --> $DIR/missing-type.rs:4:11
+   |
+LL |     let x: Iter;
+   |            ^^^^ not found in this scope
+   |


### PR DESCRIPTION
This adds support for the `-Z ui-testing` flag to the new
annotate-snippet diagnostic emitter.

Support for the flag was added to `annotate-snippet-rs` in these PRs:

* https://github.com/rust-lang/annotate-snippets-rs/pull/3
* https://github.com/rust-lang/annotate-snippets-rs/pull/5

r? @estebank 

Closes #61811