### PR TITLE
Implement Div and DivAssign for PathBuf

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -77,7 +77,7 @@ use crate::fs;
 use crate::hash::{Hash, Hasher};
 use crate::io;
 use crate::iter::{self, FusedIterator};
-use crate::ops::{self, Deref};
+use crate::ops::{self, Deref, Div, DivAssign};
 use crate::rc::Rc;
 use crate::str::FromStr;
 use crate::sync::Arc;
@@ -1705,6 +1705,54 @@ impl cmp::Ord for PathBuf {
 impl AsRef<OsStr> for PathBuf {
     fn as_ref(&self) -> &OsStr {
         &self.inner[..]
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl Div<&Path> for PathBuf {
+    type Output = PathBuf;
+    fn div(mut self, rhs: &Path) -> Self::Output {
+        self.push(rhs);
+        self
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl Div<&str> for PathBuf {
+    type Output = PathBuf;
+    fn div(mut self, rhs: &str) -> Self::Output {
+        self.push(rhs);
+        self
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl Div<&OsStr> for PathBuf {
+    type Output = PathBuf;
+    fn div(mut self, rhs: &OsStr) -> Self::Output {
+        self.push(rhs);
+        self
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl DivAssign<&Path> for PathBuf {
+    fn div_assign(&mut self, rhs: &Path) {
+        self.push(rhs);
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl DivAssign<&str> for PathBuf {
+    fn div_assign(&mut self, rhs: &str) {
+        self.push(rhs);
+    }
+}
+
+#[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
+impl DivAssign<&OsStr> for PathBuf {
+    fn div_assign(&mut self, rhs: &OsStr) {
+        self.push(rhs);
     }
 }
 

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1709,33 +1709,37 @@ impl AsRef<OsStr> for PathBuf {
 }
 
 /// Implements the `/` operator for concatenating two paths.
-/// 
-/// This consumes the `PathBuf` on the left-hand side and re-uses its buffer (growing it if necessary). This is done to avoid allocating a new `PathBuf` and copying the entire contents on every operation, which would lead to `O(n^2)` running time when building an `n`-byte path by repeated concatenation.
-/// 
-/// The path on the right-hand side is only borrowed; its contents are copied into the returned `PathBuf`.
-/// 
+///
+/// This consumes the `PathBuf` on the left-hand side and re-uses its buffer (growing it if
+/// necessary). This is done to avoid allocating a new `PathBuf` and copying the entire contents on
+/// every operation, which would lead to `O(n^2)` running time when building an `n`-byte path by
+/// repeated concatenation.
+///
+/// The path on the right-hand side is only borrowed; its contents are copied into the returned
+/// `PathBuf`.
+///
 /// # Examples
-/// 
+///
 /// Concatenating two `PathBuf`s takes the first by value and borrows the second:
-/// 
+///
 /// ```
 /// let a = PathBuf::from("hello");
 /// let b = PathBuf::from("world");
 /// let c = a + &b;
 /// // `a` is moved and can no longer be used here.
 /// ```
-/// 
+///
 /// If you want to keep using the first `PathBuf`, you can clone it and append to the clone instead:
-/// 
+///
 /// ```
 /// let a = PathBuf::from("hello");
 /// let b = PathBuf::from("world");
 /// let c = a.clone() + &b;
 /// // `a` is still valid here.
 /// ```
-/// 
+///
 /// Concatenating `&Path` slices can be done by converting the first to a `PathBuf`:
-/// 
+///
 /// ```
 /// let a = Path::new("hello");
 /// let b = Path::new("world");
@@ -1751,8 +1755,9 @@ impl Div<&Path> for PathBuf {
 }
 
 /// Implements the `/` operator for concatenating two paths.
-/// 
-/// This implementation takes a `&str` instead of a `&Path`. Refer to the `&Path` implementation for more details.
+///
+/// This implementation takes a `&str` instead of a `&Path`. Refer to the `&Path` implementation for
+/// more details.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl Div<&str> for PathBuf {
     type Output = PathBuf;
@@ -1764,8 +1769,9 @@ impl Div<&str> for PathBuf {
 
 
 /// Implements the `/` operator for concatenating two paths.
-/// 
-/// This implementation takes a `&OsStr` instead of a `&Path`. Refer to the `&Path` implementation for more details.
+///
+/// This implementation takes a `&OsStr` instead of a `&Path`. Refer to the `&Path` implementation
+/// for more details.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl Div<&OsStr> for PathBuf {
     type Output = PathBuf;
@@ -1776,9 +1782,9 @@ impl Div<&OsStr> for PathBuf {
 }
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
-/// 
+///
 /// This has the same behavior as the [`push`] method.
-/// 
+///
 /// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&Path> for PathBuf {
@@ -1789,9 +1795,9 @@ impl DivAssign<&Path> for PathBuf {
 
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
-/// 
+///
 /// This has the same behavior as the [`push`] method.
-/// 
+///
 /// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&str> for PathBuf {
@@ -1802,9 +1808,9 @@ impl DivAssign<&str> for PathBuf {
 
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
-/// 
+///
 /// This has the same behavior as the [`push`] method.
-/// 
+///
 /// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&OsStr> for PathBuf {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1723,6 +1723,7 @@ impl AsRef<OsStr> for PathBuf {
 /// Concatenating two `PathBuf`s takes the first by value and borrows the second:
 ///
 /// ```
+/// # use std::path::PathBuf;
 /// let a = PathBuf::from("hello");
 /// let b = PathBuf::from("world");
 /// let c = a + &b;
@@ -1732,6 +1733,7 @@ impl AsRef<OsStr> for PathBuf {
 /// If you want to keep using the first `PathBuf`, you can clone it and append to the clone instead:
 ///
 /// ```
+/// # use std::path::PathBuf;
 /// let a = PathBuf::from("hello");
 /// let b = PathBuf::from("world");
 /// let c = a.clone() + &b;
@@ -1741,6 +1743,7 @@ impl AsRef<OsStr> for PathBuf {
 /// Concatenating `&Path` slices can be done by converting the first to a `PathBuf`:
 ///
 /// ```
+/// # use std::path::Path;
 /// let a = Path::new("hello");
 /// let b = Path::new("world");
 /// let c = a.to_path_buf() + b;

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1708,6 +1708,39 @@ impl AsRef<OsStr> for PathBuf {
     }
 }
 
+/// Implements the `/` operator for concatenating two paths.
+/// 
+/// This consumes the `PathBuf` on the left-hand side and re-uses its buffer (growing it if necessary). This is done to avoid allocating a new `PathBuf` and copying the entire contents on every operation, which would lead to `O(n^2)` running time when building an `n`-byte path by repeated concatenation.
+/// 
+/// The path on the right-hand side is only borrowed; its contents are copied into the returned `PathBuf`.
+/// 
+/// # Examples
+/// 
+/// Concatenating two `PathBuf`s takes the first by value and borrows the second:
+/// 
+/// ```
+/// let a = PathBuf::from("hello");
+/// let b = PathBuf::from("world");
+/// let c = a + &b;
+/// // `a` is moved and can no longer be used here.
+/// ```
+/// 
+/// If you want to keep using the first `PathBuf`, you can clone it and append to the clone instead:
+/// 
+/// ```
+/// let a = PathBuf::from("hello");
+/// let b = PathBuf::from("world");
+/// let c = a.clone() + &b;
+/// // `a` is still valid here.
+/// ```
+/// 
+/// Concatenating `&Path` slices can be done by converting the first to a `PathBuf`:
+/// 
+/// ```
+/// let a = Path::new("hello");
+/// let b = Path::new("world");
+/// let c = a.to_path_buf() + b;
+/// ```
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl Div<&Path> for PathBuf {
     type Output = PathBuf;
@@ -1717,6 +1750,9 @@ impl Div<&Path> for PathBuf {
     }
 }
 
+/// Implements the `/` operator for concatenating two paths.
+/// 
+/// This implementation takes a `&str` instead of a `&Path`. Refer to the `&Path` implementation for more details.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl Div<&str> for PathBuf {
     type Output = PathBuf;
@@ -1726,6 +1762,10 @@ impl Div<&str> for PathBuf {
     }
 }
 
+
+/// Implements the `/` operator for concatenating two paths.
+/// 
+/// This implementation takes a `&OsStr` instead of a `&Path`. Refer to the `&Path` implementation for more details.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl Div<&OsStr> for PathBuf {
     type Output = PathBuf;
@@ -1735,6 +1775,9 @@ impl Div<&OsStr> for PathBuf {
     }
 }
 
+/// Implements the `/=` operator for appending to a `PathBuf`.
+/// 
+/// This has the same behavior as the [`push`][PathBuf::push] method.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&Path> for PathBuf {
     fn div_assign(&mut self, rhs: &Path) {
@@ -1742,6 +1785,10 @@ impl DivAssign<&Path> for PathBuf {
     }
 }
 
+
+/// Implements the `/=` operator for appending to a `PathBuf`.
+/// 
+/// This has the same behavior as the [`push`][PathBuf::push] method.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&str> for PathBuf {
     fn div_assign(&mut self, rhs: &str) {
@@ -1749,6 +1796,10 @@ impl DivAssign<&str> for PathBuf {
     }
 }
 
+
+/// Implements the `/=` operator for appending to a `PathBuf`.
+/// 
+/// This has the same behavior as the [`push`][PathBuf::push] method.
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&OsStr> for PathBuf {
     fn div_assign(&mut self, rhs: &OsStr) {

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1777,7 +1777,9 @@ impl Div<&OsStr> for PathBuf {
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
 /// 
-/// This has the same behavior as the [`push`][PathBuf::push] method.
+/// This has the same behavior as the [`push`] method.
+/// 
+/// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&Path> for PathBuf {
     fn div_assign(&mut self, rhs: &Path) {
@@ -1788,7 +1790,9 @@ impl DivAssign<&Path> for PathBuf {
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
 /// 
-/// This has the same behavior as the [`push`][PathBuf::push] method.
+/// This has the same behavior as the [`push`] method.
+/// 
+/// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&str> for PathBuf {
     fn div_assign(&mut self, rhs: &str) {
@@ -1799,7 +1803,9 @@ impl DivAssign<&str> for PathBuf {
 
 /// Implements the `/=` operator for appending to a `PathBuf`.
 /// 
-/// This has the same behavior as the [`push`][PathBuf::push] method.
+/// This has the same behavior as the [`push`] method.
+/// 
+/// [`push`]: struct.PathBuf.html#method.push
 #[stable(feature = "div_concat_pathbuf", since = "1.38.0")]
 impl DivAssign<&OsStr> for PathBuf {
     fn div_assign(&mut self, rhs: &OsStr) {


### PR DESCRIPTION
This change implements the `/` and `/=` operators for concatenating paths to a `PathBuf`, similar to how `+` and `+=` currently concatenate strings for `String`.

This would make it easier to build longer path values inline while improving readability. These operators have precedence in [Python 3][1] and [C++17][2], and in this implementation they can take either a `Path`, `str`, or `OsStr`.

Examples:
```rust
let home = PathBuf::from("/home");
let user = Path::new("user");
assert_eq!(Path::new("/home/user/documents"), home / user / "documents");
```

```rust
let mut base = PathBuf::from("/");
base /= "usr";
base /= OsStr::new("local");
assert_eq!(Path::from("/usr/local"), base);
```

I chose to submit a PR since that was the easier thing to do here, but if an RFC is preferred beforehand, I can do that too. 

[1]: https://docs.python.org/3/library/pathlib.html
[2]: https://en.cppreference.com/w/cpp/filesystem/path