### PR TITLE
error_index_generator should output stdout/stderr when it panics.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1493,7 +1493,7 @@ impl Step for ErrorIndex {
 
         builder.info(&format!("Testing error-index stage{}", compiler.stage));
         let _time = util::timeit(&builder);
-        builder.run(&mut tool);
+        builder.run_quiet(&mut tool);
         markdown_test(builder, compiler, &output);
     }
 }


### PR DESCRIPTION
**bootstrap change**

Call error_index_generator tool using run_quiet which will additionally print std out and std err of the command when it returns an error.
(was `run` uses `run_silent` under the covers.)

Why: PR #62871 is hitting a build error but the panic isn't getting shown so its unclear what the problem is.