### PR TITLE
add `repr(transparent)` to `IoSliceMut` where missing

### DIFF
--- a/src/libstd/sys/unix/io.rs
+++ b/src/libstd/sys/unix/io.rs
@@ -29,6 +29,7 @@ impl<'a> IoSlice<'a> {
     }
 }
 
+#[repr(transparent)]
 pub struct IoSliceMut<'a> {
     vec: iovec,
     _p: PhantomData<&'a mut [u8]>,

--- a/src/libstd/sys/wasi/io.rs
+++ b/src/libstd/sys/wasi/io.rs
@@ -29,6 +29,7 @@ impl<'a> IoSlice<'a> {
     }
 }
 
+#[repr(transparent)]
 pub struct IoSliceMut<'a> {
     vec: __wasi_iovec_t,
     _p: PhantomData<&'a mut [u8]>,

--- a/src/libstd/sys/windows/io.rs
+++ b/src/libstd/sys/windows/io.rs
@@ -29,6 +29,7 @@ impl<'a> IoSlice<'a> {
     }
 }
 
+#[repr(transparent)]
 pub struct IoSliceMut<'a> {
     vec: c::WSABUF,
     _p: PhantomData<&'a mut [u8]>,


### PR DESCRIPTION
tried using `IoSliceMut` in FFI, got `improper_ctypes` warning.

according to the docs: `IoSliceMut` is  "guaranteed to be ABI compatible with the `iovec` type" so it should be usable in FFI.
`IoSlice` is also `repr(transparent)` for every platform where these types contain `iovec`-like types.
vxworks also has `IoSliceMut` as transparent so its not even consistently one or the other.

no comment about this next to the types or in the PR that introduced the types, so assuming this was just missed. 

r? @sfackler 