### PR TITLE
Use MaybeUninit to produce more correct layouts

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -208,6 +208,8 @@ use crate::mem::ManuallyDrop;
 /// guarantee may evolve.
 #[allow(missing_debug_implementations)]
 #[stable(feature = "maybe_uninit", since = "1.36.0")]
+// Lang item so we can wrap other types in it. This is useful for generators.
+#[cfg_attr(not(bootstrap), lang = "maybe_uninit")]
 #[derive(Copy)]
 #[repr(transparent)]
 pub union MaybeUninit<T> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -365,6 +365,8 @@ language_item_table! {
 
     ManuallyDropItem,            "manually_drop",      manually_drop,           Target::Struct;
 
+    MaybeUninitLangItem,         "maybe_uninit",       maybe_uninit,            Target::Union;
+
     DebugTraitLangItem,          "debug_trait",        debug_trait,             Target::Trait;
 
     // Align offset for stride != 1, must not panic.

--- a/src/test/run-pass/generator/niche-in-generator.rs
+++ b/src/test/run-pass/generator/niche-in-generator.rs
@@ -1,0 +1,17 @@
+// Test that niche finding works with captured generator upvars.
+
+#![feature(generators)]
+
+use std::mem::size_of_val;
+
+fn take<T>(_: T) {}
+
+fn main() {
+    let x = false;
+    let gen1 = || {
+        yield;
+        take(x);
+    };
+
+    assert_eq!(size_of_val(&gen1), size_of_val(&Some(gen1)));
+}

--- a/src/test/ui/async-await/issues/issue-59972.rs
+++ b/src/test/ui/async-await/issues/issue-59972.rs
@@ -1,3 +1,7 @@
+// Incorrect handling of uninhabited types could cause us to mark generator
+// types as entirely uninhabited, when they were in fact constructible. This
+// caused us to hit "unreachable" code (illegal instruction on x86).
+
 // run-pass
 
 // compile-flags: --edition=2018
@@ -19,7 +23,18 @@ async fn contains_never() {
     let error2 = error;
 }
 
+#[allow(unused)]
+async fn overlap_never() {
+    let error1 = uninhabited_async();
+    noop().await;
+    let error2 = uninhabited_async();
+    drop(error1);
+    noop().await;
+    drop(error2);
+}
+
 #[allow(unused_must_use)]
 fn main() {
     contains_never();
+    overlap_never();
 }


### PR DESCRIPTION
This fixes a latent instance of #59972 where we would promote an uninhabited field to the generator prefix, causing the entire generator to be uninhabited.

r? @eddyb 
cc @cramertj @Zoxc 