### PR TITLE
Add lib section to rustc_lexer's Cargo.toml

### DIFF
--- a/src/librustc_lexer/Cargo.toml
+++ b/src/librustc_lexer/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 [dependencies]
 unicode-xid = { version = "0.1.0", optional = true }
 
+# Note: do not remove this blank `[lib]` section.
+# This will be used when publishing this crate as `rustc-ap-rustc_lexer`.
 [lib]
 doctest = false
 name = "rustc_lexer"

--- a/src/librustc_lexer/Cargo.toml
+++ b/src/librustc_lexer/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2018"
 # Note that this crate purposefully does not depend on other rustc crates
 [dependencies]
 unicode-xid = { version = "0.1.0", optional = true }
+
+[lib]
+doctest = false
+name = "rustc_lexer"


### PR DESCRIPTION
This is required to fix the rustc-ap-syntax build error in the recent version. The error could also be fixed on the [rustc-auto-publish](https://github.com/alexcrichton/rustc-auto-publish) side by manually adding `[lib]` section if one does not exist. The latter approach, however, may have a surprising side effect, so I am opting for a simpler solution for now.

r? @alexcrichton 