### PR TITLE
Specify explicit library (not package) name for rustc_lexer

### DIFF
--- a/src/librustc_lexer/Cargo.toml
+++ b/src/librustc_lexer/Cargo.toml
@@ -4,6 +4,9 @@ name = "rustc_lexer"
 version = "0.1.0"
 edition = "2018"
 
+[lib]
+name = "rustc_lexer"
+
 # Note that this crate purposefully does not depend on other rustc crates
 [dependencies]
 unicode-xid = { version = "0.1.0", optional = true }

--- a/src/librustc_macros/Cargo.toml
+++ b/src/librustc_macros/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Rust Project Developers"]
 edition = "2018"
 
 [lib]
+name = "rustc_macros"
 proc-macro = true
 
 [dependencies]


### PR DESCRIPTION
Hopefully fixes:

```
   Compiling rustc-ap-syntax v540.0.0
error[E0432]: unresolved import `rustc_lexer`
 --> /home/simon/.cargo/registry/src/github.com-1ecc6299db9ec823/rustc-ap-syntax-540.0.0/parse/lexer/mod.rs:8:5
  |
8 | use rustc_lexer::Base;
  |     ^^^^^^^^^^^ use of undeclared type or module `rustc_lexer`
```

For a dependency declared on `rustc-ap-rustc_lexer`, when trying to update rustfmt