### PR TITLE
Use doc comments from 'pub use' statements

### DIFF
--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -30,7 +30,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
 
     for &cnum in cx.tcx.crates().iter() {
         for &did in cx.tcx.all_trait_implementations(cnum).iter() {
-            inline::build_impl(cx, did, &mut new_items);
+            inline::build_impl(cx, did, None, &mut new_items);
         }
     }
 
@@ -66,7 +66,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
 
     for def_id in primitive_impls.iter().filter_map(|&def_id| def_id) {
         if !def_id.is_local() {
-            inline::build_impl(cx, def_id, &mut new_items);
+            inline::build_impl(cx, def_id, None, &mut new_items);
 
             // FIXME(eddyb) is this `doc(hidden)` check needed?
             if !cx.tcx.get_attrs(def_id).lists(sym::doc).has_word(sym::hidden) {
@@ -119,7 +119,7 @@ pub fn collect_trait_impls(krate: Crate, cx: &DocContext<'_>) -> Crate {
     for &trait_did in cx.all_traits.iter() {
         for &impl_node in cx.tcx.hir().trait_impls(trait_did) {
             let impl_did = cx.tcx.hir().local_def_id(impl_node);
-            inline::build_impl(cx, impl_did, &mut new_items);
+            inline::build_impl(cx, impl_did, None, &mut new_items);
         }
     }
 

--- a/src/test/rustdoc/inline_cross/add-docs.rs
+++ b/src/test/rustdoc/inline_cross/add-docs.rs
@@ -1,0 +1,9 @@
+// aux-build:add-docs.rs
+
+extern crate inner;
+
+
+// @has add_docs/struct.MyStruct.html
+// @has add_docs/struct.MyStruct.html "Doc comment from 'pub use', Doc comment from definition"
+/// Doc comment from 'pub use',
+pub use inner::MyStruct;

--- a/src/test/rustdoc/inline_cross/auxiliary/add-docs.rs
+++ b/src/test/rustdoc/inline_cross/auxiliary/add-docs.rs
@@ -1,0 +1,4 @@
+#![crate_name = "inner"]
+
+/// Doc comment from definition
+pub struct MyStruct;


### PR DESCRIPTION
Split off from #62855

Currently, rustdoc ignores any doc comments found on 'pub use'
statements. As described in issue #58700, this makes it impossible to
properly document procedural macros. Any doc comments must be written on
the procedural macro definition, which must occur in a dedicated
proc-macro crate. This means that any doc comments or doc tests cannot
reference items defined in re-exporting crate, despite the fact that
such items may be required to use the procedural macro.

To solve this issue, this commit allows doc comments to be written on
'pub use' statements. For consistency, this applies to *all* 'pub use'
statements, not just those importing procedural macros.

When inlining documentation, documentation on 'pub use' statements will
be prepended to the documentation of the inlined item. For example,
the following items:

```rust

mod other_mod {
    /// Doc comment from definition
    pub struct MyStruct;
}

/// Doc comment from 'pub use'
///
pub use other_mod::MyStruct;
```

will caues the documentation for the re-export of 'MyStruct' to be
rendered as:

```
Doc comment from 'pub use'
Doc comment from definition
```

Note the empty line in the 'pub use' doc comments - because doc comments
are concatenated as-is, this ensure that the doc comments on the
definition start on a new line.