### PR TITLE
Give built-in macros stable addresses in the standard library

### DIFF
--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -133,6 +133,14 @@ pub trait Clone : Sized {
     }
 }
 
+/// Derive macro generating an impl of the trait `Clone`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+pub macro Clone($item:item) { /* compiler built-in */ }
+
 // FIXME(aburka): these structs are used solely by #[derive] to
 // assert that every component of a type implements Clone or Copy.
 //

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -200,6 +200,14 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
 }
 
+/// Derive macro generating an impl of the trait `PartialEq`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro PartialEq($item:item) { /* compiler built-in */ }
+
 /// Trait for equality comparisons which are [equivalence relations](
 /// https://en.wikipedia.org/wiki/Equivalence_relation).
 ///
@@ -255,6 +263,14 @@ pub trait Eq: PartialEq<Self> {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn assert_receiver_is_total_eq(&self) {}
 }
+
+/// Derive macro generating an impl of the trait `Eq`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_eq)]
+pub macro Eq($item:item) { /* compiler built-in */ }
 
 // FIXME: this struct is used solely by #[derive] to
 // assert that every component of a type implements Eq.
@@ -600,6 +616,14 @@ pub trait Ord: Eq + PartialOrd<Self> {
     }
 }
 
+/// Derive macro generating an impl of the trait `Ord`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro Ord($item:item) { /* compiler built-in */ }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for Ordering {}
 
@@ -841,6 +865,14 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
         }
     }
 }
+
+/// Derive macro generating an impl of the trait `PartialOrd`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro PartialOrd($item:item) { /* compiler built-in */ }
 
 /// Compares and returns the minimum of two values.
 ///

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -115,6 +115,14 @@ pub trait Default: Sized {
     fn default() -> Self;
 }
 
+/// Derive macro generating an impl of the trait `Default`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro Default($item:item) { /* compiler built-in */ }
+
 macro_rules! default_impl {
     ($t:ty, $v:expr, $doc:tt) => {
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -545,6 +545,21 @@ pub trait Debug {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result;
 }
 
+// Separate module to reexport the macro `Debug` from prelude without the trait `Debug`.
+#[cfg(not(bootstrap))]
+pub(crate) mod macros {
+    /// Derive macro generating an impl of the trait `Debug`.
+    #[rustc_builtin_macro]
+    #[rustc_macro_transparency = "semitransparent"]
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    #[allow_internal_unstable(core_intrinsics)]
+    pub macro Debug($item:item) { /* compiler built-in */ }
+}
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(inline)]
+pub use macros::Debug;
+
 /// Format trait for an empty format, `{}`.
 ///
 /// `Display` is similar to [`Debug`][debug], but `Display` is for user-facing

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -198,6 +198,21 @@ pub trait Hash {
     }
 }
 
+// Separate module to reexport the macro `Hash` from prelude without the trait `Hash`.
+#[cfg(not(bootstrap))]
+pub(crate) mod macros {
+    /// Derive macro generating an impl of the trait `Hash`.
+    #[rustc_builtin_macro]
+    #[rustc_macro_transparency = "semitransparent"]
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    #[allow_internal_unstable(core_intrinsics)]
+    pub macro Hash($item:item) { /* compiler built-in */ }
+}
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(inline)]
+pub use macros::Hash;
+
 /// A trait for hashing an arbitrary stream of bytes.
 ///
 /// Instances of `Hasher` usually represent state that is changed while hashing

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -714,9 +714,9 @@ pub(crate) mod builtin {
     /// [`panic!`]: ../std/macro.panic.html
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro compile_error {
-        ($msg:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! compile_error {
+        ($msg:expr) => ({ /* compiler built-in */ });
         ($msg:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -768,8 +768,10 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
-    pub macro format_args {
-        ($fmt:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    #[rustc_macro_transparency = "opaque"]
+    macro_rules! format_args {
+        ($fmt:expr) => ({ /* compiler built-in */ });
         ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
     }
 
@@ -779,8 +781,10 @@ pub(crate) mod builtin {
                          language use and is subject to change")]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
-    pub macro format_args_nl {
-        ($fmt:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    #[rustc_macro_transparency = "opaque"]
+    macro_rules! format_args_nl {
+        ($fmt:expr) => ({ /* compiler built-in */ });
         ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
     }
 
@@ -817,9 +821,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro env {
-        ($name:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! env {
+        ($name:expr) => ({ /* compiler built-in */ });
         ($name:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -844,9 +848,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro option_env {
-        ($name:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! option_env {
+        ($name:expr) => ({ /* compiler built-in */ });
         ($name:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -877,9 +881,9 @@ pub(crate) mod builtin {
     #[unstable(feature = "concat_idents", issue = "29599",
                reason = "`concat_idents` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro concat_idents {
-        ($($e:ident),+) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! concat_idents {
+        ($($e:ident),+) => ({ /* compiler built-in */ });
         ($($e:ident,)+) => ({ /* compiler built-in */ })
     }
 
@@ -900,9 +904,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro concat {
-        ($($e:expr),*) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! concat {
+        ($($e:expr),*) => ({ /* compiler built-in */ });
         ($($e:expr,)*) => ({ /* compiler built-in */ })
     }
 
@@ -929,8 +933,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro line() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! line { () => { /* compiler built-in */ } }
 
     /// Expands to the column number at which it was invoked.
     ///
@@ -955,15 +959,15 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro column() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! column { () => { /* compiler built-in */ } }
 
     /// Same as `column`, but less likely to be shadowed.
     #[unstable(feature = "__rust_unstable_column", issue = "0",
                reason = "internal implementation detail of the `panic` macro")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro __rust_unstable_column() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! __rust_unstable_column { () => { /* compiler built-in */ } }
 
     /// Expands to the file name in which it was invoked.
     ///
@@ -987,8 +991,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro file() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! file { () => { /* compiler built-in */ } }
 
     /// Stringifies its arguments.
     ///
@@ -1007,8 +1011,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro stringify($($t:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! stringify { ($($t:tt)*) => { /* compiler built-in */ } }
 
     /// Includes a utf8-encoded file as a string.
     ///
@@ -1042,9 +1046,9 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include_str {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include_str {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1080,9 +1084,9 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include_bytes {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include_bytes {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1105,8 +1109,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro module_path() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! module_path { () => { /* compiler built-in */ } }
 
     /// Evaluates boolean combinations of configuration flags at compile-time.
     ///
@@ -1130,8 +1134,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro cfg($($cfg:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! cfg { ($($cfg:tt)*) => { /* compiler built-in */ } }
 
     /// Parses a file as an expression or an item according to the context.
     ///
@@ -1174,9 +1178,9 @@ pub(crate) mod builtin {
     /// "🙈🙊🙉🙈🙊🙉".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1227,10 +1231,10 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro assert {
-        ($cond:expr) => ({ /* compiler built-in */ }),
-        ($cond:expr,) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! assert {
+        ($cond:expr) => ({ /* compiler built-in */ });
+        ($cond:expr,) => ({ /* compiler built-in */ });
         ($cond:expr, $($arg:tt)+) => ({ /* compiler built-in */ })
     }
 
@@ -1238,34 +1242,34 @@ pub(crate) mod builtin {
     #[unstable(feature = "asm", issue = "29722",
                reason = "inline assembly is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro asm("assembly template"
-                  : $("output"(operand),)*
-                  : $("input"(operand),)*
-                  : $("clobbers",)*
-                  : $("options",)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! asm { ("assembly template"
+                        : $("output"(operand),)*
+                        : $("input"(operand),)*
+                        : $("clobbers",)*
+                        : $("options",)*) => { /* compiler built-in */ } }
 
     /// Module-level inline assembly.
     #[unstable(feature = "global_asm", issue = "35119",
                reason = "`global_asm!` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro global_asm("assembly") { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! global_asm { ("assembly") => { /* compiler built-in */ } }
 
     /// Prints passed tokens into the standard output.
     #[unstable(feature = "log_syntax", issue = "29598",
                reason = "`log_syntax!` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro log_syntax($($arg:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! log_syntax { ($($arg:tt)*) => { /* compiler built-in */ } }
 
     /// Enables or disables tracing functionality used for debugging other macros.
     #[unstable(feature = "trace_macros", issue = "29598",
                reason = "`trace_macros` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro trace_macros {
-        (true) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! trace_macros {
+        (true) => ({ /* compiler built-in */ });
         (false) => ({ /* compiler built-in */ })
     }
 
@@ -1298,69 +1302,6 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[rustc_macro_transparency = "semitransparent"]
     pub macro global_allocator($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Clone`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
-    pub macro Clone($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Copy`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
-    pub macro Copy($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Debug`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Debug($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Default`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Default($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Eq`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_eq)]
-    pub macro Eq($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Hash`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Hash($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Ord`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Ord($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `PartialEq`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro PartialEq($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `PartialOrd`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro PartialOrd($item:item) { /* compiler built-in */ }
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -288,6 +288,14 @@ pub trait Copy : Clone {
     // Empty.
 }
 
+/// Derive macro generating an impl of the trait `Copy`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+pub macro Copy($item:item) { /* compiler built-in */ }
+
 /// Types for which it is safe to share references between threads.
 ///
 /// This trait is automatically implemented when the compiler determines

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -48,24 +48,20 @@ pub use crate::result::Result::{self, Ok, Err};
 // Re-exported built-in macros
 #[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow(deprecated)]
 #[doc(no_inline)]
-pub use crate::macros::builtin::{
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    RustcDecodable,
-    RustcEncodable,
+pub use crate::fmt::macros::Debug;
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::hash::macros::Hash;
+
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::{
     __rust_unstable_column,
     asm,
     assert,
-    bench,
     cfg,
     column,
     compile_error,
@@ -75,7 +71,6 @@ pub use crate::macros::builtin::{
     file,
     format_args,
     format_args_nl,
-    global_allocator,
     global_asm,
     include,
     include_bytes,
@@ -85,7 +80,18 @@ pub use crate::macros::builtin::{
     module_path,
     option_env,
     stringify,
+    trace_macros,
+};
+
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow(deprecated)]
+#[doc(no_inline)]
+pub use crate::macros::builtin::{
+    RustcDecodable,
+    RustcEncodable,
+    bench,
+    global_allocator,
     test,
     test_case,
-    trace_macros,
 };

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -326,16 +326,6 @@ use prelude::v1::*;
 // Access to Bencher, etc.
 #[cfg(test)] extern crate test;
 
-// Re-export a few macros from core
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::{assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::{unreachable, unimplemented, write, writeln, todo};
-// FIXME: change this to `#[allow(deprecated)]` when we update nightly compiler.
-#[allow(deprecated_in_future)]
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::r#try;
-
 #[allow(unused_imports)] // macros from `alloc` are not used on all platforms
 #[macro_use]
 extern crate alloc as alloc_crate;
@@ -520,33 +510,52 @@ mod std_detect;
 #[cfg(not(test))]
 pub use std_detect::detect;
 
-// Document built-in macros in the crate root for consistency with libcore and existing tradition.
-// FIXME: Attribute and derive macros are not reexported because rustdoc renders them
-// as reexports rather than as macros, and that's not what we want.
-#[cfg(rustdoc)]
+// Re-export macros defined in libcore.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated_in_future)]
+pub use core::{
+    // Stable
+    assert_eq,
+    assert_ne,
+    debug_assert_eq,
+    debug_assert_ne,
+    debug_assert,
+    r#try,
+    unimplemented,
+    unreachable,
+    write,
+    writeln,
+    // Unstable
+    todo,
+};
+
+// Re-export built-in macros defined through libcore.
+#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-pub use crate::prelude::v1::{
-    __rust_unstable_column,
-    asm,
+pub use core::{
+    // Stable
     assert,
     cfg,
     column,
     compile_error,
     concat,
-    concat_idents,
     env,
     file,
     format_args,
-    format_args_nl,
-    global_asm,
     include,
     include_bytes,
     include_str,
     line,
-    log_syntax,
     module_path,
     option_env,
     stringify,
+    // Unstable
+    __rust_unstable_column,
+    asm,
+    concat_idents,
+    format_args_nl,
+    global_asm,
+    log_syntax,
     trace_macros,
 };
 

--- a/src/test/ui/imports/issue-53512.rs
+++ b/src/test/ui/imports/issue-53512.rs
@@ -1,6 +1,7 @@
 // Macro from prelude is shadowed by non-existent import recovered as `Res::Err`.
 
-use std::assert; //~ ERROR unresolved import `std::assert`
+mod m {}
+use m::assert; //~ ERROR unresolved import `m::assert`
 
 fn main() {
     assert!(true);

--- a/src/test/ui/imports/issue-53512.stderr
+++ b/src/test/ui/imports/issue-53512.stderr
@@ -1,8 +1,8 @@
-error[E0432]: unresolved import `std::assert`
-  --> $DIR/issue-53512.rs:3:5
+error[E0432]: unresolved import `m::assert`
+  --> $DIR/issue-53512.rs:4:5
    |
-LL | use std::assert;
-   |     ^^^^^^^^^^^ no `assert` in the root
+LL | use m::assert;
+   |     ^^^^^^^^^ no `assert` in `m`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/builtin-prelude-no-accidents.rs
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.rs
@@ -1,0 +1,8 @@
+// Names of public modules in libstd and libcore don't accidentally get into prelude
+// because macros with the same names are in prelude.
+
+fn main() {
+    env::current_dir; //~ ERROR use of undeclared type or module `env`
+    type A = panic::PanicInfo; //~ ERROR use of undeclared type or module `panic`
+    type B = vec::Vec<u8>; //~ ERROR use of undeclared type or module `vec`
+}

--- a/src/test/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared type or module `env`
+  --> $DIR/builtin-prelude-no-accidents.rs:5:5
+   |
+LL |     env::current_dir;
+   |     ^^^ use of undeclared type or module `env`
+
+error[E0433]: failed to resolve: use of undeclared type or module `panic`
+  --> $DIR/builtin-prelude-no-accidents.rs:6:14
+   |
+LL |     type A = panic::PanicInfo;
+   |              ^^^^^ use of undeclared type or module `panic`
+
+error[E0433]: failed to resolve: use of undeclared type or module `vec`
+  --> $DIR/builtin-prelude-no-accidents.rs:7:14
+   |
+LL |     type B = vec::Vec<u8>;
+   |              ^^^ use of undeclared type or module `vec`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/macros/builtin-std-paths-fail.rs
+++ b/src/test/ui/macros/builtin-std-paths-fail.rs
@@ -1,0 +1,21 @@
+#[derive(
+    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
+    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
+)]
+#[core::bench] //~ ERROR could not find `bench` in `core`
+#[core::global_allocator] //~ ERROR could not find `global_allocator` in `core`
+#[core::test_case] //~ ERROR could not find `test_case` in `core`
+#[core::test] //~ ERROR could not find `test` in `core`
+struct Core;
+
+#[derive(
+    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
+    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
+)]
+#[std::bench] //~ ERROR could not find `bench` in `std`
+#[std::global_allocator] //~ ERROR could not find `global_allocator` in `std`
+#[std::test_case] //~ ERROR could not find `test_case` in `std`
+#[std::test] //~ ERROR could not find `test` in `std`
+struct Std;
+
+fn main() {}

--- a/src/test/ui/macros/builtin-std-paths-fail.stderr
+++ b/src/test/ui/macros/builtin-std-paths-fail.stderr
@@ -1,0 +1,75 @@
+error[E0433]: failed to resolve: could not find `bench` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:5:9
+   |
+LL | #[core::bench]
+   |         ^^^^^ could not find `bench` in `core`
+
+error[E0433]: failed to resolve: could not find `global_allocator` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:6:9
+   |
+LL | #[core::global_allocator]
+   |         ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `core`
+
+error[E0433]: failed to resolve: could not find `test_case` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:7:9
+   |
+LL | #[core::test_case]
+   |         ^^^^^^^^^ could not find `test_case` in `core`
+
+error[E0433]: failed to resolve: could not find `test` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:8:9
+   |
+LL | #[core::test]
+   |         ^^^^ could not find `test` in `core`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:2:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:3:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
+error[E0433]: failed to resolve: could not find `bench` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:15:8
+   |
+LL | #[std::bench]
+   |        ^^^^^ could not find `bench` in `std`
+
+error[E0433]: failed to resolve: could not find `global_allocator` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:16:8
+   |
+LL | #[std::global_allocator]
+   |        ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `std`
+
+error[E0433]: failed to resolve: could not find `test_case` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:17:8
+   |
+LL | #[std::test_case]
+   |        ^^^^^^^^^ could not find `test_case` in `std`
+
+error[E0433]: failed to resolve: could not find `test` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:18:8
+   |
+LL | #[std::test]
+   |        ^^^^ could not find `test` in `std`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:12:10
+   |
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:13:10
+   |
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/macros/builtin-std-paths.rs
+++ b/src/test/ui/macros/builtin-std-paths.rs
@@ -1,0 +1,32 @@
+// check-pass
+
+#[derive(
+    core::clone::Clone,
+    core::marker::Copy,
+    core::fmt::Debug,
+    core::default::Default,
+    core::cmp::Eq,
+    core::hash::Hash,
+    core::cmp::Ord,
+    core::cmp::PartialEq,
+    core::cmp::PartialOrd,
+)]
+struct Core;
+
+#[derive(
+    std::clone::Clone,
+    std::marker::Copy,
+    std::fmt::Debug,
+    std::default::Default,
+    std::cmp::Eq,
+    std::hash::Hash,
+    std::cmp::Ord,
+    std::cmp::PartialEq,
+    std::cmp::PartialOrd,
+)]
+struct Std;
+
+fn main() {
+    core::column!();
+    std::column!();
+}


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust/pull/62086.

Derive macros corresponding to traits from libcore are now available through the same paths as those traits:
- `Clone` - `{core,std}::clone::Clone`
- `PartialEq` - `{core,std}::cmp::PartialEq`
- `Eq` - `{core,std}::cmp::Eq`
- `PartialOrd` - `{core,std}::cmp::PartialOrd`
- `Ord` - `{core,std}::cmp::Ord`
- `Default` - `{core,std}::default::Default`
- `Debug` - `{core,std}::fmt::Debug`
- `Hash` - `{core,std}::hash::Hash`
- `Copy` - `{core,std}::marker::Copy`

Fn-like built-in macros are now available through libcore and libstd's root module, by analogy with non-builtin macros defined by libcore and libstd:
```rust
{core,std}::{
    __rust_unstable_column,
    asm,
    assert,
    cfg,
    column,
    compile_error,
    concat,
    concat_idents,
    env,
    file,
    format_args,
    format_args_nl,
    global_asm,
    include,
    include_bytes,
    include_str,
    line,
    log_syntax,
    module_path,
    option_env,
    stringify,
    trace_macros,
}
```

Derive macros without a corresponding trait in libcore or libstd are still available only through prelude (also see https://github.com/rust-lang/rust/pull/62507).
Attribute macros also keep being available only through prelude, mostly because they don't have an existing practice to follow. An advice from the library team on their eventual placement would be appreciated.
```rust
    RustcDecodable,
    RustcEncodable,
    bench,
    global_allocator,
    test,
    test_case,
```

r? @alexcrichton 