### PR TITLE
Miri: fix determining size of an "extra function" allocation

### DIFF
--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -57,18 +57,12 @@ pub trait AllocMap<K: Hash + Eq, V> {
 
     /// Read-only lookup.
     fn get(&self, k: K) -> Option<&V> {
-        match self.get_or(k, || Err(())) {
-            Ok(v) => Some(v),
-            Err(()) => None,
-        }
+        self.get_or(k, || Err(())).ok()
     }
 
     /// Mutable lookup.
     fn get_mut(&mut self, k: K) -> Option<&mut V> {
-        match self.get_mut_or(k, || Err(())) {
-            Ok(v) => Some(v),
-            Err(()) => None,
-        }
+        self.get_mut_or(k, || Err(())).ok()
     }
 }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -54,6 +54,22 @@ pub trait AllocMap<K: Hash + Eq, V> {
         k: K,
         vacant: impl FnOnce() -> Result<V, E>
     ) -> Result<&mut V, E>;
+
+    /// Read-only lookup.
+    fn get(&self, k: K) -> Option<&V> {
+        match self.get_or(k, || Err(())) {
+            Ok(v) => Some(v),
+            Err(()) => None,
+        }
+    }
+
+    /// Mutable lookup.
+    fn get_mut(&mut self, k: K) -> Option<&mut V> {
+        match self.get_mut_or(k, || Err(())) {
+            Ok(v) => Some(v),
+            Err(()) => None,
+        }
+    }
 }
 
 /// Methods of this trait signifies a point where CTFE evaluation would fail

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -538,45 +538,43 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         // Don't use `self.get` here as that will
         // a) cause cycles in case `id` refers to a static
         // b) duplicate a static's allocation in miri
-        match self.alloc_map.get_or(id, || Err(())) {
-            Ok((_, alloc)) => Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align)),
-            Err(()) => {
-                // Not a local allocation, check the global `tcx.alloc_map`.
+        if let Some((_, alloc)) = self.alloc_map.get(id) {
+            return Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align));
+        }
+        // Not a local allocation, check the global `tcx.alloc_map`.
 
-                // Can't do this in the match argument, we may get cycle errors since the lock would
-                // be held throughout the match.
-                let alloc = self.tcx.alloc_map.lock().get(id);
-                match alloc {
-                    Some(GlobalAlloc::Static(did)) => {
-                        // Use size and align of the type.
-                        let ty = self.tcx.type_of(did);
-                        let layout = self.tcx.layout_of(ParamEnv::empty().and(ty)).unwrap();
-                        Ok((layout.size, layout.align.abi))
-                    },
-                    Some(GlobalAlloc::Memory(alloc)) =>
-                        // Need to duplicate the logic here, because the global allocations have
-                        // different associated types than the interpreter-local ones.
-                        Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align)),
-                    Some(GlobalAlloc::Function(_)) => {
-                        if let AllocCheck::Dereferencable = liveness {
-                            // The caller requested no function pointers.
-                            err!(DerefFunctionPointer)
-                        } else {
-                            Ok((Size::ZERO, Align::from_bytes(1).unwrap()))
-                        }
-                    },
-                    // The rest must be dead.
-                    None => if let AllocCheck::MaybeDead = liveness {
-                        // Deallocated pointers are allowed, we should be able to find
-                        // them in the map.
-                        Ok(*self.dead_alloc_map.get(&id)
-                            .expect("deallocated pointers should all be recorded in \
-                                    `dead_alloc_map`"))
-                    } else {
-                        err!(DanglingPointerDeref)
-                    },
+        // Can't do this in the match argument, we may get cycle errors since the lock would
+        // be held throughout the match.
+        let alloc = self.tcx.alloc_map.lock().get(id);
+        match alloc {
+            Some(GlobalAlloc::Static(did)) => {
+                // Use size and align of the type.
+                let ty = self.tcx.type_of(did);
+                let layout = self.tcx.layout_of(ParamEnv::empty().and(ty)).unwrap();
+                Ok((layout.size, layout.align.abi))
+            },
+            Some(GlobalAlloc::Memory(alloc)) =>
+                // Need to duplicate the logic here, because the global allocations have
+                // different associated types than the interpreter-local ones.
+                Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align)),
+            Some(GlobalAlloc::Function(_)) => {
+                if let AllocCheck::Dereferencable = liveness {
+                    // The caller requested no function pointers.
+                    err!(DerefFunctionPointer)
+                } else {
+                    Ok((Size::ZERO, Align::from_bytes(1).unwrap()))
                 }
-            }
+            },
+            // The rest must be dead.
+            None => if let AllocCheck::MaybeDead = liveness {
+                // Deallocated pointers are allowed, we should be able to find
+                // them in the map.
+                Ok(*self.dead_alloc_map.get(&id)
+                    .expect("deallocated pointers should all be recorded in \
+                            `dead_alloc_map`"))
+            } else {
+                err!(DanglingPointerDeref)
+            },
         }
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -535,14 +535,26 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         id: AllocId,
         liveness: AllocCheck,
     ) -> InterpResult<'static, (Size, Align)> {
+        // # Regular allocations
         // Don't use `self.get` here as that will
         // a) cause cycles in case `id` refers to a static
         // b) duplicate a static's allocation in miri
         if let Some((_, alloc)) = self.alloc_map.get(id) {
             return Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align));
         }
-        // Not a local allocation, check the global `tcx.alloc_map`.
 
+        // # Function pointers
+        // (both global from `alloc_map` and local from `extra_fn_ptr_map`)
+        if let Ok(_) = self.get_fn_alloc(id) {
+            return if let AllocCheck::Dereferencable = liveness {
+                // The caller requested no function pointers.
+                err!(DerefFunctionPointer)
+            } else {
+                Ok((Size::ZERO, Align::from_bytes(1).unwrap()))
+            };
+        }
+
+        // # Statics
         // Can't do this in the match argument, we may get cycle errors since the lock would
         // be held throughout the match.
         let alloc = self.tcx.alloc_map.lock().get(id);
@@ -557,14 +569,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 // Need to duplicate the logic here, because the global allocations have
                 // different associated types than the interpreter-local ones.
                 Ok((Size::from_bytes(alloc.bytes.len() as u64), alloc.align)),
-            Some(GlobalAlloc::Function(_)) => {
-                if let AllocCheck::Dereferencable = liveness {
-                    // The caller requested no function pointers.
-                    err!(DerefFunctionPointer)
-                } else {
-                    Ok((Size::ZERO, Align::from_bytes(1).unwrap()))
-                }
-            },
+            Some(GlobalAlloc::Function(_)) =>
+                bug!("We already checked function pointers above"),
             // The rest must be dead.
             None => if let AllocCheck::MaybeDead = liveness {
                 // Deallocated pointers are allowed, we should be able to find


### PR DESCRIPTION
Fixes [a bug](https://github.com/rust-lang/miri/pull/862) introduced by https://github.com/rust-lang/rust/pull/62982. Best reviewed commit-by-commit.

r? @oli-obk