### PR TITLE
tidy: Cleanup the directory whitelist

### DIFF
--- a/src/librustc_data_structures/owning_ref/mod.rs
+++ b/src/librustc_data_structures/owning_ref/mod.rs
@@ -10,7 +10,7 @@ This allows moving and dropping of a `OwningRef` without needing to recreate the
 This can sometimes be useful because Rust borrowing rules normally prevent
 moving a type that has been moved from. For example, this kind of code gets rejected:
 
-```rust,ignore
+```compile_fail,E0515
 fn return_owned_and_referenced<'a>() -> (Vec<u8>, &'a [u8]) {
     let v = vec![1, 2, 3, 4];
     let s = &v[1..3];
@@ -43,7 +43,8 @@ and preventing mutable access to root containers, which in practice requires hea
 as provided by `Box<T>`, `Rc<T>`, etc.
 
 Also provided are typedefs for common owner type combinations,
-which allow for less verbose type signatures. For example, `BoxRef<T>` instead of `OwningRef<Box<T>, T>`.
+which allow for less verbose type signatures.
+For example, `BoxRef<T>` instead of `OwningRef<Box<T>, T>`.
 
 The crate also provides the more advanced `OwningHandle` type,
 which allows more freedom in bundling a dependent handle object
@@ -495,7 +496,8 @@ impl<O, T: ?Sized> OwningRef<O, T> {
         }
     }
 
-    /// Erases the concrete base type of the owner with a trait object which implements `Send` and `Sync`.
+    /// Erases the concrete base type of the owner with a trait object
+    /// which implements `Send` and `Sync`.
     ///
     /// This allows mixing of owned references with different owner base types.
     pub fn erase_send_sync_owner<'a>(self) -> OwningRef<O::Erased, T>
@@ -507,7 +509,7 @@ impl<O, T: ?Sized> OwningRef<O, T> {
         }
     }
 
-    // TODO: wrap_owner
+    // UNIMPLEMENTED: wrap_owner
 
     // FIXME: Naming convention?
     /// A getter for the underlying owner.
@@ -753,7 +755,7 @@ impl<O, T: ?Sized> OwningRefMut<O, T> {
         }
     }
 
-    // TODO: wrap_owner
+    // UNIMPLEMENTED: wrap_owner
 
     // FIXME: Naming convention?
     /// A getter for the underlying owner.

--- a/src/librustc_data_structures/owning_ref/tests.rs
+++ b/src/librustc_data_structures/owning_ref/tests.rs
@@ -274,7 +274,9 @@ mod owning_handle {
         use std::cell::RefCell;
         let cell = Rc::new(RefCell::new(2));
         let cell_ref = RcRef::new(cell);
-        let mut handle = OwningHandle::new_with_fn(cell_ref, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
+        let mut handle = OwningHandle::new_with_fn(cell_ref, |x| {
+            unsafe { x.as_ref() }.unwrap().borrow_mut()
+        });
         assert_eq!(*handle, 2);
         *handle = 3;
         assert_eq!(*handle, 3);
@@ -319,8 +321,12 @@ mod owning_handle {
         let result = {
             let complex = Rc::new(RefCell::new(Arc::new(RwLock::new("someString"))));
             let curr = RcRef::new(complex);
-            let curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
-            let mut curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().try_write().unwrap());
+            let curr = OwningHandle::new_with_fn(curr, |x| {
+                unsafe { x.as_ref() }.unwrap().borrow_mut()
+            });
+            let mut curr = OwningHandle::new_with_fn(curr, |x| {
+                unsafe { x.as_ref() }.unwrap().try_write().unwrap()
+            });
             assert_eq!(*curr, "someString");
             *curr = "someOtherString";
             curr
@@ -353,8 +359,12 @@ mod owning_handle {
         let result = {
             let complex = Rc::new(RefCell::new(Arc::new(RwLock::new("someString"))));
             let curr = RcRef::new(complex);
-            let curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().borrow_mut());
-            let mut curr = OwningHandle::new_with_fn(curr, |x| unsafe { x.as_ref() }.unwrap().try_write().unwrap());
+            let curr = OwningHandle::new_with_fn(curr, |x| {
+                unsafe { x.as_ref() }.unwrap().borrow_mut()
+            });
+            let mut curr = OwningHandle::new_with_fn(curr, |x| {
+                unsafe { x.as_ref() }.unwrap().try_write().unwrap()
+            });
             assert_eq!(*curr, "someString");
             *curr = "someOtherString";
             curr

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -43,30 +43,18 @@ pub mod unstable_book;
 
 fn filter_dirs(path: &Path) -> bool {
     let skip = [
-        "src/llvm",
-        "src/llvm-project",
         "src/llvm-emscripten",
-        "src/libbacktrace",
-        "src/librustc_data_structures/owning_ref",
-        "src/vendor",
+        "src/llvm-project",
+        "src/stdarch",
         "src/tools/cargo",
-        "src/tools/clang",
-        "src/tools/rls",
         "src/tools/clippy",
+        "src/tools/miri",
+        "src/tools/rls",
         "src/tools/rust-installer",
         "src/tools/rustfmt",
-        "src/tools/miri",
-        "src/tools/lld",
-        "src/tools/lldb",
-        "src/target",
-        "src/stdarch",
-        "src/rust-sgx",
-        "target",
-        "vendor",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }
-
 
 fn walk_many(
     paths: &[&Path], skip: &mut dyn FnMut(&Path) -> bool, f: &mut dyn FnMut(&DirEntry, &str)


### PR DESCRIPTION
Some entries were outdated - pre-"llvm-project", pre-"crates.io", pre-"Cargo.toml outside of src".
Some entries were unnecessary - `owning_ref` could be fixed and directories outside of `src` are not visited by tidy at all.

r? @Mark-Simulacrum 