### PR TITLE
Ignore test cases that are not supported by vxWorks

### DIFF
--- a/src/test/ui/core-run-destroy.rs
+++ b/src/test/ui/core-run-destroy.rs
@@ -8,6 +8,7 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-vxworks no 'cat' and 'sleep'
 
 // N.B., these tests kill child processes. Valgrind sees these children as leaking
 // memory, which makes for some *confusing* logs. That's why these are here

--- a/src/test/ui/process/process-sigpipe.rs
+++ b/src/test/ui/process/process-sigpipe.rs
@@ -14,6 +14,7 @@
 
 // ignore-cloudabi no subprocesses support
 // ignore-emscripten no threads support
+// ignore-vxworks no 'sh'
 
 use std::process;
 use std::thread;

--- a/src/test/ui/wait-forked-but-failed-child.rs
+++ b/src/test/ui/wait-forked-but-failed-child.rs
@@ -2,6 +2,7 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-vxworks no 'ps'
 
 #![feature(rustc_private)]
 

--- a/src/test/ui/x86stdcall.rs
+++ b/src/test/ui/x86stdcall.rs
@@ -32,5 +32,6 @@ pub fn main() {
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd",
+          target_os = "vxworks",
           target_os = "solaris"))]
 pub fn main() { }


### PR DESCRIPTION

bypass x86stdcall.rs for vxworks

ignore wait-forked-but-failed-child.rs as there is no command 'ps' on vxWorks

ignore process-sigpipe.rs as there is no 'sh' on vxWorks

ignore core-run-destroy.rs as there is no 'cat' and 'sleep' on vxWorks