### PR TITLE
Remove anonymous_parameters from unrelated test

### DIFF
--- a/src/test/ui/error-codes/e0119/auxiliary/issue-23563-a.rs
+++ b/src/test/ui/error-codes/e0119/auxiliary/issue-23563-a.rs
@@ -9,7 +9,7 @@ pub trait LolInto<T>: Sized {
 }
 
 pub trait LolFrom<T> {
-    fn from(T) -> Self;
+    fn from(_: T) -> Self;
 }
 
 impl<'a, T: ?Sized, U> LolInto<U> for &'a T where T: LolTo<U> {


### PR DESCRIPTION
The parsing of anonymous_parameters is sufficiently covered by:

- [src/test/ui/issues/issue-13105.rs](https://github.com/rust-lang/rust/blob/023525dbda35748a10713471b948974b68a1c2cc/src/test/ui/issues/issue-13105.rs)
- [src/test/ui/issues/issue-13775.rs](https://github.com/rust-lang/rust/blob/023525dbda35748a10713471b948974b68a1c2cc/src/test/ui/issues/issue-13775.rs)
- [src/test/ui/issues/issue-34074.rs](https://github.com/rust-lang/rust/blob/023525dbda35748a10713471b948974b68a1c2cc/src/test/ui/issues/issue-34074.rs)

Removing anonymous_parameters from this test means fewer exclusions for me in https://github.com/dtolnay/syn/issues/644.