### PR TITLE
Turn `INCOMPLETE_FEATURES` into lint

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -63,6 +63,7 @@
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
+#![cfg_attr(not(bootstrap), allow(incomplete_features))]
 
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(test))]

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,6 +63,7 @@
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
+#![cfg_attr(not(bootstrap), allow(incomplete_features))]
 
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -97,6 +97,7 @@ macro_rules! early_lint_passes {
             DeprecatedAttr: DeprecatedAttr::new(),
             WhileTrue: WhileTrue,
             NonAsciiIdents: NonAsciiIdents,
+            IncompleteFeatures: IncompleteFeatures,
         ]);
     )
 }

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -569,10 +569,10 @@ declare_features! (
     // -------------------------------------------------------------------------
 );
 
-// Some features are known to be incomplete and using them is likely to have
-// unanticipated results, such as compiler crashes. We warn the user about these
-// to alert them.
-const INCOMPLETE_FEATURES: &[Symbol] = &[
+/// Some features are known to be incomplete and using them is likely to have
+/// unanticipated results, such as compiler crashes. We warn the user about these
+/// to alert them.
+pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::impl_trait_in_bindings,
     sym::generic_associated_types,
     sym::const_generics,
@@ -2338,15 +2338,6 @@ pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],
             }
 
             let name = mi.name_or_empty();
-            if INCOMPLETE_FEATURES.iter().any(|f| name == *f) {
-                span_handler.struct_span_warn(
-                    mi.span(),
-                    &format!(
-                        "the feature `{}` is incomplete and may cause the compiler to crash",
-                        name
-                    )
-                ).emit();
-            }
 
             if let Some(edition) = ALL_EDITIONS.iter().find(|e| name == e.feature_name()) {
                 if *edition <= crate_edition {

--- a/src/test/ui/associated-type-bounds/duplicate.stderr
+++ b/src/test/ui/associated-type-bounds/duplicate.stderr
@@ -3,6 +3,8 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0719]: the value of the associated type `Item` (from the trait `std::iter::Iterator`) is already specified
   --> $DIR/duplicate.rs:12:36

--- a/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/dyn-lcsit.stderr
@@ -3,4 +3,6 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/associated-type-bounds/lcsit.stderr
+++ b/src/test/ui/associated-type-bounds/lcsit.stderr
@@ -3,4 +3,6 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/apit-with-const-param.stderr
+++ b/src/test/ui/const-generics/apit-with-const-param.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
+++ b/src/test/ui/const-generics/array-wrapper-struct-ctor.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/broken-mir-1.stderr
+++ b/src/test/ui/const-generics/broken-mir-1.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/broken-mir-2.stderr
+++ b/src/test/ui/const-generics/broken-mir-2.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/broken-mir-2.rs:7:36

--- a/src/test/ui/const-generics/cannot-infer-const-args.stderr
+++ b/src/test/ui/const-generics/cannot-infer-const-args.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0282]: type annotations needed
   --> $DIR/cannot-infer-const-args.rs:9:5

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
+++ b/src/test/ui/const-generics/concrete-const-as-fn-arg.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/concrete-const-impl-method.stderr
+++ b/src/test/ui/const-generics/concrete-const-impl-method.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
+++ b/src/test/ui/const-generics/condition-in-trait-const-arg.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/const-arg-in-fn.stderr
+++ b/src/test/ui/const-generics/const-arg-in-fn.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -9,6 +9,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-fn-with-const-param.stderr
+++ b/src/test/ui/const-generics/const-fn-with-const-param.stderr
@@ -1,9 +1,3 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-fn-with-const-param.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error: const parameters are not permitted in `const fn`
   --> $DIR/const-fn-with-const-param.rs:4:1
    |
@@ -12,6 +6,14 @@ LL | |
 LL | |     X
 LL | | }
    | |_^
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-fn-with-const-param.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-generic-array-wrapper.stderr
+++ b/src/test/ui/const-generics/const-generic-array-wrapper.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/const-param-before-other-params.rs
+++ b/src/test/ui/const-generics/const-param-before-other-params.rs
@@ -1,5 +1,4 @@
 #![feature(const_generics)]
-//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
 fn bar<const X: (), 'a>(_: &'a ()) {
     //~^ ERROR lifetime parameters must be declared prior to const parameters

--- a/src/test/ui/const-generics/const-param-before-other-params.stderr
+++ b/src/test/ui/const-generics/const-param-before-other-params.stderr
@@ -1,17 +1,11 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-param-before-other-params.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error: lifetime parameters must be declared prior to const parameters
-  --> $DIR/const-param-before-other-params.rs:4:21
+  --> $DIR/const-param-before-other-params.rs:3:21
    |
 LL | fn bar<const X: (), 'a>(_: &'a ()) {
    |       --------------^^- help: reorder the parameters: lifetimes, then types, then consts: `<'a, const X: ()>`
 
 error: type parameters must be declared prior to const parameters
-  --> $DIR/const-param-before-other-params.rs:8:21
+  --> $DIR/const-param-before-other-params.rs:7:21
    |
 LL | fn foo<const X: (), T>(_: &T) {
    |       --------------^- help: reorder the parameters: lifetimes, then types, then consts: `<T, const X: ()>`

--- a/src/test/ui/const-generics/const-param-from-outer-fn.stderr
+++ b/src/test/ui/const-generics/const-param-from-outer-fn.stderr
@@ -1,9 +1,3 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-param-from-outer-fn.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error[E0401]: can't use generic parameters from outer function
   --> $DIR/const-param-from-outer-fn.rs:6:9
    |
@@ -13,6 +7,14 @@ LL |     fn bar() -> u32 {
    |        --- try adding a local generic parameter in this method instead
 LL |         X
    |         ^ use of generic parameter from outer function
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-param-from-outer-fn.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-param-in-trait.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -1,14 +1,16 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/const-param-type-depends-on-type-param.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error[E0671]: const parameters cannot depend on type parameters
   --> $DIR/const-param-type-depends-on-type-param.rs:9:34
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                                  ^ const parameter depends on type parameter
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/const-param-type-depends-on-type-param.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0392]: parameter `T` is never used
   --> $DIR/const-param-type-depends-on-type-param.rs:9:22

--- a/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
+++ b/src/test/ui/const-generics/const-parameter-uppercase-lint.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: const parameter `x` should have an upper case name
   --> $DIR/const-parameter-uppercase-lint.rs:6:15

--- a/src/test/ui/const-generics/const-types.stderr
+++ b/src/test/ui/const-generics/const-types.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
+++ b/src/test/ui/const-generics/derive-debug-array-wrapper.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
   --> $DIR/derive-debug-array-wrapper.rs:6:5

--- a/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
+++ b/src/test/ui/const-generics/fn-taking-const-generic-array.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/impl-const-generic-struct.stderr
+++ b/src/test/ui/const-generics/impl-const-generic-struct.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0107]: wrong number of const arguments: expected 2, found 1
   --> $DIR/incorrect-number-of-const-args.rs:9:5

--- a/src/test/ui/const-generics/issue-60818-struct-constructors.stderr
+++ b/src/test/ui/const-generics/issue-60818-struct-constructors.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/issue-61336-1.stderr
+++ b/src/test/ui/const-generics/issue-61336-1.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: array lengths can't depend on generic parameters
   --> $DIR/issue-61336-1.rs:5:9

--- a/src/test/ui/const-generics/issue-61336-2.stderr
+++ b/src/test/ui/const-generics/issue-61336-2.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: array lengths can't depend on generic parameters
   --> $DIR/issue-61336-2.rs:5:9

--- a/src/test/ui/const-generics/issue-61336.stderr
+++ b/src/test/ui/const-generics/issue-61336.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: array lengths can't depend on generic parameters
   --> $DIR/issue-61336.rs:5:9

--- a/src/test/ui/const-generics/issue-61422.stderr
+++ b/src/test/ui/const-generics/issue-61422.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/mut-ref-const-param-array.stderr
+++ b/src/test/ui/const-generics/mut-ref-const-param-array.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -1,14 +1,16 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/struct-with-invalid-const-param.rs:1:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error[E0573]: expected type, found const parameter `C`
   --> $DIR/struct-with-invalid-const-param.rs:4:23
    |
 LL | struct S<const C: u8>(C);
    |                       ^ help: a struct with a similar name exists: `S`
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/struct-with-invalid-const-param.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
+++ b/src/test/ui/const-generics/transparent-maybeunit-array-wrapper.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-1.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
+++ b/src/test/ui/const-generics/uninferred-consts-during-codegen-2.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/const-generics/unused-const-param.stderr
+++ b/src/test/ui/const-generics/unused-const-param.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/error-codes/E0730.stderr
+++ b/src/test/ui/error-codes/E0730.stderr
@@ -3,6 +3,8 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0730]: cannot pattern-match on an array without a fixed length
   --> $DIR/E0730.rs:6:9

--- a/src/test/ui/existential_types/existential_type_const.stderr
+++ b/src/test/ui/existential_types/existential_type_const.stderr
@@ -3,4 +3,6 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/hygiene/generic_params.stderr
+++ b/src/test/ui/hygiene/generic_params.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(decl_macro, rustc_attrs, const_generics)]
    |                                     ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/hygiene/issue-61574-const-parameters.stderr
+++ b/src/test/ui/hygiene/issue-61574-const-parameters.stderr
@@ -3,4 +3,6 @@ warning: the feature `const_generics` is incomplete and may cause the compiler t
    |
 LL | #![feature(const_generics)]
    |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/impl-trait-in-bindings.stderr
+++ b/src/test/ui/impl-trait-in-bindings.stderr
@@ -3,4 +3,6 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/impl-trait/bindings-opaque.stderr
+++ b/src/test/ui/impl-trait/bindings-opaque.stderr
@@ -3,6 +3,8 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0599]: no method named `count_ones` found for type `impl std::marker::Copy` in the current scope
   --> $DIR/bindings-opaque.rs:11:17

--- a/src/test/ui/impl-trait/bindings.stderr
+++ b/src/test/ui/impl-trait/bindings.stderr
@@ -1,9 +1,3 @@
-warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
-  --> $DIR/bindings.rs:1:12
-   |
-LL | #![feature(impl_trait_in_bindings)]
-   |            ^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0435]: attempt to use a non-constant value in a constant
   --> $DIR/bindings.rs:5:29
    |
@@ -27,6 +21,14 @@ error[E0435]: attempt to use a non-constant value in a constant
    |
 LL |         const foo: impl Clone = x;
    |                                 ^ non-constant value
+
+warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
+  --> $DIR/bindings.rs:1:12
+   |
+LL | #![feature(impl_trait_in_bindings)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -3,6 +3,8 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
   --> $DIR/bound-normalization-fail.rs:30:32

--- a/src/test/ui/impl-trait/bound-normalization-pass.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-pass.stderr
@@ -3,4 +3,6 @@ warning: the feature `impl_trait_in_bindings` is incomplete and may cause the co
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/issues/issue-59508-1.stderr
+++ b/src/test/ui/issues/issue-59508-1.stderr
@@ -1,14 +1,16 @@
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/issue-59508-1.rs:2:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
 error: lifetime parameters must be declared prior to type parameters
   --> $DIR/issue-59508-1.rs:12:25
    |
 LL |     pub fn do_things<T, 'a, 'b: 'a>() {
    |                     ----^^--^^----- help: reorder the parameters: lifetimes, then types, then consts: `<'a, 'b: 'a, T>`
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/issue-59508-1.rs:2:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -4,18 +4,6 @@ error: expected one of `,` or `>`, found `&&`
 LL |         true && let 1 = 1
    |              ^^ expected one of `,` or `>` here
 
-warning: the feature `const_generics` is incomplete and may cause the compiler to crash
-  --> $DIR/disallowed-positions.rs:20:12
-   |
-LL | #![feature(const_generics)]
-   |            ^^^^^^^^^^^^^^
-
-warning: the feature `let_chains` is incomplete and may cause the compiler to crash
-  --> $DIR/disallowed-positions.rs:22:12
-   |
-LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
-   |            ^^^^^^^^^^
-
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:32:9
    |
@@ -510,6 +498,20 @@ LL |         true && let 1 = 1
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
    = note: as well as when nested within `&&` and parenthesis in those conditions
+
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/disallowed-positions.rs:20:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: the feature `let_chains` is incomplete and may cause the compiler to crash
+  --> $DIR/disallowed-positions.rs:22:12
+   |
+LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
+   |            ^^^^^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:32:8

--- a/src/test/ui/rfc1598-generic-associated-types/collections.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/collections.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/collections.rs:56:90

--- a/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/construct_with_other_type.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/construct_with_other_type.rs:17:46

--- a/src/test/ui/rfc1598-generic-associated-types/empty_generics.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/empty_generics.stderr
@@ -9,6 +9,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/gat-incomplete-warning.stderr
@@ -3,4 +3,6 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/rfc1598-generic-associated-types/generic-associated-types-where.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/generic-associated-types-where.stderr
@@ -3,4 +3,6 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/generic_associated_type_undeclared_lifetimes.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/generic_associated_type_undeclared_lifetimes.rs:13:37

--- a/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/iterable.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/iterable.rs:11:47

--- a/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/parameter_number_and_kind.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/parameter_number_and_kind.rs:17:27

--- a/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/pointer_family.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/pointer_family.rs:37:21

--- a/src/test/ui/rfc1598-generic-associated-types/shadowing.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/shadowing.stderr
@@ -3,4 +3,6 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 

--- a/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/streaming_iterator.stderr
@@ -3,6 +3,8 @@ warning: the feature `generic_associated_types` is incomplete and may cause the 
    |
 LL | #![feature(generic_associated_types)]
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/streaming_iterator.rs:18:41


### PR DESCRIPTION
We do this because it is annoying to see the warning when building rustc and because this is better from a "separation of concerns" POV.

The drawback to this change is that this will respect `--cap-lints`.
Also note that this is not a buffered lint so if there are fatal parser errors then the lint will not trigger.

r? @varkor 