### PR TITLE
vxworks: Remove Linux-specific comments.

### DIFF
--- a/src/libstd/sys/vxworks/fs.rs
+++ b/src/libstd/sys/vxworks/fs.rs
@@ -287,22 +287,7 @@ impl File {
         let fd = cvt_r(|| unsafe {
             open(path.as_ptr(), flags, opts.mode as c_int)
         })?;
-        let fd = FileDesc::new(fd);
-        // Currently the standard library supports Linux 2.6.18 which did not
-        // have the O_CLOEXEC flag (passed above). If we're running on an older
-        // Linux kernel then the flag is just ignored by the OS. After we open
-        // the first file, we check whether it has CLOEXEC set. If it doesn't,
-        // we will explicitly ask for a CLOEXEC fd for every further file we
-        // open, if it does, we will skip that step.
-        //
-        // The CLOEXEC flag, however, is supported on versions of macOS/BSD/etc
-        // that we support, so we only do this on Linux currently.
-        fn ensure_cloexec(_: &FileDesc) -> io::Result<()> {
-            Ok(())
-        }
-
-        ensure_cloexec(&fd)?;
-        Ok(File(fd))
+        Ok(File(FileDesc::new(fd)))
     }
 
     pub fn file_attr(&self) -> io::Result<FileAttr> {

--- a/src/libstd/sys/vxworks/net.rs
+++ b/src/libstd/sys/vxworks/net.rs
@@ -141,10 +141,6 @@ impl Socket {
 
     pub fn accept(&self, storage: *mut sockaddr, len: *mut socklen_t)
                   -> io::Result<Socket> {
-        // Unfortunately the only known way right now to accept a socket and
-        // atomically set the CLOEXEC flag is to use the `accept4` syscall on
-        // Linux. This was added in 2.6.28, however, and because we support
-        // 2.6.18 we must detect this support dynamically.
         let fd = cvt_r(|| unsafe {
             libc::accept(self.0.raw(), storage, len)
         })?;

--- a/src/libstd/sys/vxworks/pipe.rs
+++ b/src/libstd/sys/vxworks/pipe.rs
@@ -11,11 +11,6 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     static INVALID: AtomicBool = AtomicBool::new(false);
 
     let mut fds = [0; 2];
-
-    // Unfortunately the only known way right now to create atomically set the
-    // CLOEXEC flag is to use the `pipe2` syscall on Linux. This was added in
-    // 2.6.27, however, and because we support 2.6.18 we must detect this
-    // support dynamically.
     cvt(unsafe { libc::pipe(fds.as_mut_ptr()) })?;
 
     let fd0 = FileDesc::new(fds[0]);


### PR DESCRIPTION
It looks like the VxWorks fork inadvertently left in some Linux-specific workaround comments in `libstd`, these can be removed. Came up when looking into #62516 

CC:  @BaoshanPang 