### PR TITLE
ci: Skip installing SWIG/xz on OSX 

### DIFF
--- a/.azure-pipelines/steps/run.yml
+++ b/.azure-pipelines/steps/run.yml
@@ -62,17 +62,6 @@ steps:
 - template: install-sccache.yml
 - template: install-clang.yml
 
-# Install some dependencies needed to build LLDB/Clang, currently only needed
-# during the `dist` target
-- bash: |
-    set -e
-    brew update
-    brew install xz
-    brew install swig@3
-    brew link --force swig@3
-  displayName: Install build dependencies (OSX)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'), eq(variables['SCRIPT'],'./x.py dist'))
-
 # Switch to XCode 9.3 on OSX since it seems to be the last version that supports
 # i686-apple-darwin. We'll eventually want to upgrade this and it will probably
 # force us to drop i686-apple-darwin, but let's keep the wheels turning for now.


### PR DESCRIPTION
I'm relatively certain that SWIG was only needed for LLDB which is no
longer built, and I'm hoping we can remove the xz install to remove the
reliance on `brew` for our build (which is another point of failure for
flaky networks).