### PR TITLE
Add syntactic and semantic tests for rest patterns, i.e. `..`

### DIFF
--- a/src/test/ui/pattern/rest-pat-semantic-disallowed.rs
+++ b/src/test/ui/pattern/rest-pat-semantic-disallowed.rs
@@ -1,0 +1,82 @@
+// Here we test that rest patterns, i.e. `..`, are not allowed
+// outside of slice (+ ident patterns witin those), tuple,
+// and tuple struct patterns and that duplicates are caught in these contexts.
+
+#![feature(slice_patterns, box_patterns)]
+
+fn main() {}
+
+macro_rules! mk_pat {
+    () => { .. } //~ ERROR `..` patterns are not allowed here
+}
+
+fn rest_patterns() {
+    let mk_pat!();
+
+    // Top level:
+    fn foo(..: u8) {} //~ ERROR `..` patterns are not allowed here
+    let ..;  //~ ERROR `..` patterns are not allowed here
+
+    // Box patterns:
+    let box ..;  //~ ERROR `..` patterns are not allowed here
+
+    // In or-patterns:
+    match 1 {
+        1 | .. => {} //~ ERROR `..` patterns are not allowed here
+    }
+
+    // Ref patterns:
+    let &..; //~ ERROR `..` patterns are not allowed here
+    let &mut ..; //~ ERROR `..` patterns are not allowed here
+
+    // Ident patterns:
+    let x @ ..; //~ ERROR `..` patterns are not allowed here
+    let ref x @ ..; //~ ERROR `..` patterns are not allowed here
+    let ref mut x @ ..; //~ ERROR `..` patterns are not allowed here
+
+    // Tuple:
+    let (..): (u8,); // OK.
+    let (..,): (u8,); // OK.
+    let (
+        ..,
+        .., //~ ERROR `..` can only be used once per tuple pattern
+        .. //~ ERROR `..` can only be used once per tuple pattern
+    ): (u8, u8, u8);
+    let (
+        ..,
+        x,
+        .. //~ ERROR `..` can only be used once per tuple pattern
+    ): (u8, u8, u8);
+
+    struct A(u8, u8, u8);
+
+    // Tuple struct (same idea as for tuple patterns):
+    let A(..); // OK.
+    let A(..,); // OK.
+    let A(
+        ..,
+        .., //~ ERROR `..` can only be used once per tuple struct pattern
+        .. //~ ERROR `..` can only be used once per tuple struct pattern
+    );
+    let A(
+        ..,
+        x,
+        .. //~ ERROR `..` can only be used once per tuple struct pattern
+    );
+
+    // Array/Slice:
+    let [..]: &[u8]; // OK.
+    let [..,]: &[u8]; // OK.
+    let [
+        ..,
+        .., //~ ERROR `..` can only be used once per slice pattern
+        .. //~ ERROR `..` can only be used once per slice pattern
+    ]: &[u8];
+    let [
+        ..,
+        ref x @ .., //~ ERROR `..` can only be used once per slice pattern
+        ref mut y @ .., //~ ERROR `..` can only be used once per slice pattern
+        (ref z @ ..), //~ ERROR `..` patterns are not allowed here
+        .. //~ ERROR `..` can only be used once per slice pattern
+    ]: &[u8];
+}

--- a/src/test/ui/pattern/rest-pat-semantic-disallowed.stderr
+++ b/src/test/ui/pattern/rest-pat-semantic-disallowed.stderr
@@ -1,0 +1,188 @@
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:10:13
+   |
+LL |     () => { .. }
+   |             ^^
+...
+LL |     let mk_pat!();
+   |         --------- in this macro invocation
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:18:9
+   |
+LL |     let ..;
+   |         ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:21:13
+   |
+LL |     let box ..;
+   |             ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:25:13
+   |
+LL |         1 | .. => {}
+   |             ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:29:10
+   |
+LL |     let &..;
+   |          ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:30:14
+   |
+LL |     let &mut ..;
+   |              ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:33:13
+   |
+LL |     let x @ ..;
+   |             ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:34:17
+   |
+LL |     let ref x @ ..;
+   |                 ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:35:21
+   |
+LL |     let ref mut x @ ..;
+   |                     ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` can only be used once per tuple pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:42:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+   |         ^^ can only be used once per tuple pattern
+
+error: `..` can only be used once per tuple pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:43:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+LL |         ..
+   |         ^^ can only be used once per tuple pattern
+
+error: `..` can only be used once per tuple pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:48:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         x,
+LL |         ..
+   |         ^^ can only be used once per tuple pattern
+
+error: `..` can only be used once per tuple struct pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:58:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+   |         ^^ can only be used once per tuple struct pattern
+
+error: `..` can only be used once per tuple struct pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:59:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+LL |         ..
+   |         ^^ can only be used once per tuple struct pattern
+
+error: `..` can only be used once per tuple struct pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:64:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         x,
+LL |         ..
+   |         ^^ can only be used once per tuple struct pattern
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:72:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+   |         ^^ can only be used once per slice pattern
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:73:9
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ..,
+LL |         ..
+   |         ^^ can only be used once per slice pattern
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:77:17
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ref x @ ..,
+   |                 ^^ can only be used once per slice pattern
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:78:21
+   |
+LL |         ..,
+   |         -- previously used here
+LL |         ref x @ ..,
+LL |         ref mut y @ ..,
+   |                     ^^ can only be used once per slice pattern
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:79:18
+   |
+LL |         (ref z @ ..),
+   |                  ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: `..` can only be used once per slice pattern
+  --> $DIR/rest-pat-semantic-disallowed.rs:80:9
+   |
+LL |         ..,
+   |         -- previously used here
+...
+LL |         ..
+   |         ^^ can only be used once per slice pattern
+
+error: `..` patterns are not allowed here
+  --> $DIR/rest-pat-semantic-disallowed.rs:17:12
+   |
+LL |     fn foo(..: u8) {}
+   |            ^^
+   |
+   = note: only allowed in tuple, tuple struct, and slice patterns
+
+error: aborting due to 22 previous errors
+

--- a/src/test/ui/pattern/rest-pat-syntactic.rs
+++ b/src/test/ui/pattern/rest-pat-syntactic.rs
@@ -1,0 +1,70 @@
+// Here we test that `..` is allowed in all pattern locations *syntactically*.
+// The semantic test is in `rest-pat-semantic-disallowed.rs`.
+
+// check-pass
+
+fn main() {}
+
+macro_rules! accept_pat {
+    ($p:pat) => {}
+}
+
+accept_pat!(..);
+
+#[cfg(FALSE)]
+fn rest_patterns() {
+    // Top level:
+    fn foo(..: u8) {}
+    let ..;
+
+    // Box patterns:
+    let box ..;
+
+    // In or-patterns:
+    match x {
+        .. | .. => {}
+    }
+
+    // Ref patterns:
+    let &..;
+    let &mut ..;
+
+    // Ident patterns:
+    let x @ ..;
+    let ref x @ ..;
+    let ref mut x @ ..;
+
+    // Tuple:
+    let (..); // This is interpreted as a tuple pattern, not a parenthesis one.
+    let (..,); // Allowing trailing comma.
+    let (.., .., ..); // Duplicates also.
+    let (.., P, ..); // Including with things in between.
+
+    // Tuple struct (same idea as for tuple patterns):
+    let A(..);
+    let A(..,);
+    let A(.., .., ..);
+    let A(.., P, ..);
+
+    // Array/Slice (like with tuple patterns):
+    let [..];
+    let [..,];
+    let [.., .., ..];
+    let [.., P, ..];
+
+    // Random walk to guard against special casing:
+    match x {
+        .. |
+        [
+            (
+                box ..,
+                &(..),
+                &mut ..,
+                x @ ..
+            ),
+            ref x @ ..,
+        ] |
+        ref mut x @ ..
+        => {}
+    }
+}


### PR DESCRIPTION
As per my first note in https://github.com/rust-lang/rust/issues/62254#issuecomment-515784884 this adds syntactic and semantic tests for `..` ("rest") patterns which were implemented in https://github.com/rust-lang/rust/pull/62550.

r? @estebank 