### PR TITLE
On `format!()` arg count mismatch provide extra info

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -514,10 +514,6 @@ impl<'a> Parser<'a> {
         // Width and precision
         let mut havewidth = false;
 
-        let mut width_span_start = 0;
-        if let Some((pos, '0')) = self.cur.peek() {
-            width_span_start = *pos;
-        }
         if self.consume('0') {
             // small ambiguity with '0$' as a format string. In theory this is a
             // '0' flag and then an ill-formatted format string with just a '$'
@@ -531,11 +527,11 @@ impl<'a> Parser<'a> {
             }
         }
         if !havewidth {
-            if width_span_start == 0 {
-                if let Some((pos, _)) = self.cur.peek() {
-                    width_span_start = *pos;
-                }
-            }
+            let width_span_start = if let Some((pos, _)) = self.cur.peek() {
+                *pos
+            } else {
+                0
+            };
             let (w, sp) = self.count(width_span_start);
             spec.width = w;
             spec.width_span = sp;

--- a/src/libfmt_macros/tests.rs
+++ b/src/libfmt_macros/tests.rs
@@ -12,6 +12,8 @@ fn fmtdflt() -> FormatSpec<'static> {
         flags: 0,
         precision: CountImplied,
         width: CountImplied,
+        precision_span: None,
+        width_span: None,
         ty: "",
     };
 }
@@ -79,165 +81,204 @@ fn format_position_nothing_else() {
 }
 #[test]
 fn format_type() {
-    same("{3:a}",
-         &[NextArgument(Argument {
-               position: ArgumentIs(3),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "a",
-               },
-           })]);
+    same(
+        "{3:a}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "a",
+            },
+        })]);
 }
 #[test]
 fn format_align_fill() {
-    same("{3:>}",
-         &[NextArgument(Argument {
-               position: ArgumentIs(3),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignRight,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "",
-               },
-           })]);
-    same("{3:0<}",
-         &[NextArgument(Argument {
-               position: ArgumentIs(3),
-               format: FormatSpec {
-                   fill: Some('0'),
-                   align: AlignLeft,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "",
-               },
-           })]);
-    same("{3:*<abcd}",
-         &[NextArgument(Argument {
-               position: ArgumentIs(3),
-               format: FormatSpec {
-                   fill: Some('*'),
-                   align: AlignLeft,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "abcd",
-               },
-           })]);
+    same(
+        "{3:>}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3),
+            format: FormatSpec {
+                fill: None,
+                align: AlignRight,
+                flags: 0,
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "",
+            },
+        })]);
+    same(
+        "{3:0<}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3),
+            format: FormatSpec {
+                fill: Some('0'),
+                align: AlignLeft,
+                flags: 0,
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "",
+            },
+        })]);
+    same(
+        "{3:*<abcd}",
+        &[NextArgument(Argument {
+            position: ArgumentIs(3),
+            format: FormatSpec {
+                fill: Some('*'),
+                align: AlignLeft,
+                flags: 0,
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "abcd",
+            },
+        })]);
 }
 #[test]
 fn format_counts() {
     use syntax_pos::{GLOBALS, Globals, edition};
     GLOBALS.set(&Globals::new(edition::DEFAULT_EDITION), || {
-    same("{:10s}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountIs(10),
-                   ty: "s",
-               },
-           })]);
-    same("{:10$.10s}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountIs(10),
-                   width: CountIsParam(10),
-                   ty: "s",
-               },
-           })]);
-    same("{:.*s}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(1),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountIsParam(0),
-                   width: CountImplied,
-                   ty: "s",
-               },
-           })]);
-    same("{:.10$s}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountIsParam(10),
-                   width: CountImplied,
-                   ty: "s",
-               },
-           })]);
-    same("{:a$.b$s}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountIsName(Symbol::intern("b")),
-                   width: CountIsName(Symbol::intern("a")),
-                   ty: "s",
-               },
-           })]);
+    same(
+        "{:10s}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountImplied,
+                width: CountIs(10),
+                precision_span: None,
+                width_span: None,
+                ty: "s",
+            },
+        })]);
+    same(
+        "{:10$.10s}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIs(10),
+                width: CountIsParam(10),
+                precision_span: None,
+                width_span: Some(InnerSpan::new(3, 6)),
+                ty: "s",
+            },
+        })]);
+    same(
+        "{:.*s}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(1),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsParam(0),
+                width: CountImplied,
+                precision_span: Some(InnerSpan::new(3, 5)),
+                width_span: None,
+                ty: "s",
+            },
+        })]);
+    same(
+        "{:.10$s}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsParam(10),
+                width: CountImplied,
+                precision_span: Some(InnerSpan::new(3, 7)),
+                width_span: None,
+                ty: "s",
+            },
+        })]);
+    same(
+        "{:a$.b$s}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsName(Symbol::intern("b")),
+                width: CountIsName(Symbol::intern("a")),
+                precision_span: None,
+                width_span: None,
+                ty: "s",
+            },
+        })]);
     });
 }
 #[test]
 fn format_flags() {
-    same("{:-}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: (1 << FlagSignMinus as u32),
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "",
-               },
-           })]);
-    same("{:+#}",
-         &[NextArgument(Argument {
-               position: ArgumentImplicitlyIs(0),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: (1 << FlagSignPlus as u32) | (1 << FlagAlternate as u32),
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "",
-               },
-           })]);
+    same(
+        "{:-}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: (1 << FlagSignMinus as u32),
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "",
+            },
+        })]);
+    same(
+        "{:+#}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: (1 << FlagSignPlus as u32) | (1 << FlagAlternate as u32),
+                precision: CountImplied,
+                width: CountImplied,
+                precision_span: None,
+                width_span: None,
+                ty: "",
+            },
+        })]);
 }
 #[test]
 fn format_mixture() {
-    same("abcd {3:a} efg",
-         &[String("abcd "),
-           NextArgument(Argument {
-               position: ArgumentIs(3),
-               format: FormatSpec {
-                   fill: None,
-                   align: AlignUnknown,
-                   flags: 0,
-                   precision: CountImplied,
-                   width: CountImplied,
-                   ty: "a",
-               },
-           }),
-           String(" efg")]);
+    same(
+        "abcd {3:a} efg",
+        &[
+            String("abcd "),
+            NextArgument(Argument {
+                position: ArgumentIs(3),
+                format: FormatSpec {
+                    fill: None,
+                    align: AlignUnknown,
+                    flags: 0,
+                    precision: CountImplied,
+                    width: CountImplied,
+                    precision_span: None,
+                    width_span: None,
+                    ty: "a",
+                },
+            }),
+            String(" efg"),
+        ],
+    );
 }

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -300,8 +300,8 @@ impl<'a, 'b> Context<'a, 'b> {
             let (mut refs, spans): (Vec<_>, Vec<_>) = refs.unzip();
             // Avoid `invalid reference to positional arguments 7 and 7 (there is 1 argument)`
             // for `println!("{7:7$}", 1);`
-            refs.dedup();
             refs.sort();
+            refs.dedup();
             let (arg_list, mut sp) = if refs.len() == 1 {
                 let spans: Vec<_> = spans.into_iter().filter_map(|sp| sp.map(|sp| *sp)).collect();
                 (

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -586,7 +586,7 @@ impl<'a, 'b> Context<'a, 'b> {
                     arg.position.index() == simple_arg.position.index();
 
                 if arg.format.precision_span.is_some() || arg.format.width_span.is_some() {
-                    self.arg_with_formatting.push(arg.format); //'liself.fmtsp.from_inner(span));
+                    self.arg_with_formatting.push(arg.format);
                 }
                 if !pos_simple || arg.format != simple_arg.format || fill != ' ' {
                     self.all_pieces_simple = false;

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -1402,6 +1402,7 @@ pub struct MalformedSourceMapPositions {
     pub end_pos: BytePos
 }
 
+/// Range inside of a `Span` used for diagnostics when we only have access to relative positions.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct InnerSpan {
     pub start: usize,

--- a/src/test/ui/if/ifmt-bad-arg.rs
+++ b/src/test/ui/if/ifmt-bad-arg.rs
@@ -75,4 +75,12 @@ ninth number: {
 tenth number: {}",
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     //~^^ ERROR: invalid format string
+    println!("{} {:.*} {}", 1, 3.2, 4);
+    //~^ ERROR 4 positional arguments in format string, but there are 3 arguments
+    //~| ERROR mismatched types
+    println!("{} {:07$.*} {}", 1, 3.2, 4);
+    //~^ ERROR 4 positional arguments in format string, but there are 3 arguments
+    //~| ERROR mismatched types
+    println!("{} {:07$} {}", 1, 3.2, 4);
+    //~^ ERROR 3 positional arguments in format string, but there are 3 arguments
 }

--- a/src/test/ui/if/ifmt-bad-arg.rs
+++ b/src/test/ui/if/ifmt-bad-arg.rs
@@ -82,5 +82,8 @@ tenth number: {}",
     //~^ ERROR 4 positional arguments in format string, but there are 3 arguments
     //~| ERROR mismatched types
     println!("{} {:07$} {}", 1, 3.2, 4);
-    //~^ ERROR 3 positional arguments in format string, but there are 3 arguments
+    //~^ ERROR invalid reference to positional argument 7 (there are 3 arguments)
+    println!("{:foo}", 1); //~ ERROR unknown format trait `foo`
+    println!("{5} {:4$} {6:7$}", 1);
+    //~^ ERROR invalid reference to positional arguments 4, 5, 6 and 7 (there is 1 argument)
 }

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -220,5 +220,58 @@ LL | tenth number: {}",
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: aborting due to 28 previous errors
+error: 4 positional arguments in format string, but there are 3 arguments
+  --> $DIR/ifmt-bad-arg.rs:78:15
+   |
+LL |     println!("{} {:.*} {}", 1, 3.2, 4);
+   |               ^^ ^^--^ ^^      --- this parameter corresponds to the precision flag
+   |                    |
+   |                    this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
+   |
+   = note: positional arguments are zero-based
+   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
 
+error: 4 positional arguments in format string, but there are 3 arguments
+  --> $DIR/ifmt-bad-arg.rs:81:15
+   |
+LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
+   |               ^^ ^^-----^ ^^      --- this parameter corresponds to the precision flag
+   |                    |  |
+   |                    |  this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
+   |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
+   |
+   = note: positional arguments are zero-based
+   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
+
+error: 3 positional arguments in format string, but there are 3 arguments
+  --> $DIR/ifmt-bad-arg.rs:84:15
+   |
+LL |     println!("{} {:07$} {}", 1, 3.2, 4);
+   |               ^^ ^^---^ ^^
+   |                    |
+   |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
+   |
+   = note: positional arguments are zero-based
+   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
+
+error[E0308]: mismatched types
+  --> $DIR/ifmt-bad-arg.rs:78:32
+   |
+LL |     println!("{} {:.*} {}", 1, 3.2, 4);
+   |                                ^^^ expected usize, found floating-point number
+   |
+   = note: expected type `&usize`
+              found type `&{float}`
+
+error[E0308]: mismatched types
+  --> $DIR/ifmt-bad-arg.rs:81:35
+   |
+LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
+   |                                   ^^^ expected usize, found floating-point number
+   |
+   = note: expected type `&usize`
+              found type `&{float}`
+
+error: aborting due to 33 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -243,13 +243,42 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
 
-error: 3 positional arguments in format string, but there are 3 arguments
-  --> $DIR/ifmt-bad-arg.rs:84:15
+error: invalid reference to positional argument 7 (there are 3 arguments)
+  --> $DIR/ifmt-bad-arg.rs:84:18
    |
 LL |     println!("{} {:07$} {}", 1, 3.2, 4);
-   |               ^^ ^^---^ ^^
+   |                  ^^---^
    |                    |
    |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
+   |
+   = note: positional arguments are zero-based
+   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
+
+error: unknown format trait `foo`
+  --> $DIR/ifmt-bad-arg.rs:86:24
+   |
+LL |     println!("{:foo}", 1);
+   |                        ^
+   |
+   = note: the only appropriate formatting traits are:
+           - ``, which uses the `Display` trait
+           - `?`, which uses the `Debug` trait
+           - `e`, which uses the `LowerExp` trait
+           - `E`, which uses the `UpperExp` trait
+           - `o`, which uses the `Octal` trait
+           - `p`, which uses the `Pointer` trait
+           - `b`, which uses the `Binary` trait
+           - `x`, which uses the `LowerHex` trait
+           - `X`, which uses the `UpperHex` trait
+
+error: invalid reference to positional arguments 4, 5, 6 and 7 (there is 1 argument)
+  --> $DIR/ifmt-bad-arg.rs:87:15
+   |
+LL |     println!("{5} {:4$} {6:7$}", 1);
+   |               ^^^ ^^--^ ^^^--^
+   |                     |      |
+   |                     |      this width flag expects an `usize` argument at position 7, but there is 1 argument
+   |                     this width flag expects an `usize` argument at position 4, but there is 1 argument
    |
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
@@ -272,6 +301,6 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
    = note: expected type `&usize`
               found type `&{float}`
 
-error: aborting due to 33 previous errors
+error: aborting due to 35 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -235,10 +235,10 @@ error: 4 positional arguments in format string, but there are 3 arguments
   --> $DIR/ifmt-bad-arg.rs:81:15
    |
 LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
-   |               ^^ ^^-----^ ^^      --- this parameter corresponds to the precision flag
-   |                    |  |
-   |                    |  this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
-   |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
+   |               ^^ ^^^----^ ^^      --- this parameter corresponds to the precision flag
+   |                     | |
+   |                     | this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
+   |                     this width flag expects an `usize` argument at position 7, but there are 3 arguments
    |
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
@@ -247,9 +247,9 @@ error: invalid reference to positional argument 7 (there are 3 arguments)
   --> $DIR/ifmt-bad-arg.rs:84:18
    |
 LL |     println!("{} {:07$} {}", 1, 3.2, 4);
-   |                  ^^---^
-   |                    |
-   |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
+   |                  ^^^--^
+   |                     |
+   |                     this width flag expects an `usize` argument at position 7, but there are 3 arguments
    |
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html

--- a/src/test/ui/if/ifmt-unknown-trait.stderr
+++ b/src/test/ui/if/ifmt-unknown-trait.stderr
@@ -3,6 +3,17 @@ error: unknown format trait `notimplemented`
    |
 LL |     format!("{:notimplemented}", "3");
    |                                  ^^^
+   |
+   = note: the only appropriate formatting traits are:
+           - ``, which uses the `Display` trait
+           - `?`, which uses the `Debug` trait
+           - `e`, which uses the `LowerExp` trait
+           - `E`, which uses the `UpperExp` trait
+           - `o`, which uses the `Octal` trait
+           - `p`, which uses the `Pointer` trait
+           - `b`, which uses the `Binary` trait
+           - `x`, which uses the `LowerHex` trait
+           - `X`, which uses the `UpperHex` trait
 
 error: aborting due to previous error
 


### PR DESCRIPTION
When positional width and precision formatting flags are present in a
formatting string that has an argument count mismatch, provide extra
information pointing at them making it easiser to understand where the
problem may lay:

```
error: 4 positional arguments in format string, but there are 3 arguments
  --> $DIR/ifmt-bad-arg.rs:78:15
   |
LL |     println!("{} {:.*} {}", 1, 3.2, 4);
   |               ^^ ^^--^ ^^      --- this parameter corresponds to the precision flag
   |                    |
   |                    this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
   |
   = note: positional arguments are zero-based
   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html

error: 4 positional arguments in format string, but there are 3 arguments
  --> $DIR/ifmt-bad-arg.rs:81:15
   |
LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
   |               ^^ ^^-----^ ^^      --- this parameter corresponds to the precision flag
   |                    |  |
   |                    |  this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
   |                    this width flag expects an `usize` argument at position 7, but there are 3 arguments
   |
   = note: positional arguments are zero-based
   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html

error: invalid reference to positional argument 7 (there are 3 arguments)
  --> $DIR/ifmt-bad-arg.rs:84:18
   |
LL |     println!("{} {:07$} {}", 1, 3.2, 4);
   |                  ^^^--^
   |                     |
   |                     this width flag expects an `usize` argument at position 7, but there are 3 arguments
   |
   = note: positional arguments are zero-based
   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
```

Fix #49384.