### PR TITLE
`const fn`-ify `std::any::type_name` as laid out in #63084

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -468,7 +468,8 @@ impl TypeId {
 /// The current implementation uses the same infrastructure as compiler
 /// diagnostics and debuginfo, but this is not guaranteed.
 #[stable(feature = "type_name", since = "1.38.0")]
-pub fn type_name<T: ?Sized>() -> &'static str {
+#[rustc_const_unstable(feature = "const_type_name")]
+pub const fn type_name<T: ?Sized>() -> &'static str {
     #[cfg(bootstrap)]
     unsafe {
         intrinsics::type_name::<T>()

--- a/src/test/ui/consts/const-fn-type-name-any.rs
+++ b/src/test/ui/consts/const-fn-type-name-any.rs
@@ -1,0 +1,29 @@
+// run-pass
+
+#![feature(const_fn)]
+#![feature(const_type_name)]
+#![allow(dead_code)]
+
+const fn type_name_wrapper<T>(_: &T) -> &'static str {
+    std::any::type_name::<T>()
+}
+
+struct Struct<TA, TB, TC> {
+    a: TA,
+    b: TB,
+    c: TC,
+}
+
+type StructInstantiation = Struct<i8, f64, bool>;
+
+const CONST_STRUCT: StructInstantiation = StructInstantiation { a: 12, b: 13.7, c: false };
+
+const CONST_STRUCT_NAME: &'static str = type_name_wrapper(&CONST_STRUCT);
+
+fn main() {
+    let non_const_struct = StructInstantiation { a: 87, b: 65.99, c: true };
+
+    let non_const_struct_name = type_name_wrapper(&non_const_struct);
+
+    assert_eq!(CONST_STRUCT_NAME, non_const_struct_name);
+}


### PR DESCRIPTION
This implements #63084 on nightly.

A test, based on the one I added when I implemented support for the underlying `core::intrinsics::type_name` being allowed in `const fn` contexts, is included.