### PR TITLE
Remove redundant method with const variable resolution

### DIFF
--- a/src/librustc/infer/canonical/canonicalizer.rs
+++ b/src/librustc/infer/canonical/canonicalizer.rs
@@ -693,7 +693,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         const_var: &'tcx ty::Const<'tcx>
     ) -> &'tcx ty::Const<'tcx> {
         let infcx = self.infcx.expect("encountered const-var without infcx");
-        let bound_to = infcx.resolve_const_var(const_var);
+        let bound_to = infcx.shallow_resolve(const_var);
         if bound_to != const_var {
             self.fold_const(bound_to)
         } else {

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -594,13 +594,11 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
                 ty: a.ty,
             }))
         }
-        (ConstValue::ByRef { .. }, _) => {
-            bug!(
-                "non-Scalar ConstValue encountered in super_relate_consts {:?} {:?}",
-                a,
-                b,
-            );
-        }
+
+        // FIXME(const_generics): we should either handle `Scalar::Ptr` or add a comment
+        // saying that we're not handling it intentionally.
+
+        // FIXME(const_generics): handle `ConstValue::ByRef` and `ConstValue::Slice`.
 
         // FIXME(const_generics): this is wrong, as it is a projection
         (ConstValue::Unevaluated(a_def_id, a_substs),


### PR DESCRIPTION
I've also removed a `bug!()` in const value relation code and replaced it with a `FIXME`. Now `ConstValue::Slice` and `ConstValue::ByRef` will simply fail to unify rather than ICEing, which seems more user-friendly for testers.