### PR TITLE
Add Result::cloned{,_err} and Result::copied{,_err}

### DIFF
--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -834,7 +834,7 @@ impl<T: Copy, E> Result<&T, E> {
     /// let copied = x.copied();
     /// assert_eq!(copied, Ok(12));
     /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
     fn copied(self) -> Result<T, E> {
         self.map(|&t| t)
     }
@@ -854,7 +854,7 @@ impl<T: Copy, E> Result<&mut T, E> {
     /// let copied = x.copied();
     /// assert_eq!(copied, Ok(12));
     /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
     fn copied(self) -> Result<T, E> {
         self.map(|&mut t| t)
     }
@@ -874,7 +874,7 @@ impl<T, E: Copy> Result<T, &E> {
     /// let copied = x.copied_err();
     /// assert_eq!(copied, Err(12));
     /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
     fn copied_err(self) -> Result<T, E> {
         self.map_err(|&e| e)
     }
@@ -894,7 +894,7 @@ impl<T, E: Copy> Result<T, &mut E> {
     /// let copied = x.copied();
     /// assert_eq!(cloned, Err(12));
     /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
     fn copied_err(self) -> Result<T, E> {
         self.map_err(|&mut e| e)
     }
@@ -914,7 +914,7 @@ impl<T: Clone, E> Result<&T, E> {
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Ok(12));
     /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
@@ -934,13 +934,13 @@ impl<T: Clone, E> Result<&mut T, E> {
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Ok(12));
     /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
 
-impl<T, E: Clone> Result<T, &mut E> {
+impl<T, E: Clone> Result<T, &E> {
     /// Maps a `Result<T, &E>` to a `Result<T, E>` by cloning the contents of the
     /// `Err` part.
     ///
@@ -954,7 +954,7 @@ impl<T, E: Clone> Result<T, &mut E> {
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Err(12));
     /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
     }
@@ -974,7 +974,7 @@ impl<T, E: Clone> Result<T, &mut E> {
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Err(12));
     /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
     }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -835,7 +835,7 @@ impl<T: Copy, E> Result<&T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    fn copied(self) -> Result<T, E> {
+    pub fn copied(self) -> Result<T, E> {
         self.map(|&t| t)
     }
 }
@@ -855,7 +855,7 @@ impl<T: Copy, E> Result<&mut T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    fn copied(self) -> Result<T, E> {
+    pub fn copied(self) -> Result<T, E> {
         self.map(|&mut t| t)
     }
 }
@@ -875,7 +875,7 @@ impl<T, E: Copy> Result<T, &E> {
     /// assert_eq!(copied, Err(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    fn copied_err(self) -> Result<T, E> {
+    pub fn copied_err(self) -> Result<T, E> {
         self.map_err(|&e| e)
     }
 }
@@ -895,7 +895,7 @@ impl<T, E: Copy> Result<T, &mut E> {
     /// assert_eq!(cloned, Err(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    fn copied_err(self) -> Result<T, E> {
+    pub fn copied_err(self) -> Result<T, E> {
         self.map_err(|&mut e| e)
     }
 }
@@ -915,7 +915,7 @@ impl<T: Clone, E> Result<&T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    fn cloned(self) -> Result<T, E> {
+    pub fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -935,7 +935,7 @@ impl<T: Clone, E> Result<&mut T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    fn cloned(self) -> Result<T, E> {
+    pub fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -955,7 +955,7 @@ impl<T, E: Clone> Result<T, &E> {
     /// assert_eq!(cloned, Err(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    fn cloned_err(self) -> Result<T, E> {
+    pub fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
     }
 }
@@ -975,7 +975,7 @@ impl<T, E: Clone> Result<T, &mut E> {
     /// assert_eq!(cloned, Err(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    fn cloned_err(self) -> Result<T, E> {
+    pub fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
     }
 }

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -820,6 +820,166 @@ impl<T, E> Result<T, E> {
     }
 }
 
+impl<T: Copy, E> Result<&T, E> {
+    /// Maps a `Result<&T, E>` to a `Result<T, E>` by copying the contents of the
+    /// `Ok` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// let val = 12;
+    /// let x = Ok(&val);
+    /// assert_eq!(x, Ok(&12));
+    /// let copied = x.copied();
+    /// assert_eq!(copied, Ok(12));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    fn copied(self) -> Result<T, E> {
+        self.map(|&t| t)
+    }
+}
+
+impl<T: Copy, E> Result<&mut T, E> {
+    /// Maps a `Result<&mut T, E>` to a `Result<T, E>` by copying the contents of the
+    /// `Ok` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// let val = 12;
+    /// let x = Ok(&mut val);
+    /// assert_eq!(x, Ok(&mut 12));
+    /// let copied = x.copied();
+    /// assert_eq!(copied, Ok(12));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    fn copied(self) -> Result<T, E> {
+        self.map(|&mut t| t)
+    }
+}
+
+impl<T, E: Copy> Result<T, &E> {
+    /// Maps a `Result<T, &E>` to a `Result<T, E>` by copying the contents of the
+    /// `Err` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// let val = 12;
+    /// let x = Err(&val);
+    /// assert_eq!(x, Err(&12));
+    /// let copied = x.copied_err();
+    /// assert_eq!(copied, Err(12));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    fn copied_err(self) -> Result<T, E> {
+        self.map_err(|&e| e)
+    }
+}
+
+impl<T, E: Copy> Result<T, &mut E> {
+    /// Maps a `Result<T, &mut E>` to a `Result<T, E>` by copying the contents of the
+    /// `Err` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// let val = 12;
+    /// let x = Err(&mut val);
+    /// assert_eq!(x, Err(&mut 12));
+    /// let copied = x.copied();
+    /// assert_eq!(cloned, Err(12));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "XXXXX")]
+    fn copied_err(self) -> Result<T, E> {
+        self.map_err(|&mut e| e)
+    }
+}
+
+impl<T: Clone, E> Result<&T, E> {
+    /// Maps a `Result<&T, E>` to a `Result<T, E>` by cloning the contents of the
+    /// `Ok` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// let val = 12;
+    /// let x = Ok(&val);
+    /// assert_eq!(x, Ok(&12));
+    /// let cloned = x.cloned();
+    /// assert_eq!(cloned, Ok(12));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    fn cloned(self) -> Result<T, E> {
+        self.map(|t| t.clone())
+    }
+}
+
+impl<T: Clone, E> Result<&mut T, E> {
+    /// Maps a `Result<&mut T, E>` to a `Result<T, E>` by cloning the contents of the
+    /// `Ok` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// let val = 12;
+    /// let x = Ok(&mut val);
+    /// assert_eq!(x, Ok(&mut 12));
+    /// let cloned = x.cloned();
+    /// assert_eq!(cloned, Ok(12));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    fn cloned(self) -> Result<T, E> {
+        self.map(|t| t.clone())
+    }
+}
+
+impl<T, E: Clone> Result<T, &mut E> {
+    /// Maps a `Result<T, &E>` to a `Result<T, E>` by cloning the contents of the
+    /// `Err` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// let val = 12;
+    /// let x = Err(&mut val);
+    /// assert_eq!(x, Err(&mut 12));
+    /// let cloned = x.cloned();
+    /// assert_eq!(cloned, Err(12));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    fn cloned_err(self) -> Result<T, E> {
+        self.map_err(|e| e.clone())
+    }
+}
+
+impl<T, E: Clone> Result<T, &mut E> {
+    /// Maps a `Result<T, &mut E>` to a `Result<T, E>` by cloning the contents of the
+    /// `Err` part.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// let val = 12;
+    /// let x = Err(&mut val);
+    /// assert_eq!(x, Err(&mut 12));
+    /// let cloned = x.cloned();
+    /// assert_eq!(cloned, Err(12));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "XXXXX")]
+    fn cloned_err(self) -> Result<T, E> {
+        self.map_err(|e| e.clone())
+    }
+}
+
 impl<T, E: fmt::Debug> Result<T, E> {
     /// Unwraps a result, yielding the content of an [`Ok`].
     ///

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -835,7 +835,7 @@ impl<T: Copy, E> Result<&T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
+    pub fn copied_ok(self) -> Result<T, E> {
         self.map(|&t| t)
     }
 }
@@ -855,7 +855,7 @@ impl<T: Copy, E> Result<&mut T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
+    pub fn copied_ok(self) -> Result<T, E> {
         self.map(|&mut t| t)
     }
 }
@@ -900,6 +900,74 @@ impl<T, E: Copy> Result<T, &mut E> {
     }
 }
 
+impl<T: Copy, E: Copy> Result<&T, &E> {
+    /// Maps a `Result<&T, &E>` to a `Result<T, E>` by copying the
+    /// contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// assert_eq!(Err(&1), Err(1));
+    /// assert_eq!(Ok(&42), Ok(42));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
+    pub fn copied(self) -> Result<T, E> {
+        self.copied_ok().copied_err()
+    }
+}
+
+impl<T: Copy, E: Copy> Result<&mut T, &E> {
+    /// Maps a `Result<&mut T, &E>` to a `Result<T, E>` by copying the
+    /// contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// assert_eq!(Err(&1), Err(1));
+    /// assert_eq!(Ok(&mut 42), Ok(42));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
+    pub fn copied(self) -> Result<T, E> {
+        self.copied_ok().copied_err()
+    }
+}
+
+impl<T: Copy, E: Copy> Result<&T, &mut E> {
+    /// Maps a `Result<&T, &mut E>` to a `Result<T, E>` by copying the
+    /// contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// assert_eq!(Err(&mut 1), Err(1));
+    /// assert_eq!(Ok(&42), Ok(42));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
+    pub fn copied(self) -> Result<T, E> {
+        self.copied_ok().copied_err()
+    }
+}
+
+impl<T: Copy, E: Copy> Result<&mut T, &mut E> {
+    /// Maps a `Result<&mut T, &mut E>` to a `Result<T, E>` by copying
+    /// the contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_copied)]
+    /// assert_eq!(Err(&mut 1), Err(1));
+    /// assert_eq!(Ok(&mut 42), Ok(42));
+    /// ```
+    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
+    pub fn copied(self) -> Result<T, E> {
+        self.copied_ok().copied_err()
+    }
+}
+
 impl<T: Clone, E> Result<&T, E> {
     /// Maps a `Result<&T, E>` to a `Result<T, E>` by cloning the contents of the
     /// `Ok` part.
@@ -915,7 +983,7 @@ impl<T: Clone, E> Result<&T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
+    pub fn cloned_ok(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -935,7 +1003,7 @@ impl<T: Clone, E> Result<&mut T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
+    pub fn cloned_ok(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -977,6 +1045,74 @@ impl<T, E: Clone> Result<T, &mut E> {
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     pub fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
+    }
+}
+
+impl<T: Clone, E: Clone> Result<&T, &E> {
+    /// Maps a `Result<&T, &E>` to a `Result<T, E>` by cloning the contents of the
+    /// result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// assert_eq!(Err(&1).cloned(), Err(1));
+    /// assert_eq!(Ok(&42).cloned(), Ok(42));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
+    pub fn cloned(self) -> Result<T, E> {
+        self.cloned_ok().cloned_err()
+    }
+}
+
+impl<T: Clone, E: Clone> Result<&mut T, &E> {
+    /// Maps a `Result<&mut T, &E>` to a `Result<T, E>` by cloning the
+    /// contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// assert_eq!(Err(&1).cloned(), Err(1));
+    /// assert_eq!(Ok(&mut 42).cloned(), Ok(42));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
+    pub fn cloned(self) -> Result<T, E> {
+        self.cloned_ok().cloned_err()
+    }
+}
+
+impl<T: Clone, E: Clone> Result<&T, &mut E> {
+    /// Maps a `Result<&T, &mut E>` to a `Result<T, E>` by cloning the
+    /// contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// assert_eq!(Err(&mut 1).cloned(), Err(1));
+    /// assert_eq!(Ok(&42).cloned(), Ok(42));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
+    pub fn cloned(self) -> Result<T, E> {
+        self.cloned_ok().cloned_err()
+    }
+}
+
+impl<T: Clone, E: Clone> Result<&mut T, &mut E> {
+    /// Maps a `Result<&mut T, &mut E>` to a `Result<T, E>` by cloning
+    /// the contents of the result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(result_cloned)]
+    /// assert_eq!(Err(&mut 1).cloned(), Err(1));
+    /// assert_eq!(Ok(&mut 42).cloned(), Ok(42));
+    /// ```
+    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
+    pub fn cloned(self) -> Result<T, E> {
+        self.cloned_ok().cloned_err()
     }
 }
 

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -860,46 +860,6 @@ impl<T: Copy, E> Result<&mut T, E> {
     }
 }
 
-impl<T, E: Copy> Result<T, &E> {
-    /// Maps a `Result<T, &E>` to a `Result<T, E>` by copying the contents of the
-    /// `Err` part.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// let val = 12;
-    /// let x: Result<i32, &i32> = Err(&val);
-    /// assert_eq!(x, Err(&12));
-    /// let copied = x.copied_err();
-    /// assert_eq!(copied, Err(12));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied_err(self) -> Result<T, E> {
-        self.map_err(|&e| e)
-    }
-}
-
-impl<T, E: Copy> Result<T, &mut E> {
-    /// Maps a `Result<T, &mut E>` to a `Result<T, E>` by copying the contents of the
-    /// `Err` part.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// let mut val = 12;
-    /// let x: Result<i32, &mut i32> = Err(&mut val);
-    /// assert_eq!(x, Err(&mut 12));
-    /// let copied = x.copied_err();
-    /// assert_eq!(copied, Err(12));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied_err(self) -> Result<T, E> {
-        self.map_err(|&mut e| e)
-    }
-}
-
 impl<T: Clone, E> Result<&T, E> {
     /// Maps a `Result<&T, E>` to a `Result<T, E>` by cloning the contents of the
     /// `Ok` part.
@@ -940,45 +900,6 @@ impl<T: Clone, E> Result<&mut T, E> {
     }
 }
 
-impl<T, E: Clone> Result<T, &E> {
-    /// Maps a `Result<T, &E>` to a `Result<T, E>` by cloning the contents of the
-    /// `Err` part.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// let val = 12;
-    /// let x: Result<i32, &i32> = Err(&val);
-    /// assert_eq!(x, Err(&12));
-    /// let cloned = x.cloned_err();
-    /// assert_eq!(cloned, Err(12));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned_err(self) -> Result<T, E> {
-        self.map_err(|e| e.clone())
-    }
-}
-
-impl<T, E: Clone> Result<T, &mut E> {
-    /// Maps a `Result<T, &mut E>` to a `Result<T, E>` by cloning the contents of the
-    /// `Err` part.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// let mut val = 12;
-    /// let x: Result<i32, &mut i32> = Err(&mut val);
-    /// assert_eq!(x, Err(&mut 12));
-    /// let cloned = x.cloned_err();
-    /// assert_eq!(cloned, Err(12));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned_err(self) -> Result<T, E> {
-        self.map_err(|e| e.clone())
-    }
-}
 
 impl<T, E: fmt::Debug> Result<T, E> {
     /// Unwraps a result, yielding the content of an [`Ok`].

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -829,7 +829,7 @@ impl<T: Copy, E> Result<&T, E> {
     /// ```
     /// #![feature(result_copied)]
     /// let val = 12;
-    /// let x = Ok(&val);
+    /// let x: Result<&i32, i32> = Ok(&val);
     /// assert_eq!(x, Ok(&12));
     /// let copied = x.copied();
     /// assert_eq!(copied, Ok(12));
@@ -848,8 +848,8 @@ impl<T: Copy, E> Result<&mut T, E> {
     ///
     /// ```
     /// #![feature(result_copied)]
-    /// let val = 12;
-    /// let x = Ok(&mut val);
+    /// let mut val = 12;
+    /// let x: Result<&mut i32, i32> = Ok(&mut val);
     /// assert_eq!(x, Ok(&mut 12));
     /// let copied = x.copied();
     /// assert_eq!(copied, Ok(12));
@@ -869,7 +869,7 @@ impl<T, E: Copy> Result<T, &E> {
     /// ```
     /// #![feature(result_copied)]
     /// let val = 12;
-    /// let x = Err(&val);
+    /// let x: Result<i32, &i32> = Err(&val);
     /// assert_eq!(x, Err(&12));
     /// let copied = x.copied_err();
     /// assert_eq!(copied, Err(12));
@@ -888,11 +888,11 @@ impl<T, E: Copy> Result<T, &mut E> {
     ///
     /// ```
     /// #![feature(result_copied)]
-    /// let val = 12;
-    /// let x = Err(&mut val);
+    /// let mut val = 12;
+    /// let x: Result<i32, &mut i32> = Err(&mut val);
     /// assert_eq!(x, Err(&mut 12));
-    /// let copied = x.copied();
-    /// assert_eq!(cloned, Err(12));
+    /// let copied = x.copied_err();
+    /// assert_eq!(copied, Err(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
     pub fn copied_err(self) -> Result<T, E> {
@@ -909,7 +909,7 @@ impl<T: Clone, E> Result<&T, E> {
     /// ```
     /// #![feature(result_cloned)]
     /// let val = 12;
-    /// let x = Ok(&val);
+    /// let x: Result<&i32, i32> = Ok(&val);
     /// assert_eq!(x, Ok(&12));
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Ok(12));
@@ -928,8 +928,8 @@ impl<T: Clone, E> Result<&mut T, E> {
     ///
     /// ```
     /// #![feature(result_cloned)]
-    /// let val = 12;
-    /// let x = Ok(&mut val);
+    /// let mut val = 12;
+    /// let x: Result<&mut i32, i32> = Ok(&mut val);
     /// assert_eq!(x, Ok(&mut 12));
     /// let cloned = x.cloned();
     /// assert_eq!(cloned, Ok(12));
@@ -949,9 +949,9 @@ impl<T, E: Clone> Result<T, &E> {
     /// ```
     /// #![feature(result_cloned)]
     /// let val = 12;
-    /// let x = Err(&mut val);
-    /// assert_eq!(x, Err(&mut 12));
-    /// let cloned = x.cloned();
+    /// let x: Result<i32, &i32> = Err(&val);
+    /// assert_eq!(x, Err(&12));
+    /// let cloned = x.cloned_err();
     /// assert_eq!(cloned, Err(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
@@ -968,10 +968,10 @@ impl<T, E: Clone> Result<T, &mut E> {
     ///
     /// ```
     /// #![feature(result_cloned)]
-    /// let val = 12;
-    /// let x = Err(&mut val);
+    /// let mut val = 12;
+    /// let x: Result<i32, &mut i32> = Err(&mut val);
     /// assert_eq!(x, Err(&mut 12));
-    /// let cloned = x.cloned();
+    /// let cloned = x.cloned_err();
     /// assert_eq!(cloned, Err(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]

--- a/src/libcore/result.rs
+++ b/src/libcore/result.rs
@@ -835,7 +835,7 @@ impl<T: Copy, E> Result<&T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied_ok(self) -> Result<T, E> {
+    pub fn copied(self) -> Result<T, E> {
         self.map(|&t| t)
     }
 }
@@ -855,7 +855,7 @@ impl<T: Copy, E> Result<&mut T, E> {
     /// assert_eq!(copied, Ok(12));
     /// ```
     #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied_ok(self) -> Result<T, E> {
+    pub fn copied(self) -> Result<T, E> {
         self.map(|&mut t| t)
     }
 }
@@ -900,74 +900,6 @@ impl<T, E: Copy> Result<T, &mut E> {
     }
 }
 
-impl<T: Copy, E: Copy> Result<&T, &E> {
-    /// Maps a `Result<&T, &E>` to a `Result<T, E>` by copying the
-    /// contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// assert_eq!(Err(&1), Err(1));
-    /// assert_eq!(Ok(&42), Ok(42));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
-        self.copied_ok().copied_err()
-    }
-}
-
-impl<T: Copy, E: Copy> Result<&mut T, &E> {
-    /// Maps a `Result<&mut T, &E>` to a `Result<T, E>` by copying the
-    /// contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// assert_eq!(Err(&1), Err(1));
-    /// assert_eq!(Ok(&mut 42), Ok(42));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
-        self.copied_ok().copied_err()
-    }
-}
-
-impl<T: Copy, E: Copy> Result<&T, &mut E> {
-    /// Maps a `Result<&T, &mut E>` to a `Result<T, E>` by copying the
-    /// contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// assert_eq!(Err(&mut 1), Err(1));
-    /// assert_eq!(Ok(&42), Ok(42));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
-        self.copied_ok().copied_err()
-    }
-}
-
-impl<T: Copy, E: Copy> Result<&mut T, &mut E> {
-    /// Maps a `Result<&mut T, &mut E>` to a `Result<T, E>` by copying
-    /// the contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_copied)]
-    /// assert_eq!(Err(&mut 1), Err(1));
-    /// assert_eq!(Ok(&mut 42), Ok(42));
-    /// ```
-    #[unstable(feature = "result_copied", reason = "newly added", issue = "63168")]
-    pub fn copied(self) -> Result<T, E> {
-        self.copied_ok().copied_err()
-    }
-}
-
 impl<T: Clone, E> Result<&T, E> {
     /// Maps a `Result<&T, E>` to a `Result<T, E>` by cloning the contents of the
     /// `Ok` part.
@@ -983,7 +915,7 @@ impl<T: Clone, E> Result<&T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned_ok(self) -> Result<T, E> {
+    pub fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -1003,7 +935,7 @@ impl<T: Clone, E> Result<&mut T, E> {
     /// assert_eq!(cloned, Ok(12));
     /// ```
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned_ok(self) -> Result<T, E> {
+    pub fn cloned(self) -> Result<T, E> {
         self.map(|t| t.clone())
     }
 }
@@ -1045,74 +977,6 @@ impl<T, E: Clone> Result<T, &mut E> {
     #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
     pub fn cloned_err(self) -> Result<T, E> {
         self.map_err(|e| e.clone())
-    }
-}
-
-impl<T: Clone, E: Clone> Result<&T, &E> {
-    /// Maps a `Result<&T, &E>` to a `Result<T, E>` by cloning the contents of the
-    /// result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// assert_eq!(Err(&1).cloned(), Err(1));
-    /// assert_eq!(Ok(&42).cloned(), Ok(42));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
-        self.cloned_ok().cloned_err()
-    }
-}
-
-impl<T: Clone, E: Clone> Result<&mut T, &E> {
-    /// Maps a `Result<&mut T, &E>` to a `Result<T, E>` by cloning the
-    /// contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// assert_eq!(Err(&1).cloned(), Err(1));
-    /// assert_eq!(Ok(&mut 42).cloned(), Ok(42));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
-        self.cloned_ok().cloned_err()
-    }
-}
-
-impl<T: Clone, E: Clone> Result<&T, &mut E> {
-    /// Maps a `Result<&T, &mut E>` to a `Result<T, E>` by cloning the
-    /// contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// assert_eq!(Err(&mut 1).cloned(), Err(1));
-    /// assert_eq!(Ok(&42).cloned(), Ok(42));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
-        self.cloned_ok().cloned_err()
-    }
-}
-
-impl<T: Clone, E: Clone> Result<&mut T, &mut E> {
-    /// Maps a `Result<&mut T, &mut E>` to a `Result<T, E>` by cloning
-    /// the contents of the result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(result_cloned)]
-    /// assert_eq!(Err(&mut 1).cloned(), Err(1));
-    /// assert_eq!(Ok(&mut 42).cloned(), Ok(42));
-    /// ```
-    #[unstable(feature = "result_cloned", reason = "newly added", issue = "63168")]
-    pub fn cloned(self) -> Result<T, E> {
-        self.cloned_ok().cloned_err()
     }
 }
 


### PR DESCRIPTION
This is a little nice addition to `Result`. 

1. I'm not sure how useful are `cloned_err` and `copied_err`, but for the sake of completeness they are here.
2. Naming is similar to `map`/`map_err`. I thought about naming `cloned` as `cloned_ok` and add another method called `cloned` that clones both Ok and Err, but `cloned_ok` should be more prevalent than `cloned_both`.