### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc/infer/canonical/canonicalizer.rs
+++ b/src/librustc/infer/canonical/canonicalizer.rs
@@ -693,7 +693,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         const_var: &'tcx ty::Const<'tcx>
     ) -> &'tcx ty::Const<'tcx> {
         let infcx = self.infcx.expect("encountered const-var without infcx");
-        let bound_to = infcx.resolve_const_var(const_var);
+        let bound_to = infcx.shallow_resolve(const_var);
         if bound_to != const_var {
             self.fold_const(bound_to)
         } else {

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -594,13 +594,11 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
                 ty: a.ty,
             }))
         }
-        (ConstValue::ByRef { .. }, _) => {
-            bug!(
-                "non-Scalar ConstValue encountered in super_relate_consts {:?} {:?}",
-                a,
-                b,
-            );
-        }
+
+        // FIXME(const_generics): we should either handle `Scalar::Ptr` or add a comment
+        // saying that we're not handling it intentionally.
+
+        // FIXME(const_generics): handle `ConstValue::ByRef` and `ConstValue::Slice`.
 
         // FIXME(const_generics): this is wrong, as it is a projection
         (ConstValue::Unevaluated(a_def_id, a_substs),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1864,6 +1864,12 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
+    /// Tests if this is any kind of primitive pointer type (reference, raw pointer, fn pointer).
+    #[inline]
+    pub fn is_any_ptr(&self) -> bool {
+        self.is_region_ptr() || self.is_unsafe_ptr() || self.is_fn_ptr()
+    }
+
     /// Returns `true` if this type is an `Arc<T>`.
     #[inline]
     pub fn is_arc(&self) -> bool {

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -397,7 +397,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         )
     }
 
-    fn ptr_op(
+    fn binary_ptr_op(
         _ecx: &InterpCx<'mir, 'tcx, Self>,
         _bin_op: mir::BinOp,
         _left: ImmTy<'tcx>,

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -20,10 +20,10 @@ use rustc_data_structures::fx::FxHashMap;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use crate::interpret::{self,
-    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar,
+    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar, Pointer,
     RawConst, ConstValue,
     InterpResult, InterpErrorInfo, InterpError, GlobalId, InterpCx, StackPopCleanup,
-    Allocation, AllocId, MemoryKind,
+    Allocation, AllocId, MemoryKind, Memory,
     snapshot, RefTracking, intern_const_alloc_recursive,
 };
 
@@ -394,6 +394,15 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         let intrinsic_name = &ecx.tcx.item_name(instance.def_id()).as_str()[..];
         Err(
             ConstEvalError::NeedsRfc(format!("calling intrinsic `{}`", intrinsic_name)).into()
+        )
+    }
+
+    fn ptr_to_int(
+        _mem: &Memory<'mir, 'tcx, Self>,
+        _ptr: Pointer,
+    ) -> InterpResult<'tcx, u64> {
+        Err(
+            ConstEvalError::NeedsRfc("pointer-to-integer cast".to_string()).into(),
         )
     }
 

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -250,12 +250,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             RawPtr(_) => Ok(ptr.into()),
             Int(_) | Uint(_) => {
                 let size = self.memory.pointer_size();
-
-                match self.force_bits(Scalar::Ptr(ptr), size) {
-                    Ok(bits) => self.cast_from_int(bits, src_layout, dest_layout),
-                    Err(_) if dest_layout.size == size => Ok(ptr.into()),
-                    Err(e) => Err(e),
-                }
+                let bits = self.force_bits(Scalar::Ptr(ptr), size)?;
+                self.cast_from_int(bits, src_layout, dest_layout)
             }
             _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -105,8 +105,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 assert!(
                     src.layout.ty.is_bool()       || src.layout.ty.is_char()     ||
                     src.layout.ty.is_enum()       || src.layout.ty.is_integral() ||
-                    src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()   ||
-                    src.layout.ty.is_region_ptr(),
+                    src.layout.ty.is_any_ptr(),
                     "Unexpected cast from type {:?}", src.layout.ty
                 )
         }
@@ -143,8 +142,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         }
 
         // Handle casting any ptr to raw ptr (might be a fat ptr).
-        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()) &&
-            dest_layout.ty.is_unsafe_ptr()
+        if src.layout.ty.is_any_ptr() && dest_layout.ty.is_unsafe_ptr()
         {
             // The only possible size-unequal case was handled above.
             assert_eq!(src.layout.size, dest_layout.size);

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -110,7 +110,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
         }
 
-        // Handle cast from a univariant (ZST) enum
+        // Handle cast from a univariant (ZST) enum.
         match src.layout.variants {
             layout::Variants::Single { index } => {
                 if let Some(discr) =

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -7,7 +7,7 @@ use syntax::symbol::sym;
 use rustc_apfloat::ieee::{Single, Double};
 use rustc_apfloat::{Float, FloatConvert};
 use rustc::mir::interpret::{
-    Scalar, InterpResult, Pointer, PointerArithmetic, InterpError,
+    Scalar, InterpResult, PointerArithmetic, InterpError,
 };
 use rustc::mir::CastKind;
 
@@ -111,32 +111,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
         }
 
-        // Handle casting the metadata away from a fat pointer.
-        if src.layout.ty.is_unsafe_ptr() && dest_layout.ty.is_unsafe_ptr() &&
-            dest_layout.size != src.layout.size
-        {
-            assert_eq!(src.layout.size, 2*self.memory.pointer_size());
-            assert_eq!(dest_layout.size, self.memory.pointer_size());
-            assert!(dest_layout.ty.is_unsafe_ptr());
-            return match *src {
-                Immediate::ScalarPair(data, _) => Ok(data.into()),
-                Immediate::Scalar(..) =>
-                    bug!(
-                        "{:?} input to a fat-to-thin cast ({:?} -> {:?})",
-                        *src, src.layout.ty, dest_layout.ty
-                    ),
-            };
-        }
-
-        // Handle casting reference to raw ptr or raw to other raw (might be a fat ptr).
-        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr()) &&
-            dest_layout.ty.is_unsafe_ptr()
-        {
-            // The only possible size-unequal case was handled above.
-            assert_eq!(src.layout.size, dest_layout.size);
-            return Ok(*src);
-        }
-
         // Handle cast from a univariant (ZST) enum
         match src.layout.variants {
             layout::Variants::Single { index } => {
@@ -150,12 +124,39 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             layout::Variants::Multiple { .. } => {},
         }
 
-        // Handle all the rest.
-        let val = src.to_scalar()?;
-        Ok(match val.to_bits_or_ptr(src.layout.size, self) {
-            Err(ptr) => self.cast_from_ptr(ptr, src.layout, dest_layout)?,
-            Ok(data) => self.cast_from_int(data, src.layout, dest_layout)?,
-        }.into())
+        // Handle casting the metadata away from a fat pointer.
+        if src.layout.ty.is_unsafe_ptr() && dest_layout.ty.is_unsafe_ptr() &&
+            dest_layout.size != src.layout.size
+        {
+            assert_eq!(src.layout.size, 2*self.memory.pointer_size());
+            assert_eq!(dest_layout.size, self.memory.pointer_size());
+            assert!(dest_layout.ty.is_unsafe_ptr());
+            match *src {
+                Immediate::ScalarPair(data, _) =>
+                    return Ok(data.into()),
+                Immediate::Scalar(..) =>
+                    bug!(
+                        "{:?} input to a fat-to-thin cast ({:?} -> {:?})",
+                        *src, src.layout.ty, dest_layout.ty
+                    ),
+            };
+        }
+
+        // Handle casting any ptr to raw ptr (might be a fat ptr).
+        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()) &&
+            dest_layout.ty.is_unsafe_ptr()
+        {
+            // The only possible size-unequal case was handled above.
+            assert_eq!(src.layout.size, dest_layout.size);
+            return Ok(*src);
+        }
+
+        // For all remaining casts, we either
+        // (a) cast a raw ptr to usize, or
+        // (b) cast from an integer-like (including bool, char, enums).
+        // In both cases we want the bits.
+        let bits = self.force_bits(src.to_scalar()?, src.layout.size)?;
+        Ok(self.cast_from_int(bits, src.layout, dest_layout)?.into())
     }
 
     fn cast_from_int(
@@ -233,27 +234,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Ok(Scalar::from_f64(f.convert(&mut false).value)),
             // That's it.
             _ => bug!("invalid float to {:?} cast", dest_ty),
-        }
-    }
-
-    fn cast_from_ptr(
-        &self,
-        ptr: Pointer<M::PointerTag>,
-        src_layout: TyLayout<'tcx>,
-        dest_layout: TyLayout<'tcx>,
-    ) -> InterpResult<'tcx, Scalar<M::PointerTag>> {
-        use rustc::ty::TyKind::*;
-
-        match dest_layout.ty.sty {
-            // Casting to a reference or fn pointer is not permitted by rustc,
-            // no need to support it here.
-            RawPtr(_) => Ok(ptr.into()),
-            Int(_) | Uint(_) => {
-                let size = self.memory.pointer_size();
-                let bits = self.force_bits(Scalar::Ptr(ptr), size)?;
-                self.cast_from_int(bits, src_layout, dest_layout)
-            }
-            _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }
     }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -223,7 +223,6 @@ pub trait Machine<'mir, 'tcx>: Sized {
         extra: Self::FrameExtra,
     ) -> InterpResult<'tcx>;
 
-    #[inline(always)]
     fn int_to_ptr(
         _mem: &Memory<'mir, 'tcx, Self>,
         int: u64,
@@ -235,11 +234,8 @@ pub trait Machine<'mir, 'tcx>: Sized {
         }).into())
     }
 
-    #[inline(always)]
     fn ptr_to_int(
         _mem: &Memory<'mir, 'tcx, Self>,
         _ptr: Pointer<Self::PointerTag>,
-    ) -> InterpResult<'tcx, u64> {
-        err!(ReadPointerAsBytes)
-    }
+    ) -> InterpResult<'tcx, u64>;
 }

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -155,11 +155,10 @@ pub trait Machine<'mir, 'tcx>: Sized {
         def_id: DefId,
     ) -> InterpResult<'tcx, Cow<'tcx, Allocation>>;
 
-    /// Called for all binary operations on integer(-like) types when one operand is a pointer
-    /// value, and for the `Offset` operation that is inherently about pointers.
+    /// Called for all binary operations where the LHS has pointer type.
     ///
     /// Returns a (value, overflowed) pair if the operation succeeded
-    fn ptr_op(
+    fn binary_ptr_op(
         ecx: &InterpCx<'mir, 'tcx, Self>,
         bin_op: mir::BinOp,
         left: ImmTy<'tcx, Self::PointerTag>,

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -48,11 +48,6 @@ impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
 }
 
 impl<'tcx, Tag> Immediate<Tag> {
-    #[inline]
-    pub fn from_scalar(val: Scalar<Tag>) -> Self {
-        Immediate::Scalar(ScalarMaybeUndef::Scalar(val))
-    }
-
     pub fn new_slice(
         val: Scalar<Tag>,
         len: u64,
@@ -197,7 +192,7 @@ impl<'tcx, Tag: Copy> ImmTy<'tcx, Tag>
 {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>, layout: TyLayout<'tcx>) -> Self {
-        ImmTy { imm: Immediate::from_scalar(val), layout }
+        ImmTy { imm: val.into(), layout }
     }
 
     #[inline]
@@ -255,7 +250,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let ptr = match self.check_mplace_access(mplace, None)? {
             Some(ptr) => ptr,
             None => return Ok(Some(ImmTy { // zero-sized type
-                imm: Immediate::Scalar(Scalar::zst().into()),
+                imm: Scalar::zst().into(),
                 layout: mplace.layout,
             })),
         };
@@ -266,7 +261,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     .get(ptr.alloc_id)?
                     .read_scalar(self, ptr, mplace.layout.size)?;
                 Ok(Some(ImmTy {
-                    imm: Immediate::Scalar(scalar),
+                    imm: scalar.into(),
                     layout: mplace.layout,
                 }))
             }
@@ -368,7 +363,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let field = field.try_into().unwrap();
         let field_layout = op.layout.field(self, field)?;
         if field_layout.is_zst() {
-            let immediate = Immediate::Scalar(Scalar::zst().into());
+            let immediate = Scalar::zst().into();
             return Ok(OpTy { op: Operand::Immediate(immediate), layout: field_layout });
         }
         let offset = op.layout.fields.offset(field);
@@ -378,7 +373,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // extract fields from types with `ScalarPair` ABI
             Immediate::ScalarPair(a, b) => {
                 let val = if offset.bytes() == 0 { a } else { b };
-                Immediate::Scalar(val)
+                Immediate::from(val)
             },
             Immediate::Scalar(val) =>
                 bug!("field access on non aggregate {:#?}, {:#?}", val, op.layout),
@@ -415,7 +410,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Deref => self.deref_operand(base)?.into(),
             Subslice { .. } | ConstantIndex { .. } | Index(_) => if base.layout.is_zst() {
                 OpTy {
-                    op: Operand::Immediate(Immediate::Scalar(Scalar::zst().into())),
+                    op: Operand::Immediate(Scalar::zst().into()),
                     // the actual index doesn't matter, so we just pick a convenient one like 0
                     layout: base.layout.field(self, 0)?,
                 }
@@ -439,7 +434,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let layout = self.layout_of_local(frame, local, layout)?;
         let op = if layout.is_zst() {
             // Do not read from ZST, they might not be initialized
-            Operand::Immediate(Immediate::Scalar(Scalar::zst().into()))
+            Operand::Immediate(Scalar::zst().into())
         } else {
             frame.locals[local].access()?
         };
@@ -567,7 +562,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Operand::Indirect(MemPlace::from_ptr(ptr, align))
             },
             ConstValue::Scalar(x) =>
-                Operand::Immediate(Immediate::Scalar(tag_scalar(x).into())),
+                Operand::Immediate(tag_scalar(x).into()),
             ConstValue::Slice { data, start, end } => {
                 // We rely on mutability being set correctly in `data` to prevent writes
                 // where none should happen.

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -33,6 +33,20 @@ pub enum Immediate<Tag=(), Id=AllocId> {
     ScalarPair(ScalarMaybeUndef<Tag, Id>, ScalarMaybeUndef<Tag, Id>),
 }
 
+impl<Tag> From<ScalarMaybeUndef<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: ScalarMaybeUndef<Tag>) -> Self {
+        Immediate::Scalar(val)
+    }
+}
+
+impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: Scalar<Tag>) -> Self {
+        Immediate::Scalar(val.into())
+    }
+}
+
 impl<'tcx, Tag> Immediate<Tag> {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>) -> Self {

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -302,7 +302,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
-            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+            _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`)
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -290,30 +290,29 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     FloatTy::F64 => self.binary_float_op(bin_op, left.to_f64()?, right.to_f64()?),
                 })
             }
-            _ => {
-                // Must be integer(-like) types.  Don't forget about == on fn pointers.
+            _ if left.layout.ty.is_integral() => {
+                // the RHS type can be different, e.g. for shifts -- but it has to be integral, too
                 assert!(
-                    left.layout.ty.is_integral()   ||
-                    left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr(),
-                    "Unexpected LHS type {:?} for BinOp {:?}", left.layout.ty, bin_op);
-                assert!(
-                    right.layout.ty.is_integral()   ||
-                    right.layout.ty.is_unsafe_ptr() || right.layout.ty.is_fn_ptr(),
-                    "Unexpected RHS type {:?} for BinOp {:?}", right.layout.ty, bin_op);
+                    right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
 
-                // Handle operations that support pointer values
-                if left.to_scalar_ptr()?.is_ptr() ||
-                    right.to_scalar_ptr()?.is_ptr() ||
-                    bin_op == mir::BinOp::Offset
-                {
-                    return M::ptr_op(self, bin_op, left, right);
-                }
-
-                // Everything else only works with "proper" bits
-                let l = left.to_bits().expect("we checked is_ptr");
-                let r = right.to_bits().expect("we checked is_ptr");
+                let l = self.force_bits(left.to_scalar()?, left.layout.size)?;
+                let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
+            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+                // The RHS type must be the same *or an integer type* (for `Offset`)
+                assert!(
+                    right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
+
+                M::binary_ptr_op(self, bin_op, left, right)
+            }
+            _ => bug!("Invalid MIR: bad LHS type for binop: {:?}", left.layout.ty),
         }
     }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -303,7 +303,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
-                // The RHS type must be the same *or an integer type* (for `Offset`)
+                // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -8,7 +8,7 @@ use rustc_target::spec::abi::Abi;
 
 use super::{
     InterpResult, PointerArithmetic, InterpError, Scalar,
-    InterpCx, Machine, Immediate, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
+    InterpCx, Machine, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
 };
 
 impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
@@ -462,7 +462,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // Adjust receiver argument.
                 args[0] = OpTy::from(ImmTy {
                     layout: this_receiver_ptr,
-                    imm: Immediate::Scalar(receiver_place.ptr.into())
+                    imm: receiver_place.ptr.into()
                 });
                 trace!("Patched self operand to {:#?}", args[0]);
                 // recurse with concrete function

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -5007,7 +5007,8 @@ fn sidebar_module(fmt: &mut fmt::Formatter<'_>, _it: &clean::Item,
                    ItemType::Enum, ItemType::Constant, ItemType::Static, ItemType::Trait,
                    ItemType::Function, ItemType::Typedef, ItemType::Union, ItemType::Impl,
                    ItemType::TyMethod, ItemType::Method, ItemType::StructField, ItemType::Variant,
-                   ItemType::AssocType, ItemType::AssocConst, ItemType::ForeignType] {
+                   ItemType::AssocType, ItemType::AssocConst, ItemType::ForeignType,
+                   ItemType::Keyword] {
         if items.iter().any(|it| !it.is_stripped() && it.type_() == myty) {
             let (short, name) = item_ty_to_strs(&myty);
             sidebar.push_str(&format!("<li><a href=\"#{id}\">{name}</a></li>",

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -143,6 +143,7 @@ macro_rules! maybe_whole_expr {
                         $p.token.span, ExprKind::Block(block, None), ThinVec::new()
                     ));
                 }
+                // N.B: `NtIdent(ident)` is normalized to `Ident` in `fn bump`.
                 _ => {},
             };
         }
@@ -2781,12 +2782,7 @@ impl<'a> Parser<'a> {
                     // can't continue an expression after an ident
                     token::Ident(name, is_raw) => token::ident_can_begin_expr(name, t.span, is_raw),
                     token::Literal(..) | token::Pound => true,
-                    token::Interpolated(ref nt) => match **nt {
-                        token::NtIdent(..) | token::NtExpr(..) |
-                        token::NtBlock(..) | token::NtPath(..) => true,
-                        _ => false,
-                    },
-                    _ => false
+                    _ => t.is_whole_expr(),
                 };
                 let cannot_continue_expr = self.look_ahead(1, token_cannot_continue_expr);
                 if cannot_continue_expr {

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -3741,6 +3741,7 @@ impl<'a> Parser<'a> {
         self.token.is_path_start() // e.g. `MY_CONST`;
             || self.token == token::Dot // e.g. `.5` for recovery;
             || self.token.can_begin_literal_or_bool() // e.g. `42`.
+            || self.token.is_whole_expr()
     }
 
     // Helper function to decide whether to parse as ident binding

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -478,10 +478,10 @@ impl Token {
 
     /// Would `maybe_whole_expr` in `parser.rs` return `Ok(..)`?
     /// That is, is this a pre-parsed expression dropped into the token stream
-    /// (which happens while parsing the result ofmacro expansion)?
+    /// (which happens while parsing the result of macro expansion)?
     crate fn is_whole_expr(&self) -> bool {
         if let Interpolated(ref nt) = self.kind {
-            if let NtExpr(_) | NtLiteral(_) | NtPath(_) | NtBlock(_) = **nt {
+            if let NtExpr(_) | NtLiteral(_) | NtPath(_) | NtIdent(..) | NtBlock(_) = **nt {
                 return true;
             }
         }

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -476,6 +476,19 @@ impl Token {
         false
     }
 
+    /// Would `maybe_whole_expr` in `parser.rs` return `Ok(..)`?
+    /// That is, is this a pre-parsed expression dropped into the token stream
+    /// (which happens while parsing the result ofmacro expansion)?
+    crate fn is_whole_expr(&self) -> bool {
+        if let Interpolated(ref nt) = self.kind {
+            if let NtExpr(_) | NtLiteral(_) | NtPath(_) | NtBlock(_) = **nt {
+                return true;
+            }
+        }
+
+        false
+    }
+
     /// Returns `true` if the token is either the `mut` or `const` keyword.
     crate fn is_mutability(&self) -> bool {
         self.is_keyword(kw::Mut) ||

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.rs
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.rs
@@ -19,7 +19,7 @@ fn main() {
 //      _3 = const Scalar(AllocId(1).0x0) : fn();
 //      _2 = move _3 as usize (Misc);
 //      ...
-//      _1 = const Scalar(AllocId(1).0x0) : *const fn();
+//      _1 = move _2 as *const fn() (Misc);
 //      ...
 //  }
 // END rustc.main.ConstProp.after.mir

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -4,6 +4,7 @@
 
 // @has foo/index.html '//h2[@id="keywords"]' 'Keywords'
 // @has foo/index.html '//a[@href="keyword.match.html"]' 'match'
+// @has foo/index.html '//div[@class="block items"]//a/@href' '#keywords'
 // @has foo/keyword.match.html '//a[@class="keyword"]' 'match'
 // @has foo/keyword.match.html '//span[@class="in-band"]' 'Keyword match'
 // @has foo/keyword.match.html '//section[@id="main"]//div[@class="docblock"]//p' 'this is a test!'

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
@@ -4,8 +4,8 @@ fn main() {}
 
 // unconst and bad, will thus error in miri
 const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 }; //~ ERROR any use of this
-// unconst and fine
-const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+// unconst and bad, will thus error in miri
+const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 }; //~ ERROR any use of this
 // unconst and fine
 const Y: usize = unsafe { 42usize as *const i32 as usize + 1 };
 // unconst and bad, will thus error in miri

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
@@ -9,12 +9,20 @@ LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
+  --> $DIR/const_raw_ptr_ops.rs:8:27
+   |
+LL | const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+
+error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:12:28
    |
 LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
-   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^-------
    |                            |
-   |                            "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+   |                            "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:16:26
@@ -32,5 +40,5 @@ LL | const Z3: i32 = unsafe { *(44 as *const i32) };
    |                          |
    |                          a memory access tried to interpret some bytes as a pointer
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-52442.rs
+++ b/src/test/ui/consts/const-eval/issue-52442.rs
@@ -1,5 +1,5 @@
 fn main() {
     [();  { &loop { break } as *const _ as usize } ];
     //~^ ERROR casting pointers to integers in constants is unstable
-    //~| ERROR it is undefined behavior to use this value
+    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -7,13 +7,11 @@ LL |     [();  { &loop { break } as *const _ as usize } ];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-52442.rs:2:11
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-52442.rs:2:13
    |
 LL |     [();  { &loop { break } as *const _ as usize } ];
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,3 +1,4 @@
+
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw
@@ -5,11 +6,9 @@ fn main() {
     let _: [u8; 0] = [4; {
         match &1 as *const i32 as usize {
             //~^ ERROR casting pointers to integers in constants
-            //~| NOTE for more information, see
             //~| ERROR constant contains unimplemented expression type
-            0 => 42, //~ ERROR constant contains unimplemented expression type
-            //~^ NOTE "pointer arithmetic or comparison" needs an rfc before being allowed
             //~| ERROR evaluation of constant value failed
+            0 => 42, //~ ERROR constant contains unimplemented expression type
             n => n,
         }
     }];

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,19 +8,19 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:11:13
+  --> $DIR/match-test-ptr-null.rs:10:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,22 +8,22 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:11:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
-LL |             0 => 42,
-   |             ^ "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+LL |         match &1 as *const i32 as usize {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _ = [0; (&0 as *const i32) as usize]; //~ ERROR casting pointers to integers in constants
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 }

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -7,13 +7,11 @@ LL |     let _ = [0; (&0 as *const i32) as usize];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
+error[E0080]: evaluation of constant value failed
   --> $DIR/issue-52023-array-size-pointer-cast.rs:2:17
    |
 LL |     let _ = [0; (&0 as *const i32) as usize];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issue-63115-range-pat-interpolated.rs
+++ b/src/test/ui/parser/issue-63115-range-pat-interpolated.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+#![feature(exclusive_range_pattern)]
+
+#![allow(ellipsis_inclusive_range_patterns)]
+
+fn main() {
+    macro_rules! mac_expr {
+        ($e:expr) => {
+            if let 2...$e = 3 {}
+            if let 2..=$e = 3 {}
+            if let 2..$e = 3 {}
+        }
+    }
+    mac_expr!(4);
+}

--- a/src/test/ui/parser/recover-range-pats.rs
+++ b/src/test/ui/parser/recover-range-pats.rs
@@ -121,3 +121,31 @@ fn inclusive2_to() {
     //~| ERROR `...` range patterns are deprecated
     //~| ERROR mismatched types
 }
+
+fn with_macro_expr_var() {
+    macro_rules! mac2 {
+        ($e1:expr, $e2:expr) => {
+            let $e1..$e2;
+            let $e1...$e2;
+            //~^ ERROR `...` range patterns are deprecated
+            let $e1..=$e2;
+        }
+    }
+
+    mac2!(0, 1);
+
+    macro_rules! mac {
+        ($e:expr) => {
+            let ..$e; //~ ERROR `..X` range patterns are not supported
+            let ...$e; //~ ERROR `...X` range patterns are not supported
+            //~^ ERROR `...` range patterns are deprecated
+            let ..=$e; //~ ERROR `..=X` range patterns are not supported
+            let $e..; //~ ERROR `X..` range patterns are not supported
+            let $e...; //~ ERROR `X...` range patterns are not supported
+            //~^ ERROR `...` range patterns are deprecated
+            let $e..=; //~ ERROR `X..=` range patterns are not supported
+        }
+    }
+
+    mac!(0);
+}

--- a/src/test/ui/parser/recover-range-pats.stderr
+++ b/src/test/ui/parser/recover-range-pats.stderr
@@ -214,6 +214,60 @@ error: `...X` range patterns are not supported
 LL |     if let ....3 = 0 {}
    |            ^^^^^ help: try using the minimum value for the type: `MIN...0.3`
 
+error: `..X` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:139:17
+   |
+LL |             let ..$e;
+   |                 ^^ help: try using the minimum value for the type: `MIN..0`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `...X` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:140:17
+   |
+LL |             let ...$e;
+   |                 ^^^ help: try using the minimum value for the type: `MIN...0`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `..=X` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:142:17
+   |
+LL |             let ..=$e;
+   |                 ^^^ help: try using the minimum value for the type: `MIN..=0`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `X..` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:143:19
+   |
+LL |             let $e..;
+   |                   ^^ help: try using the maximum value for the type: `0..MAX`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `X...` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:144:19
+   |
+LL |             let $e...;
+   |                   ^^^ help: try using the maximum value for the type: `0...MAX`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `X..=` range patterns are not supported
+  --> $DIR/recover-range-pats.rs:146:19
+   |
+LL |             let $e..=;
+   |                   ^^^ help: try using the maximum value for the type: `0..=MAX`
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
 error: `...` range patterns are deprecated
   --> $DIR/recover-range-pats.rs:41:13
    |
@@ -315,6 +369,33 @@ error: `...` range patterns are deprecated
    |
 LL |     if let ....3 = 0 {}
    |            ^^^ help: use `..=` for an inclusive range
+
+error: `...` range patterns are deprecated
+  --> $DIR/recover-range-pats.rs:129:20
+   |
+LL |             let $e1...$e2;
+   |                    ^^^ help: use `..=` for an inclusive range
+...
+LL |     mac2!(0, 1);
+   |     ------------ in this macro invocation
+
+error: `...` range patterns are deprecated
+  --> $DIR/recover-range-pats.rs:140:17
+   |
+LL |             let ...$e;
+   |                 ^^^ help: use `..=` for an inclusive range
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
+
+error: `...` range patterns are deprecated
+  --> $DIR/recover-range-pats.rs:144:19
+   |
+LL |             let $e...;
+   |                   ^^^ help: use `..=` for an inclusive range
+...
+LL |     mac!(0);
+   |     -------- in this macro invocation
 
 error[E0029]: only char and numeric types are allowed in range patterns
   --> $DIR/recover-range-pats.rs:19:12
@@ -532,7 +613,7 @@ LL |     if let ....3 = 0 {}
    = note: expected type `{integer}`
               found type `{float}`
 
-error: aborting due to 76 previous errors
+error: aborting due to 85 previous errors
 
 Some errors have detailed explanations: E0029, E0308.
 For more information about an error, try `rustc --explain E0029`.


### PR DESCRIPTION
Successful merges:

 - #62946 (Miri: dispatch first on the type)
 - #62971 (Add keywords item into the sidebar)
 - #63122 (Account for `maybe_whole_expr` in range patterns)
 - #63153 (Remove redundant method with const variable resolution)
 - #63170 (cleanup StringReader fields)

Failed merges:


r? @ghost