### PR TITLE
Add Iterator::try_find

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -85,6 +85,7 @@
 #![feature(extern_types)]
 #![feature(fundamental)]
 #![feature(intrinsics)]
+#![feature(try_find)]
 #![feature(is_sorted)]
 #![feature(iter_once_with)]
 #![feature(lang_items)]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -1558,6 +1558,46 @@ fn test_find_map() {
 }
 
 #[test]
+fn test_try_find() {
+    let xs: &[isize] = &[];
+    assert_eq!(xs.iter().try_find(testfn), Ok(None));
+    let xs: &[isize] = &[1, 2, 3, 4];
+    assert_eq!(xs.iter().try_find(testfn), Ok(Some(&2)));
+    let xs: &[isize] = &[1, 3, 4];
+    assert_eq!(xs.iter().try_find(testfn), Err(()));
+
+    let xs: &[isize] = &[1, 2, 3, 4, 5, 6, 7];
+    let mut iter = xs.iter();
+    assert_eq!(iter.try_find(testfn), Ok(Some(&2)));
+    assert_eq!(iter.try_find(testfn), Err(()));
+    assert_eq!(iter.next(), Some(&5));
+
+    fn testfn(x: &&isize) -> Result<bool, ()> {
+        if **x == 2 {
+            return Ok(true);
+        }
+        if **x == 4 {
+            return Err(());
+        }
+        Ok(false)
+    }
+}
+
+#[test]
+fn test_try_find_api_usability() -> Result<(), Box<dyn std::error::Error>> {
+    let a = ["1", "2"];
+
+    let is_my_num = |s: &str, search: i32| -> Result<bool, std::num::ParseIntError> {
+        Ok(s.parse::<i32>()? == search)
+    };
+
+    let val = a.iter().try_find(|&&s| is_my_num(s, 2))?;
+    assert_eq!(val, Some(&"2"));
+
+    Ok(())
+}
+
+#[test]
 fn test_position() {
     let v = &[1, 3, 9, 27, 103, 14, 11];
     assert_eq!(v.iter().position(|x| *x & 1 == 0).unwrap(), 5);

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -11,6 +11,7 @@
 #![feature(flt2dec)]
 #![feature(fmt_internals)]
 #![feature(hashmap_internals)]
+#![feature(try_find)]
 #![feature(is_sorted)]
 #![feature(iter_once_with)]
 #![feature(pattern)]


### PR DESCRIPTION
I found a need for this fn, and created this PR.

Tracking issue: #63178

I did a fair amount of thinking about the function name, and settled on the current one.
I don't see other anything else that's non-trivial here, but I'm open for debate. I just want this functionality to be there.
It couples with the `collect` trick for collecting `Result<Vec<T>, E>` from `Iterator<Item = Result<T, E>>`.

UPD:

I've already looked at `fallible_iterator` crate, but I don't think it supports my use case.
The main problem is that I can't construct a failable iterator. I have a regular iterator, and I just need to apply a predicate that can fail via `find` method.

UPD: `fallible_iterator` would work, but it's not elegant cause I'd have to make a failable iterator by mapping iterator with `Result::Ok` first.