### PR TITLE
update test cases for vxWorks

### DIFF
--- a/src/test/ui/issues/issue-2214.rs
+++ b/src/test/ui/issues/issue-2214.rs
@@ -25,10 +25,13 @@ mod m {
 
     #[link_name = "m"]
     extern {
-        #[cfg(any(unix, target_os = "cloudabi"))]
+        #[cfg(any(all(unix, not(target_os = "vxworks")), target_os = "cloudabi"))]
         #[link_name="lgamma_r"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
         #[cfg(windows)]
+        #[link_name="lgamma"]
+        pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
+        #[cfg(target_os = "vxworks")]
         #[link_name="lgamma"]
         pub fn lgamma(n: c_double, sign: &mut c_int) -> c_double;
     }

--- a/src/test/ui/process/process-envs.rs
+++ b/src/test/ui/process/process-envs.rs
@@ -2,6 +2,7 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-vxworks no 'env'
 
 use std::process::Command;
 use std::env;

--- a/src/test/ui/process/process-remove-from-env.rs
+++ b/src/test/ui/process/process-remove-from-env.rs
@@ -2,6 +2,7 @@
 // ignore-cloudabi no processes
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// ignore-vxworks no 'env'
 
 use std::process::Command;
 use std::env;


### PR DESCRIPTION
issue-2214.rs: lgamma is lgamma on vxWorks
ignore process-envs.rs and process-remove-from-env.rs as there is no 'env' on vxWorks