### PR TITLE
Explaining the reason why validation is performed in to_str of path.rs

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1819,7 +1819,7 @@ impl Path {
     /// Yields a [`&str`] slice if the `Path` is valid unicode.
     ///
     /// This conversion may entail doing a check for UTF-8 validity.
-    /// Also it it worthwhile noting that validation is performed because Non-UTF-8 strings are
+    /// Note that validation is performed because non-UTF-8 strings are
     /// perfectly valid for some OS.
     ///
     /// [`&str`]: ../primitive.str.html

--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -1819,6 +1819,8 @@ impl Path {
     /// Yields a [`&str`] slice if the `Path` is valid unicode.
     ///
     /// This conversion may entail doing a check for UTF-8 validity.
+    /// Also it it worthwhile noting that validation is performed because Non-UTF-8 strings are
+    /// perfectly valid for some OS.
     ///
     /// [`&str`]: ../primitive.str.html
     ///


### PR DESCRIPTION
I thought it's good to explain the reason for the validation during the conversion between Path/PathBuffer into str, which explains the reason for returning an Option at this point (good for beginners who are reading through the docs).