### PR TITLE
Remove the mention of LLDB from RELEASES.md

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -30,7 +30,6 @@ Compiler
 - [You can now enable Profile-Guided Optimization with the `-C profile-generate`
   and `-C profile-use` flags.][61268] For more information on how to use profile
   guided optimization, please refer to the [rustc book][rustc-book-pgo].
-- [The `rust-lldb` wrapper script should now work again.][61827]
 
 Libraries
 ---------


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/62592 (and https://github.com/rust-lang/llvm-project/pull/19 ), building the lldb-preview component has been disabled and it's not currently shipped with the macOS components it used to be shipped with. Therefore it's misleading to say it's fixed in the release notes.

Now, I'm hoping that we could ship the component eventually, but the current status of it seems to be unclear: since the upgrade to LLVM 9, some Rust-specific patches on LLDB were outdated. I don't know if the pretty-printing scripts work without them and I don't have the time to test them right now. (The patches are here: https://github.com/nikic/llvm-project/commits/llvm-9-lldb ) Additionally, there is an open PR to replace the pretty printing scripts. I'm not sure about the status of that work, now that the Rust patches on LLDB were dropped, plus it seems to be WIP: https://github.com/rust-lang/rust/pull/60826