### PR TITLE
build_helper: try less confusing method names

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -125,7 +125,7 @@ use std::os::unix::fs::symlink as symlink_file;
 use std::os::windows::fs::symlink_file;
 
 use build_helper::{
-    mtime, output, run_silent, run_suppressed, t, try_run_silent, try_run_suppressed,
+    mtime, output, run, run_suppressed, t, try_run, try_run_suppressed,
 };
 use filetime::FileTime;
 
@@ -682,7 +682,7 @@ impl Build {
     fn run(&self, cmd: &mut Command) {
         if self.config.dry_run { return; }
         self.verbose(&format!("running: {:?}", cmd));
-        run_silent(cmd)
+        run(cmd)
     }
 
     /// Runs a command, printing out nice contextual information if it fails.
@@ -698,7 +698,7 @@ impl Build {
     fn try_run(&self, cmd: &mut Command) -> bool {
         if self.config.dry_run { return true; }
         self.verbose(&format!("running: {:?}", cmd));
-        try_run_silent(cmd)
+        try_run(cmd)
     }
 
     /// Runs a command, printing out nice contextual information if it fails.

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1527,7 +1527,7 @@ impl Step for RustcGuide {
     fn run(self, builder: &Builder<'_>) {
         let src = builder.src.join("src/doc/rustc-guide");
         let mut rustbook_cmd = builder.tool_cmd(Tool::Rustbook);
-        try_run_quiet(builder, rustbook_cmd.arg("linkcheck").arg(&src));
+        try_run(builder, rustbook_cmd.arg("linkcheck").arg(&src));
     }
 }
 

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -45,7 +45,8 @@ pub fn restore_library_path() {
     }
 }
 
-pub fn run(cmd: &mut Command) {
+/// Run the command, printing what we are running.
+pub fn run_verbose(cmd: &mut Command) {
     println!("running: {:?}", cmd);
     run_silent(cmd);
 }

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -48,16 +48,16 @@ pub fn restore_library_path() {
 /// Run the command, printing what we are running.
 pub fn run_verbose(cmd: &mut Command) {
     println!("running: {:?}", cmd);
-    run_silent(cmd);
+    run(cmd);
 }
 
-pub fn run_silent(cmd: &mut Command) {
-    if !try_run_silent(cmd) {
+pub fn run(cmd: &mut Command) {
+    if !try_run(cmd) {
         std::process::exit(1);
     }
 }
 
-pub fn try_run_silent(cmd: &mut Command) -> bool {
+pub fn try_run(cmd: &mut Command) -> bool {
     let status = match cmd.status() {
         Ok(status) => status,
         Err(e) => fail(&format!(


### PR DESCRIPTION
build_helper's `*_silent` methods were likely called that way because they do not print the command being run to stdout. [In the original file this all makes sense](https://github.com/rust-lang/rust/commit/046e6874c47ec55e23b7a566bca51d2920562485#diff-5c3d6537a43ecae03014e118a7fe3321). But later it also gained `*_suppressed` methods and the difference between `silent` and `suppressed` is far from clear.

So rename `run` (which prints the command being run) to `run_verbose`. Then we can call the methods that just run a command and show its output but nothing extra `run` and `try_run`.

`run_verbose` (formerly `run`) is unused from what I can tell. Should I remove it?

r? @alexcrichton 
Cc @Mark-Simulacrum 
Also see https://github.com/rust-lang/rust/pull/63089#discussion_r308018890.