### PR TITLE
Allow trailing comma in macro 2.0 declarations.

### DIFF
--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -282,7 +282,10 @@ pub fn compile(
         quoted::TokenTree::Sequence(
             DelimSpan::dummy(),
             Lrc::new(quoted::SequenceRepetition {
-                tts: vec![quoted::TokenTree::token(token::Semi, def.span)],
+                tts: vec![quoted::TokenTree::token(
+                    if body.legacy { token::Semi } else { token::Comma },
+                    def.span,
+                )],
                 separator: None,
                 kleene: quoted::KleeneToken::new(quoted::KleeneOp::ZeroOrMore, def.span),
                 num_captures: 0,

--- a/src/test/ui/macros/issue-63102.rs
+++ b/src/test/ui/macros/issue-63102.rs
@@ -1,0 +1,8 @@
+// check-pass
+
+#![feature(decl_macro)]
+macro foo {
+    () => {},
+}
+
+fn main() {}


### PR DESCRIPTION
This should hopefully close #63102. 