### PR TITLE
Fix rustc-guide toolstate tracking.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1527,7 +1527,12 @@ impl Step for RustcGuide {
     fn run(self, builder: &Builder<'_>) {
         let src = builder.src.join("src/doc/rustc-guide");
         let mut rustbook_cmd = builder.tool_cmd(Tool::Rustbook);
-        try_run(builder, rustbook_cmd.arg("linkcheck").arg(&src));
+        let toolstate = if try_run(builder, rustbook_cmd.arg("linkcheck").arg(&src)) {
+            ToolState::TestPass
+        } else {
+            ToolState::TestFail
+        };
+        builder.save_toolstate("rustc-guide", toolstate);
     }
 }
 


### PR DESCRIPTION
The rustc-guide is still not saving its toolstate.  It needs to be done explicitly.

Note: There are some confusing bits here, like without `--no-fail-fast`, it saves the wrong value in `toolstates.json`.  Also, "rustbook" is always added as "test-fail".  Presumably [this code](https://github.com/rust-lang/rust/blame/63c1f17d950bfefc8f356777f124f304f0575c76/src/bootstrap/tool.rs#L201-L205) assumes everything fails until it passes tests, which is a bit confusing for things that don't run tests.

cc @mark-i-m 
