### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -59,7 +59,6 @@ extern crate rustc_plugin;
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
-use syntax::ext::build::AstBuilder;  // A trait for expr_usize.
 use syntax_pos::Span;
 use rustc_plugin::Registry;
 
@@ -163,13 +162,6 @@ can continue and find further errors.
 
 To print syntax fragments for debugging, you can use `span_note` together with
 `syntax::print::pprust::*_to_string`.
-
-The example above produced an integer literal using `AstBuilder::expr_usize`.
-As an alternative to the `AstBuilder` trait, `libsyntax` provides a set of
-quasiquote macros. They are undocumented and very rough around the edges.
-However, the implementation may be a good starting point for an improved
-quasiquote as an ordinary plugin library.
-
 
 # Lint plugins
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_spanned_attr_outer(e.span, attr::mk_attr_id(), allow)
+                    attr::mk_attr_outer(e.span, attr::mk_attr_id(), allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_attr_outer(e.span, allow)
+                    attr::mk_attr_outer(allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_attr_outer(e.span, attr::mk_attr_id(), allow)
+                    attr::mk_attr_outer(e.span, allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/infer/canonical/canonicalizer.rs
+++ b/src/librustc/infer/canonical/canonicalizer.rs
@@ -693,7 +693,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         const_var: &'tcx ty::Const<'tcx>
     ) -> &'tcx ty::Const<'tcx> {
         let infcx = self.infcx.expect("encountered const-var without infcx");
-        let bound_to = infcx.resolve_const_var(const_var);
+        let bound_to = infcx.shallow_resolve(const_var);
         if bound_to != const_var {
             self.fold_const(bound_to)
         } else {

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -594,13 +594,11 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
                 ty: a.ty,
             }))
         }
-        (ConstValue::ByRef { .. }, _) => {
-            bug!(
-                "non-Scalar ConstValue encountered in super_relate_consts {:?} {:?}",
-                a,
-                b,
-            );
-        }
+
+        // FIXME(const_generics): we should either handle `Scalar::Ptr` or add a comment
+        // saying that we're not handling it intentionally.
+
+        // FIXME(const_generics): handle `ConstValue::ByRef` and `ConstValue::Slice`.
 
         // FIXME(const_generics): this is wrong, as it is a projection
         (ConstValue::Unevaluated(a_def_id, a_substs),

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1863,6 +1863,12 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
+    /// Tests if this is any kind of primitive pointer type (reference, raw pointer, fn pointer).
+    #[inline]
+    pub fn is_any_ptr(&self) -> bool {
+        self.is_region_ptr() || self.is_unsafe_ptr() || self.is_fn_ptr()
+    }
+
     /// Returns `true` if this type is an `Arc<T>`.
     #[inline]
     pub fn is_arc(&self) -> bool {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -980,14 +980,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     fn get_attributes(&self, item: &Entry<'tcx>, sess: &Session) -> Vec<ast::Attribute> {
-        item.attributes
-            .decode((self, sess))
-            .map(|mut attr| {
-                // Need new unique IDs: old thread-local IDs won't map to new threads.
-                attr.id = attr::mk_attr_id();
-                attr
-            })
-            .collect()
+        item.attributes.decode((self, sess)).collect()
     }
 
     // Translate a DefId from the current compilation environment to a DefId

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -397,7 +397,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         )
     }
 
-    fn ptr_op(
+    fn binary_ptr_op(
         _ecx: &InterpCx<'mir, 'tcx, Self>,
         _bin_op: mir::BinOp,
         _left: ImmTy<'tcx>,

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -20,10 +20,10 @@ use rustc_data_structures::fx::FxHashMap;
 use syntax::source_map::{Span, DUMMY_SP};
 
 use crate::interpret::{self,
-    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar,
+    PlaceTy, MPlaceTy, OpTy, ImmTy, Immediate, Scalar, Pointer,
     RawConst, ConstValue,
     InterpResult, InterpErrorInfo, InterpError, GlobalId, InterpCx, StackPopCleanup,
-    Allocation, AllocId, MemoryKind,
+    Allocation, AllocId, MemoryKind, Memory,
     snapshot, RefTracking, intern_const_alloc_recursive,
 };
 
@@ -394,6 +394,15 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         let intrinsic_name = &ecx.tcx.item_name(instance.def_id()).as_str()[..];
         Err(
             ConstEvalError::NeedsRfc(format!("calling intrinsic `{}`", intrinsic_name)).into()
+        )
+    }
+
+    fn ptr_to_int(
+        _mem: &Memory<'mir, 'tcx, Self>,
+        _ptr: Pointer,
+    ) -> InterpResult<'tcx, u64> {
+        Err(
+            ConstEvalError::NeedsRfc("pointer-to-integer cast".to_string()).into(),
         )
     }
 

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -250,12 +250,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             RawPtr(_) => Ok(ptr.into()),
             Int(_) | Uint(_) => {
                 let size = self.memory.pointer_size();
-
-                match self.force_bits(Scalar::Ptr(ptr), size) {
-                    Ok(bits) => self.cast_from_int(bits, src_layout, dest_layout),
-                    Err(_) if dest_layout.size == size => Ok(ptr.into()),
-                    Err(e) => Err(e),
-                }
+                let bits = self.force_bits(Scalar::Ptr(ptr), size)?;
+                self.cast_from_int(bits, src_layout, dest_layout)
             }
             _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -105,8 +105,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 assert!(
                     src.layout.ty.is_bool()       || src.layout.ty.is_char()     ||
                     src.layout.ty.is_enum()       || src.layout.ty.is_integral() ||
-                    src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()   ||
-                    src.layout.ty.is_region_ptr(),
+                    src.layout.ty.is_any_ptr(),
                     "Unexpected cast from type {:?}", src.layout.ty
                 )
         }
@@ -143,8 +142,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         }
 
         // Handle casting any ptr to raw ptr (might be a fat ptr).
-        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()) &&
-            dest_layout.ty.is_unsafe_ptr()
+        if src.layout.ty.is_any_ptr() && dest_layout.ty.is_unsafe_ptr()
         {
             // The only possible size-unequal case was handled above.
             assert_eq!(src.layout.size, dest_layout.size);

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -110,7 +110,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
         }
 
-        // Handle cast from a univariant (ZST) enum
+        // Handle cast from a univariant (ZST) enum.
         match src.layout.variants {
             layout::Variants::Single { index } => {
                 if let Some(discr) =

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -7,7 +7,7 @@ use syntax::symbol::sym;
 use rustc_apfloat::ieee::{Single, Double};
 use rustc_apfloat::{Float, FloatConvert};
 use rustc::mir::interpret::{
-    Scalar, InterpResult, Pointer, PointerArithmetic, InterpError,
+    Scalar, InterpResult, PointerArithmetic, InterpError,
 };
 use rustc::mir::CastKind;
 
@@ -111,32 +111,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 )
         }
 
-        // Handle casting the metadata away from a fat pointer.
-        if src.layout.ty.is_unsafe_ptr() && dest_layout.ty.is_unsafe_ptr() &&
-            dest_layout.size != src.layout.size
-        {
-            assert_eq!(src.layout.size, 2*self.memory.pointer_size());
-            assert_eq!(dest_layout.size, self.memory.pointer_size());
-            assert!(dest_layout.ty.is_unsafe_ptr());
-            return match *src {
-                Immediate::ScalarPair(data, _) => Ok(data.into()),
-                Immediate::Scalar(..) =>
-                    bug!(
-                        "{:?} input to a fat-to-thin cast ({:?} -> {:?})",
-                        *src, src.layout.ty, dest_layout.ty
-                    ),
-            };
-        }
-
-        // Handle casting reference to raw ptr or raw to other raw (might be a fat ptr).
-        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr()) &&
-            dest_layout.ty.is_unsafe_ptr()
-        {
-            // The only possible size-unequal case was handled above.
-            assert_eq!(src.layout.size, dest_layout.size);
-            return Ok(*src);
-        }
-
         // Handle cast from a univariant (ZST) enum
         match src.layout.variants {
             layout::Variants::Single { index } => {
@@ -150,12 +124,39 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             layout::Variants::Multiple { .. } => {},
         }
 
-        // Handle all the rest.
-        let val = src.to_scalar()?;
-        Ok(match val.to_bits_or_ptr(src.layout.size, self) {
-            Err(ptr) => self.cast_from_ptr(ptr, src.layout, dest_layout)?,
-            Ok(data) => self.cast_from_int(data, src.layout, dest_layout)?,
-        }.into())
+        // Handle casting the metadata away from a fat pointer.
+        if src.layout.ty.is_unsafe_ptr() && dest_layout.ty.is_unsafe_ptr() &&
+            dest_layout.size != src.layout.size
+        {
+            assert_eq!(src.layout.size, 2*self.memory.pointer_size());
+            assert_eq!(dest_layout.size, self.memory.pointer_size());
+            assert!(dest_layout.ty.is_unsafe_ptr());
+            match *src {
+                Immediate::ScalarPair(data, _) =>
+                    return Ok(data.into()),
+                Immediate::Scalar(..) =>
+                    bug!(
+                        "{:?} input to a fat-to-thin cast ({:?} -> {:?})",
+                        *src, src.layout.ty, dest_layout.ty
+                    ),
+            };
+        }
+
+        // Handle casting any ptr to raw ptr (might be a fat ptr).
+        if (src.layout.ty.is_region_ptr() || src.layout.ty.is_unsafe_ptr() || src.layout.ty.is_fn_ptr()) &&
+            dest_layout.ty.is_unsafe_ptr()
+        {
+            // The only possible size-unequal case was handled above.
+            assert_eq!(src.layout.size, dest_layout.size);
+            return Ok(*src);
+        }
+
+        // For all remaining casts, we either
+        // (a) cast a raw ptr to usize, or
+        // (b) cast from an integer-like (including bool, char, enums).
+        // In both cases we want the bits.
+        let bits = self.force_bits(src.to_scalar()?, src.layout.size)?;
+        Ok(self.cast_from_int(bits, src.layout, dest_layout)?.into())
     }
 
     fn cast_from_int(
@@ -233,27 +234,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Ok(Scalar::from_f64(f.convert(&mut false).value)),
             // That's it.
             _ => bug!("invalid float to {:?} cast", dest_ty),
-        }
-    }
-
-    fn cast_from_ptr(
-        &self,
-        ptr: Pointer<M::PointerTag>,
-        src_layout: TyLayout<'tcx>,
-        dest_layout: TyLayout<'tcx>,
-    ) -> InterpResult<'tcx, Scalar<M::PointerTag>> {
-        use rustc::ty::TyKind::*;
-
-        match dest_layout.ty.sty {
-            // Casting to a reference or fn pointer is not permitted by rustc,
-            // no need to support it here.
-            RawPtr(_) => Ok(ptr.into()),
-            Int(_) | Uint(_) => {
-                let size = self.memory.pointer_size();
-                let bits = self.force_bits(Scalar::Ptr(ptr), size)?;
-                self.cast_from_int(bits, src_layout, dest_layout)
-            }
-            _ => bug!("invalid MIR: ptr to {:?} cast", dest_layout.ty)
         }
     }
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -165,11 +165,10 @@ pub trait Machine<'mir, 'tcx>: Sized {
         def_id: DefId,
     ) -> InterpResult<'tcx, Cow<'tcx, Allocation>>;
 
-    /// Called for all binary operations on integer(-like) types when one operand is a pointer
-    /// value, and for the `Offset` operation that is inherently about pointers.
+    /// Called for all binary operations where the LHS has pointer type.
     ///
     /// Returns a (value, overflowed) pair if the operation succeeded
-    fn ptr_op(
+    fn binary_ptr_op(
         ecx: &InterpCx<'mir, 'tcx, Self>,
         bin_op: mir::BinOp,
         left: ImmTy<'tcx, Self::PointerTag>,

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -233,7 +233,6 @@ pub trait Machine<'mir, 'tcx>: Sized {
         extra: Self::FrameExtra,
     ) -> InterpResult<'tcx>;
 
-    #[inline(always)]
     fn int_to_ptr(
         _mem: &Memory<'mir, 'tcx, Self>,
         int: u64,
@@ -245,11 +244,8 @@ pub trait Machine<'mir, 'tcx>: Sized {
         }).into())
     }
 
-    #[inline(always)]
     fn ptr_to_int(
         _mem: &Memory<'mir, 'tcx, Self>,
         _ptr: Pointer<Self::PointerTag>,
-    ) -> InterpResult<'tcx, u64> {
-        err!(ReadPointerAsBytes)
-    }
+    ) -> InterpResult<'tcx, u64>;
 }

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -48,11 +48,6 @@ impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
 }
 
 impl<'tcx, Tag> Immediate<Tag> {
-    #[inline]
-    pub fn from_scalar(val: Scalar<Tag>) -> Self {
-        Immediate::Scalar(ScalarMaybeUndef::Scalar(val))
-    }
-
     pub fn new_slice(
         val: Scalar<Tag>,
         len: u64,
@@ -197,7 +192,7 @@ impl<'tcx, Tag: Copy> ImmTy<'tcx, Tag>
 {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>, layout: TyLayout<'tcx>) -> Self {
-        ImmTy { imm: Immediate::from_scalar(val), layout }
+        ImmTy { imm: val.into(), layout }
     }
 
     #[inline]
@@ -255,7 +250,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let ptr = match self.check_mplace_access(mplace, None)? {
             Some(ptr) => ptr,
             None => return Ok(Some(ImmTy { // zero-sized type
-                imm: Immediate::Scalar(Scalar::zst().into()),
+                imm: Scalar::zst().into(),
                 layout: mplace.layout,
             })),
         };
@@ -266,7 +261,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     .get(ptr.alloc_id)?
                     .read_scalar(self, ptr, mplace.layout.size)?;
                 Ok(Some(ImmTy {
-                    imm: Immediate::Scalar(scalar),
+                    imm: scalar.into(),
                     layout: mplace.layout,
                 }))
             }
@@ -368,7 +363,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let field = field.try_into().unwrap();
         let field_layout = op.layout.field(self, field)?;
         if field_layout.is_zst() {
-            let immediate = Immediate::Scalar(Scalar::zst().into());
+            let immediate = Scalar::zst().into();
             return Ok(OpTy { op: Operand::Immediate(immediate), layout: field_layout });
         }
         let offset = op.layout.fields.offset(field);
@@ -378,7 +373,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // extract fields from types with `ScalarPair` ABI
             Immediate::ScalarPair(a, b) => {
                 let val = if offset.bytes() == 0 { a } else { b };
-                Immediate::Scalar(val)
+                Immediate::from(val)
             },
             Immediate::Scalar(val) =>
                 bug!("field access on non aggregate {:#?}, {:#?}", val, op.layout),
@@ -415,7 +410,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Deref => self.deref_operand(base)?.into(),
             Subslice { .. } | ConstantIndex { .. } | Index(_) => if base.layout.is_zst() {
                 OpTy {
-                    op: Operand::Immediate(Immediate::Scalar(Scalar::zst().into())),
+                    op: Operand::Immediate(Scalar::zst().into()),
                     // the actual index doesn't matter, so we just pick a convenient one like 0
                     layout: base.layout.field(self, 0)?,
                 }
@@ -439,7 +434,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let layout = self.layout_of_local(frame, local, layout)?;
         let op = if layout.is_zst() {
             // Do not read from ZST, they might not be initialized
-            Operand::Immediate(Immediate::Scalar(Scalar::zst().into()))
+            Operand::Immediate(Scalar::zst().into())
         } else {
             frame.locals[local].access()?
         };
@@ -567,7 +562,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 Operand::Indirect(MemPlace::from_ptr(ptr, align))
             },
             ConstValue::Scalar(x) =>
-                Operand::Immediate(Immediate::Scalar(tag_scalar(x).into())),
+                Operand::Immediate(tag_scalar(x).into()),
             ConstValue::Slice { data, start, end } => {
                 // We rely on mutability being set correctly in `data` to prevent writes
                 // where none should happen.

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -33,6 +33,20 @@ pub enum Immediate<Tag=(), Id=AllocId> {
     ScalarPair(ScalarMaybeUndef<Tag, Id>, ScalarMaybeUndef<Tag, Id>),
 }
 
+impl<Tag> From<ScalarMaybeUndef<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: ScalarMaybeUndef<Tag>) -> Self {
+        Immediate::Scalar(val)
+    }
+}
+
+impl<Tag> From<Scalar<Tag>> for Immediate<Tag> {
+    #[inline(always)]
+    fn from(val: Scalar<Tag>) -> Self {
+        Immediate::Scalar(val.into())
+    }
+}
+
 impl<'tcx, Tag> Immediate<Tag> {
     #[inline]
     pub fn from_scalar(val: Scalar<Tag>) -> Self {

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -302,7 +302,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
-            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+            _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`)
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -290,30 +290,29 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     FloatTy::F64 => self.binary_float_op(bin_op, left.to_f64()?, right.to_f64()?),
                 })
             }
-            _ => {
-                // Must be integer(-like) types.  Don't forget about == on fn pointers.
+            _ if left.layout.ty.is_integral() => {
+                // the RHS type can be different, e.g. for shifts -- but it has to be integral, too
                 assert!(
-                    left.layout.ty.is_integral()   ||
-                    left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr(),
-                    "Unexpected LHS type {:?} for BinOp {:?}", left.layout.ty, bin_op);
-                assert!(
-                    right.layout.ty.is_integral()   ||
-                    right.layout.ty.is_unsafe_ptr() || right.layout.ty.is_fn_ptr(),
-                    "Unexpected RHS type {:?} for BinOp {:?}", right.layout.ty, bin_op);
+                    right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
 
-                // Handle operations that support pointer values
-                if left.to_scalar_ptr()?.is_ptr() ||
-                    right.to_scalar_ptr()?.is_ptr() ||
-                    bin_op == mir::BinOp::Offset
-                {
-                    return M::ptr_op(self, bin_op, left, right);
-                }
-
-                // Everything else only works with "proper" bits
-                let l = left.to_bits().expect("we checked is_ptr");
-                let r = right.to_bits().expect("we checked is_ptr");
+                let l = self.force_bits(left.to_scalar()?, left.layout.size)?;
+                let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
+            _ if left.layout.ty.is_unsafe_ptr() || left.layout.ty.is_fn_ptr() => {
+                // The RHS type must be the same *or an integer type* (for `Offset`)
+                assert!(
+                    right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
+                    "Unexpected types for BinOp: {:?} {:?} {:?}",
+                    left.layout.ty, bin_op, right.layout.ty
+                );
+
+                M::binary_ptr_op(self, bin_op, left, right)
+            }
+            _ => bug!("Invalid MIR: bad LHS type for binop: {:?}", left.layout.ty),
         }
     }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -303,7 +303,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
-                // The RHS type must be the same *or an integer type* (for `Offset`)
+                // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
                     right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -8,7 +8,7 @@ use rustc_target::spec::abi::Abi;
 
 use super::{
     InterpResult, PointerArithmetic, InterpError, Scalar,
-    InterpCx, Machine, Immediate, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
+    InterpCx, Machine, OpTy, ImmTy, PlaceTy, MPlaceTy, StackPopCleanup, FnVal,
 };
 
 impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
@@ -462,7 +462,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 // Adjust receiver argument.
                 args[0] = OpTy::from(ImmTy {
                     layout: this_receiver_ptr,
-                    imm: Immediate::Scalar(receiver_place.ptr.into())
+                    imm: receiver_place.ptr.into()
                 });
                 trace!("Patched self operand to {:#?}", args[0]);
                 // recurse with concrete function

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2104,9 +2104,7 @@ pub enum AttrStyle {
     Inner,
 }
 
-#[derive(
-    Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, PartialOrd, Ord, Copy,
-)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Copy)]
 pub struct AttrId(pub usize);
 
 impl Idx for AttrId {
@@ -2115,6 +2113,18 @@ impl Idx for AttrId {
     }
     fn index(self) -> usize {
         self.0
+    }
+}
+
+impl rustc_serialize::Encodable for AttrId {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_unit()
+    }
+}
+
+impl rustc_serialize::Decodable for AttrId {
+    fn decode<D: Decoder>(d: &mut D) -> Result<AttrId, D::Error> {
+        d.read_nil().map(|_| crate::attr::mk_attr_id())
     }
 }
 

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -929,7 +929,7 @@ pub fn find_transparency(
 pub fn check_builtin_macro_attribute(ecx: &ExtCtxt<'_>, meta_item: &MetaItem, name: Symbol) {
     // All the built-in macro attributes are "words" at the moment.
     let template = AttributeTemplate { word: true, list: None, name_value_str: None };
-    let attr = ecx.attribute(meta_item.span, meta_item.clone());
+    let attr = ecx.attribute(meta_item.clone());
     check_builtin_attribute(ecx.parse_sess, &attr, name, template);
 }
 

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -3,7 +3,6 @@
 use crate::ast::{self, Attribute, MetaItem, NestedMetaItem};
 use crate::early_buffered_lints::BufferedEarlyLintId;
 use crate::ext::base::ExtCtxt;
-use crate::ext::build::AstBuilder;
 use crate::feature_gate::{Features, GatedCfg};
 use crate::parse::ParseSess;
 

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -6,9 +6,10 @@ pub use builtin::*;
 pub use IntType::*;
 pub use ReprAttr::*;
 pub use StabilityLevel::*;
+pub use crate::ast::Attribute;
 
 use crate::ast;
-use crate::ast::{AttrId, Attribute, AttrStyle, Name, Ident, Path, PathSegment};
+use crate::ast::{AttrId, AttrStyle, Name, Ident, Path, PathSegment};
 use crate::ast::{MetaItem, MetaItemKind, NestedMetaItem};
 use crate::ast::{Lit, LitKind, Expr, Item, Local, Stmt, StmtKind, GenericParam};
 use crate::mut_visit::visit_clobber;
@@ -328,13 +329,14 @@ impl Attribute {
             let meta = mk_name_value_item_str(
                 Ident::with_empty_ctxt(sym::doc),
                 dummy_spanned(Symbol::intern(&strip_doc_comment_decoration(&comment.as_str()))));
-            let mut attr = if self.style == ast::AttrStyle::Outer {
-                mk_attr_outer(self.span, self.id, meta)
-            } else {
-                mk_attr_inner(self.span, self.id, meta)
-            };
-            attr.is_sugared_doc = true;
-            f(&attr)
+            f(&Attribute {
+                id: self.id,
+                style: self.style,
+                path: meta.path,
+                tokens: meta.node.tokens(meta.span),
+                is_sugared_doc: true,
+                span: self.span,
+            })
         } else {
             f(self)
         }
@@ -377,9 +379,9 @@ pub fn mk_attr_id() -> AttrId {
 }
 
 /// Returns an inner attribute with the given value and span.
-pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(span: Span, item: MetaItem) -> Attribute {
     Attribute {
-        id,
+        id: mk_attr_id(),
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
@@ -389,9 +391,9 @@ pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
 }
 
 /// Returns an outer attribute with the given value and span.
-pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(span: Span, item: MetaItem) -> Attribute {
     Attribute {
-        id,
+        id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
@@ -400,12 +402,12 @@ pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     }
 }
 
-pub fn mk_sugared_doc_attr(id: AttrId, text: Symbol, span: Span) -> Attribute {
+pub fn mk_sugared_doc_attr(text: Symbol, span: Span) -> Attribute {
     let style = doc_comment_style(&text.as_str());
     let lit_kind = LitKind::Str(text, ast::StrStyle::Cooked);
     let lit = Lit::from_lit_kind(lit_kind, span);
     Attribute {
-        id,
+        id: mk_attr_id(),
         style,
         path: Path::from_ident(Ident::with_empty_ctxt(sym::doc).with_span_pos(span)),
         tokens: MetaItemKind::NameValue(lit).tokens(span),

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -376,37 +376,27 @@ pub fn mk_attr_id() -> AttrId {
     AttrId(id)
 }
 
-/// Returns an inner attribute with the given value.
-pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
-    mk_spanned_attr_inner(span, id, item)
-}
-
 /// Returns an inner attribute with the given value and span.
-pub fn mk_spanned_attr_inner(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id,
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span: sp,
+        span,
     }
 }
 
-/// Returns an outer attribute with the given value.
-pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
-    mk_spanned_attr_outer(span, id, item)
-}
-
 /// Returns an outer attribute with the given value and span.
-pub fn mk_spanned_attr_outer(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id,
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span: sp,
+        span,
     }
 }
 

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -379,26 +379,26 @@ pub fn mk_attr_id() -> AttrId {
 }
 
 /// Returns an inner attribute with the given value and span.
-pub fn mk_attr_inner(span: Span, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(item: MetaItem) -> Attribute {
     Attribute {
         id: mk_attr_id(),
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span,
+        span: item.span,
     }
 }
 
 /// Returns an outer attribute with the given value and span.
-pub fn mk_attr_outer(span: Span, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(item: MetaItem) -> Attribute {
     Attribute {
         id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span,
+        span: item.span,
     }
 }
 

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -4,7 +4,6 @@ use std::env;
 use crate::ast::{self, Ident, Name};
 use crate::source_map;
 use crate::ext::base::{ExtCtxt, MacEager, MacResult};
-use crate::ext::build::AstBuilder;
 use crate::parse::token::{self, Token};
 use crate::ptr::P;
 use crate::symbol::kw;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(sp, attr::mk_attr_id(), mi)
+        attr::mk_attr_outer(sp, mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -870,21 +870,21 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
-        attr::mk_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
+        attr::mk_word_item(Ident::new(w, sp))
     }
 
     pub fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
-        attr::mk_nested_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
+        attr::mk_nested_word_item(Ident::new(w, sp))
     }
 
     pub fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
                  -> ast::MetaItem {
-        attr::mk_list_item(sp, Ident::with_empty_ctxt(name).with_span_pos(sp), mis)
+        attr::mk_list_item(sp, Ident::new(name, sp), mis)
     }
 
     pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
                        -> ast::MetaItem {
-        attr::mk_name_value_item(span, Ident::with_empty_ctxt(name).with_span_pos(span),
+        attr::mk_name_value_item(span, Ident::new(name, span),
                                  lit_kind, span)
     }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_spanned_attr_outer(sp, attr::mk_attr_id(), mi)
+        attr::mk_attr_outer(sp, attr::mk_attr_id(), mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -259,7 +259,7 @@ pub trait AstBuilder {
                     generics: Generics) -> P<ast::Item>;
     fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item>;
 
-    fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute;
+    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute;
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem;
 
@@ -1134,8 +1134,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item_ty_poly(span, name, ty, Generics::default())
     }
 
-    fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(sp, mi)
+    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
+        attr::mk_attr_outer(mi.span, mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -9,295 +9,20 @@ use crate::ThinVec;
 use rustc_target::spec::abi::Abi;
 use syntax_pos::{Pos, Span};
 
-pub trait AstBuilder {
-    // Paths
-    fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path;
-    fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path;
-    fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path;
-    fn path_all(&self, sp: Span,
-                global: bool,
-                idents: Vec<ast::Ident>,
-                args: Vec<ast::GenericArg>,
-                constraints: Vec<ast::AssocTyConstraint>)
-        -> ast::Path;
+// Left so that Cargo tests don't break, this can be removed once those no longer use it
+pub trait AstBuilder {}
 
-    fn qpath(&self, self_type: P<ast::Ty>,
-             trait_path: ast::Path,
-             ident: ast::Ident)
-             -> (ast::QSelf, ast::Path);
-    fn qpath_all(&self, self_type: P<ast::Ty>,
-                trait_path: ast::Path,
-                ident: ast::Ident,
-                args: Vec<ast::GenericArg>,
-                constraints: Vec<ast::AssocTyConstraint>)
-                -> (ast::QSelf, ast::Path);
-
-    // types and consts
-    fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy;
-
-    fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty>;
-    fn ty_path(&self, path: ast::Path) -> P<ast::Ty>;
-    fn ty_ident(&self, span: Span, idents: ast::Ident) -> P<ast::Ty>;
-    fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst;
-    fn const_ident(&self, span: Span, idents: ast::Ident) -> ast::AnonConst;
-
-    fn ty_rptr(&self, span: Span,
-               ty: P<ast::Ty>,
-               lifetime: Option<ast::Lifetime>,
-               mutbl: ast::Mutability) -> P<ast::Ty>;
-    fn ty_ptr(&self, span: Span,
-              ty: P<ast::Ty>,
-              mutbl: ast::Mutability) -> P<ast::Ty>;
-
-    fn ty_infer(&self, sp: Span) -> P<ast::Ty>;
-
-    fn typaram(&self,
-               span: Span,
-               id: ast::Ident,
-               attrs: Vec<ast::Attribute>,
-               bounds: ast::GenericBounds,
-               default: Option<P<ast::Ty>>) -> ast::GenericParam;
-
-    fn trait_ref(&self, path: ast::Path) -> ast::TraitRef;
-    fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef;
-    fn trait_bound(&self, path: ast::Path) -> ast::GenericBound;
-    fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime;
-    fn lifetime_def(&self,
-                    span: Span,
-                    ident: ast::Ident,
-                    attrs: Vec<ast::Attribute>,
-                    bounds: ast::GenericBounds)
-                    -> ast::GenericParam;
-
-    // Statements
-    fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident, ex: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_let_typed(&self,
-                      sp: Span,
-                      mutbl: bool,
-                      ident: ast::Ident,
-                      typ: P<ast::Ty>,
-                      ex: P<ast::Expr>)
-                      -> ast::Stmt;
-    fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt;
-    fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt;
-
-    // Blocks
-    fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block>;
-    fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block>;
-
-    // Expressions
-    fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr>;
-    fn expr_path(&self, path: ast::Path) -> P<ast::Expr>;
-    fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr>;
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr>;
-
-    fn expr_self(&self, span: Span) -> P<ast::Expr>;
-    fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
-                   lhs: P<ast::Expr>, rhs: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr>;
-
-    fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_field_access(&self, span: Span, expr: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr>;
-    fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>,
-                             idx: usize) -> P<ast::Expr>;
-    fn expr_call(&self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_call_ident(&self, span: Span, id: ast::Ident, args: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident>,
-                        args: Vec<P<ast::Expr>> ) -> P<ast::Expr>;
-    fn expr_method_call(&self, span: Span,
-                        expr: P<ast::Expr>, ident: ast::Ident,
-                        args: Vec<P<ast::Expr>> ) -> P<ast::Expr>;
-    fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr>;
-    fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr>;
-
-    fn field_imm(&self, span: Span, name: Ident, e: P<ast::Expr>) -> ast::Field;
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field>) -> P<ast::Expr>;
-    fn expr_struct_ident(&self, span: Span, id: ast::Ident,
-                         fields: Vec<ast::Field>) -> P<ast::Expr>;
-
-    fn expr_lit(&self, sp: Span, lit: ast::LitKind) -> P<ast::Expr>;
-
-    fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr>;
-    fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr>;
-    fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr>;
-    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr>;
-    fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr>;
-    fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr>;
-
-    fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr>;
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr>;
-
-    fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_none(&self, sp: Span) -> P<ast::Expr>;
-
-    fn expr_break(&self, sp: Span) -> P<ast::Expr>;
-
-    fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-
-    fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr>;
-    fn expr_unreachable(&self, span: Span) -> P<ast::Expr>;
-
-    fn expr_ok(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_err(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_try(&self, span: Span, head: P<ast::Expr>) -> P<ast::Expr>;
-
-    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat>;
-    fn pat_wild(&self, span: Span) -> P<ast::Pat>;
-    fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat>;
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat>;
-
-    fn pat_ident_binding_mode(&self,
-                              span: Span,
-                              ident: ast::Ident,
-                              bm: ast::BindingMode) -> P<ast::Pat>;
-    fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat>;
-    fn pat_tuple_struct(&self, span: Span, path: ast::Path,
-                        subpats: Vec<P<ast::Pat>>) -> P<ast::Pat>;
-    fn pat_struct(&self, span: Span, path: ast::Path,
-                  field_pats: Vec<Spanned<ast::FieldPat>>) -> P<ast::Pat>;
-    fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat>;
-
-    fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-    fn pat_none(&self, span: Span) -> P<ast::Pat>;
-
-    fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-    fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-
-    fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm;
-    fn arm_unreachable(&self, span: Span) -> ast::Arm;
-
-    fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm> ) -> P<ast::Expr>;
-    fn expr_if(&self, span: Span,
-               cond: P<ast::Expr>, then: P<ast::Expr>, els: Option<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr>;
-
-    fn lambda_fn_decl(&self,
-                      span: Span,
-                      fn_decl: P<ast::FnDecl>,
-                      body: P<ast::Expr>,
-                      fn_decl_span: Span)
-                      -> P<ast::Expr>;
-
-    fn lambda(&self, span: Span, ids: Vec<ast::Ident>, body: P<ast::Expr>) -> P<ast::Expr>;
-    fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr>;
-    fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr>;
-
-    fn lambda_stmts(&self, span: Span, ids: Vec<ast::Ident>,
-                    blk: Vec<ast::Stmt>) -> P<ast::Expr>;
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr>;
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
-                      ident: ast::Ident) -> P<ast::Expr>;
-
-    // Items
-    fn item(&self, span: Span,
-            name: Ident, attrs: Vec<ast::Attribute> , node: ast::ItemKind) -> P<ast::Item>;
-
-    fn arg(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> ast::Arg;
-    // FIXME: unused `self`
-    fn fn_decl(&self, inputs: Vec<ast::Arg> , output: ast::FunctionRetTy) -> P<ast::FnDecl>;
-
-    fn item_fn_poly(&self,
-                    span: Span,
-                    name: Ident,
-                    inputs: Vec<ast::Arg> ,
-                    output: P<ast::Ty>,
-                    generics: Generics,
-                    body: P<ast::Block>) -> P<ast::Item>;
-    fn item_fn(&self,
-               span: Span,
-               name: Ident,
-               inputs: Vec<ast::Arg> ,
-               output: P<ast::Ty>,
-               body: P<ast::Block>) -> P<ast::Item>;
-
-    fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant;
-    fn item_enum_poly(&self,
-                      span: Span,
-                      name: Ident,
-                      enum_definition: ast::EnumDef,
-                      generics: Generics) -> P<ast::Item>;
-    fn item_enum(&self, span: Span, name: Ident, enum_def: ast::EnumDef) -> P<ast::Item>;
-
-    fn item_struct_poly(&self,
-                        span: Span,
-                        name: Ident,
-                        struct_def: ast::VariantData,
-                        generics: Generics) -> P<ast::Item>;
-    fn item_struct(&self, span: Span, name: Ident, struct_def: ast::VariantData) -> P<ast::Item>;
-
-    fn item_mod(&self, span: Span, inner_span: Span,
-                name: Ident, attrs: Vec<ast::Attribute>,
-                items: Vec<P<ast::Item>>) -> P<ast::Item>;
-
-    fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item>;
-
-    fn item_static(&self,
-                   span: Span,
-                   name: Ident,
-                   ty: P<ast::Ty>,
-                   mutbl: ast::Mutability,
-                   expr: P<ast::Expr>)
-                   -> P<ast::Item>;
-
-    fn item_const(&self,
-                   span: Span,
-                   name: Ident,
-                   ty: P<ast::Ty>,
-                   expr: P<ast::Expr>)
-                   -> P<ast::Item>;
-
-    fn item_ty_poly(&self,
-                    span: Span,
-                    name: Ident,
-                    ty: P<ast::Ty>,
-                    generics: Generics) -> P<ast::Item>;
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item>;
-
-    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute;
-
-    fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem;
-
-    fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem;
-
-    fn meta_list(&self,
-                 sp: Span,
-                 name: ast::Name,
-                 mis: Vec<ast::NestedMetaItem> )
-                 -> ast::MetaItem;
-    fn meta_name_value(&self,
-                       sp: Span,
-                       name: ast::Name,
-                       value: ast::LitKind)
-                       -> ast::MetaItem;
-
-    fn item_use(&self, sp: Span,
-                vis: ast::Visibility, vp: P<ast::UseTree>) -> P<ast::Item>;
-    fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item>;
-    fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
-                        ident: Option<ast::Ident>, path: ast::Path) -> P<ast::Item>;
-    fn item_use_list(&self, sp: Span, vis: ast::Visibility,
-                     path: Vec<ast::Ident>, imports: &[ast::Ident]) -> P<ast::Item>;
-    fn item_use_glob(&self, sp: Span,
-                     vis: ast::Visibility, path: Vec<ast::Ident>) -> P<ast::Item>;
-}
-
-impl<'a> AstBuilder for ExtCtxt<'a> {
-    fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
+impl<'a> ExtCtxt<'a> {
+    pub fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
         self.path_all(span, false, strs, vec![], vec![])
     }
-    fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path {
+    pub fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path {
         self.path(span, vec![id])
     }
-    fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
+    pub fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
         self.path_all(span, true, strs, vec![], vec![])
     }
-    fn path_all(&self,
+    pub fn path_all(&self,
                 span: Span,
                 global: bool,
                 mut idents: Vec<ast::Ident> ,
@@ -330,7 +55,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     /// Constructs a qualified path.
     ///
     /// Constructs a path like `<self_type as trait_path>::ident`.
-    fn qpath(&self,
+    pub fn qpath(&self,
              self_type: P<ast::Ty>,
              trait_path: ast::Path,
              ident: ast::Ident)
@@ -341,7 +66,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     /// Constructs a qualified path.
     ///
     /// Constructs a path like `<self_type as trait_path>::ident<'a, T, A = Bar>`.
-    fn qpath_all(&self,
+    pub fn qpath_all(&self,
                  self_type: P<ast::Ty>,
                  trait_path: ast::Path,
                  ident: ast::Ident,
@@ -363,14 +88,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }, path)
     }
 
-    fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy {
+    pub fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy {
         ast::MutTy {
             ty,
             mutbl,
         }
     }
 
-    fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty> {
+    pub fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty> {
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
             span,
@@ -378,18 +103,18 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn ty_path(&self, path: ast::Path) -> P<ast::Ty> {
+    pub fn ty_path(&self, path: ast::Path) -> P<ast::Ty> {
         self.ty(path.span, ast::TyKind::Path(None, path))
     }
 
     // Might need to take bounds as an argument in the future, if you ever want
     // to generate a bounded existential trait type.
-    fn ty_ident(&self, span: Span, ident: ast::Ident)
+    pub fn ty_ident(&self, span: Span, ident: ast::Ident)
         -> P<ast::Ty> {
         self.ty_path(self.path_ident(span, ident))
     }
 
-    fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst {
+    pub fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst {
         ast::AnonConst {
             id: ast::DUMMY_NODE_ID,
             value: P(ast::Expr {
@@ -401,11 +126,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn const_ident(&self, span: Span, ident: ast::Ident) -> ast::AnonConst {
+    pub fn const_ident(&self, span: Span, ident: ast::Ident) -> ast::AnonConst {
         self.anon_const(span, ast::ExprKind::Path(None, self.path_ident(span, ident)))
     }
 
-    fn ty_rptr(&self,
+    pub fn ty_rptr(&self,
                span: Span,
                ty: P<ast::Ty>,
                lifetime: Option<ast::Lifetime>,
@@ -415,7 +140,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 ast::TyKind::Rptr(lifetime, self.ty_mt(ty, mutbl)))
     }
 
-    fn ty_ptr(&self,
+    pub fn ty_ptr(&self,
               span: Span,
               ty: P<ast::Ty>,
               mutbl: ast::Mutability)
@@ -424,11 +149,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 ast::TyKind::Ptr(self.ty_mt(ty, mutbl)))
     }
 
-    fn ty_infer(&self, span: Span) -> P<ast::Ty> {
+    pub fn ty_infer(&self, span: Span) -> P<ast::Ty> {
         self.ty(span, ast::TyKind::Infer)
     }
 
-    fn typaram(&self,
+    pub fn typaram(&self,
                span: Span,
                ident: ast::Ident,
                attrs: Vec<ast::Attribute>,
@@ -445,14 +170,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn trait_ref(&self, path: ast::Path) -> ast::TraitRef {
+    pub fn trait_ref(&self, path: ast::Path) -> ast::TraitRef {
         ast::TraitRef {
             path,
             ref_id: ast::DUMMY_NODE_ID,
         }
     }
 
-    fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef {
+    pub fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef {
         ast::PolyTraitRef {
             bound_generic_params: Vec::new(),
             trait_ref: self.trait_ref(path),
@@ -460,16 +185,16 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn trait_bound(&self, path: ast::Path) -> ast::GenericBound {
+    pub fn trait_bound(&self, path: ast::Path) -> ast::GenericBound {
         ast::GenericBound::Trait(self.poly_trait_ref(path.span, path),
                                  ast::TraitBoundModifier::None)
     }
 
-    fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime {
+    pub fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime {
         ast::Lifetime { id: ast::DUMMY_NODE_ID, ident: ident.with_span_pos(span) }
     }
 
-    fn lifetime_def(&self,
+    pub fn lifetime_def(&self,
                     span: Span,
                     ident: ast::Ident,
                     attrs: Vec<ast::Attribute>,
@@ -485,7 +210,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt {
+    pub fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
@@ -493,7 +218,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt {
+    pub fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
@@ -501,7 +226,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
+    pub fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
                 ex: P<ast::Expr>) -> ast::Stmt {
         let pat = if mutbl {
             let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Mutable);
@@ -524,7 +249,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_let_typed(&self,
+    pub fn stmt_let_typed(&self,
                       sp: Span,
                       mutbl: bool,
                       ident: ast::Ident,
@@ -553,7 +278,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     // Generates `let _: Type;`, which is usually used for type assertions.
-    fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt {
+    pub fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt {
         let local = P(ast::Local {
             pat: self.pat_wild(span),
             ty: Some(ty),
@@ -569,7 +294,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt {
+    pub fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             node: ast::StmtKind::Item(item),
@@ -577,14 +302,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block> {
+    pub fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block> {
         self.block(expr.span, vec![ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
             node: ast::StmtKind::Expr(expr),
         }])
     }
-    fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block> {
+    pub fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block> {
         P(ast::Block {
            stmts,
            id: ast::DUMMY_NODE_ID,
@@ -593,7 +318,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr> {
+    pub fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr> {
         P(ast::Expr {
             id: ast::DUMMY_NODE_ID,
             node,
@@ -602,61 +327,65 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn expr_path(&self, path: ast::Path) -> P<ast::Expr> {
+    pub fn expr_path(&self, path: ast::Path) -> P<ast::Expr> {
         self.expr(path.span, ast::ExprKind::Path(None, path))
     }
 
     /// Constructs a `QPath` expression.
-    fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr> {
+    pub fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Path(Some(qself), path))
     }
 
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr> {
+    pub fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr> {
         self.expr_path(self.path_ident(span, id))
     }
-    fn expr_self(&self, span: Span) -> P<ast::Expr> {
+    pub fn expr_self(&self, span: Span) -> P<ast::Expr> {
         self.expr_ident(span, Ident::with_empty_ctxt(kw::SelfLower))
     }
 
-    fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
+    pub fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
                    lhs: P<ast::Expr>, rhs: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Binary(Spanned { node: op, span: sp }, lhs, rhs))
     }
 
-    fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr_unary(sp, UnOp::Deref, e)
     }
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Unary(op, e))
     }
 
-    fn expr_field_access(&self, sp: Span, expr: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
+    pub fn expr_field_access(
+        &self, sp: Span, expr: P<ast::Expr>, ident: ast::Ident,
+    ) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Field(expr, ident.with_span_pos(sp)))
     }
-    fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>, idx: usize) -> P<ast::Expr> {
+    pub fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>, idx: usize) -> P<ast::Expr> {
         let ident = Ident::from_str(&idx.to_string()).with_span_pos(sp);
         self.expr(sp, ast::ExprKind::Field(expr, ident))
     }
-    fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Immutable, e))
     }
-    fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Mutable, e))
     }
 
-    fn expr_call(&self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_call(
+        &self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>,
+    ) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Call(expr, args))
     }
-    fn expr_call_ident(&self, span: Span, id: ast::Ident,
+    pub fn expr_call_ident(&self, span: Span, id: ast::Ident,
                        args: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Call(self.expr_ident(span, id), args))
     }
-    fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
+    pub fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
                       args: Vec<P<ast::Expr>> ) -> P<ast::Expr> {
         let pathexpr = self.expr_path(self.path_global(sp, fn_path));
         self.expr_call(sp, pathexpr, args)
     }
-    fn expr_method_call(&self, span: Span,
+    pub fn expr_method_call(&self, span: Span,
                         expr: P<ast::Expr>,
                         ident: ast::Ident,
                         mut args: Vec<P<ast::Expr>> ) -> P<ast::Expr> {
@@ -664,10 +393,10 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let segment = ast::PathSegment::from_ident(ident.with_span_pos(span));
         self.expr(span, ast::ExprKind::MethodCall(segment, args))
     }
-    fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr> {
+    pub fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr> {
         self.expr(b.span, ast::ExprKind::Block(b, None))
     }
-    fn field_imm(&self, span: Span, ident: Ident, e: P<ast::Expr>) -> ast::Field {
+    pub fn field_imm(&self, span: Span, ident: Ident, e: P<ast::Expr>) -> ast::Field {
         ast::Field {
             ident: ident.with_span_pos(span),
             expr: e,
@@ -676,23 +405,25 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             attrs: ThinVec::new(),
         }
     }
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field>) -> P<ast::Expr> {
+    pub fn expr_struct(
+        &self, span: Span, path: ast::Path, fields: Vec<ast::Field>
+    ) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Struct(path, fields, None))
     }
-    fn expr_struct_ident(&self, span: Span,
+    pub fn expr_struct_ident(&self, span: Span,
                          id: ast::Ident, fields: Vec<ast::Field>) -> P<ast::Expr> {
         self.expr_struct(span, self.path_ident(span, id), fields)
     }
 
-    fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
+    pub fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
         let lit = ast::Lit::from_lit_kind(lit_kind, span);
         self.expr(span, ast::ExprKind::Lit(lit))
     }
-    fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr> {
+    pub fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr> {
         self.expr_lit(span, ast::LitKind::Int(i as u128,
                                               ast::LitIntType::Unsigned(ast::UintTy::Usize)))
     }
-    fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr> {
+    pub fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr> {
         if i < 0 {
             let i = (-i) as u128;
             let lit_ty = ast::LitIntType::Signed(ast::IntTy::Isize);
@@ -703,59 +434,59 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                 ast::LitIntType::Signed(ast::IntTy::Isize)))
         }
     }
-    fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
+    pub fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U32)))
     }
-    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
+    pub fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U16)))
     }
-    fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
+    pub fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128, ast::LitIntType::Unsigned(ast::UintTy::U8)))
     }
-    fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr> {
+    pub fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Bool(value))
     }
 
-    fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Array(exprs))
     }
-    fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr> {
         self.expr_call_global(sp, self.std_path(&[sym::vec, sym::Vec, sym::new]),
                               Vec::new())
     }
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr_addr_of(sp, self.expr_vec(sp, exprs))
     }
-    fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr> {
+    pub fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Str(s, ast::StrStyle::Cooked))
     }
 
-    fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr> {
+    pub fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Cast(expr, ty))
     }
 
-    fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let some = self.std_path(&[sym::option, sym::Option, sym::Some]);
         self.expr_call_global(sp, some, vec![expr])
     }
 
-    fn expr_none(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_none(&self, sp: Span) -> P<ast::Expr> {
         let none = self.std_path(&[sym::option, sym::Option, sym::None]);
         let none = self.path_global(sp, none);
         self.expr_path(none)
     }
 
-    fn expr_break(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_break(&self, sp: Span) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Break(None, None))
     }
 
-    fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Tup(exprs))
     }
 
-    fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr> {
+    pub fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr> {
         let loc = self.source_map().lookup_char_pos(span.lo());
         let expr_file = self.expr_str(span, Symbol::intern(&loc.file.name.to_string()));
         let expr_line = self.expr_u32(span, loc.line as u32);
@@ -770,21 +501,21 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 expr_loc_ptr])
     }
 
-    fn expr_unreachable(&self, span: Span) -> P<ast::Expr> {
+    pub fn expr_unreachable(&self, span: Span) -> P<ast::Expr> {
         self.expr_fail(span, Symbol::intern("internal error: entered unreachable code"))
     }
 
-    fn expr_ok(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_ok(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let ok = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         self.expr_call_global(sp, ok, vec![expr])
     }
 
-    fn expr_err(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_err(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let err = self.std_path(&[sym::result, sym::Result, sym::Err]);
         self.expr_call_global(sp, err, vec![expr])
     }
 
-    fn expr_try(&self, sp: Span, head: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_try(&self, sp: Span, head: P<ast::Expr>) -> P<ast::Expr> {
         let ok = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         let ok_path = self.path_global(sp, ok);
         let err = self.std_path(&[sym::result, sym::Result, sym::Err]);
@@ -814,67 +545,67 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
 
-    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat> {
+    pub fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat> {
         P(ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span })
     }
-    fn pat_wild(&self, span: Span) -> P<ast::Pat> {
+    pub fn pat_wild(&self, span: Span) -> P<ast::Pat> {
         self.pat(span, PatKind::Wild)
     }
-    fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat> {
+    pub fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat> {
         self.pat(span, PatKind::Lit(expr))
     }
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat> {
+    pub fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat> {
         let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Immutable);
         self.pat_ident_binding_mode(span, ident, binding_mode)
     }
 
-    fn pat_ident_binding_mode(&self,
+    pub fn pat_ident_binding_mode(&self,
                               span: Span,
                               ident: ast::Ident,
                               bm: ast::BindingMode) -> P<ast::Pat> {
         let pat = PatKind::Ident(bm, ident.with_span_pos(span), None);
         self.pat(span, pat)
     }
-    fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat> {
+    pub fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat> {
         self.pat(span, PatKind::Path(None, path))
     }
-    fn pat_tuple_struct(&self, span: Span, path: ast::Path,
+    pub fn pat_tuple_struct(&self, span: Span, path: ast::Path,
                         subpats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::TupleStruct(path, subpats))
     }
-    fn pat_struct(&self, span: Span, path: ast::Path,
+    pub fn pat_struct(&self, span: Span, path: ast::Path,
                   field_pats: Vec<Spanned<ast::FieldPat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::Struct(path, field_pats, false))
     }
-    fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
+    pub fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::Tuple(pats))
     }
 
-    fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::option, sym::Option, sym::Some]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn pat_none(&self, span: Span) -> P<ast::Pat> {
+    pub fn pat_none(&self, span: Span) -> P<ast::Pat> {
         let some = self.std_path(&[sym::option, sym::Option, sym::None]);
         let path = self.path_global(span, some);
         self.pat_path(span, path)
     }
 
-    fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::result, sym::Result, sym::Err]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm {
+    pub fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm {
         ast::Arm {
             attrs: vec![],
             pats,
@@ -884,25 +615,25 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn arm_unreachable(&self, span: Span) -> ast::Arm {
+    pub fn arm_unreachable(&self, span: Span) -> ast::Arm {
         self.arm(span, vec![self.pat_wild(span)], self.expr_unreachable(span))
     }
 
-    fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm>) -> P<Expr> {
+    pub fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm>) -> P<Expr> {
         self.expr(span, ast::ExprKind::Match(arg, arms))
     }
 
-    fn expr_if(&self, span: Span, cond: P<ast::Expr>,
+    pub fn expr_if(&self, span: Span, cond: P<ast::Expr>,
                then: P<ast::Expr>, els: Option<P<ast::Expr>>) -> P<ast::Expr> {
         let els = els.map(|x| self.expr_block(self.block_expr(x)));
         self.expr(span, ast::ExprKind::If(cond, self.block_expr(then), els))
     }
 
-    fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr> {
+    pub fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Loop(block, None))
     }
 
-    fn lambda_fn_decl(&self,
+    pub fn lambda_fn_decl(&self,
                       span: Span,
                       fn_decl: P<ast::FnDecl>,
                       body: P<ast::Expr>,
@@ -916,7 +647,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                fn_decl_span))
     }
 
-    fn lambda(&self,
+    pub fn lambda(&self,
               span: Span,
               ids: Vec<ast::Ident>,
               body: P<ast::Expr>)
@@ -937,30 +668,30 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                span))
     }
 
-    fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr> {
         self.lambda(span, Vec::new(), body)
     }
 
-    fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
+    pub fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
         self.lambda(span, vec![ident], body)
     }
 
-    fn lambda_stmts(&self,
+    pub fn lambda_stmts(&self,
                     span: Span,
                     ids: Vec<ast::Ident>,
                     stmts: Vec<ast::Stmt>)
                     -> P<ast::Expr> {
         self.lambda(span, ids, self.expr_block(self.block(span, stmts)))
     }
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr> {
+    pub fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr> {
         self.lambda0(span, self.expr_block(self.block(span, stmts)))
     }
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
+    pub fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
                       ident: ast::Ident) -> P<ast::Expr> {
         self.lambda1(span, self.expr_block(self.block(span, stmts)), ident)
     }
 
-    fn arg(&self, span: Span, ident: ast::Ident, ty: P<ast::Ty>) -> ast::Arg {
+    pub fn arg(&self, span: Span, ident: ast::Ident, ty: P<ast::Ty>) -> ast::Arg {
         let arg_pat = self.pat_ident(span, ident);
         ast::Arg {
             attrs: ThinVec::default(),
@@ -972,7 +703,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     // FIXME: unused `self`
-    fn fn_decl(&self, inputs: Vec<ast::Arg>, output: ast::FunctionRetTy) -> P<ast::FnDecl> {
+    pub fn fn_decl(&self, inputs: Vec<ast::Arg>, output: ast::FunctionRetTy) -> P<ast::FnDecl> {
         P(ast::FnDecl {
             inputs,
             output,
@@ -980,7 +711,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item(&self, span: Span, name: Ident,
+    pub fn item(&self, span: Span, name: Ident,
             attrs: Vec<ast::Attribute>, node: ast::ItemKind) -> P<ast::Item> {
         // FIXME: Would be nice if our generated code didn't violate
         // Rust coding conventions
@@ -995,7 +726,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item_fn_poly(&self,
+    pub fn item_fn_poly(&self,
                     span: Span,
                     name: Ident,
                     inputs: Vec<ast::Arg> ,
@@ -1016,7 +747,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                               body))
     }
 
-    fn item_fn(&self,
+    pub fn item_fn(&self,
                span: Span,
                name: Ident,
                inputs: Vec<ast::Arg> ,
@@ -1032,7 +763,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             body)
     }
 
-    fn variant(&self, span: Span, ident: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
+    pub fn variant(&self, span: Span, ident: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
             ast::StructField {
                 span: ty.span,
@@ -1060,19 +791,19 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                })
     }
 
-    fn item_enum_poly(&self, span: Span, name: Ident,
+    pub fn item_enum_poly(&self, span: Span, name: Ident,
                       enum_definition: ast::EnumDef,
                       generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Enum(enum_definition, generics))
     }
 
-    fn item_enum(&self, span: Span, name: Ident,
+    pub fn item_enum(&self, span: Span, name: Ident,
                  enum_definition: ast::EnumDef) -> P<ast::Item> {
         self.item_enum_poly(span, name, enum_definition,
                             Generics::default())
     }
 
-    fn item_struct(&self, span: Span, name: Ident,
+    pub fn item_struct(&self, span: Span, name: Ident,
                    struct_def: ast::VariantData) -> P<ast::Item> {
         self.item_struct_poly(
             span,
@@ -1082,12 +813,12 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         )
     }
 
-    fn item_struct_poly(&self, span: Span, name: Ident,
+    pub fn item_struct_poly(&self, span: Span, name: Ident,
         struct_def: ast::VariantData, generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Struct(struct_def, generics))
     }
 
-    fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
+    pub fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
                 attrs: Vec<ast::Attribute>,
                 items: Vec<P<ast::Item>>) -> P<ast::Item> {
         self.item(
@@ -1102,11 +833,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         )
     }
 
-    fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item> {
+    pub fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::ExternCrate(None))
     }
 
-    fn item_static(&self,
+    pub fn item_static(&self,
                    span: Span,
                    name: Ident,
                    ty: P<ast::Ty>,
@@ -1116,7 +847,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item(span, name, Vec::new(), ast::ItemKind::Static(ty, mutbl, expr))
     }
 
-    fn item_const(&self,
+    pub fn item_const(&self,
                   span: Span,
                   name: Ident,
                   ty: P<ast::Ty>,
@@ -1125,39 +856,39 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item(span, name, Vec::new(), ast::ItemKind::Const(ty, expr))
     }
 
-    fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
+    pub fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
                     generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Ty(ty, generics))
     }
 
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
+    pub fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
         self.item_ty_poly(span, name, ty, Generics::default())
     }
 
-    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
+    pub fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
         attr::mk_attr_outer(mi)
     }
 
-    fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
+    pub fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
         attr::mk_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
     }
 
-    fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
+    pub fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
         attr::mk_nested_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
     }
 
-    fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
+    pub fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
                  -> ast::MetaItem {
         attr::mk_list_item(sp, Ident::with_empty_ctxt(name).with_span_pos(sp), mis)
     }
 
-    fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
+    pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
                        -> ast::MetaItem {
         attr::mk_name_value_item(span, Ident::with_empty_ctxt(name).with_span_pos(span),
                                  lit_kind, span)
     }
 
-    fn item_use(&self, sp: Span,
+    pub fn item_use(&self, sp: Span,
                 vis: ast::Visibility, vp: P<ast::UseTree>) -> P<ast::Item> {
         P(ast::Item {
             id: ast::DUMMY_NODE_ID,
@@ -1170,11 +901,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item> {
+    pub fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item> {
         self.item_use_simple_(sp, vis, None, path)
     }
 
-    fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
+    pub fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         rename: Option<ast::Ident>, path: ast::Path) -> P<ast::Item> {
         self.item_use(sp, vis, P(ast::UseTree {
             span: sp,
@@ -1183,7 +914,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }))
     }
 
-    fn item_use_list(&self, sp: Span, vis: ast::Visibility,
+    pub fn item_use_list(&self, sp: Span, vis: ast::Visibility,
                      path: Vec<ast::Ident>, imports: &[ast::Ident]) -> P<ast::Item> {
         let imports = imports.iter().map(|id| {
             (ast::UseTree {
@@ -1200,7 +931,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }))
     }
 
-    fn item_use_glob(&self, sp: Span,
+    pub fn item_use_glob(&self, sp: Span,
                      vis: ast::Visibility, path: Vec<ast::Ident>) -> P<ast::Item> {
         self.item_use(sp, vis, P(ast::UseTree {
             span: sp,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(mi.span, mi)
+        attr::mk_attr_outer(mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1341,8 +1341,8 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
 
             let meta = attr::mk_list_item(DUMMY_SP, Ident::with_empty_ctxt(sym::doc), items);
             match at.style {
-                ast::AttrStyle::Inner => *at = attr::mk_spanned_attr_inner(at.span, at.id, meta),
-                ast::AttrStyle::Outer => *at = attr::mk_spanned_attr_outer(at.span, at.id, meta),
+                ast::AttrStyle::Inner => *at = attr::mk_attr_inner(at.span, at.id, meta),
+                ast::AttrStyle::Outer => *at = attr::mk_attr_outer(at.span, at.id, meta),
             }
         } else {
             noop_visit_attribute(at, self)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1340,10 +1340,14 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             }
 
             let meta = attr::mk_list_item(DUMMY_SP, Ident::with_empty_ctxt(sym::doc), items);
-            match at.style {
-                ast::AttrStyle::Inner => *at = attr::mk_attr_inner(at.span, at.id, meta),
-                ast::AttrStyle::Outer => *at = attr::mk_attr_outer(at.span, at.id, meta),
-            }
+            *at = attr::Attribute {
+                span: at.span,
+                id: at.id,
+                style: at.style,
+                path: meta.path,
+                tokens: meta.node.tokens(meta.span),
+                is_sugared_doc: false,
+            };
         } else {
             noop_visit_attribute(at, self)
         }

--- a/src/libsyntax/ext/proc_macro.rs
+++ b/src/libsyntax/ext/proc_macro.rs
@@ -2,7 +2,6 @@ use crate::ast::{self, ItemKind, Attribute, Mac};
 use crate::attr::{mark_used, mark_known, HasAttrs};
 use crate::errors::{Applicability, FatalError};
 use crate::ext::base::{self, *};
-use crate::ext::build::AstBuilder;
 use crate::ext::proc_macro_server;
 use crate::parse::{self, token};
 use crate::parse::parser::PathStyle;

--- a/src/libsyntax/ext/proc_macro.rs
+++ b/src/libsyntax/ext/proc_macro.rs
@@ -239,11 +239,11 @@ crate fn add_derived_markers<T: HasAttrs>(
     item.visit_attrs(|attrs| {
         if names.contains(&sym::Eq) && names.contains(&sym::PartialEq) {
             let meta = cx.meta_word(span, sym::structural_match);
-            attrs.push(cx.attribute(span, meta));
+            attrs.push(cx.attribute(meta));
         }
         if names.contains(&sym::Copy) {
             let meta = cx.meta_word(span, sym::rustc_copy_clone_marker);
-            attrs.push(cx.attribute(span, meta));
+            attrs.push(cx.attribute(meta));
         }
     });
 }

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -53,7 +53,7 @@ impl<'a> Parser<'a> {
                     just_parsed_doc_comment = false;
                 }
                 token::DocComment(s) => {
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
+                    let attr = attr::mk_sugared_doc_attr(s, self.token.span);
                     if attr.style != ast::AttrStyle::Outer {
                         let mut err = self.fatal("expected outer doc comment");
                         err.note("inner doc comments like this (starting with \
@@ -239,7 +239,7 @@ impl<'a> Parser<'a> {
                 }
                 token::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
+                    let attr = attr::mk_sugared_doc_attr(s, self.token.span);
                     if attr.style == ast::AttrStyle::Inner {
                         attrs.push(attr);
                         self.bump();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6396,15 +6396,8 @@ impl<'a> Parser<'a> {
                     self.eval_src_mod(path, directory_ownership, id.to_string(), id_span)?;
                 // Record that we fetched the mod from an external file
                 if warn {
-                    let attr = Attribute {
-                        id: attr::mk_attr_id(),
-                        style: ast::AttrStyle::Outer,
-                        path: ast::Path::from_ident(
-                            Ident::with_empty_ctxt(sym::warn_directory_ownership)),
-                        tokens: TokenStream::empty(),
-                        is_sugared_doc: false,
-                        span: DUMMY_SP,
-                    };
+                    let attr = attr::mk_attr_outer(
+                        attr::mk_word_item(Ident::with_empty_ctxt(sym::warn_directory_ownership)));
                     attr::mark_known(&attr);
                     attrs.push(attr);
                 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -123,12 +123,12 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
         let pi_nested = attr::mk_nested_word_item(ast::Ident::with_empty_ctxt(sym::prelude_import));
         let list = attr::mk_list_item(
             DUMMY_SP, ast::Ident::with_empty_ctxt(sym::feature), vec![pi_nested]);
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), list);
+        let fake_attr = attr::mk_attr_inner(DUMMY_SP, list);
         s.print_attribute(&fake_attr);
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::no_std));
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), no_std_meta);
+        let fake_attr = attr::mk_attr_inner(DUMMY_SP, no_std_meta);
         s.print_attribute(&fake_attr);
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -123,12 +123,12 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
         let pi_nested = attr::mk_nested_word_item(ast::Ident::with_empty_ctxt(sym::prelude_import));
         let list = attr::mk_list_item(
             DUMMY_SP, ast::Ident::with_empty_ctxt(sym::feature), vec![pi_nested]);
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, list);
+        let fake_attr = attr::mk_attr_inner(list);
         s.print_attribute(&fake_attr);
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::no_std));
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, no_std_meta);
+        let fake_attr = attr::mk_attr_inner(no_std_meta);
         s.print_attribute(&fake_attr);
     }
 

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -3,7 +3,6 @@ use errors::{Applicability, DiagnosticBuilder};
 use syntax::ast::{self, *};
 use syntax::source_map::Spanned;
 use syntax::ext::base::*;
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token::{self, TokenKind};
 use syntax::parse::parser::Parser;
 use syntax::print::pprust;

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -6,7 +6,6 @@ use errors::DiagnosticBuilder;
 
 use syntax::ast;
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::attr;
 use syntax::tokenstream;
 use syntax::parse::token;

--- a/src/libsyntax_ext/concat.rs
+++ b/src/libsyntax_ext/concat.rs
@@ -1,6 +1,5 @@
 use syntax::ast;
 use syntax::ext::base;
-use syntax::ext::build::AstBuilder;
 use syntax::symbol::Symbol;
 use syntax::tokenstream;
 

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -77,7 +77,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt<'_>,
     }
 
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -5,7 +5,6 @@ use crate::deriving::generic::ty::*;
 use syntax::ast::{self, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
 use syntax::attr;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem, GenericArg};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -17,7 +17,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,
     let inline = cx.meta_word(span, sym::inline);
     let hidden = cx.meta_list_item_word(span, sym::hidden);
     let doc = cx.meta_list(span, sym::doc, vec![hidden]);
-    let attrs = vec![cx.attribute(span, inline), cx.attribute(span, doc)];
+    let attrs = vec![cx.attribute(inline), cx.attribute(doc)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -15,7 +15,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt<'_>,
                            item: &Annotatable,
                            push: &mut dyn FnMut(Annotatable)) {
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -63,7 +63,7 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
     macro_rules! md {
         ($name:expr, $f:ident) => { {
             let inline = cx.meta_word(span, sym::inline);
-            let attrs = vec![cx.attribute(span, inline)];
+            let attrs = vec![cx.attribute(inline)];
             MethodDef {
                 name: $name,
                 generics: LifetimeBounds::empty(),

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -6,7 +6,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -19,7 +19,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt<'_>,
     macro_rules! md {
         ($name:expr, $op:expr, $equal:expr) => { {
             let inline = cx.meta_word(span, sym::inline);
-            let attrs = vec![cx.attribute(span, inline)];
+            let attrs = vec![cx.attribute(inline)];
             MethodDef {
                 name: $name,
                 generics: LifetimeBounds::empty(),
@@ -43,7 +43,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt<'_>,
                                     PathKind::Std));
 
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
 
     let partial_cmp_def = MethodDef {
         name: "partial_cmp",

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -7,7 +7,6 @@ use rustc_data_structures::thin_vec::ThinVec;
 use syntax::ast::{self, Ident};
 use syntax::ast::{Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::{DUMMY_SP, Span};

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -7,7 +7,6 @@ use crate::deriving::generic::ty::*;
 use syntax::ast;
 use syntax::ast::{Expr, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem};
 use syntax::ext::base::{Annotatable, DummyResult, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym};
 use syntax::span_err;

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -16,7 +16,7 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt<'_>,
                                item: &Annotatable,
                                push: &mut dyn FnMut(Annotatable)) {
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/encodable.rs
+++ b/src/libsyntax_ext/deriving/encodable.rs
@@ -88,7 +88,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, ExprKind, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -187,7 +187,6 @@ use syntax::ast::{self, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
 use syntax::ast::{VariantData, GenericParamKind, GenericArg};
 use syntax::attr;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::source_map::{self, respan};
 use syntax::util::map_in_place::MapInPlace;
 use syntax::ptr::P;

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -666,14 +666,13 @@ impl<'a> TraitDef<'a> {
         let path = cx.path_all(self.span, false, vec![type_ident], self_params, vec![]);
         let self_type = cx.ty_path(path);
 
-        let attr = cx.attribute(self.span,
-                                cx.meta_word(self.span, sym::automatically_derived));
+        let attr = cx.attribute(cx.meta_word(self.span, sym::automatically_derived));
         // Just mark it now since we know that it'll end up used downstream
         attr::mark_used(&attr);
         let opt_trait_ref = Some(trait_ref);
         let unused_qual = {
             let word = cx.meta_list_item_word(self.span, Symbol::intern("unused_qualifications"));
-            cx.attribute(self.span, cx.meta_list(self.span, sym::allow, vec![word]))
+            cx.attribute(cx.meta_list(self.span, sym::allow, vec![word]))
         };
 
         let mut a = vec![attr, unused_qual];

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -6,7 +6,6 @@ pub use Ty::*;
 
 use syntax::ast::{self, Expr, GenericParamKind, Generics, Ident, SelfKind, GenericArg};
 use syntax::ext::base::ExtCtxt;
-use syntax::ext::build::AstBuilder;
 use syntax::source_map::{respan, DUMMY_SP};
 use syntax::ptr::P;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/hash.rs
+++ b/src/libsyntax_ext/deriving/hash.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -2,7 +2,6 @@
 
 use syntax::ast::{self, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt, MultiItemModifier};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, sym};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -5,7 +5,6 @@
 
 use syntax::ast::{self, Ident, GenericArg};
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;
 use syntax::tokenstream;

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -8,7 +8,6 @@ use errors::Applicability;
 
 use syntax::ast;
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, sym};

--- a/src/libsyntax_ext/global_allocator.rs
+++ b/src/libsyntax_ext/global_allocator.rs
@@ -110,7 +110,7 @@ impl AllocFnFactory<'_, '_> {
     fn attrs(&self) -> Vec<Attribute> {
         let special = sym::rustc_std_internal_symbol;
         let special = self.cx.meta_word(self.span, special);
-        vec![self.cx.attribute(self.span, special)]
+        vec![self.cx.attribute(special)]
     }
 
     fn arg_ty(

--- a/src/libsyntax_ext/global_allocator.rs
+++ b/src/libsyntax_ext/global_allocator.rs
@@ -3,7 +3,6 @@ use syntax::ast::{self, Arg, Attribute, Expr, FnHeader, Generics, Ident};
 use syntax::attr::check_builtin_macro_attribute;
 use syntax::ext::allocator::{AllocatorKind, AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};

--- a/src/libsyntax_ext/plugin_macro_defs.rs
+++ b/src/libsyntax_ext/plugin_macro_defs.rs
@@ -16,14 +16,8 @@ use syntax_pos::hygiene::{ExpnId, ExpnInfo, ExpnKind, MacroKind};
 use std::mem;
 
 fn plugin_macro_def(name: Name, span: Span) -> P<Item> {
-    let rustc_builtin_macro = Attribute {
-        id: attr::mk_attr_id(),
-        style: AttrStyle::Outer,
-        path: Path::from_ident(Ident::new(sym::rustc_builtin_macro, span)),
-        tokens: TokenStream::empty(),
-        is_sugared_doc: false,
-        span,
-    };
+    let rustc_builtin_macro = attr::mk_attr_outer(
+        attr::mk_word_item(Ident::new(sym::rustc_builtin_macro, span)));
 
     let parens: TreeAndJoint = TokenTree::Delimited(
         DelimSpan::from_single(span), token::Paren, TokenStream::empty()

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -337,7 +337,7 @@ fn mk_decls(
 
     let hidden = cx.meta_list_item_word(span, sym::hidden);
     let doc = cx.meta_list(span, sym::doc, vec![hidden]);
-    let doc_hidden = cx.attribute(span, doc);
+    let doc_hidden = cx.attribute(doc);
 
     let proc_macro = Ident::with_empty_ctxt(sym::proc_macro);
     let krate = cx.item(span,
@@ -394,7 +394,7 @@ fn mk_decls(
         cx.expr_vec_slice(span, decls),
     ).map(|mut i| {
         let attr = cx.meta_word(span, sym::rustc_proc_macro_decls);
-        i.attrs.push(cx.attribute(span, attr));
+        i.attrs.push(cx.attribute(attr));
         i.vis = respan(span, ast::VisibilityKind::Public);
         i
     });

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -4,7 +4,6 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::source_map::{ExpnInfo, ExpnKind, respan};
 use syntax::ext::base::{ExtCtxt, MacroKind};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
 use syntax::ext::hygiene::ExpnId;
 use syntax::ext::proc_macro::is_proc_macro_attr;

--- a/src/libsyntax_ext/source_util.rs
+++ b/src/libsyntax_ext/source_util.rs
@@ -1,6 +1,5 @@
 use syntax::{ast, panictry};
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::{self, token, DirectoryOwnership};
 use syntax::print::pprust;
 use syntax::ptr::P;

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -42,7 +42,6 @@ pub fn inject(
         krate.module.items.insert(0, P(ast::Item {
             attrs: vec![attr::mk_attr_outer(
                 DUMMY_SP,
-                attr::mk_attr_id(),
                 attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::macro_use))
             )],
             vis: dummy_spanned(ast::VisibilityKind::Inherited),

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -41,7 +41,6 @@ pub fn inject(
         };
         krate.module.items.insert(0, P(ast::Item {
             attrs: vec![attr::mk_attr_outer(
-                DUMMY_SP,
                 attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::macro_use))
             )],
             vis: dummy_spanned(ast::VisibilityKind::Inherited),

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -4,7 +4,6 @@ use syntax::ext::hygiene::{ExpnId, MacroKind};
 use syntax::ptr::P;
 use syntax::source_map::{ExpnInfo, ExpnKind, dummy_spanned, respan};
 use syntax::symbol::{Ident, Symbol, kw, sym};
-use syntax::tokenstream::TokenStream;
 use syntax_pos::DUMMY_SP;
 
 use std::iter;
@@ -62,14 +61,8 @@ pub fn inject(
     ));
 
     krate.module.items.insert(0, P(ast::Item {
-        attrs: vec![ast::Attribute {
-            style: ast::AttrStyle::Outer,
-            path: ast::Path::from_ident(ast::Ident::new(sym::prelude_import, span)),
-            tokens: TokenStream::empty(),
-            id: attr::mk_attr_id(),
-            is_sugared_doc: false,
-            span,
-        }],
+        attrs: vec![attr::mk_attr_outer(
+            attr::mk_word_item(ast::Ident::new(sym::prelude_import, span)))],
         vis: respan(span.shrink_to_lo(), ast::VisibilityKind::Inherited),
         node: ast::ItemKind::Use(P(ast::UseTree {
             prefix: ast::Path {

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -36,8 +36,7 @@ pub fn expand_test_case(
         item.vis = respan(item.vis.span, ast::VisibilityKind::Public);
         item.ident = item.ident.gensym();
         item.attrs.push(
-            ecx.attribute(sp,
-                ecx.meta_word(sp, sym::rustc_test_marker))
+            ecx.attribute(ecx.meta_word(sp, sym::rustc_test_marker))
         );
         item
     });
@@ -150,11 +149,11 @@ pub fn expand_test_or_bench(
     let mut test_const = cx.item(sp, ast::Ident::new(item.ident.name, sp).gensym(),
         vec![
             // #[cfg(test)]
-            cx.attribute(attr_sp, cx.meta_list(attr_sp, sym::cfg, vec![
+            cx.attribute(cx.meta_list(attr_sp, sym::cfg, vec![
                 cx.meta_list_item_word(attr_sp, sym::test)
             ])),
             // #[rustc_test_marker]
-            cx.attribute(attr_sp, cx.meta_word(attr_sp, sym::rustc_test_marker)),
+            cx.attribute(cx.meta_word(attr_sp, sym::rustc_test_marker)),
         ],
         // const $ident: test::TestDescAndFn =
         ast::ItemKind::Const(cx.ty(sp, ast::TyKind::Path(None, test_path("TestDescAndFn"))),

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -4,7 +4,6 @@
 use syntax::ast;
 use syntax::attr::{self, check_builtin_macro_attribute};
 use syntax::ext::base::*;
-use syntax::ext::build::AstBuilder;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::print::pprust;
 use syntax::source_map::respan;

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -294,7 +294,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     // #![main]
     let main_meta = ecx.meta_word(sp, sym::main);
-    let main_attr = ecx.attribute(sp, main_meta);
+    let main_attr = ecx.attribute(main_meta);
 
     // extern crate test as test_gensym
     let test_extern_stmt = ecx.stmt_item(sp, ecx.item(sp,

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -161,7 +161,6 @@ impl MutVisitor for EntryPointCleaner {
                     let allow_dead_code_item = attr::mk_list_item(DUMMY_SP, allow_ident,
                                                                   vec![dc_nested]);
                     let allow_dead_code = attr::mk_attr_outer(DUMMY_SP,
-                                                              attr::mk_attr_id(),
                                                               allow_dead_code_item);
 
                     ast::Item {

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -6,7 +6,6 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::entry::{self, EntryPointType};
 use syntax::ext::base::{ExtCtxt, Resolver};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
 use syntax::ext::hygiene::{ExpnId, MacroKind};
 use syntax::feature_gate::Features;

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -160,8 +160,7 @@ impl MutVisitor for EntryPointCleaner {
                     let dc_nested = attr::mk_nested_word_item(Ident::from_str("dead_code"));
                     let allow_dead_code_item = attr::mk_list_item(DUMMY_SP, allow_ident,
                                                                   vec![dc_nested]);
-                    let allow_dead_code = attr::mk_attr_outer(DUMMY_SP,
-                                                              allow_dead_code_item);
+                    let allow_dead_code = attr::mk_attr_outer(allow_dead_code_item);
 
                     ast::Item {
                         id,

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.rs
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.rs
@@ -19,7 +19,7 @@ fn main() {
 //      _3 = const Scalar(AllocId(1).0x0) : fn();
 //      _2 = move _3 as usize (Misc);
 //      ...
-//      _1 = const Scalar(AllocId(1).0x0) : *const fn();
+//      _1 = move _2 as *const fn() (Misc);
 //      ...
 //  }
 // END rustc.main.ConstProp.after.mir

--- a/src/test/ui-fulldeps/auxiliary/plugin-args.rs
+++ b/src/test/ui-fulldeps/auxiliary/plugin-args.rs
@@ -11,7 +11,6 @@ extern crate rustc_driver;
 
 use std::borrow::ToOwned;
 use syntax::ast;
-use syntax::ext::build::AstBuilder;
 use syntax::ext::base::{SyntaxExtension, SyntaxExtensionKind};
 use syntax::ext::base::{TTMacroExpander, ExtCtxt, MacResult, MacEager};
 use syntax::print::pprust;

--- a/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
+++ b/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
@@ -18,7 +18,6 @@ extern crate rustc_driver;
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
-use syntax::ext::build::AstBuilder;  // A trait for expr_usize.
 use syntax_pos::Span;
 use rustc_plugin::Registry;
 

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.rs
@@ -4,8 +4,8 @@ fn main() {}
 
 // unconst and bad, will thus error in miri
 const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 }; //~ ERROR any use of this
-// unconst and fine
-const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+// unconst and bad, will thus error in miri
+const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 }; //~ ERROR any use of this
 // unconst and fine
 const Y: usize = unsafe { 42usize as *const i32 as usize + 1 };
 // unconst and bad, will thus error in miri

--- a/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
+++ b/src/test/ui/consts/const-eval/const_raw_ptr_ops.stderr
@@ -9,12 +9,20 @@ LL | const X: bool = unsafe { &1 as *const i32 == &2 as *const i32 };
    = note: `#[deny(const_err)]` on by default
 
 error: any use of this value will cause an error
+  --> $DIR/const_raw_ptr_ops.rs:8:27
+   |
+LL | const X2: bool = unsafe { 42 as *const i32 == 43 as *const i32 };
+   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+
+error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:12:28
    |
 LL | const Y2: usize = unsafe { &1 as *const i32 as usize + 1 };
-   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   | ---------------------------^^^^^^^^^^^^^^^^^^^^^^^^^-------
    |                            |
-   |                            "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+   |                            "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: any use of this value will cause an error
   --> $DIR/const_raw_ptr_ops.rs:16:26
@@ -32,5 +40,5 @@ LL | const Z3: i32 = unsafe { *(44 as *const i32) };
    |                          |
    |                          a memory access tried to interpret some bytes as a pointer
 
-error: aborting due to 4 previous errors
+error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-eval/issue-52442.rs
+++ b/src/test/ui/consts/const-eval/issue-52442.rs
@@ -1,5 +1,5 @@
 fn main() {
     [();  { &loop { break } as *const _ as usize } ];
     //~^ ERROR casting pointers to integers in constants is unstable
-    //~| ERROR it is undefined behavior to use this value
+    //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-eval/issue-52442.stderr
+++ b/src/test/ui/consts/const-eval/issue-52442.stderr
@@ -7,13 +7,11 @@ LL |     [();  { &loop { break } as *const _ as usize } ];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-52442.rs:2:11
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-52442.rs:2:13
    |
 LL |     [();  { &loop { break } as *const _ as usize } ];
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,4 +1,3 @@
-
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.rs
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.rs
@@ -1,3 +1,4 @@
+
 fn main() {
     // Make sure match uses the usual pointer comparison code path -- i.e., it should complain
     // that pointer comparison is disallowed, not that parts of a pointer are accessed as raw
@@ -5,11 +6,9 @@ fn main() {
     let _: [u8; 0] = [4; {
         match &1 as *const i32 as usize {
             //~^ ERROR casting pointers to integers in constants
-            //~| NOTE for more information, see
             //~| ERROR constant contains unimplemented expression type
-            0 => 42, //~ ERROR constant contains unimplemented expression type
-            //~^ NOTE "pointer arithmetic or comparison" needs an rfc before being allowed
             //~| ERROR evaluation of constant value failed
+            0 => 42, //~ ERROR constant contains unimplemented expression type
             n => n,
         }
     }];

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,19 +8,19 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:11:13
+  --> $DIR/match-test-ptr-null.rs:10:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:7:15
+  --> $DIR/match-test-ptr-null.rs:6:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants

--- a/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
+++ b/src/test/ui/consts/const-eval/match-test-ptr-null.stderr
@@ -1,5 +1,5 @@
 error[E0658]: casting pointers to integers in constants is unstable
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,22 +8,22 @@ LL |         match &1 as *const i32 as usize {
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:6:15
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
 LL |         match &1 as *const i32 as usize {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0019]: constant contains unimplemented expression type
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:11:13
    |
 LL |             0 => 42,
    |             ^
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/match-test-ptr-null.rs:10:13
+  --> $DIR/match-test-ptr-null.rs:7:15
    |
-LL |             0 => 42,
-   |             ^ "pointer arithmetic or comparison" needs an rfc before being allowed inside constants
+LL |         match &1 as *const i32 as usize {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/issue-51559.rs
+++ b/src/test/ui/consts/issue-51559.rs
@@ -2,6 +2,6 @@
 
 const BAR: *mut () = ((|| 3) as fn() -> i32) as *mut ();
 pub const FOO: usize = unsafe { BAR as usize };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR any use of this value will cause an error
 
 fn main() {}

--- a/src/test/ui/consts/issue-51559.stderr
+++ b/src/test/ui/consts/issue-51559.stderr
@@ -1,11 +1,12 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-51559.rs:4:1
+error: any use of this value will cause an error
+  --> $DIR/issue-51559.rs:4:33
    |
 LL | pub const FOO: usize = unsafe { BAR as usize };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
+   | --------------------------------^^^^^^^^^^^^---
+   |                                 |
+   |                                 "pointer-to-integer cast" needs an rfc before being allowed inside constants
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: `#[deny(const_err)]` on by default
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.rs
@@ -1,4 +1,4 @@
 fn main() {
     let _ = [0; (&0 as *const i32) as usize]; //~ ERROR casting pointers to integers in constants
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 }

--- a/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
+++ b/src/test/ui/issues/issue-52023-array-size-pointer-cast.stderr
@@ -7,13 +7,11 @@ LL |     let _ = [0; (&0 as *const i32) as usize];
    = note: for more information, see https://github.com/rust-lang/rust/issues/51910
    = help: add `#![feature(const_raw_ptr_to_usize_cast)]` to the crate attributes to enable
 
-error[E0080]: it is undefined behavior to use this value
+error[E0080]: evaluation of constant value failed
   --> $DIR/issue-52023-array-size-pointer-cast.rs:2:17
    |
 LL |     let _ = [0; (&0 as *const i32) as usize];
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ "pointer-to-integer cast" needs an rfc before being allowed inside constants
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #62946 (Miri: dispatch first on the type)
 - #63146 (Cleanup syntax::attr)
 - #63153 (Remove redundant method with const variable resolution)

Failed merges:

 - #62969 (Changing the structure of `mir::interpret::InterpError`)

r? @ghost