### PR TITLE
dead_code: Properly inspect fields in struct patterns with type relative paths

### DIFF
--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -269,8 +269,9 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat) {
         match pat.node {
-            PatKind::Struct(hir::QPath::Resolved(_, ref path), ref fields, _) => {
-                self.handle_field_pattern_match(pat, path.res, fields);
+            PatKind::Struct(ref path, ref fields, _) => {
+                let res = self.tables.qpath_res(path, pat.hir_id);
+                self.handle_field_pattern_match(pat, res, fields);
             }
             PatKind::Path(ref qpath @ hir::QPath::TypeRelative(..)) => {
                 let res = self.tables.qpath_res(qpath, pat.hir_id);

--- a/src/test/ui/type-alias-enum-variants/issue-63151-dead-code-lint-fields-in-patterns.rs
+++ b/src/test/ui/type-alias-enum-variants/issue-63151-dead-code-lint-fields-in-patterns.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+// Regression test for the issue #63151:
+// Spurious unused field warning when matching variants under a `Self` scope
+//
+// This test checks that the `dead_code` lint properly inspects fields
+// in struct patterns that use a type relative path.
+
+#![deny(dead_code)]
+
+enum Enum {
+    Variant { field: usize }
+}
+
+impl Enum {
+    fn read_field(self) -> usize {
+        match self {
+            Self::Variant { field } => field
+        }
+    }
+}
+
+fn main() {
+    let e = Enum::Variant { field: 42 };
+    println!("{}", e.read_field());
+}


### PR DESCRIPTION
Closes #63151.