### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -57,14 +57,14 @@
 # support. You'll need to write a target specification at least, and most
 # likely, teach rustc about the C ABI of the target. Get in touch with the
 # Rust team and file an issue if you need assistance in porting!
-#targets = "X86;ARM;AArch64;Mips;PowerPC;SystemZ;MSP430;Sparc;NVPTX;Hexagon"
+#targets = "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;X86"
 
 # LLVM experimental targets to build support for. These targets are specified in
 # the same format as above, but since these targets are experimental, they are
 # not built by default and the experimental Rust compilation targets that depend
 # on them will not work unless the user opts in to building them. By default the
-# `WebAssembly` and `RISCV` targets are enabled when compiling LLVM from scratch.
-#experimental-targets = "WebAssembly;RISCV"
+# `WebAssembly` target is enabled when compiling LLVM from scratch.
+#experimental-targets = "WebAssembly"
 
 # Cap the number of parallel linker invocations when compiling LLVM.
 # This can be useful when building LLVM with debug info, which significantly

--- a/config.toml.example
+++ b/config.toml.example
@@ -57,14 +57,13 @@
 # support. You'll need to write a target specification at least, and most
 # likely, teach rustc about the C ABI of the target. Get in touch with the
 # Rust team and file an issue if you need assistance in porting!
-#targets = "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;X86"
+#targets = "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86"
 
 # LLVM experimental targets to build support for. These targets are specified in
 # the same format as above, but since these targets are experimental, they are
 # not built by default and the experimental Rust compilation targets that depend
-# on them will not work unless the user opts in to building them. By default the
-# `WebAssembly` target is enabled when compiling LLVM from scratch.
-#experimental-targets = "WebAssembly"
+# on them will not work unless the user opts in to building them.
+#experimental-targets = ""
 
 # Cap the number of parallel linker invocations when compiling LLVM.
 # This can be useful when building LLVM with debug info, which significantly

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -75,7 +75,7 @@ pub struct Config {
     pub llvm_link_shared: bool,
     pub llvm_clang_cl: Option<String>,
     pub llvm_targets: Option<String>,
-    pub llvm_experimental_targets: String,
+    pub llvm_experimental_targets: Option<String>,
     pub llvm_link_jobs: Option<u32>,
     pub llvm_version_suffix: Option<String>,
     pub llvm_use_linker: Option<String>,
@@ -524,8 +524,7 @@ impl Config {
             set(&mut config.llvm_static_stdcpp, llvm.static_libstdcpp);
             set(&mut config.llvm_link_shared, llvm.link_shared);
             config.llvm_targets = llvm.targets.clone();
-            config.llvm_experimental_targets = llvm.experimental_targets.clone()
-                .unwrap_or_else(|| "WebAssembly;RISCV".to_string());
+            config.llvm_experimental_targets = llvm.experimental_targets.clone();
             config.llvm_link_jobs = llvm.link_jobs;
             config.llvm_version_suffix = llvm.version_suffix.clone();
             config.llvm_clang_cl = llvm.clang_cl.clone();

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -125,14 +125,17 @@ impl Step for Llvm {
         } else {
             match builder.config.llvm_targets {
                 Some(ref s) => s,
-                None => "X86;ARM;AArch64;Mips;PowerPC;SystemZ;MSP430;Sparc;NVPTX;Hexagon",
+                None => "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;X86",
             }
         };
 
         let llvm_exp_targets = if self.emscripten {
             ""
         } else {
-            &builder.config.llvm_experimental_targets[..]
+            match builder.config.llvm_experimental_targets {
+                Some(ref s) => s,
+                None => "WebAssembly",
+            }
         };
 
         let assertions = if builder.config.llvm_assertions {"ON"} else {"OFF"};

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -125,7 +125,8 @@ impl Step for Llvm {
         } else {
             match builder.config.llvm_targets {
                 Some(ref s) => s,
-                None => "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86",
+                None => "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;\
+                         Sparc;SystemZ;WebAssembly;X86",
             }
         };
 

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -125,7 +125,7 @@ impl Step for Llvm {
         } else {
             match builder.config.llvm_targets {
                 Some(ref s) => s,
-                None => "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;X86",
+                None => "AArch64;ARM;Hexagon;MSP430;Mips;NVPTX;PowerPC;RISCV;Sparc;SystemZ;WebAssembly;X86",
             }
         };
 
@@ -134,7 +134,7 @@ impl Step for Llvm {
         } else {
             match builder.config.llvm_experimental_targets {
                 Some(ref s) => s,
-                None => "WebAssembly",
+                None => "",
             }
         };
 

--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -59,7 +59,6 @@ extern crate rustc_plugin;
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
-use syntax::ext::build::AstBuilder;  // A trait for expr_usize.
 use syntax_pos::Span;
 use rustc_plugin::Registry;
 
@@ -163,13 +162,6 @@ can continue and find further errors.
 
 To print syntax fragments for debugging, you can use `span_note` together with
 `syntax::print::pprust::*_to_string`.
-
-The example above produced an integer literal using `AstBuilder::expr_usize`.
-As an alternative to the `AstBuilder` trait, `libsyntax` provides a set of
-quasiquote macros. They are undocumented and very rough around the edges.
-However, the implementation may be a good starting point for an improved
-quasiquote as an ordinary plugin library.
-
 
 # Lint plugins
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_spanned_attr_outer(e.span, attr::mk_attr_id(), allow)
+                    attr::mk_attr_outer(e.span, attr::mk_attr_id(), allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_attr_outer(e.span, allow)
+                    attr::mk_attr_outer(allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -5168,7 +5168,7 @@ impl<'a> LoweringContext<'a> {
                         let uc_nested = attr::mk_nested_word_item(uc_ident);
                         attr::mk_list_item(e.span, allow_ident, vec![uc_nested])
                     };
-                    attr::mk_attr_outer(e.span, attr::mk_attr_id(), allow)
+                    attr::mk_attr_outer(e.span, allow)
                 };
                 let attrs = vec![attr];
 

--- a/src/librustc/middle/dead.rs
+++ b/src/librustc/middle/dead.rs
@@ -269,8 +269,9 @@ impl<'a, 'tcx> Visitor<'tcx> for MarkSymbolVisitor<'a, 'tcx> {
 
     fn visit_pat(&mut self, pat: &'tcx hir::Pat) {
         match pat.node {
-            PatKind::Struct(hir::QPath::Resolved(_, ref path), ref fields, _) => {
-                self.handle_field_pattern_match(pat, path.res, fields);
+            PatKind::Struct(ref path, ref fields, _) => {
+                let res = self.tables.qpath_res(path, pat.hir_id);
+                self.handle_field_pattern_match(pat, res, fields);
             }
             PatKind::Path(ref qpath @ hir::QPath::TypeRelative(..)) => {
                 let res = self.tables.qpath_res(qpath, pat.hir_id);

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -363,7 +363,7 @@ impl fmt::Debug for UndefinedBehaviorInfo {
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub enum UnsupportedOpInfo<'tcx> {
     /// Handle cases which for which we do not have a fixed variant.
-    Unimplemented(String),
+    Unsupported(String),
 
     // -- Everything below is not classified yet --
     FunctionAbiMismatch(Abi, Abi),
@@ -390,20 +390,14 @@ pub enum UnsupportedOpInfo<'tcx> {
     ReadUndefBytes(Size),
     DeadLocal,
     InvalidBoolOp(mir::BinOp),
-    InlineAsm,
     UnimplementedTraitSelection,
     CalledClosureAsFunction,
     NoMirFor(String),
-    /// This variant is used by machines to signal their own errors that do not
-    /// match an existing variant.
-    MachineError(String),
     DerefFunctionPointer,
     ExecuteMemory,
-    Intrinsic(String),
     InvalidChar(u128),
     OutOfTls,
     TlsOutOfBounds,
-    AbiViolation(String),
     AlignmentCheckFailed {
         required: Align,
         has: Align,
@@ -513,8 +507,6 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
                     initializer"),
             AssumptionNotHeld =>
                 write!(f, "`assume` argument was false"),
-            InlineAsm =>
-                write!(f, "miri does not support inline assembly"),
             ReallocateNonBasePtr =>
                 write!(f, "tried to reallocate with a pointer not to the beginning of an \
                     existing object"),
@@ -537,10 +529,7 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
             HeapAllocNonPowerOfTwoAlignment(_) =>
                 write!(f, "tried to re-, de-, or allocate heap memory with alignment that is \
                     not a power of two"),
-            MachineError(ref msg) |
-            Unimplemented(ref msg) |
-            AbiViolation(ref msg) |
-            Intrinsic(ref msg) =>
+            Unsupported(ref msg) =>
                 write!(f, "{}", msg),
         }
     }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -341,16 +341,16 @@ impl fmt::Debug for InvalidProgramInfo<'tcx> {
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
-pub enum UndefinedBehaviourInfo {
+pub enum UndefinedBehaviorInfo {
     /// Handle cases which for which we do not have a fixed variant.
     Ub(String),
     /// Unreachable code was executed.
     Unreachable,
 }
 
-impl fmt::Debug for UndefinedBehaviourInfo {
+impl fmt::Debug for UndefinedBehaviorInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use UndefinedBehaviourInfo::*;
+        use UndefinedBehaviorInfo::*;
         match self {
             Ub(ref msg) =>
                 write!(f, "{}", msg),
@@ -572,7 +572,7 @@ pub enum InterpError<'tcx> {
     /// The program panicked.
     Panic(PanicInfo<u64>),
     /// The program caused undefined behavior.
-    UndefinedBehaviour(UndefinedBehaviourInfo),
+    UndefinedBehavior(UndefinedBehaviorInfo),
     /// The program did something the interpreter does not support (some of these *might* be UB
     /// but the interpreter is not sure).
     Unsupported(UnsupportedOpInfo<'tcx>),
@@ -603,7 +603,7 @@ impl fmt::Debug for InterpError<'_> {
                 write!(f, "{:?}", msg),
             InvalidProgram(ref msg) =>
                 write!(f, "{:?}", msg),
-            UndefinedBehaviour(ref msg) =>
+            UndefinedBehavior(ref msg) =>
                 write!(f, "{:?}", msg),
             ResourceExhaustion(ref msg) =>
                 write!(f, "{:?}", msg),

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -21,8 +21,8 @@ macro_rules! err_inval {
 #[macro_export]
 macro_rules! err_ub {
     ($($tt:tt)*) => {
-        $crate::mir::interpret::InterpError::UndefinedBehaviour(
-            $crate::mir::interpret::UndefinedBehaviourInfo::$($tt)*
+        $crate::mir::interpret::InterpError::UndefinedBehavior(
+            $crate::mir::interpret::UndefinedBehaviorInfo::$($tt)*
         )
     };
 }
@@ -78,7 +78,7 @@ mod pointer;
 pub use self::error::{
     InterpErrorInfo, InterpResult, InterpError, AssertMessage, ConstEvalErr, struct_error,
     FrameInfo, ConstEvalRawResult, ConstEvalResult, ErrorHandled, PanicInfo, UnsupportedOpInfo,
-    InvalidProgramInfo, ResourceExhaustionInfo, UndefinedBehaviourInfo,
+    InvalidProgramInfo, ResourceExhaustionInfo, UndefinedBehaviorInfo,
 };
 
 pub use self::value::{Scalar, ScalarMaybeUndef, RawConst, ConstValue};

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -51,6 +51,11 @@ macro_rules! throw_unsup {
 }
 
 #[macro_export]
+macro_rules! throw_unsup_format {
+    ($($tt:tt)*) => { throw_unsup!(Unsupported(format!($($tt)*))) };
+}
+
+#[macro_export]
 macro_rules! throw_inval {
     ($($tt:tt)*) => { return Err(err_inval!($($tt)*).into()) };
 }
@@ -58,6 +63,11 @@ macro_rules! throw_inval {
 #[macro_export]
 macro_rules! throw_ub {
     ($($tt:tt)*) => { return Err(err_ub!($($tt)*).into()) };
+}
+
+#[macro_export]
+macro_rules! throw_ub_format {
+    ($($tt:tt)*) => { throw_ub!(Ub(format!($($tt)*))) };
 }
 
 #[macro_export]

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -980,14 +980,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     fn get_attributes(&self, item: &Entry<'tcx>, sess: &Session) -> Vec<ast::Attribute> {
-        item.attributes
-            .decode((self, sess))
-            .map(|mut attr| {
-                // Need new unique IDs: old thread-local IDs won't map to new threads.
-                attr.id = attr::mk_attr_id();
-                attr
-            })
-            .collect()
+        item.attributes.decode((self, sess)).collect()
     }
 
     // Translate a DefId from the current compilation environment to a DefId

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -181,15 +181,15 @@ fn eval_body_using_ecx<'mir, 'tcx>(
     Ok(ret)
 }
 
-impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalError {
-    fn into(self) -> InterpErrorInfo<'tcx> {
-        err_unsup!(MachineError(self.to_string())).into()
-    }
-}
-
 #[derive(Clone, Debug)]
 enum ConstEvalError {
     NeedsRfc(String),
+}
+
+impl<'tcx> Into<InterpErrorInfo<'tcx>> for ConstEvalError {
+    fn into(self) -> InterpErrorInfo<'tcx> {
+        err_unsup!(Unsupported(self.to_string())).into()
+    }
 }
 
 impl fmt::Display for ConstEvalError {
@@ -341,7 +341,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
         debug!("eval_fn_call: {:?}", instance);
         // Only check non-glue functions
         if let ty::InstanceDef::Item(def_id) = instance.def {
-            // Execution might have wandered off into other crates, so we cannot to a stability-
+            // Execution might have wandered off into other crates, so we cannot do a stability-
             // sensitive check here.  But we can at least rule out functions that are not const
             // at all.
             if !ecx.tcx.is_const_fn_raw(def_id) {
@@ -352,7 +352,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
                     ecx.goto_block(ret)?; // fully evaluated and done
                     Ok(None)
                 } else {
-                    throw_unsup!(MachineError(format!("calling non-const function `{}`", instance)))
+                    throw_unsup_format!("calling non-const function `{}`", instance)
                 };
             }
         }

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -199,7 +199,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             },
 
             // Casts to bool are not permitted by rustc, no need to handle them here.
-            _ => throw_unsup!(Unimplemented(format!("int to {:?} cast", dest_layout.ty))),
+            _ => bug!("invalid int to {:?} cast", dest_layout.ty),
         }
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -66,9 +66,9 @@ impl<'tcx, Other> FnVal<'tcx, Other> {
         match self {
             FnVal::Instance(instance) =>
                 Ok(instance),
-            FnVal::Other(_) => throw_unsup!(MachineError(format!(
-                "Expected instance function pointer, got 'other' pointer"
-            ))),
+            FnVal::Other(_) => throw_unsup_format!(
+                "'foreign' function pointers are not supported in this context"
+            ),
         }
     }
 }
@@ -834,9 +834,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                     if (src.offset <= dest.offset && src.offset + size > dest.offset) ||
                         (dest.offset <= src.offset && dest.offset + size > src.offset)
                     {
-                        throw_unsup!(Intrinsic(
-                            "copy_nonoverlapping called on overlapping ranges".to_string(),
-                        ))
+                        throw_ub_format!(
+                            "copy_nonoverlapping called on overlapping ranges"
+                        )
                     }
                 }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -147,15 +147,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         // For the remaining ops, the types must be the same on both sides
         if left_layout.ty != right_layout.ty {
-            let msg = format!(
-                "unimplemented asymmetric binary op {:?}: {:?} ({:?}), {:?} ({:?})",
+            bug!(
+                "invalid asymmetric binary op {:?}: {:?} ({:?}), {:?} ({:?})",
                 bin_op,
-                l,
-                left_layout.ty,
-                r,
-                right_layout.ty
-            );
-            throw_unsup!(Unimplemented(msg))
+                l, left_layout.ty,
+                r, right_layout.ty,
+            )
         }
 
         // Operations that need special treatment for signed integers
@@ -243,14 +240,13 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             _ => {
-                let msg = format!(
-                    "unimplemented binary op {:?}: {:?}, {:?} (both {:?})",
+                bug!(
+                    "invalid binary op {:?}: {:?}, {:?} (both {:?})",
                     bin_op,
                     l,
                     r,
                     right_layout.ty,
-                );
-                throw_unsup!(Unimplemented(msg))
+                )
             }
         };
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -121,7 +121,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // size of MIR constantly.
             Nop => {}
 
-            InlineAsm { .. } => throw_unsup!(InlineAsm),
+            InlineAsm { .. } => throw_unsup_format!("inline assembly is not supported"),
         }
 
         self.stack[frame_idx].stmt += 1;

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -88,8 +88,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         (FnVal::Instance(self.resolve(def_id, substs)?), sig.abi())
                     },
                     _ => {
-                        let msg = format!("can't handle callee of type {:?}", func.layout.ty);
-                        throw_unsup!(Unimplemented(msg))
+                        bug!("invalid callee of type {:?}", func.layout.ty)
                     }
                 };
                 let args = self.eval_operands(args)?;

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -260,7 +260,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 match diagnostic.error {
                     Exit(_) => bug!("the CTFE program cannot exit"),
                     Unsupported(_)
-                    | UndefinedBehaviour(_)
+                    | UndefinedBehavior(_)
                     | InvalidProgram(_)
                     | ResourceExhaustion(_) => {
                         // Ignore these errors.

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2104,9 +2104,7 @@ pub enum AttrStyle {
     Inner,
 }
 
-#[derive(
-    Clone, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, PartialOrd, Ord, Copy,
-)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord, Copy)]
 pub struct AttrId(pub usize);
 
 impl Idx for AttrId {
@@ -2115,6 +2113,18 @@ impl Idx for AttrId {
     }
     fn index(self) -> usize {
         self.0
+    }
+}
+
+impl rustc_serialize::Encodable for AttrId {
+    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+        s.emit_unit()
+    }
+}
+
+impl rustc_serialize::Decodable for AttrId {
+    fn decode<D: Decoder>(d: &mut D) -> Result<AttrId, D::Error> {
+        d.read_nil().map(|_| crate::attr::mk_attr_id())
     }
 }
 

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -929,7 +929,7 @@ pub fn find_transparency(
 pub fn check_builtin_macro_attribute(ecx: &ExtCtxt<'_>, meta_item: &MetaItem, name: Symbol) {
     // All the built-in macro attributes are "words" at the moment.
     let template = AttributeTemplate { word: true, list: None, name_value_str: None };
-    let attr = ecx.attribute(meta_item.span, meta_item.clone());
+    let attr = ecx.attribute(meta_item.clone());
     check_builtin_attribute(ecx.parse_sess, &attr, name, template);
 }
 

--- a/src/libsyntax/attr/builtin.rs
+++ b/src/libsyntax/attr/builtin.rs
@@ -3,7 +3,6 @@
 use crate::ast::{self, Attribute, MetaItem, NestedMetaItem};
 use crate::early_buffered_lints::BufferedEarlyLintId;
 use crate::ext::base::ExtCtxt;
-use crate::ext::build::AstBuilder;
 use crate::feature_gate::{Features, GatedCfg};
 use crate::parse::ParseSess;
 

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -6,9 +6,10 @@ pub use builtin::*;
 pub use IntType::*;
 pub use ReprAttr::*;
 pub use StabilityLevel::*;
+pub use crate::ast::Attribute;
 
 use crate::ast;
-use crate::ast::{AttrId, Attribute, AttrStyle, Name, Ident, Path, PathSegment};
+use crate::ast::{AttrId, AttrStyle, Name, Ident, Path, PathSegment};
 use crate::ast::{MetaItem, MetaItemKind, NestedMetaItem};
 use crate::ast::{Lit, LitKind, Expr, Item, Local, Stmt, StmtKind, GenericParam};
 use crate::mut_visit::visit_clobber;
@@ -328,13 +329,14 @@ impl Attribute {
             let meta = mk_name_value_item_str(
                 Ident::with_empty_ctxt(sym::doc),
                 dummy_spanned(Symbol::intern(&strip_doc_comment_decoration(&comment.as_str()))));
-            let mut attr = if self.style == ast::AttrStyle::Outer {
-                mk_attr_outer(self.span, self.id, meta)
-            } else {
-                mk_attr_inner(self.span, self.id, meta)
-            };
-            attr.is_sugared_doc = true;
-            f(&attr)
+            f(&Attribute {
+                id: self.id,
+                style: self.style,
+                path: meta.path,
+                tokens: meta.node.tokens(meta.span),
+                is_sugared_doc: true,
+                span: self.span,
+            })
         } else {
             f(self)
         }
@@ -377,9 +379,9 @@ pub fn mk_attr_id() -> AttrId {
 }
 
 /// Returns an inner attribute with the given value and span.
-pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(span: Span, item: MetaItem) -> Attribute {
     Attribute {
-        id,
+        id: mk_attr_id(),
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
@@ -389,9 +391,9 @@ pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
 }
 
 /// Returns an outer attribute with the given value and span.
-pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(span: Span, item: MetaItem) -> Attribute {
     Attribute {
-        id,
+        id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
@@ -400,12 +402,12 @@ pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     }
 }
 
-pub fn mk_sugared_doc_attr(id: AttrId, text: Symbol, span: Span) -> Attribute {
+pub fn mk_sugared_doc_attr(text: Symbol, span: Span) -> Attribute {
     let style = doc_comment_style(&text.as_str());
     let lit_kind = LitKind::Str(text, ast::StrStyle::Cooked);
     let lit = Lit::from_lit_kind(lit_kind, span);
     Attribute {
-        id,
+        id: mk_attr_id(),
         style,
         path: Path::from_ident(Ident::with_empty_ctxt(sym::doc).with_span_pos(span)),
         tokens: MetaItemKind::NameValue(lit).tokens(span),

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -376,37 +376,27 @@ pub fn mk_attr_id() -> AttrId {
     AttrId(id)
 }
 
-/// Returns an inner attribute with the given value.
-pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
-    mk_spanned_attr_inner(span, id, item)
-}
-
 /// Returns an inner attribute with the given value and span.
-pub fn mk_spanned_attr_inner(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id,
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span: sp,
+        span,
     }
 }
 
-/// Returns an outer attribute with the given value.
-pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
-    mk_spanned_attr_outer(span, id, item)
-}
-
 /// Returns an outer attribute with the given value and span.
-pub fn mk_spanned_attr_outer(sp: Span, id: AttrId, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(span: Span, id: AttrId, item: MetaItem) -> Attribute {
     Attribute {
         id,
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span: sp,
+        span,
     }
 }
 

--- a/src/libsyntax/attr/mod.rs
+++ b/src/libsyntax/attr/mod.rs
@@ -379,26 +379,26 @@ pub fn mk_attr_id() -> AttrId {
 }
 
 /// Returns an inner attribute with the given value and span.
-pub fn mk_attr_inner(span: Span, item: MetaItem) -> Attribute {
+pub fn mk_attr_inner(item: MetaItem) -> Attribute {
     Attribute {
         id: mk_attr_id(),
         style: ast::AttrStyle::Inner,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span,
+        span: item.span,
     }
 }
 
 /// Returns an outer attribute with the given value and span.
-pub fn mk_attr_outer(span: Span, item: MetaItem) -> Attribute {
+pub fn mk_attr_outer(item: MetaItem) -> Attribute {
     Attribute {
         id: mk_attr_id(),
         style: ast::AttrStyle::Outer,
         path: item.path,
         tokens: item.node.tokens(item.span),
         is_sugared_doc: false,
-        span,
+        span: item.span,
     }
 }
 

--- a/src/libsyntax/diagnostics/plugin.rs
+++ b/src/libsyntax/diagnostics/plugin.rs
@@ -4,7 +4,6 @@ use std::env;
 use crate::ast::{self, Ident, Name};
 use crate::source_map;
 use crate::ext::base::{ExtCtxt, MacEager, MacResult};
-use crate::ext::build::AstBuilder;
 use crate::parse::token::{self, Token};
 use crate::ptr::P;
 use crate::symbol::kw;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(sp, attr::mk_attr_id(), mi)
+        attr::mk_attr_outer(sp, mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -870,21 +870,21 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
-        attr::mk_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
+        attr::mk_word_item(Ident::new(w, sp))
     }
 
     pub fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
-        attr::mk_nested_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
+        attr::mk_nested_word_item(Ident::new(w, sp))
     }
 
     pub fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
                  -> ast::MetaItem {
-        attr::mk_list_item(sp, Ident::with_empty_ctxt(name).with_span_pos(sp), mis)
+        attr::mk_list_item(sp, Ident::new(name, sp), mis)
     }
 
     pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
                        -> ast::MetaItem {
-        attr::mk_name_value_item(span, Ident::with_empty_ctxt(name).with_span_pos(span),
+        attr::mk_name_value_item(span, Ident::new(name, span),
                                  lit_kind, span)
     }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_spanned_attr_outer(sp, attr::mk_attr_id(), mi)
+        attr::mk_attr_outer(sp, attr::mk_attr_id(), mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -259,7 +259,7 @@ pub trait AstBuilder {
                     generics: Generics) -> P<ast::Item>;
     fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item>;
 
-    fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute;
+    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute;
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem;
 
@@ -1134,8 +1134,8 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item_ty_poly(span, name, ty, Generics::default())
     }
 
-    fn attribute(&self, sp: Span, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(sp, mi)
+    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
+        attr::mk_attr_outer(mi.span, mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -9,295 +9,20 @@ use crate::ThinVec;
 use rustc_target::spec::abi::Abi;
 use syntax_pos::{Pos, Span};
 
-pub trait AstBuilder {
-    // Paths
-    fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path;
-    fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path;
-    fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path;
-    fn path_all(&self, sp: Span,
-                global: bool,
-                idents: Vec<ast::Ident>,
-                args: Vec<ast::GenericArg>,
-                constraints: Vec<ast::AssocTyConstraint>)
-        -> ast::Path;
+// Left so that Cargo tests don't break, this can be removed once those no longer use it
+pub trait AstBuilder {}
 
-    fn qpath(&self, self_type: P<ast::Ty>,
-             trait_path: ast::Path,
-             ident: ast::Ident)
-             -> (ast::QSelf, ast::Path);
-    fn qpath_all(&self, self_type: P<ast::Ty>,
-                trait_path: ast::Path,
-                ident: ast::Ident,
-                args: Vec<ast::GenericArg>,
-                constraints: Vec<ast::AssocTyConstraint>)
-                -> (ast::QSelf, ast::Path);
-
-    // types and consts
-    fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy;
-
-    fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty>;
-    fn ty_path(&self, path: ast::Path) -> P<ast::Ty>;
-    fn ty_ident(&self, span: Span, idents: ast::Ident) -> P<ast::Ty>;
-    fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst;
-    fn const_ident(&self, span: Span, idents: ast::Ident) -> ast::AnonConst;
-
-    fn ty_rptr(&self, span: Span,
-               ty: P<ast::Ty>,
-               lifetime: Option<ast::Lifetime>,
-               mutbl: ast::Mutability) -> P<ast::Ty>;
-    fn ty_ptr(&self, span: Span,
-              ty: P<ast::Ty>,
-              mutbl: ast::Mutability) -> P<ast::Ty>;
-
-    fn ty_infer(&self, sp: Span) -> P<ast::Ty>;
-
-    fn typaram(&self,
-               span: Span,
-               id: ast::Ident,
-               attrs: Vec<ast::Attribute>,
-               bounds: ast::GenericBounds,
-               default: Option<P<ast::Ty>>) -> ast::GenericParam;
-
-    fn trait_ref(&self, path: ast::Path) -> ast::TraitRef;
-    fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef;
-    fn trait_bound(&self, path: ast::Path) -> ast::GenericBound;
-    fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime;
-    fn lifetime_def(&self,
-                    span: Span,
-                    ident: ast::Ident,
-                    attrs: Vec<ast::Attribute>,
-                    bounds: ast::GenericBounds)
-                    -> ast::GenericParam;
-
-    // Statements
-    fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident, ex: P<ast::Expr>) -> ast::Stmt;
-    fn stmt_let_typed(&self,
-                      sp: Span,
-                      mutbl: bool,
-                      ident: ast::Ident,
-                      typ: P<ast::Ty>,
-                      ex: P<ast::Expr>)
-                      -> ast::Stmt;
-    fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt;
-    fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt;
-
-    // Blocks
-    fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block>;
-    fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block>;
-
-    // Expressions
-    fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr>;
-    fn expr_path(&self, path: ast::Path) -> P<ast::Expr>;
-    fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr>;
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr>;
-
-    fn expr_self(&self, span: Span) -> P<ast::Expr>;
-    fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
-                   lhs: P<ast::Expr>, rhs: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr>;
-
-    fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_field_access(&self, span: Span, expr: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr>;
-    fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>,
-                             idx: usize) -> P<ast::Expr>;
-    fn expr_call(&self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_call_ident(&self, span: Span, id: ast::Ident, args: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident>,
-                        args: Vec<P<ast::Expr>> ) -> P<ast::Expr>;
-    fn expr_method_call(&self, span: Span,
-                        expr: P<ast::Expr>, ident: ast::Ident,
-                        args: Vec<P<ast::Expr>> ) -> P<ast::Expr>;
-    fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr>;
-    fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr>;
-
-    fn field_imm(&self, span: Span, name: Ident, e: P<ast::Expr>) -> ast::Field;
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field>) -> P<ast::Expr>;
-    fn expr_struct_ident(&self, span: Span, id: ast::Ident,
-                         fields: Vec<ast::Field>) -> P<ast::Expr>;
-
-    fn expr_lit(&self, sp: Span, lit: ast::LitKind) -> P<ast::Expr>;
-
-    fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr>;
-    fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr>;
-    fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr>;
-    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr>;
-    fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr>;
-    fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr>;
-
-    fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr>;
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr>;
-
-    fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_none(&self, sp: Span) -> P<ast::Expr>;
-
-    fn expr_break(&self, sp: Span) -> P<ast::Expr>;
-
-    fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr>;
-
-    fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr>;
-    fn expr_unreachable(&self, span: Span) -> P<ast::Expr>;
-
-    fn expr_ok(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_err(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Expr>;
-    fn expr_try(&self, span: Span, head: P<ast::Expr>) -> P<ast::Expr>;
-
-    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat>;
-    fn pat_wild(&self, span: Span) -> P<ast::Pat>;
-    fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat>;
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat>;
-
-    fn pat_ident_binding_mode(&self,
-                              span: Span,
-                              ident: ast::Ident,
-                              bm: ast::BindingMode) -> P<ast::Pat>;
-    fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat>;
-    fn pat_tuple_struct(&self, span: Span, path: ast::Path,
-                        subpats: Vec<P<ast::Pat>>) -> P<ast::Pat>;
-    fn pat_struct(&self, span: Span, path: ast::Path,
-                  field_pats: Vec<Spanned<ast::FieldPat>>) -> P<ast::Pat>;
-    fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat>;
-
-    fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-    fn pat_none(&self, span: Span) -> P<ast::Pat>;
-
-    fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-    fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat>;
-
-    fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm;
-    fn arm_unreachable(&self, span: Span) -> ast::Arm;
-
-    fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm> ) -> P<ast::Expr>;
-    fn expr_if(&self, span: Span,
-               cond: P<ast::Expr>, then: P<ast::Expr>, els: Option<P<ast::Expr>>) -> P<ast::Expr>;
-    fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr>;
-
-    fn lambda_fn_decl(&self,
-                      span: Span,
-                      fn_decl: P<ast::FnDecl>,
-                      body: P<ast::Expr>,
-                      fn_decl_span: Span)
-                      -> P<ast::Expr>;
-
-    fn lambda(&self, span: Span, ids: Vec<ast::Ident>, body: P<ast::Expr>) -> P<ast::Expr>;
-    fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr>;
-    fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr>;
-
-    fn lambda_stmts(&self, span: Span, ids: Vec<ast::Ident>,
-                    blk: Vec<ast::Stmt>) -> P<ast::Expr>;
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr>;
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
-                      ident: ast::Ident) -> P<ast::Expr>;
-
-    // Items
-    fn item(&self, span: Span,
-            name: Ident, attrs: Vec<ast::Attribute> , node: ast::ItemKind) -> P<ast::Item>;
-
-    fn arg(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> ast::Arg;
-    // FIXME: unused `self`
-    fn fn_decl(&self, inputs: Vec<ast::Arg> , output: ast::FunctionRetTy) -> P<ast::FnDecl>;
-
-    fn item_fn_poly(&self,
-                    span: Span,
-                    name: Ident,
-                    inputs: Vec<ast::Arg> ,
-                    output: P<ast::Ty>,
-                    generics: Generics,
-                    body: P<ast::Block>) -> P<ast::Item>;
-    fn item_fn(&self,
-               span: Span,
-               name: Ident,
-               inputs: Vec<ast::Arg> ,
-               output: P<ast::Ty>,
-               body: P<ast::Block>) -> P<ast::Item>;
-
-    fn variant(&self, span: Span, name: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant;
-    fn item_enum_poly(&self,
-                      span: Span,
-                      name: Ident,
-                      enum_definition: ast::EnumDef,
-                      generics: Generics) -> P<ast::Item>;
-    fn item_enum(&self, span: Span, name: Ident, enum_def: ast::EnumDef) -> P<ast::Item>;
-
-    fn item_struct_poly(&self,
-                        span: Span,
-                        name: Ident,
-                        struct_def: ast::VariantData,
-                        generics: Generics) -> P<ast::Item>;
-    fn item_struct(&self, span: Span, name: Ident, struct_def: ast::VariantData) -> P<ast::Item>;
-
-    fn item_mod(&self, span: Span, inner_span: Span,
-                name: Ident, attrs: Vec<ast::Attribute>,
-                items: Vec<P<ast::Item>>) -> P<ast::Item>;
-
-    fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item>;
-
-    fn item_static(&self,
-                   span: Span,
-                   name: Ident,
-                   ty: P<ast::Ty>,
-                   mutbl: ast::Mutability,
-                   expr: P<ast::Expr>)
-                   -> P<ast::Item>;
-
-    fn item_const(&self,
-                   span: Span,
-                   name: Ident,
-                   ty: P<ast::Ty>,
-                   expr: P<ast::Expr>)
-                   -> P<ast::Item>;
-
-    fn item_ty_poly(&self,
-                    span: Span,
-                    name: Ident,
-                    ty: P<ast::Ty>,
-                    generics: Generics) -> P<ast::Item>;
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item>;
-
-    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute;
-
-    fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem;
-
-    fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem;
-
-    fn meta_list(&self,
-                 sp: Span,
-                 name: ast::Name,
-                 mis: Vec<ast::NestedMetaItem> )
-                 -> ast::MetaItem;
-    fn meta_name_value(&self,
-                       sp: Span,
-                       name: ast::Name,
-                       value: ast::LitKind)
-                       -> ast::MetaItem;
-
-    fn item_use(&self, sp: Span,
-                vis: ast::Visibility, vp: P<ast::UseTree>) -> P<ast::Item>;
-    fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item>;
-    fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
-                        ident: Option<ast::Ident>, path: ast::Path) -> P<ast::Item>;
-    fn item_use_list(&self, sp: Span, vis: ast::Visibility,
-                     path: Vec<ast::Ident>, imports: &[ast::Ident]) -> P<ast::Item>;
-    fn item_use_glob(&self, sp: Span,
-                     vis: ast::Visibility, path: Vec<ast::Ident>) -> P<ast::Item>;
-}
-
-impl<'a> AstBuilder for ExtCtxt<'a> {
-    fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
+impl<'a> ExtCtxt<'a> {
+    pub fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
         self.path_all(span, false, strs, vec![], vec![])
     }
-    fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path {
+    pub fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path {
         self.path(span, vec![id])
     }
-    fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
+    pub fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
         self.path_all(span, true, strs, vec![], vec![])
     }
-    fn path_all(&self,
+    pub fn path_all(&self,
                 span: Span,
                 global: bool,
                 mut idents: Vec<ast::Ident> ,
@@ -330,7 +55,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     /// Constructs a qualified path.
     ///
     /// Constructs a path like `<self_type as trait_path>::ident`.
-    fn qpath(&self,
+    pub fn qpath(&self,
              self_type: P<ast::Ty>,
              trait_path: ast::Path,
              ident: ast::Ident)
@@ -341,7 +66,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     /// Constructs a qualified path.
     ///
     /// Constructs a path like `<self_type as trait_path>::ident<'a, T, A = Bar>`.
-    fn qpath_all(&self,
+    pub fn qpath_all(&self,
                  self_type: P<ast::Ty>,
                  trait_path: ast::Path,
                  ident: ast::Ident,
@@ -363,14 +88,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }, path)
     }
 
-    fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy {
+    pub fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy {
         ast::MutTy {
             ty,
             mutbl,
         }
     }
 
-    fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty> {
+    pub fn ty(&self, span: Span, ty: ast::TyKind) -> P<ast::Ty> {
         P(ast::Ty {
             id: ast::DUMMY_NODE_ID,
             span,
@@ -378,18 +103,18 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn ty_path(&self, path: ast::Path) -> P<ast::Ty> {
+    pub fn ty_path(&self, path: ast::Path) -> P<ast::Ty> {
         self.ty(path.span, ast::TyKind::Path(None, path))
     }
 
     // Might need to take bounds as an argument in the future, if you ever want
     // to generate a bounded existential trait type.
-    fn ty_ident(&self, span: Span, ident: ast::Ident)
+    pub fn ty_ident(&self, span: Span, ident: ast::Ident)
         -> P<ast::Ty> {
         self.ty_path(self.path_ident(span, ident))
     }
 
-    fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst {
+    pub fn anon_const(&self, span: Span, expr: ast::ExprKind) -> ast::AnonConst {
         ast::AnonConst {
             id: ast::DUMMY_NODE_ID,
             value: P(ast::Expr {
@@ -401,11 +126,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn const_ident(&self, span: Span, ident: ast::Ident) -> ast::AnonConst {
+    pub fn const_ident(&self, span: Span, ident: ast::Ident) -> ast::AnonConst {
         self.anon_const(span, ast::ExprKind::Path(None, self.path_ident(span, ident)))
     }
 
-    fn ty_rptr(&self,
+    pub fn ty_rptr(&self,
                span: Span,
                ty: P<ast::Ty>,
                lifetime: Option<ast::Lifetime>,
@@ -415,7 +140,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 ast::TyKind::Rptr(lifetime, self.ty_mt(ty, mutbl)))
     }
 
-    fn ty_ptr(&self,
+    pub fn ty_ptr(&self,
               span: Span,
               ty: P<ast::Ty>,
               mutbl: ast::Mutability)
@@ -424,11 +149,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 ast::TyKind::Ptr(self.ty_mt(ty, mutbl)))
     }
 
-    fn ty_infer(&self, span: Span) -> P<ast::Ty> {
+    pub fn ty_infer(&self, span: Span) -> P<ast::Ty> {
         self.ty(span, ast::TyKind::Infer)
     }
 
-    fn typaram(&self,
+    pub fn typaram(&self,
                span: Span,
                ident: ast::Ident,
                attrs: Vec<ast::Attribute>,
@@ -445,14 +170,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn trait_ref(&self, path: ast::Path) -> ast::TraitRef {
+    pub fn trait_ref(&self, path: ast::Path) -> ast::TraitRef {
         ast::TraitRef {
             path,
             ref_id: ast::DUMMY_NODE_ID,
         }
     }
 
-    fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef {
+    pub fn poly_trait_ref(&self, span: Span, path: ast::Path) -> ast::PolyTraitRef {
         ast::PolyTraitRef {
             bound_generic_params: Vec::new(),
             trait_ref: self.trait_ref(path),
@@ -460,16 +185,16 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn trait_bound(&self, path: ast::Path) -> ast::GenericBound {
+    pub fn trait_bound(&self, path: ast::Path) -> ast::GenericBound {
         ast::GenericBound::Trait(self.poly_trait_ref(path.span, path),
                                  ast::TraitBoundModifier::None)
     }
 
-    fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime {
+    pub fn lifetime(&self, span: Span, ident: ast::Ident) -> ast::Lifetime {
         ast::Lifetime { id: ast::DUMMY_NODE_ID, ident: ident.with_span_pos(span) }
     }
 
-    fn lifetime_def(&self,
+    pub fn lifetime_def(&self,
                     span: Span,
                     ident: ast::Ident,
                     attrs: Vec<ast::Attribute>,
@@ -485,7 +210,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt {
+    pub fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
@@ -493,7 +218,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt {
+    pub fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
@@ -501,7 +226,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
+    pub fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
                 ex: P<ast::Expr>) -> ast::Stmt {
         let pat = if mutbl {
             let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Mutable);
@@ -524,7 +249,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_let_typed(&self,
+    pub fn stmt_let_typed(&self,
                       sp: Span,
                       mutbl: bool,
                       ident: ast::Ident,
@@ -553,7 +278,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     // Generates `let _: Type;`, which is usually used for type assertions.
-    fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt {
+    pub fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt {
         let local = P(ast::Local {
             pat: self.pat_wild(span),
             ty: Some(ty),
@@ -569,7 +294,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt {
+    pub fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt {
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             node: ast::StmtKind::Item(item),
@@ -577,14 +302,14 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block> {
+    pub fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block> {
         self.block(expr.span, vec![ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             span: expr.span,
             node: ast::StmtKind::Expr(expr),
         }])
     }
-    fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block> {
+    pub fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block> {
         P(ast::Block {
            stmts,
            id: ast::DUMMY_NODE_ID,
@@ -593,7 +318,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr> {
+    pub fn expr(&self, span: Span, node: ast::ExprKind) -> P<ast::Expr> {
         P(ast::Expr {
             id: ast::DUMMY_NODE_ID,
             node,
@@ -602,61 +327,65 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn expr_path(&self, path: ast::Path) -> P<ast::Expr> {
+    pub fn expr_path(&self, path: ast::Path) -> P<ast::Expr> {
         self.expr(path.span, ast::ExprKind::Path(None, path))
     }
 
     /// Constructs a `QPath` expression.
-    fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr> {
+    pub fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Path(Some(qself), path))
     }
 
-    fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr> {
+    pub fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr> {
         self.expr_path(self.path_ident(span, id))
     }
-    fn expr_self(&self, span: Span) -> P<ast::Expr> {
+    pub fn expr_self(&self, span: Span) -> P<ast::Expr> {
         self.expr_ident(span, Ident::with_empty_ctxt(kw::SelfLower))
     }
 
-    fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
+    pub fn expr_binary(&self, sp: Span, op: ast::BinOpKind,
                    lhs: P<ast::Expr>, rhs: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Binary(Spanned { node: op, span: sp }, lhs, rhs))
     }
 
-    fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr_unary(sp, UnOp::Deref, e)
     }
-    fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Unary(op, e))
     }
 
-    fn expr_field_access(&self, sp: Span, expr: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
+    pub fn expr_field_access(
+        &self, sp: Span, expr: P<ast::Expr>, ident: ast::Ident,
+    ) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Field(expr, ident.with_span_pos(sp)))
     }
-    fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>, idx: usize) -> P<ast::Expr> {
+    pub fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>, idx: usize) -> P<ast::Expr> {
         let ident = Ident::from_str(&idx.to_string()).with_span_pos(sp);
         self.expr(sp, ast::ExprKind::Field(expr, ident))
     }
-    fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Immutable, e))
     }
-    fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Mutable, e))
     }
 
-    fn expr_call(&self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_call(
+        &self, span: Span, expr: P<ast::Expr>, args: Vec<P<ast::Expr>>,
+    ) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Call(expr, args))
     }
-    fn expr_call_ident(&self, span: Span, id: ast::Ident,
+    pub fn expr_call_ident(&self, span: Span, id: ast::Ident,
                        args: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Call(self.expr_ident(span, id), args))
     }
-    fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
+    pub fn expr_call_global(&self, sp: Span, fn_path: Vec<ast::Ident> ,
                       args: Vec<P<ast::Expr>> ) -> P<ast::Expr> {
         let pathexpr = self.expr_path(self.path_global(sp, fn_path));
         self.expr_call(sp, pathexpr, args)
     }
-    fn expr_method_call(&self, span: Span,
+    pub fn expr_method_call(&self, span: Span,
                         expr: P<ast::Expr>,
                         ident: ast::Ident,
                         mut args: Vec<P<ast::Expr>> ) -> P<ast::Expr> {
@@ -664,10 +393,10 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         let segment = ast::PathSegment::from_ident(ident.with_span_pos(span));
         self.expr(span, ast::ExprKind::MethodCall(segment, args))
     }
-    fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr> {
+    pub fn expr_block(&self, b: P<ast::Block>) -> P<ast::Expr> {
         self.expr(b.span, ast::ExprKind::Block(b, None))
     }
-    fn field_imm(&self, span: Span, ident: Ident, e: P<ast::Expr>) -> ast::Field {
+    pub fn field_imm(&self, span: Span, ident: Ident, e: P<ast::Expr>) -> ast::Field {
         ast::Field {
             ident: ident.with_span_pos(span),
             expr: e,
@@ -676,23 +405,25 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             attrs: ThinVec::new(),
         }
     }
-    fn expr_struct(&self, span: Span, path: ast::Path, fields: Vec<ast::Field>) -> P<ast::Expr> {
+    pub fn expr_struct(
+        &self, span: Span, path: ast::Path, fields: Vec<ast::Field>
+    ) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Struct(path, fields, None))
     }
-    fn expr_struct_ident(&self, span: Span,
+    pub fn expr_struct_ident(&self, span: Span,
                          id: ast::Ident, fields: Vec<ast::Field>) -> P<ast::Expr> {
         self.expr_struct(span, self.path_ident(span, id), fields)
     }
 
-    fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
+    pub fn expr_lit(&self, span: Span, lit_kind: ast::LitKind) -> P<ast::Expr> {
         let lit = ast::Lit::from_lit_kind(lit_kind, span);
         self.expr(span, ast::ExprKind::Lit(lit))
     }
-    fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr> {
+    pub fn expr_usize(&self, span: Span, i: usize) -> P<ast::Expr> {
         self.expr_lit(span, ast::LitKind::Int(i as u128,
                                               ast::LitIntType::Unsigned(ast::UintTy::Usize)))
     }
-    fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr> {
+    pub fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr> {
         if i < 0 {
             let i = (-i) as u128;
             let lit_ty = ast::LitIntType::Signed(ast::IntTy::Isize);
@@ -703,59 +434,59 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                 ast::LitIntType::Signed(ast::IntTy::Isize)))
         }
     }
-    fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
+    pub fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U32)))
     }
-    fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
+    pub fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U16)))
     }
-    fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
+    pub fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128, ast::LitIntType::Unsigned(ast::UintTy::U8)))
     }
-    fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr> {
+    pub fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Bool(value))
     }
 
-    fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Array(exprs))
     }
-    fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr> {
         self.expr_call_global(sp, self.std_path(&[sym::vec, sym::Vec, sym::new]),
                               Vec::new())
     }
-    fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr_addr_of(sp, self.expr_vec(sp, exprs))
     }
-    fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr> {
+    pub fn expr_str(&self, sp: Span, s: Symbol) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Str(s, ast::StrStyle::Cooked))
     }
 
-    fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr> {
+    pub fn expr_cast(&self, sp: Span, expr: P<ast::Expr>, ty: P<ast::Ty>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Cast(expr, ty))
     }
 
-    fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let some = self.std_path(&[sym::option, sym::Option, sym::Some]);
         self.expr_call_global(sp, some, vec![expr])
     }
 
-    fn expr_none(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_none(&self, sp: Span) -> P<ast::Expr> {
         let none = self.std_path(&[sym::option, sym::Option, sym::None]);
         let none = self.path_global(sp, none);
         self.expr_path(none)
     }
 
-    fn expr_break(&self, sp: Span) -> P<ast::Expr> {
+    pub fn expr_break(&self, sp: Span) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Break(None, None))
     }
 
-    fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
+    pub fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Tup(exprs))
     }
 
-    fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr> {
+    pub fn expr_fail(&self, span: Span, msg: Symbol) -> P<ast::Expr> {
         let loc = self.source_map().lookup_char_pos(span.lo());
         let expr_file = self.expr_str(span, Symbol::intern(&loc.file.name.to_string()));
         let expr_line = self.expr_u32(span, loc.line as u32);
@@ -770,21 +501,21 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                 expr_loc_ptr])
     }
 
-    fn expr_unreachable(&self, span: Span) -> P<ast::Expr> {
+    pub fn expr_unreachable(&self, span: Span) -> P<ast::Expr> {
         self.expr_fail(span, Symbol::intern("internal error: entered unreachable code"))
     }
 
-    fn expr_ok(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_ok(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let ok = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         self.expr_call_global(sp, ok, vec![expr])
     }
 
-    fn expr_err(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_err(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let err = self.std_path(&[sym::result, sym::Result, sym::Err]);
         self.expr_call_global(sp, err, vec![expr])
     }
 
-    fn expr_try(&self, sp: Span, head: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn expr_try(&self, sp: Span, head: P<ast::Expr>) -> P<ast::Expr> {
         let ok = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         let ok_path = self.path_global(sp, ok);
         let err = self.std_path(&[sym::result, sym::Result, sym::Err]);
@@ -814,67 +545,67 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
 
-    fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat> {
+    pub fn pat(&self, span: Span, pat: PatKind) -> P<ast::Pat> {
         P(ast::Pat { id: ast::DUMMY_NODE_ID, node: pat, span })
     }
-    fn pat_wild(&self, span: Span) -> P<ast::Pat> {
+    pub fn pat_wild(&self, span: Span) -> P<ast::Pat> {
         self.pat(span, PatKind::Wild)
     }
-    fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat> {
+    pub fn pat_lit(&self, span: Span, expr: P<ast::Expr>) -> P<ast::Pat> {
         self.pat(span, PatKind::Lit(expr))
     }
-    fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat> {
+    pub fn pat_ident(&self, span: Span, ident: ast::Ident) -> P<ast::Pat> {
         let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Immutable);
         self.pat_ident_binding_mode(span, ident, binding_mode)
     }
 
-    fn pat_ident_binding_mode(&self,
+    pub fn pat_ident_binding_mode(&self,
                               span: Span,
                               ident: ast::Ident,
                               bm: ast::BindingMode) -> P<ast::Pat> {
         let pat = PatKind::Ident(bm, ident.with_span_pos(span), None);
         self.pat(span, pat)
     }
-    fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat> {
+    pub fn pat_path(&self, span: Span, path: ast::Path) -> P<ast::Pat> {
         self.pat(span, PatKind::Path(None, path))
     }
-    fn pat_tuple_struct(&self, span: Span, path: ast::Path,
+    pub fn pat_tuple_struct(&self, span: Span, path: ast::Path,
                         subpats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::TupleStruct(path, subpats))
     }
-    fn pat_struct(&self, span: Span, path: ast::Path,
+    pub fn pat_struct(&self, span: Span, path: ast::Path,
                   field_pats: Vec<Spanned<ast::FieldPat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::Struct(path, field_pats, false))
     }
-    fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
+    pub fn pat_tuple(&self, span: Span, pats: Vec<P<ast::Pat>>) -> P<ast::Pat> {
         self.pat(span, PatKind::Tuple(pats))
     }
 
-    fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_some(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::option, sym::Option, sym::Some]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn pat_none(&self, span: Span) -> P<ast::Pat> {
+    pub fn pat_none(&self, span: Span) -> P<ast::Pat> {
         let some = self.std_path(&[sym::option, sym::Option, sym::None]);
         let path = self.path_global(span, some);
         self.pat_path(span, path)
     }
 
-    fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_ok(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
+    pub fn pat_err(&self, span: Span, pat: P<ast::Pat>) -> P<ast::Pat> {
         let some = self.std_path(&[sym::result, sym::Result, sym::Err]);
         let path = self.path_global(span, some);
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm {
+    pub fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm {
         ast::Arm {
             attrs: vec![],
             pats,
@@ -884,25 +615,25 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }
     }
 
-    fn arm_unreachable(&self, span: Span) -> ast::Arm {
+    pub fn arm_unreachable(&self, span: Span) -> ast::Arm {
         self.arm(span, vec![self.pat_wild(span)], self.expr_unreachable(span))
     }
 
-    fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm>) -> P<Expr> {
+    pub fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm>) -> P<Expr> {
         self.expr(span, ast::ExprKind::Match(arg, arms))
     }
 
-    fn expr_if(&self, span: Span, cond: P<ast::Expr>,
+    pub fn expr_if(&self, span: Span, cond: P<ast::Expr>,
                then: P<ast::Expr>, els: Option<P<ast::Expr>>) -> P<ast::Expr> {
         let els = els.map(|x| self.expr_block(self.block_expr(x)));
         self.expr(span, ast::ExprKind::If(cond, self.block_expr(then), els))
     }
 
-    fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr> {
+    pub fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr> {
         self.expr(span, ast::ExprKind::Loop(block, None))
     }
 
-    fn lambda_fn_decl(&self,
+    pub fn lambda_fn_decl(&self,
                       span: Span,
                       fn_decl: P<ast::FnDecl>,
                       body: P<ast::Expr>,
@@ -916,7 +647,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                fn_decl_span))
     }
 
-    fn lambda(&self,
+    pub fn lambda(&self,
               span: Span,
               ids: Vec<ast::Ident>,
               body: P<ast::Expr>)
@@ -937,30 +668,30 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                                                span))
     }
 
-    fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr> {
+    pub fn lambda0(&self, span: Span, body: P<ast::Expr>) -> P<ast::Expr> {
         self.lambda(span, Vec::new(), body)
     }
 
-    fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
+    pub fn lambda1(&self, span: Span, body: P<ast::Expr>, ident: ast::Ident) -> P<ast::Expr> {
         self.lambda(span, vec![ident], body)
     }
 
-    fn lambda_stmts(&self,
+    pub fn lambda_stmts(&self,
                     span: Span,
                     ids: Vec<ast::Ident>,
                     stmts: Vec<ast::Stmt>)
                     -> P<ast::Expr> {
         self.lambda(span, ids, self.expr_block(self.block(span, stmts)))
     }
-    fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr> {
+    pub fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr> {
         self.lambda0(span, self.expr_block(self.block(span, stmts)))
     }
-    fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
+    pub fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
                       ident: ast::Ident) -> P<ast::Expr> {
         self.lambda1(span, self.expr_block(self.block(span, stmts)), ident)
     }
 
-    fn arg(&self, span: Span, ident: ast::Ident, ty: P<ast::Ty>) -> ast::Arg {
+    pub fn arg(&self, span: Span, ident: ast::Ident, ty: P<ast::Ty>) -> ast::Arg {
         let arg_pat = self.pat_ident(span, ident);
         ast::Arg {
             attrs: ThinVec::default(),
@@ -972,7 +703,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     // FIXME: unused `self`
-    fn fn_decl(&self, inputs: Vec<ast::Arg>, output: ast::FunctionRetTy) -> P<ast::FnDecl> {
+    pub fn fn_decl(&self, inputs: Vec<ast::Arg>, output: ast::FunctionRetTy) -> P<ast::FnDecl> {
         P(ast::FnDecl {
             inputs,
             output,
@@ -980,7 +711,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item(&self, span: Span, name: Ident,
+    pub fn item(&self, span: Span, name: Ident,
             attrs: Vec<ast::Attribute>, node: ast::ItemKind) -> P<ast::Item> {
         // FIXME: Would be nice if our generated code didn't violate
         // Rust coding conventions
@@ -995,7 +726,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item_fn_poly(&self,
+    pub fn item_fn_poly(&self,
                     span: Span,
                     name: Ident,
                     inputs: Vec<ast::Arg> ,
@@ -1016,7 +747,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                               body))
     }
 
-    fn item_fn(&self,
+    pub fn item_fn(&self,
                span: Span,
                name: Ident,
                inputs: Vec<ast::Arg> ,
@@ -1032,7 +763,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
             body)
     }
 
-    fn variant(&self, span: Span, ident: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
+    pub fn variant(&self, span: Span, ident: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
             ast::StructField {
                 span: ty.span,
@@ -1060,19 +791,19 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
                })
     }
 
-    fn item_enum_poly(&self, span: Span, name: Ident,
+    pub fn item_enum_poly(&self, span: Span, name: Ident,
                       enum_definition: ast::EnumDef,
                       generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Enum(enum_definition, generics))
     }
 
-    fn item_enum(&self, span: Span, name: Ident,
+    pub fn item_enum(&self, span: Span, name: Ident,
                  enum_definition: ast::EnumDef) -> P<ast::Item> {
         self.item_enum_poly(span, name, enum_definition,
                             Generics::default())
     }
 
-    fn item_struct(&self, span: Span, name: Ident,
+    pub fn item_struct(&self, span: Span, name: Ident,
                    struct_def: ast::VariantData) -> P<ast::Item> {
         self.item_struct_poly(
             span,
@@ -1082,12 +813,12 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         )
     }
 
-    fn item_struct_poly(&self, span: Span, name: Ident,
+    pub fn item_struct_poly(&self, span: Span, name: Ident,
         struct_def: ast::VariantData, generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Struct(struct_def, generics))
     }
 
-    fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
+    pub fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
                 attrs: Vec<ast::Attribute>,
                 items: Vec<P<ast::Item>>) -> P<ast::Item> {
         self.item(
@@ -1102,11 +833,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         )
     }
 
-    fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item> {
+    pub fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::ExternCrate(None))
     }
 
-    fn item_static(&self,
+    pub fn item_static(&self,
                    span: Span,
                    name: Ident,
                    ty: P<ast::Ty>,
@@ -1116,7 +847,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item(span, name, Vec::new(), ast::ItemKind::Static(ty, mutbl, expr))
     }
 
-    fn item_const(&self,
+    pub fn item_const(&self,
                   span: Span,
                   name: Ident,
                   ty: P<ast::Ty>,
@@ -1125,39 +856,39 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         self.item(span, name, Vec::new(), ast::ItemKind::Const(ty, expr))
     }
 
-    fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
+    pub fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
                     generics: Generics) -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Ty(ty, generics))
     }
 
-    fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
+    pub fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
         self.item_ty_poly(span, name, ty, Generics::default())
     }
 
-    fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
+    pub fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
         attr::mk_attr_outer(mi)
     }
 
-    fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
+    pub fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
         attr::mk_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
     }
 
-    fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
+    pub fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
         attr::mk_nested_word_item(Ident::with_empty_ctxt(w).with_span_pos(sp))
     }
 
-    fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
+    pub fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
                  -> ast::MetaItem {
         attr::mk_list_item(sp, Ident::with_empty_ctxt(name).with_span_pos(sp), mis)
     }
 
-    fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
+    pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
                        -> ast::MetaItem {
         attr::mk_name_value_item(span, Ident::with_empty_ctxt(name).with_span_pos(span),
                                  lit_kind, span)
     }
 
-    fn item_use(&self, sp: Span,
+    pub fn item_use(&self, sp: Span,
                 vis: ast::Visibility, vp: P<ast::UseTree>) -> P<ast::Item> {
         P(ast::Item {
             id: ast::DUMMY_NODE_ID,
@@ -1170,11 +901,11 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         })
     }
 
-    fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item> {
+    pub fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item> {
         self.item_use_simple_(sp, vis, None, path)
     }
 
-    fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
+    pub fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
                         rename: Option<ast::Ident>, path: ast::Path) -> P<ast::Item> {
         self.item_use(sp, vis, P(ast::UseTree {
             span: sp,
@@ -1183,7 +914,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }))
     }
 
-    fn item_use_list(&self, sp: Span, vis: ast::Visibility,
+    pub fn item_use_list(&self, sp: Span, vis: ast::Visibility,
                      path: Vec<ast::Ident>, imports: &[ast::Ident]) -> P<ast::Item> {
         let imports = imports.iter().map(|id| {
             (ast::UseTree {
@@ -1200,7 +931,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
         }))
     }
 
-    fn item_use_glob(&self, sp: Span,
+    pub fn item_use_glob(&self, sp: Span,
                      vis: ast::Visibility, path: Vec<ast::Ident>) -> P<ast::Item> {
         self.item_use(sp, vis, P(ast::UseTree {
             span: sp,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1135,7 +1135,7 @@ impl<'a> AstBuilder for ExtCtxt<'a> {
     }
 
     fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
-        attr::mk_attr_outer(mi.span, mi)
+        attr::mk_attr_outer(mi)
     }
 
     fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1341,8 +1341,8 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
 
             let meta = attr::mk_list_item(DUMMY_SP, Ident::with_empty_ctxt(sym::doc), items);
             match at.style {
-                ast::AttrStyle::Inner => *at = attr::mk_spanned_attr_inner(at.span, at.id, meta),
-                ast::AttrStyle::Outer => *at = attr::mk_spanned_attr_outer(at.span, at.id, meta),
+                ast::AttrStyle::Inner => *at = attr::mk_attr_inner(at.span, at.id, meta),
+                ast::AttrStyle::Outer => *at = attr::mk_attr_outer(at.span, at.id, meta),
             }
         } else {
             noop_visit_attribute(at, self)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -1340,10 +1340,14 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
             }
 
             let meta = attr::mk_list_item(DUMMY_SP, Ident::with_empty_ctxt(sym::doc), items);
-            match at.style {
-                ast::AttrStyle::Inner => *at = attr::mk_attr_inner(at.span, at.id, meta),
-                ast::AttrStyle::Outer => *at = attr::mk_attr_outer(at.span, at.id, meta),
-            }
+            *at = attr::Attribute {
+                span: at.span,
+                id: at.id,
+                style: at.style,
+                path: meta.path,
+                tokens: meta.node.tokens(meta.span),
+                is_sugared_doc: false,
+            };
         } else {
             noop_visit_attribute(at, self)
         }

--- a/src/libsyntax/ext/proc_macro.rs
+++ b/src/libsyntax/ext/proc_macro.rs
@@ -2,7 +2,6 @@ use crate::ast::{self, ItemKind, Attribute, Mac};
 use crate::attr::{mark_used, mark_known, HasAttrs};
 use crate::errors::{Applicability, FatalError};
 use crate::ext::base::{self, *};
-use crate::ext::build::AstBuilder;
 use crate::ext::proc_macro_server;
 use crate::parse::{self, token};
 use crate::parse::parser::PathStyle;

--- a/src/libsyntax/ext/proc_macro.rs
+++ b/src/libsyntax/ext/proc_macro.rs
@@ -239,11 +239,11 @@ crate fn add_derived_markers<T: HasAttrs>(
     item.visit_attrs(|attrs| {
         if names.contains(&sym::Eq) && names.contains(&sym::PartialEq) {
             let meta = cx.meta_word(span, sym::structural_match);
-            attrs.push(cx.attribute(span, meta));
+            attrs.push(cx.attribute(meta));
         }
         if names.contains(&sym::Copy) {
             let meta = cx.meta_word(span, sym::rustc_copy_clone_marker);
-            attrs.push(cx.attribute(span, meta));
+            attrs.push(cx.attribute(meta));
         }
     });
 }

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -748,7 +748,7 @@ impl TokenSet {
 }
 
 // Checks that `matcher` is internally consistent and that it
-// can legally by followed by a token N, for all N in `follow`.
+// can legally be followed by a token `N`, for all `N` in `follow`.
 // (If `follow` is empty, then it imposes no constraint on
 // the `matcher`.)
 //

--- a/src/libsyntax/ext/tt/quoted.rs
+++ b/src/libsyntax/ext/tt/quoted.rs
@@ -27,7 +27,7 @@ impl Delimited {
         let open_span = if span.is_dummy() {
             span
         } else {
-            span.with_lo(span.lo() + BytePos(self.delim.len() as u32))
+            span.with_hi(span.lo() + BytePos(self.delim.len() as u32))
         };
         TokenTree::token(token::OpenDelim(self.delim), open_span)
     }

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -53,7 +53,7 @@ impl<'a> Parser<'a> {
                     just_parsed_doc_comment = false;
                 }
                 token::DocComment(s) => {
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
+                    let attr = attr::mk_sugared_doc_attr(s, self.token.span);
                     if attr.style != ast::AttrStyle::Outer {
                         let mut err = self.fatal("expected outer doc comment");
                         err.note("inner doc comments like this (starting with \
@@ -239,7 +239,7 @@ impl<'a> Parser<'a> {
                 }
                 token::DocComment(s) => {
                     // we need to get the position of this token before we bump.
-                    let attr = attr::mk_sugared_doc_attr(attr::mk_attr_id(), s, self.token.span);
+                    let attr = attr::mk_sugared_doc_attr(s, self.token.span);
                     if attr.style == ast::AttrStyle::Inner {
                         attrs.push(attr);
                         self.bump();

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -6396,15 +6396,8 @@ impl<'a> Parser<'a> {
                     self.eval_src_mod(path, directory_ownership, id.to_string(), id_span)?;
                 // Record that we fetched the mod from an external file
                 if warn {
-                    let attr = Attribute {
-                        id: attr::mk_attr_id(),
-                        style: ast::AttrStyle::Outer,
-                        path: ast::Path::from_ident(
-                            Ident::with_empty_ctxt(sym::warn_directory_ownership)),
-                        tokens: TokenStream::empty(),
-                        is_sugared_doc: false,
-                        span: DUMMY_SP,
-                    };
+                    let attr = attr::mk_attr_outer(
+                        attr::mk_word_item(Ident::with_empty_ctxt(sym::warn_directory_ownership)));
                     attr::mark_known(&attr);
                     attrs.push(attr);
                 }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -123,12 +123,12 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
         let pi_nested = attr::mk_nested_word_item(ast::Ident::with_empty_ctxt(sym::prelude_import));
         let list = attr::mk_list_item(
             DUMMY_SP, ast::Ident::with_empty_ctxt(sym::feature), vec![pi_nested]);
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), list);
+        let fake_attr = attr::mk_attr_inner(DUMMY_SP, list);
         s.print_attribute(&fake_attr);
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::no_std));
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, attr::mk_attr_id(), no_std_meta);
+        let fake_attr = attr::mk_attr_inner(DUMMY_SP, no_std_meta);
         s.print_attribute(&fake_attr);
     }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -123,12 +123,12 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
         let pi_nested = attr::mk_nested_word_item(ast::Ident::with_empty_ctxt(sym::prelude_import));
         let list = attr::mk_list_item(
             DUMMY_SP, ast::Ident::with_empty_ctxt(sym::feature), vec![pi_nested]);
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, list);
+        let fake_attr = attr::mk_attr_inner(list);
         s.print_attribute(&fake_attr);
 
         // #![no_std]
         let no_std_meta = attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::no_std));
-        let fake_attr = attr::mk_attr_inner(DUMMY_SP, no_std_meta);
+        let fake_attr = attr::mk_attr_inner(no_std_meta);
         s.print_attribute(&fake_attr);
     }
 

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -3,7 +3,6 @@ use errors::{Applicability, DiagnosticBuilder};
 use syntax::ast::{self, *};
 use syntax::source_map::Spanned;
 use syntax::ext::base::*;
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token::{self, TokenKind};
 use syntax::parse::parser::Parser;
 use syntax::print::pprust;

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -6,7 +6,6 @@ use errors::DiagnosticBuilder;
 
 use syntax::ast;
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::attr;
 use syntax::tokenstream;
 use syntax::parse::token;

--- a/src/libsyntax_ext/concat.rs
+++ b/src/libsyntax_ext/concat.rs
@@ -1,6 +1,5 @@
 use syntax::ast;
 use syntax::ext::base;
-use syntax::ext::build::AstBuilder;
 use syntax::symbol::Symbol;
 use syntax::tokenstream;
 

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -77,7 +77,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt<'_>,
     }
 
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -5,7 +5,6 @@ use crate::deriving::generic::ty::*;
 use syntax::ast::{self, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
 use syntax::attr;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem, GenericArg};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -17,7 +17,7 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,
     let inline = cx.meta_word(span, sym::inline);
     let hidden = cx.meta_list_item_word(span, sym::hidden);
     let doc = cx.meta_list(span, sym::doc, vec![hidden]);
-    let attrs = vec![cx.attribute(span, inline), cx.attribute(span, doc)];
+    let attrs = vec![cx.attribute(inline), cx.attribute(doc)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -15,7 +15,7 @@ pub fn expand_deriving_ord(cx: &mut ExtCtxt<'_>,
                            item: &Annotatable,
                            push: &mut dyn FnMut(Annotatable)) {
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -63,7 +63,7 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
     macro_rules! md {
         ($name:expr, $f:ident) => { {
             let inline = cx.meta_word(span, sym::inline);
-            let attrs = vec![cx.attribute(span, inline)];
+            let attrs = vec![cx.attribute(inline)];
             MethodDef {
                 name: $name,
                 generics: LifetimeBounds::empty(),

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -6,7 +6,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, BinOpKind, Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -19,7 +19,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt<'_>,
     macro_rules! md {
         ($name:expr, $op:expr, $equal:expr) => { {
             let inline = cx.meta_word(span, sym::inline);
-            let attrs = vec![cx.attribute(span, inline)];
+            let attrs = vec![cx.attribute(inline)];
             MethodDef {
                 name: $name,
                 generics: LifetimeBounds::empty(),
@@ -43,7 +43,7 @@ pub fn expand_deriving_partial_ord(cx: &mut ExtCtxt<'_>,
                                     PathKind::Std));
 
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
 
     let partial_cmp_def = MethodDef {
         name: "partial_cmp",

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -7,7 +7,6 @@ use rustc_data_structures::thin_vec::ThinVec;
 use syntax::ast::{self, Ident};
 use syntax::ast::{Expr, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::{DUMMY_SP, Span};

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -7,7 +7,6 @@ use crate::deriving::generic::ty::*;
 use syntax::ast;
 use syntax::ast::{Expr, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem};
 use syntax::ext::base::{Annotatable, DummyResult, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym};
 use syntax::span_err;

--- a/src/libsyntax_ext/deriving/default.rs
+++ b/src/libsyntax_ext/deriving/default.rs
@@ -16,7 +16,7 @@ pub fn expand_deriving_default(cx: &mut ExtCtxt<'_>,
                                item: &Annotatable,
                                push: &mut dyn FnMut(Annotatable)) {
     let inline = cx.meta_word(span, sym::inline);
-    let attrs = vec![cx.attribute(span, inline)];
+    let attrs = vec![cx.attribute(inline)];
     let trait_def = TraitDef {
         span,
         attributes: Vec::new(),

--- a/src/libsyntax_ext/deriving/encodable.rs
+++ b/src/libsyntax_ext/deriving/encodable.rs
@@ -88,7 +88,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, ExprKind, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::Symbol;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -187,7 +187,6 @@ use syntax::ast::{self, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
 use syntax::ast::{VariantData, GenericParamKind, GenericArg};
 use syntax::attr;
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::source_map::{self, respan};
 use syntax::util::map_in_place::MapInPlace;
 use syntax::ptr::P;

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -666,14 +666,13 @@ impl<'a> TraitDef<'a> {
         let path = cx.path_all(self.span, false, vec![type_ident], self_params, vec![]);
         let self_type = cx.ty_path(path);
 
-        let attr = cx.attribute(self.span,
-                                cx.meta_word(self.span, sym::automatically_derived));
+        let attr = cx.attribute(cx.meta_word(self.span, sym::automatically_derived));
         // Just mark it now since we know that it'll end up used downstream
         attr::mark_used(&attr);
         let opt_trait_ref = Some(trait_ref);
         let unused_qual = {
             let word = cx.meta_list_item_word(self.span, Symbol::intern("unused_qualifications"));
-            cx.attribute(self.span, cx.meta_list(self.span, sym::allow, vec![word]))
+            cx.attribute(cx.meta_list(self.span, sym::allow, vec![word]))
         };
 
         let mut a = vec![attr, unused_qual];

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -6,7 +6,6 @@ pub use Ty::*;
 
 use syntax::ast::{self, Expr, GenericParamKind, Generics, Ident, SelfKind, GenericArg};
 use syntax::ext::base::ExtCtxt;
-use syntax::ext::build::AstBuilder;
 use syntax::source_map::{respan, DUMMY_SP};
 use syntax::ptr::P;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/hash.rs
+++ b/src/libsyntax_ext/deriving/hash.rs
@@ -4,7 +4,6 @@ use crate::deriving::generic::ty::*;
 
 use syntax::ast::{Expr, MetaItem, Mutability};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/mod.rs
+++ b/src/libsyntax_ext/deriving/mod.rs
@@ -2,7 +2,6 @@
 
 use syntax::ast::{self, MetaItem};
 use syntax::ext::base::{Annotatable, ExtCtxt, MultiItemModifier};
-use syntax::ext::build::AstBuilder;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, sym};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -5,7 +5,6 @@
 
 use syntax::ast::{self, Ident, GenericArg};
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;
 use syntax::tokenstream;

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -8,7 +8,6 @@ use errors::Applicability;
 
 use syntax::ast;
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::token;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, sym};

--- a/src/libsyntax_ext/global_allocator.rs
+++ b/src/libsyntax_ext/global_allocator.rs
@@ -110,7 +110,7 @@ impl AllocFnFactory<'_, '_> {
     fn attrs(&self) -> Vec<Attribute> {
         let special = sym::rustc_std_internal_symbol;
         let special = self.cx.meta_word(self.span, special);
-        vec![self.cx.attribute(self.span, special)]
+        vec![self.cx.attribute(special)]
     }
 
     fn arg_ty(

--- a/src/libsyntax_ext/global_allocator.rs
+++ b/src/libsyntax_ext/global_allocator.rs
@@ -3,7 +3,6 @@ use syntax::ast::{self, Arg, Attribute, Expr, FnHeader, Generics, Ident};
 use syntax::attr::check_builtin_macro_attribute;
 use syntax::ext::allocator::{AllocatorKind, AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
 use syntax::ext::base::{Annotatable, ExtCtxt};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};

--- a/src/libsyntax_ext/plugin_macro_defs.rs
+++ b/src/libsyntax_ext/plugin_macro_defs.rs
@@ -16,14 +16,8 @@ use syntax_pos::hygiene::{ExpnId, ExpnInfo, ExpnKind, MacroKind};
 use std::mem;
 
 fn plugin_macro_def(name: Name, span: Span) -> P<Item> {
-    let rustc_builtin_macro = Attribute {
-        id: attr::mk_attr_id(),
-        style: AttrStyle::Outer,
-        path: Path::from_ident(Ident::new(sym::rustc_builtin_macro, span)),
-        tokens: TokenStream::empty(),
-        is_sugared_doc: false,
-        span,
-    };
+    let rustc_builtin_macro = attr::mk_attr_outer(
+        attr::mk_word_item(Ident::new(sym::rustc_builtin_macro, span)));
 
     let parens: TreeAndJoint = TokenTree::Delimited(
         DelimSpan::from_single(span), token::Paren, TokenStream::empty()

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -337,7 +337,7 @@ fn mk_decls(
 
     let hidden = cx.meta_list_item_word(span, sym::hidden);
     let doc = cx.meta_list(span, sym::doc, vec![hidden]);
-    let doc_hidden = cx.attribute(span, doc);
+    let doc_hidden = cx.attribute(doc);
 
     let proc_macro = Ident::with_empty_ctxt(sym::proc_macro);
     let krate = cx.item(span,
@@ -394,7 +394,7 @@ fn mk_decls(
         cx.expr_vec_slice(span, decls),
     ).map(|mut i| {
         let attr = cx.meta_word(span, sym::rustc_proc_macro_decls);
-        i.attrs.push(cx.attribute(span, attr));
+        i.attrs.push(cx.attribute(attr));
         i.vis = respan(span, ast::VisibilityKind::Public);
         i
     });

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -4,7 +4,6 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::source_map::{ExpnInfo, ExpnKind, respan};
 use syntax::ext::base::{ExtCtxt, MacroKind};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
 use syntax::ext::hygiene::ExpnId;
 use syntax::ext::proc_macro::is_proc_macro_attr;

--- a/src/libsyntax_ext/source_util.rs
+++ b/src/libsyntax_ext/source_util.rs
@@ -1,6 +1,5 @@
 use syntax::{ast, panictry};
 use syntax::ext::base::{self, *};
-use syntax::ext::build::AstBuilder;
 use syntax::parse::{self, token, DirectoryOwnership};
 use syntax::print::pprust;
 use syntax::ptr::P;

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -42,7 +42,6 @@ pub fn inject(
         krate.module.items.insert(0, P(ast::Item {
             attrs: vec![attr::mk_attr_outer(
                 DUMMY_SP,
-                attr::mk_attr_id(),
                 attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::macro_use))
             )],
             vis: dummy_spanned(ast::VisibilityKind::Inherited),

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -41,7 +41,6 @@ pub fn inject(
         };
         krate.module.items.insert(0, P(ast::Item {
             attrs: vec![attr::mk_attr_outer(
-                DUMMY_SP,
                 attr::mk_word_item(ast::Ident::with_empty_ctxt(sym::macro_use))
             )],
             vis: dummy_spanned(ast::VisibilityKind::Inherited),

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -4,7 +4,6 @@ use syntax::ext::hygiene::{ExpnId, MacroKind};
 use syntax::ptr::P;
 use syntax::source_map::{ExpnInfo, ExpnKind, dummy_spanned, respan};
 use syntax::symbol::{Ident, Symbol, kw, sym};
-use syntax::tokenstream::TokenStream;
 use syntax_pos::DUMMY_SP;
 
 use std::iter;
@@ -62,14 +61,8 @@ pub fn inject(
     ));
 
     krate.module.items.insert(0, P(ast::Item {
-        attrs: vec![ast::Attribute {
-            style: ast::AttrStyle::Outer,
-            path: ast::Path::from_ident(ast::Ident::new(sym::prelude_import, span)),
-            tokens: TokenStream::empty(),
-            id: attr::mk_attr_id(),
-            is_sugared_doc: false,
-            span,
-        }],
+        attrs: vec![attr::mk_attr_outer(
+            attr::mk_word_item(ast::Ident::new(sym::prelude_import, span)))],
         vis: respan(span.shrink_to_lo(), ast::VisibilityKind::Inherited),
         node: ast::ItemKind::Use(P(ast::UseTree {
             prefix: ast::Path {

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -36,8 +36,7 @@ pub fn expand_test_case(
         item.vis = respan(item.vis.span, ast::VisibilityKind::Public);
         item.ident = item.ident.gensym();
         item.attrs.push(
-            ecx.attribute(sp,
-                ecx.meta_word(sp, sym::rustc_test_marker))
+            ecx.attribute(ecx.meta_word(sp, sym::rustc_test_marker))
         );
         item
     });
@@ -150,11 +149,11 @@ pub fn expand_test_or_bench(
     let mut test_const = cx.item(sp, ast::Ident::new(item.ident.name, sp).gensym(),
         vec![
             // #[cfg(test)]
-            cx.attribute(attr_sp, cx.meta_list(attr_sp, sym::cfg, vec![
+            cx.attribute(cx.meta_list(attr_sp, sym::cfg, vec![
                 cx.meta_list_item_word(attr_sp, sym::test)
             ])),
             // #[rustc_test_marker]
-            cx.attribute(attr_sp, cx.meta_word(attr_sp, sym::rustc_test_marker)),
+            cx.attribute(cx.meta_word(attr_sp, sym::rustc_test_marker)),
         ],
         // const $ident: test::TestDescAndFn =
         ast::ItemKind::Const(cx.ty(sp, ast::TyKind::Path(None, test_path("TestDescAndFn"))),

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -4,7 +4,6 @@
 use syntax::ast;
 use syntax::attr::{self, check_builtin_macro_attribute};
 use syntax::ext::base::*;
-use syntax::ext::build::AstBuilder;
 use syntax::ext::hygiene::SyntaxContext;
 use syntax::print::pprust;
 use syntax::source_map::respan;

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -294,7 +294,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     // #![main]
     let main_meta = ecx.meta_word(sp, sym::main);
-    let main_attr = ecx.attribute(sp, main_meta);
+    let main_attr = ecx.attribute(main_meta);
 
     // extern crate test as test_gensym
     let test_extern_stmt = ecx.stmt_item(sp, ecx.item(sp,

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -161,7 +161,6 @@ impl MutVisitor for EntryPointCleaner {
                     let allow_dead_code_item = attr::mk_list_item(DUMMY_SP, allow_ident,
                                                                   vec![dc_nested]);
                     let allow_dead_code = attr::mk_attr_outer(DUMMY_SP,
-                                                              attr::mk_attr_id(),
                                                               allow_dead_code_item);
 
                     ast::Item {

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -6,7 +6,6 @@ use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::entry::{self, EntryPointType};
 use syntax::ext::base::{ExtCtxt, Resolver};
-use syntax::ext::build::AstBuilder;
 use syntax::ext::expand::ExpansionConfig;
 use syntax::ext::hygiene::{ExpnId, MacroKind};
 use syntax::feature_gate::Features;

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -160,8 +160,7 @@ impl MutVisitor for EntryPointCleaner {
                     let dc_nested = attr::mk_nested_word_item(Ident::from_str("dead_code"));
                     let allow_dead_code_item = attr::mk_list_item(DUMMY_SP, allow_ident,
                                                                   vec![dc_nested]);
-                    let allow_dead_code = attr::mk_attr_outer(DUMMY_SP,
-                                                              allow_dead_code_item);
+                    let allow_dead_code = attr::mk_attr_outer(allow_dead_code_item);
 
                     ast::Item {
                         id,

--- a/src/test/ui-fulldeps/auxiliary/plugin-args.rs
+++ b/src/test/ui-fulldeps/auxiliary/plugin-args.rs
@@ -11,7 +11,6 @@ extern crate rustc_driver;
 
 use std::borrow::ToOwned;
 use syntax::ast;
-use syntax::ext::build::AstBuilder;
 use syntax::ext::base::{SyntaxExtension, SyntaxExtensionKind};
 use syntax::ext::base::{TTMacroExpander, ExtCtxt, MacResult, MacEager};
 use syntax::print::pprust;

--- a/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
+++ b/src/test/ui-fulldeps/auxiliary/roman-numerals.rs
@@ -18,7 +18,6 @@ extern crate rustc_driver;
 use syntax::parse::token::{self, Token};
 use syntax::tokenstream::TokenTree;
 use syntax::ext::base::{ExtCtxt, MacResult, DummyResult, MacEager};
-use syntax::ext::build::AstBuilder;  // A trait for expr_usize.
 use syntax_pos::Span;
 use rustc_plugin::Registry;
 

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -4,7 +4,7 @@ error: any use of this value will cause an error
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
-   |                             Overflowing shift by 8 in unchecked_shl
+   |                             Overflowing shift by 8 in `unchecked_shl`
    |
    = note: `#[deny(const_err)]` on by default
 
@@ -14,7 +14,7 @@ error: any use of this value will cause an error
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 16 in unchecked_shl
+   |                               Overflowing shift by 16 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:18:31
@@ -22,7 +22,7 @@ error: any use of this value will cause an error
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 32 in unchecked_shl
+   |                               Overflowing shift by 32 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:20:31
@@ -30,7 +30,7 @@ error: any use of this value will cause an error
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 64 in unchecked_shl
+   |                               Overflowing shift by 64 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:22:33
@@ -38,7 +38,7 @@ error: any use of this value will cause an error
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 128 in unchecked_shl
+   |                                 Overflowing shift by 128 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:27:29
@@ -46,7 +46,7 @@ error: any use of this value will cause an error
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
-   |                             Overflowing shift by 8 in unchecked_shl
+   |                             Overflowing shift by 8 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:29:31
@@ -54,7 +54,7 @@ error: any use of this value will cause an error
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 16 in unchecked_shl
+   |                               Overflowing shift by 16 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:31:31
@@ -62,7 +62,7 @@ error: any use of this value will cause an error
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 32 in unchecked_shl
+   |                               Overflowing shift by 32 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:33:31
@@ -70,7 +70,7 @@ error: any use of this value will cause an error
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 64 in unchecked_shl
+   |                               Overflowing shift by 64 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:35:33
@@ -78,7 +78,7 @@ error: any use of this value will cause an error
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 128 in unchecked_shl
+   |                                 Overflowing shift by 128 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:40:33
@@ -86,7 +86,7 @@ error: any use of this value will cause an error
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 255 in unchecked_shl
+   |                                 Overflowing shift by 255 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:42:35
@@ -94,7 +94,7 @@ error: any use of this value will cause an error
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 65535 in unchecked_shl
+   |                                   Overflowing shift by 65535 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:44:35
@@ -102,7 +102,7 @@ error: any use of this value will cause an error
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 4294967295 in unchecked_shl
+   |                                   Overflowing shift by 4294967295 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:46:35
@@ -110,7 +110,7 @@ error: any use of this value will cause an error
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 18446744073709551615 in unchecked_shl
+   |                                   Overflowing shift by 18446744073709551615 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:48:37
@@ -118,7 +118,7 @@ error: any use of this value will cause an error
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
-   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shl
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:54:40
@@ -126,7 +126,7 @@ error: any use of this value will cause an error
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
-   |                                        Overflowing shift by 250 in unchecked_shl
+   |                                        Overflowing shift by 250 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:56:42
@@ -134,7 +134,7 @@ error: any use of this value will cause an error
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 65523 in unchecked_shl
+   |                                          Overflowing shift by 65523 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:58:42
@@ -142,7 +142,7 @@ error: any use of this value will cause an error
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 4294967271 in unchecked_shl
+   |                                          Overflowing shift by 4294967271 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:60:42
@@ -150,7 +150,7 @@ error: any use of this value will cause an error
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 18446744073709551586 in unchecked_shl
+   |                                          Overflowing shift by 18446744073709551586 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:62:44
@@ -158,7 +158,7 @@ error: any use of this value will cause an error
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
-   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shl
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:69:29
@@ -166,7 +166,7 @@ error: any use of this value will cause an error
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
-   |                             Overflowing shift by 8 in unchecked_shr
+   |                             Overflowing shift by 8 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:71:31
@@ -174,7 +174,7 @@ error: any use of this value will cause an error
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 16 in unchecked_shr
+   |                               Overflowing shift by 16 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:73:31
@@ -182,7 +182,7 @@ error: any use of this value will cause an error
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 32 in unchecked_shr
+   |                               Overflowing shift by 32 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:75:31
@@ -190,7 +190,7 @@ error: any use of this value will cause an error
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 64 in unchecked_shr
+   |                               Overflowing shift by 64 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:77:33
@@ -198,7 +198,7 @@ error: any use of this value will cause an error
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 128 in unchecked_shr
+   |                                 Overflowing shift by 128 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:82:29
@@ -206,7 +206,7 @@ error: any use of this value will cause an error
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                             |
-   |                             Overflowing shift by 8 in unchecked_shr
+   |                             Overflowing shift by 8 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:84:31
@@ -214,7 +214,7 @@ error: any use of this value will cause an error
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 16 in unchecked_shr
+   |                               Overflowing shift by 16 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:86:31
@@ -222,7 +222,7 @@ error: any use of this value will cause an error
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 32 in unchecked_shr
+   |                               Overflowing shift by 32 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:88:31
@@ -230,7 +230,7 @@ error: any use of this value will cause an error
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
    | ------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                               |
-   |                               Overflowing shift by 64 in unchecked_shr
+   |                               Overflowing shift by 64 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:90:33
@@ -238,7 +238,7 @@ error: any use of this value will cause an error
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 128 in unchecked_shr
+   |                                 Overflowing shift by 128 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:95:33
@@ -246,7 +246,7 @@ error: any use of this value will cause an error
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
    | --------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                 |
-   |                                 Overflowing shift by 255 in unchecked_shr
+   |                                 Overflowing shift by 255 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:97:35
@@ -254,7 +254,7 @@ error: any use of this value will cause an error
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 65535 in unchecked_shr
+   |                                   Overflowing shift by 65535 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:99:35
@@ -262,7 +262,7 @@ error: any use of this value will cause an error
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 4294967295 in unchecked_shr
+   |                                   Overflowing shift by 4294967295 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:101:35
@@ -270,7 +270,7 @@ error: any use of this value will cause an error
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
    | ----------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                   |
-   |                                   Overflowing shift by 18446744073709551615 in unchecked_shr
+   |                                   Overflowing shift by 18446744073709551615 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:103:37
@@ -278,7 +278,7 @@ error: any use of this value will cause an error
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
    | ------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                     |
-   |                                     Overflowing shift by 340282366920938463463374607431768211455 in unchecked_shr
+   |                                     Overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:109:40
@@ -286,7 +286,7 @@ error: any use of this value will cause an error
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
    | ---------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                        |
-   |                                        Overflowing shift by 250 in unchecked_shr
+   |                                        Overflowing shift by 250 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:111:42
@@ -294,7 +294,7 @@ error: any use of this value will cause an error
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 65523 in unchecked_shr
+   |                                          Overflowing shift by 65523 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:113:42
@@ -302,7 +302,7 @@ error: any use of this value will cause an error
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 4294967271 in unchecked_shr
+   |                                          Overflowing shift by 4294967271 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:115:42
@@ -310,7 +310,7 @@ error: any use of this value will cause an error
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
    | -----------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                          |
-   |                                          Overflowing shift by 18446744073709551586 in unchecked_shr
+   |                                          Overflowing shift by 18446744073709551586 in `unchecked_shr`
 
 error: any use of this value will cause an error
   --> $DIR/const-int-unchecked.rs:117:44
@@ -318,7 +318,7 @@ error: any use of this value will cause an error
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
    | -------------------------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
    |                                            |
-   |                                            Overflowing shift by 340282366920938463463374607431768211363 in unchecked_shr
+   |                                            Overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
 
 error: aborting due to 40 previous errors
 

--- a/src/test/ui/macros/macro-follow.stderr
+++ b/src/test/ui/macros/macro-follow.stderr
@@ -1,24 +1,24 @@
 error: `$p:pat` is followed by `(`, which is not allowed for `pat` fragments
-  --> $DIR/macro-follow.rs:8:14
+  --> $DIR/macro-follow.rs:8:13
    |
 LL |     ($p:pat ()) => {};
-   |              ^ not allowed after `pat` fragments
+   |             ^ not allowed after `pat` fragments
    |
    = note: allowed there are: `=>`, `,`, `=`, `|`, `if` or `in`
 
 error: `$p:pat` is followed by `[`, which is not allowed for `pat` fragments
-  --> $DIR/macro-follow.rs:9:14
+  --> $DIR/macro-follow.rs:9:13
    |
 LL |     ($p:pat []) => {};
-   |              ^ not allowed after `pat` fragments
+   |             ^ not allowed after `pat` fragments
    |
    = note: allowed there are: `=>`, `,`, `=`, `|`, `if` or `in`
 
 error: `$p:pat` is followed by `{`, which is not allowed for `pat` fragments
-  --> $DIR/macro-follow.rs:10:14
+  --> $DIR/macro-follow.rs:10:13
    |
 LL |     ($p:pat {}) => {};
-   |              ^ not allowed after `pat` fragments
+   |             ^ not allowed after `pat` fragments
    |
    = note: allowed there are: `=>`, `,`, `=`, `|`, `if` or `in`
 
@@ -135,26 +135,26 @@ LL |     ($p:pat $m:meta) => {};
    = note: allowed there are: `=>`, `,`, `=`, `|`, `if` or `in`
 
 error: `$e:expr` is followed by `(`, which is not allowed for `expr` fragments
-  --> $DIR/macro-follow.rs:28:15
+  --> $DIR/macro-follow.rs:28:14
    |
 LL |     ($e:expr ()) => {};
-   |               ^ not allowed after `expr` fragments
+   |              ^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$e:expr` is followed by `[`, which is not allowed for `expr` fragments
-  --> $DIR/macro-follow.rs:29:15
+  --> $DIR/macro-follow.rs:29:14
    |
 LL |     ($e:expr []) => {};
-   |               ^ not allowed after `expr` fragments
+   |              ^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$e:expr` is followed by `{`, which is not allowed for `expr` fragments
-  --> $DIR/macro-follow.rs:30:15
+  --> $DIR/macro-follow.rs:30:14
    |
 LL |     ($e:expr {}) => {};
-   |               ^ not allowed after `expr` fragments
+   |              ^ not allowed after `expr` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
@@ -303,10 +303,10 @@ LL |     ($e:expr $m:meta) => {};
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$t:ty` is followed by `(`, which is not allowed for `ty` fragments
-  --> $DIR/macro-follow.rs:53:13
+  --> $DIR/macro-follow.rs:53:12
    |
 LL |     ($t:ty ()) => {};
-   |             ^ not allowed after `ty` fragments
+   |            ^ not allowed after `ty` fragments
    |
    = note: allowed there are: `{`, `[`, `=>`, `,`, `>`, `=`, `:`, `;`, `|`, `as` or `where`
 
@@ -407,26 +407,26 @@ LL |     ($t:ty $m:meta) => {};
    = note: allowed there are: `{`, `[`, `=>`, `,`, `>`, `=`, `:`, `;`, `|`, `as` or `where`
 
 error: `$s:stmt` is followed by `(`, which is not allowed for `stmt` fragments
-  --> $DIR/macro-follow.rs:71:15
+  --> $DIR/macro-follow.rs:71:14
    |
 LL |     ($s:stmt ()) => {};
-   |               ^ not allowed after `stmt` fragments
+   |              ^ not allowed after `stmt` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$s:stmt` is followed by `[`, which is not allowed for `stmt` fragments
-  --> $DIR/macro-follow.rs:72:15
+  --> $DIR/macro-follow.rs:72:14
    |
 LL |     ($s:stmt []) => {};
-   |               ^ not allowed after `stmt` fragments
+   |              ^ not allowed after `stmt` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$s:stmt` is followed by `{`, which is not allowed for `stmt` fragments
-  --> $DIR/macro-follow.rs:73:15
+  --> $DIR/macro-follow.rs:73:14
    |
 LL |     ($s:stmt {}) => {};
-   |               ^ not allowed after `stmt` fragments
+   |              ^ not allowed after `stmt` fragments
    |
    = note: allowed there are: `=>`, `,` or `;`
 
@@ -575,10 +575,10 @@ LL |     ($s:stmt $m:meta) => {};
    = note: allowed there are: `=>`, `,` or `;`
 
 error: `$p:path` is followed by `(`, which is not allowed for `path` fragments
-  --> $DIR/macro-follow.rs:95:15
+  --> $DIR/macro-follow.rs:95:14
    |
 LL |     ($p:path ()) => {};
-   |               ^ not allowed after `path` fragments
+   |              ^ not allowed after `path` fragments
    |
    = note: allowed there are: `{`, `[`, `=>`, `,`, `>`, `=`, `:`, `;`, `|`, `as` or `where`
 

--- a/src/test/ui/type-alias-enum-variants/issue-63151-dead-code-lint-fields-in-patterns.rs
+++ b/src/test/ui/type-alias-enum-variants/issue-63151-dead-code-lint-fields-in-patterns.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+// Regression test for the issue #63151:
+// Spurious unused field warning when matching variants under a `Self` scope
+//
+// This test checks that the `dead_code` lint properly inspects fields
+// in struct patterns that use a type relative path.
+
+#![deny(dead_code)]
+
+enum Enum {
+    Variant { field: usize }
+}
+
+impl Enum {
+    fn read_field(self) -> usize {
+        match self {
+            Self::Variant { field } => field
+        }
+    }
+}
+
+fn main() {
+    let e = Enum::Variant { field: 42 };
+    println!("{}", e.read_field());
+}


### PR DESCRIPTION
Successful merges:

 - #62954 (Fix typo in Delimited::open_tt)
 - #63146 (Cleanup syntax::attr)
 - #63218 (rustbuild: RISC-V is no longer an experimental LLVM target)
 - #63227 (dead_code: Properly inspect fields in struct patterns with type relative paths)
 - #63229 (A bit of Miri error cleanup)

Failed merges:


r? @ghost