### PR TITLE
More Miri error tweaks

### DIFF
--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -348,6 +348,8 @@ pub enum UndefinedBehaviorInfo {
     UbExperimental(String),
     /// Unreachable code was executed.
     Unreachable,
+    /// An `assume` was run on a `false` condition,
+    AssumptionNotHeld,
 }
 
 impl fmt::Debug for UndefinedBehaviorInfo {
@@ -358,6 +360,8 @@ impl fmt::Debug for UndefinedBehaviorInfo {
                 write!(f, "{}", msg),
             Unreachable =>
                 write!(f, "entered unreachable code"),
+            AssumptionNotHeld =>
+                write!(f, "`assume` argument was false"),
         }
     }
 }
@@ -408,7 +412,6 @@ pub enum UnsupportedOpInfo<'tcx> {
     VtableForArgumentlessMethod,
     ModifiedConstantMemory,
     ModifiedStatic,
-    AssumptionNotHeld,
     TypeNotPrimitive(Ty<'tcx>),
     ReallocatedWrongMemoryKind(String, String),
     DeallocatedWrongMemoryKind(String, String),
@@ -507,8 +510,6 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
             ModifiedStatic =>
                 write!(f, "tried to modify a static's initial value from another static's \
                     initializer"),
-            AssumptionNotHeld =>
-                write!(f, "`assume` argument was false"),
             ReallocateNonBasePtr =>
                 write!(f, "tried to reallocate with a pointer not to the beginning of an \
                     existing object"),

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -348,8 +348,6 @@ pub enum UndefinedBehaviorInfo {
     UbExperimental(String),
     /// Unreachable code was executed.
     Unreachable,
-    /// An `assume` was run on a `false` condition,
-    AssumptionNotHeld,
 }
 
 impl fmt::Debug for UndefinedBehaviorInfo {
@@ -360,8 +358,6 @@ impl fmt::Debug for UndefinedBehaviorInfo {
                 write!(f, "{}", msg),
             Unreachable =>
                 write!(f, "entered unreachable code"),
-            AssumptionNotHeld =>
-                write!(f, "`assume` argument was false"),
         }
     }
 }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -342,8 +342,10 @@ impl fmt::Debug for InvalidProgramInfo<'tcx> {
 
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub enum UndefinedBehaviorInfo {
-    /// Handle cases which for which we do not have a fixed variant.
+    /// Free-form case. Only for errors that are never caught!
     Ub(String),
+    /// Free-form case for experimental UB. Only for errors that are never caught!
+    UbExperimental(String),
     /// Unreachable code was executed.
     Unreachable,
 }
@@ -352,7 +354,7 @@ impl fmt::Debug for UndefinedBehaviorInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use UndefinedBehaviorInfo::*;
         match self {
-            Ub(ref msg) =>
+            Ub(msg) | UbExperimental(msg) =>
                 write!(f, "{}", msg),
             Unreachable =>
                 write!(f, "entered unreachable code"),
@@ -362,7 +364,7 @@ impl fmt::Debug for UndefinedBehaviorInfo {
 
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub enum UnsupportedOpInfo<'tcx> {
-    /// Handle cases which for which we do not have a fixed variant.
+    /// Free-form case. Only for errors that are never caught!
     Unsupported(String),
 
     // -- Everything below is not classified yet --

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -10,6 +10,11 @@ macro_rules! err_unsup {
 }
 
 #[macro_export]
+macro_rules! err_unsup_format {
+    ($($tt:tt)*) => { err_unsup!(Unsupported(format!($($tt)*))) };
+}
+
+#[macro_export]
 macro_rules! err_inval {
     ($($tt:tt)*) => {
         $crate::mir::interpret::InterpError::InvalidProgram(
@@ -25,6 +30,11 @@ macro_rules! err_ub {
             $crate::mir::interpret::UndefinedBehaviorInfo::$($tt)*
         )
     };
+}
+
+#[macro_export]
+macro_rules! err_ub_format {
+    ($($tt:tt)*) => { err_ub!(Ub(format!($($tt)*))) };
 }
 
 #[macro_export]


### PR DESCRIPTION
* Add `err_` version of the `_format!` macros
* Add `UbExperimental` variant so that Miri can mark some UB as experimental (e.g. Stacked Borrows)

r? @oli-obk 