### PR TITLE
diagnostics: Describe crate root modules in `DefKind::Mod` as "crate"

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -1,4 +1,4 @@
-use crate::hir::def_id::DefId;
+use crate::hir::def_id::{DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use crate::util::nodemap::DefIdMap;
 use syntax::ast;
 use syntax::ext::base::MacroKind;
@@ -81,9 +81,11 @@ pub enum DefKind {
 }
 
 impl DefKind {
-    pub fn descr(self) -> &'static str {
+    pub fn descr(self, def_id: DefId) -> &'static str {
         match self {
             DefKind::Fn => "function",
+            DefKind::Mod if def_id.index == CRATE_DEF_INDEX && def_id.krate != LOCAL_CRATE =>
+                "crate",
             DefKind::Mod => "module",
             DefKind::Static => "static",
             DefKind::Enum => "enum",
@@ -366,7 +368,7 @@ impl<Id> Res<Id> {
     /// A human readable name for the res kind ("function", "module", etc.).
     pub fn descr(&self) -> &'static str {
         match *self {
-            Res::Def(kind, _) => kind.descr(),
+            Res::Def(kind, def_id) => kind.descr(def_id),
             Res::SelfCtor(..) => "self constructor",
             Res::PrimTy(..) => "builtin type",
             Res::Local(..) => "local variable",

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -1259,7 +1259,7 @@ impl<'a, 'tcx> Visitor<'tcx> for TypePrivacyVisitor<'a, 'tcx> {
                     hir::QPath::Resolved(_, ref path) => path.to_string(),
                     hir::QPath::TypeRelative(_, ref segment) => segment.ident.to_string(),
                 };
-                let msg = format!("{} `{}` is private", kind.descr(), name);
+                let msg = format!("{} `{}` is private", kind.descr(def_id), name);
                 self.tcx.sess.span_err(span, &msg);
                 return;
             }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -319,11 +319,12 @@ impl<'a> Resolver<'a> {
                 err
             }
             ResolutionError::BindingShadowsSomethingUnacceptable(what_binding, name, binding) => {
-                let shadows_what = binding.descr();
+                let res = binding.res();
+                let shadows_what = res.descr();
                 let mut err = struct_span_err!(self.session, span, E0530, "{}s cannot shadow {}s",
                                             what_binding, shadows_what);
                 err.span_label(span, format!("cannot be named the same as {} {}",
-                                            binding.article(), shadows_what));
+                                            res.article(), shadows_what));
                 let participle = if binding.is_import() { "imported" } else { "defined" };
                 let msg = format!("the {} `{}` is {} here", shadows_what, name, participle);
                 err.span_label(binding.span, msg);

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -88,10 +88,9 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                 let mod_prefix = match self.resolve_path(
                     mod_path, Some(TypeNS), false, span, CrateLint::No
                 ) {
-                    PathResult::Module(ModuleOrUniformRoot::Module(module)) =>
-                        module.def_kind(),
+                    PathResult::Module(ModuleOrUniformRoot::Module(module)) => module.res(),
                     _ => None,
-                }.map_or(String::new(), |kind| format!("{} ", kind.descr()));
+                }.map_or(String::new(), |res| format!("{} ", res.descr()));
                 (mod_prefix, format!("`{}`", Segment::names_to_string(mod_path)))
             };
             (format!("cannot find {} `{}` in {}{}", expected, item_str, mod_prefix, mod_str),

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1707,7 +1707,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
         let kind = DefKind::AssocTy;
         if !item.vis.is_accessible_from(def_scope, tcx) {
-            let msg = format!("{} `{}` is private", kind.descr(), assoc_ident);
+            let msg = format!("{} `{}` is private", kind.descr(item.def_id), assoc_ident);
             tcx.sess.span_err(span, &msg);
         }
         tcx.check_stability(item.def_id, Some(hir_ref_id), span);
@@ -1722,7 +1722,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
 
             let mut could_refer_to = |kind: DefKind, def_id, also| {
                 let note_msg = format!("`{}` could{} refer to {} defined here",
-                                       assoc_ident, also, kind.descr());
+                                       assoc_ident, also, kind.descr(def_id));
                 err.span_note(tcx.def_span(def_id), &note_msg);
             };
             could_refer_to(DefKind::Variant, variant_def_id, "");

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -522,7 +522,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         &format!(
                             "there is {} {} with a similar name",
                             def_kind.article(),
-                            def_kind.descr(),
+                            def_kind.descr(lev_candidate.def_id),
                         ),
                         lev_candidate.ident.to_string(),
                         Applicability::MaybeIncorrect,
@@ -543,9 +543,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 err.emit();
             }
 
-            MethodError::PrivateMatch(kind, _, out_of_scope_traits) => {
+            MethodError::PrivateMatch(kind, def_id, out_of_scope_traits) => {
                 let mut err = struct_span_err!(self.tcx.sess, span, E0624,
-                                               "{} `{}` is private", kind.descr(), item_name);
+                                               "{} `{}` is private", kind.descr(def_id), item_name);
                 self.suggest_valid_traits(&mut err, out_of_scope_traits);
                 err.emit();
             }

--- a/src/test/ui/extern/extern-crate-visibility.rs
+++ b/src/test/ui/extern/extern-crate-visibility.rs
@@ -3,10 +3,10 @@ mod foo {
 }
 
 // Check that private crates can be used from outside their modules, albeit with warnings
-use foo::core::cell; //~ ERROR extern crate `core` is private
+use foo::core::cell; //~ ERROR crate `core` is private
 
 fn f() {
-    foo::core::cell::Cell::new(0); //~ ERROR extern crate `core` is private
+    foo::core::cell::Cell::new(0); //~ ERROR crate `core` is private
 
     use foo::*;
     mod core {} // Check that private crates are not glob imported

--- a/src/test/ui/extern/extern-crate-visibility.stderr
+++ b/src/test/ui/extern/extern-crate-visibility.stderr
@@ -1,10 +1,10 @@
-error[E0603]: extern crate `core` is private
+error[E0603]: crate `core` is private
   --> $DIR/extern-crate-visibility.rs:6:10
    |
 LL | use foo::core::cell;
    |          ^^^^
 
-error[E0603]: extern crate `core` is private
+error[E0603]: crate `core` is private
   --> $DIR/extern-crate-visibility.rs:9:10
    |
 LL |     foo::core::cell::Cell::new(0);

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -14,7 +14,7 @@ LL |         Vec::panic!();
    |         ^^^ ambiguous name
    |
    = note: `Vec` could refer to a struct from prelude
-note: `Vec` could also refer to the extern crate imported here
+note: `Vec` could also refer to the crate imported here
   --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:5:9
    |
 LL |         extern crate std as Vec;

--- a/src/test/ui/imports/glob-conflict-cross-crate.rs
+++ b/src/test/ui/imports/glob-conflict-cross-crate.rs
@@ -3,6 +3,6 @@
 extern crate glob_conflict;
 
 fn main() {
-    glob_conflict::f(); //~ ERROR cannot find function `f` in module `glob_conflict`
+    glob_conflict::f(); //~ ERROR cannot find function `f` in crate `glob_conflict`
     glob_conflict::glob::f(); //~ ERROR cannot find function `f` in module `glob_conflict::glob`
 }

--- a/src/test/ui/imports/glob-conflict-cross-crate.stderr
+++ b/src/test/ui/imports/glob-conflict-cross-crate.stderr
@@ -1,4 +1,4 @@
-error[E0425]: cannot find function `f` in module `glob_conflict`
+error[E0425]: cannot find function `f` in crate `glob_conflict`
   --> $DIR/glob-conflict-cross-crate.rs:6:20
    |
 LL |     glob_conflict::f();

--- a/src/test/ui/imports/issue-56125.stderr
+++ b/src/test/ui/imports/issue-56125.stderr
@@ -10,8 +10,8 @@ error[E0659]: `issue_56125` is ambiguous (name vs any other name during import r
 LL |     use issue_56125::last_segment::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
-   = note: `issue_56125` could refer to an extern crate passed with `--extern`
-   = help: use `::issue_56125` to refer to this extern crate unambiguously
+   = note: `issue_56125` could refer to a crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here
   --> $DIR/issue-56125.rs:6:9
    |
@@ -25,8 +25,8 @@ error[E0659]: `issue_56125` is ambiguous (name vs any other name during import r
 LL |     use issue_56125::non_last_segment::non_last_segment::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
-   = note: `issue_56125` could refer to an extern crate passed with `--extern`
-   = help: use `::issue_56125` to refer to this extern crate unambiguously
+   = note: `issue_56125` could refer to a crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here
   --> $DIR/issue-56125.rs:11:9
    |
@@ -40,8 +40,8 @@ error[E0659]: `issue_56125` is ambiguous (name vs any other name during import r
 LL |     use issue_56125::*;
    |         ^^^^^^^^^^^ ambiguous name
    |
-   = note: `issue_56125` could refer to an extern crate passed with `--extern`
-   = help: use `::issue_56125` to refer to this extern crate unambiguously
+   = note: `issue_56125` could refer to a crate passed with `--extern`
+   = help: use `::issue_56125` to refer to this crate unambiguously
 note: `issue_56125` could also refer to the module imported here
   --> $DIR/issue-56125.rs:18:9
    |

--- a/src/test/ui/imports/issue-57539.stderr
+++ b/src/test/ui/imports/issue-57539.stderr
@@ -4,8 +4,8 @@ error[E0659]: `core` is ambiguous (name vs any other name during import resoluti
 LL |     use core;
    |         ^^^^ ambiguous name
    |
-   = note: `core` could refer to a built-in extern crate
-   = help: use `::core` to refer to this extern crate unambiguously
+   = note: `core` could refer to a built-in crate
+   = help: use `::core` to refer to this crate unambiguously
 note: `core` could also refer to the module imported here
   --> $DIR/issue-57539.rs:5:9
    |

--- a/src/test/ui/macros/macro-path-prelude-shadowing.stderr
+++ b/src/test/ui/macros/macro-path-prelude-shadowing.stderr
@@ -4,7 +4,7 @@ error[E0659]: `std` is ambiguous (glob import vs any other name from outer scope
 LL |         std::panic!();
    |         ^^^ ambiguous name
    |
-   = note: `std` could refer to a built-in extern crate
+   = note: `std` could refer to a built-in crate
 note: `std` could also refer to the module imported here
   --> $DIR/macro-path-prelude-shadowing.rs:27:9
    |

--- a/src/test/ui/no-link.rs
+++ b/src/test/ui/no-link.rs
@@ -4,5 +4,5 @@
 extern crate empty_struct;
 
 fn main() {
-    empty_struct::XEmpty1; //~ ERROR cannot find value `XEmpty1` in module `empty_struct`
+    empty_struct::XEmpty1; //~ ERROR cannot find value `XEmpty1` in crate `empty_struct`
 }

--- a/src/test/ui/no-link.stderr
+++ b/src/test/ui/no-link.stderr
@@ -1,4 +1,4 @@
-error[E0425]: cannot find value `XEmpty1` in module `empty_struct`
+error[E0425]: cannot find value `XEmpty1` in crate `empty_struct`
   --> $DIR/no-link.rs:7:19
    |
 LL |     empty_struct::XEmpty1;

--- a/src/test/ui/recursion/recursive-reexports.rs
+++ b/src/test/ui/recursion/recursive-reexports.rs
@@ -2,6 +2,6 @@
 
 extern crate recursive_reexports;
 
-fn f() -> recursive_reexports::S {} //~ ERROR cannot find type `S` in module `recursive_reexports`
+fn f() -> recursive_reexports::S {} //~ ERROR cannot find type `S` in crate `recursive_reexports`
 
 fn main() {}

--- a/src/test/ui/recursion/recursive-reexports.stderr
+++ b/src/test/ui/recursion/recursive-reexports.stderr
@@ -1,4 +1,4 @@
-error[E0412]: cannot find type `S` in module `recursive_reexports`
+error[E0412]: cannot find type `S` in crate `recursive_reexports`
   --> $DIR/recursive-reexports.rs:5:32
    |
 LL | fn f() -> recursive_reexports::S {}

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -1,4 +1,4 @@
-error[E0425]: cannot find value `A` in module `namespaced_enums`
+error[E0425]: cannot find value `A` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:5:31
    |
 LL |     let _ = namespaced_enums::A;
@@ -8,7 +8,7 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use namespaced_enums::Foo::A;
    |
 
-error[E0425]: cannot find function `B` in module `namespaced_enums`
+error[E0425]: cannot find function `B` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:7:31
    |
 LL |     let _ = namespaced_enums::B(10);
@@ -18,7 +18,7 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use namespaced_enums::Foo::B;
    |
 
-error[E0422]: cannot find struct, variant or union type `C` in module `namespaced_enums`
+error[E0422]: cannot find struct, variant or union type `C` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:9:31
    |
 LL |     let _ = namespaced_enums::C { a: 10 };

--- a/src/test/ui/rfc-2126-extern-absolute-paths/single-segment.rs
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/single-segment.rs
@@ -6,6 +6,6 @@ use crate; //~ ERROR crate root imports need to be explicitly named: `use crate 
 use *; //~ ERROR cannot glob-import all possible crates
 
 fn main() {
-    let s = ::xcrate; //~ ERROR expected value, found module `xcrate`
+    let s = ::xcrate; //~ ERROR expected value, found crate `xcrate`
                       //~^ NOTE not a value
 }

--- a/src/test/ui/rfc-2126-extern-absolute-paths/single-segment.stderr
+++ b/src/test/ui/rfc-2126-extern-absolute-paths/single-segment.stderr
@@ -10,7 +10,7 @@ error: cannot glob-import all possible crates
 LL | use *;
    |     ^
 
-error[E0423]: expected value, found module `xcrate`
+error[E0423]: expected value, found crate `xcrate`
   --> $DIR/single-segment.rs:9:13
    |
 LL |     let s = ::xcrate;

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros-nested.stderr
@@ -4,8 +4,8 @@ error[E0659]: `std` is ambiguous (name vs any other name during import resolutio
 LL |     pub use std::io;
    |             ^^^ ambiguous name
    |
-   = note: `std` could refer to a built-in extern crate
-   = help: use `::std` to refer to this extern crate unambiguously
+   = note: `std` could refer to a built-in crate
+   = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here
   --> $DIR/ambiguity-macros-nested.rs:13:13
    |

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-macros.stderr
@@ -4,8 +4,8 @@ error[E0659]: `std` is ambiguous (name vs any other name during import resolutio
 LL | use std::io;
    |     ^^^ ambiguous name
    |
-   = note: `std` could refer to a built-in extern crate
-   = help: use `::std` to refer to this extern crate unambiguously
+   = note: `std` could refer to a built-in crate
+   = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here
   --> $DIR/ambiguity-macros.rs:12:9
    |

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity-nested.stderr
@@ -4,8 +4,8 @@ error[E0659]: `std` is ambiguous (name vs any other name during import resolutio
 LL |     pub use std::io;
    |             ^^^ ambiguous name
    |
-   = note: `std` could refer to a built-in extern crate
-   = help: use `::std` to refer to this extern crate unambiguously
+   = note: `std` could refer to a built-in crate
+   = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here
   --> $DIR/ambiguity-nested.rs:11:5
    |

--- a/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/ambiguity.stderr
@@ -4,8 +4,8 @@ error[E0659]: `std` is ambiguous (name vs any other name during import resolutio
 LL | use std::io;
    |     ^^^ ambiguous name
    |
-   = note: `std` could refer to a built-in extern crate
-   = help: use `::std` to refer to this extern crate unambiguously
+   = note: `std` could refer to a built-in crate
+   = help: use `::std` to refer to this crate unambiguously
 note: `std` could also refer to the module defined here
   --> $DIR/ambiguity.rs:8:1
    |

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
@@ -4,8 +4,8 @@ error[E0659]: `issue_56596` is ambiguous (name vs any other name during import r
 LL | use issue_56596;
    |     ^^^^^^^^^^^ ambiguous name
    |
-   = note: `issue_56596` could refer to an extern crate passed with `--extern`
-   = help: use `::issue_56596` to refer to this extern crate unambiguously
+   = note: `issue_56596` could refer to a crate passed with `--extern`
+   = help: use `::issue_56596` to refer to this crate unambiguously
 note: `issue_56596` could also refer to the module imported here
   --> $DIR/issue-56596.rs:11:5
    |

--- a/src/test/ui/suggestions/type-ascription-instead-of-path.rs
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path.rs
@@ -1,5 +1,5 @@
 fn main() {
     std:io::stdin();
     //~^ ERROR failed to resolve: use of undeclared type or module `io`
-    //~| ERROR expected value, found module
+    //~| ERROR expected value, found crate
 }

--- a/src/test/ui/suggestions/type-ascription-instead-of-path.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path.stderr
@@ -4,7 +4,7 @@ error[E0433]: failed to resolve: use of undeclared type or module `io`
 LL |     std:io::stdin();
    |         ^^ use of undeclared type or module `io`
 
-error[E0423]: expected value, found module `std`
+error[E0423]: expected value, found crate `std`
   --> $DIR/type-ascription-instead-of-path.rs:2:5
    |
 LL |     std:io::stdin();


### PR DESCRIPTION
Or we can use "extern crate" like resolve previously did sometimes, not sure.

r? @davidtwco 