### PR TITLE
Fix std::path::MAIN_SEPARATOR's doc rendering

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -279,7 +279,7 @@ pub fn is_separator(c: char) -> bool {
 
 /// The primary separator of path components for the current platform.
 ///
-/// For example, `/` on Unix and `\` on Windows.
+/// For example, `/` on Unix and `\\` on Windows.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAIN_SEPARATOR: char = crate::sys::path::MAIN_SEP;
 


### PR DESCRIPTION
Before:
![before SS](https://user-images.githubusercontent.com/6709544/62429082-5da28a00-b70a-11e9-9cd5-f0a80d5acd7a.png)

After:
![after SS](https://user-images.githubusercontent.com/6709544/62429083-6004e400-b70a-11e9-9439-802225389916.png)