### PR TITLE
Don't recommend `extern crate` syntax

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -4091,7 +4091,7 @@ impl<'a> Resolver<'a> {
                                 )),
                             )
                         } else if !ident.is_reserved() {
-                            (format!("maybe a missing `extern crate {};`?", ident), None)
+                            (format!("maybe a missing crate `{}`?", ident), None)
                         } else {
                             // the parser will already have complained about the keyword being used
                             return PathResult::NonModule(PartialRes::new(Res::Err));

--- a/src/test/ui/error-codes/E0432.stderr
+++ b/src/test/ui/error-codes/E0432.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `something`
   --> $DIR/E0432.rs:1:5
    |
 LL | use something::Foo;
-   |     ^^^^^^^^^ maybe a missing `extern crate something;`?
+   |     ^^^^^^^^^ maybe a missing crate `something`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern-prelude-fail.stderr
+++ b/src/test/ui/extern-prelude-fail.stderr
@@ -2,13 +2,13 @@ error[E0432]: unresolved import `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:7:9
    |
 LL |     use extern_prelude::S;
-   |         ^^^^^^^^^^^^^^ maybe a missing `extern crate extern_prelude;`?
+   |         ^^^^^^^^^^^^^^ maybe a missing crate `extern_prelude`?
 
-error[E0433]: failed to resolve: maybe a missing `extern crate extern_prelude;`?
+error[E0433]: failed to resolve: maybe a missing crate `extern_prelude`?
   --> $DIR/extern-prelude-fail.rs:8:15
    |
 LL |     let s = ::extern_prelude::S;
-   |               ^^^^^^^^^^^^^^ maybe a missing `extern crate extern_prelude;`?
+   |               ^^^^^^^^^^^^^^ maybe a missing crate `extern_prelude`?
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
+++ b/src/test/ui/feature-gates/feature-gate-extern_absolute_paths.stderr
@@ -2,13 +2,13 @@ error[E0432]: unresolved import `core`
   --> $DIR/feature-gate-extern_absolute_paths.rs:1:5
    |
 LL | use core::default;
-   |     ^^^^ maybe a missing `extern crate core;`?
+   |     ^^^^ maybe a missing crate `core`?
 
-error[E0433]: failed to resolve: maybe a missing `extern crate core;`?
+error[E0433]: failed to resolve: maybe a missing crate `core`?
   --> $DIR/feature-gate-extern_absolute_paths.rs:4:19
    |
 LL |     let _: u8 = ::core::default::Default();
-   |                   ^^^^ maybe a missing `extern crate core;`?
+   |                   ^^^^ maybe a missing crate `core`?
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/import3.stderr
+++ b/src/test/ui/import3.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `main`
   --> $DIR/import3.rs:2:5
    |
 LL | use main::bar;
-   |     ^^^^ maybe a missing `extern crate main;`?
+   |     ^^^^ maybe a missing crate `main`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/issue-53269.stderr
+++ b/src/test/ui/imports/issue-53269.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `nonexistent_module`
   --> $DIR/issue-53269.rs:6:9
    |
 LL |     use nonexistent_module::mac;
-   |         ^^^^^^^^^^^^^^^^^^ maybe a missing `extern crate nonexistent_module;`?
+   |         ^^^^^^^^^^^^^^^^^^ maybe a missing crate `nonexistent_module`?
 
 error[E0659]: `mac` is ambiguous (`macro_rules` vs non-`macro_rules` from other module)
   --> $DIR/issue-53269.rs:8:5

--- a/src/test/ui/imports/issue-55457.stderr
+++ b/src/test/ui/imports/issue-55457.stderr
@@ -11,7 +11,7 @@ error[E0432]: unresolved import `non_existent`
   --> $DIR/issue-55457.rs:2:5
    |
 LL | use non_existent::non_existent;
-   |     ^^^^^^^^^^^^ maybe a missing `extern crate non_existent;`?
+   |     ^^^^^^^^^^^^ maybe a missing crate `non_existent`?
 
 error: cannot determine resolution for the derive macro `NonExistent`
   --> $DIR/issue-55457.rs:5:10

--- a/src/test/ui/imports/unresolved-imports-used.stderr
+++ b/src/test/ui/imports/unresolved-imports-used.stderr
@@ -8,7 +8,7 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-imports-used.rs:10:5
    |
 LL | use foo::bar;
-   |     ^^^ maybe a missing `extern crate foo;`?
+   |     ^^^ maybe a missing crate `foo`?
 
 error[E0603]: function `quz` is private
   --> $DIR/unresolved-imports-used.rs:8:10

--- a/src/test/ui/issues/issue-1697.rs
+++ b/src/test/ui/issues/issue-1697.rs
@@ -1,6 +1,6 @@
 // Testing that we don't fail abnormally after hitting the errors
 
 use unresolved::*; //~ ERROR unresolved import `unresolved` [E0432]
-                   //~^ maybe a missing `extern crate unresolved;`?
+                   //~^ maybe a missing crate `unresolved`?
 
 fn main() {}

--- a/src/test/ui/issues/issue-1697.stderr
+++ b/src/test/ui/issues/issue-1697.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-1697.rs:3:5
    |
 LL | use unresolved::*;
-   |     ^^^^^^^^^^ maybe a missing `extern crate unresolved;`?
+   |     ^^^^^^^^^^ maybe a missing crate `unresolved`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-33464.stderr
+++ b/src/test/ui/issues/issue-33464.stderr
@@ -2,19 +2,19 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:3:5
    |
 LL | use abc::one_el;
-   |     ^^^ maybe a missing `extern crate abc;`?
+   |     ^^^ maybe a missing crate `abc`?
 
 error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:5:5
    |
 LL | use abc::{a, bbb, cccccc};
-   |     ^^^ maybe a missing `extern crate abc;`?
+   |     ^^^ maybe a missing crate `abc`?
 
 error[E0432]: unresolved import `a_very_long_name`
   --> $DIR/issue-33464.rs:7:5
    |
 LL | use a_very_long_name::{el, el2};
-   |     ^^^^^^^^^^^^^^^^ maybe a missing `extern crate a_very_long_name;`?
+   |     ^^^^^^^^^^^^^^^^ maybe a missing crate `a_very_long_name`?
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-36881.stderr
+++ b/src/test/ui/issues/issue-36881.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `issue_36881_aux`
   --> $DIR/issue-36881.rs:5:9
    |
 LL |     use issue_36881_aux::Foo;
-   |         ^^^^^^^^^^^^^^^ maybe a missing `extern crate issue_36881_aux;`?
+   |         ^^^^^^^^^^^^^^^ maybe a missing crate `issue_36881_aux`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-37887.stderr
+++ b/src/test/ui/issues/issue-37887.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `libc`
   --> $DIR/issue-37887.rs:3:9
    |
 LL |     use libc::*;
-   |         ^^^^ maybe a missing `extern crate libc;`?
+   |         ^^^^ maybe a missing crate `libc`?
 
 error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/issue-37887.rs:2:5

--- a/src/test/ui/macros/meta-item-absolute-path.stderr
+++ b/src/test/ui/macros/meta-item-absolute-path.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing `extern crate Absolute;`?
+error[E0433]: failed to resolve: maybe a missing crate `Absolute`?
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ maybe a missing `extern crate Absolute;`?
+   |            ^^^^^^^^ maybe a missing crate `Absolute`?
 
 error: aborting due to previous error
 

--- a/src/test/ui/privacy/restricted/test.rs
+++ b/src/test/ui/privacy/restricted/test.rs
@@ -47,6 +47,6 @@ fn main() {
 }
 
 mod pathological {
-    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: maybe a missing `extern crate bad;`?
+    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: maybe a missing crate `bad`?
     pub(in foo) mod m2 {} //~ ERROR visibilities can only be restricted to ancestor modules
 }

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: maybe a missing `extern crate bad;`?
+error[E0433]: failed to resolve: maybe a missing crate `bad`?
   --> $DIR/test.rs:50:12
    |
 LL |     pub(in bad::path) mod m1 {}
-   |            ^^^ maybe a missing `extern crate bad;`?
+   |            ^^^ maybe a missing crate `bad`?
 
 error: visibilities can only be restricted to ancestor modules
   --> $DIR/test.rs:51:12

--- a/src/test/ui/unresolved/unresolved-import.rs
+++ b/src/test/ui/unresolved/unresolved-import.rs
@@ -1,5 +1,5 @@
 use foo::bar; //~ ERROR unresolved import `foo` [E0432]
-              //~^ maybe a missing `extern crate foo;`?
+              //~^ maybe a missing crate `foo`?
 
 use bar::Baz as x; //~ ERROR unresolved import `bar::Baz` [E0432]
                    //~| no `Baz` in `bar`

--- a/src/test/ui/unresolved/unresolved-import.stderr
+++ b/src/test/ui/unresolved/unresolved-import.stderr
@@ -2,7 +2,7 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-import.rs:1:5
    |
 LL | use foo::bar;
-   |     ^^^ maybe a missing `extern crate foo;`?
+   |     ^^^ maybe a missing crate `foo`?
 
 error[E0432]: unresolved import `bar::Baz`
   --> $DIR/unresolved-import.rs:4:5

--- a/src/test/ui/use/use-mod/use-mod-4.stderr
+++ b/src/test/ui/use/use-mod/use-mod-4.stderr
@@ -14,7 +14,7 @@ error[E0432]: unresolved import `foo`
   --> $DIR/use-mod-4.rs:1:5
    |
 LL | use foo::self;
-   |     ^^^ maybe a missing `extern crate foo;`?
+   |     ^^^ maybe a missing crate `foo`?
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
`extern crate` syntax is not a good recommendation any more, so I've changed it to just print a suggested crate name.

