### PR TITLE
tests for async/await drop order

### DIFF
--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -93,9 +93,27 @@ async fn joined_with_noop() {
     joiner.await
 }
 
+async fn mixed_sizes() {
+    let a = BigFut::new();
+    let b = BigFut::new();
+    let c = BigFut::new();
+    let d = BigFut::new();
+    let e = BigFut::new();
+    let joiner = Joiner {
+        a: Some(a),
+        b: Some(b),
+        c: Some(c),
+    };
+
+    d.await;
+    e.await;
+    joiner.await;
+}
+
 fn main() {
     assert_eq!(1028, std::mem::size_of_val(&single()));
     assert_eq!(1032, std::mem::size_of_val(&single_with_noop()));
     assert_eq!(3084, std::mem::size_of_val(&joined()));
     assert_eq!(3084, std::mem::size_of_val(&joined_with_noop()));
+    assert_eq!(7188, std::mem::size_of_val(&mixed_sizes()));
 }

--- a/src/test/ui/async-await/drop-order/drop-order-for-locals-when-cancelled.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-for-locals-when-cancelled.rs
@@ -1,0 +1,176 @@
+// aux-build:arc_wake.rs
+// edition:2018
+// run-pass
+
+#![allow(unused_variables)]
+#![deny(dead_code)]
+#![feature(async_await)]
+
+// Test that the drop order for locals in a fn and async fn matches up.
+extern crate arc_wake;
+
+use arc_wake::ArcWake;
+use std::cell::RefCell;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+struct EmptyWaker;
+
+impl ArcWake for EmptyWaker {
+    fn wake(self: Arc<Self>) {}
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum DropOrder {
+    Function,
+    Val(&'static str),
+}
+
+type DropOrderListPtr = Rc<RefCell<Vec<DropOrder>>>;
+
+struct D(&'static str, DropOrderListPtr);
+
+impl Drop for D {
+    fn drop(&mut self) {
+        self.1.borrow_mut().push(DropOrder::Val(self.0));
+    }
+}
+
+struct NeverReady;
+
+impl Future for NeverReady {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+async fn simple_variable_declaration_async(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    NeverReady.await;
+}
+
+fn simple_variable_declaration_sync(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+}
+
+async fn varable_completely_contained_within_block_async(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    async {
+        let x = D("x", l.clone());
+    }
+        .await;
+    let y = D("y", l.clone());
+    NeverReady.await;
+}
+
+fn varable_completely_contained_within_block_sync(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    {
+        let x = D("x", l.clone());
+    }
+    let y = D("y", l.clone());
+}
+
+async fn variables_moved_into_separate_blocks_async(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    async move { x }.await;
+    async move { y }.await;
+    NeverReady.await;
+}
+
+fn variables_moved_into_separate_blocks_sync(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    {
+        x
+    };
+    {
+        y
+    };
+}
+
+async fn variables_moved_into_same_block_async(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    async move {
+        x;
+        y;
+    };
+    NeverReady.await;
+}
+
+fn variables_moved_into_same_block_sync(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    {
+        x;
+        y;
+    };
+    return;
+}
+
+async fn move_after_current_await_doesnt_affect_order(l: DropOrderListPtr) {
+    l.borrow_mut().push(DropOrder::Function);
+    let x = D("x", l.clone());
+    let y = D("y", l.clone());
+    NeverReady.await;
+    async move {
+        x;
+        y;
+    };
+}
+
+fn assert_drop_order_after_cancel<Fut: Future<Output = ()>>(
+    f: impl FnOnce(DropOrderListPtr) -> Fut,
+    g: impl FnOnce(DropOrderListPtr),
+) {
+    let empty = Arc::new(EmptyWaker);
+    let waker = ArcWake::into_waker(empty);
+    let mut cx = Context::from_waker(&waker);
+
+    let actual_order = Rc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(f(actual_order.clone()));
+    let _ = fut.as_mut().poll(&mut cx);
+    drop(fut);
+
+    let expected_order = Rc::new(RefCell::new(Vec::new()));
+    g(expected_order.clone());
+    assert_eq!(*actual_order.borrow(), *expected_order.borrow());
+}
+
+fn main() {
+    assert_drop_order_after_cancel(
+        simple_variable_declaration_async,
+        simple_variable_declaration_sync,
+    );
+    assert_drop_order_after_cancel(
+        varable_completely_contained_within_block_async,
+        varable_completely_contained_within_block_sync,
+    );
+    assert_drop_order_after_cancel(
+        variables_moved_into_separate_blocks_async,
+        variables_moved_into_separate_blocks_sync,
+    );
+    assert_drop_order_after_cancel(
+        variables_moved_into_same_block_async,
+        variables_moved_into_same_block_sync,
+    );
+    assert_drop_order_after_cancel(
+        move_after_current_await_doesnt_affect_order,
+        simple_variable_declaration_sync,
+    );
+}

--- a/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
@@ -1,0 +1,307 @@
+// aux-build:arc_wake.rs
+// edition:2018
+// run-pass
+
+#![allow(unused_variables)]
+#![feature(async_await)]
+
+// Test that the drop order for parameters in a fn and async fn matches up. Also test that
+// parameters (used or unused) are not dropped until the async fn is cancelled.
+// This file is mostly copy-pasted from drop-order-for-async-fn-parameters.rs
+
+extern crate arc_wake;
+
+use arc_wake::ArcWake;
+use std::cell::RefCell;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+struct EmptyWaker;
+
+impl ArcWake for EmptyWaker {
+    fn wake(self: Arc<Self>) {}
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum DropOrder {
+    Function,
+    Val(&'static str),
+}
+
+type DropOrderListPtr = Rc<RefCell<Vec<DropOrder>>>;
+
+struct D(&'static str, DropOrderListPtr);
+
+impl Drop for D {
+    fn drop(&mut self) {
+        self.1.borrow_mut().push(DropOrder::Val(self.0));
+    }
+}
+
+struct NeverReady;
+
+impl Future for NeverReady {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        Poll::Pending
+    }
+}
+
+/// Check that unused bindings are dropped after the function is polled.
+async fn foo_async(x: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+    NeverReady.await;
+}
+
+fn foo_sync(x: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+/// Check that underscore patterns are dropped after the function is polled.
+async fn bar_async(x: D, _: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+    NeverReady.await;
+}
+
+fn bar_sync(x: D, _: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+/// Check that underscore patterns within more complex patterns are dropped after the function
+/// is polled.
+async fn baz_async((x, _): (D, D)) {
+    x.1.borrow_mut().push(DropOrder::Function);
+    NeverReady.await;
+}
+
+fn baz_sync((x, _): (D, D)) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+/// Check that underscore and unused bindings within and outwith more complex patterns are dropped
+/// after the function is polled.
+async fn foobar_async(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+    NeverReady.await;
+}
+
+fn foobar_sync(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+    x.1.borrow_mut().push(DropOrder::Function);
+}
+
+struct Foo;
+
+impl Foo {
+    /// Check that unused bindings are dropped after the method is polled.
+    async fn foo_async(x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn foo_sync(x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore patterns are dropped after the method is polled.
+    async fn bar_async(x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn bar_sync(x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore patterns within more complex patterns are dropped after the method
+    /// is polled.
+    async fn baz_async((x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn baz_sync((x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore and unused bindings within and outwith more complex patterns are
+    /// dropped after the method is polled.
+    async fn foobar_async(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn foobar_sync(x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+}
+
+struct Bar<'a>(PhantomData<&'a ()>);
+
+impl<'a> Bar<'a> {
+    /// Check that unused bindings are dropped after the method with self is polled.
+    async fn foo_async(&'a self, x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn foo_sync(&'a self, x: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore patterns are dropped after the method with self is polled.
+    async fn bar_async(&'a self, x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn bar_sync(&'a self, x: D, _: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore patterns within more complex patterns are dropped after the method
+    /// with self is polled.
+    async fn baz_async(&'a self, (x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn baz_sync(&'a self, (x, _): (D, D)) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+
+    /// Check that underscore and unused bindings within and outwith more complex patterns are
+    /// dropped after the method with self is polled.
+    async fn foobar_async(&'a self, x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+        NeverReady.await;
+    }
+
+    fn foobar_sync(&'a self, x: D, (a, _, _c): (D, D, D), _: D, _y: D) {
+        x.1.borrow_mut().push(DropOrder::Function);
+    }
+}
+
+fn assert_drop_order_after_cancel<Fut: Future<Output = ()>>(
+    f: impl FnOnce(DropOrderListPtr) -> Fut,
+    g: impl FnOnce(DropOrderListPtr),
+) {
+    let empty = Arc::new(EmptyWaker);
+    let waker = ArcWake::into_waker(empty);
+    let mut cx = Context::from_waker(&waker);
+
+    let actual_order = Rc::new(RefCell::new(Vec::new()));
+    let mut fut = Box::pin(f(actual_order.clone()));
+    let _ = fut.as_mut().poll(&mut cx);
+
+    // Parameters are never dropped until the future completes.
+    assert_eq!(*actual_order.borrow(), vec![DropOrder::Function]);
+    
+    drop(fut);
+
+    let expected_order = Rc::new(RefCell::new(Vec::new()));
+    g(expected_order.clone());
+    assert_eq!(*actual_order.borrow(), *expected_order.borrow());
+}
+
+fn main() {
+    // Free functions (see doc comment on function for what it tests).
+    assert_drop_order_after_cancel(
+        |l| foo_async(D("x", l.clone()), D("_y", l.clone())),
+        |l| foo_sync(D("x", l.clone()), D("_y", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| bar_async(D("x", l.clone()), D("_", l.clone())),
+        |l| bar_sync(D("x", l.clone()), D("_", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| baz_async((D("x", l.clone()), D("_", l.clone()))),
+        |l| baz_sync((D("x", l.clone()), D("_", l.clone()))),
+    );
+    assert_drop_order_after_cancel(
+        |l| {
+            foobar_async(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+        |l| {
+            foobar_sync(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+    );
+
+    // Methods w/out self (see doc comment on function for what it tests).
+    assert_drop_order_after_cancel(
+        |l| Foo::foo_async(D("x", l.clone()), D("_y", l.clone())),
+        |l| Foo::foo_sync(D("x", l.clone()), D("_y", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| Foo::bar_async(D("x", l.clone()), D("_", l.clone())),
+        |l| Foo::bar_sync(D("x", l.clone()), D("_", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| Foo::baz_async((D("x", l.clone()), D("_", l.clone()))),
+        |l| Foo::baz_sync((D("x", l.clone()), D("_", l.clone()))),
+    );
+    assert_drop_order_after_cancel(
+        |l| {
+            Foo::foobar_async(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+        |l| {
+            Foo::foobar_sync(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+    );
+
+    // Methods (see doc comment on function for what it tests).
+    let b = Bar(Default::default());
+    assert_drop_order_after_cancel(
+        |l| b.foo_async(D("x", l.clone()), D("_y", l.clone())),
+        |l| b.foo_sync(D("x", l.clone()), D("_y", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| b.bar_async(D("x", l.clone()), D("_", l.clone())),
+        |l| b.bar_sync(D("x", l.clone()), D("_", l.clone())),
+    );
+    assert_drop_order_after_cancel(
+        |l| b.baz_async((D("x", l.clone()), D("_", l.clone()))),
+        |l| b.baz_sync((D("x", l.clone()), D("_", l.clone()))),
+    );
+    assert_drop_order_after_cancel(
+        |l| {
+            b.foobar_async(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+        |l| {
+            b.foobar_sync(
+                D("x", l.clone()),
+                (D("a", l.clone()), D("_", l.clone()), D("_c", l.clone())),
+                D("_", l.clone()),
+                D("_y", l.clone()),
+            )
+        },
+    );
+}

--- a/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
+++ b/src/test/ui/async-await/drop-order/drop-order-when-cancelled.rs
@@ -199,7 +199,7 @@ fn assert_drop_order_after_cancel<Fut: Future<Output = ()>>(
 
     // Parameters are never dropped until the future completes.
     assert_eq!(*actual_order.borrow(), vec![DropOrder::Function]);
-    
+
     drop(fut);
 
     let expected_order = Rc::new(RefCell::new(Vec::new()));


### PR DESCRIPTION
This is just me helping out with https://github.com/rust-lang/rust/issues/62121 where I can.

I'm also going to use this as a public place to collect my thoughts about what has already been done and what hasn't (adding comments to the dropbox paper doc was quickly getting spammy).

I've tried to keep my commit messages similar to the line items on https://paper.dropbox.com/doc/async.await-Call-for-Tests--AiKouT0L41mSnK1741s~TiiRAg-nMyZGrra7dz9KcFRMLKJy as possible.

A bunch of my tests are likely to be either redundant with other tests, or lower quality than other tests that people are writing. A reasonable approach might be to tell me which commits you want to keep and I'll throw away the rest of them.

The part from the dropbox paper doc that I'm concentrating on here is:
(items marked with `?` are ones that I can't immediately think of how to test, so I will leave for other people. Items with checkboxes are things that I have done or will try to do next)

### Dynamic semantics
- `async`/`await` with unusual locals:
    - ? partially uninhabited
    - ? conditionally initialized
    - ~drop impls~ already done in src/test/ui/async-await/drop-order/*
    - ? nested drop impls
    - ~partially moved (e.g., `let x = (vec![], vec![]); drop(x.0); foo.await; drop(x.1);`)~ see  https://github.com/rust-lang/rust/pull/63310 
- Control flow:
    - basic
    - complex
- [x] `.await` while holding variables of different sizes
- (possibly) drop order
    - [x] including drop order for locals when a future is dropped part-way through execution
         - Parameters' drop order is covered in my commit f40190a
    - ~An async fn version of `dynamic-drop.rs`~ 
        - already done by matthewjasper in https://github.com/rust-lang/rust/pull/62193/files
- ? interaction with const eval, promoteds, and temporaries
- [x] drop the resulting future and check that local variables and parameters are dropped in the expected order (interaction with cancellation, in other words)
    - also in f40190a

Explanation of commits:

* 0a1bdd4 is the simplest place I could think of to explicitly test `.await` while holding variables of different sizes. I'm pretty sure that this will end up being redundant with something else, so I'm happy to drop it.
* f40190a is a copy-paste from `drop-order-for-async-fn-parameters.rs` with `NeverReady.await` dumped on the end of each testcase. 
    * Normally I don't like copy-paste-based tests, but `drop-order-for-async-fn-parameters-by-ref-binding.rs` is also copy-paste, so I thought it might be okay.
    * [x] I'm a bit sad that this doesn't cover non-parameter locals, but I think it should be easy enough to extend in that direction, so I might have a crack at that tomorrow.
* c4940e0f90 makes a bunch of local variables and moves them into either `{}` blocks or `async move {}` blocks, checking for any surprising differences.
    * I have tried to give the test functions descriptive names
    * I have not duplicated the tests for methods with/without self.
    * I think that all of these tests could be rewritten to be clearer if I could write down the expected drop order next to each test.