### PR TITLE
Deduplicate rustc_demangle in librustc_codegen_llvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,6 @@ dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_llvm 0.0.0",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/librustc_codegen_llvm/Cargo.toml
+++ b/src/librustc_codegen_llvm/Cargo.toml
@@ -14,7 +14,6 @@ test = false
 cc = "1.0.1" # Used to locate MSVC
 num_cpus = "1.0"
 tempfile = "3.0"
-rustc-demangle = "0.1.15"
 rustc_llvm = { path = "../librustc_llvm" }
 memmap = "0.6"
 

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -25,6 +25,7 @@
 use back::write::{create_target_machine, create_informational_target_machine};
 use syntax_pos::symbol::Symbol;
 
+extern crate rustc_demangle;
 extern crate flate2;
 #[macro_use] extern crate bitflags;
 extern crate libc;


### PR DESCRIPTION
This commit removes the crates.io dependency of `rustc-demangle` from
`rustc_codegen_llvm`. This crate is actually already pulled in to part
of the `librustc_driver` build and with the upcoming pipelining
implementation in Cargo it causes build issues if `rustc-demangle` is
left to its own devices.

This is not currently required, but once pipelining is enabled for
rustc's own build it will be required to build correctly.