### PR TITLE
assume_init: warn about valid != safe

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -402,6 +402,13 @@ impl<T> MaybeUninit<T> {
     ///
     /// [inv]: #initialization-invariant
     ///
+    /// On top of that, remember that most types have additional invariants beyond merely
+    /// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
+    /// is considered initialized because the only requirement the compiler knows about it
+    /// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
+    /// *immediate* undefined behavior, but will cause undefined behavior with most
+    /// safe operations (including dropping it).
+    ///
     /// # Examples
     ///
     /// Correct usage of this method:

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -51,7 +51,8 @@ use crate::mem::ManuallyDrop;
 ///
 /// On top of that, remember that most types have additional invariants beyond merely
 /// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
-/// is considered initialized because the only requirement the compiler knows about it
+/// is considered initialized (under the current implementation, this does not constitute
+/// a stable guarantee) because the only requirement the compiler knows about it
 /// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
 /// *immediate* undefined behavior, but will cause undefined behavior with most
 /// safe operations (including dropping it).
@@ -404,7 +405,8 @@ impl<T> MaybeUninit<T> {
     ///
     /// On top of that, remember that most types have additional invariants beyond merely
     /// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
-    /// is considered initialized because the only requirement the compiler knows about it
+    /// is considered initialized (under the current implementation, this does not constitute
+    /// a stable guarantee) because the only requirement the compiler knows about it
     /// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
     /// *immediate* undefined behavior, but will cause undefined behavior with most
     /// safe operations (including dropping it).

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -51,7 +51,7 @@ use crate::mem::ManuallyDrop;
 ///
 /// On top of that, remember that most types have additional invariants beyond merely
 /// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
-/// is considered initialized (under the current implementation, this does not constitute
+/// is considered initialized (under the current implementation; this does not constitute
 /// a stable guarantee) because the only requirement the compiler knows about it
 /// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
 /// *immediate* undefined behavior, but will cause undefined behavior with most
@@ -405,7 +405,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// On top of that, remember that most types have additional invariants beyond merely
     /// being considered initialized at the type level. For example, a `1`-initialized [`Vec<T>`]
-    /// is considered initialized (under the current implementation, this does not constitute
+    /// is considered initialized (under the current implementation; this does not constitute
     /// a stable guarantee) because the only requirement the compiler knows about it
     /// is that the data pointer must be non-null. Creating such a `Vec<T>` does not cause
     /// *immediate* undefined behavior, but will cause undefined behavior with most


### PR DESCRIPTION
We have this warning in the type-level docs, but it seems worth repeating it on the function.