### PR TITLE
Adapt AddRetag for shallow retagging

### DIFF
--- a/src/test/mir-opt/retag.rs
+++ b/src/test/mir-opt/retag.rs
@@ -1,3 +1,4 @@
+// ignore-wasm32-bare compiled with panic=abort by default
 // ignore-tidy-linelength
 // compile-flags: -Z mir-emit-retag -Z mir-opt-level=0 -Z span_free_formats
 

--- a/src/test/mir-opt/retag.rs
+++ b/src/test/mir-opt/retag.rs
@@ -11,6 +11,10 @@ impl Test {
     fn foo_shr<'x>(&self, x: &'x i32) -> &'x i32 { x }
 }
 
+impl Drop for Test {
+    fn drop(&mut self) {}
+}
+
 fn main() {
     let mut x = 0;
     {
@@ -60,10 +64,12 @@ fn main() {
 //     ...
 //     bb0: {
 //         ...
-//         _3 = const Test::foo(move _4, move _6) -> bb1;
+//         _3 = const Test::foo(move _4, move _6) -> [return: bb2, unwind: bb3];
 //     }
 //
-//     bb1: {
+//     ...
+//
+//     bb2: {
 //         Retag(_3);
 //         ...
 //         _9 = move _3;
@@ -80,25 +86,20 @@ fn main() {
 //         _12 = move _13 as *mut i32 (Misc);
 //         Retag([raw] _12);
 //         ...
-//         _16 = move _17(move _18) -> bb2;
+//         _16 = move _17(move _18) -> bb5;
 //     }
 //
-//     bb2: {
+//     bb5: {
 //         Retag(_16);
 //         ...
-//         _20 = const Test::foo_shr(move _21, move _23) -> bb3;
-//     }
-//
-//     bb3: {
-//         ...
-//         return;
+//         _20 = const Test::foo_shr(move _21, move _23) -> [return: bb6, unwind: bb7];
 //     }
 //
 //     ...
 // }
 // END rustc.main.EraseRegions.after.mir
 // START rustc.main-{{closure}}.EraseRegions.after.mir
-// fn main::{{closure}}#0(_1: &[closure@HirId { owner: DefIndex(20), local_id: 72 }], _2: &i32) -> &i32 {
+// fn main::{{closure}}#0(_1: &[closure@HirId { owner: DefIndex(22), local_id: 72 }], _2: &i32) -> &i32 {
 //     ...
 //     bb0: {
 //         Retag([fn entry] _1);
@@ -113,3 +114,17 @@ fn main() {
 //     }
 // }
 // END rustc.main-{{closure}}.EraseRegions.after.mir
+// START rustc.ptr-real_drop_in_place.Test.SimplifyCfg-make_shim.after.mir
+// fn  std::ptr::real_drop_in_place(_1: &mut Test) -> () {
+//     ...
+//     bb0: {
+//         Retag([raw] _1);
+//         _2 = &mut (*_1);
+//         _3 = const <Test as std::ops::Drop>::drop(move _2) -> bb1;
+//     }
+//
+//     bb1: {
+//         return;
+//     }
+// }
+// END rustc.ptr-real_drop_in_place.Test.SimplifyCfg-make_shim.after.mir


### PR DESCRIPTION
With https://github.com/rust-lang/miri/pull/872, Miri only retags "bare" references, not those nested in compound types. This adjust `Retag` statement generation to don't emit retags if they are definitely not a bare reference.

I also expanded the mir-opt test to cover the `Retag` in the drop shim, which had previously not been tested.