### PR TITLE
don't ignore mir_dump folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ config.mk
 config.stamp
 keywords.md
 lexer.ml
-mir_dump
 Session.vim
 src/etc/dl
 tmp.*.rs


### PR DESCRIPTION
I dumped some MIR and wondered why `git status` wouldn't show the tree as dirty, reminding me to clean up after myself. Turns out this folder was explicitly gitignored. I don't think it should be.

If someone doesn't want to clean up that way, they can add it to `.git/info/exclude`.

(That file seems like it could need some general cleanup, honestly, but that's for another day.)