### PR TITLE
Tests around moving parts of structs and tuples across await points

### DIFF
--- a/src/test/ui/async-await/move-part-await-return-rest-struct.rs
+++ b/src/test/ui/async-await/move-part-await-return-rest-struct.rs
@@ -1,0 +1,20 @@
+// build-pass
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+struct Small {
+    x: Vec<usize>,
+    y: Vec<usize>,
+}
+
+// You are allowed to move out part of a struct to an async fn, you still
+// have access to remaining parts after awaiting
+async fn move_part_await_return_rest_struct() -> Vec<usize> {
+    let s = Small { x: vec![31], y: vec![19, 1441] };
+    needs_vec(s.x).await;
+    s.y
+}
+
+async fn needs_vec(_vec: Vec<usize>) {}

--- a/src/test/ui/async-await/move-part-await-return-rest-tuple.rs
+++ b/src/test/ui/async-await/move-part-await-return-rest-tuple.rs
@@ -1,0 +1,14 @@
+// build-pass
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+async fn move_part_await_return_rest_tuple() -> Vec<usize> {
+    let x = (vec![3], vec![4, 4]);
+    drop(x.1);
+    echo(x.0[0]).await;
+    x.0
+}
+
+async fn echo(x: usize) -> usize { x }

--- a/src/test/ui/async-await/no-move-across-await-struct.rs
+++ b/src/test/ui/async-await/no-move-across-await-struct.rs
@@ -1,0 +1,19 @@
+// compile-fail
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+async fn no_move_across_await_struct() -> Vec<usize> {
+    let s = Small { x: vec![31], y: vec![19, 1441] };
+    needs_vec(s.x).await;
+    s.x
+    //~^ ERROR use of moved value: `s.x`
+}
+
+struct Small {
+    x: Vec<usize>,
+    y: Vec<usize>,
+}
+
+async fn needs_vec(_vec: Vec<usize>) {}

--- a/src/test/ui/async-await/no-move-across-await-struct.stderr
+++ b/src/test/ui/async-await/no-move-across-await-struct.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `s.x`
+  --> $DIR/no-move-across-await-struct.rs:10:5
+   |
+LL |     needs_vec(s.x).await;
+   |               --- value moved here
+LL |     s.x
+   |     ^^^ value used here after move
+   |
+   = note: move occurs because `s.x` has type `std::vec::Vec<usize>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/async-await/no-move-across-await-tuple.rs
+++ b/src/test/ui/async-await/no-move-across-await-tuple.rs
@@ -1,0 +1,15 @@
+// compile-fail
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+async fn no_move_across_await_tuple() -> Vec<usize> {
+    let x = (vec![3], vec![4, 4]);
+    drop(x.1);
+    nothing().await;
+    x.1
+    //~^ ERROR use of moved value: `x.1`
+}
+
+async fn nothing() {}

--- a/src/test/ui/async-await/no-move-across-await-tuple.stderr
+++ b/src/test/ui/async-await/no-move-across-await-tuple.stderr
@@ -1,0 +1,14 @@
+error[E0382]: use of moved value: `x.1`
+  --> $DIR/no-move-across-await-tuple.rs:11:5
+   |
+LL |     drop(x.1);
+   |          --- value moved here
+LL |     nothing().await;
+LL |     x.1
+   |     ^^^ value used here after move
+   |
+   = note: move occurs because `x.1` has type `std::vec::Vec<usize>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
r? cramertj

Per the [dropbox paper](https://paper.dropbox.com/doc/async.await-Call-for-Tests--AiR3vlp1s_Kw0yzWZ1sWMnaIAQ-nMyZGrra7dz9KcFRMLKJy) about more tests, it appears there are some tests wanted around local variables (under the section ["Dynamic semantics"](https://paper.dropbox.com/doc/async.await-Call-for-Tests--AiR3vlp1s_Kw0yzWZ1sWMnaIAg-nMyZGrra7dz9KcFRMLKJy#:uid=122335511260129643493892&h2=Dynamic-semantics)). Here is one commit, and I can probably get code up for other scenarios listed there, although I may not have the full background to know what is being targeted by the tests. Please assist me if I'm off course, thanks!

---
- Executed all 4 new tests
- Executed `tidy` command