### PR TITLE
Test conditional initialization validation in async fns

### DIFF
--- a/src/test/ui/async-await/conditional-and-guaranteed-initialization.rs
+++ b/src/test/ui/async-await/conditional-and-guaranteed-initialization.rs
@@ -1,0 +1,18 @@
+// check-pass
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+async fn conditional_and_guaranteed_initialization(x: usize) -> usize {
+    let y;
+    if x > 5 {
+        y = echo(10).await;
+    } else {
+        y = get_something().await;
+    }
+    y
+}
+
+async fn echo(x: usize) -> usize { x }
+async fn get_something() -> usize { 10 }

--- a/src/test/ui/async-await/no-non-guaranteed-initialization.rs
+++ b/src/test/ui/async-await/no-non-guaranteed-initialization.rs
@@ -1,0 +1,16 @@
+// compile-fail
+// edition:2018
+// compile-flags: --crate-type lib
+
+#![feature(async_await)]
+
+async fn no_non_guaranteed_initialization(x: usize) -> usize {
+    let y;
+    if x > 5 {
+        y = echo(10).await;
+    }
+    y
+    //~^ use of possibly uninitialized variable: `y`
+}
+
+async fn echo(x: usize) -> usize { x + 1 }

--- a/src/test/ui/async-await/no-non-guaranteed-initialization.stderr
+++ b/src/test/ui/async-await/no-non-guaranteed-initialization.stderr
@@ -1,0 +1,9 @@
+error[E0381]: use of possibly uninitialized variable: `y`
+  --> $DIR/no-non-guaranteed-initialization.rs:12:5
+   |
+LL |     y
+   |     ^ use of possibly uninitialized `y`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
r? @cramertj 

Per [paper doc](https://paper.dropbox.com/doc/async.await-Call-for-Tests--AiWF2Nt8tgDiA70qFI~oiLOOAg-nMyZGrra7dz9KcFRMLKJy) calling for async/.await tests, tests are desired for conditionally initialized local variables. This PR hopes to provide tests for that.

#63294 seems to be tracking the items from the paper doc that this PR is related to 
#62121 is an open issue asking for more async/.await tests that this relates to

---
:+1: executed 2 new tests
:+1: tidy