### PR TITLE
Add an overflow check in truncate implementation for Unix.

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -468,6 +468,8 @@ impl File {
     /// # Errors
     ///
     /// This function will return an error if the file is not opened for writing.
+    /// Also, std::io::ErrorKind::InvalidInput will be returned if the desired
+    /// length would cause an overflow due to the implementation specifics.
     ///
     /// # Examples
     ///

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -1,6 +1,5 @@
 use crate::os::unix::prelude::*;
 
-use crate::convert::TryInto;
 use crate::ffi::{CString, CStr, OsString, OsStr};
 use crate::fmt;
 use crate::io::{self, Error, ErrorKind, SeekFrom, IoSlice, IoSliceMut};
@@ -556,6 +555,7 @@ impl File {
 
         #[cfg(not(target_os = "android"))]
         {
+            use crate::convert::TryInto;
             let size: off64_t = size
                 .try_into()
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;


### PR DESCRIPTION
Closes #63326.
cc @alexcrichton 