### PR TITLE
Tweak mismatched types error

### DIFF
--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -287,7 +287,7 @@ impl<'hir> Map<'hir> {
         self.definitions.def_index_to_hir_id(def_id.to_def_id().index)
     }
 
-    fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
+    pub fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
         let node = if let Some(node) = self.find(hir_id) {
             node
         } else {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -662,19 +662,22 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     }
                 }
                 _ => {
+                    // `last_ty` can be `!`, `expected` will have better info when present.
+                    let t = self.resolve_vars_if_possible(&match exp_found {
+                        Some(ty::error::ExpectedFound { expected, .. }) => expected,
+                        _ => last_ty,
+                    });
                     let msg = "`match` arms have incompatible types";
                     err.span_label(cause.span, msg);
                     if prior_arms.len() <= 4 {
                         for sp in prior_arms {
-                            err.span_label(*sp, format!(
-                                "this is found to be of type `{}`",
-                                self.resolve_vars_if_possible(&last_ty),
-                            ));
+                            err.span_label( *sp, format!("this is found to be of type `{}`", t));
                         }
                     } else if let Some(sp) = prior_arms.last() {
-                        err.span_label(*sp, format!(
-                            "this and all prior arms are found to be of type `{}`", last_ty,
-                        ));
+                        err.span_label(
+                            *sp,
+                            format!("this and all prior arms are found to be of type `{}`", t),
+                        );
                     }
                 }
             },
@@ -1143,27 +1146,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
                 (_, false, _) => {
                     if let Some(exp_found) = exp_found {
-                        let (def_id, ret_ty) = match exp_found.found.sty {
-                            ty::FnDef(def, _) => {
-                                (Some(def), Some(self.tcx.fn_sig(def).output()))
-                            }
-                            _ => (None, None),
-                        };
-
-                        let exp_is_struct = match exp_found.expected.sty {
-                            ty::Adt(def, _) => def.is_struct(),
-                            _ => false,
-                        };
-
-                        if let (Some(def_id), Some(ret_ty)) = (def_id, ret_ty) {
-                            if exp_is_struct && &exp_found.expected == ret_ty.skip_binder() {
-                                let message = format!(
-                                    "did you mean `{}(/* fields */)`?",
-                                    self.tcx.def_path_str(def_id)
-                                );
-                                diag.span_label(span, message);
-                            }
-                        }
                         self.suggest_as_ref_where_appropriate(span, &exp_found, diag);
                     }
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -559,6 +559,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
+                            ty::Error | ty::Never => return,
                             _ => "value",
                         });
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -550,18 +550,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     assert!(e_ty.is_unit());
                     let ty = coerce.expected_ty();
                     coerce.coerce_forced_unit(self, &cause, &mut |err| {
-                        let msg = "give it a value of the expected type";
-                        let label = destination.label
-                            .map(|l| format!(" {}", l.ident))
-                            .unwrap_or_else(String::new);
-                        let sugg = format!("break{} {}", label, match ty.sty {
+                        let val = match ty.sty {
                             ty::Bool => "true",
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
                             ty::Error | ty::Never => return,
                             _ => "value",
-                        });
+                        };
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, val);
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
                     }, false);
                 }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -548,7 +548,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     coerce.coerce(self, &cause, e, e_ty);
                 } else {
                     assert!(e_ty.is_unit());
-                    coerce.coerce_forced_unit(self, &cause, &mut |_| (), true);
+                    let ty = coerce.expected_ty();
+                    coerce.coerce_forced_unit(self, &cause, &mut |err| {
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, match ty.sty {
+                            ty::Bool => "true",
+                            ty::Char => "'a'",
+                            ty::Int(_) | ty::Uint(_) => "42",
+                            ty::Float(_) => "3.14159",
+                            _ => "value",
+                        });
+                        err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
+                    }, false);
                 }
             } else {
                 // If `ctxt.coerce` is `None`, we can just ignore

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,7 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function's body doesn't `return` a value",
+                                "this function implicitly returns `()` as its body has no tail \
+                                 or `return` expression",
                             );
                         }
                     }, false);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return");
+                            err.span_label(fn_span, "this function's body doesn't return a value");
                         }
                     }, false);
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,8 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function implicitly returns `()` as its body has no tail \
-                                 or `return` expression",
+                                "implicitly returns `()` as its body has no tail or `return` \
+                                 expression",
                             );
                         }
                     }, false);
@@ -3880,10 +3880,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         sugg_call = fields.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
                         match hir.as_local_hir_id(def_id).and_then(|hir_id| hir.def_kind(hir_id)) {
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, _)) => {
-                                msg = "instatiate this tuple variant";
+                                msg = "instantiate this tuple variant";
                             }
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Struct, _)) => {
-                                msg = "instatiate this tuple struct";
+                                msg = "instantiate this tuple struct";
                             }
                             _ => {}
                         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return a value");
+                            err.span_label(
+                                fn_span,
+                                "this function's body doesn't `return` a value",
+                            );
                         }
                     }, false);
                 }

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn return_targets_async_block_not_fn() -> u8 {
    |    ---------------------------------      ^^ expected u8, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u8`
               found type `()`
@@ -57,7 +57,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_fn() -> Result<u8, MyErr> {
    |    ----------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`
@@ -68,7 +68,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_async_fn() -> Result<u8, MyErr> {
    |    ----------------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-27042.stderr
+++ b/src/test/ui/issues/issue-27042.stderr
@@ -12,10 +12,13 @@ error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:6:16
    |
 LL |         loop { break };
-   |                ^^^^^ expected (), found i32
+   |                ^^^^^
+   |                |
+   |                expected i32, found ()
+   |                help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:8:9

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function implicitly returns `()` as its body has no tail or `return` expression
+   |        implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't `return` a value
+   |        this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return a value
+   |        this function's body doesn't `return` a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return
+   |        this function's body doesn't return a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-34334.rs
+++ b/src/test/ui/issues/issue-34334.rs
@@ -5,6 +5,7 @@ fn main () {
     //~| ERROR mismatched types
     //~| ERROR invalid left-hand side expression
     //~| ERROR expected expression, found reserved identifier `_`
+    //~| ERROR expected expression, found reserved identifier `_`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR no method named `iter` found for type `()` in the current scope
 }

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -4,6 +4,12 @@ error: expected expression, found reserved identifier `_`
 LL |     let sr: Vec<(u32, _, _) = vec![];
    |                       ^ expected expression
 
+error: expected expression, found reserved identifier `_`
+  --> $DIR/issue-34334.rs:2:26
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                          ^ expected expression
+
 error: expected one of `,` or `>`, found `=`
   --> $DIR/issue-34334.rs:2:29
    |
@@ -36,12 +42,12 @@ LL |     let sr: Vec<(u32, _, _) = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ left-hand of expression not valid
 
 error[E0599]: no method named `iter` found for type `()` in the current scope
-  --> $DIR/issue-34334.rs:8:36
+  --> $DIR/issue-34334.rs:9:36
    |
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                    ^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0423, E0599.
 For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -1,11 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
+LL | struct Foo(u32);
+   | ---------------- fn(u32) -> Foo {Foo} defined here
+LL | 
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     did you mean `Foo(/* fields */)`?
+   |              |     help: use parentheses to call this function: `Foo(...)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to call this function: `Foo(...)`
+   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
+   |              |     help: use parentheses to instantiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return a value
+   |                                this function's body doesn't `return` a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return
+   |                                this function's body doesn't return a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function implicitly returns `()` as its body has no tail or `return` expression
+   |                                implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't `return` a value
+   |                                this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,7 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^
-   |                               |
-   |                               expected !, found ()
-   |                               help: give it a value of the expected type: `break value`
+   |                               ^^^^^ expected !, found ()
    |
    = note: expected type `!`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^ expected (), found !
+   |                               ^^^^^
+   |                               |
+   |                               expected !, found ()
+   |                               help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `!`
+   = note: expected type `!`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:11:19
@@ -153,10 +156,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:90:9
    |
 LL |         break;
-   |         ^^^^^ expected (), found integer
+   |         ^^^^^
+   |         |
+   |         expected integer, found ()
+   |         help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `{integer}`
+   = note: expected type `{integer}`
+              found type `()`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/loops/loop-labeled-break-value.stderr
+++ b/src/test/ui/loops/loop-labeled-break-value.stderr
@@ -2,28 +2,37 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:3:29
    |
 LL |         let _: i32 = loop { break };
-   |                             ^^^^^ expected (), found i32
+   |                             ^^^^^
+   |                             |
+   |                             expected i32, found ()
+   |                             help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:6:37
    |
 LL |         let _: i32 = 'inner: loop { break 'inner };
-   |                                     ^^^^^^^^^^^^ expected (), found i32
+   |                                     ^^^^^^^^^^^^
+   |                                     |
+   |                                     expected i32, found ()
+   |                                     help: give it a value of the expected type: `break 'inner 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:9:45
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
-   |                                             ^^^^^^^^^^^^^ expected (), found i32
+   |                                             ^^^^^^^^^^^^^
+   |                                             |
+   |                                             expected i32, found ()
+   |                                             help: give it a value of the expected type: `break 'inner2 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/loops/loop-properly-diverging-2.stderr
+++ b/src/test/ui/loops/loop-properly-diverging-2.stderr
@@ -2,10 +2,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-properly-diverging-2.rs:2:23
    |
 LL |   let x: i32 = loop { break };
-   |                       ^^^^^ expected (), found i32
+   |                       ^^^^^
+   |                       |
+   |                       expected i32, found ()
+   |                       help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-arm-resolving-to-never.rs
+++ b/src/test/ui/match/match-arm-resolving-to-never.rs
@@ -1,0 +1,19 @@
+enum E {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+}
+
+fn main() {
+    match E::F {
+        E::A => 1,
+        E::B => 2,
+        E::C => 3,
+        E::D => 4,
+        E::E => unimplemented!(""),
+        E::F => "", //~ ERROR match arms have incompatible types
+    };
+}

--- a/src/test/ui/match/match-arm-resolving-to-never.stderr
+++ b/src/test/ui/match/match-arm-resolving-to-never.stderr
@@ -1,0 +1,22 @@
+error[E0308]: match arms have incompatible types
+  --> $DIR/match-arm-resolving-to-never.rs:17:17
+   |
+LL | /     match E::F {
+LL | |         E::A => 1,
+LL | |         E::B => 2,
+LL | |         E::C => 3,
+LL | |         E::D => 4,
+LL | |         E::E => unimplemented!(""),
+   | |                 ------------------ this and all prior arms are found to be of type `{integer}`
+LL | |         E::F => "",
+   | |                 ^^ expected integer, found reference
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected type `{integer}`
+              found type `&'static str`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't `return` a value
+   |                      this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return a value
+   |                      this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function implicitly returns `()` as its body has no tail or `return` expression
+   |                      implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return
+   |                      this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
+   |                    help: use parentheses to instantiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to call this function: `Z::Fn(...)`
+   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `m::E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -195,8 +195,14 @@ LL |     let _: Z = m::n::Z::Unit {};
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
+LL |             Fn(u8),
+   |             ------ fn(u8) -> m::n::Z {m::n::Z::Fn} defined here
+...
 LL |         let _: Z = Z::Fn;
-   |                    ^^^^^ expected enum `m::n::Z`, found fn item
+   |                    ^^^^^
+   |                    |
+   |                    expected enum `m::n::Z`, found fn item
+   |                    help: use parentheses to call this function: `Z::Fn(...)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -219,8 +225,14 @@ LL |         let _ = Z::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = m::E::Fn;
-   |                ^^^^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `m::E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -243,8 +255,14 @@ LL |     let _: E = m::E::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = E::Fn;
-   |                ^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
+   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<'static>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<'static>}`

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<ReStatic>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<ReStatic>}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
@@ -1,0 +1,19 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+struct S(usize, usize);
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+}
+
+fn main() {
+    let _: usize = foo(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: S = S(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: usize = T::baz(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
@@ -1,0 +1,38 @@
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:24
+   |
+LL |     let _: usize = foo(_, _);
+   |                        ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:27
+   |
+LL |     let _: usize = foo(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:18
+   |
+LL |     let _: S = S(_, _);
+   |                  ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:21
+   |
+LL |     let _: S = S(_, _);
+   |                     ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:27
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:30
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                              ^ expected expression
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -11,7 +11,18 @@ struct V();
 
 trait T {
     fn baz(x: usize, y: usize) -> usize { x }
-    fn bat() -> usize { 42 }
+    fn bat(x: usize) -> usize { 42 }
+    fn bax(x: usize) -> usize { 42 }
+    fn bach(x: usize) -> usize;
+    fn ban(&self) -> usize { 42 }
+    fn bal(&self) -> usize;
+}
+
+struct X;
+
+impl T for X {
+    fn bach(x: usize) -> usize { 42 }
+    fn bal(&self) -> usize { 42 }
 }
 
 fn main() {
@@ -23,4 +34,12 @@ fn main() {
     let _: usize = T::bat; //~ ERROR mismatched types
     let _: E = E::A; //~ ERROR mismatched types
     let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
+    let _: usize = X::baz; //~ ERROR mismatched types
+    let _: usize = X::bat; //~ ERROR mismatched types
+    let _: usize = X::bax; //~ ERROR mismatched types
+    let _: usize = X::bach; //~ ERROR mismatched types
+    let _: usize = X::ban; //~ ERROR mismatched types
+    let _: usize = X::bal; //~ ERROR mismatched types
+    let _: usize = X.ban; //~ ERROR attempted to take value of method
+    let _: usize = X.bal; //~ ERROR attempted to take value of method
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -1,0 +1,20 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+fn bar() -> usize { 42 }
+
+struct S(usize, usize);
+struct V();
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+    fn bat() -> usize { 42 }
+}
+
+fn main() {
+    let _: usize = foo; //~ ERROR mismatched types
+    let _: S = S; //~ ERROR mismatched types
+    let _: usize = bar; //~ ERROR mismatched types
+    let _: V = V; //~ ERROR mismatched types
+    let _: usize = T::baz; //~ ERROR mismatched types
+    let _: usize = T::bat; //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -3,6 +3,10 @@ fn foo(a: usize, b: usize) -> usize { a }
 fn bar() -> usize { 42 }
 
 struct S(usize, usize);
+enum E {
+    A(usize),
+    B { a: usize },
+}
 struct V();
 
 trait T {
@@ -17,4 +21,6 @@ fn main() {
     let _: V = V; //~ ERROR mismatched types
     let _: usize = T::baz; //~ ERROR mismatched types
     let _: usize = T::bat; //~ ERROR mismatched types
+    let _: E = E::A; //~ ERROR mismatched types
+    let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -32,7 +32,7 @@ LL |     let _: S = S;
    |                ^
    |                |
    |                expected struct `S`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |                help: use parentheses to instantiate this tuple struct: `S(_, _)`
    |
    = note: expected type `S`
               found type `fn(usize, usize) -> S {S}`
@@ -62,7 +62,7 @@ LL |     let _: V = V;
    |                ^
    |                |
    |                expected struct `V`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |                help: use parentheses to instantiate this tuple struct: `V()`
    |
    = note: expected type `V`
               found type `fn() -> V {V}`
@@ -107,7 +107,7 @@ LL |     let _: E = E::A;
    |                ^^^^
    |                |
    |                expected enum `E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::A(_)`
    |
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,5 @@
 error[E0423]: expected value, found struct variant `E::B`
-  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:36:16
    |
 LL |     let _: E = E::B;
    |                ^^^-
@@ -8,7 +8,7 @@ LL |     let _: E = E::B;
    |                did you mean `E::B { /* fields */ }`?
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:29:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -23,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -38,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -53,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -68,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -77,28 +77,28 @@ LL |     let _: usize = T::baz;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::baz(...)`
+   |                    help: use parentheses to call this function: `T::baz(x, y)`
    |
    = note: expected type `usize`
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
    |
-LL |     fn bat() -> usize { 42 }
-   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
 ...
 LL |     let _: usize = T::bat;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::bat()`
+   |                    help: use parentheses to call this function: `T::bat(x)`
    |
    = note: expected type `usize`
-              found type `fn() -> usize {<_ as T>::bat}`
+              found type `fn(usize) -> usize {<_ as T>::bat}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
    |     -------- fn(usize) -> E {E::A} defined here
@@ -112,7 +112,109 @@ LL |     let _: E = E::A;
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`
 
-error: aborting due to 8 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
+...
+LL |     let _: usize = X::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::baz(x, y)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<X as T>::baz}`
 
-Some errors have detailed explanations: E0308, E0423.
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
+   |
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
+...
+LL |     let _: usize = X::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bat(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bat}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
+   |
+LL |     fn bax(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
+...
+LL |     let _: usize = X::bax;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bax(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bax}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
+   |
+LL |     fn bach(x: usize) -> usize;
+   |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
+...
+LL |     let _: usize = X::bach;
+   |                    ^^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bach(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bach}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
+   |
+LL |     fn ban(&self) -> usize { 42 }
+   |     ---------------------- for<'r> fn(&'r X) -> usize {<X as T>::ban} defined here
+...
+LL |     let _: usize = X::ban;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::ban(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::ban}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
+   |
+LL |     fn bal(&self) -> usize;
+   |     ----------------------- for<'r> fn(&'r X) -> usize {<X as T>::bal} defined here
+...
+LL |     let _: usize = X::bal;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bal(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::bal}`
+
+error[E0615]: attempted to take value of method `ban` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:43:22
+   |
+LL |     let _: usize = X.ban;
+   |                      ^^^ help: use parentheses to call the method: `ban()`
+
+error[E0615]: attempted to take value of method `bal` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:44:22
+   |
+LL |     let _: usize = X.bal;
+   |                      ^^^ help: use parentheses to call the method: `bal()`
+
+error: aborting due to 16 previous errors
+
+Some errors have detailed explanations: E0308, E0423, E0615.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,14 @@
+error[E0423]: expected value, found struct variant `E::B`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+   |
+LL |     let _: E = E::B;
+   |                ^^^-
+   |                |  |
+   |                |  help: a tuple variant with a similar name exists: `A`
+   |                did you mean `E::B { /* fields */ }`?
+
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -14,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -29,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -44,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -59,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -74,7 +83,7 @@ LL |     let _: usize = T::baz;
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
    |
 LL |     fn bat() -> usize { 42 }
    |     ----------------- fn() -> usize {<_ as T>::bat} defined here
@@ -88,6 +97,22 @@ LL |     let _: usize = T::bat;
    = note: expected type `usize`
               found type `fn() -> usize {<_ as T>::bat}`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+   |
+LL |     A(usize),
+   |     -------- fn(usize) -> E {E::A} defined here
+...
+LL |     let _: E = E::A;
+   |                ^^^^
+   |                |
+   |                expected enum `E`, found fn item
+   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |
+   = note: expected type `E`
+              found type `fn(usize) -> E {E::A}`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0423.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,0 +1,93 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+   |
+LL | fn foo(a: usize, b: usize) -> usize { a }
+   | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
+...
+LL |     let _: usize = foo;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `foo(a, b)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {foo}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+   |
+LL | struct S(usize, usize);
+   | ----------------------- fn(usize, usize) -> S {S} defined here
+...
+LL |     let _: S = S;
+   |                ^
+   |                |
+   |                expected struct `S`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |
+   = note: expected type `S`
+              found type `fn(usize, usize) -> S {S}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+   |
+LL | fn bar() -> usize { 42 }
+   | ----------------- fn() -> usize {bar} defined here
+...
+LL |     let _: usize = bar;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `bar()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {bar}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+   |
+LL | struct V();
+   | ----------- fn() -> V {V} defined here
+...
+LL |     let _: V = V;
+   |                ^
+   |                |
+   |                expected struct `V`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |
+   = note: expected type `V`
+              found type `fn() -> V {V}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
+...
+LL |     let _: usize = T::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::baz(...)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<_ as T>::baz}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+   |
+LL |     fn bat() -> usize { 42 }
+   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+...
+LL |     let _: usize = T::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::bat()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {<_ as T>::bat}`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
- Change expected/found for type mismatches in `break`
- Be more accurate when talking about diverging match arms
- Tweak wording of function without a return value
- Suggest calling bare functions when their return value can be coerced to the expected type
- Give more parsing errors when encountering `foo(_, _, _)`

Fix #51767, fix #62677, fix #63136, cc #37384, cc #35241, cc #51669.