### PR TITLE
Don't use remap-path-prefix in dep-info files.

### DIFF
--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -661,7 +661,7 @@ fn write_out_deps(compiler: &Compiler, outputs: &OutputFilenames, out_filenames:
             .iter()
             .filter(|fmap| fmap.is_real_file())
             .filter(|fmap| !fmap.is_imported())
-            .map(|fmap| escape_dep_filename(&fmap.name))
+            .map(|fmap| escape_dep_filename(&fmap.unmapped_path.as_ref().unwrap_or(&fmap.name)))
             .collect();
 
         if sess.binary_dep_depinfo() {


### PR DESCRIPTION
This changes it so that dep-info files do not use remapped paths.

Having remapped paths causes problems with Cargo because if you remap to a nonexistent path (like `/rustc/$HASH` which rustc distributions do), then Cargo's change tracking thinks the files don't exist and will always rebuild.

I don't actually know if this is a good idea. I think it makes sense, but I do not know what the exact requirements are for reproducible builds. I consider these files separate from the binary artifacts generated, and as a build-system helper, so it seems reasonable to me.

I'm also not sure if this needs a test. I'll definitely add one on the cargo side if this is merged.

Closes #63329
