### PR TITLE
Lint on some incorrect uses of mem::zeroed / mem::uninitialized

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -13,6 +13,7 @@ use crate::mem::ManuallyDrop;
 /// ever gets used to access memory:
 ///
 /// ```rust,no_run
+/// # #![allow(invalid_value)]
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let x: &i32 = unsafe { mem::zeroed() }; // undefined behavior!
@@ -27,6 +28,7 @@ use crate::mem::ManuallyDrop;
 /// always be `true` or `false`. Hence, creating an uninitialized `bool` is undefined behavior:
 ///
 /// ```rust,no_run
+/// # #![allow(invalid_value)]
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let b: bool = unsafe { mem::uninitialized() }; // undefined behavior!
@@ -40,6 +42,7 @@ use crate::mem::ManuallyDrop;
 /// which otherwise can hold any *fixed* bit pattern:
 ///
 /// ```rust,no_run
+/// # #![allow(invalid_value)]
 /// use std::mem::{self, MaybeUninit};
 ///
 /// let x: i32 = unsafe { mem::uninitialized() }; // undefined behavior!

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -445,7 +445,8 @@ pub const fn needs_drop<T>() -> bool {
 ///
 /// *Incorrect* usage of this function: initializing a reference with zero.
 ///
-/// ```no_run
+/// ```rust,no_run
+/// # #![allow(invalid_value)]
 /// use std::mem;
 ///
 /// let _x: &i32 = unsafe { mem::zeroed() }; // Undefined behavior!

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1843,6 +1843,7 @@ pub struct VariantDef {
     /// Flags of the variant (e.g. is field list non-exhaustive)?
     flags: VariantFlags,
     /// Recovered?
+    // FIXME: Needs proper doc. Recovered whom from what?
     pub recovered: bool,
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1842,8 +1842,8 @@ pub struct VariantDef {
     pub ctor_kind: CtorKind,
     /// Flags of the variant (e.g. is field list non-exhaustive)?
     flags: VariantFlags,
-    /// Recovered?
-    // FIXME: Needs proper doc. Recovered whom from what?
+    /// Variant is obtained as part of recovering from a syntactic error.
+    /// May be incomplete or bogus.
     pub recovered: bool,
 }
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1949,7 +1949,7 @@ pub struct FieldDef {
 pub struct AdtDef {
     /// `DefId` of the struct, enum or union item.
     pub did: DefId,
-    /// Variants of the ADT. If this is a struct or enum, then there will be a single variant.
+    /// Variants of the ADT. If this is a struct or union, then there will be a single variant.
     pub variants: IndexVec<self::layout::VariantIdx, VariantDef>,
     /// Flags of the ADT (e.g. is this a struct? is this non-exhaustive?)
     flags: AdtFlags,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2565,6 +2565,8 @@ impl<'tcx> AdtDef {
 }
 
 impl<'tcx> FieldDef {
+    /// Returns the type of this field. The `subst` is typically obtained
+    /// via the second field of `TyKind::AdtDef`.
     pub fn ty(&self, tcx: TyCtxt<'tcx>, subst: SubstsRef<'tcx>) -> Ty<'tcx> {
         tcx.type_of(self.did).subst(tcx, subst)
     }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -171,6 +171,7 @@ pub enum TyKind<'tcx> {
     Never,
 
     /// A tuple type. For example, `(i32, bool)`.
+    /// Use `TyS::tuple_fields` to iterate over the field types.
     Tuple(SubstsRef<'tcx>),
 
     /// The projection of an associated type. For example,
@@ -1723,8 +1724,8 @@ impl<'tcx> TyS<'tcx> {
                     })
                 })
             }
-            ty::Tuple(tys) => tys.iter().any(|ty| {
-                ty.expect_ty().conservative_is_privately_uninhabited(tcx)
+            ty::Tuple(..) => self.tuple_fields().any(|ty| {
+                ty.conservative_is_privately_uninhabited(tcx)
             }),
             ty::Array(ty, len) => {
                 match len.try_eval_usize(tcx, ParamEnv::empty()) {
@@ -2100,6 +2101,15 @@ impl<'tcx> TyS<'tcx> {
         match self.sty {
             Adt(adt, _) => Some(adt),
             _ => None,
+        }
+    }
+
+    /// Iterates over tuple fields.
+    /// Panics when called on anything but a tuple.
+    pub fn tuple_fields(&self) -> impl DoubleEndedIterator<Item=Ty<'tcx>> {
+        match self.sty {
+            Tuple(substs) => substs.iter().map(|field| field.expect_ty()),
+            _ => bug!("tuple_fields called on non-tuple"),
         }
     }
 

--- a/src/librustc/ty/util.rs
+++ b/src/librustc/ty/util.rs
@@ -845,15 +845,15 @@ impl<'tcx> ty::TyS<'tcx> {
             ty: Ty<'tcx>,
         ) -> Representability {
             match ty.sty {
-                Tuple(ref ts) => {
+                Tuple(..) => {
                     // Find non representable
-                    fold_repr(ts.iter().map(|ty| {
+                    fold_repr(ty.tuple_fields().map(|ty| {
                         is_type_structurally_recursive(
                             tcx,
                             sp,
                             seen,
                             representable_cache,
-                            ty.expect_ty(),
+                            ty,
                         )
                     }))
                 }
@@ -1095,7 +1095,7 @@ fn needs_drop_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>
         // state transformation pass
         ty::Generator(..) => true,
 
-        ty::Tuple(ref tys) => tys.iter().map(|k| k.expect_ty()).any(needs_drop),
+        ty::Tuple(..) => ty.tuple_fields().any(needs_drop),
 
         // unions don't have destructors because of the child types,
         // only if they manually implement `Drop` (handled above).

--- a/src/librustc/ty/walk.rs
+++ b/src/librustc/ty/walk.rs
@@ -119,8 +119,8 @@ fn push_subtypes<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent_ty: Ty<'tcx>) {
         ty::GeneratorWitness(ts) => {
             stack.extend(ts.skip_binder().iter().cloned().rev());
         }
-        ty::Tuple(ts) => {
-            stack.extend(ts.iter().map(|k| k.expect_ty()).rev());
+        ty::Tuple(..) => {
+            stack.extend(parent_ty.tuple_fields().rev());
         }
         ty::FnDef(_, substs) => {
             stack.extend(substs.types().rev());

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1903,14 +1903,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                         _ => true, // Conservative fallback for multi-variant enum.
                     }
                 }
-                Tuple(substs) => {
+                Tuple(..) => {
                     // Proceed recursively, check all fields.
-                    substs.iter().all(|field| {
-                        ty_maybe_allows_zero_init(
-                            tcx,
-                            field.expect_ty(),
-                        )
-                    })
+                    ty.tuple_fields().all(|field| ty_maybe_allows_zero_init(tcx, field))
                 }
                 // FIXME: Would be nice to also warn for `NonNull`/`NonZero*`.
                 // Conservative fallback.

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1908,6 +1908,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                     ty.tuple_fields().all(|field| ty_maybe_allows_zero_init(tcx, field))
                 }
                 // FIXME: Would be nice to also warn for `NonNull`/`NonZero*`.
+                // FIXME: *Only for `mem::uninitialized`*, we could also warn for `bool`,
+                //        `char`, and any multivariant enum.
                 // Conservative fallback.
                 _ => true,
             }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -177,6 +177,7 @@ macro_rules! late_lint_mod_passes {
             UnreachablePub: UnreachablePub,
 
             ExplicitOutlivesRequirements: ExplicitOutlivesRequirements,
+            InvalidValue: InvalidValue,
         ]);
     )
 }

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -324,7 +324,7 @@ fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -
                 substs.upvar_tys(def_id, tcx)
             )
         }
-        ty::Tuple(tys) => builder.tuple_like_shim(dest, src, tys.iter().map(|k| k.expect_ty())),
+        ty::Tuple(..) => builder.tuple_like_shim(dest, src, self_ty.tuple_fields()),
         _ => {
             bug!("clone shim for `{:?}` which is not `Copy` and is not an aggregate", self_ty)
         }

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -804,8 +804,8 @@ where
                 let tys : Vec<_> = substs.upvar_tys(def_id, self.tcx()).collect();
                 self.open_drop_for_tuple(&tys)
             }
-            ty::Tuple(tys) => {
-                let tys: Vec<_> = tys.iter().map(|k| k.expect_ty()).collect();
+            ty::Tuple(..) => {
+                let tys: Vec<_> = ty.tuple_fields().collect();
                 self.open_drop_for_tuple(&tys)
             }
             ty::Adt(def, substs) => {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -412,6 +412,7 @@ symbols! {
         match_beginning_vert,
         match_default_bindings,
         may_dangle,
+        mem,
         member_constraints,
         message,
         meta,
@@ -695,6 +696,7 @@ symbols! {
         underscore_imports,
         underscore_lifetimes,
         uniform_paths,
+        uninitialized,
         universal_impl_trait,
         unmarked_api,
         unreachable_code,
@@ -726,6 +728,7 @@ symbols! {
         windows,
         windows_subsystem,
         Yield,
+        zeroed,
     }
 }
 

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -1,0 +1,28 @@
+// ignore-tidy-linelength
+// This test checks that calling `mem::{uninitialized,zeroed}` with certain types results
+// in a lint.
+
+#![feature(never_type)]
+#![allow(deprecated)]
+#![deny(invalid_value)]
+
+use std::mem;
+
+fn main() {
+    unsafe {
+        let _val: ! = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: ! = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: &'static i32 = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: &'static i32 = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: fn() = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: fn() = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        // Some types that should work just fine.
+        let _val: Option<&'static i32> = mem::zeroed();
+        let _val: Option<fn()> = mem::zeroed();
+        let _val: bool = mem::zeroed();
+        let _val: i32 = mem::zeroed();
+    }
+}

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -6,22 +6,52 @@
 #![allow(deprecated)]
 #![deny(invalid_value)]
 
-use std::mem;
+use std::mem::{self, MaybeUninit};
+
+enum Void {}
+
+struct Ref(&'static i32);
+
+struct Wrap<T> { wrapped: T }
+
+#[allow(unused)]
+fn generic<T: 'static>() {
+    unsafe {
+        let _val: &'static T = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: &'static T = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: Wrap<&'static T> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: Wrap<&'static T> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+    }
+}
 
 fn main() {
     unsafe {
         let _val: ! = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: ! = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
+        let _val: (i32, !) = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: (i32, !) = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: Void = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: Void = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
         let _val: &'static i32 = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: &'static i32 = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: Ref = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: Ref = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
         let _val: fn() = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: fn() = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
+        let _val: Wrap<fn()> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: Wrap<fn()> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
         // Some types that should work just fine.
         let _val: Option<&'static i32> = mem::zeroed();
         let _val: Option<fn()> = mem::zeroed();
+        let _val: MaybeUninit<&'static i32> = mem::zeroed();
         let _val: bool = mem::zeroed();
         let _val: i32 = mem::zeroed();
     }

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -1,44 +1,169 @@
-error: the type `!` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:15:23
+error: the type `&'static T` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:20:32
    |
-LL |         let _val: ! = mem::zeroed();
-   |                       ^^^^^^^^^^^^^
+LL |         let _val: &'static T = mem::zeroed();
+   |                                ^^^^^^^^^^^^^
    |
 note: lint level defined here
   --> $DIR/uninitialized-zeroed.rs:7:9
    |
 LL | #![deny(invalid_value)]
    |         ^^^^^^^^^^^^^
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `&'static T` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:21:32
+   |
+LL |         let _val: &'static T = mem::uninitialized();
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Wrap<&'static T>` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:23:38
+   |
+LL |         let _val: Wrap<&'static T> = mem::zeroed();
+   |                                      ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Wrap<&'static T>` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:24:38
+   |
+LL |         let _val: Wrap<&'static T> = mem::uninitialized();
+   |                                      ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `!` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:30:23
+   |
+LL |         let _val: ! = mem::zeroed();
+   |                       ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
 error: the type `!` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:16:23
+  --> $DIR/uninitialized-zeroed.rs:31:23
    |
 LL |         let _val: ! = mem::uninitialized();
    |                       ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `(i32, !)` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:33:30
+   |
+LL |         let _val: (i32, !) = mem::zeroed();
+   |                              ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `(i32, !)` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:34:30
+   |
+LL |         let _val: (i32, !) = mem::uninitialized();
+   |                              ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Void` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:36:26
+   |
+LL |         let _val: Void = mem::zeroed();
+   |                          ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Void` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:37:26
+   |
+LL |         let _val: Void = mem::uninitialized();
+   |                          ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
 error: the type `&'static i32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:21:34
+  --> $DIR/uninitialized-zeroed.rs:39:34
    |
 LL |         let _val: &'static i32 = mem::zeroed();
    |                                  ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
 error: the type `&'static i32` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:22:34
+  --> $DIR/uninitialized-zeroed.rs:40:34
    |
 LL |         let _val: &'static i32 = mem::uninitialized();
    |                                  ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Ref` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:42:25
+   |
+LL |         let _val: Ref = mem::zeroed();
+   |                         ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Ref` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:43:25
+   |
+LL |         let _val: Ref = mem::uninitialized();
+   |                         ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
 error: the type `fn()` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:24:26
+  --> $DIR/uninitialized-zeroed.rs:45:26
    |
 LL |         let _val: fn() = mem::zeroed();
    |                          ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
 error: the type `fn()` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:25:26
+  --> $DIR/uninitialized-zeroed.rs:46:26
    |
 LL |         let _val: fn() = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
 
-error: aborting due to 6 previous errors
+error: the type `Wrap<fn()>` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:48:32
+   |
+LL |         let _val: Wrap<fn()> = mem::zeroed();
+   |                                ^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: the type `Wrap<fn()>` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:49:32
+   |
+LL |         let _val: Wrap<fn()> = mem::uninitialized();
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this means that this code causes undefined behavior when executed
+   = help: use `MaybeUninit` instead
+
+error: aborting due to 18 previous errors
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -1,0 +1,44 @@
+error: the type `!` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:15:23
+   |
+LL |         let _val: ! = mem::zeroed();
+   |                       ^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/uninitialized-zeroed.rs:7:9
+   |
+LL | #![deny(invalid_value)]
+   |         ^^^^^^^^^^^^^
+
+error: the type `!` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:16:23
+   |
+LL |         let _val: ! = mem::uninitialized();
+   |                       ^^^^^^^^^^^^^^^^^^^^
+
+error: the type `&'static i32` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:21:34
+   |
+LL |         let _val: &'static i32 = mem::zeroed();
+   |                                  ^^^^^^^^^^^^^
+
+error: the type `&'static i32` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:22:34
+   |
+LL |         let _val: &'static i32 = mem::uninitialized();
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+
+error: the type `fn()` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:24:26
+   |
+LL |         let _val: fn() = mem::zeroed();
+   |                          ^^^^^^^^^^^^^
+
+error: the type `fn()` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:25:26
+   |
+LL |         let _val: fn() = mem::uninitialized();
+   |                          ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/panic-uninitialized-zeroed.rs
@@ -4,7 +4,7 @@
 // in a runtime panic.
 
 #![feature(never_type)]
-#![allow(deprecated)]
+#![allow(deprecated, invalid_value)]
 
 use std::{mem, panic};
 


### PR DESCRIPTION
Cc https://github.com/rust-lang/rust/issues/62825 and https://internals.rust-lang.org/t/make-mem-uninitialized-and-mem-zeroed-panic-for-some-types-where-0-is-a-niche/10605

This does not yet handle `NonNull`/`NonZero*`, but it is a start.

I also improved some doc issues I hit on the way, and added a useful helper to `TyS`.

EDIT: I added the relnotes label mostly as a proposal -- I think this is worth mentioning, but leave the decision up to the release team.