### PR TITLE
Issue#63183: Add fs::read_dir() and ReadDir warning about iterator order + example

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -114,6 +114,11 @@ pub struct Metadata(fs_imp::FileAttr);
 /// information like the entry's path and possibly other metadata can be
 /// learned.
 ///
+/// #### Note: Iteration Order is Implementation-Defined
+///
+/// The order in which this iterator returns entries is platform and filesystem
+/// dependent.
+///
 /// # Errors
 ///
 /// This [`io::Result`] will be an [`Err`] if there's some sort of intermittent
@@ -1959,6 +1964,11 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// [changes]: ../io/index.html#platform-specific-behavior
 ///
+/// #### Note: Iteration Order is Implementation-Defined
+///
+/// The order in which this iterator returns entries is platform and filesystem
+/// dependent.
+///
 /// # Errors
 ///
 /// This function will return an error in the following situations, but is not
@@ -1988,6 +1998,28 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///             }
 ///         }
 ///     }
+///     Ok(())
+/// }
+/// ```
+///
+/// ```rust,no_run
+/// use std::{fs, io};
+///
+/// fn main() -> io::Result<()> {
+///     // The order read_dir returns entries is not guaranteed. If reproducible
+///     // ordering is required the entries should be explicitly sorted.
+///     let mut entries = fs::read_dir(".")?
+///         .map(|res| res.map(|e| e.path()))
+///         .collect::<Result<Vec<_>, io::Error>>()?;
+///
+///     println!(
+///         "Entries before sorting (may or may not be sorted already): {:?}",
+///         entries
+///     );
+///
+///     entries.sort();
+///
+///     println!("Entries after sorting: {:?}", entries);
 ///     Ok(())
 /// }
 /// ```

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2002,7 +2002,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// use std::{fs, io};
 ///
 /// fn main() -> io::Result<()> {
-///     // The order read_dir returns entries is not guaranteed. If reproducible
+///     // The order in which `read_dir` returns entries is not guaranteed. If reproducible
 ///     // ordering is required the entries should be explicitly sorted.
 ///     let mut entries = fs::read_dir(".")?
 ///         .map(|res| res.map(|e| e.path()))

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -114,8 +114,6 @@ pub struct Metadata(fs_imp::FileAttr);
 /// information like the entry's path and possibly other metadata can be
 /// learned.
 ///
-/// #### Note: Iteration Order is Implementation-Defined
-///
 /// The order in which this iterator returns entries is platform and filesystem
 /// dependent.
 ///
@@ -1963,8 +1961,6 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// Note that, this [may change in the future][changes].
 ///
 /// [changes]: ../io/index.html#platform-specific-behavior
-///
-/// #### Note: Iteration Order is Implementation-Defined
 ///
 /// The order in which this iterator returns entries is platform and filesystem
 /// dependent.

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2008,14 +2008,14 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///         .map(|res| res.map(|e| e.path()))
 ///         .collect::<Result<Vec<_>, io::Error>>()?;
 ///
-///     println!(
-///         "Entries before sorting (may or may not be sorted already): {:?}",
-///         entries
-///     );
+///     // println!(
+///     //     "Entries before sorting (may or may not be sorted already): {:?}",
+///     //     entries
+///     // );
 ///
 ///     entries.sort();
 ///
-///     println!("Entries after sorting: {:?}", entries);
+///     // println!("Entries after sorting: {:?}", entries);
 ///     Ok(())
 /// }
 /// ```

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -2002,20 +2002,17 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
 /// use std::{fs, io};
 ///
 /// fn main() -> io::Result<()> {
-///     // The order in which `read_dir` returns entries is not guaranteed. If reproducible
-///     // ordering is required the entries should be explicitly sorted.
 ///     let mut entries = fs::read_dir(".")?
 ///         .map(|res| res.map(|e| e.path()))
 ///         .collect::<Result<Vec<_>, io::Error>>()?;
 ///
-///     // println!(
-///     //     "Entries before sorting (may or may not be sorted already): {:?}",
-///     //     entries
-///     // );
+///     // The order in which `read_dir` returns entries is not guaranteed. If reproducible
+///     // ordering is required the entries should be explicitly sorted.
 ///
 ///     entries.sort();
 ///
-///     // println!("Entries after sorting: {:?}", entries);
+///     // The entries have now been sorted by their path.
+///
 ///     Ok(())
 /// }
 /// ```


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/issues/63183

Add warning about iterator order to read_dir and ReadDir, add example of explicitly ordering direntrys.