### PR TITLE
move of packed fields might or might not occur when they actually are sufficiently aligned

### DIFF
--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -188,7 +188,7 @@
 //! you do not accidentally use `self`/`this` in a way that is in conflict with pinning.
 //!
 //! Moreover, if your type is `#[repr(packed)]`, the compiler will automatically
-//! move fields around to be able to drop them. In a packed struct, it might even do
+//! move fields around to be able to drop them. It might even do
 //! that for fields that happen to be sufficiently aligned. As a consequence, you cannot use
 //! pinning with a `#[repr(packed)]` type.
 //!

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -188,7 +188,8 @@
 //! you do not accidentally use `self`/`this` in a way that is in conflict with pinning.
 //!
 //! Moreover, if your type is `#[repr(packed)]`, the compiler will automatically
-//! move fields around to be able to drop them. As a consequence, you cannot use
+//! move fields around to be able to drop them. In a packed struct, it might even do
+//! that for fields that happen to be sufficiently aligned. As a consequence, you cannot use
 //! pinning with a `#[repr(packed)]` type.
 //!
 //! # Projections and Structural Pinning


### PR DESCRIPTION
See https://github.com/taiki-e/pin-project/pull/34, where it was pointed out that we actually don't move fields of 1-aligned types when dropping a packed struct -- but e.g. in a `packed(2)` struct, we don't do something similar for 2-aligned types. The code for that is [here](https://github.com/rust-lang/rust/blob/db7c773a6be2f050d1d1504763819ea3916f5428/src/librustc_mir/util/alignment.rs#L7).