### PR TITLE
More explicit diagnostic when using a `vec![]` in a pattern

### DIFF
--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -6,6 +6,7 @@ use crate::config::StripUnconfigured;
 use crate::ext::base::*;
 use crate::ext::proc_macro::collect_derives;
 use crate::ext::hygiene::{ExpnId, SyntaxContext, ExpnInfo, ExpnKind};
+use crate::ext::tt::macro_rules::annotate_err_with_kind;
 use crate::ext::placeholders::{placeholder, PlaceholderExpander};
 use crate::feature_gate::{self, Features, GateIssue, is_builtin_attr, emit_feature_err};
 use crate::mut_visit::*;
@@ -701,21 +702,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
-                match kind {
-                    AstFragmentKind::Ty => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a type",
-                        );
-                    }
-                    AstFragmentKind::Pat => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a pattern",
-                        );
-                    }
-                    _ => {}
-                };
+                annotate_err_with_kind(&mut err, kind, span);
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -686,12 +686,13 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         );
     }
 
-    fn parse_ast_fragment(&mut self,
-                          toks: TokenStream,
-                          kind: AstFragmentKind,
-                          path: &Path,
-                          span: Span)
-                          -> AstFragment {
+    fn parse_ast_fragment(
+        &mut self,
+        toks: TokenStream,
+        kind: AstFragmentKind,
+        path: &Path,
+        span: Span,
+    ) -> AstFragment {
         let mut parser = self.cx.new_parser_from_tts(&toks.into_trees().collect::<Vec<_>>());
         match parser.parse_ast_fragment(kind, false) {
             Ok(fragment) => {
@@ -700,6 +701,21 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
+                match kind {
+                    AstFragmentKind::Ty => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a type",
+                        );
+                    }
+                    AstFragmentKind::Pat => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a pattern",
+                        );
+                    }
+                    _ => {}
+                };
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -17,7 +17,7 @@ use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{DelimSpan, TokenStream, TokenTree};
 use crate::{ast, attr, attr::TransparencyError};
 
-use errors::FatalError;
+use errors::{DiagnosticBuilder, FatalError};
 use log::debug;
 use syntax_pos::Span;
 
@@ -41,6 +41,18 @@ pub struct ParserAnyMacro<'a> {
     /// The ident of the macro we're parsing
     macro_ident: ast::Ident,
     arm_span: Span,
+}
+
+pub fn annotate_err_with_kind(err: &mut DiagnosticBuilder<'_>, kind: AstFragmentKind, span: Span) {
+    match kind {
+        AstFragmentKind::Ty => {
+            err.span_label(span, "this macro call doesn't expand to a type");
+        }
+        AstFragmentKind::Pat => {
+            err.span_label(span, "this macro call doesn't expand to a pattern");
+        }
+        _ => {}
+    };
 }
 
 impl<'a> ParserAnyMacro<'a> {
@@ -71,27 +83,30 @@ impl<'a> ParserAnyMacro<'a> {
                 e.span_label(site_span, "in this macro invocation");
             }
             match kind {
-                AstFragmentKind::Ty => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a type",
-                    );
-                }
                 AstFragmentKind::Pat if macro_ident.name == sym::vec => {
-                    e.span_label(
-                        site_span,
-                        "use a slice pattern here instead",
-                    );
+                    let mut suggestion = None;
+                    if let Ok(code) = parser.sess.source_map().span_to_snippet(site_span) {
+                        if let Some(bang) = code.find('!') {
+                            suggestion = Some(code[bang + 1..].to_string());
+                        }
+                    }
+                    if let Some(suggestion) = suggestion {
+                        e.span_suggestion(
+                            site_span,
+                            "use a slice pattern here instead",
+                            suggestion,
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        e.span_label(
+                            site_span,
+                            "use a slice pattern here instead",
+                        );
+                    }
                     e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
-                              rust-2018/slice-patterns.html");
+                            rust-2018/slice-patterns.html");
                 }
-                AstFragmentKind::Pat => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a pattern",
-                    );
-                }
-                _ => {}
+                _ => annotate_err_with_kind(&mut e, kind, site_span),
             };
             e
         }));

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -70,6 +70,29 @@ impl<'a> ParserAnyMacro<'a> {
             } else if !parser.sess.source_map().span_to_filename(parser.token.span).is_real() {
                 e.span_label(site_span, "in this macro invocation");
             }
+            match kind {
+                AstFragmentKind::Ty => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a type",
+                    );
+                }
+                AstFragmentKind::Pat if macro_ident.name == sym::vec => {
+                    e.span_label(
+                        site_span,
+                        "use a slice pattern here instead",
+                    );
+                    e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
+                              rust-2018/slice-patterns.html");
+                }
+                AstFragmentKind::Pat => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a pattern",
+                    );
+                }
+                _ => {}
+            };
             e
         }));
 

--- a/src/test/ui/proc-macro/lifetimes.stderr
+++ b/src/test/ui/proc-macro/lifetimes.stderr
@@ -2,7 +2,7 @@ error: expected type, found `'`
   --> $DIR/lifetimes.rs:9:10
    |
 LL | type A = single_quote_alone!();
-   |          ^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^ this macro call doesn't expand to a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/vec-macro-in-pattern.fixed
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.fixed
@@ -2,7 +2,7 @@
 fn main() {
     // everything after `.as_ref` should be suggested
     match Some(vec![3]).as_ref().map(|v| v.as_slice()) {
-        Some(vec![_x]) => (), //~ ERROR unexpected `(` after qualified path
+        Some([_x]) => (), //~ ERROR unexpected `(` after qualified path
         _ => (),
     }
 }

--- a/src/test/ui/suggestions/vec-macro-in-pattern.rs
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.rs
@@ -1,0 +1,6 @@
+fn main() {
+    match Some(vec![3]) {
+        Some(vec![x]) => (), //~ ERROR unexpected `(` after qualified path
+        _ => (),
+    }
+}

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,0 +1,15 @@
+error: unexpected `(` after qualified path
+  --> $DIR/vec-macro-in-pattern.rs:3:14
+   |
+LL |         Some(vec![x]) => (),
+   |              ^^^^^^^
+   |              |
+   |              unexpected `(` after qualified path
+   |              in this macro invocation
+   |              use a slice pattern here instead
+   |
+   = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,12 +1,12 @@
 error: unexpected `(` after qualified path
-  --> $DIR/vec-macro-in-pattern.rs:3:14
+  --> $DIR/vec-macro-in-pattern.rs:5:14
    |
-LL |         Some(vec![x]) => (),
-   |              ^^^^^^^
+LL |         Some(vec![_x]) => (),
+   |              ^^^^^^^^
    |              |
    |              unexpected `(` after qualified path
    |              in this macro invocation
-   |              use a slice pattern here instead
+   |              help: use a slice pattern here instead: `[_x]`
    |
    = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -6,6 +6,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   |     |
    |                   |     expected type
    |                   |     in this macro invocation
+   |                   |     this macro call doesn't expand to a type
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`


### PR DESCRIPTION
```
error: unexpected `(` after qualified path
  --> $DIR/vec-macro-in-pattern.rs:3:14
   |
LL |         Some(vec![x]) => (),
   |              ^^^^^^^
   |              |
   |              unexpected `(` after qualified path
   |              in this macro invocation
   |              use a slice pattern here instead
   |
   = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

Fix #61933.