### PR TITLE
enable flt2dec tests in Miri

### DIFF
--- a/src/libcore/tests/num/dec2flt/mod.rs
+++ b/src/libcore/tests/num/dec2flt/mod.rs
@@ -77,6 +77,7 @@ fn infinity() {
 fn zero() {
     test_literal!(0.0);
     test_literal!(1e-325);
+    #[cfg(not(miri))] // Miri is too slow
     test_literal!(1e-326);
     #[cfg(not(miri))] // Miri is too slow
     test_literal!(1e-500);

--- a/src/libcore/tests/num/flt2dec/estimator.rs
+++ b/src/libcore/tests/num/flt2dec/estimator.rs
@@ -45,7 +45,7 @@ fn test_estimate_scaling_factor() {
     #[cfg(not(miri))] // Miri is too slow
     let iter = -1074..972;
     #[cfg(miri)]
-    let iter = (-1074..972).step_by(11);
+    let iter = (-1074..972).step_by(37);
 
     for i in iter {
         let expected = super::ldexp_f64(1.0, i).log10().ceil();

--- a/src/libcore/tests/num/flt2dec/estimator.rs
+++ b/src/libcore/tests/num/flt2dec/estimator.rs
@@ -42,7 +42,12 @@ fn test_estimate_scaling_factor() {
     assert_almost_eq!(estimate_scaling_factor(1, -1074), -323);
     assert_almost_eq!(estimate_scaling_factor(0x1fffffffffffff, 971), 309);
 
-    for i in -1074..972 {
+    #[cfg(not(miri))] // Miri is too slow
+    let iter = -1074..972;
+    #[cfg(miri)]
+    let iter = (-1074..972).step_by(11);
+
+    for i in iter {
         let expected = super::ldexp_f64(1.0, i).log10().ceil();
         assert_almost_eq!(estimate_scaling_factor(1, i as i16), expected as i16);
     }

--- a/src/libcore/tests/num/flt2dec/mod.rs
+++ b/src/libcore/tests/num/flt2dec/mod.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))] // Miri does not implement ldexp, which most tests here need
-
 use std::prelude::v1::*;
 use std::{str, i16, f32, f64, fmt};
 
@@ -257,6 +255,7 @@ pub fn f32_shortest_sanity_test<F>(mut f: F) where F: FnMut(&Decoded, &mut [u8])
     check_shortest!(f(minf32) => b"1", -44);
 }
 
+#[cfg(not(miri))] // Miri is too slow
 pub fn f32_exact_sanity_test<F>(mut f: F)
         where F: FnMut(&Decoded, &mut [u8], i16) -> (usize, i16) {
     let minf32 = ldexp_f32(1.0, -149);
@@ -362,6 +361,7 @@ pub fn f64_shortest_sanity_test<F>(mut f: F) where F: FnMut(&Decoded, &mut [u8])
     check_shortest!(f(minf64) => b"5", -323);
 }
 
+#[cfg(not(miri))] // Miri is too slow
 pub fn f64_exact_sanity_test<F>(mut f: F)
         where F: FnMut(&Decoded, &mut [u8], i16) -> (usize, i16) {
     let minf64 = ldexp_f64(1.0, -1074);
@@ -552,6 +552,10 @@ pub fn to_shortest_str_test<F>(mut f_: F)
     assert_eq!(to_string(f, minf64, Minus,   0, false), format!("0.{:0>323}5", ""));
     assert_eq!(to_string(f, minf64, Minus, 324, false), format!("0.{:0>323}5", ""));
     assert_eq!(to_string(f, minf64, Minus, 325, false), format!("0.{:0>323}50", ""));
+
+    if cfg!(miri) { // Miri is too slow
+        return;
+    }
 
     // very large output
     assert_eq!(to_string(f, 1.1, Minus, 80000, false), format!("1.1{:0>79999}", ""));
@@ -807,6 +811,10 @@ pub fn to_exact_exp_str_test<F>(mut f_: F)
                "1.401298464324817070923729583289916131280261941876515771757068283\
                  8897910826858606014866381883621215820312500000000000000000000000e-45");
 
+    if cfg!(miri) { // Miri is too slow
+        return;
+    }
+
     assert_eq!(to_string(f, f64::MAX, Minus,   1, false), "2e308");
     assert_eq!(to_string(f, f64::MAX, Minus,   2, false), "1.8e308");
     assert_eq!(to_string(f, f64::MAX, Minus,   4, false), "1.798e308");
@@ -1039,6 +1047,10 @@ pub fn to_exact_fixed_str_test<F>(mut f_: F)
                "340282346638528859811704183484516925440.0");
     assert_eq!(to_string(f, f32::MAX, Minus, 2, false),
                "340282346638528859811704183484516925440.00");
+
+    if cfg!(miri) { // Miri is too slow
+        return;
+    }
 
     let minf32 = ldexp_f32(1.0, -149);
     assert_eq!(to_string(f, minf32, Minus,   0, false), "0");

--- a/src/libcore/tests/num/flt2dec/random.rs
+++ b/src/libcore/tests/num/flt2dec/random.rs
@@ -109,8 +109,13 @@ pub fn f32_exhaustive_equivalence_test<F, G>(f: F, g: G, k: usize)
 #[test]
 fn shortest_random_equivalence_test() {
     use core::num::flt2dec::strategy::dragon::format_shortest as fallback;
-    f64_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, 10_000);
-    f32_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, 10_000);
+    #[cfg(not(miri))] // Miri is too slow
+    const N: usize = 10_000;
+    #[cfg(miri)]
+    const N: usize = 20;
+
+    f64_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, N);
+    f32_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, N);
 }
 
 #[test] #[ignore] // it is too expensive
@@ -138,17 +143,27 @@ fn shortest_f64_hard_random_equivalence_test() {
 #[test]
 fn exact_f32_random_equivalence_test() {
     use core::num::flt2dec::strategy::dragon::format_exact as fallback;
+    #[cfg(not(miri))] // Miri is too slow
+    const N: usize = 1_000;
+    #[cfg(miri)]
+    const N: usize = 10;
+
     for k in 1..21 {
         f32_random_equivalence_test(|d, buf| format_exact_opt(d, buf, i16::MIN),
-                                             |d, buf| fallback(d, buf, i16::MIN), k, 1_000);
+                                             |d, buf| fallback(d, buf, i16::MIN), k, N);
     }
 }
 
 #[test]
 fn exact_f64_random_equivalence_test() {
     use core::num::flt2dec::strategy::dragon::format_exact as fallback;
+    #[cfg(not(miri))] // Miri is too slow
+    const N: usize = 1_000;
+    #[cfg(miri)]
+    const N: usize = 5;
+
     for k in 1..21 {
         f64_random_equivalence_test(|d, buf| format_exact_opt(d, buf, i16::MIN),
-                                             |d, buf| fallback(d, buf, i16::MIN), k, 1_000);
+                                             |d, buf| fallback(d, buf, i16::MIN), k, N);
     }
 }

--- a/src/libcore/tests/num/flt2dec/random.rs
+++ b/src/libcore/tests/num/flt2dec/random.rs
@@ -112,7 +112,7 @@ fn shortest_random_equivalence_test() {
     #[cfg(not(miri))] // Miri is too slow
     const N: usize = 10_000;
     #[cfg(miri)]
-    const N: usize = 20;
+    const N: usize = 10;
 
     f64_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, N);
     f32_random_equivalence_test(format_shortest_opt, fallback, MAX_SIG_DIGITS, N);
@@ -146,7 +146,7 @@ fn exact_f32_random_equivalence_test() {
     #[cfg(not(miri))] // Miri is too slow
     const N: usize = 1_000;
     #[cfg(miri)]
-    const N: usize = 10;
+    const N: usize = 3;
 
     for k in 1..21 {
         f32_random_equivalence_test(|d, buf| format_exact_opt(d, buf, i16::MIN),
@@ -160,7 +160,7 @@ fn exact_f64_random_equivalence_test() {
     #[cfg(not(miri))] // Miri is too slow
     const N: usize = 1_000;
     #[cfg(miri)]
-    const N: usize = 5;
+    const N: usize = 3;
 
     for k in 1..21 {
         f64_random_equivalence_test(|d, buf| format_exact_opt(d, buf, i16::MIN),

--- a/src/libcore/tests/num/flt2dec/strategy/dragon.rs
+++ b/src/libcore/tests/num/flt2dec/strategy/dragon.rs
@@ -23,6 +23,7 @@ fn shortest_sanity_test() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn exact_sanity_test() {
     // This test ends up running what I can only assume is some corner-ish case
     // of the `exp2` library function, defined in whatever C runtime we're

--- a/src/libcore/tests/num/flt2dec/strategy/grisu.rs
+++ b/src/libcore/tests/num/flt2dec/strategy/grisu.rs
@@ -36,6 +36,7 @@ fn shortest_sanity_test() {
 }
 
 #[test]
+#[cfg(not(miri))] // Miri is too slow
 fn exact_sanity_test() {
     // See comments in dragon.rs's exact_sanity_test for why this test is
     // ignored on MSVC


### PR DESCRIPTION
With ldexp implemented (thanks to @christianpoveda), we can finally enable these tests in Miri. Well, most of them -- some are just too slow.