### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -329,8 +329,8 @@ impl<'a, B: ?Sized> PartialOrd for Cow<'a, B>
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: ?Sized> fmt::Debug for Cow<'_, B>
-    where B: fmt::Debug + ToOwned,
-          <B as ToOwned>::Owned: fmt::Debug
+where
+    B: fmt::Debug + ToOwned<Owned: fmt::Debug>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -342,8 +342,8 @@ impl<B: ?Sized> fmt::Debug for Cow<'_, B>
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: ?Sized> fmt::Display for Cow<'_, B>
-    where B: fmt::Display + ToOwned,
-          <B as ToOwned>::Owned: fmt::Display
+where
+    B: fmt::Display + ToOwned<Owned: fmt::Display>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -355,8 +355,8 @@ impl<B: ?Sized> fmt::Display for Cow<'_, B>
 
 #[stable(feature = "default", since = "1.11.0")]
 impl<B: ?Sized> Default for Cow<'_, B>
-    where B: ToOwned,
-          <B as ToOwned>::Owned: Default
+where
+    B: ToOwned<Owned: Default>,
 {
     /// Creates an owned Cow<'a, B> with the default value for the contained owned value.
     fn default() -> Self {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -122,6 +122,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 // Allow testing this library
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -8,6 +8,7 @@
 #![feature(trusted_len)]
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]
+#![feature(associated_type_bounds)]
 
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -1638,10 +1638,12 @@ mod pattern {
         }
     }
 
-    fn cmp_search_to_vec<'a, P: Pattern<'a>>(rev: bool, pat: P, haystack: &'a str,
-                                             right: Vec<SearchStep>)
-    where P::Searcher: ReverseSearcher<'a>
-    {
+    fn cmp_search_to_vec<'a>(
+        rev: bool,
+        pat: impl Pattern<'a, Searcher: ReverseSearcher<'a>>,
+        haystack: &'a str,
+        right: Vec<SearchStep>
+    ) {
         let mut searcher = pat.into_searcher(haystack);
         let mut v = vec![];
         loop {

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -513,7 +513,7 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T where T: AsRef<U>
 
 // FIXME (#45742): replace the above impls for &/&mut with the following more general one:
 // // As lifts over Deref
-// impl<D: ?Sized + Deref, U: ?Sized> AsRef<U> for D where D::Target: AsRef<U> {
+// impl<D: ?Sized + Deref<Target: AsRef<U>>, U: ?Sized> AsRef<U> for D {
 //     fn as_ref(&self) -> &U {
 //         self.deref().as_ref()
 //     }
@@ -530,7 +530,7 @@ impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T where T: AsMut<U>
 
 // FIXME (#45742): replace the above impl for &mut with the following more general one:
 // // AsMut lifts over DerefMut
-// impl<D: ?Sized + Deref, U: ?Sized> AsMut<U> for D where D::Target: AsMut<U> {
+// impl<D: ?Sized + Deref<Target: AsMut<U>>, U: ?Sized> AsMut<U> for D {
 //     fn as_mut(&mut self) -> &mut U {
 //         self.deref_mut().as_mut()
 //     }

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -111,8 +111,7 @@ impl<F: ?Sized + Future + Unpin> Future for &mut F {
 #[stable(feature = "futures_api", since = "1.36.0")]
 impl<P> Future for Pin<P>
 where
-    P: Unpin + ops::DerefMut,
-    P::Target: Future,
+    P: Unpin + ops::DerefMut<Target: Future>,
 {
     type Output = <<P as ops::Deref>::Target as Future>::Output;
 

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -195,8 +195,8 @@ pub trait FromIterator<A>: Sized {
 ///
 /// ```rust
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
-///     where T: IntoIterator,
-///           T::Item: std::fmt::Debug,
+/// where
+///     T: IntoIterator<Item: std::fmt::Debug>,
 /// {
 ///     collection
 ///         .into_iter()

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -194,11 +194,10 @@ pub trait FromIterator<A>: Sized {
 /// `Item`:
 ///
 /// ```rust
-/// #![feature(associated_type_bounds)]
-///
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
 /// where
-///     T: IntoIterator<Item: std::fmt::Debug>,
+///     T: IntoIterator,
+///     T::Item: std::fmt::Debug,
 /// {
 ///     collection
 ///         .into_iter()

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -194,6 +194,8 @@ pub trait FromIterator<A>: Sized {
 /// `Item`:
 ///
 /// ```rust
+/// #![feature(associated_type_bounds)]
+///
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
 /// where
 ///     T: IntoIterator<Item: std::fmt::Debug>,

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -132,6 +132,7 @@
 #![feature(maybe_uninit_slice, maybe_uninit_array)]
 #![feature(external_doc)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -439,10 +439,7 @@ where
     }
 }
 
-impl<P: Deref> Pin<P>
-where
-    P::Target: Unpin,
-{
+impl<P: Deref<Target: Unpin>> Pin<P> {
     /// Construct a new `Pin<P>` around a pointer to some data of a type that
     /// implements [`Unpin`].
     ///
@@ -730,10 +727,7 @@ impl<P: Deref> Deref for Pin<P> {
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P: DerefMut> DerefMut for Pin<P>
-where
-    P::Target: Unpin
-{
+impl<P: DerefMut<Target: Unpin>> DerefMut for Pin<P> {
     fn deref_mut(&mut self) -> &mut P::Target {
         Pin::get_mut(Pin::as_mut(self))
     }

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -851,8 +851,9 @@ unsafe impl TrustedRandomAccess for Bytes<'_> {
 /// wrapper types of the form X<'a, P>
 macro_rules! derive_pattern_clone {
     (clone $t:ident with |$s:ident| $e:expr) => {
-        impl<'a, P: Pattern<'a>> Clone for $t<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $t<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 let $s = self;
@@ -928,8 +929,9 @@ macro_rules! generate_pattern_iterators {
         pub struct $forward_iterator<'a, P: Pattern<'a>>($internal_iterator<'a, P>);
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> fmt::Debug for $forward_iterator<'a, P>
-            where P::Searcher: fmt::Debug
+        impl<'a, P> fmt::Debug for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: fmt::Debug>,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple(stringify!($forward_iterator))
@@ -949,8 +951,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Clone for $forward_iterator<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 $forward_iterator(self.0.clone())
@@ -962,8 +965,9 @@ macro_rules! generate_pattern_iterators {
         pub struct $reverse_iterator<'a, P: Pattern<'a>>($internal_iterator<'a, P>);
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> fmt::Debug for $reverse_iterator<'a, P>
-            where P::Searcher: fmt::Debug
+        impl<'a, P> fmt::Debug for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: fmt::Debug>,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple(stringify!($reverse_iterator))
@@ -973,8 +977,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Iterator for $reverse_iterator<'a, P>
-            where P::Searcher: ReverseSearcher<'a>
+        impl<'a, P> Iterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
         {
             type Item = $iterty;
 
@@ -985,8 +990,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Clone for $reverse_iterator<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 $reverse_iterator(self.0.clone())
@@ -997,8 +1003,10 @@ macro_rules! generate_pattern_iterators {
         impl<'a, P: Pattern<'a>> FusedIterator for $forward_iterator<'a, P> {}
 
         #[stable(feature = "fused", since = "1.26.0")]
-        impl<'a, P: Pattern<'a>> FusedIterator for $reverse_iterator<'a, P>
-            where P::Searcher: ReverseSearcher<'a> {}
+        impl<'a, P> FusedIterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
+        {}
 
         generate_pattern_iterators!($($t)* with $(#[$common_stability_attribute])*,
                                                 $forward_iterator,
@@ -1010,8 +1018,9 @@ macro_rules! generate_pattern_iterators {
                            $reverse_iterator:ident, $iterty:ty
     } => {
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> DoubleEndedIterator for $forward_iterator<'a, P>
-            where P::Searcher: DoubleEndedSearcher<'a>
+        impl<'a, P> DoubleEndedIterator for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
         {
             #[inline]
             fn next_back(&mut self) -> Option<$iterty> {
@@ -1020,8 +1029,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> DoubleEndedIterator for $reverse_iterator<'a, P>
-            where P::Searcher: DoubleEndedSearcher<'a>
+        impl<'a, P> DoubleEndedIterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
         {
             #[inline]
             fn next_back(&mut self) -> Option<$iterty> {
@@ -1049,7 +1059,10 @@ struct SplitInternal<'a, P: Pattern<'a>> {
     finished: bool,
 }
 
-impl<'a, P: Pattern<'a>> fmt::Debug for SplitInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for SplitInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitInternal")
             .field("start", &self.start)
@@ -1166,7 +1179,10 @@ struct SplitNInternal<'a, P: Pattern<'a>> {
     count: usize,
 }
 
-impl<'a, P: Pattern<'a>> fmt::Debug for SplitNInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for SplitNInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitNInternal")
             .field("iter", &self.iter)
@@ -1222,7 +1238,10 @@ derive_pattern_clone!{
 
 struct MatchIndicesInternal<'a, P: Pattern<'a>>(P::Searcher);
 
-impl<'a, P: Pattern<'a>> fmt::Debug for MatchIndicesInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for MatchIndicesInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("MatchIndicesInternal")
             .field(&self.0)
@@ -1273,7 +1292,10 @@ derive_pattern_clone!{
 
 struct MatchesInternal<'a, P: Pattern<'a>>(P::Searcher);
 
-impl<'a, P: Pattern<'a>> fmt::Debug for MatchesInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for MatchesInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("MatchesInternal")
             .field(&self.0)
@@ -2882,8 +2904,9 @@ impl str {
     /// assert!(!bananas.ends_with("nana"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ends_with<'a, P: Pattern<'a>>(&'a self, pat: P) -> bool
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn ends_with<'a, P>(&'a self, pat: P) -> bool
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         pat.is_suffix_of(self)
     }
@@ -2975,8 +2998,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rfind<'a, P: Pattern<'a>>(&'a self, pat: P) -> Option<usize>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rfind<'a, P>(&'a self, pat: P) -> Option<usize>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         pat.into_searcher(self).next_match_back().map(|(i, _)| i)
     }
@@ -3142,8 +3166,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplit<'a, P: Pattern<'a>>(&'a self, pat: P) -> RSplit<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplit<'a, P>(&'a self, pat: P) -> RSplit<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplit(self.split(pat).0)
     }
@@ -3233,8 +3258,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplit_terminator<'a, P: Pattern<'a>>(&'a self, pat: P) -> RSplitTerminator<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplit_terminator<'a, P>(&'a self, pat: P) -> RSplitTerminator<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplitTerminator(self.split_terminator(pat).0)
     }
@@ -3333,8 +3359,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplitn<'a, P: Pattern<'a>>(&'a self, n: usize, pat: P) -> RSplitN<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplitn<'a, P>(&'a self, n: usize, pat: P) -> RSplitN<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplitN(self.splitn(n, pat).0)
     }
@@ -3406,8 +3433,9 @@ impl str {
     /// ```
     #[stable(feature = "str_matches", since = "1.2.0")]
     #[inline]
-    pub fn rmatches<'a, P: Pattern<'a>>(&'a self, pat: P) -> RMatches<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rmatches<'a, P>(&'a self, pat: P) -> RMatches<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RMatches(self.matches(pat).0)
     }
@@ -3491,8 +3519,9 @@ impl str {
     /// ```
     #[stable(feature = "str_match_indices", since = "1.5.0")]
     #[inline]
-    pub fn rmatch_indices<'a, P: Pattern<'a>>(&'a self, pat: P) -> RMatchIndices<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rmatch_indices<'a, P>(&'a self, pat: P) -> RMatchIndices<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RMatchIndices(self.match_indices(pat).0)
     }
@@ -3700,8 +3729,9 @@ impl str {
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn trim_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: DoubleEndedSearcher<'a>
+    pub fn trim_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
     {
         let mut i = 0;
         let mut j = 0;
@@ -3792,8 +3822,9 @@ impl str {
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
-    pub fn trim_end_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn trim_end_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         let mut j = 0;
         let mut matcher = pat.into_searcher(self);
@@ -3880,8 +3911,9 @@ impl str {
         reason = "superseded by `trim_end_matches`",
         suggestion = "trim_end_matches",
     )]
-    pub fn trim_right_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn trim_right_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         self.trim_end_matches(pat)
     }

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -512,7 +512,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
-    pub const fn as_secs_f64(&self) -> f64 {
+    pub fn as_secs_f64(&self) -> f64 {
         (self.secs as f64) + (self.nanos as f64) / (NANOS_PER_SEC as f64)
     }
 
@@ -529,7 +529,7 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
-    pub const fn as_secs_f32(&self) -> f32 {
+    pub fn as_secs_f32(&self) -> f32 {
         (self.secs as f32) + (self.nanos as f32) / (NANOS_PER_SEC as f32)
     }
 

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -505,13 +505,12 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.as_secs_f64(), 2.7);
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub const fn as_secs_f64(&self) -> f64 {
         (self.secs as f64) + (self.nanos as f64) / (NANOS_PER_SEC as f64)
@@ -523,13 +522,12 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.as_secs_f32(), 2.7);
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub const fn as_secs_f32(&self) -> f32 {
         (self.secs as f32) + (self.nanos as f32) / (NANOS_PER_SEC as f32)
@@ -543,13 +541,12 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::from_secs_f64(2.7);
     /// assert_eq!(dur, Duration::new(2, 700_000_000));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn from_secs_f64(secs: f64) -> Duration {
         const MAX_NANOS_F64: f64 =
@@ -579,13 +576,12 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::from_secs_f32(2.7);
     /// assert_eq!(dur, Duration::new(2, 700_000_000));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn from_secs_f32(secs: f32) -> Duration {
         const MAX_NANOS_F32: f32 =
@@ -614,14 +610,13 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
     /// assert_eq!(dur.mul_f64(3.14), Duration::new(8, 478_000_000));
     /// assert_eq!(dur.mul_f64(3.14e5), Duration::new(847_800, 0));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn mul_f64(self, rhs: f64) -> Duration {
         Duration::from_secs_f64(rhs * self.as_secs_f64())
@@ -634,7 +629,6 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -643,7 +637,7 @@ impl Duration {
     /// assert_eq!(dur.mul_f32(3.14), Duration::new(8, 478_000_640));
     /// assert_eq!(dur.mul_f32(3.14e5), Duration::new(847799, 969_120_256));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn mul_f32(self, rhs: f32) -> Duration {
         Duration::from_secs_f32(rhs * self.as_secs_f32())
@@ -656,7 +650,6 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -664,7 +657,7 @@ impl Duration {
     /// // note that truncation is used, not rounding
     /// assert_eq!(dur.div_f64(3.14e5), Duration::new(0, 8_598));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn div_f64(self, rhs: f64) -> Duration {
         Duration::from_secs_f64(self.as_secs_f64() / rhs)
@@ -677,7 +670,6 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur = Duration::new(2, 700_000_000);
@@ -687,7 +679,7 @@ impl Duration {
     /// // note that truncation is used, not rounding
     /// assert_eq!(dur.div_f32(3.14e5), Duration::new(0, 8_598));
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn div_f32(self, rhs: f32) -> Duration {
         Duration::from_secs_f32(self.as_secs_f32() / rhs)
@@ -697,14 +689,13 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration_f64(dur2), 0.5);
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn div_duration_f64(self, rhs: Duration) -> f64 {
         self.as_secs_f64() / rhs.as_secs_f64()
@@ -714,14 +705,13 @@ impl Duration {
     ///
     /// # Examples
     /// ```
-    /// #![feature(duration_float)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration_f32(dur2), 0.5);
     /// ```
-    #[unstable(feature = "duration_float", issue = "54361")]
+    #[stable(feature = "duration_float", since = "1.38.0")]
     #[inline]
     pub fn div_duration_f32(self, rhs: Duration) -> f32 {
         self.as_secs_f32() / rhs.as_secs_f32()

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -689,6 +689,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// #![feature(div_duration)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);
@@ -705,6 +706,7 @@ impl Duration {
     ///
     /// # Examples
     /// ```
+    /// #![feature(div_duration)]
     /// use std::time::Duration;
     ///
     /// let dur1 = Duration::new(2, 700_000_000);

--- a/src/libcore/time.rs
+++ b/src/libcore/time.rs
@@ -695,7 +695,7 @@ impl Duration {
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration_f64(dur2), 0.5);
     /// ```
-    #[stable(feature = "duration_float", since = "1.38.0")]
+    #[unstable(feature = "div_duration", issue = "63139")]
     #[inline]
     pub fn div_duration_f64(self, rhs: Duration) -> f64 {
         self.as_secs_f64() / rhs.as_secs_f64()
@@ -711,7 +711,7 @@ impl Duration {
     /// let dur2 = Duration::new(5, 400_000_000);
     /// assert_eq!(dur1.div_duration_f32(dur2), 0.5);
     /// ```
-    #[stable(feature = "duration_float", since = "1.38.0")]
+    #[unstable(feature = "div_duration", issue = "63139")]
     #[inline]
     pub fn div_duration_f32(self, rhs: Duration) -> f32 {
         self.as_secs_f32() / rhs.as_secs_f32()

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -287,7 +287,7 @@ impl<'hir> Map<'hir> {
         self.definitions.def_index_to_hir_id(def_id.to_def_id().index)
     }
 
-    fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
+    pub fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
         let node = if let Some(node) = self.find(hir_id) {
             node
         } else {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -662,19 +662,22 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     }
                 }
                 _ => {
+                    // `last_ty` can be `!`, `expected` will have better info when present.
+                    let t = self.resolve_vars_if_possible(&match exp_found {
+                        Some(ty::error::ExpectedFound { expected, .. }) => expected,
+                        _ => last_ty,
+                    });
                     let msg = "`match` arms have incompatible types";
                     err.span_label(cause.span, msg);
                     if prior_arms.len() <= 4 {
                         for sp in prior_arms {
-                            err.span_label(*sp, format!(
-                                "this is found to be of type `{}`",
-                                self.resolve_vars_if_possible(&last_ty),
-                            ));
+                            err.span_label( *sp, format!("this is found to be of type `{}`", t));
                         }
                     } else if let Some(sp) = prior_arms.last() {
-                        err.span_label(*sp, format!(
-                            "this and all prior arms are found to be of type `{}`", last_ty,
-                        ));
+                        err.span_label(
+                            *sp,
+                            format!("this and all prior arms are found to be of type `{}`", t),
+                        );
                     }
                 }
             },
@@ -1143,27 +1146,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
                 (_, false, _) => {
                     if let Some(exp_found) = exp_found {
-                        let (def_id, ret_ty) = match exp_found.found.sty {
-                            ty::FnDef(def, _) => {
-                                (Some(def), Some(self.tcx.fn_sig(def).output()))
-                            }
-                            _ => (None, None),
-                        };
-
-                        let exp_is_struct = match exp_found.expected.sty {
-                            ty::Adt(def, _) => def.is_struct(),
-                            _ => false,
-                        };
-
-                        if let (Some(def_id), Some(ret_ty)) = (def_id, ret_ty) {
-                            if exp_is_struct && &exp_found.expected == ret_ty.skip_binder() {
-                                let message = format!(
-                                    "did you mean `{}(/* fields */)`?",
-                                    self.tcx.def_path_str(def_id)
-                                );
-                                diag.span_label(span, message);
-                            }
-                        }
                         self.suggest_as_ref_where_appropriate(span, &exp_found, diag);
                     }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -61,6 +61,7 @@
 #![feature(proc_macro_hygiene)]
 #![feature(log_syntax)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3901,7 +3901,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // each predicate must be preceded by the obligations required
         // to normalize it.
         // for example, if we have:
-        //    impl<U: Iterator, V: Iterator<Item=U>> Foo for V where U::Item: Copy
+        //    impl<U: Iterator<Item: Copy>, V: Iterator<Item = U>> Foo for V
         // the impl will have the following predicates:
         //    <V as Iterator>::Item = U,
         //    U: Iterator, U: Sized,

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -980,8 +980,7 @@ EnumTypeFoldableImpl! {
         (chalk_engine::DelayedLiteral::Negative)(a),
         (chalk_engine::DelayedLiteral::Positive)(a, b),
     } where
-        C: chalk_engine::context::Context + Clone,
-        C::CanonicalConstrainedSubst: TypeFoldable<'tcx>,
+        C: chalk_engine::context::Context<CanonicalConstrainedSubst: TypeFoldable<'tcx>> + Clone,
 }
 
 EnumTypeFoldableImpl! {
@@ -989,8 +988,7 @@ EnumTypeFoldableImpl! {
         (chalk_engine::Literal::Negative)(a),
         (chalk_engine::Literal::Positive)(a),
     } where
-        C: chalk_engine::context::Context + Clone,
-        C::GoalInEnvironment: Clone + TypeFoldable<'tcx>,
+        C: chalk_engine::context::Context<GoalInEnvironment: Clone + TypeFoldable<'tcx>> + Clone,
 }
 
 CloneTypeFoldableAndLiftImpls! {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2663,8 +2663,8 @@ impl<'tcx> TyCtxt<'tcx> {
                         unsafety: hir::Unsafety,
                         abi: abi::Abi)
         -> <I::Item as InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>>::Output
-        where I: Iterator,
-              I::Item: InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>
+    where
+        I: Iterator<Item: InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>>,
     {
         inputs.chain(iter::once(output)).intern_with(|xs| ty::FnSig {
             inputs_and_output: self.intern_type_list(xs),

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2027,9 +2027,9 @@ impl ty::query::TyCtxtAt<'tcx> {
 
 impl<'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
 where
-    C: LayoutOf<Ty = Ty<'tcx>> + HasTyCtxt<'tcx>,
-    C::TyLayout: MaybeResult<TyLayout<'tcx>>,
-    C: HasParamEnv<'tcx>,
+    C: LayoutOf<Ty = Ty<'tcx>, TyLayout: MaybeResult<TyLayout<'tcx>>>
+        + HasTyCtxt<'tcx>
+        + HasParamEnv<'tcx>,
 {
     fn for_variant(this: TyLayout<'tcx>, cx: &C, variant_index: VariantIdx) -> TyLayout<'tcx> {
         let details = match this.variants {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -1055,9 +1055,8 @@ fn encode_query_results<'a, 'tcx, Q, E>(
     query_result_index: &mut EncodedQueryResultIndex,
 ) -> Result<(), E::Error>
 where
-    Q: super::config::QueryDescription<'tcx>,
+    Q: super::config::QueryDescription<'tcx, Value: Encodable>,
     E: 'a + TyEncoder,
-    Q::Value: Encodable,
 {
     let desc = &format!("encode_query_results for {}",
         ::std::any::type_name::<Q>());

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -278,6 +278,7 @@ fn fat_lto(cgcx: &CodegenContext<LlvmCodegenBackend>,
                 }
             }
         }).collect::<Vec<_>>();
+        // Sort the modules to ensure we produce deterministic results.
         new_modules.sort_by(|module1, module2| module1.1.partial_cmp(&module2.1).unwrap());
         serialized_modules.extend(new_modules);
         serialized_modules.extend(cached_modules.into_iter().map(|(buffer, wp)| {

--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -265,7 +265,7 @@ fn fat_lto(cgcx: &CodegenContext<LlvmCodegenBackend>,
         // and we want to move everything to the same LLVM context. Currently the
         // way we know of to do that is to serialize them to a string and them parse
         // them later. Not great but hey, that's why it's "fat" LTO, right?
-        serialized_modules.extend(modules.into_iter().map(|module| {
+        let mut new_modules = modules.into_iter().map(|module| {
             match module {
                 FatLTOInput::InMemory(module) => {
                     let buffer = ModuleBuffer::new(module.module_llvm.llmod());
@@ -277,7 +277,9 @@ fn fat_lto(cgcx: &CodegenContext<LlvmCodegenBackend>,
                     (SerializedModule::Local(buffer), llmod_id)
                 }
             }
-        }));
+        }).collect::<Vec<_>>();
+        new_modules.sort_by(|module1, module2| module1.1.partial_cmp(&module2.1).unwrap());
+        serialized_modules.extend(new_modules);
         serialized_modules.extend(cached_modules.into_iter().map(|(buffer, wp)| {
             (buffer, CString::new(wp.cgu_name).unwrap())
         }));

--- a/src/librustc_codegen_ssa/back/command.rs
+++ b/src/librustc_codegen_ssa/back/command.rs
@@ -50,8 +50,8 @@ impl Command {
     }
 
     pub fn args<I>(&mut self, args: I) -> &mut Command
-        where I: IntoIterator,
-              I::Item: AsRef<OsStr>,
+    where
+        I: IntoIterator<Item: AsRef<OsStr>>,
     {
         for arg in args {
             self._arg(arg.as_ref());

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -755,15 +755,6 @@ pub enum FatLTOInput<B: WriteBackendMethods> {
     InMemory(ModuleCodegen<B::Module>),
 }
 
-impl<B: WriteBackendMethods> FatLTOInput<B> {
-    fn name(&'a self) -> &'a String {
-        match self {
-            FatLTOInput::Serialized { name, buffer: _ } => &name,
-            FatLTOInput::InMemory(module) => &module.name,
-        }
-    }
-}
-
 fn execute_work_item<B: ExtraBackendMethods>(
     cgcx: &CodegenContext<B>,
     work_item: WorkItem<B>,
@@ -1354,14 +1345,9 @@ fn start_executing_work<B: ExtraBackendMethods>(
                     assert!(!started_lto);
                     started_lto = true;
 
-                    let mut needs_fat_lto: Vec<FatLTOInput<B>> = mem::take(&mut needs_fat_lto);
+                    let needs_fat_lto = mem::take(&mut needs_fat_lto);
                     let needs_thin_lto = mem::take(&mut needs_thin_lto);
                     let import_only_modules = mem::take(&mut lto_import_only_modules);
-
-                    // Regardless of what order these modules completed in, report them to
-                    // the backend in the same order every time to ensure that we're handing
-                    // out deterministic results.
-                    needs_fat_lto.sort_by(|m1, m2| m1.name().cmp(m2.name()));
 
                     for (work, cost) in generate_lto_work(&cgcx, needs_fat_lto,
                                                           needs_thin_lto, import_only_modules) {

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -11,6 +11,7 @@
 #![feature(nll)]
 #![feature(trusted_len)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -23,6 +23,7 @@
 #![feature(core_intrinsics)]
 #![feature(integer_atomics)]
 #![feature(test)]
+#![feature(associated_type_bounds)]
 
 #![cfg_attr(unix, feature(libc))]
 

--- a/src/librustc_data_structures/owning_ref/mod.rs
+++ b/src/librustc_data_structures/owning_ref/mod.rs
@@ -847,7 +847,9 @@ pub trait ToHandleMut {
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandle<Handle = H>, H: Deref,
+where
+    O: StableAddress<Target: ToHandle<Handle = H>>,
+    H: Deref,
 {
     /// Creates a new `OwningHandle` for a type that implements `ToHandle`. For types
     /// that don't implement `ToHandle`, callers may invoke `new_with_fn`, which accepts
@@ -858,7 +860,9 @@ impl<O, H> OwningHandle<O, H>
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandleMut<HandleMut = H>, H: DerefMut,
+where
+    O: StableAddress<Target: ToHandleMut<HandleMut = H>>,
+    H: DerefMut,
 {
     /// Creates a new mutable `OwningHandle` for a type that implements `ToHandleMut`.
     pub fn new_mut(o: O) -> Self {

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -589,10 +589,8 @@ impl<E:Idx> GenKillSet<E> {
         self.gen_set.insert(e);
         self.kill_set.remove(e);
     }
-    fn gen_all<I>(&mut self, i: I)
-        where I: IntoIterator,
-              I::Item: Borrow<E>
-    {
+
+    fn gen_all(&mut self, i: impl IntoIterator<Item: Borrow<E>>) {
         for j in i {
             self.gen(*j.borrow());
         }
@@ -603,10 +601,7 @@ impl<E:Idx> GenKillSet<E> {
         self.kill_set.insert(e);
     }
 
-    fn kill_all<I>(&mut self, i: I)
-        where I: IntoIterator,
-              I::Item: Borrow<E>
-    {
+    fn kill_all(&mut self, i: impl IntoIterator<Item: Borrow<E>>) {
         for j in i {
             self.kill(*j.borrow());
         }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -23,6 +23,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(trusted_len)]
 #![feature(try_blocks)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -559,6 +559,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
+                            ty::Error | ty::Never => return,
                             _ => "value",
                         });
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -550,18 +550,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     assert!(e_ty.is_unit());
                     let ty = coerce.expected_ty();
                     coerce.coerce_forced_unit(self, &cause, &mut |err| {
-                        let msg = "give it a value of the expected type";
-                        let label = destination.label
-                            .map(|l| format!(" {}", l.ident))
-                            .unwrap_or_else(String::new);
-                        let sugg = format!("break{} {}", label, match ty.sty {
+                        let val = match ty.sty {
                             ty::Bool => "true",
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
                             ty::Error | ty::Never => return,
                             _ => "value",
-                        });
+                        };
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, val);
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
                     }, false);
                 }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -548,7 +548,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     coerce.coerce(self, &cause, e, e_ty);
                 } else {
                     assert!(e_ty.is_unit());
-                    coerce.coerce_forced_unit(self, &cause, &mut |_| (), true);
+                    let ty = coerce.expected_ty();
+                    coerce.coerce_forced_unit(self, &cause, &mut |err| {
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, match ty.sty {
+                            ty::Bool => "true",
+                            ty::Char => "'a'",
+                            ty::Int(_) | ty::Uint(_) => "42",
+                            ty::Float(_) => "3.14159",
+                            _ => "value",
+                        });
+                        err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
+                    }, false);
                 }
             } else {
                 // If `ctxt.coerce` is `None`, we can just ignore

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,7 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function's body doesn't `return` a value",
+                                "this function implicitly returns `()` as its body has no tail \
+                                 or `return` expression",
                             );
                         }
                     }, false);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return");
+                            err.span_label(fn_span, "this function's body doesn't return a value");
                         }
                     }, false);
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,8 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function implicitly returns `()` as its body has no tail \
-                                 or `return` expression",
+                                "implicitly returns `()` as its body has no tail or `return` \
+                                 expression",
                             );
                         }
                     }, false);
@@ -3880,10 +3880,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         sugg_call = fields.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
                         match hir.as_local_hir_id(def_id).and_then(|hir_id| hir.def_kind(hir_id)) {
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, _)) => {
-                                msg = "instatiate this tuple variant";
+                                msg = "instantiate this tuple variant";
                             }
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Struct, _)) => {
-                                msg = "instatiate this tuple struct";
+                                msg = "instantiate this tuple struct";
                             }
                             _ => {}
                         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return a value");
+                            err.span_label(
+                                fn_span,
+                                "this function's body doesn't `return` a value",
+                            );
                         }
                     }, false);
                 }

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -9,10 +9,7 @@ use std::sync::Arc;
 
 use smallvec::{Array, SmallVec};
 
-impl<A> Encodable for SmallVec<A>
-    where A: Array,
-          A::Item: Encodable
-{
+impl<A: Array<Item: Encodable>> Encodable for SmallVec<A> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
@@ -23,10 +20,7 @@ impl<A> Encodable for SmallVec<A>
     }
 }
 
-impl<A> Decodable for SmallVec<A>
-    where A: Array,
-          A::Item: Decodable
-{
+impl<A: Array<Item: Decodable>> Decodable for SmallVec<A> {
     fn decode<D: Decoder>(d: &mut D) -> Result<SmallVec<A>, D::Error> {
         d.read_seq(|d, len| {
             let mut vec = SmallVec::with_capacity(len);

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -13,6 +13,7 @@ Core encoding and decoding interfaces.
 #![feature(specialization)]
 #![feature(never_type)]
 #![feature(nll)]
+#![feature(associated_type_bounds)]
 #![cfg_attr(test, feature(test))]
 
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable};

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -244,7 +244,6 @@
 #![feature(cfg_target_has_atomic)]
 #![feature(cfg_target_thread_local)]
 #![feature(char_error_internals)]
-#![feature(checked_duration_since)]
 #![feature(clamp)]
 #![feature(compiler_builtins_lib)]
 #![feature(concat_idents)]

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -238,6 +238,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(array_error_internals)]
 #![feature(asm)]
+#![feature(associated_type_bounds)]
 #![feature(bind_by_move_pattern_guards)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]

--- a/src/libstd/sys/sgx/abi/usercalls/alloc.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/alloc.rs
@@ -522,7 +522,11 @@ impl<T: ?Sized> Drop for User<T> where T: UserSafe {
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<UserRef<U>> for UserRef<T> {}
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
-impl<T, I: SliceIndex<[T]>> Index<I> for UserRef<[T]> where [T]: UserSafe, I::Output: UserSafe {
+impl<T, I> Index<I> for UserRef<[T]>
+where
+    [T]: UserSafe,
+    I: SliceIndex<[T], Output: UserSafe>,
+{
     type Output = UserRef<I::Output>;
 
     #[inline]
@@ -538,7 +542,11 @@ impl<T, I: SliceIndex<[T]>> Index<I> for UserRef<[T]> where [T]: UserSafe, I::Ou
 }
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
-impl<T, I: SliceIndex<[T]>> IndexMut<I> for UserRef<[T]> where [T]: UserSafe, I::Output: UserSafe {
+impl<T, I> IndexMut<I> for UserRef<[T]>
+where
+    [T]: UserSafe,
+    I: SliceIndex<[T], Output: UserSafe>,
+{
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut UserRef<I::Output> {
         unsafe {

--- a/src/libstd/time.rs
+++ b/src/libstd/time.rs
@@ -221,7 +221,6 @@ impl Instant {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(checked_duration_since)]
     /// use std::time::{Duration, Instant};
     /// use std::thread::sleep;
     ///
@@ -231,7 +230,7 @@ impl Instant {
     /// println!("{:?}", new_now.checked_duration_since(now));
     /// println!("{:?}", now.checked_duration_since(new_now)); // None
     /// ```
-    #[unstable(feature = "checked_duration_since", issue = "58402")]
+    #[stable(feature = "checked_duration_since", since = "1.38.0")]
     pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
         self.0.checked_sub_instant(&earlier.0)
     }
@@ -242,7 +241,6 @@ impl Instant {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(checked_duration_since)]
     /// use std::time::{Duration, Instant};
     /// use std::thread::sleep;
     ///
@@ -252,7 +250,7 @@ impl Instant {
     /// println!("{:?}", new_now.saturating_duration_since(now));
     /// println!("{:?}", now.saturating_duration_since(new_now)); // 0ns
     /// ```
-    #[unstable(feature = "checked_duration_since", issue = "58402")]
+    #[stable(feature = "checked_duration_since", since = "1.38.0")]
     pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
         self.checked_duration_since(earlier).unwrap_or(Duration::new(0, 0))
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -6,6 +6,7 @@ use crate::config::StripUnconfigured;
 use crate::ext::base::*;
 use crate::ext::proc_macro::collect_derives;
 use crate::ext::hygiene::{ExpnId, SyntaxContext, ExpnInfo, ExpnKind};
+use crate::ext::tt::macro_rules::annotate_err_with_kind;
 use crate::ext::placeholders::{placeholder, PlaceholderExpander};
 use crate::feature_gate::{self, Features, GateIssue, is_builtin_attr, emit_feature_err};
 use crate::mut_visit::*;
@@ -701,21 +702,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
-                match kind {
-                    AstFragmentKind::Ty => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a type",
-                        );
-                    }
-                    AstFragmentKind::Pat => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a pattern",
-                        );
-                    }
-                    _ => {}
-                };
+                annotate_err_with_kind(&mut err, kind, span);
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -686,12 +686,13 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         );
     }
 
-    fn parse_ast_fragment(&mut self,
-                          toks: TokenStream,
-                          kind: AstFragmentKind,
-                          path: &Path,
-                          span: Span)
-                          -> AstFragment {
+    fn parse_ast_fragment(
+        &mut self,
+        toks: TokenStream,
+        kind: AstFragmentKind,
+        path: &Path,
+        span: Span,
+    ) -> AstFragment {
         let mut parser = self.cx.new_parser_from_tts(&toks.into_trees().collect::<Vec<_>>());
         match parser.parse_ast_fragment(kind, false) {
             Ok(fragment) => {
@@ -700,6 +701,21 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
+                match kind {
+                    AstFragmentKind::Ty => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a type",
+                        );
+                    }
+                    AstFragmentKind::Pat => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a pattern",
+                        );
+                    }
+                    _ => {}
+                };
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -17,7 +17,7 @@ use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{DelimSpan, TokenStream, TokenTree};
 use crate::{ast, attr, attr::TransparencyError};
 
-use errors::FatalError;
+use errors::{DiagnosticBuilder, FatalError};
 use log::debug;
 use syntax_pos::Span;
 
@@ -41,6 +41,18 @@ pub struct ParserAnyMacro<'a> {
     /// The ident of the macro we're parsing
     macro_ident: ast::Ident,
     arm_span: Span,
+}
+
+pub fn annotate_err_with_kind(err: &mut DiagnosticBuilder<'_>, kind: AstFragmentKind, span: Span) {
+    match kind {
+        AstFragmentKind::Ty => {
+            err.span_label(span, "this macro call doesn't expand to a type");
+        }
+        AstFragmentKind::Pat => {
+            err.span_label(span, "this macro call doesn't expand to a pattern");
+        }
+        _ => {}
+    };
 }
 
 impl<'a> ParserAnyMacro<'a> {
@@ -71,27 +83,30 @@ impl<'a> ParserAnyMacro<'a> {
                 e.span_label(site_span, "in this macro invocation");
             }
             match kind {
-                AstFragmentKind::Ty => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a type",
-                    );
-                }
                 AstFragmentKind::Pat if macro_ident.name == sym::vec => {
-                    e.span_label(
-                        site_span,
-                        "use a slice pattern here instead",
-                    );
+                    let mut suggestion = None;
+                    if let Ok(code) = parser.sess.source_map().span_to_snippet(site_span) {
+                        if let Some(bang) = code.find('!') {
+                            suggestion = Some(code[bang + 1..].to_string());
+                        }
+                    }
+                    if let Some(suggestion) = suggestion {
+                        e.span_suggestion(
+                            site_span,
+                            "use a slice pattern here instead",
+                            suggestion,
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        e.span_label(
+                            site_span,
+                            "use a slice pattern here instead",
+                        );
+                    }
                     e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
-                              rust-2018/slice-patterns.html");
+                            rust-2018/slice-patterns.html");
                 }
-                AstFragmentKind::Pat => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a pattern",
-                    );
-                }
-                _ => {}
+                _ => annotate_err_with_kind(&mut e, kind, site_span),
             };
             e
         }));

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -70,6 +70,29 @@ impl<'a> ParserAnyMacro<'a> {
             } else if !parser.sess.source_map().span_to_filename(parser.token.span).is_real() {
                 e.span_label(site_span, "in this macro invocation");
             }
+            match kind {
+                AstFragmentKind::Ty => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a type",
+                    );
+                }
+                AstFragmentKind::Pat if macro_ident.name == sym::vec => {
+                    e.span_label(
+                        site_span,
+                        "use a slice pattern here instead",
+                    );
+                    e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
+                              rust-2018/slice-patterns.html");
+                }
+                AstFragmentKind::Pat => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a pattern",
+                    );
+                }
+                _ => {}
+            };
             e
         }));
 

--- a/src/test/run-make-fulldeps/reproducible-build-2/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build-2/Makefile
@@ -1,0 +1,16 @@
+-include ../tools.mk
+
+# ignore-musl
+# ignore-windows
+# Objects are reproducible but their path is not.
+
+all:  \
+	fat_lto
+
+fat_lto:
+	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) reproducible-build-aux.rs
+	$(RUSTC) reproducible-build.rs -C lto=fat
+	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
+	$(RUSTC) reproducible-build.rs -C lto=fat
+	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1

--- a/src/test/run-make-fulldeps/reproducible-build-2/linker.rs
+++ b/src/test/run-make-fulldeps/reproducible-build-2/linker.rs
@@ -1,0 +1,44 @@
+use std::env;
+use std::path::Path;
+use std::fs::File;
+use std::io::{Read, Write};
+
+fn main() {
+    let mut dst = env::current_exe().unwrap();
+    dst.pop();
+    dst.push("linker-arguments1");
+    if dst.exists() {
+        dst.pop();
+        dst.push("linker-arguments2");
+        assert!(!dst.exists());
+    }
+
+    let mut out = String::new();
+    for arg in env::args().skip(1) {
+        let path = Path::new(&arg);
+        if !path.is_file() {
+            out.push_str(&arg);
+            out.push_str("\n");
+            continue
+        }
+
+        let mut contents = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut contents).unwrap();
+
+        out.push_str(&format!("{}: {}\n", arg, hash(&contents)));
+    }
+
+    File::create(dst).unwrap().write_all(out.as_bytes()).unwrap();
+}
+
+// fnv hash for now
+fn hash(contents: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325;
+
+    for byte in contents {
+        hash = hash ^ (*byte as u64);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+
+    hash
+}

--- a/src/test/run-make-fulldeps/reproducible-build-2/reproducible-build-aux.rs
+++ b/src/test/run-make-fulldeps/reproducible-build-2/reproducible-build-aux.rs
@@ -1,0 +1,28 @@
+#![crate_type="lib"]
+
+pub static STATIC: i32 = 1234;
+
+pub struct Struct<T1, T2> {
+    _t1: std::marker::PhantomData<T1>,
+    _t2: std::marker::PhantomData<T2>,
+}
+
+pub fn regular_fn(_: i32) {}
+
+pub fn generic_fn<T1, T2>() {}
+
+impl<T1, T2> Drop for Struct<T1, T2> {
+    fn drop(&mut self) {}
+}
+
+pub enum Enum {
+    Variant1,
+    Variant2(u32),
+    Variant3 { x: u32 }
+}
+
+pub struct TupleStruct(pub i8, pub i16, pub i32, pub i64);
+
+pub trait Trait<T1, T2> {
+    fn foo(&self);
+}

--- a/src/test/run-make-fulldeps/reproducible-build-2/reproducible-build.rs
+++ b/src/test/run-make-fulldeps/reproducible-build-2/reproducible-build.rs
@@ -1,0 +1,116 @@
+// This test case makes sure that two identical invocations of the compiler
+// (i.e., same code base, same compile-flags, same compiler-versions, etc.)
+// produce the same output. In the past, symbol names of monomorphized functions
+// were not deterministic (which we want to avoid).
+//
+// The test tries to exercise as many different paths into symbol name
+// generation as possible:
+//
+// - regular functions
+// - generic functions
+// - methods
+// - statics
+// - closures
+// - enum variant constructors
+// - tuple struct constructors
+// - drop glue
+// - FnOnce adapters
+// - Trait object shims
+// - Fn Pointer shims
+
+#![allow(dead_code, warnings)]
+
+extern crate reproducible_build_aux;
+
+static STATIC: i32 = 1234;
+
+pub struct Struct<T1, T2> {
+    x: T1,
+    y: T2,
+}
+
+fn regular_fn(_: i32) {}
+
+fn generic_fn<T1, T2>() {}
+
+impl<T1, T2> Drop for Struct<T1, T2> {
+    fn drop(&mut self) {}
+}
+
+pub enum Enum {
+    Variant1,
+    Variant2(u32),
+    Variant3 { x: u32 }
+}
+
+struct TupleStruct(i8, i16, i32, i64);
+
+impl TupleStruct {
+    pub fn bar(&self) {}
+}
+
+trait Trait<T1, T2> {
+    fn foo(&self);
+}
+
+impl Trait<i32, u64> for u64 {
+    fn foo(&self) {}
+}
+
+impl reproducible_build_aux::Trait<char, String> for TupleStruct {
+    fn foo(&self) {}
+}
+
+fn main() {
+    regular_fn(STATIC);
+    generic_fn::<u32, char>();
+    generic_fn::<char, Struct<u32, u64>>();
+    generic_fn::<Struct<u64, u32>, reproducible_build_aux::Struct<u32, u64>>();
+
+    let dropped = Struct {
+        x: "",
+        y: 'a',
+    };
+
+    let _ = Enum::Variant1;
+    let _ = Enum::Variant2(0);
+    let _ = Enum::Variant3 { x: 0 };
+    let _ = TupleStruct(1, 2, 3, 4);
+
+    let closure  = |x| {
+        x + 1i32
+    };
+
+    fn inner<F: Fn(i32) -> i32>(f: F) -> i32 {
+        f(STATIC)
+    }
+
+    println!("{}", inner(closure));
+
+    let object_shim: &Trait<i32, u64> = &0u64;
+    object_shim.foo();
+
+    fn with_fn_once_adapter<F: FnOnce(i32)>(f: F) {
+        f(0);
+    }
+
+    with_fn_once_adapter(|_:i32| { });
+
+    reproducible_build_aux::regular_fn(STATIC);
+    reproducible_build_aux::generic_fn::<u32, char>();
+    reproducible_build_aux::generic_fn::<char, Struct<u32, u64>>();
+    reproducible_build_aux::generic_fn::<Struct<u64, u32>,
+                                         reproducible_build_aux::Struct<u32, u64>>();
+
+    let _ = reproducible_build_aux::Enum::Variant1;
+    let _ = reproducible_build_aux::Enum::Variant2(0);
+    let _ = reproducible_build_aux::Enum::Variant3 { x: 0 };
+    let _ = reproducible_build_aux::TupleStruct(1, 2, 3, 4);
+
+    let object_shim: &reproducible_build_aux::Trait<char, String> = &TupleStruct(0, 1, 2, 3);
+    object_shim.foo();
+
+    let pointer_shim: &Fn(i32) = &regular_fn;
+
+    TupleStruct(1, 2, 3, 4).bar();
+}

--- a/src/test/run-make-fulldeps/reproducible-build/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build/Makefile
@@ -10,8 +10,7 @@ all:  \
 	link_paths \
 	remap_paths \
 	different_source_dirs \
-	extern_flags \
-	fat_lto
+	extern_flags
 
 smoke:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
@@ -77,11 +76,3 @@ extern_flags:
 		--extern reproducible_build_aux=$(TMPDIR)/libbar.rlib \
 		--crate-type rlib
 	cmp "$(TMPDIR)/libreproducible_build.rlib" "$(TMPDIR)/libfoo.rlib" || exit 1
-
-fat_lto:
-	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
-	$(RUSTC) reproducible-build-aux.rs
-	$(RUSTC) reproducible-build.rs -C lto=fat
-	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
-	$(RUSTC) reproducible-build.rs -C lto=fat
-	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1

--- a/src/test/run-make-fulldeps/reproducible-build/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build/Makefile
@@ -81,7 +81,7 @@ extern_flags:
 fat_lto:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
 	$(RUSTC) reproducible-build-aux.rs
-	$(RUSTC) reproducible-build.rs -C lto=fat -C opt-level=1
+	$(RUSTC) reproducible-build.rs -C lto=fat
 	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
-	$(RUSTC) reproducible-build.rs -C lto=fat -C opt-level=1
+	$(RUSTC) reproducible-build.rs -C lto=fat
 	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1

--- a/src/test/run-make-fulldeps/reproducible-build/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build/Makefile
@@ -10,7 +10,8 @@ all:  \
 	link_paths \
 	remap_paths \
 	different_source_dirs \
-	extern_flags
+	extern_flags \
+	fat_lto
 
 smoke:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
@@ -76,3 +77,11 @@ extern_flags:
 		--extern reproducible_build_aux=$(TMPDIR)/libbar.rlib \
 		--crate-type rlib
 	cmp "$(TMPDIR)/libreproducible_build.rlib" "$(TMPDIR)/libfoo.rlib" || exit 1
+
+fat_lto:
+	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) reproducible-build-aux.rs
+	$(RUSTC) reproducible-build.rs -C lto=fat
+	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
+	$(RUSTC) reproducible-build.rs -C lto=fat
+	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1

--- a/src/test/run-make-fulldeps/reproducible-build/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build/Makefile
@@ -81,7 +81,7 @@ extern_flags:
 fat_lto:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
 	$(RUSTC) reproducible-build-aux.rs
-	$(RUSTC) reproducible-build.rs -C lto=fat
+	$(RUSTC) reproducible-build.rs -C lto=fat -C opt-level=1
 	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
-	$(RUSTC) reproducible-build.rs -C lto=fat
+	$(RUSTC) reproducible-build.rs -C lto=fat -C opt-level=1
 	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn return_targets_async_block_not_fn() -> u8 {
    |    ---------------------------------      ^^ expected u8, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u8`
               found type `()`
@@ -57,7 +57,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_fn() -> Result<u8, MyErr> {
    |    ----------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`
@@ -68,7 +68,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_async_fn() -> Result<u8, MyErr> {
    |    ----------------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-27042.stderr
+++ b/src/test/ui/issues/issue-27042.stderr
@@ -12,10 +12,13 @@ error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:6:16
    |
 LL |         loop { break };
-   |                ^^^^^ expected (), found i32
+   |                ^^^^^
+   |                |
+   |                expected i32, found ()
+   |                help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:8:9

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function implicitly returns `()` as its body has no tail or `return` expression
+   |        implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't `return` a value
+   |        this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return a value
+   |        this function's body doesn't `return` a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return
+   |        this function's body doesn't return a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-34334.rs
+++ b/src/test/ui/issues/issue-34334.rs
@@ -5,6 +5,7 @@ fn main () {
     //~| ERROR mismatched types
     //~| ERROR invalid left-hand side expression
     //~| ERROR expected expression, found reserved identifier `_`
+    //~| ERROR expected expression, found reserved identifier `_`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR no method named `iter` found for type `()` in the current scope
 }

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -4,6 +4,12 @@ error: expected expression, found reserved identifier `_`
 LL |     let sr: Vec<(u32, _, _) = vec![];
    |                       ^ expected expression
 
+error: expected expression, found reserved identifier `_`
+  --> $DIR/issue-34334.rs:2:26
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                          ^ expected expression
+
 error: expected one of `,` or `>`, found `=`
   --> $DIR/issue-34334.rs:2:29
    |
@@ -36,12 +42,12 @@ LL |     let sr: Vec<(u32, _, _) = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ left-hand of expression not valid
 
 error[E0599]: no method named `iter` found for type `()` in the current scope
-  --> $DIR/issue-34334.rs:8:36
+  --> $DIR/issue-34334.rs:9:36
    |
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                    ^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0423, E0599.
 For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -1,11 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
+LL | struct Foo(u32);
+   | ---------------- fn(u32) -> Foo {Foo} defined here
+LL | 
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     did you mean `Foo(/* fields */)`?
+   |              |     help: use parentheses to call this function: `Foo(...)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to call this function: `Foo(...)`
+   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
+   |              |     help: use parentheses to instantiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return a value
+   |                                this function's body doesn't `return` a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return
+   |                                this function's body doesn't return a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function implicitly returns `()` as its body has no tail or `return` expression
+   |                                implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't `return` a value
+   |                                this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,7 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^
-   |                               |
-   |                               expected !, found ()
-   |                               help: give it a value of the expected type: `break value`
+   |                               ^^^^^ expected !, found ()
    |
    = note: expected type `!`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^ expected (), found !
+   |                               ^^^^^
+   |                               |
+   |                               expected !, found ()
+   |                               help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `!`
+   = note: expected type `!`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:11:19
@@ -153,10 +156,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:90:9
    |
 LL |         break;
-   |         ^^^^^ expected (), found integer
+   |         ^^^^^
+   |         |
+   |         expected integer, found ()
+   |         help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `{integer}`
+   = note: expected type `{integer}`
+              found type `()`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/loops/loop-labeled-break-value.stderr
+++ b/src/test/ui/loops/loop-labeled-break-value.stderr
@@ -2,28 +2,37 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:3:29
    |
 LL |         let _: i32 = loop { break };
-   |                             ^^^^^ expected (), found i32
+   |                             ^^^^^
+   |                             |
+   |                             expected i32, found ()
+   |                             help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:6:37
    |
 LL |         let _: i32 = 'inner: loop { break 'inner };
-   |                                     ^^^^^^^^^^^^ expected (), found i32
+   |                                     ^^^^^^^^^^^^
+   |                                     |
+   |                                     expected i32, found ()
+   |                                     help: give it a value of the expected type: `break 'inner 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:9:45
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
-   |                                             ^^^^^^^^^^^^^ expected (), found i32
+   |                                             ^^^^^^^^^^^^^
+   |                                             |
+   |                                             expected i32, found ()
+   |                                             help: give it a value of the expected type: `break 'inner2 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/loops/loop-properly-diverging-2.stderr
+++ b/src/test/ui/loops/loop-properly-diverging-2.stderr
@@ -2,10 +2,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-properly-diverging-2.rs:2:23
    |
 LL |   let x: i32 = loop { break };
-   |                       ^^^^^ expected (), found i32
+   |                       ^^^^^
+   |                       |
+   |                       expected i32, found ()
+   |                       help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-arm-resolving-to-never.rs
+++ b/src/test/ui/match/match-arm-resolving-to-never.rs
@@ -1,0 +1,19 @@
+enum E {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+}
+
+fn main() {
+    match E::F {
+        E::A => 1,
+        E::B => 2,
+        E::C => 3,
+        E::D => 4,
+        E::E => unimplemented!(""),
+        E::F => "", //~ ERROR match arms have incompatible types
+    };
+}

--- a/src/test/ui/match/match-arm-resolving-to-never.stderr
+++ b/src/test/ui/match/match-arm-resolving-to-never.stderr
@@ -1,0 +1,22 @@
+error[E0308]: match arms have incompatible types
+  --> $DIR/match-arm-resolving-to-never.rs:17:17
+   |
+LL | /     match E::F {
+LL | |         E::A => 1,
+LL | |         E::B => 2,
+LL | |         E::C => 3,
+LL | |         E::D => 4,
+LL | |         E::E => unimplemented!(""),
+   | |                 ------------------ this and all prior arms are found to be of type `{integer}`
+LL | |         E::F => "",
+   | |                 ^^ expected integer, found reference
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected type `{integer}`
+              found type `&'static str`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't `return` a value
+   |                      this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return a value
+   |                      this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function implicitly returns `()` as its body has no tail or `return` expression
+   |                      implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return
+   |                      this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/proc-macro/lifetimes.stderr
+++ b/src/test/ui/proc-macro/lifetimes.stderr
@@ -2,7 +2,7 @@ error: expected type, found `'`
   --> $DIR/lifetimes.rs:9:10
    |
 LL | type A = single_quote_alone!();
-   |          ^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^ this macro call doesn't expand to a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
+   |                    help: use parentheses to instantiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to call this function: `Z::Fn(...)`
+   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `m::E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -195,8 +195,14 @@ LL |     let _: Z = m::n::Z::Unit {};
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
+LL |             Fn(u8),
+   |             ------ fn(u8) -> m::n::Z {m::n::Z::Fn} defined here
+...
 LL |         let _: Z = Z::Fn;
-   |                    ^^^^^ expected enum `m::n::Z`, found fn item
+   |                    ^^^^^
+   |                    |
+   |                    expected enum `m::n::Z`, found fn item
+   |                    help: use parentheses to call this function: `Z::Fn(...)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -219,8 +225,14 @@ LL |         let _ = Z::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = m::E::Fn;
-   |                ^^^^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `m::E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -243,8 +255,14 @@ LL |     let _: E = m::E::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = E::Fn;
-   |                ^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
+   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/specialization/issue-36804.rs
+++ b/src/test/ui/specialization/issue-36804.rs
@@ -1,0 +1,31 @@
+// check-pass
+#![feature(specialization)]
+
+pub struct Cloned<I>(I);
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+where
+    I: Iterator<Item = &'a T>,
+    T: Clone,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        unimplemented!()
+    }
+}
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+where
+    I: Iterator<Item = &'a T>,
+    T: Copy,
+{
+    fn count(self) -> usize {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    let a = [1,2,3,4];
+    Cloned(a.iter()).count();
+}

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<'static>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<'static>}`

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<ReStatic>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<ReStatic>}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
@@ -1,0 +1,19 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+struct S(usize, usize);
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+}
+
+fn main() {
+    let _: usize = foo(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: S = S(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: usize = T::baz(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
@@ -1,0 +1,38 @@
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:24
+   |
+LL |     let _: usize = foo(_, _);
+   |                        ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:27
+   |
+LL |     let _: usize = foo(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:18
+   |
+LL |     let _: S = S(_, _);
+   |                  ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:21
+   |
+LL |     let _: S = S(_, _);
+   |                     ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:27
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:30
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                              ^ expected expression
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -11,7 +11,18 @@ struct V();
 
 trait T {
     fn baz(x: usize, y: usize) -> usize { x }
-    fn bat() -> usize { 42 }
+    fn bat(x: usize) -> usize { 42 }
+    fn bax(x: usize) -> usize { 42 }
+    fn bach(x: usize) -> usize;
+    fn ban(&self) -> usize { 42 }
+    fn bal(&self) -> usize;
+}
+
+struct X;
+
+impl T for X {
+    fn bach(x: usize) -> usize { 42 }
+    fn bal(&self) -> usize { 42 }
 }
 
 fn main() {
@@ -23,4 +34,12 @@ fn main() {
     let _: usize = T::bat; //~ ERROR mismatched types
     let _: E = E::A; //~ ERROR mismatched types
     let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
+    let _: usize = X::baz; //~ ERROR mismatched types
+    let _: usize = X::bat; //~ ERROR mismatched types
+    let _: usize = X::bax; //~ ERROR mismatched types
+    let _: usize = X::bach; //~ ERROR mismatched types
+    let _: usize = X::ban; //~ ERROR mismatched types
+    let _: usize = X::bal; //~ ERROR mismatched types
+    let _: usize = X.ban; //~ ERROR attempted to take value of method
+    let _: usize = X.bal; //~ ERROR attempted to take value of method
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -1,0 +1,20 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+fn bar() -> usize { 42 }
+
+struct S(usize, usize);
+struct V();
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+    fn bat() -> usize { 42 }
+}
+
+fn main() {
+    let _: usize = foo; //~ ERROR mismatched types
+    let _: S = S; //~ ERROR mismatched types
+    let _: usize = bar; //~ ERROR mismatched types
+    let _: V = V; //~ ERROR mismatched types
+    let _: usize = T::baz; //~ ERROR mismatched types
+    let _: usize = T::bat; //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -3,6 +3,10 @@ fn foo(a: usize, b: usize) -> usize { a }
 fn bar() -> usize { 42 }
 
 struct S(usize, usize);
+enum E {
+    A(usize),
+    B { a: usize },
+}
 struct V();
 
 trait T {
@@ -17,4 +21,6 @@ fn main() {
     let _: V = V; //~ ERROR mismatched types
     let _: usize = T::baz; //~ ERROR mismatched types
     let _: usize = T::bat; //~ ERROR mismatched types
+    let _: E = E::A; //~ ERROR mismatched types
+    let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -32,7 +32,7 @@ LL |     let _: S = S;
    |                ^
    |                |
    |                expected struct `S`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |                help: use parentheses to instantiate this tuple struct: `S(_, _)`
    |
    = note: expected type `S`
               found type `fn(usize, usize) -> S {S}`
@@ -62,7 +62,7 @@ LL |     let _: V = V;
    |                ^
    |                |
    |                expected struct `V`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |                help: use parentheses to instantiate this tuple struct: `V()`
    |
    = note: expected type `V`
               found type `fn() -> V {V}`
@@ -107,7 +107,7 @@ LL |     let _: E = E::A;
    |                ^^^^
    |                |
    |                expected enum `E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::A(_)`
    |
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,5 @@
 error[E0423]: expected value, found struct variant `E::B`
-  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:36:16
    |
 LL |     let _: E = E::B;
    |                ^^^-
@@ -8,7 +8,7 @@ LL |     let _: E = E::B;
    |                did you mean `E::B { /* fields */ }`?
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:29:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -23,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -38,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -53,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -68,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -77,28 +77,28 @@ LL |     let _: usize = T::baz;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::baz(...)`
+   |                    help: use parentheses to call this function: `T::baz(x, y)`
    |
    = note: expected type `usize`
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
    |
-LL |     fn bat() -> usize { 42 }
-   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
 ...
 LL |     let _: usize = T::bat;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::bat()`
+   |                    help: use parentheses to call this function: `T::bat(x)`
    |
    = note: expected type `usize`
-              found type `fn() -> usize {<_ as T>::bat}`
+              found type `fn(usize) -> usize {<_ as T>::bat}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
    |     -------- fn(usize) -> E {E::A} defined here
@@ -112,7 +112,109 @@ LL |     let _: E = E::A;
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`
 
-error: aborting due to 8 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
+...
+LL |     let _: usize = X::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::baz(x, y)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<X as T>::baz}`
 
-Some errors have detailed explanations: E0308, E0423.
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
+   |
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
+...
+LL |     let _: usize = X::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bat(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bat}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
+   |
+LL |     fn bax(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
+...
+LL |     let _: usize = X::bax;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bax(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bax}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
+   |
+LL |     fn bach(x: usize) -> usize;
+   |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
+...
+LL |     let _: usize = X::bach;
+   |                    ^^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bach(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bach}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
+   |
+LL |     fn ban(&self) -> usize { 42 }
+   |     ---------------------- for<'r> fn(&'r X) -> usize {<X as T>::ban} defined here
+...
+LL |     let _: usize = X::ban;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::ban(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::ban}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
+   |
+LL |     fn bal(&self) -> usize;
+   |     ----------------------- for<'r> fn(&'r X) -> usize {<X as T>::bal} defined here
+...
+LL |     let _: usize = X::bal;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bal(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::bal}`
+
+error[E0615]: attempted to take value of method `ban` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:43:22
+   |
+LL |     let _: usize = X.ban;
+   |                      ^^^ help: use parentheses to call the method: `ban()`
+
+error[E0615]: attempted to take value of method `bal` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:44:22
+   |
+LL |     let _: usize = X.bal;
+   |                      ^^^ help: use parentheses to call the method: `bal()`
+
+error: aborting due to 16 previous errors
+
+Some errors have detailed explanations: E0308, E0423, E0615.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,14 @@
+error[E0423]: expected value, found struct variant `E::B`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+   |
+LL |     let _: E = E::B;
+   |                ^^^-
+   |                |  |
+   |                |  help: a tuple variant with a similar name exists: `A`
+   |                did you mean `E::B { /* fields */ }`?
+
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -14,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -29,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -44,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -59,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -74,7 +83,7 @@ LL |     let _: usize = T::baz;
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
    |
 LL |     fn bat() -> usize { 42 }
    |     ----------------- fn() -> usize {<_ as T>::bat} defined here
@@ -88,6 +97,22 @@ LL |     let _: usize = T::bat;
    = note: expected type `usize`
               found type `fn() -> usize {<_ as T>::bat}`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+   |
+LL |     A(usize),
+   |     -------- fn(usize) -> E {E::A} defined here
+...
+LL |     let _: E = E::A;
+   |                ^^^^
+   |                |
+   |                expected enum `E`, found fn item
+   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |
+   = note: expected type `E`
+              found type `fn(usize) -> E {E::A}`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0423.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,0 +1,93 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+   |
+LL | fn foo(a: usize, b: usize) -> usize { a }
+   | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
+...
+LL |     let _: usize = foo;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `foo(a, b)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {foo}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+   |
+LL | struct S(usize, usize);
+   | ----------------------- fn(usize, usize) -> S {S} defined here
+...
+LL |     let _: S = S;
+   |                ^
+   |                |
+   |                expected struct `S`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |
+   = note: expected type `S`
+              found type `fn(usize, usize) -> S {S}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+   |
+LL | fn bar() -> usize { 42 }
+   | ----------------- fn() -> usize {bar} defined here
+...
+LL |     let _: usize = bar;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `bar()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {bar}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+   |
+LL | struct V();
+   | ----------- fn() -> V {V} defined here
+...
+LL |     let _: V = V;
+   |                ^
+   |                |
+   |                expected struct `V`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |
+   = note: expected type `V`
+              found type `fn() -> V {V}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
+...
+LL |     let _: usize = T::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::baz(...)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<_ as T>::baz}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+   |
+LL |     fn bat() -> usize { 42 }
+   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+...
+LL |     let _: usize = T::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::bat()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {<_ as T>::bat}`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/vec-macro-in-pattern.fixed
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.fixed
@@ -2,7 +2,7 @@
 fn main() {
     // everything after `.as_ref` should be suggested
     match Some(vec![3]).as_ref().map(|v| v.as_slice()) {
-        Some(vec![_x]) => (), //~ ERROR unexpected `(` after qualified path
+        Some([_x]) => (), //~ ERROR unexpected `(` after qualified path
         _ => (),
     }
 }

--- a/src/test/ui/suggestions/vec-macro-in-pattern.rs
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.rs
@@ -1,0 +1,6 @@
+fn main() {
+    match Some(vec![3]) {
+        Some(vec![x]) => (), //~ ERROR unexpected `(` after qualified path
+        _ => (),
+    }
+}

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,0 +1,15 @@
+error: unexpected `(` after qualified path
+  --> $DIR/vec-macro-in-pattern.rs:3:14
+   |
+LL |         Some(vec![x]) => (),
+   |              ^^^^^^^
+   |              |
+   |              unexpected `(` after qualified path
+   |              in this macro invocation
+   |              use a slice pattern here instead
+   |
+   = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,12 +1,12 @@
 error: unexpected `(` after qualified path
-  --> $DIR/vec-macro-in-pattern.rs:3:14
+  --> $DIR/vec-macro-in-pattern.rs:5:14
    |
-LL |         Some(vec![x]) => (),
-   |              ^^^^^^^
+LL |         Some(vec![_x]) => (),
+   |              ^^^^^^^^
    |              |
    |              unexpected `(` after qualified path
    |              in this macro invocation
-   |              use a slice pattern here instead
+   |              help: use a slice pattern here instead: `[_x]`
    |
    = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -6,6 +6,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   |     |
    |                   |     expected type
    |                   |     in this macro invocation
+   |                   |     this macro call doesn't expand to a type
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`

--- a/src/test/ui/typeid-intrinsic.rs
+++ b/src/test/ui/typeid-intrinsic.rs
@@ -78,10 +78,20 @@ pub fn main() {
     assert_eq!(TypeId::of::<other1::U32Iterator>(), other1::id_u32_iterator());
     assert_eq!(other1::id_i32_iterator(), other2::id_i32_iterator());
     assert_eq!(other1::id_u32_iterator(), other2::id_u32_iterator());
-    assert!(other1::id_i32_iterator() != other1::id_u32_iterator());
-    assert!(TypeId::of::<other1::I32Iterator>() != TypeId::of::<other1::U32Iterator>());
+    assert_ne!(other1::id_i32_iterator(), other1::id_u32_iterator());
+    assert_ne!(TypeId::of::<other1::I32Iterator>(), TypeId::of::<other1::U32Iterator>());
 
     // Check fn pointer against collisions
-    assert!(TypeId::of::<fn(fn(A) -> A) -> A>() !=
-            TypeId::of::<fn(fn() -> A, A) -> A>());
+    assert_ne!(
+        TypeId::of::<fn(fn(A) -> A) -> A>(),
+        TypeId::of::<fn(fn() -> A, A) -> A>()
+    );
+    assert_ne!(
+        TypeId::of::<for<'a> fn(&'a i32) -> &'a i32>(),
+        TypeId::of::<for<'a> fn(&'a i32) -> &'static i32>()
+    );
+    assert_ne!(
+        TypeId::of::<for<'a, 'b> fn(&'a i32, &'b i32) -> &'a i32>(),
+        TypeId::of::<for<'a, 'b> fn(&'b i32, &'a i32) -> &'a i32>()
+    );
 }


### PR DESCRIPTION
Successful merges:

 - #62756 (Stabilize duration_float)
 - #62860 (Stabilize checked_duration_since for 1.38.0)
 - #63337 (Tweak mismatched types error)
 - #63350 (Use associated_type_bounds where applicable - closes #61738)
 - #63352 (Sort the fat LTO modules to produce deterministic output.)
 - #63394 (Add test for issue 36804)
 - #63399 (More explicit diagnostic when using a `vec![]` in a pattern)
 - #63419 (check against more collisions for TypeId of fn pointer)

Failed merges:


r? @ghost