### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/liballoc/borrow.rs
+++ b/src/liballoc/borrow.rs
@@ -329,8 +329,8 @@ impl<'a, B: ?Sized> PartialOrd for Cow<'a, B>
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: ?Sized> fmt::Debug for Cow<'_, B>
-    where B: fmt::Debug + ToOwned,
-          <B as ToOwned>::Owned: fmt::Debug
+where
+    B: fmt::Debug + ToOwned<Owned: fmt::Debug>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -342,8 +342,8 @@ impl<B: ?Sized> fmt::Debug for Cow<'_, B>
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<B: ?Sized> fmt::Display for Cow<'_, B>
-    where B: fmt::Display + ToOwned,
-          <B as ToOwned>::Owned: fmt::Display
+where
+    B: fmt::Display + ToOwned<Owned: fmt::Display>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -355,8 +355,8 @@ impl<B: ?Sized> fmt::Display for Cow<'_, B>
 
 #[stable(feature = "default", since = "1.11.0")]
 impl<B: ?Sized> Default for Cow<'_, B>
-    where B: ToOwned,
-          <B as ToOwned>::Owned: Default
+where
+    B: ToOwned<Owned: Default>,
 {
     /// Creates an owned Cow<'a, B> with the default value for the contained owned value.
     fn default() -> Self {

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -122,6 +122,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 // Allow testing this library
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -8,6 +8,7 @@
 #![feature(trusted_len)]
 #![feature(try_reserve)]
 #![feature(unboxed_closures)]
+#![feature(associated_type_bounds)]
 
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -1638,10 +1638,12 @@ mod pattern {
         }
     }
 
-    fn cmp_search_to_vec<'a, P: Pattern<'a>>(rev: bool, pat: P, haystack: &'a str,
-                                             right: Vec<SearchStep>)
-    where P::Searcher: ReverseSearcher<'a>
-    {
+    fn cmp_search_to_vec<'a>(
+        rev: bool,
+        pat: impl Pattern<'a, Searcher: ReverseSearcher<'a>>,
+        haystack: &'a str,
+        right: Vec<SearchStep>
+    ) {
         let mut searcher = pat.into_searcher(haystack);
         let mut v = vec![];
         loop {

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -133,6 +133,14 @@ pub trait Clone : Sized {
     }
 }
 
+/// Derive macro generating an impl of the trait `Clone`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+pub macro Clone($item:item) { /* compiler built-in */ }
+
 // FIXME(aburka): these structs are used solely by #[derive] to
 // assert that every component of a type implements Clone or Copy.
 //

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -200,6 +200,14 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     fn ne(&self, other: &Rhs) -> bool { !self.eq(other) }
 }
 
+/// Derive macro generating an impl of the trait `PartialEq`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro PartialEq($item:item) { /* compiler built-in */ }
+
 /// Trait for equality comparisons which are [equivalence relations](
 /// https://en.wikipedia.org/wiki/Equivalence_relation).
 ///
@@ -255,6 +263,14 @@ pub trait Eq: PartialEq<Self> {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn assert_receiver_is_total_eq(&self) {}
 }
+
+/// Derive macro generating an impl of the trait `Eq`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_eq)]
+pub macro Eq($item:item) { /* compiler built-in */ }
 
 // FIXME: this struct is used solely by #[derive] to
 // assert that every component of a type implements Eq.
@@ -600,6 +616,14 @@ pub trait Ord: Eq + PartialOrd<Self> {
     }
 }
 
+/// Derive macro generating an impl of the trait `Ord`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro Ord($item:item) { /* compiler built-in */ }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Eq for Ordering {}
 
@@ -841,6 +865,14 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
         }
     }
 }
+
+/// Derive macro generating an impl of the trait `PartialOrd`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro PartialOrd($item:item) { /* compiler built-in */ }
 
 /// Compares and returns the minimum of two values.
 ///

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -513,7 +513,7 @@ impl<T: ?Sized, U: ?Sized> AsRef<U> for &mut T where T: AsRef<U>
 
 // FIXME (#45742): replace the above impls for &/&mut with the following more general one:
 // // As lifts over Deref
-// impl<D: ?Sized + Deref, U: ?Sized> AsRef<U> for D where D::Target: AsRef<U> {
+// impl<D: ?Sized + Deref<Target: AsRef<U>>, U: ?Sized> AsRef<U> for D {
 //     fn as_ref(&self) -> &U {
 //         self.deref().as_ref()
 //     }
@@ -530,7 +530,7 @@ impl<T: ?Sized, U: ?Sized> AsMut<U> for &mut T where T: AsMut<U>
 
 // FIXME (#45742): replace the above impl for &mut with the following more general one:
 // // AsMut lifts over DerefMut
-// impl<D: ?Sized + Deref, U: ?Sized> AsMut<U> for D where D::Target: AsMut<U> {
+// impl<D: ?Sized + Deref<Target: AsMut<U>>, U: ?Sized> AsMut<U> for D {
 //     fn as_mut(&mut self) -> &mut U {
 //         self.deref_mut().as_mut()
 //     }

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -115,6 +115,14 @@ pub trait Default: Sized {
     fn default() -> Self;
 }
 
+/// Derive macro generating an impl of the trait `Default`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics)]
+pub macro Default($item:item) { /* compiler built-in */ }
+
 macro_rules! default_impl {
     ($t:ty, $v:expr, $doc:tt) => {
         #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -545,6 +545,21 @@ pub trait Debug {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result;
 }
 
+// Separate module to reexport the macro `Debug` from prelude without the trait `Debug`.
+#[cfg(not(bootstrap))]
+pub(crate) mod macros {
+    /// Derive macro generating an impl of the trait `Debug`.
+    #[rustc_builtin_macro]
+    #[rustc_macro_transparency = "semitransparent"]
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    #[allow_internal_unstable(core_intrinsics)]
+    pub macro Debug($item:item) { /* compiler built-in */ }
+}
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(inline)]
+pub use macros::Debug;
+
 /// Format trait for an empty format, `{}`.
 ///
 /// `Display` is similar to [`Debug`][debug], but `Display` is for user-facing

--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -111,8 +111,7 @@ impl<F: ?Sized + Future + Unpin> Future for &mut F {
 #[stable(feature = "futures_api", since = "1.36.0")]
 impl<P> Future for Pin<P>
 where
-    P: Unpin + ops::DerefMut,
-    P::Target: Future,
+    P: Unpin + ops::DerefMut<Target: Future>,
 {
     type Output = <<P as ops::Deref>::Target as Future>::Output;
 

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -198,6 +198,21 @@ pub trait Hash {
     }
 }
 
+// Separate module to reexport the macro `Hash` from prelude without the trait `Hash`.
+#[cfg(not(bootstrap))]
+pub(crate) mod macros {
+    /// Derive macro generating an impl of the trait `Hash`.
+    #[rustc_builtin_macro]
+    #[rustc_macro_transparency = "semitransparent"]
+    #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+    #[allow_internal_unstable(core_intrinsics)]
+    pub macro Hash($item:item) { /* compiler built-in */ }
+}
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(inline)]
+pub use macros::Hash;
+
 /// A trait for hashing an arbitrary stream of bytes.
 ///
 /// Instances of `Hasher` usually represent state that is changed while hashing

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -195,8 +195,8 @@ pub trait FromIterator<A>: Sized {
 ///
 /// ```rust
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
-///     where T: IntoIterator,
-///           T::Item: std::fmt::Debug,
+/// where
+///     T: IntoIterator<Item: std::fmt::Debug>,
 /// {
 ///     collection
 ///         .into_iter()

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -194,11 +194,10 @@ pub trait FromIterator<A>: Sized {
 /// `Item`:
 ///
 /// ```rust
-/// #![feature(associated_type_bounds)]
-///
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
 /// where
-///     T: IntoIterator<Item: std::fmt::Debug>,
+///     T: IntoIterator,
+///     T::Item: std::fmt::Debug,
 /// {
 ///     collection
 ///         .into_iter()

--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -194,6 +194,8 @@ pub trait FromIterator<A>: Sized {
 /// `Item`:
 ///
 /// ```rust
+/// #![feature(associated_type_bounds)]
+///
 /// fn collect_as_strings<T>(collection: T) -> Vec<String>
 /// where
 ///     T: IntoIterator<Item: std::fmt::Debug>,

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -132,6 +132,7 @@
 #![feature(maybe_uninit_slice, maybe_uninit_array)]
 #![feature(external_doc)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -714,9 +714,9 @@ pub(crate) mod builtin {
     /// [`panic!`]: ../std/macro.panic.html
     #[stable(feature = "compile_error_macro", since = "1.20.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro compile_error {
-        ($msg:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! compile_error {
+        ($msg:expr) => ({ /* compiler built-in */ });
         ($msg:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -768,8 +768,10 @@ pub(crate) mod builtin {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
-    pub macro format_args {
-        ($fmt:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    #[rustc_macro_transparency = "opaque"]
+    macro_rules! format_args {
+        ($fmt:expr) => ({ /* compiler built-in */ });
         ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
     }
 
@@ -779,8 +781,10 @@ pub(crate) mod builtin {
                          language use and is subject to change")]
     #[allow_internal_unstable(fmt_internals)]
     #[rustc_builtin_macro]
-    pub macro format_args_nl {
-        ($fmt:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    #[rustc_macro_transparency = "opaque"]
+    macro_rules! format_args_nl {
+        ($fmt:expr) => ({ /* compiler built-in */ });
         ($fmt:expr, $($args:tt)*) => ({ /* compiler built-in */ })
     }
 
@@ -817,9 +821,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro env {
-        ($name:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! env {
+        ($name:expr) => ({ /* compiler built-in */ });
         ($name:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -844,9 +848,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro option_env {
-        ($name:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! option_env {
+        ($name:expr) => ({ /* compiler built-in */ });
         ($name:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -877,9 +881,9 @@ pub(crate) mod builtin {
     #[unstable(feature = "concat_idents", issue = "29599",
                reason = "`concat_idents` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro concat_idents {
-        ($($e:ident),+) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! concat_idents {
+        ($($e:ident),+) => ({ /* compiler built-in */ });
         ($($e:ident,)+) => ({ /* compiler built-in */ })
     }
 
@@ -900,9 +904,9 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro concat {
-        ($($e:expr),*) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! concat {
+        ($($e:expr),*) => ({ /* compiler built-in */ });
         ($($e:expr,)*) => ({ /* compiler built-in */ })
     }
 
@@ -929,8 +933,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro line() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! line { () => { /* compiler built-in */ } }
 
     /// Expands to the column number at which it was invoked.
     ///
@@ -955,15 +959,15 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro column() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! column { () => { /* compiler built-in */ } }
 
     /// Same as `column`, but less likely to be shadowed.
     #[unstable(feature = "__rust_unstable_column", issue = "0",
                reason = "internal implementation detail of the `panic` macro")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro __rust_unstable_column() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! __rust_unstable_column { () => { /* compiler built-in */ } }
 
     /// Expands to the file name in which it was invoked.
     ///
@@ -987,8 +991,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro file() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! file { () => { /* compiler built-in */ } }
 
     /// Stringifies its arguments.
     ///
@@ -1007,8 +1011,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro stringify($($t:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! stringify { ($($t:tt)*) => { /* compiler built-in */ } }
 
     /// Includes a utf8-encoded file as a string.
     ///
@@ -1042,9 +1046,9 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include_str {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include_str {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1080,9 +1084,9 @@ pub(crate) mod builtin {
     /// Compiling 'main.rs' and running the resulting binary will print "adiós".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include_bytes {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include_bytes {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1105,8 +1109,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro module_path() { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! module_path { () => { /* compiler built-in */ } }
 
     /// Evaluates boolean combinations of configuration flags at compile-time.
     ///
@@ -1130,8 +1134,8 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro cfg($($cfg:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! cfg { ($($cfg:tt)*) => { /* compiler built-in */ } }
 
     /// Parses a file as an expression or an item according to the context.
     ///
@@ -1174,9 +1178,9 @@ pub(crate) mod builtin {
     /// "🙈🙊🙉🙈🙊🙉".
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro include {
-        ($file:expr) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! include {
+        ($file:expr) => ({ /* compiler built-in */ });
         ($file:expr,) => ({ /* compiler built-in */ })
     }
 
@@ -1227,10 +1231,10 @@ pub(crate) mod builtin {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro assert {
-        ($cond:expr) => ({ /* compiler built-in */ }),
-        ($cond:expr,) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! assert {
+        ($cond:expr) => ({ /* compiler built-in */ });
+        ($cond:expr,) => ({ /* compiler built-in */ });
         ($cond:expr, $($arg:tt)+) => ({ /* compiler built-in */ })
     }
 
@@ -1238,34 +1242,34 @@ pub(crate) mod builtin {
     #[unstable(feature = "asm", issue = "29722",
                reason = "inline assembly is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro asm("assembly template"
-                  : $("output"(operand),)*
-                  : $("input"(operand),)*
-                  : $("clobbers",)*
-                  : $("options",)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! asm { ("assembly template"
+                        : $("output"(operand),)*
+                        : $("input"(operand),)*
+                        : $("clobbers",)*
+                        : $("options",)*) => { /* compiler built-in */ } }
 
     /// Module-level inline assembly.
     #[unstable(feature = "global_asm", issue = "35119",
                reason = "`global_asm!` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro global_asm("assembly") { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! global_asm { ("assembly") => { /* compiler built-in */ } }
 
     /// Prints passed tokens into the standard output.
     #[unstable(feature = "log_syntax", issue = "29598",
                reason = "`log_syntax!` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro log_syntax($($arg:tt)*) { /* compiler built-in */ }
+    #[macro_export]
+    macro_rules! log_syntax { ($($arg:tt)*) => { /* compiler built-in */ } }
 
     /// Enables or disables tracing functionality used for debugging other macros.
     #[unstable(feature = "trace_macros", issue = "29598",
                reason = "`trace_macros` is not stable enough for use and is subject to change")]
     #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    pub macro trace_macros {
-        (true) => ({ /* compiler built-in */ }),
+    #[macro_export]
+    macro_rules! trace_macros {
+        (true) => ({ /* compiler built-in */ });
         (false) => ({ /* compiler built-in */ })
     }
 
@@ -1298,69 +1302,6 @@ pub(crate) mod builtin {
     #[rustc_builtin_macro]
     #[rustc_macro_transparency = "semitransparent"]
     pub macro global_allocator($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Clone`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
-    pub macro Clone($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Copy`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
-    pub macro Copy($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Debug`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Debug($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Default`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Default($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Eq`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics, derive_eq)]
-    pub macro Eq($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Hash`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Hash($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `Ord`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro Ord($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `PartialEq`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro PartialEq($item:item) { /* compiler built-in */ }
-
-    /// Derive macro generating an impl of the trait `PartialOrd`.
-    #[rustc_builtin_macro]
-    #[rustc_macro_transparency = "semitransparent"]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[allow_internal_unstable(core_intrinsics)]
-    pub macro PartialOrd($item:item) { /* compiler built-in */ }
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -288,6 +288,14 @@ pub trait Copy : Clone {
     // Empty.
 }
 
+/// Derive macro generating an impl of the trait `Copy`.
+#[cfg(not(bootstrap))]
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow_internal_unstable(core_intrinsics, derive_clone_copy)]
+pub macro Copy($item:item) { /* compiler built-in */ }
+
 /// Types for which it is safe to share references between threads.
 ///
 /// This trait is automatically implemented when the compiler determines

--- a/src/libcore/pin.rs
+++ b/src/libcore/pin.rs
@@ -439,10 +439,7 @@ where
     }
 }
 
-impl<P: Deref> Pin<P>
-where
-    P::Target: Unpin,
-{
+impl<P: Deref<Target: Unpin>> Pin<P> {
     /// Construct a new `Pin<P>` around a pointer to some data of a type that
     /// implements [`Unpin`].
     ///
@@ -730,10 +727,7 @@ impl<P: Deref> Deref for Pin<P> {
 }
 
 #[stable(feature = "pin", since = "1.33.0")]
-impl<P: DerefMut> DerefMut for Pin<P>
-where
-    P::Target: Unpin
-{
+impl<P: DerefMut<Target: Unpin>> DerefMut for Pin<P> {
     fn deref_mut(&mut self) -> &mut P::Target {
         Pin::get_mut(Pin::as_mut(self))
     }

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -48,24 +48,20 @@ pub use crate::result::Result::{self, Ok, Err};
 // Re-exported built-in macros
 #[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-#[allow(deprecated)]
 #[doc(no_inline)]
-pub use crate::macros::builtin::{
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    RustcDecodable,
-    RustcEncodable,
+pub use crate::fmt::macros::Debug;
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::hash::macros::Hash;
+
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[doc(no_inline)]
+pub use crate::{
     __rust_unstable_column,
     asm,
     assert,
-    bench,
     cfg,
     column,
     compile_error,
@@ -75,7 +71,6 @@ pub use crate::macros::builtin::{
     file,
     format_args,
     format_args_nl,
-    global_allocator,
     global_asm,
     include,
     include_bytes,
@@ -85,7 +80,18 @@ pub use crate::macros::builtin::{
     module_path,
     option_env,
     stringify,
+    trace_macros,
+};
+
+#[cfg(not(bootstrap))]
+#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[allow(deprecated)]
+#[doc(no_inline)]
+pub use crate::macros::builtin::{
+    RustcDecodable,
+    RustcEncodable,
+    bench,
+    global_allocator,
     test,
     test_case,
-    trace_macros,
 };

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -851,8 +851,9 @@ unsafe impl TrustedRandomAccess for Bytes<'_> {
 /// wrapper types of the form X<'a, P>
 macro_rules! derive_pattern_clone {
     (clone $t:ident with |$s:ident| $e:expr) => {
-        impl<'a, P: Pattern<'a>> Clone for $t<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $t<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 let $s = self;
@@ -928,8 +929,9 @@ macro_rules! generate_pattern_iterators {
         pub struct $forward_iterator<'a, P: Pattern<'a>>($internal_iterator<'a, P>);
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> fmt::Debug for $forward_iterator<'a, P>
-            where P::Searcher: fmt::Debug
+        impl<'a, P> fmt::Debug for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: fmt::Debug>,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple(stringify!($forward_iterator))
@@ -949,8 +951,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Clone for $forward_iterator<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 $forward_iterator(self.0.clone())
@@ -962,8 +965,9 @@ macro_rules! generate_pattern_iterators {
         pub struct $reverse_iterator<'a, P: Pattern<'a>>($internal_iterator<'a, P>);
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> fmt::Debug for $reverse_iterator<'a, P>
-            where P::Searcher: fmt::Debug
+        impl<'a, P> fmt::Debug for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: fmt::Debug>,
         {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_tuple(stringify!($reverse_iterator))
@@ -973,8 +977,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Iterator for $reverse_iterator<'a, P>
-            where P::Searcher: ReverseSearcher<'a>
+        impl<'a, P> Iterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
         {
             type Item = $iterty;
 
@@ -985,8 +990,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> Clone for $reverse_iterator<'a, P>
-            where P::Searcher: Clone
+        impl<'a, P> Clone for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: Clone>,
         {
             fn clone(&self) -> Self {
                 $reverse_iterator(self.0.clone())
@@ -997,8 +1003,10 @@ macro_rules! generate_pattern_iterators {
         impl<'a, P: Pattern<'a>> FusedIterator for $forward_iterator<'a, P> {}
 
         #[stable(feature = "fused", since = "1.26.0")]
-        impl<'a, P: Pattern<'a>> FusedIterator for $reverse_iterator<'a, P>
-            where P::Searcher: ReverseSearcher<'a> {}
+        impl<'a, P> FusedIterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
+        {}
 
         generate_pattern_iterators!($($t)* with $(#[$common_stability_attribute])*,
                                                 $forward_iterator,
@@ -1010,8 +1018,9 @@ macro_rules! generate_pattern_iterators {
                            $reverse_iterator:ident, $iterty:ty
     } => {
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> DoubleEndedIterator for $forward_iterator<'a, P>
-            where P::Searcher: DoubleEndedSearcher<'a>
+        impl<'a, P> DoubleEndedIterator for $forward_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
         {
             #[inline]
             fn next_back(&mut self) -> Option<$iterty> {
@@ -1020,8 +1029,9 @@ macro_rules! generate_pattern_iterators {
         }
 
         $(#[$common_stability_attribute])*
-        impl<'a, P: Pattern<'a>> DoubleEndedIterator for $reverse_iterator<'a, P>
-            where P::Searcher: DoubleEndedSearcher<'a>
+        impl<'a, P> DoubleEndedIterator for $reverse_iterator<'a, P>
+        where
+            P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
         {
             #[inline]
             fn next_back(&mut self) -> Option<$iterty> {
@@ -1049,7 +1059,10 @@ struct SplitInternal<'a, P: Pattern<'a>> {
     finished: bool,
 }
 
-impl<'a, P: Pattern<'a>> fmt::Debug for SplitInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for SplitInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitInternal")
             .field("start", &self.start)
@@ -1166,7 +1179,10 @@ struct SplitNInternal<'a, P: Pattern<'a>> {
     count: usize,
 }
 
-impl<'a, P: Pattern<'a>> fmt::Debug for SplitNInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for SplitNInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SplitNInternal")
             .field("iter", &self.iter)
@@ -1222,7 +1238,10 @@ derive_pattern_clone!{
 
 struct MatchIndicesInternal<'a, P: Pattern<'a>>(P::Searcher);
 
-impl<'a, P: Pattern<'a>> fmt::Debug for MatchIndicesInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for MatchIndicesInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("MatchIndicesInternal")
             .field(&self.0)
@@ -1273,7 +1292,10 @@ derive_pattern_clone!{
 
 struct MatchesInternal<'a, P: Pattern<'a>>(P::Searcher);
 
-impl<'a, P: Pattern<'a>> fmt::Debug for MatchesInternal<'a, P> where P::Searcher: fmt::Debug {
+impl<'a, P> fmt::Debug for MatchesInternal<'a, P>
+where
+    P: Pattern<'a, Searcher: fmt::Debug>,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("MatchesInternal")
             .field(&self.0)
@@ -2882,8 +2904,9 @@ impl str {
     /// assert!(!bananas.ends_with("nana"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn ends_with<'a, P: Pattern<'a>>(&'a self, pat: P) -> bool
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn ends_with<'a, P>(&'a self, pat: P) -> bool
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         pat.is_suffix_of(self)
     }
@@ -2975,8 +2998,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rfind<'a, P: Pattern<'a>>(&'a self, pat: P) -> Option<usize>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rfind<'a, P>(&'a self, pat: P) -> Option<usize>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         pat.into_searcher(self).next_match_back().map(|(i, _)| i)
     }
@@ -3142,8 +3166,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplit<'a, P: Pattern<'a>>(&'a self, pat: P) -> RSplit<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplit<'a, P>(&'a self, pat: P) -> RSplit<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplit(self.split(pat).0)
     }
@@ -3233,8 +3258,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplit_terminator<'a, P: Pattern<'a>>(&'a self, pat: P) -> RSplitTerminator<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplit_terminator<'a, P>(&'a self, pat: P) -> RSplitTerminator<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplitTerminator(self.split_terminator(pat).0)
     }
@@ -3333,8 +3359,9 @@ impl str {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
-    pub fn rsplitn<'a, P: Pattern<'a>>(&'a self, n: usize, pat: P) -> RSplitN<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rsplitn<'a, P>(&'a self, n: usize, pat: P) -> RSplitN<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RSplitN(self.splitn(n, pat).0)
     }
@@ -3406,8 +3433,9 @@ impl str {
     /// ```
     #[stable(feature = "str_matches", since = "1.2.0")]
     #[inline]
-    pub fn rmatches<'a, P: Pattern<'a>>(&'a self, pat: P) -> RMatches<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rmatches<'a, P>(&'a self, pat: P) -> RMatches<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RMatches(self.matches(pat).0)
     }
@@ -3491,8 +3519,9 @@ impl str {
     /// ```
     #[stable(feature = "str_match_indices", since = "1.5.0")]
     #[inline]
-    pub fn rmatch_indices<'a, P: Pattern<'a>>(&'a self, pat: P) -> RMatchIndices<'a, P>
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn rmatch_indices<'a, P>(&'a self, pat: P) -> RMatchIndices<'a, P>
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         RMatchIndices(self.match_indices(pat).0)
     }
@@ -3700,8 +3729,9 @@ impl str {
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn trim_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: DoubleEndedSearcher<'a>
+    pub fn trim_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: DoubleEndedSearcher<'a>>,
     {
         let mut i = 0;
         let mut j = 0;
@@ -3792,8 +3822,9 @@ impl str {
     #[must_use = "this returns the trimmed string as a new slice, \
                   without modifying the original"]
     #[stable(feature = "trim_direction", since = "1.30.0")]
-    pub fn trim_end_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn trim_end_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         let mut j = 0;
         let mut matcher = pat.into_searcher(self);
@@ -3880,8 +3911,9 @@ impl str {
         reason = "superseded by `trim_end_matches`",
         suggestion = "trim_end_matches",
     )]
-    pub fn trim_right_matches<'a, P: Pattern<'a>>(&'a self, pat: P) -> &'a str
-        where P::Searcher: ReverseSearcher<'a>
+    pub fn trim_right_matches<'a, P>(&'a self, pat: P) -> &'a str
+    where
+        P: Pattern<'a, Searcher: ReverseSearcher<'a>>,
     {
         self.trim_end_matches(pat)
     }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -287,7 +287,7 @@ impl<'hir> Map<'hir> {
         self.definitions.def_index_to_hir_id(def_id.to_def_id().index)
     }
 
-    fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
+    pub fn def_kind(&self, hir_id: HirId) -> Option<DefKind> {
         let node = if let Some(node) = self.find(hir_id) {
             node
         } else {

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -662,19 +662,22 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     }
                 }
                 _ => {
+                    // `last_ty` can be `!`, `expected` will have better info when present.
+                    let t = self.resolve_vars_if_possible(&match exp_found {
+                        Some(ty::error::ExpectedFound { expected, .. }) => expected,
+                        _ => last_ty,
+                    });
                     let msg = "`match` arms have incompatible types";
                     err.span_label(cause.span, msg);
                     if prior_arms.len() <= 4 {
                         for sp in prior_arms {
-                            err.span_label(*sp, format!(
-                                "this is found to be of type `{}`",
-                                self.resolve_vars_if_possible(&last_ty),
-                            ));
+                            err.span_label( *sp, format!("this is found to be of type `{}`", t));
                         }
                     } else if let Some(sp) = prior_arms.last() {
-                        err.span_label(*sp, format!(
-                            "this and all prior arms are found to be of type `{}`", last_ty,
-                        ));
+                        err.span_label(
+                            *sp,
+                            format!("this and all prior arms are found to be of type `{}`", t),
+                        );
                     }
                 }
             },
@@ -1143,27 +1146,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
                 (_, false, _) => {
                     if let Some(exp_found) = exp_found {
-                        let (def_id, ret_ty) = match exp_found.found.sty {
-                            ty::FnDef(def, _) => {
-                                (Some(def), Some(self.tcx.fn_sig(def).output()))
-                            }
-                            _ => (None, None),
-                        };
-
-                        let exp_is_struct = match exp_found.expected.sty {
-                            ty::Adt(def, _) => def.is_struct(),
-                            _ => false,
-                        };
-
-                        if let (Some(def_id), Some(ret_ty)) = (def_id, ret_ty) {
-                            if exp_is_struct && &exp_found.expected == ret_ty.skip_binder() {
-                                let message = format!(
-                                    "did you mean `{}(/* fields */)`?",
-                                    self.tcx.def_path_str(def_id)
-                                );
-                                diag.span_label(span, message);
-                            }
-                        }
                         self.suggest_as_ref_where_appropriate(span, &exp_found, diag);
                     }
 

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -61,6 +61,7 @@
 #![feature(proc_macro_hygiene)]
 #![feature(log_syntax)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="512"]
 

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -3901,7 +3901,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // each predicate must be preceded by the obligations required
         // to normalize it.
         // for example, if we have:
-        //    impl<U: Iterator, V: Iterator<Item=U>> Foo for V where U::Item: Copy
+        //    impl<U: Iterator<Item: Copy>, V: Iterator<Item = U>> Foo for V
         // the impl will have the following predicates:
         //    <V as Iterator>::Item = U,
         //    U: Iterator, U: Sized,

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -980,8 +980,7 @@ EnumTypeFoldableImpl! {
         (chalk_engine::DelayedLiteral::Negative)(a),
         (chalk_engine::DelayedLiteral::Positive)(a, b),
     } where
-        C: chalk_engine::context::Context + Clone,
-        C::CanonicalConstrainedSubst: TypeFoldable<'tcx>,
+        C: chalk_engine::context::Context<CanonicalConstrainedSubst: TypeFoldable<'tcx>> + Clone,
 }
 
 EnumTypeFoldableImpl! {
@@ -989,8 +988,7 @@ EnumTypeFoldableImpl! {
         (chalk_engine::Literal::Negative)(a),
         (chalk_engine::Literal::Positive)(a),
     } where
-        C: chalk_engine::context::Context + Clone,
-        C::GoalInEnvironment: Clone + TypeFoldable<'tcx>,
+        C: chalk_engine::context::Context<GoalInEnvironment: Clone + TypeFoldable<'tcx>> + Clone,
 }
 
 CloneTypeFoldableAndLiftImpls! {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2663,8 +2663,8 @@ impl<'tcx> TyCtxt<'tcx> {
                         unsafety: hir::Unsafety,
                         abi: abi::Abi)
         -> <I::Item as InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>>::Output
-        where I: Iterator,
-              I::Item: InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>
+    where
+        I: Iterator<Item: InternIteratorElement<Ty<'tcx>, ty::FnSig<'tcx>>>,
     {
         inputs.chain(iter::once(output)).intern_with(|xs| ty::FnSig {
             inputs_and_output: self.intern_type_list(xs),

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2027,9 +2027,9 @@ impl ty::query::TyCtxtAt<'tcx> {
 
 impl<'tcx, C> TyLayoutMethods<'tcx, C> for Ty<'tcx>
 where
-    C: LayoutOf<Ty = Ty<'tcx>> + HasTyCtxt<'tcx>,
-    C::TyLayout: MaybeResult<TyLayout<'tcx>>,
-    C: HasParamEnv<'tcx>,
+    C: LayoutOf<Ty = Ty<'tcx>, TyLayout: MaybeResult<TyLayout<'tcx>>>
+        + HasTyCtxt<'tcx>
+        + HasParamEnv<'tcx>,
 {
     fn for_variant(this: TyLayout<'tcx>, cx: &C, variant_index: VariantIdx) -> TyLayout<'tcx> {
         let details = match this.variants {

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -1055,9 +1055,8 @@ fn encode_query_results<'a, 'tcx, Q, E>(
     query_result_index: &mut EncodedQueryResultIndex,
 ) -> Result<(), E::Error>
 where
-    Q: super::config::QueryDescription<'tcx>,
+    Q: super::config::QueryDescription<'tcx, Value: Encodable>,
     E: 'a + TyEncoder,
-    Q::Value: Encodable,
 {
     let desc = &format!("encode_query_results for {}",
         ::std::any::type_name::<Q>());

--- a/src/librustc_codegen_ssa/back/command.rs
+++ b/src/librustc_codegen_ssa/back/command.rs
@@ -50,8 +50,8 @@ impl Command {
     }
 
     pub fn args<I>(&mut self, args: I) -> &mut Command
-        where I: IntoIterator,
-              I::Item: AsRef<OsStr>,
+    where
+        I: IntoIterator<Item: AsRef<OsStr>>,
     {
         for arg in args {
             self._arg(arg.as_ref());

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -11,6 +11,7 @@
 #![feature(nll)]
 #![feature(trusted_len)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -23,6 +23,7 @@
 #![feature(core_intrinsics)]
 #![feature(integer_atomics)]
 #![feature(test)]
+#![feature(associated_type_bounds)]
 
 #![cfg_attr(unix, feature(libc))]
 

--- a/src/librustc_data_structures/owning_ref/mod.rs
+++ b/src/librustc_data_structures/owning_ref/mod.rs
@@ -847,7 +847,9 @@ pub trait ToHandleMut {
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandle<Handle = H>, H: Deref,
+where
+    O: StableAddress<Target: ToHandle<Handle = H>>,
+    H: Deref,
 {
     /// Creates a new `OwningHandle` for a type that implements `ToHandle`. For types
     /// that don't implement `ToHandle`, callers may invoke `new_with_fn`, which accepts
@@ -858,7 +860,9 @@ impl<O, H> OwningHandle<O, H>
 }
 
 impl<O, H> OwningHandle<O, H>
-    where O: StableAddress, O::Target: ToHandleMut<HandleMut = H>, H: DerefMut,
+where
+    O: StableAddress<Target: ToHandleMut<HandleMut = H>>,
+    H: DerefMut,
 {
     /// Creates a new mutable `OwningHandle` for a type that implements `ToHandleMut`.
     pub fn new_mut(o: O) -> Self {

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -589,10 +589,8 @@ impl<E:Idx> GenKillSet<E> {
         self.gen_set.insert(e);
         self.kill_set.remove(e);
     }
-    fn gen_all<I>(&mut self, i: I)
-        where I: IntoIterator,
-              I::Item: Borrow<E>
-    {
+
+    fn gen_all(&mut self, i: impl IntoIterator<Item: Borrow<E>>) {
         for j in i {
             self.gen(*j.borrow());
         }
@@ -603,10 +601,7 @@ impl<E:Idx> GenKillSet<E> {
         self.kill_set.insert(e);
     }
 
-    fn kill_all<I>(&mut self, i: I)
-        where I: IntoIterator,
-              I::Item: Borrow<E>
-    {
+    fn kill_all(&mut self, i: impl IntoIterator<Item: Borrow<E>>) {
         for j in i {
             self.kill(*j.borrow());
         }

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -23,6 +23,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(trusted_len)]
 #![feature(try_blocks)]
 #![feature(mem_take)]
+#![feature(associated_type_bounds)]
 
 #![recursion_limit="256"]
 

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -65,10 +65,13 @@ fn add_typo_suggestion(
     false
 }
 
-fn add_module_candidates(
-    module: Module<'_>, names: &mut Vec<TypoSuggestion>, filter_fn: &impl Fn(Res) -> bool
+fn add_module_candidates<'a>(
+    resolver: &mut Resolver<'a>,
+    module: Module<'a>,
+    names: &mut Vec<TypoSuggestion>,
+    filter_fn: &impl Fn(Res) -> bool,
 ) {
-    for (&(ident, _), resolution) in module.resolutions.borrow().iter() {
+    for (&(ident, _), resolution) in resolver.resolutions(module).borrow().iter() {
         if let Some(binding) = resolution.borrow().binding {
             let res = binding.res();
             if filter_fn(res) {
@@ -593,10 +596,10 @@ impl<'a> Resolver<'a> {
                 Scope::CrateRoot => {
                     let root_ident = Ident::new(kw::PathRoot, ident.span);
                     let root_module = this.resolve_crate_root(root_ident);
-                    add_module_candidates(root_module, &mut suggestions, filter_fn);
+                    add_module_candidates(this, root_module, &mut suggestions, filter_fn);
                 }
                 Scope::Module(module) => {
-                    add_module_candidates(module, &mut suggestions, filter_fn);
+                    add_module_candidates(this, module, &mut suggestions, filter_fn);
                 }
                 Scope::MacroUsePrelude => {
                     suggestions.extend(this.macro_use_prelude.iter().filter_map(|(name, binding)| {
@@ -644,7 +647,7 @@ impl<'a> Resolver<'a> {
                 Scope::StdLibPrelude => {
                     if let Some(prelude) = this.prelude {
                         let mut tmp_suggestions = Vec::new();
-                        add_module_candidates(prelude, &mut tmp_suggestions, filter_fn);
+                        add_module_candidates(this, prelude, &mut tmp_suggestions, filter_fn);
                         suggestions.extend(tmp_suggestions.into_iter().filter(|s| {
                             use_prelude || this.is_builtin_macro(s.res.opt_def_id())
                         }));
@@ -694,7 +697,9 @@ impl<'a> Resolver<'a> {
         if path.len() == 1 {
             // Search in lexical scope.
             // Walk backwards up the ribs in scope and collect candidates.
-            for rib in self.ribs[ns].iter().rev() {
+            // Ribs have to be cloned to avoid borrowing the resolver.
+            let ribs = self.ribs[ns].clone();
+            for rib in ribs.iter().rev() {
                 // Locals and type parameters
                 for (ident, &res) in &rib.bindings {
                     if filter_fn(res) {
@@ -704,7 +709,7 @@ impl<'a> Resolver<'a> {
                 // Items in scope
                 if let RibKind::ModuleRibKind(module) = rib.kind {
                     // Items from this module
-                    add_module_candidates(module, &mut names, &filter_fn);
+                    add_module_candidates(self, module, &mut names, &filter_fn);
 
                     if let ModuleKind::Block(..) = module.kind {
                         // We can see through blocks
@@ -732,7 +737,7 @@ impl<'a> Resolver<'a> {
                             }));
 
                             if let Some(prelude) = self.prelude {
-                                add_module_candidates(prelude, &mut names, &filter_fn);
+                                add_module_candidates(self, prelude, &mut names, &filter_fn);
                             }
                         }
                         break;
@@ -754,7 +759,7 @@ impl<'a> Resolver<'a> {
                 mod_path, Some(TypeNS), false, span, CrateLint::No
             ) {
                 if let ModuleOrUniformRoot::Module(module) = module {
-                    add_module_candidates(module, &mut names, &filter_fn);
+                    add_module_candidates(self, module, &mut names, &filter_fn);
                 }
             }
         }
@@ -792,11 +797,9 @@ impl<'a> Resolver<'a> {
         while let Some((in_module,
                         path_segments,
                         in_module_is_extern)) = worklist.pop() {
-            self.populate_module_if_necessary(in_module);
-
             // We have to visit module children in deterministic order to avoid
             // instabilities in reported imports (#43552).
-            in_module.for_each_child_stable(|ident, ns, name_binding| {
+            in_module.for_each_child_stable(self, |this, ident, ns, name_binding| {
                 // avoid imports entirely
                 if name_binding.is_import() && !name_binding.is_extern_crate() { return; }
                 // avoid non-importable candidates as well
@@ -830,7 +833,7 @@ impl<'a> Resolver<'a> {
                         // outside crate private modules => no need to check this)
                         if !in_module_is_extern || name_binding.vis == ty::Visibility::Public {
                             let did = match res {
-                                Res::Def(DefKind::Ctor(..), did) => self.parent(did),
+                                Res::Def(DefKind::Ctor(..), did) => this.parent(did),
                                 _ => res.opt_def_id(),
                             };
                             candidates.push(ImportSuggestion { did, path });
@@ -890,8 +893,6 @@ impl<'a> Resolver<'a> {
                         krate: crate_id,
                         index: CRATE_DEF_INDEX,
                     });
-                    self.populate_module_if_necessary(&crate_root);
-
                     suggestions.extend(self.lookup_import_candidates_from_module(
                         lookup_ident, namespace, crate_root, ident, &filter_fn));
                 }
@@ -910,9 +911,7 @@ impl<'a> Resolver<'a> {
             // abort if the module is already found
             if result.is_some() { break; }
 
-            self.populate_module_if_necessary(in_module);
-
-            in_module.for_each_child_stable(|ident, _, name_binding| {
+            in_module.for_each_child_stable(self, |_, ident, _, name_binding| {
                 // abort if the module is already found or if name_binding is private external
                 if result.is_some() || !name_binding.vis.is_visible_locally() {
                     return
@@ -943,10 +942,8 @@ impl<'a> Resolver<'a> {
 
     fn collect_enum_variants(&mut self, def_id: DefId) -> Option<Vec<Path>> {
         self.find_module(def_id).map(|(enum_module, enum_import_suggestion)| {
-            self.populate_module_if_necessary(enum_module);
-
             let mut variants = Vec::new();
-            enum_module.for_each_child_stable(|ident, _, name_binding| {
+            enum_module.for_each_child_stable(self, |_, ident, _, name_binding| {
                 if let Res::Def(DefKind::Variant, _) = name_binding.res() {
                     let mut segms = enum_import_suggestion.path.segments.clone();
                     segms.push(ast::PathSegment::from_ident(ident));
@@ -1147,7 +1144,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
     ///            at the root of the crate instead of the module where it is defined
     /// ```
     pub(crate) fn check_for_module_export_macro(
-        &self,
+        &mut self,
         directive: &'b ImportDirective<'b>,
         module: ModuleOrUniformRoot<'b>,
         ident: Ident,
@@ -1168,7 +1165,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             return None;
         }
 
-        let resolutions = crate_module.resolutions.borrow();
+        let resolutions = self.resolutions(crate_module).borrow();
         let resolution = resolutions.get(&(ident, MacroNS))?;
         let binding = resolution.borrow().binding()?;
         if let Res::Def(DefKind::Macro(MacroKind::Bang), _) = binding.res() {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -5,7 +5,7 @@ use crate::{CrateLint, Module, ModuleOrUniformRoot, PerNS, ScopeSet, ParentScope
 use crate::Determinacy::{self, *};
 use crate::Namespace::{self, TypeNS, MacroNS};
 use crate::{NameBinding, NameBindingKind, ToNameBinding, PathResult, PrivacyError};
-use crate::{Resolver, Segment};
+use crate::{Resolutions, Resolver, Segment};
 use crate::{names_to_string, module_to_string};
 use crate::{resolve_error, ResolutionError};
 use crate::ModuleKind;
@@ -156,9 +156,21 @@ impl<'a> NameResolution<'a> {
 }
 
 impl<'a> Resolver<'a> {
-    fn resolution(&self, module: Module<'a>, ident: Ident, ns: Namespace)
+    crate fn resolutions(&mut self, module: Module<'a>) -> &'a Resolutions<'a> {
+        if module.populate_on_access.get() {
+            module.populate_on_access.set(false);
+            let def_id = module.def_id().expect("unpopulated module without a def-id");
+            for child in self.cstore.item_children_untracked(def_id, self.session) {
+                let child = child.map_id(|_| panic!("unexpected id"));
+                self.build_reduced_graph_for_external_crate_res(module, child);
+            }
+        }
+        &module.lazy_resolutions
+    }
+
+    fn resolution(&mut self, module: Module<'a>, ident: Ident, ns: Namespace)
                   -> &'a RefCell<NameResolution<'a>> {
-        *module.resolutions.borrow_mut().entry((ident.modern(), ns))
+        *self.resolutions(module).borrow_mut().entry((ident.modern(), ns))
                .or_insert_with(|| self.arenas.alloc_name_resolution())
     }
 
@@ -238,8 +250,6 @@ impl<'a> Resolver<'a> {
                 return binding.map_err(|determinacy| (determinacy, Weak::No));
             }
         };
-
-        self.populate_module_if_necessary(module);
 
         let resolution = self.resolution(module, ident, ns)
             .try_borrow_mut()
@@ -1079,7 +1089,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
             return if all_ns_failed {
                 let resolutions = match module {
-                    ModuleOrUniformRoot::Module(module) => Some(module.resolutions.borrow()),
+                    ModuleOrUniformRoot::Module(module) => Some(self.resolutions(module).borrow()),
                     _ => None,
                 };
                 let resolutions = resolutions.as_ref().into_iter().flat_map(|r| r.iter());
@@ -1317,8 +1327,6 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             }
         };
 
-        self.populate_module_if_necessary(module);
-
         if module.is_trait() {
             self.session.span_err(directive.span, "items in traits are not importable.");
             return;
@@ -1334,7 +1342,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
         // Ensure that `resolutions` isn't borrowed during `try_define`,
         // since it might get updated via a glob cycle.
-        let bindings = module.resolutions.borrow().iter().filter_map(|(&ident, resolution)| {
+        let bindings = self.resolutions(module).borrow().iter().filter_map(|(&ident, resolution)| {
             resolution.borrow().binding().map(|binding| (ident, binding))
         }).collect::<Vec<_>>();
         for ((mut ident, ns), binding) in bindings {
@@ -1361,7 +1369,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
         let mut reexports = Vec::new();
 
-        for (&(ident, ns), resolution) in module.resolutions.borrow().iter() {
+        for (&(ident, ns), resolution) in self.resolutions(module).borrow().iter() {
             let resolution = &mut *resolution.borrow_mut();
             let binding = match resolution.binding {
                 Some(binding) => binding,
@@ -1420,8 +1428,8 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                             Some(ModuleOrUniformRoot::Module(module)) => module,
                             _ => bug!("module should exist"),
                         };
-                        let resolutions = imported_module.parent.expect("parent should exist")
-                            .resolutions.borrow();
+                        let parent_module = imported_module.parent.expect("parent should exist");
+                        let resolutions = self.resolutions(parent_module).borrow();
                         let enum_path_segment_index = directive.module_path.len() - 1;
                         let enum_ident = directive.module_path[enum_path_segment_index].ident;
 

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -559,6 +559,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
+                            ty::Error | ty::Never => return,
                             _ => "value",
                         });
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -550,18 +550,19 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     assert!(e_ty.is_unit());
                     let ty = coerce.expected_ty();
                     coerce.coerce_forced_unit(self, &cause, &mut |err| {
-                        let msg = "give it a value of the expected type";
-                        let label = destination.label
-                            .map(|l| format!(" {}", l.ident))
-                            .unwrap_or_else(String::new);
-                        let sugg = format!("break{} {}", label, match ty.sty {
+                        let val = match ty.sty {
                             ty::Bool => "true",
                             ty::Char => "'a'",
                             ty::Int(_) | ty::Uint(_) => "42",
                             ty::Float(_) => "3.14159",
                             ty::Error | ty::Never => return,
                             _ => "value",
-                        });
+                        };
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, val);
                         err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
                     }, false);
                 }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -548,7 +548,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     coerce.coerce(self, &cause, e, e_ty);
                 } else {
                     assert!(e_ty.is_unit());
-                    coerce.coerce_forced_unit(self, &cause, &mut |_| (), true);
+                    let ty = coerce.expected_ty();
+                    coerce.coerce_forced_unit(self, &cause, &mut |err| {
+                        let msg = "give it a value of the expected type";
+                        let label = destination.label
+                            .map(|l| format!(" {}", l.ident))
+                            .unwrap_or_else(String::new);
+                        let sugg = format!("break{} {}", label, match ty.sty {
+                            ty::Bool => "true",
+                            ty::Char => "'a'",
+                            ty::Int(_) | ty::Uint(_) => "42",
+                            ty::Float(_) => "3.14159",
+                            _ => "value",
+                        });
+                        err.span_suggestion(expr.span, msg, sugg, Applicability::HasPlaceholders);
+                    }, false);
                 }
             } else {
                 // If `ctxt.coerce` is `None`, we can just ignore

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,7 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function's body doesn't `return` a value",
+                                "this function implicitly returns `()` as its body has no tail \
+                                 or `return` expression",
                             );
                         }
                     }, false);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return");
+                            err.span_label(fn_span, "this function's body doesn't return a value");
                         }
                     }, false);
                 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3711,8 +3711,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         if let Some(fn_span) = fn_span {
                             err.span_label(
                                 fn_span,
-                                "this function implicitly returns `()` as its body has no tail \
-                                 or `return` expression",
+                                "implicitly returns `()` as its body has no tail or `return` \
+                                 expression",
                             );
                         }
                     }, false);
@@ -3880,10 +3880,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         sugg_call = fields.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
                         match hir.as_local_hir_id(def_id).and_then(|hir_id| hir.def_kind(hir_id)) {
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Variant, _)) => {
-                                msg = "instatiate this tuple variant";
+                                msg = "instantiate this tuple variant";
                             }
                             Some(hir::def::DefKind::Ctor(hir::def::CtorOf::Struct, _)) => {
-                                msg = "instatiate this tuple struct";
+                                msg = "instantiate this tuple struct";
                             }
                             _ => {}
                         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3709,7 +3709,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.consider_hint_about_removing_semicolon(blk, expected_ty, err);
                         }
                         if let Some(fn_span) = fn_span {
-                            err.span_label(fn_span, "this function's body doesn't return a value");
+                            err.span_label(
+                                fn_span,
+                                "this function's body doesn't `return` a value",
+                            );
                         }
                     }, false);
                 }

--- a/src/libserialize/collection_impls.rs
+++ b/src/libserialize/collection_impls.rs
@@ -9,10 +9,7 @@ use std::sync::Arc;
 
 use smallvec::{Array, SmallVec};
 
-impl<A> Encodable for SmallVec<A>
-    where A: Array,
-          A::Item: Encodable
-{
+impl<A: Array<Item: Encodable>> Encodable for SmallVec<A> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         s.emit_seq(self.len(), |s| {
             for (i, e) in self.iter().enumerate() {
@@ -23,10 +20,7 @@ impl<A> Encodable for SmallVec<A>
     }
 }
 
-impl<A> Decodable for SmallVec<A>
-    where A: Array,
-          A::Item: Decodable
-{
+impl<A: Array<Item: Decodable>> Decodable for SmallVec<A> {
     fn decode<D: Decoder>(d: &mut D) -> Result<SmallVec<A>, D::Error> {
         d.read_seq(|d, len| {
             let mut vec = SmallVec::with_capacity(len);

--- a/src/libserialize/lib.rs
+++ b/src/libserialize/lib.rs
@@ -13,6 +13,7 @@ Core encoding and decoding interfaces.
 #![feature(specialization)]
 #![feature(never_type)]
 #![feature(nll)]
+#![feature(associated_type_bounds)]
 #![cfg_attr(test, feature(test))]
 
 pub use self::serialize::{Decoder, Encoder, Decodable, Encodable};

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -326,16 +326,6 @@ use prelude::v1::*;
 // Access to Bencher, etc.
 #[cfg(test)] extern crate test;
 
-// Re-export a few macros from core
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::{assert_eq, assert_ne, debug_assert, debug_assert_eq, debug_assert_ne};
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::{unreachable, unimplemented, write, writeln, todo};
-// FIXME: change this to `#[allow(deprecated)]` when we update nightly compiler.
-#[allow(deprecated_in_future)]
-#[stable(feature = "rust1", since = "1.0.0")]
-pub use core::r#try;
-
 #[allow(unused_imports)] // macros from `alloc` are not used on all platforms
 #[macro_use]
 extern crate alloc as alloc_crate;
@@ -520,33 +510,52 @@ mod std_detect;
 #[cfg(not(test))]
 pub use std_detect::detect;
 
-// Document built-in macros in the crate root for consistency with libcore and existing tradition.
-// FIXME: Attribute and derive macros are not reexported because rustdoc renders them
-// as reexports rather than as macros, and that's not what we want.
-#[cfg(rustdoc)]
+// Re-export macros defined in libcore.
+#[stable(feature = "rust1", since = "1.0.0")]
+#[allow(deprecated_in_future)]
+pub use core::{
+    // Stable
+    assert_eq,
+    assert_ne,
+    debug_assert_eq,
+    debug_assert_ne,
+    debug_assert,
+    r#try,
+    unimplemented,
+    unreachable,
+    write,
+    writeln,
+    // Unstable
+    todo,
+};
+
+// Re-export built-in macros defined through libcore.
+#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
-pub use crate::prelude::v1::{
-    __rust_unstable_column,
-    asm,
+pub use core::{
+    // Stable
     assert,
     cfg,
     column,
     compile_error,
     concat,
-    concat_idents,
     env,
     file,
     format_args,
-    format_args_nl,
-    global_asm,
     include,
     include_bytes,
     include_str,
     line,
-    log_syntax,
     module_path,
     option_env,
     stringify,
+    // Unstable
+    __rust_unstable_column,
+    asm,
+    concat_idents,
+    format_args_nl,
+    global_asm,
+    log_syntax,
     trace_macros,
 };
 

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -238,6 +238,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(array_error_internals)]
 #![feature(asm)]
+#![feature(associated_type_bounds)]
 #![feature(bind_by_move_pattern_guards)]
 #![feature(box_syntax)]
 #![feature(c_variadic)]

--- a/src/libstd/sys/sgx/abi/usercalls/alloc.rs
+++ b/src/libstd/sys/sgx/abi/usercalls/alloc.rs
@@ -522,7 +522,11 @@ impl<T: ?Sized> Drop for User<T> where T: UserSafe {
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<UserRef<U>> for UserRef<T> {}
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
-impl<T, I: SliceIndex<[T]>> Index<I> for UserRef<[T]> where [T]: UserSafe, I::Output: UserSafe {
+impl<T, I> Index<I> for UserRef<[T]>
+where
+    [T]: UserSafe,
+    I: SliceIndex<[T], Output: UserSafe>,
+{
     type Output = UserRef<I::Output>;
 
     #[inline]
@@ -538,7 +542,11 @@ impl<T, I: SliceIndex<[T]>> Index<I> for UserRef<[T]> where [T]: UserSafe, I::Ou
 }
 
 #[unstable(feature = "sgx_platform", issue = "56975")]
-impl<T, I: SliceIndex<[T]>> IndexMut<I> for UserRef<[T]> where [T]: UserSafe, I::Output: UserSafe {
+impl<T, I> IndexMut<I> for UserRef<[T]>
+where
+    [T]: UserSafe,
+    I: SliceIndex<[T], Output: UserSafe>,
+{
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut UserRef<I::Output> {
         unsafe {

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -6,6 +6,7 @@ use crate::config::StripUnconfigured;
 use crate::ext::base::*;
 use crate::ext::proc_macro::collect_derives;
 use crate::ext::hygiene::{ExpnId, SyntaxContext, ExpnInfo, ExpnKind};
+use crate::ext::tt::macro_rules::annotate_err_with_kind;
 use crate::ext::placeholders::{placeholder, PlaceholderExpander};
 use crate::feature_gate::{self, Features, GateIssue, is_builtin_attr, emit_feature_err};
 use crate::mut_visit::*;
@@ -701,21 +702,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
-                match kind {
-                    AstFragmentKind::Ty => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a type",
-                        );
-                    }
-                    AstFragmentKind::Pat => {
-                        err.span_label(
-                            span,
-                            "this macro call doesn't expand to a pattern",
-                        );
-                    }
-                    _ => {}
-                };
+                annotate_err_with_kind(&mut err, kind, span);
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -686,12 +686,13 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         );
     }
 
-    fn parse_ast_fragment(&mut self,
-                          toks: TokenStream,
-                          kind: AstFragmentKind,
-                          path: &Path,
-                          span: Span)
-                          -> AstFragment {
+    fn parse_ast_fragment(
+        &mut self,
+        toks: TokenStream,
+        kind: AstFragmentKind,
+        path: &Path,
+        span: Span,
+    ) -> AstFragment {
         let mut parser = self.cx.new_parser_from_tts(&toks.into_trees().collect::<Vec<_>>());
         match parser.parse_ast_fragment(kind, false) {
             Ok(fragment) => {
@@ -700,6 +701,21 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
             }
             Err(mut err) => {
                 err.set_span(span);
+                match kind {
+                    AstFragmentKind::Ty => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a type",
+                        );
+                    }
+                    AstFragmentKind::Pat => {
+                        err.span_label(
+                            span,
+                            "this macro call doesn't expand to a pattern",
+                        );
+                    }
+                    _ => {}
+                };
                 err.emit();
                 self.cx.trace_macros_diag();
                 kind.dummy(span)

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -17,7 +17,7 @@ use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{DelimSpan, TokenStream, TokenTree};
 use crate::{ast, attr, attr::TransparencyError};
 
-use errors::FatalError;
+use errors::{DiagnosticBuilder, FatalError};
 use log::debug;
 use syntax_pos::Span;
 
@@ -41,6 +41,18 @@ pub struct ParserAnyMacro<'a> {
     /// The ident of the macro we're parsing
     macro_ident: ast::Ident,
     arm_span: Span,
+}
+
+pub fn annotate_err_with_kind(err: &mut DiagnosticBuilder<'_>, kind: AstFragmentKind, span: Span) {
+    match kind {
+        AstFragmentKind::Ty => {
+            err.span_label(span, "this macro call doesn't expand to a type");
+        }
+        AstFragmentKind::Pat => {
+            err.span_label(span, "this macro call doesn't expand to a pattern");
+        }
+        _ => {}
+    };
 }
 
 impl<'a> ParserAnyMacro<'a> {
@@ -71,27 +83,30 @@ impl<'a> ParserAnyMacro<'a> {
                 e.span_label(site_span, "in this macro invocation");
             }
             match kind {
-                AstFragmentKind::Ty => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a type",
-                    );
-                }
                 AstFragmentKind::Pat if macro_ident.name == sym::vec => {
-                    e.span_label(
-                        site_span,
-                        "use a slice pattern here instead",
-                    );
+                    let mut suggestion = None;
+                    if let Ok(code) = parser.sess.source_map().span_to_snippet(site_span) {
+                        if let Some(bang) = code.find('!') {
+                            suggestion = Some(code[bang + 1..].to_string());
+                        }
+                    }
+                    if let Some(suggestion) = suggestion {
+                        e.span_suggestion(
+                            site_span,
+                            "use a slice pattern here instead",
+                            suggestion,
+                            Applicability::MachineApplicable,
+                        );
+                    } else {
+                        e.span_label(
+                            site_span,
+                            "use a slice pattern here instead",
+                        );
+                    }
                     e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
-                              rust-2018/slice-patterns.html");
+                            rust-2018/slice-patterns.html");
                 }
-                AstFragmentKind::Pat => {
-                    e.span_label(
-                        site_span,
-                        "this macro call doesn't expand to a pattern",
-                    );
-                }
-                _ => {}
+                _ => annotate_err_with_kind(&mut e, kind, site_span),
             };
             e
         }));

--- a/src/libsyntax/ext/tt/macro_rules.rs
+++ b/src/libsyntax/ext/tt/macro_rules.rs
@@ -70,6 +70,29 @@ impl<'a> ParserAnyMacro<'a> {
             } else if !parser.sess.source_map().span_to_filename(parser.token.span).is_real() {
                 e.span_label(site_span, "in this macro invocation");
             }
+            match kind {
+                AstFragmentKind::Ty => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a type",
+                    );
+                }
+                AstFragmentKind::Pat if macro_ident.name == sym::vec => {
+                    e.span_label(
+                        site_span,
+                        "use a slice pattern here instead",
+                    );
+                    e.help("for more information, see https://doc.rust-lang.org/edition-guide/\
+                              rust-2018/slice-patterns.html");
+                }
+                AstFragmentKind::Pat => {
+                    e.span_label(
+                        site_span,
+                        "this macro call doesn't expand to a pattern",
+                    );
+                }
+                _ => {}
+            };
             e
         }));
 

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn return_targets_async_block_not_fn() -> u8 {
    |    ---------------------------------      ^^ expected u8, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u8`
               found type `()`
@@ -57,7 +57,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_fn() -> Result<u8, MyErr> {
    |    ----------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`
@@ -68,7 +68,7 @@ error[E0308]: mismatched types
 LL | fn rethrow_targets_async_block_not_async_fn() -> Result<u8, MyErr> {
    |    ----------------------------------------      ^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `std::result::Result<u8, MyErr>`
               found type `()`

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/consider-removing-last-semi.stderr
+++ b/src/test/ui/block-result/consider-removing-last-semi.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     0u8;
 LL |     "bla".to_string();
    |                      - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn g() -> String {
    |    -      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "this won't work".to_string();
 LL |     "removeme".to_string();
    |                           - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-11714.stderr
+++ b/src/test/ui/block-result/issue-11714.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn blah() -> i32 {
    |    ----      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/block-result/issue-13428.stderr
+++ b/src/test/ui/block-result/issue-13428.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 ...
 LL |     ;
    |     - help: consider removing this semicolon
@@ -18,7 +18,7 @@ error[E0308]: mismatched types
 LL | fn bar() -> String {
    |    ---      ^^^^^^ expected struct `std::string::String`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     "foobar".to_string()
 LL |     ;
    |     - help: consider removing this semicolon

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
+++ b/src/test/ui/coercion/coercion-missing-tail-expected-type.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn plus_one(x: i32) -> i32 {
    |    --------            ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x + 1;
    |          - help: consider removing this semicolon
    |
@@ -17,7 +17,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> Result<u8, u64> {
    |    ---      ^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Ok(1);
    |          - help: consider removing this semicolon
    |

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -13,8 +13,7 @@ error[E0659]: `Vec` is ambiguous (macro-expanded name vs less macro-expanded nam
 LL |         Vec::panic!();
    |         ^^^ ambiguous name
    |
-   = note: `Vec` could refer to a struct from prelude
-note: `Vec` could also refer to the extern crate imported here
+note: `Vec` could refer to the extern crate imported here
   --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:5:9
    |
 LL |         extern crate std as Vec;
@@ -22,6 +21,11 @@ LL |         extern crate std as Vec;
 ...
 LL | define_vec!();
    | -------------- in this macro invocation
+note: `Vec` could also refer to the struct defined here
+  --> $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL | pub use crate::vec::Vec;
+   |         ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/imports/glob-shadowing.stderr
+++ b/src/test/ui/imports/glob-shadowing.stderr
@@ -4,14 +4,18 @@ error[E0659]: `env` is ambiguous (glob import vs any other name from outer scope
 LL |         let x = env!("PATH");
    |                 ^^^ ambiguous name
    |
-   = note: `env` could refer to a macro from prelude
-note: `env` could also refer to the macro imported here
+note: `env` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:9:9
    |
 LL |     use m::*;
    |         ^^^^
    = help: consider adding an explicit import of `env` to disambiguate
    = help: or use `self::env` to refer to this macro unambiguously
+note: `env` could also refer to the macro defined here
+  --> $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL |     env,
+   |     ^^^
 
 error[E0659]: `env` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
   --> $DIR/glob-shadowing.rs:19:21
@@ -19,13 +23,17 @@ error[E0659]: `env` is ambiguous (glob import vs any other name from outer scope
 LL |             let x = env!("PATH");
    |                     ^^^ ambiguous name
    |
-   = note: `env` could refer to a macro from prelude
-note: `env` could also refer to the macro imported here
+note: `env` could refer to the macro imported here
   --> $DIR/glob-shadowing.rs:17:13
    |
 LL |         use m::*;
    |             ^^^^
    = help: consider adding an explicit import of `env` to disambiguate
+note: `env` could also refer to the macro defined here
+  --> $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL |     env,
+   |     ^^^
 
 error[E0659]: `fenv` is ambiguous (glob import vs any other name from outer scope during import/macro resolution)
   --> $DIR/glob-shadowing.rs:29:21

--- a/src/test/ui/imports/issue-53512.rs
+++ b/src/test/ui/imports/issue-53512.rs
@@ -1,6 +1,7 @@
 // Macro from prelude is shadowed by non-existent import recovered as `Res::Err`.
 
-use std::assert; //~ ERROR unresolved import `std::assert`
+mod m {}
+use m::assert; //~ ERROR unresolved import `m::assert`
 
 fn main() {
     assert!(true);

--- a/src/test/ui/imports/issue-53512.stderr
+++ b/src/test/ui/imports/issue-53512.stderr
@@ -1,8 +1,8 @@
-error[E0432]: unresolved import `std::assert`
-  --> $DIR/issue-53512.rs:3:5
+error[E0432]: unresolved import `m::assert`
+  --> $DIR/issue-53512.rs:4:5
    |
-LL | use std::assert;
-   |     ^^^^^^^^^^^ no `assert` in the root
+LL | use m::assert;
+   |     ^^^^^^^^^ no `assert` in `m`
 
 error: aborting due to previous error
 

--- a/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
+++ b/src/test/ui/imports/local-modularized-tricky-fail-1.stderr
@@ -27,8 +27,7 @@ error[E0659]: `include` is ambiguous (macro-expanded name vs less macro-expanded
 LL | include!();
    | ^^^^^^^ ambiguous name
    |
-   = note: `include` could refer to a macro from prelude
-note: `include` could also refer to the macro defined here
+note: `include` could refer to the macro defined here
   --> $DIR/local-modularized-tricky-fail-1.rs:17:5
    |
 LL | /     macro_rules! include {
@@ -39,6 +38,11 @@ LL | |     }
 LL |       define_include!();
    |       ------------------ in this macro invocation
    = help: use `crate::include` to refer to this macro unambiguously
+note: `include` could also refer to the macro defined here
+  --> $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL |     include,
+   |     ^^^^^^^
 
 error[E0659]: `panic` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
   --> $DIR/local-modularized-tricky-fail-1.rs:35:5

--- a/src/test/ui/issues/issue-27033.stderr
+++ b/src/test/ui/issues/issue-27033.stderr
@@ -3,6 +3,11 @@ error[E0530]: match bindings cannot shadow unit variants
    |
 LL |         None @ _ => {}
    |         ^^^^ cannot be named the same as a unit variant
+   | 
+  ::: $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL | pub use crate::option::Option::{self, Some, None};
+   |                                             ---- the unit variant `None` is defined here
 
 error[E0530]: match bindings cannot shadow constants
   --> $DIR/issue-27033.rs:7:9

--- a/src/test/ui/issues/issue-27042.stderr
+++ b/src/test/ui/issues/issue-27042.stderr
@@ -12,10 +12,13 @@ error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:6:16
    |
 LL |         loop { break };
-   |                ^^^^^ expected (), found i32
+   |                ^^^^^
+   |                |
+   |                expected i32, found ()
+   |                help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/issue-27042.rs:8:9

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function implicitly returns `()` as its body has no tail or `return` expression
+   |        implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't `return` a value
+   |        this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return a value
+   |        this function's body doesn't `return` a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-32323.stderr
+++ b/src/test/ui/issues/issue-32323.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | pub fn f<'a, T: Tr<'a>>() -> <T as Tr<'a>>::Out {}
    |        -                     ^^^^^^^^^^^^^^^^^^ expected associated type, found ()
    |        |
-   |        this function's body doesn't return
+   |        this function's body doesn't return a value
    |
    = note: expected type `<T as Tr<'a>>::Out`
               found type `()`

--- a/src/test/ui/issues/issue-34334.rs
+++ b/src/test/ui/issues/issue-34334.rs
@@ -5,6 +5,7 @@ fn main () {
     //~| ERROR mismatched types
     //~| ERROR invalid left-hand side expression
     //~| ERROR expected expression, found reserved identifier `_`
+    //~| ERROR expected expression, found reserved identifier `_`
     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
     //~^ ERROR no method named `iter` found for type `()` in the current scope
 }

--- a/src/test/ui/issues/issue-34334.stderr
+++ b/src/test/ui/issues/issue-34334.stderr
@@ -4,6 +4,12 @@ error: expected expression, found reserved identifier `_`
 LL |     let sr: Vec<(u32, _, _) = vec![];
    |                       ^ expected expression
 
+error: expected expression, found reserved identifier `_`
+  --> $DIR/issue-34334.rs:2:26
+   |
+LL |     let sr: Vec<(u32, _, _) = vec![];
+   |                          ^ expected expression
+
 error: expected one of `,` or `>`, found `=`
   --> $DIR/issue-34334.rs:2:29
    |
@@ -36,12 +42,12 @@ LL |     let sr: Vec<(u32, _, _) = vec![];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ left-hand of expression not valid
 
 error[E0599]: no method named `iter` found for type `()` in the current scope
-  --> $DIR/issue-34334.rs:8:36
+  --> $DIR/issue-34334.rs:9:36
    |
 LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_receiver)| {}).collect();
    |                                    ^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0070, E0308, E0423, E0599.
 For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -1,11 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/issue-35241.rs:3:20
    |
+LL | struct Foo(u32);
+   | ---------------- fn(u32) -> Foo {Foo} defined here
+LL | 
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     did you mean `Foo(/* fields */)`?
+   |              |     help: use parentheses to call this function: `Foo(...)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to call this function: `Foo(...)`
+   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -8,7 +8,7 @@ LL | fn test() -> Foo { Foo }
    |              ---   ^^^
    |              |     |
    |              |     expected struct `Foo`, found fn item
-   |              |     help: use parentheses to instatiate this tuple struct: `Foo(_)`
+   |              |     help: use parentheses to instantiate this tuple struct: `Foo(_)`
    |              expected `Foo` because of return type
    |
    = note: expected type `Foo`

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -16,7 +16,7 @@ error[E0308]: mismatched types
 LL | fn foo() -> bool {
    |    ---      ^^^^ expected bool, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |
 LL |     break true;
    |               - help: consider removing this semicolon

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-44023.stderr
+++ b/src/test/ui/issues/issue-44023.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn საჭმელად_გემრიელი_სადილი ( ) -> isize {
    |    ------------------------        ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/issues/issue-6458-4.stderr
+++ b/src/test/ui/issues/issue-6458-4.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn foo(b: bool) -> Result<bool,String> {
    |    ---             ^^^^^^^^^^^^^^^^^^^ expected enum `std::result::Result`, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     Err("bar".to_string());
    |                           - help: consider removing this semicolon
    |

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-forgot-ret.stderr
+++ b/src/test/ui/liveness/liveness-forgot-ret.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f(a: isize) -> isize { if god_exists(a) { return 5; }; }
    |    -              ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-missing-ret2.stderr
+++ b/src/test/ui/liveness/liveness-missing-ret2.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return a value
+   |                                this function's body doesn't `return` a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't return
+   |                                this function's body doesn't return a value
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function implicitly returns `()` as its body has no tail or `return` expression
+   |                                implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
+++ b/src/test/ui/liveness/liveness-return-last-stmt-semi.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! test { () => { fn foo() -> i32 { 1; } } }
    |                                ---      ^^^    - help: consider removing this semicolon
    |                                |        |
    |                                |        expected i32, found ()
-   |                                this function's body doesn't `return` a value
+   |                                this function implicitly returns `()` as its body has no tail or `return` expression
 ...
 LL |     test!();
    |     -------- in this macro invocation
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn no_return() -> i32 {}
    |    ---------      ^^^ expected i32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `i32`
               found type `()`
@@ -30,7 +30,7 @@ error[E0308]: mismatched types
 LL | fn bar(x: u32) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
 LL |     x * 2;
    |          - help: consider removing this semicolon
    |
@@ -43,7 +43,7 @@ error[E0308]: mismatched types
 LL | fn baz(x: u64) -> u32 {
    |    ---            ^^^ expected u32, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `u32`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,7 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^
-   |                               |
-   |                               expected !, found ()
-   |                               help: give it a value of the expected type: `break value`
+   |                               ^^^^^ expected !, found ()
    |
    = note: expected type `!`
               found type `()`

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -90,10 +90,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:4:31
    |
 LL |     let val: ! = loop { break break; };
-   |                               ^^^^^ expected (), found !
+   |                               ^^^^^
+   |                               |
+   |                               expected !, found ()
+   |                               help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `!`
+   = note: expected type `!`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:11:19
@@ -153,10 +156,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-break-value.rs:90:9
    |
 LL |         break;
-   |         ^^^^^ expected (), found integer
+   |         ^^^^^
+   |         |
+   |         expected integer, found ()
+   |         help: give it a value of the expected type: `break value`
    |
-   = note: expected type `()`
-              found type `{integer}`
+   = note: expected type `{integer}`
+              found type `()`
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/loops/loop-labeled-break-value.stderr
+++ b/src/test/ui/loops/loop-labeled-break-value.stderr
@@ -2,28 +2,37 @@ error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:3:29
    |
 LL |         let _: i32 = loop { break };
-   |                             ^^^^^ expected (), found i32
+   |                             ^^^^^
+   |                             |
+   |                             expected i32, found ()
+   |                             help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:6:37
    |
 LL |         let _: i32 = 'inner: loop { break 'inner };
-   |                                     ^^^^^^^^^^^^ expected (), found i32
+   |                                     ^^^^^^^^^^^^
+   |                                     |
+   |                                     expected i32, found ()
+   |                                     help: give it a value of the expected type: `break 'inner 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error[E0308]: mismatched types
   --> $DIR/loop-labeled-break-value.rs:9:45
    |
 LL |         let _: i32 = 'inner2: loop { loop { break 'inner2 } };
-   |                                             ^^^^^^^^^^^^^ expected (), found i32
+   |                                             ^^^^^^^^^^^^^
+   |                                             |
+   |                                             expected i32, found ()
+   |                                             help: give it a value of the expected type: `break 'inner2 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/loops/loop-properly-diverging-2.stderr
+++ b/src/test/ui/loops/loop-properly-diverging-2.stderr
@@ -2,10 +2,13 @@ error[E0308]: mismatched types
   --> $DIR/loop-properly-diverging-2.rs:2:23
    |
 LL |   let x: i32 = loop { break };
-   |                       ^^^^^ expected (), found i32
+   |                       ^^^^^
+   |                       |
+   |                       expected i32, found ()
+   |                       help: give it a value of the expected type: `break 42`
    |
-   = note: expected type `()`
-              found type `i32`
+   = note: expected type `i32`
+              found type `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/macros/builtin-prelude-no-accidents.rs
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.rs
@@ -1,0 +1,8 @@
+// Names of public modules in libstd and libcore don't accidentally get into prelude
+// because macros with the same names are in prelude.
+
+fn main() {
+    env::current_dir; //~ ERROR use of undeclared type or module `env`
+    type A = panic::PanicInfo; //~ ERROR use of undeclared type or module `panic`
+    type B = vec::Vec<u8>; //~ ERROR use of undeclared type or module `vec`
+}

--- a/src/test/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/src/test/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,0 +1,21 @@
+error[E0433]: failed to resolve: use of undeclared type or module `env`
+  --> $DIR/builtin-prelude-no-accidents.rs:5:5
+   |
+LL |     env::current_dir;
+   |     ^^^ use of undeclared type or module `env`
+
+error[E0433]: failed to resolve: use of undeclared type or module `panic`
+  --> $DIR/builtin-prelude-no-accidents.rs:6:14
+   |
+LL |     type A = panic::PanicInfo;
+   |              ^^^^^ use of undeclared type or module `panic`
+
+error[E0433]: failed to resolve: use of undeclared type or module `vec`
+  --> $DIR/builtin-prelude-no-accidents.rs:7:14
+   |
+LL |     type B = vec::Vec<u8>;
+   |              ^^^ use of undeclared type or module `vec`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/macros/builtin-std-paths-fail.rs
+++ b/src/test/ui/macros/builtin-std-paths-fail.rs
@@ -1,0 +1,21 @@
+#[derive(
+    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
+    core::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `core`
+)]
+#[core::bench] //~ ERROR could not find `bench` in `core`
+#[core::global_allocator] //~ ERROR could not find `global_allocator` in `core`
+#[core::test_case] //~ ERROR could not find `test_case` in `core`
+#[core::test] //~ ERROR could not find `test` in `core`
+struct Core;
+
+#[derive(
+    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
+    std::RustcDecodable, //~ ERROR could not find `RustcDecodable` in `std`
+)]
+#[std::bench] //~ ERROR could not find `bench` in `std`
+#[std::global_allocator] //~ ERROR could not find `global_allocator` in `std`
+#[std::test_case] //~ ERROR could not find `test_case` in `std`
+#[std::test] //~ ERROR could not find `test` in `std`
+struct Std;
+
+fn main() {}

--- a/src/test/ui/macros/builtin-std-paths-fail.stderr
+++ b/src/test/ui/macros/builtin-std-paths-fail.stderr
@@ -1,0 +1,75 @@
+error[E0433]: failed to resolve: could not find `bench` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:5:9
+   |
+LL | #[core::bench]
+   |         ^^^^^ could not find `bench` in `core`
+
+error[E0433]: failed to resolve: could not find `global_allocator` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:6:9
+   |
+LL | #[core::global_allocator]
+   |         ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `core`
+
+error[E0433]: failed to resolve: could not find `test_case` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:7:9
+   |
+LL | #[core::test_case]
+   |         ^^^^^^^^^ could not find `test_case` in `core`
+
+error[E0433]: failed to resolve: could not find `test` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:8:9
+   |
+LL | #[core::test]
+   |         ^^^^ could not find `test` in `core`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:2:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `core`
+  --> $DIR/builtin-std-paths-fail.rs:3:11
+   |
+LL |     core::RustcDecodable,
+   |           ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `core`
+
+error[E0433]: failed to resolve: could not find `bench` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:15:8
+   |
+LL | #[std::bench]
+   |        ^^^^^ could not find `bench` in `std`
+
+error[E0433]: failed to resolve: could not find `global_allocator` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:16:8
+   |
+LL | #[std::global_allocator]
+   |        ^^^^^^^^^^^^^^^^ could not find `global_allocator` in `std`
+
+error[E0433]: failed to resolve: could not find `test_case` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:17:8
+   |
+LL | #[std::test_case]
+   |        ^^^^^^^^^ could not find `test_case` in `std`
+
+error[E0433]: failed to resolve: could not find `test` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:18:8
+   |
+LL | #[std::test]
+   |        ^^^^ could not find `test` in `std`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:12:10
+   |
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+
+error[E0433]: failed to resolve: could not find `RustcDecodable` in `std`
+  --> $DIR/builtin-std-paths-fail.rs:13:10
+   |
+LL |     std::RustcDecodable,
+   |          ^^^^^^^^^^^^^^ could not find `RustcDecodable` in `std`
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/macros/builtin-std-paths.rs
+++ b/src/test/ui/macros/builtin-std-paths.rs
@@ -1,0 +1,32 @@
+// check-pass
+
+#[derive(
+    core::clone::Clone,
+    core::marker::Copy,
+    core::fmt::Debug,
+    core::default::Default,
+    core::cmp::Eq,
+    core::hash::Hash,
+    core::cmp::Ord,
+    core::cmp::PartialEq,
+    core::cmp::PartialOrd,
+)]
+struct Core;
+
+#[derive(
+    std::clone::Clone,
+    std::marker::Copy,
+    std::fmt::Debug,
+    std::default::Default,
+    std::cmp::Eq,
+    std::hash::Hash,
+    std::cmp::Ord,
+    std::cmp::PartialEq,
+    std::cmp::PartialOrd,
+)]
+struct Std;
+
+fn main() {
+    core::column!();
+    std::column!();
+}

--- a/src/test/ui/match/match-arm-resolving-to-never.rs
+++ b/src/test/ui/match/match-arm-resolving-to-never.rs
@@ -1,0 +1,19 @@
+enum E {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+}
+
+fn main() {
+    match E::F {
+        E::A => 1,
+        E::B => 2,
+        E::C => 3,
+        E::D => 4,
+        E::E => unimplemented!(""),
+        E::F => "", //~ ERROR match arms have incompatible types
+    };
+}

--- a/src/test/ui/match/match-arm-resolving-to-never.stderr
+++ b/src/test/ui/match/match-arm-resolving-to-never.stderr
@@ -1,0 +1,22 @@
+error[E0308]: match arms have incompatible types
+  --> $DIR/match-arm-resolving-to-never.rs:17:17
+   |
+LL | /     match E::F {
+LL | |         E::A => 1,
+LL | |         E::B => 2,
+LL | |         E::C => 3,
+LL | |         E::D => 4,
+LL | |         E::E => unimplemented!(""),
+   | |                 ------------------ this and all prior arms are found to be of type `{integer}`
+LL | |         E::F => "",
+   | |                 ^^ expected integer, found reference
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected type `{integer}`
+              found type `&'static str`
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/missing/missing-return.stderr
+++ b/src/test/ui/missing/missing-return.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { }
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't `return` a value
+   |                      this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return a value
+   |                      this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function implicitly returns `()` as its body has no tail or `return` expression
+   |                      implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62881.stderr
+++ b/src/test/ui/parser/issue-62881.stderr
@@ -19,7 +19,7 @@ error[E0308]: mismatched types
 LL | fn f() -> isize { fn f() -> isize {} pub f<
    |                      -      ^^^^^ expected isize, found ()
    |                      |
-   |                      this function's body doesn't return
+   |                      this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return a value
+   |    this function's body doesn't `return` a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't `return` a value
+   |    this function implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function implicitly returns `()` as its body has no tail or `return` expression
+   |    implicitly returns `()` as its body has no tail or `return` expression
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -38,7 +38,7 @@ error[E0308]: mismatched types
 LL | fn v() -> isize {
    |    -      ^^^^^ expected isize, found ()
    |    |
-   |    this function's body doesn't return
+   |    this function's body doesn't return a value
    |
    = note: expected type `isize`
               found type `()`

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -3,288 +3,384 @@ error[E0603]: tuple struct `A` is private
    |
 LL |     let a = a::A(());
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:52:16
    |
 LL |     let b = a::B(2);
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:53:16
    |
 LL |     let c = a::C(2, 3);
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:56:12
    |
 LL |     let a::A(()) = a;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:57:12
    |
 LL |     let a::A(_) = a;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:58:18
    |
 LL |     match a { a::A(()) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:59:18
    |
 LL |     match a { a::A(_) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:61:12
    |
 LL |     let a::B(_) = b;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:62:12
    |
 LL |     let a::B(_b) = b;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:63:18
    |
 LL |     match b { a::B(_) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:64:18
    |
 LL |     match b { a::B(_b) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:65:18
    |
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:65:32
    |
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:68:12
    |
 LL |     let a::C(_, _) = c;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:69:12
    |
 LL |     let a::C(_a, _) = c;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:70:12
    |
 LL |     let a::C(_, _b) = c;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:71:12
    |
 LL |     let a::C(_a, _b) = c;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:72:18
    |
 LL |     match c { a::C(_, _) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:73:18
    |
 LL |     match c { a::C(_a, _) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:74:18
    |
 LL |     match c { a::C(_, _b) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:75:18
    |
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:83:17
    |
 LL |     let a2 = a::A;
    |                 ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:84:17
    |
 LL |     let b2 = a::B;
    |                 ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:85:17
    |
 LL |     let c2 = a::C;
    |                 ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:90:20
    |
 LL |     let a = other::A(());
    |                    ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:91:20
    |
 LL |     let b = other::B(2);
    |                    ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:92:20
    |
 LL |     let c = other::C(2, 3);
    |                    ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:95:16
    |
 LL |     let other::A(()) = a;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:96:16
    |
 LL |     let other::A(_) = a;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:97:22
    |
 LL |     match a { other::A(()) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:98:22
    |
 LL |     match a { other::A(_) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:100:16
    |
 LL |     let other::B(_) = b;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:101:16
    |
 LL |     let other::B(_b) = b;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:102:22
    |
 LL |     match b { other::B(_) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:103:22
    |
 LL |     match b { other::B(_b) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:104:22
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:104:40
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} }
    |                                        ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:107:16
    |
 LL |     let other::C(_, _) = c;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:108:16
    |
 LL |     let other::C(_a, _) = c;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:109:16
    |
 LL |     let other::C(_, _b) = c;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:110:16
    |
 LL |     let other::C(_a, _b) = c;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:111:22
    |
 LL |     match c { other::C(_, _) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:112:22
    |
 LL |     match c { other::C(_a, _) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:113:22
    |
 LL |     match c { other::C(_, _b) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:114:22
    |
 LL |     match c { other::C(_a, _b) => {} }
    |                      ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:122:21
    |
 LL |     let a2 = other::A;
    |                     ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:123:21
    |
 LL |     let b2 = other::B;
    |                     ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:124:21
    |
 LL |     let c2 = other::C;
    |                     ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/proc-macro/lifetimes.stderr
+++ b/src/test/ui/proc-macro/lifetimes.stderr
@@ -2,7 +2,7 @@ error: expected type, found `'`
   --> $DIR/lifetimes.rs:9:10
    |
 LL | type A = single_quote_alone!();
-   |          ^^^^^^^^^^^^^^^^^^^^^
+   |          ^^^^^^^^^^^^^^^^^^^^^ this macro call doesn't expand to a type
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
+   |                    help: use parentheses to instantiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to call this function: `Z::Fn(...)`
+   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `m::E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to call this function: `E::Fn(...)`
+   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -195,8 +195,14 @@ LL |     let _: Z = m::n::Z::Unit {};
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:27:20
    |
+LL |             Fn(u8),
+   |             ------ fn(u8) -> m::n::Z {m::n::Z::Fn} defined here
+...
 LL |         let _: Z = Z::Fn;
-   |                    ^^^^^ expected enum `m::n::Z`, found fn item
+   |                    ^^^^^
+   |                    |
+   |                    expected enum `m::n::Z`, found fn item
+   |                    help: use parentheses to call this function: `Z::Fn(...)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -219,8 +225,14 @@ LL |         let _ = Z::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = m::E::Fn;
-   |                ^^^^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `m::E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -243,8 +255,14 @@ LL |     let _: E = m::E::Unit;
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
    |
+LL |         Fn(u8),
+   |         ------ fn(u8) -> m::E {m::E::Fn} defined here
+...
 LL |     let _: E = E::Fn;
-   |                ^^^^^ expected enum `m::E`, found fn item
+   |                ^^^^^
+   |                |
+   |                expected enum `m::E`, found fn item
+   |                help: use parentheses to call this function: `E::Fn(...)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -202,7 +202,7 @@ LL |         let _: Z = Z::Fn;
    |                    ^^^^^
    |                    |
    |                    expected enum `m::n::Z`, found fn item
-   |                    help: use parentheses to instatiate this tuple struct: `Z::Fn(_)`
+   |                    help: use parentheses to instatiate this tuple variant: `Z::Fn(_)`
    |
    = note: expected type `m::n::Z`
               found type `fn(u8) -> m::n::Z {m::n::Z::Fn}`
@@ -232,7 +232,7 @@ LL |     let _: E = m::E::Fn;
    |                ^^^^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `m::E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `m::E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`
@@ -262,7 +262,7 @@ LL |     let _: E = E::Fn;
    |                ^^^^^
    |                |
    |                expected enum `m::E`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `E::Fn(_)`
+   |                help: use parentheses to instatiate this tuple variant: `E::Fn(_)`
    |
    = note: expected type `m::E`
               found type `fn(u8) -> m::E {m::E::Fn}`

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -34,36 +34,48 @@ error[E0603]: tuple struct `Z` is private
    |
 LL |         n::Z;
    |            ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:29:8
    |
 LL |     m::S;
    |        ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:31:19
    |
 LL |     let _: S = m::S(2);
    |                   ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `Z` is private
   --> $DIR/privacy-struct-ctor.rs:35:11
    |
 LL |     m::n::Z;
    |           ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:41:16
    |
 LL |     xcrate::m::S;
    |                ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `Z` is private
   --> $DIR/privacy-struct-ctor.rs:45:19
    |
 LL |     xcrate::m::n::Z;
    |                   ^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -15,6 +15,8 @@ error[E0603]: tuple struct `TupleStruct` is private
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
    |                                ^^^^^^^^^^^
+   |
+   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: unit struct `UnitStruct` is private
   --> $DIR/struct.rs:32:32

--- a/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -3,6 +3,8 @@ error[E0603]: tuple variant `Tuple` is private
    |
 LL |     let variant_tuple = NonExhaustiveVariants::Tuple(640);
    |                                                ^^^^^
+   |
+   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:14:47
@@ -21,12 +23,16 @@ error[E0603]: tuple variant `Tuple` is private
    |
 LL |         NonExhaustiveVariants::Tuple(fe_tpl) => "",
    |                                ^^^^^
+   |
+   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:26:35
    |
 LL |     if let NonExhaustiveVariants::Tuple(fe_tpl) = variant_struct {
    |                                   ^^^^^
+   |
+   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0639]: cannot create non-exhaustive variant using struct expression
   --> $DIR/variant.rs:8:26

--- a/src/test/ui/specialization/issue-36804.rs
+++ b/src/test/ui/specialization/issue-36804.rs
@@ -1,0 +1,31 @@
+// check-pass
+#![feature(specialization)]
+
+pub struct Cloned<I>(I);
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+where
+    I: Iterator<Item = &'a T>,
+    T: Clone,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        unimplemented!()
+    }
+}
+
+impl<'a, I, T: 'a> Iterator for Cloned<I>
+where
+    I: Iterator<Item = &'a T>,
+    T: Copy,
+{
+    fn count(self) -> usize {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    let a = [1,2,3,4];
+    Cloned(a.iter()).count();
+}

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::bar::<'static, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static>>::bar::<'static, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<'static, 'static, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<'static, 'static, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<'static>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<'static>}`

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -1,8 +1,14 @@
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:16:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::bar::<ReStatic, char>}`
@@ -10,8 +16,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:25:17
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic>>::bar::<ReStatic, char>}`
@@ -19,8 +31,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u32>>::bar::<'static, char>;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:33:17
    |
+LL |     fn baz() {}
+   |     -------- fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz} defined here
+...
 LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `<i8 as Foo<'static, 'static,  u8>>::baz()`
    |
    = note: expected type `()`
               found type `fn() {<i8 as Foo<ReStatic, ReStatic, u8>>::baz}`
@@ -28,8 +46,14 @@ LL |     let x: () = <i8 as Foo<'static, 'static,  u8>>::baz;
 error[E0308]: mismatched types
   --> $DIR/substs-ppaux.rs:41:17
    |
+LL | fn foo<'z>() where &'z (): Sized {
+   | -------------------------------- fn() {foo::<ReStatic>} defined here
+...
 LL |     let x: () = foo::<'static>;
-   |                 ^^^^^^^^^^^^^^ expected (), found fn item
+   |                 ^^^^^^^^^^^^^^
+   |                 |
+   |                 expected (), found fn item
+   |                 help: use parentheses to call this function: `foo::<'static>()`
    |
    = note: expected type `()`
               found type `fn() {foo::<ReStatic>}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.rs
@@ -1,0 +1,19 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+struct S(usize, usize);
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+}
+
+fn main() {
+    let _: usize = foo(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: S = S(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+    let _: usize = T::baz(_, _);
+    //~^ ERROR expected expression
+    //~| ERROR expected expression
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-with-underscore-args.stderr
@@ -1,0 +1,38 @@
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:24
+   |
+LL |     let _: usize = foo(_, _);
+   |                        ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:10:27
+   |
+LL |     let _: usize = foo(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:18
+   |
+LL |     let _: S = S(_, _);
+   |                  ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:13:21
+   |
+LL |     let _: S = S(_, _);
+   |                     ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:27
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                           ^ expected expression
+
+error: expected expression, found reserved identifier `_`
+  --> $DIR/fn-or-tuple-struct-with-underscore-args.rs:16:30
+   |
+LL |     let _: usize = T::baz(_, _);
+   |                              ^ expected expression
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -11,7 +11,18 @@ struct V();
 
 trait T {
     fn baz(x: usize, y: usize) -> usize { x }
-    fn bat() -> usize { 42 }
+    fn bat(x: usize) -> usize { 42 }
+    fn bax(x: usize) -> usize { 42 }
+    fn bach(x: usize) -> usize;
+    fn ban(&self) -> usize { 42 }
+    fn bal(&self) -> usize;
+}
+
+struct X;
+
+impl T for X {
+    fn bach(x: usize) -> usize { 42 }
+    fn bal(&self) -> usize { 42 }
 }
 
 fn main() {
@@ -23,4 +34,12 @@ fn main() {
     let _: usize = T::bat; //~ ERROR mismatched types
     let _: E = E::A; //~ ERROR mismatched types
     let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
+    let _: usize = X::baz; //~ ERROR mismatched types
+    let _: usize = X::bat; //~ ERROR mismatched types
+    let _: usize = X::bax; //~ ERROR mismatched types
+    let _: usize = X::bach; //~ ERROR mismatched types
+    let _: usize = X::ban; //~ ERROR mismatched types
+    let _: usize = X::bal; //~ ERROR mismatched types
+    let _: usize = X.ban; //~ ERROR attempted to take value of method
+    let _: usize = X.bal; //~ ERROR attempted to take value of method
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -1,0 +1,20 @@
+fn foo(a: usize, b: usize) -> usize { a }
+
+fn bar() -> usize { 42 }
+
+struct S(usize, usize);
+struct V();
+
+trait T {
+    fn baz(x: usize, y: usize) -> usize { x }
+    fn bat() -> usize { 42 }
+}
+
+fn main() {
+    let _: usize = foo; //~ ERROR mismatched types
+    let _: S = S; //~ ERROR mismatched types
+    let _: usize = bar; //~ ERROR mismatched types
+    let _: V = V; //~ ERROR mismatched types
+    let _: usize = T::baz; //~ ERROR mismatched types
+    let _: usize = T::bat; //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -3,6 +3,10 @@ fn foo(a: usize, b: usize) -> usize { a }
 fn bar() -> usize { 42 }
 
 struct S(usize, usize);
+enum E {
+    A(usize),
+    B { a: usize },
+}
 struct V();
 
 trait T {
@@ -17,4 +21,6 @@ fn main() {
     let _: V = V; //~ ERROR mismatched types
     let _: usize = T::baz; //~ ERROR mismatched types
     let _: usize = T::bat; //~ ERROR mismatched types
+    let _: E = E::A; //~ ERROR mismatched types
+    let _: E = E::B; //~ ERROR expected value, found struct variant `E::B`
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -32,7 +32,7 @@ LL |     let _: S = S;
    |                ^
    |                |
    |                expected struct `S`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |                help: use parentheses to instantiate this tuple struct: `S(_, _)`
    |
    = note: expected type `S`
               found type `fn(usize, usize) -> S {S}`
@@ -62,7 +62,7 @@ LL |     let _: V = V;
    |                ^
    |                |
    |                expected struct `V`, found fn item
-   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |                help: use parentheses to instantiate this tuple struct: `V()`
    |
    = note: expected type `V`
               found type `fn() -> V {V}`
@@ -107,7 +107,7 @@ LL |     let _: E = E::A;
    |                ^^^^
    |                |
    |                expected enum `E`, found fn item
-   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |                help: use parentheses to instantiate this tuple variant: `E::A(_)`
    |
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,5 @@
 error[E0423]: expected value, found struct variant `E::B`
-  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:36:16
    |
 LL |     let _: E = E::B;
    |                ^^^-
@@ -8,7 +8,7 @@ LL |     let _: E = E::B;
    |                did you mean `E::B { /* fields */ }`?
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:29:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -23,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:30:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -38,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:31:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -53,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:32:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -68,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:33:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -77,28 +77,28 @@ LL |     let _: usize = T::baz;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::baz(...)`
+   |                    help: use parentheses to call this function: `T::baz(x, y)`
    |
    = note: expected type `usize`
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:34:20
    |
-LL |     fn bat() -> usize { 42 }
-   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<_ as T>::bat} defined here
 ...
 LL |     let _: usize = T::bat;
    |                    ^^^^^^
    |                    |
    |                    expected usize, found fn item
-   |                    help: use parentheses to call this function: `T::bat()`
+   |                    help: use parentheses to call this function: `T::bat(x)`
    |
    = note: expected type `usize`
-              found type `fn() -> usize {<_ as T>::bat}`
+              found type `fn(usize) -> usize {<_ as T>::bat}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:35:16
    |
 LL |     A(usize),
    |     -------- fn(usize) -> E {E::A} defined here
@@ -112,7 +112,109 @@ LL |     let _: E = E::A;
    = note: expected type `E`
               found type `fn(usize) -> E {E::A}`
 
-error: aborting due to 8 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:37:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<X as T>::baz} defined here
+...
+LL |     let _: usize = X::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::baz(x, y)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<X as T>::baz}`
 
-Some errors have detailed explanations: E0308, E0423.
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:38:20
+   |
+LL |     fn bat(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bat} defined here
+...
+LL |     let _: usize = X::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bat(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bat}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:39:20
+   |
+LL |     fn bax(x: usize) -> usize { 42 }
+   |     ------------------------- fn(usize) -> usize {<X as T>::bax} defined here
+...
+LL |     let _: usize = X::bax;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bax(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bax}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:40:20
+   |
+LL |     fn bach(x: usize) -> usize;
+   |     --------------------------- fn(usize) -> usize {<X as T>::bach} defined here
+...
+LL |     let _: usize = X::bach;
+   |                    ^^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bach(x)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize) -> usize {<X as T>::bach}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:41:20
+   |
+LL |     fn ban(&self) -> usize { 42 }
+   |     ---------------------- for<'r> fn(&'r X) -> usize {<X as T>::ban} defined here
+...
+LL |     let _: usize = X::ban;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::ban(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::ban}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:42:20
+   |
+LL |     fn bal(&self) -> usize;
+   |     ----------------------- for<'r> fn(&'r X) -> usize {<X as T>::bal} defined here
+...
+LL |     let _: usize = X::bal;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `X::bal(_)`
+   |
+   = note: expected type `usize`
+              found type `for<'r> fn(&'r X) -> usize {<X as T>::bal}`
+
+error[E0615]: attempted to take value of method `ban` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:43:22
+   |
+LL |     let _: usize = X.ban;
+   |                      ^^^ help: use parentheses to call the method: `ban()`
+
+error[E0615]: attempted to take value of method `bal` on type `X`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:44:22
+   |
+LL |     let _: usize = X.bal;
+   |                      ^^^ help: use parentheses to call the method: `bal()`
+
+error: aborting due to 16 previous errors
+
+Some errors have detailed explanations: E0308, E0423, E0615.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,5 +1,14 @@
+error[E0423]: expected value, found struct variant `E::B`
+  --> $DIR/fn-or-tuple-struct-without-args.rs:25:16
+   |
+LL |     let _: E = E::B;
+   |                ^^^-
+   |                |  |
+   |                |  help: a tuple variant with a similar name exists: `A`
+   |                did you mean `E::B { /* fields */ }`?
+
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
    |
 LL | fn foo(a: usize, b: usize) -> usize { a }
    | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
@@ -14,7 +23,7 @@ LL |     let _: usize = foo;
               found type `fn(usize, usize) -> usize {foo}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:16
    |
 LL | struct S(usize, usize);
    | ----------------------- fn(usize, usize) -> S {S} defined here
@@ -29,7 +38,7 @@ LL |     let _: S = S;
               found type `fn(usize, usize) -> S {S}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:20:20
    |
 LL | fn bar() -> usize { 42 }
    | ----------------- fn() -> usize {bar} defined here
@@ -44,7 +53,7 @@ LL |     let _: usize = bar;
               found type `fn() -> usize {bar}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+  --> $DIR/fn-or-tuple-struct-without-args.rs:21:16
    |
 LL | struct V();
    | ----------- fn() -> V {V} defined here
@@ -59,7 +68,7 @@ LL |     let _: V = V;
               found type `fn() -> V {V}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:22:20
    |
 LL |     fn baz(x: usize, y: usize) -> usize { x }
    |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
@@ -74,7 +83,7 @@ LL |     let _: usize = T::baz;
               found type `fn(usize, usize) -> usize {<_ as T>::baz}`
 
 error[E0308]: mismatched types
-  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+  --> $DIR/fn-or-tuple-struct-without-args.rs:23:20
    |
 LL |     fn bat() -> usize { 42 }
    |     ----------------- fn() -> usize {<_ as T>::bat} defined here
@@ -88,6 +97,22 @@ LL |     let _: usize = T::bat;
    = note: expected type `usize`
               found type `fn() -> usize {<_ as T>::bat}`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:24:16
+   |
+LL |     A(usize),
+   |     -------- fn(usize) -> E {E::A} defined here
+...
+LL |     let _: E = E::A;
+   |                ^^^^
+   |                |
+   |                expected enum `E`, found fn item
+   |                help: use parentheses to instatiate this tuple variant: `E::A(_)`
+   |
+   = note: expected type `E`
+              found type `fn(usize) -> E {E::A}`
 
-For more information about this error, try `rustc --explain E0308`.
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0308, E0423.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,0 +1,93 @@
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:14:20
+   |
+LL | fn foo(a: usize, b: usize) -> usize { a }
+   | ----------------------------------- fn(usize, usize) -> usize {foo} defined here
+...
+LL |     let _: usize = foo;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `foo(a, b)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {foo}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:15:16
+   |
+LL | struct S(usize, usize);
+   | ----------------------- fn(usize, usize) -> S {S} defined here
+...
+LL |     let _: S = S;
+   |                ^
+   |                |
+   |                expected struct `S`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `S(_, _)`
+   |
+   = note: expected type `S`
+              found type `fn(usize, usize) -> S {S}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:16:20
+   |
+LL | fn bar() -> usize { 42 }
+   | ----------------- fn() -> usize {bar} defined here
+...
+LL |     let _: usize = bar;
+   |                    ^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `bar()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {bar}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:17:16
+   |
+LL | struct V();
+   | ----------- fn() -> V {V} defined here
+...
+LL |     let _: V = V;
+   |                ^
+   |                |
+   |                expected struct `V`, found fn item
+   |                help: use parentheses to instatiate this tuple struct: `V()`
+   |
+   = note: expected type `V`
+              found type `fn() -> V {V}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:18:20
+   |
+LL |     fn baz(x: usize, y: usize) -> usize { x }
+   |     ----------------------------------- fn(usize, usize) -> usize {<_ as T>::baz} defined here
+...
+LL |     let _: usize = T::baz;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::baz(...)`
+   |
+   = note: expected type `usize`
+              found type `fn(usize, usize) -> usize {<_ as T>::baz}`
+
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:19:20
+   |
+LL |     fn bat() -> usize { 42 }
+   |     ----------------- fn() -> usize {<_ as T>::bat} defined here
+...
+LL |     let _: usize = T::bat;
+   |                    ^^^^^^
+   |                    |
+   |                    expected usize, found fn item
+   |                    help: use parentheses to call this function: `T::bat()`
+   |
+   = note: expected type `usize`
+              found type `fn() -> usize {<_ as T>::bat}`
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/suggestions/vec-macro-in-pattern.fixed
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.fixed
@@ -2,7 +2,7 @@
 fn main() {
     // everything after `.as_ref` should be suggested
     match Some(vec![3]).as_ref().map(|v| v.as_slice()) {
-        Some(vec![_x]) => (), //~ ERROR unexpected `(` after qualified path
+        Some([_x]) => (), //~ ERROR unexpected `(` after qualified path
         _ => (),
     }
 }

--- a/src/test/ui/suggestions/vec-macro-in-pattern.rs
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.rs
@@ -1,0 +1,6 @@
+fn main() {
+    match Some(vec![3]) {
+        Some(vec![x]) => (), //~ ERROR unexpected `(` after qualified path
+        _ => (),
+    }
+}

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,0 +1,15 @@
+error: unexpected `(` after qualified path
+  --> $DIR/vec-macro-in-pattern.rs:3:14
+   |
+LL |         Some(vec![x]) => (),
+   |              ^^^^^^^
+   |              |
+   |              unexpected `(` after qualified path
+   |              in this macro invocation
+   |              use a slice pattern here instead
+   |
+   = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/vec-macro-in-pattern.stderr
+++ b/src/test/ui/suggestions/vec-macro-in-pattern.stderr
@@ -1,12 +1,12 @@
 error: unexpected `(` after qualified path
-  --> $DIR/vec-macro-in-pattern.rs:3:14
+  --> $DIR/vec-macro-in-pattern.rs:5:14
    |
-LL |         Some(vec![x]) => (),
-   |              ^^^^^^^
+LL |         Some(vec![_x]) => (),
+   |              ^^^^^^^^
    |              |
    |              unexpected `(` after qualified path
    |              in this macro invocation
-   |              use a slice pattern here instead
+   |              help: use a slice pattern here instead: `[_x]`
    |
    = help: for more information, see https://doc.rust-lang.org/edition-guide/rust-2018/slice-patterns.html
    = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

--- a/src/test/ui/type/ascription/issue-47666.stderr
+++ b/src/test/ui/type/ascription/issue-47666.stderr
@@ -6,6 +6,7 @@ LL |     let _ = Option:Some(vec![0, 1]);
    |                   |     |
    |                   |     expected type
    |                   |     in this macro invocation
+   |                   |     this macro call doesn't expand to a type
    |                   help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`

--- a/src/test/ui/typeid-intrinsic.rs
+++ b/src/test/ui/typeid-intrinsic.rs
@@ -78,10 +78,20 @@ pub fn main() {
     assert_eq!(TypeId::of::<other1::U32Iterator>(), other1::id_u32_iterator());
     assert_eq!(other1::id_i32_iterator(), other2::id_i32_iterator());
     assert_eq!(other1::id_u32_iterator(), other2::id_u32_iterator());
-    assert!(other1::id_i32_iterator() != other1::id_u32_iterator());
-    assert!(TypeId::of::<other1::I32Iterator>() != TypeId::of::<other1::U32Iterator>());
+    assert_ne!(other1::id_i32_iterator(), other1::id_u32_iterator());
+    assert_ne!(TypeId::of::<other1::I32Iterator>(), TypeId::of::<other1::U32Iterator>());
 
     // Check fn pointer against collisions
-    assert!(TypeId::of::<fn(fn(A) -> A) -> A>() !=
-            TypeId::of::<fn(fn() -> A, A) -> A>());
+    assert_ne!(
+        TypeId::of::<fn(fn(A) -> A) -> A>(),
+        TypeId::of::<fn(fn() -> A, A) -> A>()
+    );
+    assert_ne!(
+        TypeId::of::<for<'a> fn(&'a i32) -> &'a i32>(),
+        TypeId::of::<for<'a> fn(&'a i32) -> &'static i32>()
+    );
+    assert_ne!(
+        TypeId::of::<for<'a, 'b> fn(&'a i32, &'b i32) -> &'a i32>(),
+        TypeId::of::<for<'a, 'b> fn(&'b i32, &'a i32) -> &'a i32>()
+    );
 }


### PR DESCRIPTION
Successful merges:

 - #63056 (Give built-in macros stable addresses in the standard library)
 - #63149 (resolve: Populate external modules in more automatic and lazy way)
 - #63337 (Tweak mismatched types error)
 - #63350 (Use associated_type_bounds where applicable - closes #61738)
 - #63394 (Add test for issue 36804)
 - #63399 (More explicit diagnostic when using a `vec![]` in a pattern)
 - #63419 (check against more collisions for TypeId of fn pointer)
 - #63423 (Mention that tuple structs are private if any of their fields are)

Failed merges:


r? @ghost