### PR TITLE
resolve: Remove remaining special cases from built-in macros

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -126,8 +126,6 @@ impl<'a> Resolver<'a> {
         };
         if let Some(id) = self.definitions.as_local_node_id(def_id) {
             self.local_macro_def_scopes[&id]
-        } else if self.is_builtin_macro(Some(def_id)) {
-            self.injected_crate.unwrap_or(self.graph_root)
         } else {
             let module_def_id = ty::DefIdTree::parent(&*self, def_id).unwrap();
             self.get_module(module_def_id)
@@ -596,11 +594,6 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                 };
 
                 self.r.populate_module_if_necessary(module);
-                if let Some(name) = self.r.session.parse_sess.injected_crate_name.try_get() {
-                    if name.as_str() == ident.name.as_str() {
-                        self.r.injected_crate = Some(module);
-                    }
-                }
 
                 let used = self.process_legacy_macro_imports(item, module);
                 let binding =

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -929,8 +929,6 @@ pub struct Resolver<'a> {
     /// it's not used during normal resolution, only for better error reporting.
     struct_constructors: DefIdMap<(Res, ty::Visibility)>,
 
-    injected_crate: Option<Module<'a>>,
-
     /// Features enabled for this crate.
     active_features: FxHashSet<Symbol>,
 }
@@ -1168,7 +1166,6 @@ impl<'a> Resolver<'a> {
             unused_macros: Default::default(),
             proc_macro_stubs: Default::default(),
             special_derives: Default::default(),
-            injected_crate: None,
             active_features:
                 features.declared_lib_features.iter().map(|(feat, ..)| *feat)
                     .chain(features.declared_lang_features.iter().map(|(feat, ..)| *feat))

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -854,8 +854,6 @@ impl<'a> Resolver<'a> {
                 if ext.is_builtin {
                     // The macro is a built-in, replace only the expander function.
                     result.kind = ext.kind;
-                    // Also reset its edition to the global one for compatibility.
-                    result.edition = self.session.edition();
                 } else {
                     // The macro is from a plugin, the in-source definition is dummy,
                     // take all the data from the resolver.

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -592,8 +592,8 @@ pub struct SyntaxExtension {
     pub helper_attrs: Vec<Symbol>,
     /// Edition of the crate in which this macro is defined.
     pub edition: Edition,
-    /// Built-in macros have a couple of special properties (meaning of `$crate`,
-    /// availability in `#[no_implicit_prelude]` modules), so we have to keep this flag.
+    /// Built-in macros have a couple of special properties like availability
+    /// in `#[no_implicit_prelude]` modules, so we have to keep this flag.
     pub is_builtin: bool,
     /// We have to identify macros providing a `Copy` impl early for compatibility reasons.
     pub is_derive_copy: bool,

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -495,7 +495,7 @@ impl<'a> ExtCtxt<'a> {
         let expr_loc_ptr = self.expr_addr_of(span, expr_loc_tuple);
         self.expr_call_global(
             span,
-            self.std_path(&[sym::rt, sym::begin_panic]),
+            [sym::std, sym::rt, sym::begin_panic].iter().map(|s| Ident::new(*s, span)).collect(),
             vec![
                 self.expr_str(span, msg),
                 expr_loc_ptr])

--- a/src/test/pretty/dollar-crate.pp
+++ b/src/test/pretty/dollar-crate.pp
@@ -10,9 +10,9 @@ extern crate std;
 
 fn main() {
     {
-        ::std::io::_print(::std::fmt::Arguments::new_v1(&["rust\n"],
-                                                        &match () {
-                                                             () => [],
-                                                         }));
+        ::std::io::_print(::core::fmt::Arguments::new_v1(&["rust\n"],
+                                                         &match () {
+                                                              () => [],
+                                                          }));
     };
 }

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -30,7 +30,7 @@ pub fn bar() ({
 
 
                   ((::alloc::fmt::format as
-                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::std::fmt::Arguments>::new_v1
+                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::core::fmt::Arguments>::new_v1
                                                                                                            as
                                                                                                            fn(&[&str], &[std::fmt::ArgumentV1<'_>]) -> std::fmt::Arguments<'_> {std::fmt::Arguments::<'_>::new_v1})((&([("test"
                                                                                                                                                                                                                             as

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -5,11 +5,10 @@
 #![feature(box_syntax)]
 #![feature(rustc_private)]
 
-extern crate serialize;
-use serialize as rustc_serialize;
+extern crate serialize as rustc_serialize;
 
-use serialize::{Encodable, Decodable};
-use serialize::json;
+use rustc_serialize::{Encodable, Decodable};
+use rustc_serialize::json;
 
 #[derive(RustcEncodable, RustcDecodable)]
 struct A {

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -7,12 +7,11 @@
 
 #![feature(rustc_private)]
 
-extern crate serialize;
-use serialize as rustc_serialize;
+extern crate serialize as rustc_serialize;
 
 use std::cell::{Cell, RefCell};
-use serialize::{Encodable, Decodable};
-use serialize::json;
+use rustc_serialize::{Encodable, Decodable};
+use rustc_serialize::json;
 
 #[derive(RustcEncodable, RustcDecodable)]
 struct A {

--- a/src/test/ui-fulldeps/deriving-global.rs
+++ b/src/test/ui-fulldeps/deriving-global.rs
@@ -2,8 +2,7 @@
 
 #![feature(rustc_private)]
 
-extern crate serialize;
-use serialize as rustc_serialize;
+extern crate serialize as rustc_serialize;
 
 mod submod {
     // if any of these are implemented without global calls for any

--- a/src/test/ui-fulldeps/deriving-hygiene.rs
+++ b/src/test/ui-fulldeps/deriving-hygiene.rs
@@ -2,8 +2,7 @@
 
 #![allow(non_upper_case_globals)]
 #![feature(rustc_private)]
-extern crate serialize;
-use serialize as rustc_serialize;
+extern crate serialize as rustc_serialize;
 
 pub const other: u8 = 1;
 pub const f: u8 = 1;

--- a/src/test/ui-fulldeps/issue-11881.rs
+++ b/src/test/ui-fulldeps/issue-11881.rs
@@ -6,17 +6,16 @@
 
 #![feature(rustc_private)]
 
-extern crate serialize;
-use serialize as rustc_serialize;
+extern crate serialize as rustc_serialize;
 
 use std::io::Cursor;
 use std::io::prelude::*;
 use std::fmt;
 use std::slice;
 
-use serialize::{Encodable, Encoder};
-use serialize::json;
-use serialize::opaque;
+use rustc_serialize::{Encodable, Encoder};
+use rustc_serialize::json;
+use rustc_serialize::opaque;
 
 #[derive(RustcEncodable)]
 struct Foo {


### PR DESCRIPTION
Edition and definition sites of the macros are now also taken from the `#[rustc_builtin_macro]` definitions in `libcore`.

---
The edition switch may be a breaking change for `Rustc{Encodable,Decodable}` derives if they are used in combination with the unstable crate `serialize` from sysroot like this
```rust
extern crate serialize;
use serialize as rustc_serialize;

#[derive(RustcEncodable)]
struct S;
```
(see the updated `ui-fulldeps` tests).