### PR TITLE
rustc_target: use Integer instead of Primitive for discriminants and niches.

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -63,7 +63,7 @@ pub struct CrateDebugContext<'a, 'tcx> {
     llmod: &'a llvm::Module,
     builder: &'a mut DIBuilder<'a>,
     created_files: RefCell<FxHashMap<(Option<String>, Option<String>), &'a DIFile>>,
-    created_enum_disr_types: RefCell<FxHashMap<(DefId, layout::Primitive), &'a DIType>>,
+    created_enum_disr_types: RefCell<FxHashMap<(DefId, layout::Integer), &'a DIType>>,
 
     type_map: RefCell<TypeMap<'a, 'tcx>>,
     namespace_map: RefCell<DefIdMap<&'a DIScope>>,

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -963,7 +963,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
                 _ => return,
             };
 
-            let discr_size = tag.value.size(&cx.tcx).bytes();
+            let discr_size = tag.value.size().bytes();
 
             debug!("enum `{}` is {} bytes large with layout:\n{:#?}",
                    t, layout.size.bytes(), layout);

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -1010,7 +1010,7 @@ where
                 // raw discriminants for enums are isize or bigger during
                 // their computation, but the in-memory tag is the smallest possible
                 // representation
-                let size = discr.value.size(self);
+                let size = discr.value.size();
                 let discr_val = truncate(discr_val, size);
 
                 let discr_dest = self.place_field(dest, discr_index as u64)?;


### PR DESCRIPTION
Instead of signed/unsigned integers or [pointers](https://github.com/rust-lang/rust/issues/62138#issuecomment-520154725), discriminants (tag/niche-filling) and niches are now always unsigned integers (signedness is handled when reading them as signed values).
This does seems like a simplification, but only slightly (perhaps I haven't cleaned up everything that had to special-case signed integers or pointers).

To avoid some duplication, `Scalar` was made generic over the type of its `value` field.

See https://github.com/rust-lang/rust/issues/62138#issuecomment-520154725 for some of the discussion that led to me trying this out.

cc @RalfJung @oli-obk @nagisa

(As I wrote this, just noticed 3 tests failed, AFAICT all because of signedness)