### PR TITLE
Generate urls for default trait items as well

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -375,7 +375,7 @@ impl Step for Standalone {
                up_to_date(&footer, &html) &&
                up_to_date(&favicon, &html) &&
                up_to_date(&full_toc, &html) &&
-               up_to_date(&version_info, &html) &&
+               (version_info.exists() && up_to_date(&version_info, &html)) &&
                (builder.config.dry_run || up_to_date(&rustdoc, &html)) {
                 continue
             }

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -169,7 +169,7 @@ pub trait Hash {
     /// println!("Hash is {:x}!", hasher.finish());
     /// ```
     ///
-    /// [`Hasher`]: trait.Hasher.html
+    /// [`Hasher`]: hash::Hasher
     #[stable(feature = "rust1", since = "1.0.0")]
     fn hash<H: Hasher>(&self, state: &mut H);
 
@@ -187,7 +187,7 @@ pub trait Hash {
     /// println!("Hash is {:x}!", hasher.finish());
     /// ```
     ///
-    /// [`Hasher`]: trait.Hasher.html
+    /// [`Hasher`]: hash::Hasher
     #[stable(feature = "hash_slice", since = "1.3.0")]
     fn hash_slice<H: Hasher>(data: &[Self], state: &mut H)
         where Self: Sized


### PR DESCRIPTION
Fixes #62741

cc @rust-lang/rustdoc 

I expect this PR to fail since a lot(?) of new URLs will be generated. I used the same model as for short doc on items in module view.