### PR TITLE
Move sqrt from `std` to `core`

### DIFF
--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -584,7 +584,7 @@ impl f32 {
     /// # Examples
     ///
     /// ```
-    /// use std::f32;
+    /// use core::f32;
     ///
     /// let positive = 4.0_f32;
     /// let negative = -4.0_f32;

--- a/src/libcore/num/f32.rs
+++ b/src/libcore/num/f32.rs
@@ -576,4 +576,31 @@ impl f32 {
     pub fn from_ne_bytes(bytes: [u8; 4]) -> Self {
         Self::from_bits(u32::from_ne_bytes(bytes))
     }
+
+    /// Takes the square root of a number.
+    ///
+    /// Returns NaN if `self` is a negative number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::f32;
+    ///
+    /// let positive = 4.0_f32;
+    /// let negative = -4.0_f32;
+    ///
+    /// let abs_difference = (positive.sqrt() - 2.0).abs();
+    ///
+    /// assert!(abs_difference <= f32::EPSILON);
+    /// assert!(negative.sqrt().is_nan());
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
+    pub fn sqrt(self) -> f32 {
+        if self < 0.0 {
+            NAN
+        } else {
+            unsafe { intrinsics::sqrtf32(self) }
+        }
+    }
 }

--- a/src/libcore/num/f64.rs
+++ b/src/libcore/num/f64.rs
@@ -589,4 +589,29 @@ impl f64 {
     pub fn from_ne_bytes(bytes: [u8; 8]) -> Self {
         Self::from_bits(u64::from_ne_bytes(bytes))
     }
+
+    /// Takes the square root of a number.
+    ///
+    /// Returns NaN if `self` is a negative number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let positive = 4.0_f64;
+    /// let negative = -4.0_f64;
+    ///
+    /// let abs_difference = (positive.sqrt() - 2.0).abs();
+    ///
+    /// assert!(abs_difference < 1e-10);
+    /// assert!(negative.sqrt().is_nan());
+    /// ```
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[inline]
+    pub fn sqrt(self) -> f64 {
+        if self < 0.0 {
+            NAN
+        } else {
+            unsafe { intrinsics::sqrtf64(self) }
+        }
+    }
 }

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -350,33 +350,6 @@ impl f32 {
         return unsafe { intrinsics::powf32(self, n) };
     }
 
-    /// Takes the square root of a number.
-    ///
-    /// Returns NaN if `self` is a negative number.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::f32;
-    ///
-    /// let positive = 4.0_f32;
-    /// let negative = -4.0_f32;
-    ///
-    /// let abs_difference = (positive.sqrt() - 2.0).abs();
-    ///
-    /// assert!(abs_difference <= f32::EPSILON);
-    /// assert!(negative.sqrt().is_nan());
-    /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
-    pub fn sqrt(self) -> f32 {
-        if self < 0.0 {
-            NAN
-        } else {
-            unsafe { intrinsics::sqrtf32(self) }
-        }
-    }
-
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// # Examples

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -317,31 +317,6 @@ impl f64 {
         unsafe { intrinsics::powf64(self, n) }
     }
 
-    /// Takes the square root of a number.
-    ///
-    /// Returns NaN if `self` is a negative number.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let positive = 4.0_f64;
-    /// let negative = -4.0_f64;
-    ///
-    /// let abs_difference = (positive.sqrt() - 2.0).abs();
-    ///
-    /// assert!(abs_difference < 1e-10);
-    /// assert!(negative.sqrt().is_nan());
-    /// ```
-    #[stable(feature = "rust1", since = "1.0.0")]
-    #[inline]
-    pub fn sqrt(self) -> f64 {
-        if self < 0.0 {
-            NAN
-        } else {
-            unsafe { intrinsics::sqrtf64(self) }
-        }
-    }
-
     /// Returns `e^(self)`, (the exponential function).
     ///
     /// # Examples


### PR DESCRIPTION
Per https://github.com/rust-lang/rust/issues/50145#issuecomment-500585278 and https://github.com/rust-lang/rust/issues/50145#issuecomment-520169062

* This PR moves the `sqrt` method of the `f32` and `f64` types from `libstd` to `libcore`.
* I literally just cut and pasted the methods from one place to the other, it was simpler than I expected it to be.
* I didn't alter any tests, though naturally any tests that check methods available on a type in std should also still work if the method is available on the type in core.
* I didn't add and _new_ tests that check that the functionality is available in just core, because I don't know where those tests go. There's a whole lot of folders and no `tests/` folder in the project root like a normal crate has. Someone please tell me.
* I didn't put this behind a feature flag because I don't know how to do that, and also I'm not sure that a feature flag is necessary. If a feature flag _is_ necessary someone also please explain how to do that.

cc @varkor, cc @alexcrichton