### PR TITLE
Add Catalyst (iOS apps running on macOS) target

### DIFF
--- a/src/librustc_target/spec/apple_ios_base.rs
+++ b/src/librustc_target/spec/apple_ios_base.rs
@@ -13,7 +13,8 @@ pub enum Arch {
     Armv7s,
     Arm64,
     I386,
-    X86_64
+    X86_64,
+    X86_64_macabi,
 }
 
 impl Arch {
@@ -23,7 +24,8 @@ impl Arch {
             Armv7s => "armv7s",
             Arm64 => "arm64",
             I386 => "i386",
-            X86_64 => "x86_64"
+            X86_64 => "x86_64",
+            X86_64_macabi => "x86_64"
         }
     }
 }
@@ -67,7 +69,8 @@ pub fn get_sdk_root(sdk_name: &str) -> Result<String, String> {
 fn build_pre_link_args(arch: Arch) -> Result<LinkArgs, String> {
     let sdk_name = match arch {
         Armv7 | Armv7s | Arm64 => "iphoneos",
-        I386 | X86_64 => "iphonesimulator"
+        I386 | X86_64 => "iphonesimulator",
+        X86_64_macabi => "macosx10.15",
     };
 
     let arch_name = arch.to_string();
@@ -93,6 +96,7 @@ fn target_cpu(arch: Arch) -> String {
         Arm64 => "cyclone",
         I386 => "yonah",
         X86_64 => "core2",
+        X86_64_macabi => "core2",
     }.to_string()
 }
 

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -425,6 +425,7 @@ supported_targets! {
     ("aarch64-apple-ios", aarch64_apple_ios),
     ("armv7-apple-ios", armv7_apple_ios),
     ("armv7s-apple-ios", armv7s_apple_ios),
+    ("x86_64-apple-ios-macabi", x86_64_apple_ios_macabi),
 
     ("armebv7r-none-eabi", armebv7r_none_eabi),
     ("armebv7r-none-eabihf", armebv7r_none_eabihf),

--- a/src/librustc_target/spec/x86_64_apple_ios_macabi.rs
+++ b/src/librustc_target/spec/x86_64_apple_ios_macabi.rs
@@ -1,0 +1,23 @@
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+use super::apple_ios_base::{opts, Arch};
+
+pub fn target() -> TargetResult {
+    let base = opts(Arch::X86_64_macabi)?;
+    Ok(Target {
+        llvm_target: "x86_64-apple-ios13.0-macabi".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:o-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        arch: "x86_64".to_string(),
+        target_os: "ios".to_string(),
+        target_env: String::new(),
+        target_vendor: "apple".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            max_atomic_width: Some(64),
+            stack_probes: true,
+            .. base
+        }
+    })
+}


### PR DESCRIPTION
This is a first attempt of adding support for the new [Apple Catalyst](https://developer.apple.com/ipad-apps-for-mac/) target (i.e. running iOS apps on macOS). Currently, `rustc` supports the iOS and iOS simulator targets for iOS:
- iOS: ARM cpu, iOS SDK, linked agains the iOS ABI
- Simulator: X86_64 cpu, iOS SDK, linked against the iOS ABI

Apple Catalyst will add an additional target:
- Macabi: X86_64 CPU, iOS SDK, linked again the macOS ABI.

Note, it the actual SDK is the also the macOS 10.15 SDK, but the symbols are the iOS SDK symbols as they were added to macOS with 10.15.

I've collected additional information via links in the open question sections below. This is way out of my comfort zone so please excuse whatever errors I may have made.

# Open Questions:

## Clang Version
It seems to me that `macabi` has not been merged into `clang` yet, I don't know whether that is a requirement rustc to compile, or if it is sufficient if the Clang that is used on a developers system is the correct one supporting macabi (that comes with current Xcode)


## Hardcoded iOS version

`swift-llvm` actually used [x86_64-apple-ios13.0-macabi](https://github.com/apple/swift-llvm/commit/3f1fd4f46a8e82cee6fffb284ee46daf8ddf66ae) as the target triple which hard-codes the current iOS version. A post on stackoverflow [points out that `MIN_IOS_VERSION` and `MIN_OSX_VERSION` should be used when compiling C code for clang (`-target x86_64-apple-ios${MIN_IOS_VERSION}-macabi`)](https://stackoverflow.com/questions/56487645/how-to-compile-a-3rd-party-library-to-be-used-with-uikit-for-mac-catalyst). However, I wasn't entirely sure how to do that in this PR. Pointers welcome.


## Data Layout
I'm probably using the wrong data-layout. I don't know whether it should be the macOS version or the iOS version. This is probably easier to answer for somebody who understands these things much better than me. I just copied the iOS Simulator X86_64 version as it seems to be (based on what I understand) that Catalyst is just the simulator target build against a different SDK.


# Current State
1. I got it to compile
2. I could successfully compile a `macabi` `libcore` via `cargo build --target x86_64-apple-ios-macabi`

I'm not sure what needs to be done next. Supposedly I need to compile everything into a toolchain somehow that I can then test via `rustup` to make sure that a binary compiled against the toolchain also works with Catalyst. [I read this article, but I'm still lost](https://www.reddit.com/r/rust/comments/5ag60z/how_do_i_bootstrap_rust_to_crosscompile_for_a_new/d9gicr2/) and would love pointers what to do next here.

# Additional Information
- [Commit adding Catalyst support to the Swift Clang Fork](https://github.com/CocoaPods/CocoaPods/issues/8877)
- [Compiling C to Catalyst Discussion](https://github.com/CocoaPods/CocoaPods/issues/8877)
- [CocoaPods Discussion on Adding Catalyst support](https://github.com/CocoaPods/CocoaPods/issues/8877)
