### PR TITLE
Document `From` trait for `BinaryHeap`

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1163,6 +1163,9 @@ impl<T> FusedIterator for Drain<'_, T> {}
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
+    /// Converts a `Vec` into a `BinaryHeap`.
+    ///
+    /// This conversion happens in-place, and has O(n) time complexity.
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
         heap.rebuild();

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1163,9 +1163,9 @@ impl<T> FusedIterator for Drain<'_, T> {}
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
-    /// Converts a `Vec` into a `BinaryHeap`.
+    /// Converts a `Vec<T>` into a `BinaryHeap<T>`.
     ///
-    /// This conversion happens in-place, and has O(n) time complexity.
+    /// This conversion happens in-place, and has `O(n)` time complexity.
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
         heap.rebuild();


### PR DESCRIPTION
This PR solves part of #51430. (cc @skade)

The comments described allocation and time complexity of the conversion from Vec to BinaryHeap

The complexity description of BinaryHeap operations is available at mod level:
https://doc.rust-lang.org/alloc/collections/binary_heap/index.html

But it doesn't show up at BinaryHeap page:
https://doc.rust-lang.org/alloc/collections/binary_heap/struct.BinaryHeap.html