### PR TITLE
Remove redundancy from the implementation of C variadics.

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -633,9 +633,7 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
         TyKind::Typeof(ref expression) => {
             visitor.visit_anon_const(expression)
         }
-        TyKind::CVarArgs(ref lt) => {
-            visitor.visit_lifetime(lt)
-        }
+        TyKind::CVarArgs |
         TyKind::Infer | TyKind::Err => {}
     }
 }

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -633,7 +633,6 @@ pub fn walk_ty<'v, V: Visitor<'v>>(visitor: &mut V, typ: &'v Ty) {
         TyKind::Typeof(ref expression) => {
             visitor.visit_anon_const(expression)
         }
-        TyKind::CVarArgs |
         TyKind::Infer | TyKind::Err => {}
     }
 }

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2168,7 +2168,7 @@ impl<'a> LoweringContext<'a> {
         P(hir::FnDecl {
             inputs,
             output,
-            c_variadic: decl.c_variadic,
+            c_variadic: decl.c_variadic(),
             implicit_self: decl.inputs.get(0).map_or(
                 hir::ImplicitSelfKind::None,
                 |arg| {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1335,8 +1335,8 @@ impl<'a> LoweringContext<'a> {
                     }
                 }
             }
-            TyKind::Mac(_) => bug!("`TyMac` should have been expanded by now"),
-            TyKind::CVarArgs => hir::TyKind::CVarArgs,
+            TyKind::Mac(_) => bug!("`TyKind::Mac` should have been expanded by now"),
+            TyKind::CVarArgs => bug!("`TyKind::CVarArgs` should have been handled elsewhere"),
         };
 
         hir::Ty {
@@ -2088,7 +2088,14 @@ impl<'a> LoweringContext<'a> {
     }
 
     fn lower_fn_params_to_names(&mut self, decl: &FnDecl) -> hir::HirVec<Ident> {
-        decl.inputs
+        // Skip the `...` (`CVarArgs`) trailing arguments from the AST,
+        // as they are not explicit in HIR/Ty function signatures.
+        // (instead, the `c_variadic` flag is set to `true`)
+        let mut inputs = &decl.inputs[..];
+        if decl.c_variadic() {
+            inputs = &inputs[..inputs.len() - 1];
+        }
+        inputs
             .iter()
             .map(|param| match param.pat.kind {
                 PatKind::Ident(_, ident, _) => ident,
@@ -2125,10 +2132,19 @@ impl<'a> LoweringContext<'a> {
             self.anonymous_lifetime_mode
         };
 
+        let c_variadic = decl.c_variadic();
+
         // Remember how many lifetimes were already around so that we can
         // only look at the lifetime parameters introduced by the arguments.
         let inputs = self.with_anonymous_lifetime_mode(lt_mode, |this| {
-            decl.inputs
+            // Skip the `...` (`CVarArgs`) trailing arguments from the AST,
+            // as they are not explicit in HIR/Ty function signatures.
+            // (instead, the `c_variadic` flag is set to `true`)
+            let mut inputs = &decl.inputs[..];
+            if c_variadic {
+                inputs = &inputs[..inputs.len() - 1];
+            }
+            inputs
                 .iter()
                 .map(|param| {
                     if let Some((_, ibty)) = &mut in_band_ty_params {
@@ -2163,7 +2179,7 @@ impl<'a> LoweringContext<'a> {
         P(hir::FnDecl {
             inputs,
             output,
-            c_variadic: decl.c_variadic(),
+            c_variadic,
             implicit_self: decl.inputs.get(0).map_or(
                 hir::ImplicitSelfKind::None,
                 |arg| {

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1336,12 +1336,7 @@ impl<'a> LoweringContext<'a> {
                 }
             }
             TyKind::Mac(_) => bug!("`TyMac` should have been expanded by now"),
-            TyKind::CVarArgs => {
-                // Create the implicit lifetime of the "spoofed" `VaListImpl`.
-                let span = self.sess.source_map().next_point(t.span.shrink_to_lo());
-                let lt = self.new_implicit_lifetime(span);
-                hir::TyKind::CVarArgs(lt)
-            },
+            TyKind::CVarArgs => hir::TyKind::CVarArgs,
         };
 
         hir::Ty {

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -450,7 +450,6 @@ impl LoweringContext<'_> {
         let ast_decl = FnDecl {
             inputs: vec![],
             output,
-            c_variadic: false
         };
         let decl = self.lower_fn_decl(&ast_decl, None, /* impl trait allowed */ false, None);
         let body_id = self.lower_fn_body(&ast_decl, |this| {
@@ -739,7 +738,6 @@ impl LoweringContext<'_> {
         let outer_decl = FnDecl {
             inputs: decl.inputs.clone(),
             output: FunctionRetTy::Default(fn_decl_span),
-            c_variadic: false,
         };
         // We need to lower the declaration outside the new scope, because we
         // have to conserve the state of being inside a loop condition for the

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2018,7 +2018,7 @@ pub enum TyKind {
     Err,
     /// Placeholder for C-variadic arguments. We "spoof" the `VaListImpl` created
     /// from the variadic arguments. This type is only valid up to typeck.
-    CVarArgs(Lifetime),
+    CVarArgs,
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2016,9 +2016,6 @@ pub enum TyKind {
     Infer,
     /// Placeholder for a type that has failed to be defined.
     Err,
-    /// Placeholder for C-variadic arguments. We "spoof" the `VaListImpl` created
-    /// from the variadic arguments. This type is only valid up to typeck.
-    CVarArgs,
 }
 
 #[derive(Copy, Clone, RustcEncodable, RustcDecodable, Debug, HashStable)]

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -361,9 +361,6 @@ impl<'a> State<'a> {
                 self.s.word("/*ERROR*/");
                 self.pclose();
             }
-            hir::TyKind::CVarArgs => {
-                self.s.word("...");
-            }
         }
         self.end()
     }

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -361,7 +361,7 @@ impl<'a> State<'a> {
                 self.s.word("/*ERROR*/");
                 self.pclose();
             }
-            hir::TyKind::CVarArgs(_) => {
+            hir::TyKind::CVarArgs => {
                 self.s.word("...");
             }
         }

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -764,13 +764,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                     });
                 }
             }
-            hir::TyKind::CVarArgs(ref lt) => {
-                // Resolve the generated lifetime for the C-variadic arguments.
-                // The lifetime is generated in AST -> HIR lowering.
-                if lt.name.is_elided() {
-                    self.resolve_elided_lifetimes(vec![lt])
-                }
-            }
             _ => intravisit::walk_ty(self, ty),
         }
     }
@@ -2378,7 +2371,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                             self.visit_lifetime(lifetime);
                         }
                     }
-                    hir::TyKind::CVarArgs(_) => {}
                     _ => {
                         intravisit::walk_ty(self, ty);
                     }

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -25,7 +25,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
 pub use rustc_target::abi::*;
 use rustc_target::spec::{HasTargetSpec, abi::Abi as SpecAbi};
 use rustc_target::abi::call::{
-    ArgAttribute, ArgAttributes, ArgType, Conv, FnType, IgnoreMode, PassMode, Reg, RegKind
+    ArgAttribute, ArgAttributes, ArgType, Conv, FnType, PassMode, Reg, RegKind
 };
 
 pub trait IntegerExt {
@@ -2722,14 +2722,6 @@ where
             }
         };
 
-        // Store the index of the last argument. This is useful for working with
-        // C-compatible variadic arguments.
-        let last_arg_idx = if sig.inputs().is_empty() {
-            None
-        } else {
-            Some(sig.inputs().len() - 1)
-        };
-
         let arg_of = |ty: Ty<'tcx>, arg_idx: Option<usize>| {
             let is_return = arg_idx.is_none();
             let mut arg = mk_arg_type(ty, arg_idx);
@@ -2739,30 +2731,7 @@ where
                 // The same is true for s390x-unknown-linux-gnu
                 // and sparc64-unknown-linux-gnu.
                 if is_return || rust_abi || (!win_x64_gnu && !linux_s390x && !linux_sparc64) {
-                    arg.mode = PassMode::Ignore(IgnoreMode::Zst);
-                }
-            }
-
-            // If this is a C-variadic function, this is not the return value,
-            // and there is one or more fixed arguments; ensure that the `VaListImpl`
-            // is ignored as an argument.
-            if sig.c_variadic {
-                match (last_arg_idx, arg_idx) {
-                    (Some(last_idx), Some(cur_idx)) if last_idx == cur_idx => {
-                        let va_list_did = match cx.tcx().lang_items().va_list() {
-                            Some(did) => did,
-                            None => bug!("`va_list` lang item required for C-variadic functions"),
-                        };
-                        match ty.kind {
-                            ty::Adt(def, _) if def.did == va_list_did => {
-                                // This is the "spoofed" `VaListImpl`. Set the arguments mode
-                                // so that it will be ignored.
-                                arg.mode = PassMode::Ignore(IgnoreMode::CVarArgs);
-                            }
-                            _ => (),
-                        }
-                    }
-                    _ => {}
+                    arg.mode = PassMode::Ignore;
                 }
             }
 

--- a/src/librustc_codegen_llvm/abi.rs
+++ b/src/librustc_codegen_llvm/abi.rs
@@ -264,7 +264,7 @@ impl ArgTypeExt<'ll, 'tcx> for ArgType<'tcx, Ty<'tcx>> {
             val
         };
         match self.mode {
-            PassMode::Ignore(_) => {}
+            PassMode::Ignore => {}
             PassMode::Pair(..) => {
                 OperandValue::Pair(next(), next()).store(bx, dst);
             }
@@ -319,9 +319,7 @@ impl<'tcx> FnTypeLlvmExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
         );
 
         let llreturn_ty = match self.ret.mode {
-            PassMode::Ignore(IgnoreMode::Zst) => cx.type_void(),
-            PassMode::Ignore(IgnoreMode::CVarArgs) =>
-                bug!("`va_list` should never be a return type"),
+            PassMode::Ignore => cx.type_void(),
             PassMode::Direct(_) | PassMode::Pair(..) => {
                 self.ret.layout.immediate_llvm_type(cx)
             }
@@ -339,7 +337,7 @@ impl<'tcx> FnTypeLlvmExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
             }
 
             let llarg_ty = match arg.mode {
-                PassMode::Ignore(_) => continue,
+                PassMode::Ignore => continue,
                 PassMode::Direct(_) => arg.layout.immediate_llvm_type(cx),
                 PassMode::Pair(..) => {
                     llargument_tys.push(arg.layout.scalar_pair_element_llvm_type(cx, 0, true));
@@ -408,7 +406,7 @@ impl<'tcx> FnTypeLlvmExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                 apply(&ArgAttributes::new(), None);
             }
             match arg.mode {
-                PassMode::Ignore(_) => {}
+                PassMode::Ignore => {}
                 PassMode::Direct(ref attrs) |
                 PassMode::Indirect(ref attrs, None) => apply(attrs, Some(arg.layout.llvm_type(cx))),
                 PassMode::Indirect(ref attrs, Some(ref extra_attrs)) => {
@@ -455,7 +453,7 @@ impl<'tcx> FnTypeLlvmExt<'tcx> for FnType<'tcx, Ty<'tcx>> {
                 apply(&ArgAttributes::new(), None);
             }
             match arg.mode {
-                PassMode::Ignore(_) => {}
+                PassMode::Ignore => {}
                 PassMode::Direct(ref attrs) |
                 PassMode::Indirect(ref attrs, None) => apply(attrs, Some(arg.layout.llvm_type(bx))),
                 PassMode::Indirect(ref attrs, Some(ref extra_attrs)) => {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -3,7 +3,7 @@ use rustc::ty::{self, Ty, TypeFoldable, Instance};
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt, FnTypeExt};
 use rustc::mir::{self, Place, PlaceBase, Static, StaticKind};
 use rustc::mir::interpret::PanicInfo;
-use rustc_target::abi::call::{ArgType, FnType, PassMode, IgnoreMode};
+use rustc_target::abi::call::{ArgType, FnType, PassMode};
 use rustc_target::spec::abi::Abi;
 use crate::base;
 use crate::MemFlags;
@@ -242,13 +242,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
         let llval = match self.fn_ty.ret.mode {
-            PassMode::Ignore(IgnoreMode::Zst) | PassMode::Indirect(..) => {
+            PassMode::Ignore | PassMode::Indirect(..) => {
                 bx.ret_void();
                 return;
-            }
-
-            PassMode::Ignore(IgnoreMode::CVarArgs) => {
-                bug!("C-variadic arguments should never be the return type");
             }
 
             PassMode::Direct(_) | PassMode::Pair(..) => {
@@ -502,10 +498,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             return;
         }
 
-        // The "spoofed" `VaListImpl` added to a C-variadic functions signature
-        // should not be included in the `extra_args` calculation.
-        let extra_args_start_idx = sig.inputs().len() - if sig.c_variadic { 1 } else { 0 };
-        let extra_args = &args[extra_args_start_idx..];
+        let extra_args = &args[sig.inputs().len()..];
         let extra_args = extra_args.iter().map(|op_arg| {
             let op_ty = op_arg.ty(self.mir, bx.tcx());
             self.monomorphize(&op_ty)
@@ -691,26 +684,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             (&args[..], None)
         };
 
-        // Useful determining if the current argument is the "spoofed" `VaListImpl`
-        let last_arg_idx = if sig.inputs().is_empty() {
-            None
-        } else {
-            Some(sig.inputs().len() - 1)
-        };
         'make_args: for (i, arg) in first_args.iter().enumerate() {
-            // If this is a C-variadic function the function signature contains
-            // an "spoofed" `VaListImpl`. This argument is ignored, but we need to
-            // populate it with a dummy operand so that the users real arguments
-            // are not overwritten.
-            let i = if sig.c_variadic && last_arg_idx.map(|x| i >= x).unwrap_or(false) {
-                if i + 1 < fn_ty.args.len() {
-                    i + 1
-                } else {
-                    break 'make_args
-                }
-            } else {
-                i
-            };
             let mut op = self.codegen_operand(&mut bx, arg);
 
             if let (0, Some(ty::InstanceDef::Virtual(_, idx))) = (i, def) {

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -944,15 +944,8 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         let def_id = self.cx.tcx.hir().local_def_id(id);
         let sig = self.cx.tcx.fn_sig(def_id);
         let sig = self.cx.tcx.erase_late_bound_regions(&sig);
-        let inputs = if sig.c_variadic {
-            // Don't include the spoofed `VaListImpl` in the functions list
-            // of inputs.
-            &sig.inputs()[..sig.inputs().len() - 1]
-        } else {
-            &sig.inputs()[..]
-        };
 
-        for (input_ty, input_hir) in inputs.iter().zip(&decl.inputs) {
+        for (input_ty, input_hir) in sig.inputs().iter().zip(&decl.inputs) {
             self.check_type_for_ffi_and_report_errors(input_hir.span, input_ty);
         }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1726,17 +1726,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         from_hir_call: bool,
     ) {
         debug!("check_call_inputs({:?}, {:?})", sig, args);
-        // Do not count the `VaListImpl` argument as a "true" argument to
-        // a C-variadic function.
-        let inputs = if sig.c_variadic {
-            &sig.inputs()[..sig.inputs().len() - 1]
-        } else {
-            &sig.inputs()[..]
-        };
-        if args.len() < inputs.len() || (args.len() > inputs.len() && !sig.c_variadic) {
+        if args.len() < sig.inputs().len() || (args.len() > sig.inputs().len() && !sig.c_variadic) {
             span_mirbug!(self, term, "call to {:?} with wrong # of args", sig);
         }
-        for (n, (fn_arg, op_arg)) in inputs.iter().zip(args).enumerate() {
+        for (n, (fn_arg, op_arg)) in sig.inputs().iter().zip(args).enumerate() {
             let op_arg_ty = op_arg.ty(body, self.tcx());
             let category = if from_hir_call {
                 ConstraintCategory::CallArgument

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -24,17 +24,9 @@ mod x86_win64;
 mod wasm32;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum IgnoreMode {
-    /// C-variadic arguments.
-    CVarArgs,
-    /// A zero-sized type.
-    Zst,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PassMode {
-    /// Ignore the argument (useful for empty structs and C-variadic args).
-    Ignore(IgnoreMode),
+    /// Ignore the argument.
+    Ignore,
     /// Pass the argument directly.
     Direct(ArgAttributes),
     /// Pass a pair's elements directly in two arguments.
@@ -490,7 +482,7 @@ impl<'a, Ty> ArgType<'a, Ty> {
 
     pub fn is_ignore(&self) -> bool {
         match self.mode {
-            PassMode::Ignore(_) => true,
+            PassMode::Ignore => true,
             _ => false
         }
     }

--- a/src/librustc_target/abi/call/x86.rs
+++ b/src/librustc_target/abi/call/x86.rs
@@ -88,7 +88,7 @@ pub fn compute_abi_info<'a, Ty, C>(cx: &C, fty: &mut FnType<'a, Ty>, flavor: Fla
 
         for arg in &mut fty.args {
             let attrs = match arg.mode {
-                PassMode::Ignore(_) |
+                PassMode::Ignore |
                 PassMode::Indirect(_, None) => continue,
                 PassMode::Direct(ref mut attrs) => attrs,
                 PassMode::Pair(..) |

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2148,13 +2148,16 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 // handled specially and will not descend into this routine.
                 self.ty_infer(None, ast_ty.span)
             }
-            hir::TyKind::CVarArgs(lt) => {
+            hir::TyKind::CVarArgs => {
                 let va_list_did = match tcx.lang_items().va_list() {
                     Some(did) => did,
                     None => span_bug!(ast_ty.span,
                                       "`va_list` lang item required for variadics"),
                 };
-                let region = self.ast_region_to_region(&lt, None);
+                // FIXME(eddyb) compute this in the body and don't let it reach the signature.
+                // HACK(eddyb) the `123` anon index is only temporary, to keep tests passing.
+                // Ideally this would use `ReScope` or similar.
+                let region = tcx.mk_region(ty::ReLateBound(ty::INNERMOST, ty::BrAnon(123)));
                 tcx.type_of(va_list_did).subst(tcx, &[region.into()])
             }
             hir::TyKind::Err => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2148,18 +2148,6 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 // handled specially and will not descend into this routine.
                 self.ty_infer(None, ast_ty.span)
             }
-            hir::TyKind::CVarArgs => {
-                let va_list_did = match tcx.lang_items().va_list() {
-                    Some(did) => did,
-                    None => span_bug!(ast_ty.span,
-                                      "`va_list` lang item required for variadics"),
-                };
-                // FIXME(eddyb) compute this in the body and don't let it reach the signature.
-                // HACK(eddyb) the `123` anon index is only temporary, to keep tests passing.
-                // Ideally this would use `ReScope` or similar.
-                let region = tcx.mk_region(ty::ReLateBound(ty::INNERMOST, ty::BrAnon(123)));
-                tcx.type_of(va_list_did).subst(tcx, &[region.into()])
-            }
             hir::TyKind::Err => {
                 tcx.types.err
             }

--- a/src/librustc_typeck/check/callee.rs
+++ b/src/librustc_typeck/check/callee.rs
@@ -397,27 +397,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .0;
         let fn_sig = self.normalize_associated_types_in(call_expr.span, &fn_sig);
 
-        let inputs = if fn_sig.c_variadic {
-            if fn_sig.inputs().len() > 1 {
-                &fn_sig.inputs()[..fn_sig.inputs().len() - 1]
-            } else {
-                span_bug!(call_expr.span,
-                          "C-variadic functions are only valid with one or more fixed arguments");
-            }
-        } else {
-            &fn_sig.inputs()[..]
-        };
         // Call the generic checker.
         let expected_arg_tys = self.expected_inputs_for_expected_output(
             call_expr.span,
             expected,
             fn_sig.output(),
-            inputs,
+            fn_sig.inputs(),
         );
         self.check_argument_types(
             call_expr.span,
             call_expr,
-            inputs,
+            fn_sig.inputs(),
             &expected_arg_tys[..],
             arg_exprs,
             fn_sig.c_variadic,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -3032,7 +3032,7 @@ impl Clean<Type> for hir::Ty {
             TyKind::BareFn(ref barefn) => BareFunction(box barefn.clean(cx)),
             TyKind::Infer | TyKind::Err => Infer,
             TyKind::Typeof(..) => panic!("unimplemented type {:?}", self.kind),
-            TyKind::CVarArgs(_) => CVarArgs,
+            TyKind::CVarArgs => CVarArgs,
         }
     }
 }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2032,6 +2032,7 @@ impl Clean<Item> for doctree::Function<'_> {
 pub struct FnDecl {
     pub inputs: Arguments,
     pub output: FunctionRetTy,
+    pub c_variadic: bool,
     pub attrs: Attributes,
 }
 
@@ -2110,6 +2111,7 @@ impl<'a, A: Copy> Clean<FnDecl> for (&'a hir::FnDecl, A)
         FnDecl {
             inputs: (&self.0.inputs[..], self.1).clean(cx),
             output: self.0.output.clean(cx),
+            c_variadic: self.0.c_variadic,
             attrs: Attributes::default(),
         }
     }
@@ -2127,6 +2129,7 @@ impl<'tcx> Clean<FnDecl> for (DefId, ty::PolyFnSig<'tcx>) {
         FnDecl {
             output: Return(sig.skip_binder().output().clean(cx)),
             attrs: Attributes::default(),
+            c_variadic: sig.skip_binder().c_variadic,
             inputs: Arguments {
                 values: sig.skip_binder().inputs().iter().map(|t| {
                     Argument {
@@ -2545,7 +2548,6 @@ pub enum Type {
     Slice(Box<Type>),
     Array(Box<Type>, String),
     Never,
-    CVarArgs,
     RawPointer(Mutability, Box<Type>),
     BorrowedRef {
         lifetime: Option<Lifetime>,
@@ -2583,7 +2585,6 @@ pub enum PrimitiveType {
     Reference,
     Fn,
     Never,
-    CVarArgs,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -2787,7 +2788,6 @@ impl PrimitiveType {
             Reference => "reference",
             Fn => "fn",
             Never => "never",
-            CVarArgs => "...",
         }
     }
 
@@ -3032,7 +3032,6 @@ impl Clean<Type> for hir::Ty {
             TyKind::BareFn(ref barefn) => BareFunction(box barefn.clean(cx)),
             TyKind::Infer | TyKind::Err => Infer,
             TyKind::Typeof(..) => panic!("unimplemented type {:?}", self.kind),
-            TyKind::CVarArgs => CVarArgs,
         }
     }
 }
@@ -3980,7 +3979,6 @@ fn build_deref_target_impls(cx: &DocContext<'_>,
             Reference => None,
             Fn => None,
             Never => None,
-            CVarArgs => tcx.lang_items().va_list(),
         };
         if let Some(did) = did {
             if !did.is_local() {

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -657,7 +657,6 @@ fn fmt_type(t: &clean::Type, f: &mut fmt::Formatter<'_>, use_absolute: bool) -> 
             primitive_link(f, PrimitiveType::Array, &format!("; {}]", n))
         }
         clean::Never => primitive_link(f, PrimitiveType::Never, "!"),
-        clean::CVarArgs => primitive_link(f, PrimitiveType::CVarArgs, "..."),
         clean::RawPointer(m, ref t) => {
             let m = match m {
                 clean::Immutable => "const",
@@ -903,12 +902,15 @@ impl clean::BareFunctionDecl {
 impl clean::FnDecl {
     crate fn print(&self) -> impl fmt::Display + '_ {
         display_fn(move |f| {
+        let ellipsis = if self.c_variadic { ", ..." } else { "" };
             if f.alternate() {
                 write!(f,
-                    "({args:#}){arrow:#}", args = self.inputs.print(), arrow = self.output.print())
+                    "({args:#}{ellipsis}){arrow:#}",
+                    args = self.inputs.print(), ellipsis = ellipsis, arrow = self.output.print())
             } else {
                 write!(f,
-                    "({args}){arrow}", args = self.inputs.print(), arrow = self.output.print())
+                    "({args}{ellipsis}){arrow}",
+                    args = self.inputs.print(), ellipsis = ellipsis, arrow = self.output.print())
             }
         })
     }
@@ -975,7 +977,12 @@ impl Function<'_> {
                 }
             }
 
-            let args_plain = format!("({})", args_plain);
+            let mut args_plain = format!("({})", args_plain);
+
+            if decl.c_variadic {
+                args.push_str(",<br> ...");
+                args_plain.push_str(", ...");
+            }
 
             let output = if let hir::IsAsync::Async = asyncness {
                 Cow::Owned(decl.sugared_async_return_type())

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1893,7 +1893,6 @@ impl Param {
 pub struct FnDecl {
     pub inputs: Vec<Param>,
     pub output: FunctionRetTy,
-    pub c_variadic: bool,
 }
 
 impl FnDecl {
@@ -1902,6 +1901,12 @@ impl FnDecl {
     }
     pub fn has_self(&self) -> bool {
         self.inputs.get(0).map(Param::is_self).unwrap_or(false)
+    }
+    pub fn c_variadic(&self) -> bool {
+        self.inputs.last().map(|arg| match arg.ty.kind {
+            TyKind::CVarArgs => true,
+            _ => false,
+        }).unwrap_or(false)
     }
 }
 

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -562,7 +562,6 @@ impl<'a> ExtCtxt<'a> {
         P(ast::FnDecl {
             inputs,
             output,
-            c_variadic: false
         })
     }
 

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -531,7 +531,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             self.check_abi(header.abi, span);
         }
 
-        if fn_decl.c_variadic {
+        if fn_decl.c_variadic() {
             gate_feature_post!(&self, c_variadic, span, "C-variadic functions are unstable");
         }
 
@@ -564,7 +564,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 if block.is_none() {
                     self.check_abi(sig.header.abi, ti.span);
                 }
-                if sig.decl.c_variadic {
+                if sig.decl.c_variadic() {
                     gate_feature_post!(&self, c_variadic, ti.span,
                                        "C-variadic functions are unstable");
                 }
@@ -601,7 +601,12 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
 
         match ii.kind {
-            ast::ImplItemKind::Method(..) => {}
+            ast::ImplItemKind::Method(ref sig, _) => {
+                if sig.decl.c_variadic() {
+                    gate_feature_post!(&self, c_variadic, ii.span,
+                                       "C-variadic functions are unstable");
+                }
+            }
             ast::ImplItemKind::OpaqueTy(..) => {
                 gate_feature_post!(
                     &self,

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -717,7 +717,7 @@ pub fn noop_visit_asyncness<T: MutVisitor>(asyncness: &mut IsAsync, vis: &mut T)
 }
 
 pub fn noop_visit_fn_decl<T: MutVisitor>(decl: &mut P<FnDecl>, vis: &mut T) {
-    let FnDecl { inputs, output, c_variadic: _ } = decl.deref_mut();
+    let FnDecl { inputs, output } = decl.deref_mut();
     inputs.flat_map_in_place(|param| vis.flat_map_param(param));
     match output {
         FunctionRetTy::Default(span) => vis.visit_span(span),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1194,7 +1194,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_fn_params(&mut self, named_params: bool, allow_c_variadic: bool)
-                     -> PResult<'a, (Vec<Param> , bool)> {
+                     -> PResult<'a, Vec<Param>> {
         let sp = self.token.span;
         let mut c_variadic = false;
         let (params, _): (Vec<Option<Param>>, _) = self.parse_paren_comma_seq(|p| {
@@ -1218,6 +1218,8 @@ impl<'a> Parser<'a> {
                             let span = p.token.span;
                             p.span_err(span,
                                 "`...` must be the last argument of a C-variadic function");
+                            // FIXME(eddyb) this should probably still push `CVarArgs`.
+                            // Maybe AST validation/HIR lowering should emit the above error?
                             Ok(None)
                         } else {
                             Ok(Some(param))
@@ -1245,7 +1247,7 @@ impl<'a> Parser<'a> {
                           "C-variadic function must be declared with at least one named argument");
         }
 
-        Ok((params, c_variadic))
+        Ok(params)
     }
 
     /// Returns the parsed optional self parameter and whether a self shortcut was used.
@@ -1414,7 +1416,6 @@ impl<'a> Parser<'a> {
         Ok(P(FnDecl {
             inputs: fn_inputs,
             output: self.parse_ret_ty(true)?,
-            c_variadic: false
         }))
     }
 

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -1176,7 +1176,6 @@ impl<'a> Parser<'a> {
         Ok(P(FnDecl {
             inputs: inputs_captures,
             output,
-            c_variadic: false
         }))
     }
 

--- a/src/libsyntax/parse/parser/item.rs
+++ b/src/libsyntax/parse/parser/item.rs
@@ -1292,13 +1292,12 @@ impl<'a> Parser<'a> {
 
     /// Parses the argument list and result type of a function declaration.
     fn parse_fn_decl(&mut self, allow_c_variadic: bool) -> PResult<'a, P<FnDecl>> {
-        let (args, c_variadic) = self.parse_fn_params(true, allow_c_variadic)?;
+        let args = self.parse_fn_params(true, allow_c_variadic)?;
         let ret_ty = self.parse_ret_ty(true)?;
 
         Ok(P(FnDecl {
             inputs: args,
             output: ret_ty,
-            c_variadic,
         }))
     }
 

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -292,12 +292,11 @@ impl<'a> Parser<'a> {
         };
 
         self.expect_keyword(kw::Fn)?;
-        let (inputs, c_variadic) = self.parse_fn_params(false, true)?;
+        let inputs = self.parse_fn_params(false, true)?;
         let ret_ty = self.parse_ret_ty(false)?;
         let decl = P(FnDecl {
             inputs,
             output: ret_ty,
-            c_variadic,
         });
         Ok(TyKind::BareFn(P(BareFnTy {
             abi,

--- a/src/libsyntax/print/pprust/tests.rs
+++ b/src/libsyntax/print/pprust/tests.rs
@@ -29,7 +29,6 @@ fn test_fun_to_string() {
         let decl = ast::FnDecl {
             inputs: Vec::new(),
             output: ast::FunctionRetTy::Default(syntax_pos::DUMMY_SP),
-            c_variadic: false
         };
         let generics = ast::Generics::default();
         assert_eq!(

--- a/src/test/rustdoc/variadic.rs
+++ b/src/test/rustdoc/variadic.rs
@@ -1,4 +1,4 @@
 extern "C" {
-    // @has variadic/fn.foo.html //pre 'pub unsafe extern "C" fn foo(x: i32, _: ...)'
+    // @has variadic/fn.foo.html //pre 'pub unsafe extern "C" fn foo(x: i32, ...)'
     pub fn foo(x: i32, ...);
 }

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -114,7 +114,6 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
                 let decl = P(FnDecl {
                     inputs: vec![],
                     output: FunctionRetTy::Default(DUMMY_SP),
-                    c_variadic: false,
                 });
                 iter_exprs(depth - 1, &mut |e| g(
                         ExprKind::Closure(CaptureBy::Value,

--- a/src/test/ui/c-variadic/variadic-ffi-1.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-1.stderr
@@ -29,7 +29,7 @@ LL |         let x: unsafe extern "C" fn(f: isize, x: u8) = foo;
    |                                                        ^^^ expected non-variadic fn, found variadic function
    |
    = note: expected type `unsafe extern "C" fn(isize, u8)`
-              found type `for<'r> unsafe extern "C" fn(isize, u8, std::ffi::VaListImpl<'r>, ...) {foo}`
+              found type `unsafe extern "C" fn(isize, u8, ...) {foo}`
 
 error[E0308]: mismatched types
   --> $DIR/variadic-ffi-1.rs:20:54
@@ -37,7 +37,7 @@ error[E0308]: mismatched types
 LL |         let y: extern "C" fn(f: isize, x: u8, ...) = bar;
    |                                                      ^^^ expected variadic fn, found non-variadic function
    |
-   = note: expected type `for<'r> extern "C" fn(isize, u8, std::ffi::VaListImpl<'r>, ...)`
+   = note: expected type `extern "C" fn(isize, u8, ...)`
               found type `extern "C" fn(isize, u8) {bar}`
 
 error[E0617]: can't pass `f32` to variadic function

--- a/src/test/ui/c-variadic/variadic-ffi-4.nll.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.nll.stderr
@@ -1,18 +1,30 @@
-error[E0621]: explicit lifetime required in the type of `ap`
+error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:8:5
    |
 LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
-   |                                                       --- help: add explicit lifetime `'f` to the type of `ap`: `core::ffi::VaListImpl<'f>`
+   |                                     --            -- has type `core::ffi::VaListImpl<'1>`
+   |                                     |
+   |                                     lifetime `'f` defined here
 LL |     ap
-   |     ^^ lifetime `'f` required
+   |     ^^ function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'f`
 
-error[E0621]: explicit lifetime required in the type of `ap`
+error: lifetime may not live long enough
+  --> $DIR/variadic-ffi-4.rs:8:5
+   |
+LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
+   |                                     --            -- has type `core::ffi::VaListImpl<'1>`
+   |                                     |
+   |                                     lifetime `'f` defined here
+LL |     ap
+   |     ^^ returning this value requires that `'1` must outlive `'f`
+
+error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:12:5
    |
 LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
-   |                                                   --- help: add explicit lifetime `'static` to the type of `ap`: `core::ffi::VaListImpl<'static>`
+   |                                               -- has type `core::ffi::VaListImpl<'1>`
 LL |     ap
-   |     ^^ lifetime `'static` required
+   |     ^^ returning this value requires that `'1` must outlive `'static`
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:16:33
@@ -44,7 +56,7 @@ LL |     *ap0 = ap1;
    |     ^^^^ assignment requires that `'2` must outlive `'1`
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:25:5
+  --> $DIR/variadic-ffi-4.rs:24:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               ---                   ------- has type `core::ffi::VaListImpl<'2>`
@@ -54,7 +66,7 @@ LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:25:5
+  --> $DIR/variadic-ffi-4.rs:24:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               ---                   ------- has type `core::ffi::VaListImpl<'2>`
@@ -64,7 +76,7 @@ LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ assignment requires that `'2` must outlive `'1`
 
 error[E0384]: cannot assign to immutable argument `ap0`
-  --> $DIR/variadic-ffi-4.rs:25:5
+  --> $DIR/variadic-ffi-4.rs:24:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               --- help: make this binding mutable: `mut ap0`
@@ -72,7 +84,7 @@ LL |     ap0 = &mut ap1;
    |     ^^^^^^^^^^^^^^ cannot assign to immutable argument
 
 error[E0597]: `ap1` does not live long enough
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
    |                                                    - let's call the lifetime of this reference `'1`
@@ -86,7 +98,7 @@ LL | }
    | - `ap1` dropped here while still borrowed
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:33:12
+  --> $DIR/variadic-ffi-4.rs:31:12
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               -------                   ------- has type `core::ffi::VaListImpl<'2>`
@@ -96,7 +108,7 @@ LL |     *ap0 = ap1.clone();
    |            ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
 
 error: lifetime may not live long enough
-  --> $DIR/variadic-ffi-4.rs:33:12
+  --> $DIR/variadic-ffi-4.rs:31:12
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
    |                                               -------                   ------- has type `core::ffi::VaListImpl<'2>`
@@ -105,7 +117,7 @@ LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut
 LL |     *ap0 = ap1.clone();
    |            ^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
 
-error: aborting due to 11 previous errors
+error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0384, E0597, E0621.
+Some errors have detailed explanations: E0384, E0597.
 For more information about an error, try `rustc --explain E0384`.

--- a/src/test/ui/c-variadic/variadic-ffi-4.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-4.rs
@@ -5,11 +5,11 @@
 use core::ffi::{VaList, VaListImpl};
 
 pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
-    ap //~ ERROR: explicit lifetime required
+    ap //~ ERROR: mismatched types
 }
 
 pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
-    ap //~ ERROR: explicit lifetime required
+    ap //~ ERROR: mismatched types
 }
 
 pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
@@ -18,18 +18,15 @@ pub unsafe extern "C" fn no_escape2(_: usize, ap: ...) {
 
 pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
     *ap0 = ap1; //~ ERROR: mismatched types
-    //~^ ERROR: mismatched types
 }
 
 pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
     ap0 = &mut ap1;
     //~^ ERROR: a value of type `core::ffi::VaListImpl<'_>` is borrowed for too long
-    //~^^ ERROR: mismatched types
-    //~^^^ ERROR: mismatched types
-    //~^^^^ ERROR: cannot infer an appropriate lifetime
+    //~| ERROR: mismatched types
+    //~| ERROR: cannot infer an appropriate lifetime
 }
 
 pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
     *ap0 = ap1.clone(); //~ ERROR: mismatched types
-    //~^ ERROR: mismatched types
 }

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -47,7 +47,7 @@ LL |     *ap0 = ap1;
    |
    = note: expected type `core::ffi::VaListImpl<'_>`
               found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #3 defined on the function body at 19:1...
+note: the anonymous lifetime #124 defined on the function body at 19:1...
   --> $DIR/variadic-ffi-4.rs:19:1
    |
 LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -80,7 +80,7 @@ LL | |     *ap0 = ap1;
 LL | |
 LL | | }
    | |_^
-note: ...does not necessarily outlive the anonymous lifetime #3 defined on the function body at 19:1
+note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 19:1
   --> $DIR/variadic-ffi-4.rs:19:1
    |
 LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -106,7 +106,7 @@ LL | |
 LL | |
 LL | | }
    | |_^
-note: but the borrow lasts for the anonymous lifetime #3 defined on the function body at 24:1
+note: but the borrow lasts for the anonymous lifetime #124 defined on the function body at 24:1
   --> $DIR/variadic-ffi-4.rs:24:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
@@ -126,7 +126,7 @@ LL |     ap0 = &mut ap1;
    |
    = note: expected type `&mut core::ffi::VaListImpl<'_>`
               found type `&mut core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #3 defined on the function body at 24:1...
+note: the anonymous lifetime #124 defined on the function body at 24:1...
   --> $DIR/variadic-ffi-4.rs:24:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
@@ -168,7 +168,7 @@ LL | |
 LL | |
 LL | | }
    | |_^
-note: ...does not necessarily outlive the anonymous lifetime #3 defined on the function body at 24:1
+note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 24:1
   --> $DIR/variadic-ffi-4.rs:24:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
@@ -186,7 +186,7 @@ error[E0495]: cannot infer an appropriate lifetime for borrow expression due to 
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #3 defined on the function body at 24:1...
+note: first, the lifetime cannot outlive the anonymous lifetime #124 defined on the function body at 24:1...
   --> $DIR/variadic-ffi-4.rs:24:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
@@ -227,7 +227,7 @@ LL |     *ap0 = ap1.clone();
    |
    = note: expected type `core::ffi::VaListImpl<'_>`
               found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #3 defined on the function body at 32:1...
+note: the anonymous lifetime #124 defined on the function body at 32:1...
   --> $DIR/variadic-ffi-4.rs:32:1
    |
 LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
@@ -260,7 +260,7 @@ LL | |     *ap0 = ap1.clone();
 LL | |
 LL | | }
    | |_^
-note: ...does not necessarily outlive the anonymous lifetime #3 defined on the function body at 32:1
+note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 32:1
   --> $DIR/variadic-ffi-4.rs:32:1
    |
 LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -1,18 +1,42 @@
-error[E0621]: explicit lifetime required in the type of `ap`
+error[E0308]: mismatched types
   --> $DIR/variadic-ffi-4.rs:8:5
    |
-LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
-   |                                                       --- help: add explicit lifetime `'f` to the type of `ap`: `core::ffi::VaListImpl<'f>`
 LL |     ap
-   |     ^^ lifetime `'f` required
+   |     ^^ lifetime mismatch
+   |
+   = note: expected type `core::ffi::VaListImpl<'f>`
+              found type `core::ffi::VaListImpl<'_>`
+note: the scope of call-site for function at 7:78...
+  --> $DIR/variadic-ffi-4.rs:7:78
+   |
+LL |   pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
+   |  ______________________________________________________________________________^
+LL | |     ap
+LL | | }
+   | |_^
+note: ...does not necessarily outlive the lifetime 'f as defined on the function body at 7:37
+  --> $DIR/variadic-ffi-4.rs:7:37
+   |
+LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f> {
+   |                                     ^^
 
-error[E0621]: explicit lifetime required in the type of `ap`
+error[E0308]: mismatched types
   --> $DIR/variadic-ffi-4.rs:12:5
    |
-LL | pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
-   |                                                   --- help: add explicit lifetime `'static` to the type of `ap`: `core::ffi::VaListImpl<'static>`
 LL |     ap
-   |     ^^ lifetime `'static` required
+   |     ^^ lifetime mismatch
+   |
+   = note: expected type `core::ffi::VaListImpl<'static>`
+              found type `core::ffi::VaListImpl<'_>`
+note: the scope of call-site for function at 11:79...
+  --> $DIR/variadic-ffi-4.rs:11:79
+   |
+LL |   pub unsafe extern "C" fn no_escape1(_: usize, ap: ...) -> VaListImpl<'static> {
+   |  _______________________________________________________________________________^
+LL | |     ap
+LL | | }
+   | |_^
+   = note: ...does not necessarily outlive the static lifetime
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
   --> $DIR/variadic-ffi-4.rs:16:33
@@ -47,12 +71,12 @@ LL |     *ap0 = ap1;
    |
    = note: expected type `core::ffi::VaListImpl<'_>`
               found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #124 defined on the function body at 19:1...
-  --> $DIR/variadic-ffi-4.rs:19:1
+note: the scope of call-site for function at 19:87...
+  --> $DIR/variadic-ffi-4.rs:19:87
    |
-LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+LL |   pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+   |  _______________________________________________________________________________________^
 LL | |     *ap0 = ap1;
-LL | |
 LL | | }
    | |_^
 note: ...does not necessarily outlive the anonymous lifetime #2 defined on the function body at 19:1
@@ -60,89 +84,31 @@ note: ...does not necessarily outlive the anonymous lifetime #2 defined on the f
    |
 LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
 LL | |     *ap0 = ap1;
-LL | |
-LL | | }
-   | |_^
-
-error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-4.rs:20:12
-   |
-LL |     *ap0 = ap1;
-   |            ^^^ lifetime mismatch
-   |
-   = note: expected type `core::ffi::VaListImpl<'_>`
-              found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #2 defined on the function body at 19:1...
-  --> $DIR/variadic-ffi-4.rs:19:1
-   |
-LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     *ap0 = ap1;
-LL | |
-LL | | }
-   | |_^
-note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 19:1
-  --> $DIR/variadic-ffi-4.rs:19:1
-   |
-LL | / pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     *ap0 = ap1;
-LL | |
 LL | | }
    | |_^
 
 error[E0490]: a value of type `core::ffi::VaListImpl<'_>` is borrowed for too long
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^
    |
-note: the type is valid for the anonymous lifetime #1 defined on the function body at 24:1
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: the type is valid for the anonymous lifetime #1 defined on the function body at 23:1
+  --> $DIR/variadic-ffi-4.rs:23:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
 LL | |     ap0 = &mut ap1;
-LL | |
 LL | |
 LL | |
 LL | |
 LL | | }
    | |_^
-note: but the borrow lasts for the anonymous lifetime #124 defined on the function body at 24:1
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: but the borrow lasts for the scope of call-site for function at 23:83
+  --> $DIR/variadic-ffi-4.rs:23:83
    |
-LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+LL |   pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+   |  ___________________________________________________________________________________^
 LL | |     ap0 = &mut ap1;
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | }
-   | |_^
-
-error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-4.rs:25:11
-   |
-LL |     ap0 = &mut ap1;
-   |           ^^^^^^^^ lifetime mismatch
-   |
-   = note: expected type `&mut core::ffi::VaListImpl<'_>`
-              found type `&mut core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #124 defined on the function body at 24:1...
-  --> $DIR/variadic-ffi-4.rs:24:1
-   |
-LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     ap0 = &mut ap1;
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | }
-   | |_^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the function body at 24:1
-  --> $DIR/variadic-ffi-4.rs:24:1
-   |
-LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     ap0 = &mut ap1;
-LL | |
 LL | |
 LL | |
 LL | |
@@ -150,30 +116,29 @@ LL | | }
    | |_^
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^ lifetime mismatch
    |
    = note: expected type `&mut core::ffi::VaListImpl<'_>`
               found type `&mut core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #2 defined on the function body at 24:1...
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: the scope of call-site for function at 23:83...
+  --> $DIR/variadic-ffi-4.rs:23:83
    |
-LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+LL |   pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+   |  ___________________________________________________________________________________^
 LL | |     ap0 = &mut ap1;
-LL | |
 LL | |
 LL | |
 LL | |
 LL | | }
    | |_^
-note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 24:1
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: ...does not necessarily outlive the anonymous lifetime #2 defined on the function body at 23:1
+  --> $DIR/variadic-ffi-4.rs:23:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
 LL | |     ap0 = &mut ap1;
-LL | |
 LL | |
 LL | |
 LL | |
@@ -181,95 +146,67 @@ LL | | }
    | |_^
 
 error[E0495]: cannot infer an appropriate lifetime for borrow expression due to conflicting requirements
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #124 defined on the function body at 24:1...
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: first, the lifetime cannot outlive the scope of call-site for function at 23:83...
+  --> $DIR/variadic-ffi-4.rs:23:83
    |
-LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+LL |   pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
+   |  ___________________________________________________________________________________^
 LL | |     ap0 = &mut ap1;
-LL | |
 LL | |
 LL | |
 LL | |
 LL | | }
    | |_^
 note: ...so that the type `core::ffi::VaListImpl<'_>` is not borrowed for too long
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^
-note: but, the lifetime must be valid for the anonymous lifetime #1 defined on the function body at 24:1...
-  --> $DIR/variadic-ffi-4.rs:24:1
+note: but, the lifetime must be valid for the anonymous lifetime #1 defined on the function body at 23:1...
+  --> $DIR/variadic-ffi-4.rs:23:1
    |
 LL | / pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
 LL | |     ap0 = &mut ap1;
 LL | |
 LL | |
 LL | |
-LL | |
 LL | | }
    | |_^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/variadic-ffi-4.rs:25:11
+  --> $DIR/variadic-ffi-4.rs:24:11
    |
 LL |     ap0 = &mut ap1;
    |           ^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-4.rs:33:12
+  --> $DIR/variadic-ffi-4.rs:31:12
    |
 LL |     *ap0 = ap1.clone();
    |            ^^^^^^^^^^^ lifetime mismatch
    |
    = note: expected type `core::ffi::VaListImpl<'_>`
               found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #124 defined on the function body at 32:1...
-  --> $DIR/variadic-ffi-4.rs:32:1
+note: the scope of call-site for function at 30:87...
+  --> $DIR/variadic-ffi-4.rs:30:87
    |
-LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+LL |   pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
+   |  _______________________________________________________________________________________^
 LL | |     *ap0 = ap1.clone();
-LL | |
 LL | | }
    | |_^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the function body at 32:1
-  --> $DIR/variadic-ffi-4.rs:32:1
+note: ...does not necessarily outlive the anonymous lifetime #2 defined on the function body at 30:1
+  --> $DIR/variadic-ffi-4.rs:30:1
    |
 LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
 LL | |     *ap0 = ap1.clone();
-LL | |
-LL | | }
-   | |_^
-
-error[E0308]: mismatched types
-  --> $DIR/variadic-ffi-4.rs:33:12
-   |
-LL |     *ap0 = ap1.clone();
-   |            ^^^^^^^^^^^ lifetime mismatch
-   |
-   = note: expected type `core::ffi::VaListImpl<'_>`
-              found type `core::ffi::VaListImpl<'_>`
-note: the anonymous lifetime #2 defined on the function body at 32:1...
-  --> $DIR/variadic-ffi-4.rs:32:1
-   |
-LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     *ap0 = ap1.clone();
-LL | |
-LL | | }
-   | |_^
-note: ...does not necessarily outlive the anonymous lifetime #124 defined on the function body at 32:1
-  --> $DIR/variadic-ffi-4.rs:32:1
-   |
-LL | / pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-LL | |     *ap0 = ap1.clone();
-LL | |
 LL | | }
    | |_^
 
-error: aborting due to 11 previous errors
+error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0308, E0621.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/error-codes/E0617.rs
+++ b/src/test/ui/error-codes/E0617.rs
@@ -1,5 +1,3 @@
-// ignore-tidy-linelength
-
 extern {
     fn printf(c: *const i8, ...);
 }
@@ -22,7 +20,7 @@ fn main() {
         //~^ ERROR can't pass `u16` to variadic function
         //~| HELP cast the value to `c_uint`
         printf(::std::ptr::null(), printf);
-        //~^ ERROR can't pass `for<'r> unsafe extern "C" fn(*const i8, std::ffi::VaListImpl<'r>, ...) {printf}` to variadic function
-        //~| HELP cast the value to `for<'r> unsafe extern "C" fn(*const i8, std::ffi::VaListImpl<'r>, ...)`
+        //~^ ERROR can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
+        //~| HELP cast the value to `unsafe extern "C" fn(*const i8, ...)`
     }
 }

--- a/src/test/ui/error-codes/E0617.stderr
+++ b/src/test/ui/error-codes/E0617.stderr
@@ -1,42 +1,42 @@
 error[E0617]: can't pass `f32` to variadic function
-  --> $DIR/E0617.rs:9:36
+  --> $DIR/E0617.rs:7:36
    |
 LL |         printf(::std::ptr::null(), 0f32);
    |                                    ^^^^ help: cast the value to `c_double`: `0f32 as c_double`
 
 error[E0617]: can't pass `i8` to variadic function
-  --> $DIR/E0617.rs:12:36
+  --> $DIR/E0617.rs:10:36
    |
 LL |         printf(::std::ptr::null(), 0i8);
    |                                    ^^^ help: cast the value to `c_int`: `0i8 as c_int`
 
 error[E0617]: can't pass `i16` to variadic function
-  --> $DIR/E0617.rs:15:36
+  --> $DIR/E0617.rs:13:36
    |
 LL |         printf(::std::ptr::null(), 0i16);
    |                                    ^^^^ help: cast the value to `c_int`: `0i16 as c_int`
 
 error[E0617]: can't pass `u8` to variadic function
-  --> $DIR/E0617.rs:18:36
+  --> $DIR/E0617.rs:16:36
    |
 LL |         printf(::std::ptr::null(), 0u8);
    |                                    ^^^ help: cast the value to `c_uint`: `0u8 as c_uint`
 
 error[E0617]: can't pass `u16` to variadic function
-  --> $DIR/E0617.rs:21:36
+  --> $DIR/E0617.rs:19:36
    |
 LL |         printf(::std::ptr::null(), 0u16);
    |                                    ^^^^ help: cast the value to `c_uint`: `0u16 as c_uint`
 
-error[E0617]: can't pass `for<'r> unsafe extern "C" fn(*const i8, std::ffi::VaListImpl<'r>, ...) {printf}` to variadic function
-  --> $DIR/E0617.rs:24:36
+error[E0617]: can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to variadic function
+  --> $DIR/E0617.rs:22:36
    |
 LL |         printf(::std::ptr::null(), printf);
    |                                    ^^^^^^
-help: cast the value to `for<'r> unsafe extern "C" fn(*const i8, std::ffi::VaListImpl<'r>, ...)`
+help: cast the value to `unsafe extern "C" fn(*const i8, ...)`
    |
-LL |         printf(::std::ptr::null(), printf as for<'r> unsafe extern "C" fn(*const i8, std::ffi::VaListImpl<'r>, ...));
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         printf(::std::ptr::null(), printf as unsafe extern "C" fn(*const i8, ...));
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/symbol-names/impl1.legacy.stderr
+++ b/src/test/ui/symbol-names/impl1.legacy.stderr
@@ -46,26 +46,26 @@ error: def-path(bar::<impl foo::Foo>::baz)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN198_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17h6f205aef6a8ccc7bE)
-  --> $DIR/impl1.rs:63:13
+error: symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17h059bf53000885489E)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method::h6f205aef6a8ccc7b)
-  --> $DIR/impl1.rs:63:13
+error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method::h059bf53000885489)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
-  --> $DIR/impl1.rs:63:13
+error: demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
-  --> $DIR/impl1.rs:70:13
+error: def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8, ...)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
+  --> $DIR/impl1.rs:68:13
    |
 LL |             #[rustc_def_path]
    |             ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/symbol-names/impl1.rs
+++ b/src/test/ui/symbol-names/impl1.rs
@@ -57,19 +57,17 @@ fn main() {
         }
 
         // Test type mangling, by putting them in an `impl` header.
-        // FIXME(eddyb) test C varargs when `core::ffi::VaListImpl` stops leaking into the signature
-        // (which is a problem because `core` has an unpredictable hash) - see also #44930.
-        impl Bar for [&'_ (dyn Foo<Assoc = extern fn(&u8, /*...*/)> + AutoTrait); 3] {
+        impl Bar for [&'_ (dyn Foo<Assoc = extern fn(&u8, ...)> + AutoTrait); 3] {
             #[rustc_symbol_name]
-            //[legacy]~^ ERROR symbol-name(_ZN198_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method
-            //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method
-            //[legacy]~| ERROR demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
-             //[v0]~^^^^ ERROR symbol-name(_RNvXNCNvCs4fqI2P2rA04_5impl14mains_0ARDNtB6_3Foop5AssocFG_KCRL0_hEuNtB6_9AutoTraitEL_j3_NtB2_3Bar6method)
-                //[v0]~| ERROR demangling(<[&dyn impl1[317d481089b8c8fe]::Foo<Assoc = for<'a> extern "C" fn(&'a u8)> + impl1[317d481089b8c8fe]::AutoTrait; 3: usize] as impl1[317d481089b8c8fe]::main::{closure#1}::Bar>::method)
-                //[v0]~| ERROR demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
+            //[legacy]~^ ERROR symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method
+            //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method
+            //[legacy]~| ERROR demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
+             //[v0]~^^^^ ERROR symbol-name(_RNvXNCNvCs4fqI2P2rA04_5impl14mains_0ARDNtB6_3Foop5AssocFG_KCRL0_hvEuNtB6_9AutoTraitEL_j3_NtB2_3Bar6method)
+                //[v0]~| ERROR demangling(<[&dyn impl1[317d481089b8c8fe]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[317d481089b8c8fe]::AutoTrait; 3: usize] as impl1[317d481089b8c8fe]::main::{closure#1}::Bar>::method)
+                //[v0]~| ERROR demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
             #[rustc_def_path]
-            //[legacy]~^ ERROR def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
-               //[v0]~^^ ERROR def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
+            //[legacy]~^ ERROR def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8, ...)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
+               //[v0]~^^ ERROR def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8, ...)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
             fn method(&self) {}
         }
     };

--- a/src/test/ui/symbol-names/impl1.v0.stderr
+++ b/src/test/ui/symbol-names/impl1.v0.stderr
@@ -46,26 +46,26 @@ error: def-path(bar::<impl foo::Foo>::baz)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_RNvXNCNvCs4fqI2P2rA04_5impl14mains_0ARDNtB6_3Foop5AssocFG_KCRL0_hEuNtB6_9AutoTraitEL_j3_NtB2_3Bar6method)
-  --> $DIR/impl1.rs:63:13
+error: symbol-name(_RNvXNCNvCs4fqI2P2rA04_5impl14mains_0ARDNtB6_3Foop5AssocFG_KCRL0_hvEuNtB6_9AutoTraitEL_j3_NtB2_3Bar6method)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<[&dyn impl1[317d481089b8c8fe]::Foo<Assoc = for<'a> extern "C" fn(&'a u8)> + impl1[317d481089b8c8fe]::AutoTrait; 3: usize] as impl1[317d481089b8c8fe]::main::{closure#1}::Bar>::method)
-  --> $DIR/impl1.rs:63:13
+error: demangling(<[&dyn impl1[317d481089b8c8fe]::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1[317d481089b8c8fe]::AutoTrait; 3: usize] as impl1[317d481089b8c8fe]::main::{closure#1}::Bar>::method)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
-  --> $DIR/impl1.rs:63:13
+error: demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)
+  --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
-  --> $DIR/impl1.rs:70:13
+error: def-path(<[&dyn Foo<Assoc = for<'r> extern "C" fn(&'r u8, ...)> + AutoTrait; _] as main::{{closure}}#1::Bar>::method)
+  --> $DIR/impl1.rs:68:13
    |
 LL |             #[rustc_def_path]
    |             ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This cleanup was first described in https://github.com/rust-lang/rust/issues/44930#issuecomment-497163539:

* AST doesn't track `c_variadic: bool` anymore, relying solely on a trailing `CVarArgs` type in fn signatures
* HIR doesn't have a `CVarArgs` anymore, relying solely on `c_variadic: bool`
  * same for `ty::FnSig` (see tests for diagnostics improvements from that)
  * `{hir,mir}::Body` have one extra argument than the signature when `c_variadic == true`
  * `rustc_typeck` and `rustc_mir::{build,borrowck}` need to give that argument the right type (which no longer uses a lifetime parameter, but a function-internal scope)
* `rustc_target::abi::call` doesn't need special hacks anymore (since it never sees the `VaListImpl` now, it's all inside the body)

r? @nagisa / @rkruppe cc @dlrobertson @oli-obk