### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1163,6 +1163,9 @@ impl<T> FusedIterator for Drain<'_, T> {}
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
+    /// Converts a `Vec` into a `BinaryHeap`.
+    ///
+    /// This conversion happens in-place, and has O(n) time complexity.
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
         heap.rebuild();

--- a/src/liballoc/collections/binary_heap.rs
+++ b/src/liballoc/collections/binary_heap.rs
@@ -1163,9 +1163,9 @@ impl<T> FusedIterator for Drain<'_, T> {}
 
 #[stable(feature = "binary_heap_extras_15", since = "1.5.0")]
 impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
-    /// Converts a `Vec` into a `BinaryHeap`.
+    /// Converts a `Vec<T>` into a `BinaryHeap<T>`.
     ///
-    /// This conversion happens in-place, and has O(n) time complexity.
+    /// This conversion happens in-place, and has `O(n)` time complexity.
     fn from(vec: Vec<T>) -> BinaryHeap<T> {
         let mut heap = BinaryHeap { data: vec };
         heap.rebuild();

--- a/src/libcore/ascii.rs
+++ b/src/libcore/ascii.rs
@@ -14,6 +14,7 @@
 use crate::fmt;
 use crate::ops::Range;
 use crate::iter::FusedIterator;
+use crate::str::from_utf8_unchecked;
 
 /// An iterator over the escaped version of a byte.
 ///
@@ -22,6 +23,7 @@ use crate::iter::FusedIterator;
 ///
 /// [`escape_default`]: fn.escape_default.html
 #[stable(feature = "rust1", since = "1.0.0")]
+#[derive(Clone)]
 pub struct EscapeDefault {
     range: Range<usize>,
     data: [u8; 4],
@@ -129,6 +131,13 @@ impl DoubleEndedIterator for EscapeDefault {
 impl ExactSizeIterator for EscapeDefault {}
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDefault {}
+
+#[stable(feature = "ascii_escape_display", since = "1.39.0")]
+impl fmt::Display for EscapeDefault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(unsafe { from_utf8_unchecked(&self.data[self.range.clone()]) })
+    }
+}
 
 #[stable(feature = "std_debug", since = "1.16.0")]
 impl fmt::Debug for EscapeDefault {

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -553,8 +553,6 @@ impl<H> PartialEq for BuildHasherDefault<H> {
 #[stable(since = "1.29.0", feature = "build_hasher_eq")]
 impl<H> Eq for BuildHasherDefault<H> {}
 
-//////////////////////////////////////////////////////////////////////////////
-
 mod impls {
     use crate::mem;
     use crate::slice;

--- a/src/librustc_target/spec/mips64_unknown_linux_muslabi64.rs
+++ b/src/librustc_target/spec/mips64_unknown_linux_muslabi64.rs
@@ -1,0 +1,25 @@
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "mips64r2".to_string();
+    base.features = "+mips64r2".to_string();
+    base.max_atomic_width = Some(64);
+    Ok(Target {
+        // LLVM doesn't recognize "muslabi64" yet.
+        llvm_target: "mips64-unknown-linux-musl".to_string(),
+        target_endian: "big".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            target_mcount: "_mcount".to_string(),
+            .. base
+        },
+    })
+}

--- a/src/librustc_target/spec/mips64el_unknown_linux_muslabi64.rs
+++ b/src/librustc_target/spec/mips64el_unknown_linux_muslabi64.rs
@@ -1,0 +1,25 @@
+use crate::spec::{LinkerFlavor, Target, TargetOptions, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "mips64r2".to_string();
+    base.features = "+mips64r2".to_string();
+    base.max_atomic_width = Some(64);
+    Ok(Target {
+        // LLVM doesn't recognize "muslabi64" yet.
+        llvm_target: "mips64el-unknown-linux-musl".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        target_os: "linux".to_string(),
+        target_env: "musl".to_string(),
+        target_vendor: "unknown".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+        options: TargetOptions {
+            target_mcount: "_mcount".to_string(),
+            .. base
+        },
+    })
+}

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -371,6 +371,8 @@ supported_targets! {
     ("i586-unknown-linux-musl", i586_unknown_linux_musl),
     ("mips-unknown-linux-musl", mips_unknown_linux_musl),
     ("mipsel-unknown-linux-musl", mipsel_unknown_linux_musl),
+    ("mips64-unknown-linux-muslabi64", mips64_unknown_linux_muslabi64),
+    ("mips64el-unknown-linux-muslabi64", mips64el_unknown_linux_muslabi64),
     ("hexagon-unknown-linux-musl", hexagon_unknown_linux_musl),
 
     ("mips-unknown-linux-uclibc", mips_unknown_linux_uclibc),

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1236,7 +1236,7 @@ impl<'a> Parser<'a> {
 
         let args: Vec<_> = args.into_iter().filter_map(|x| x).collect();
 
-        if c_variadic && args.is_empty() {
+        if c_variadic && args.len() <= 1 {
             self.span_err(sp,
                           "C-variadic function must be declared with at least one named argument");
         }

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -224,6 +224,10 @@ impl<'a> Parser<'a> {
                 self.err_dotdotdot_syntax(self.token.span);
             }
 
+            if self.token == token::LArrow {
+                self.err_larrow_operator(self.token.span);
+            }
+
             self.bump();
             if op.is_comparison() {
                 self.check_no_chained_comparison(&lhs, &op);
@@ -1700,6 +1704,19 @@ impl<'a> Parser<'a> {
                 Applicability::MaybeIncorrect
             )
             .emit();
+    }
+
+    fn err_larrow_operator(&self, span: Span) {
+        self.struct_span_err(
+            span,
+            "unexpected token: `<-`"
+        ).span_suggestion(
+            span,
+            "if you meant to write a comparison against a negative value, add a \
+             space in between `<` and `-`",
+            "< -".to_string(),
+            Applicability::MaybeIncorrect
+        ).emit();
     }
 
     fn mk_assign_op(&self, binop: BinOp, lhs: P<Expr>, rhs: P<Expr>) -> ExprKind {

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -97,6 +97,8 @@ impl AssocOp {
             // DotDotDot is no longer supported, but we need some way to display the error
             token::DotDotDot => Some(DotDotEq),
             token::Colon => Some(Colon),
+            // `<-` should probably be `< -`
+            token::LArrow => Some(Less),
             _ if t.is_keyword(kw::As) => Some(As),
             _ => None
         }

--- a/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.rs
+++ b/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.rs
@@ -1,0 +1,6 @@
+extern {
+    fn foo(...);
+    //~^ ERROR C-variadic function must be declared with at least one named argument
+}
+
+fn main() {}

--- a/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-no-fixed-args.stderr
@@ -1,0 +1,8 @@
+error: C-variadic function must be declared with at least one named argument
+  --> $DIR/variadic-ffi-no-fixed-args.rs:2:11
+   |
+LL |     fn foo(...);
+   |           ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/obsolete-in-place/bad.rs
+++ b/src/test/ui/obsolete-in-place/bad.rs
@@ -2,7 +2,7 @@
 
 fn foo() {
     let (x, y) = (0, 0);
-    x <- y; //~ ERROR expected one of
+    x <- y; //~ ERROR unexpected token: `<-`
 }
 
 fn main() {

--- a/src/test/ui/obsolete-in-place/bad.stderr
+++ b/src/test/ui/obsolete-in-place/bad.stderr
@@ -1,8 +1,12 @@
-error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `<-`
+error: unexpected token: `<-`
   --> $DIR/bad.rs:5:7
    |
 LL |     x <- y;
-   |       ^^ expected one of 8 possible tokens here
+   |       ^^
+help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
+   |
+LL |     x < - y;
+   |       ^^^
 
 error: expected expression, found keyword `in`
   --> $DIR/bad.rs:10:5

--- a/src/test/ui/placement-syntax.rs
+++ b/src/test/ui/placement-syntax.rs
@@ -1,6 +1,6 @@
 fn main() {
     let x = -5;
-    if x<-1 { //~ ERROR expected `{`, found `<-`
+    if x<-1 { //~ ERROR unexpected token: `<-`
         println!("ok");
     }
 }

--- a/src/test/ui/placement-syntax.stderr
+++ b/src/test/ui/placement-syntax.stderr
@@ -1,10 +1,12 @@
-error: expected `{`, found `<-`
+error: unexpected token: `<-`
   --> $DIR/placement-syntax.rs:3:9
    |
 LL |     if x<-1 {
-   |     --  ^^ expected `{`
-   |     |
-   |     this `if` statement has a condition, but no block
+   |         ^^
+help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
+   |
+LL |     if x< -1 {
+   |         ^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #63165 (Add builtin targets for mips64(el)-unknown-linux-muslabi64)
 - #63421 (Implement Clone, Display for ascii::EscapeDefault)
 - #63459 (syntax: account for CVarArgs being in the argument list.)
 - #63475 (Bring back suggestion for splitting `<-` into `< -`)
 - #63486 (Document `From` trait for `BinaryHeap`)
 - #63493 (Remove unneeded comment in src/libcore/hash/mod.rs)

Failed merges:


r? @ghost