### PR TITLE
1.37.0 stable

### DIFF
--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -30,6 +30,10 @@ steps:
 - bash: printenv | sort
   displayName: Show environment variables
 
+# Log the date, even on failure. Attempting to debug SSL certificate errors.
+- bash: date
+  displayName: Print out date (before build)
+
 - bash: |
     set -e
     df -h
@@ -198,3 +202,8 @@ steps:
   condition: variables['AWS_SECRET_ACCESS_KEY']
   continueOnError: true
   displayName: Upload CPU usage statistics
+
+# Log the date, even on failure. Attempting to debug SSL certificate errors.
+- bash: date
+  continueOnError: true
+  displayName: Print out date (after build)

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -45,7 +45,7 @@ fi
 #
 # FIXME: need a scheme for changing this `nightly` value to `beta` and `stable`
 #        either automatically or manually.
-export RUST_RELEASE_CHANNEL=beta
+export RUST_RELEASE_CHANNEL=stable
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNEL"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -1116,19 +1116,18 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 bug!("try_report_cannot_return_reference_to_local: not a local")
             };
             match self.body.local_kind(local) {
-                LocalKind::ReturnPointer | LocalKind::Temp => {
-                    (
-                        "temporary value".to_string(),
-                        "temporary value created here".to_string(),
-                    )
-                }
-                LocalKind::Arg => {
-                    (
-                        "function parameter".to_string(),
-                        "function parameter borrowed here".to_string(),
-                    )
-                },
-                LocalKind::Var => bug!("local variable without a name"),
+                LocalKind::ReturnPointer | LocalKind::Temp => (
+                    "temporary value".to_string(),
+                    "temporary value created here".to_string(),
+                ),
+                LocalKind::Arg => (
+                    "function parameter".to_string(),
+                    "function parameter borrowed here".to_string(),
+                ),
+                LocalKind::Var => (
+                    "local binding".to_string(),
+                    "local binding introduced here".to_string(),
+                ),
             }
         };
 

--- a/src/librustc_mir/interpret/machine.rs
+++ b/src/librustc_mir/interpret/machine.rs
@@ -54,6 +54,11 @@ pub trait AllocMap<K: Hash + Eq, V> {
         k: K,
         vacant: impl FnOnce() -> Result<V, E>
     ) -> Result<&mut V, E>;
+
+    /// Read-only lookup.
+    fn get(&self, k: K) -> Option<&V> {
+        self.get_or(k, || Err(())).ok()
+    }
 }
 
 /// Methods of this trait signifies a point where CTFE evaluation would fail

--- a/src/test/ui/borrowck/return-local-binding-from-desugaring.rs
+++ b/src/test/ui/borrowck/return-local-binding-from-desugaring.rs
@@ -1,0 +1,33 @@
+// To avoid leaking the names of local bindings from expressions like for loops, #60984
+// explicitly ignored them, but an assertion that `LocalKind::Var` *must* have a name would
+// trigger an ICE. Before this change, this file's output would be:
+// ```
+// error[E0515]: cannot return value referencing local variable `__next`
+//   --> return-local-binding-from-desugaring.rs:LL:CC
+//    |
+// LL |     for ref x in xs {
+//    |         ----- `__next` is borrowed here
+// ...
+// LL |     result
+//    |     ^^^^^^ returns a value referencing data owned by the current function
+// ```
+// FIXME: ideally `LocalKind` would carry more information to more accurately explain the problem.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+fn group_by<I, F, T>(xs: &mut I, f: F) -> HashMap<T, Vec<&I::Item>>
+where
+    I: Iterator,
+    F: Fn(&I::Item) -> T,
+    T: Eq + Hash,
+{
+    let mut result = HashMap::new();
+    for ref x in xs {
+        let key = f(x);
+        result.entry(key).or_insert(Vec::new()).push(x);
+    }
+    result //~ ERROR cannot return value referencing local binding
+}
+
+fn main() {}

--- a/src/test/ui/borrowck/return-local-binding-from-desugaring.stderr
+++ b/src/test/ui/borrowck/return-local-binding-from-desugaring.stderr
@@ -1,0 +1,12 @@
+error[E0515]: cannot return value referencing local binding
+  --> $DIR/return-local-binding-from-desugaring.rs:30:5
+   |
+LL |     for ref x in xs {
+   |                  -- local binding introduced here
+...
+LL |     result
+   |     ^^^^^^ returns a value referencing data owned by the current function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0515`.

--- a/src/test/ui/consts/static-cycle-error.rs
+++ b/src/test/ui/consts/static-cycle-error.rs
@@ -1,0 +1,11 @@
+// compile-pass
+
+struct Foo {
+    foo: Option<&'static Foo>
+}
+
+static FOO: Foo = Foo {
+    foo: Some(&FOO),
+};
+
+fn main() {}


### PR DESCRIPTION
This promotes beta to stable and backports a few PRs:

 - Avoid ICE when referencing desugared local binding in borrow error (#63051)
 - Don't access a static just for its size and alignment (#62982) via 331e09b143aebfcf82dc1f9b69b31ee0083cbf0b