### PR TITLE
use `ParamName` to track in-scope lifetimes instead of Ident

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -136,6 +136,9 @@ pub struct LoweringContext<'a> {
     /// When `is_collectin_in_band_lifetimes` is true, each lifetime is checked
     /// against this list to see if it is already in-scope, or if a definition
     /// needs to be created for it.
+    ///
+    /// We always store a `modern()` version of the param-name in this
+    /// vector.
     in_scope_lifetimes: Vec<ParamName>,
 
     current_module: NodeId,

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -60,10 +60,12 @@ impl<'tcx, 'interner> Visitor<'tcx> for ItemLowerer<'tcx, 'interner> {
     fn visit_item(&mut self, item: &'tcx Item) {
         let mut item_hir_id = None;
         self.lctx.with_hir_id_owner(item.id, |lctx| {
-            if let Some(hir_item) = lctx.lower_item(item) {
-                item_hir_id = Some(hir_item.hir_id);
-                lctx.insert_item(hir_item);
-            }
+            lctx.without_in_scope_lifetime_defs(|lctx| {
+                if let Some(hir_item) = lctx.lower_item(item) {
+                    item_hir_id = Some(hir_item.hir_id);
+                    lctx.insert_item(hir_item);
+                }
+            })
         });
 
         if let Some(hir_id) = item_hir_id {
@@ -131,6 +133,28 @@ impl LoweringContext<'_> {
         let res = f(self);
 
         self.in_scope_lifetimes.truncate(old_len);
+        res
+    }
+
+    // Clears (and restores) the `in_scope_lifetimes` field. Used when
+    // visiting nested items, which never inherit in-scope lifetimes
+    // from their surrounding environment.
+    fn without_in_scope_lifetime_defs<T>(
+        &mut self,
+        f: impl FnOnce(&mut LoweringContext<'_>) -> T,
+    ) -> T {
+        let old_in_scope_lifetimes = std::mem::replace(&mut self.in_scope_lifetimes, vec![]);
+
+        // this vector is only used when walking over impl headers,
+        // input types, and the like, and should not be non-empty in
+        // between items
+        assert!(self.lifetimes_to_define.is_empty());
+
+        let res = f(self);
+
+        assert!(self.in_scope_lifetimes.is_empty());
+        self.in_scope_lifetimes = old_in_scope_lifetimes;
+
         res
     }
 

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -123,7 +123,7 @@ impl LoweringContext<'_> {
             _ => &[],
         };
         let lt_def_names = parent_generics.iter().filter_map(|param| match param.kind {
-            hir::GenericParamKind::Lifetime { .. } => Some(param.name),
+            hir::GenericParamKind::Lifetime { .. } => Some(param.name.modern()),
             _ => None,
         });
         self.in_scope_lifetimes.extend(lt_def_names);

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -123,7 +123,7 @@ impl LoweringContext<'_> {
             _ => &[],
         };
         let lt_def_names = parent_generics.iter().filter_map(|param| match param.kind {
-            hir::GenericParamKind::Lifetime { .. } => Some(param.name.ident().modern()),
+            hir::GenericParamKind::Lifetime { .. } => Some(param.name),
             _ => None,
         });
         self.in_scope_lifetimes.extend(lt_def_names);

--- a/src/test/ui/async-await/async-fn-elided-impl-lifetime-parameter.rs
+++ b/src/test/ui/async-await/async-fn-elided-impl-lifetime-parameter.rs
@@ -1,0 +1,16 @@
+// Check that `async fn` inside of an impl with `'_`
+// in the header compiles correctly.
+//
+// Regression test for #63500.
+//
+// check-pass
+
+#![feature(async_await)]
+
+struct Foo<'a>(&'a u8);
+
+impl Foo<'_> {
+    async fn bar() {}
+}
+
+fn main() { }

--- a/src/test/ui/async-await/async-fn-elided-impl-lifetime-parameter.rs
+++ b/src/test/ui/async-await/async-fn-elided-impl-lifetime-parameter.rs
@@ -4,6 +4,7 @@
 // Regression test for #63500.
 //
 // check-pass
+// edition:2018
 
 #![feature(async_await)]
 

--- a/src/test/ui/async-await/nested-in-impl.rs
+++ b/src/test/ui/async-await/nested-in-impl.rs
@@ -1,0 +1,17 @@
+// Test that async fn works when nested inside of
+// impls with lifetime parameters.
+//
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+struct Foo<'a>(&'a ());
+
+impl<'a> Foo<'a> {
+    fn test() {
+        async fn test() {}
+    }
+}
+
+fn main() { }

--- a/src/test/ui/in-band-lifetimes/nested-items.rs
+++ b/src/test/ui/in-band-lifetimes/nested-items.rs
@@ -1,0 +1,20 @@
+// Test that the `'a` from the impl doesn't
+// prevent us from creating a `'a` parameter
+// on the `blah` function.
+//
+// check-pass
+
+#![feature(in_band_lifetimes)]
+
+struct Foo<'a> {
+    x: &'a u32
+
+}
+
+impl Foo<'a> {
+    fn method(&self) {
+        fn blah(f: Foo<'a>) { }
+    }
+}
+
+fn main() { }


### PR DESCRIPTION
Also, clear in-scope lifetimes when visiting nested items.

Fixes #63500.
Fixes #63225.
Fixes #52532.

r? @cramertj 