### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -273,7 +273,7 @@ jobs:
         MSYS_BITS: 32
         RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
         SCRIPT: make ci-subset-1
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
         MINGW_DIR: mingw32
         # FIXME(#59637)
@@ -283,14 +283,14 @@ jobs:
         MSYS_BITS: 32
         RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
         SCRIPT: make ci-subset-2
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
         MINGW_DIR: mingw32
       x86_64-mingw-1:
         MSYS_BITS: 64
         SCRIPT: make ci-subset-1
         RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
         MINGW_DIR: mingw64
         # FIXME(#59637)
@@ -300,7 +300,7 @@ jobs:
         MSYS_BITS: 64
         SCRIPT: make ci-subset-2
         RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
         MINGW_DIR: mingw64
 
@@ -327,7 +327,7 @@ jobs:
         MSYS_BITS: 32
         RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools --enable-profiler
         SCRIPT: python x.py dist
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
         MINGW_DIR: mingw32
         DIST_REQUIRE_ALL_TOOLS: 1
@@ -336,7 +336,7 @@ jobs:
         MSYS_BITS: 64
         SCRIPT: python x.py dist
         RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler
-        MINGW_URL: https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+        MINGW_URL: https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
         MINGW_ARCHIVE: x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z
         MINGW_DIR: mingw64
         DIST_REQUIRE_ALL_TOOLS: 1

--- a/src/ci/azure-pipelines/steps/install-clang.yml
+++ b/src/ci/azure-pipelines/steps/install-clang.yml
@@ -36,7 +36,7 @@ steps:
     set -e
     mkdir -p citools
     cd citools
-    curl -f https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/LLVM-7.0.0-win64.tar.gz | tar xzf -
+    curl -f https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/LLVM-7.0.0-win64.tar.gz | tar xzf -
     echo "##vso[task.setvariable variable=RUST_CONFIGURE_ARGS]$RUST_CONFIGURE_ARGS --set llvm.clang-cl=`pwd`/clang-rust/bin/clang-cl.exe"
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['MINGW_URL'],''))
   displayName: Install clang (Windows)

--- a/src/ci/azure-pipelines/steps/install-sccache.yml
+++ b/src/ci/azure-pipelines/steps/install-sccache.yml
@@ -2,14 +2,14 @@ steps:
 
 - bash: |
     set -e
-    curl -fo /usr/local/bin/sccache https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2018-04-02-sccache-x86_64-apple-darwin
+    curl -fo /usr/local/bin/sccache https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2018-04-02-sccache-x86_64-apple-darwin
     chmod +x /usr/local/bin/sccache
   displayName: Install sccache (OSX)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - script: |
     md sccache
-    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf sccache\sccache.exe https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2018-04-26-sccache-x86_64-pc-windows-msvc"
+    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf sccache\sccache.exe https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2018-04-26-sccache-x86_64-pc-windows-msvc"
     echo ##vso[task.prependpath]%CD%\sccache
   displayName: Install sccache (Windows)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/src/ci/azure-pipelines/steps/install-windows-build-deps.yml
+++ b/src/ci/azure-pipelines/steps/install-windows-build-deps.yml
@@ -4,7 +4,7 @@ steps:
 # https://github.com/wixtoolset/wix3 originally
 - bash: |
     set -e
-    curl -O https://rust-lang-ci2.s3-us-west-1.amazonaws.com/rust-ci-mirror/wix311-binaries.zip
+    curl -O https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/wix311-binaries.zip
     echo "##vso[task.setvariable variable=WIX]`pwd`/wix"
     mkdir -p wix/bin
     cd wix/bin
@@ -18,7 +18,7 @@ steps:
 # one is MSI installers and one is EXE, but they're not used so frequently at
 # this point anyway so perhaps it's a wash!
 - script: |
-    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf is-install.exe https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2017-08-22-is.exe"
+    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf is-install.exe https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2017-08-22-is.exe"
     is-install.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP-
     echo ##vso[task.prependpath]C:\Program Files (x86)\Inno Setup 5
   displayName: Install InnoSetup
@@ -109,7 +109,7 @@ steps:
 # Note that this is originally from the github releases patch of Ninja
 - script: |
     md ninja
-    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf 2017-03-15-ninja-win.zip https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2017-03-15-ninja-win.zip"
+    powershell -Command "$ProgressPreference = 'SilentlyContinue'; iwr -outf 2017-03-15-ninja-win.zip https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2017-03-15-ninja-win.zip"
     7z x -oninja 2017-03-15-ninja-win.zip
     del 2017-03-15-ninja-win.zip
     set RUST_CONFIGURE_ARGS=%RUST_CONFIGURE_ARGS% --enable-ninja

--- a/src/ci/docker/armhf-gnu/Dockerfile
+++ b/src/ci/docker/armhf-gnu/Dockerfile
@@ -72,7 +72,7 @@ RUN arm-linux-gnueabihf-gcc addentropy.c -o rootfs/addentropy -static
 
 # TODO: What is this?!
 # Source of the file: https://github.com/vfdev-5/qemu-rpi2-vexpress/raw/master/vexpress-v2p-ca15-tc1.dtb
-RUN curl -O https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/vexpress-v2p-ca15-tc1.dtb
+RUN curl -O https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/vexpress-v2p-ca15-tc1.dtb
 
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh

--- a/src/ci/docker/dist-various-1/install-mips-musl.sh
+++ b/src/ci/docker/dist-various-1/install-mips-musl.sh
@@ -5,7 +5,7 @@ mkdir /usr/local/mips-linux-musl
 # originally from
 # https://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/
 # OpenWrt-Toolchain-ar71xx-generic_gcc-5.3.0_musl-1.1.16.Linux-x86_64.tar.bz2
-URL="https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror"
+URL="https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc"
 FILE="OpenWrt-Toolchain-ar71xx-generic_gcc-5.3.0_musl-1.1.16.Linux-x86_64.tar.bz2"
 curl -L "$URL/$FILE" | tar xjf - -C /usr/local/mips-linux-musl --strip-components=2
 

--- a/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
@@ -5,7 +5,7 @@
 set -ex
 
 # Originally from https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-curl https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/clang%2Bllvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | \
+curl https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/clang%2Bllvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | \
   tar xJf -
 export PATH=`pwd`/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
 

--- a/src/ci/docker/dist-x86_64-linux/build-openssl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-openssl.sh
@@ -4,7 +4,7 @@ set -ex
 source shared.sh
 
 VERSION=1.0.2k
-URL=https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/openssl-$VERSION.tar.gz
+URL=https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/openssl-$VERSION.tar.gz
 
 curl $URL | tar xzf -
 

--- a/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
+++ b/src/ci/docker/dist-x86_64-netbsd/build-netbsd-toolchain.sh
@@ -25,7 +25,7 @@ cd netbsd
 
 mkdir -p /x-tools/x86_64-unknown-netbsd/sysroot
 
-URL=https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror
+URL=https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc
 
 # Originally from ftp://ftp.netbsd.org/pub/NetBSD/NetBSD-$BSD/source/sets/*.tgz
 curl $URL/2018-03-01-netbsd-src.tgz | tar xzf -

--- a/src/ci/docker/scripts/android-sdk-manager.py
+++ b/src/ci/docker/scripts/android-sdk-manager.py
@@ -23,8 +23,9 @@ REPOSITORIES = [
 HOST_OS = "linux"
 
 # Mirroring options
-MIRROR_BUCKET = "rust-lang-ci2"
-MIRROR_BASE_DIR = "rust-ci-mirror/android/"
+MIRROR_BUCKET = "rust-lang-ci-mirrors"
+MIRROR_BUCKET_REGION = "us-west-1"
+MIRROR_BASE_DIR = "rustc/android/"
 
 import argparse
 import hashlib
@@ -144,7 +145,8 @@ def cli_install(args):
     lockfile = Lockfile(args.lockfile)
     for package in lockfile.packages.values():
         # Download the file from the mirror into a temp file
-        url = "https://" + MIRROR_BUCKET + ".s3.amazonaws.com/" + MIRROR_BASE_DIR
+        url = "https://" + MIRROR_BUCKET + ".s3-" + MIRROR_BUCKET_REGION + \
+              ".amazonaws.com/" + MIRROR_BASE_DIR
         downloaded = package.download(url)
         # Extract the file in a temporary directory
         extract_dir = tempfile.mkdtemp()

--- a/src/ci/docker/scripts/freebsd-toolchain.sh
+++ b/src/ci/docker/scripts/freebsd-toolchain.sh
@@ -59,7 +59,7 @@ done
 
 # Originally downloaded from:
 # https://download.freebsd.org/ftp/releases/${freebsd_arch}/${freebsd_version}-RELEASE/base.txz
-URL=https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2019-04-04-freebsd-${freebsd_arch}-${freebsd_version}-RELEASE-base.txz
+URL=https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2019-04-04-freebsd-${freebsd_arch}-${freebsd_version}-RELEASE-base.txz
 curl "$URL" | tar xJf - -C "$sysroot" --wildcards "${files_to_extract[@]}"
 
 # Fix up absolute symlinks from the system image.  This can be removed

--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -1,6 +1,6 @@
 set -ex
 
 curl -fo /usr/local/bin/sccache \
-  https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2018-04-02-sccache-x86_64-unknown-linux-musl
+  https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2018-04-02-sccache-x86_64-unknown-linux-musl
 
 chmod +x /usr/local/bin/sccache

--- a/src/ci/install-awscli.sh
+++ b/src/ci/install-awscli.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-MIRROR="https://rust-lang-ci2.s3.amazonaws.com/rust-ci-mirror/2019-07-27-awscli.tar"
+MIRROR="https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/2019-07-27-awscli.tar"
 DEPS_DIR="/tmp/awscli-deps"
 
 pip="pip"

--- a/src/test/ui/async-await/issue-61949-self-return-type.rs
+++ b/src/test/ui/async-await/issue-61949-self-return-type.rs
@@ -1,0 +1,28 @@
+// ignore-tidy-linelength
+// edition:2018
+#![feature(async_await)]
+
+// This test checks that `Self` is prohibited as a return type. See #61949 for context.
+
+pub struct Foo<'a> {
+    pub bar: &'a i32,
+}
+
+impl<'a> Foo<'a> {
+    pub async fn new(_bar: &'a i32) -> Self {
+    //~^ ERROR `async fn` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
+        Foo {
+            bar: &22
+        }
+    }
+}
+
+async fn foo() {
+    let x = {
+        let bar = 22;
+        Foo::new(&bar).await
+    };
+    drop(x);
+}
+
+fn main() { }

--- a/src/test/ui/async-await/issue-61949-self-return-type.stderr
+++ b/src/test/ui/async-await/issue-61949-self-return-type.stderr
@@ -1,0 +1,8 @@
+error: `async fn` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
+  --> $DIR/issue-61949-self-return-type.rs:12:40
+   |
+LL |     pub async fn new(_bar: &'a i32) -> Self {
+   |                                        ^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/impl-trait/bound-normalization-fail.rs
+++ b/src/test/ui/impl-trait/bound-normalization-fail.rs
@@ -1,4 +1,5 @@
 // compile-fail
+// ignore-tidy-linelength
 // edition:2018
 
 #![feature(async_await)]
@@ -44,7 +45,8 @@ mod lifetimes {
 
     /// Missing bound constraining `Assoc`, `T::Assoc` can't be normalized further.
     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
-        //~^ ERROR: type mismatch
+    //~^ ERROR: type mismatch
+    //~^^ ERROR `impl Trait` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
         Foo(())
     }
 }

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -1,5 +1,5 @@
 warning: the feature `impl_trait_in_bindings` is incomplete and may cause the compiler to crash
-  --> $DIR/bound-normalization-fail.rs:5:12
+  --> $DIR/bound-normalization-fail.rs:6:12
    |
 LL | #![feature(impl_trait_in_bindings)]
    |            ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #![feature(impl_trait_in_bindings)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
-  --> $DIR/bound-normalization-fail.rs:29:32
+  --> $DIR/bound-normalization-fail.rs:30:32
    |
 LL |     fn foo_fail<T: Trait>() -> impl FooLike<Output=T::Assoc> {
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found associated type
@@ -16,8 +16,14 @@ LL |     fn foo_fail<T: Trait>() -> impl FooLike<Output=T::Assoc> {
               found type `<T as impl_trait::Trait>::Assoc`
    = note: the return type of a function must have a statically known size
 
+error: `impl Trait` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
+  --> $DIR/bound-normalization-fail.rs:47:41
+   |
+LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
-  --> $DIR/bound-normalization-fail.rs:46:41
+  --> $DIR/bound-normalization-fail.rs:47:41
    |
 LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected (), found associated type
@@ -26,6 +32,6 @@ LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output=T::Assoc> {
               found type `<T as lifetimes::Trait<'static>>::Assoc`
    = note: the return type of a function must have a statically known size
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime-async.rs
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime-async.rs
@@ -1,0 +1,37 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+struct Foo;
+
+impl Foo {
+    async fn pin_ref(self: Pin<&Self>) -> Pin<&Self> { self }
+
+    async fn pin_mut(self: Pin<&mut Self>) -> Pin<&mut Self> { self }
+
+    async fn pin_pin_pin_ref(self: Pin<Pin<Pin<&Self>>>) -> Pin<Pin<Pin<&Self>>> { self }
+
+    async fn pin_ref_impl_trait(self: Pin<&Self>) -> impl Clone + '_ { self }
+
+    fn b(self: Pin<&Foo>, f: &Foo) -> Pin<&Foo> { self }
+}
+
+type Alias<T> = Pin<T>;
+impl Foo {
+    async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> Alias<&Self> { self }
+}
+
+// FIXME(Centril): extend with the rest of the non-`async fn` test
+// when we allow `async fn`s inside traits and trait implementations.
+
+fn main() {
+    let mut foo = Foo;
+    { Pin::new(&foo).pin_ref() };
+    { Pin::new(&mut foo).pin_mut() };
+    { Pin::new(Pin::new(Pin::new(&foo))).pin_pin_pin_ref() };
+    { Pin::new(&foo).pin_ref_impl_trait() };
+}

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
@@ -1,0 +1,14 @@
+error: lifetime may not live long enough
+  --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:10:48
+   |
+LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
+   |                          -                     ^^^^^^^^ returning this value requires that `'_` must outlive `'static`
+   |                          |
+   |                          lifetime `'_` defined here
+help: to allow this `impl Trait` to capture borrowed data with lifetime `'_`, add `'_` as a constraint
+   |
+LL |     async fn f(self: Pin<&Self>) -> impl Clone + '_ { self }
+   |                                     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.rs
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.rs
@@ -1,0 +1,16 @@
+// edition:2018
+
+#![feature(async_await)]
+
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    async fn f(self: Pin<&Self>) -> impl Clone { self }
+    //~^ ERROR cannot infer an appropriate lifetime
+}
+
+fn main() {
+    { Pin::new(&Foo).f() };
+}

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.stderr
@@ -1,0 +1,20 @@
+error: cannot infer an appropriate lifetime
+  --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:10:16
+   |
+LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
+   |                ^^^^                 ---------- this return type evaluates to the `'static` lifetime...
+   |                |
+   |                ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 10:26
+  --> $DIR/arbitrary_self_types_pin_lifetime_impl_trait-async.rs:10:26
+   |
+LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
+   |                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 10:26
+   |
+LL |     async fn f(self: Pin<&Self>) -> impl Clone + '_ { self }
+   |                                     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.nll.stderr
@@ -1,0 +1,27 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:10:45
+   |
+LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
+   |                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:60
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                                                            ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:67
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                                                                   ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.rs
@@ -1,0 +1,28 @@
+// edition:2018
+
+#![feature(async_await)]
+
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
+    //~^ ERROR missing lifetime specifier
+    //~| ERROR cannot infer an appropriate lifetime
+    // FIXME: should be E0623?
+
+    async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+    //~^ ERROR missing lifetime specifier
+    //~| ERROR cannot infer an appropriate lifetime
+    //~| ERROR missing lifetime specifier
+    //~| ERROR cannot infer an appropriate lifetime
+    // FIXME: should be E0623?
+}
+
+type Alias<T> = Pin<T>;
+impl Foo {
+    async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg } //~ ERROR E0623
+}
+
+fn main() {}

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -1,0 +1,88 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:10:45
+   |
+LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
+   |                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:60
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                                                            ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:67
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                                                                   ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:10:33
+   |
+LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
+   |                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                 |
+   |                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 10:26
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:10:26
+   |
+LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
+   |                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 10:26
+   |
+LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo + '_ { f }
+   |                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:16
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                ^^^^ ...but this borrow...             ----------------- this return type evaluates to the `'static` lifetime...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:26
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:26
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:26
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) + '_ { (self, f) }
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:34
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                                  ^                    ----------------- this return type evaluates to the `'static` lifetime...
+   |                                  |
+   |                                  ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:26
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:15:26
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
+   |                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:26
+   |
+LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) + '_ { (self, f) }
+   |                                                       ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0623]: lifetime mismatch
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:25:58
+   |
+LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
+   |                                  -----                   ^^^
+   |                                  |                       |
+   |                                  |                       ...but data from `arg` is returned here
+   |                                  this parameter and the return type are declared with different lifetimes...
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/README.md
+++ b/src/test/ui/self/elision/README.md
@@ -42,3 +42,34 @@ In each case, we test the following patterns:
 - `self: Box<Pin<XXX>>`
 
 In the non-reference cases, `Pin` causes errors so we substitute `Rc`.
+
+### `async fn`
+
+For each of the tests above we also check that `async fn` behaves as an `fn` would.
+These tests are in files named `*-async.rs`.
+
+Legends:
+- ✓ ⟹ Yes / Pass
+- X ⟹ No
+- α ⟹ lifetime mismatch
+- β ⟹ cannot infer an appropriate lifetime
+- γ ⟹ missing lifetime specifier
+
+| `async` file | Pass? | Conforms to `fn`? | How does it diverge? <br/> `fn` ⟶ `async fn` |
+| --- | --- | --- | --- |
+| `self-async.rs` | ✓ | ✓ | N/A |
+| `struct-async.rs`| ✓ | ✓ | N/A |
+| `alias-async.rs`| ✓ | ✓ | N/A |
+| `assoc-async.rs`| ✓ | ✓ | N/A |
+| `ref-self-async.rs` | X | X | α ⟶ β + γ |
+| `ref-mut-self-async.rs` | X | X | α ⟶ β + γ |
+| `ref-struct-async.rs` | X | X | α ⟶ β + γ |
+| `ref-mut-struct-async.rs` | X | X | α ⟶ β + γ |
+| `ref-alias-async.rs` | X | X | ✓ ⟶ β + γ |
+| `ref-assoc-async.rs` | X | X | ✓ ⟶ β + γ |
+| `ref-mut-alias-async.rs` | X | X | ✓ ⟶ β + γ |
+| `lt-self-async.rs` | ✓ | ✓ | N/A
+| `lt-struct-async.rs` | ✓ | ✓ | N/A
+| `lt-alias-async.rs` | ✓ | ✓ | N/A
+| `lt-assoc-async.rs` | ✓ | ✓ | N/A
+| `lt-ref-self-async.rs` | X | X | α ⟶ β + γ

--- a/src/test/ui/self/elision/alias-async.rs
+++ b/src/test/ui/self/elision/alias-async.rs
@@ -1,0 +1,39 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+struct Struct { }
+
+type Alias = Struct;
+
+impl Struct {
+    // Test using an alias for `Struct`:
+
+    async fn alias(self: Alias, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_Alias(self: Box<Alias>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn rc_Alias(self: Rc<Alias>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_box_Alias(self: Box<Box<Alias>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_rc_Alias(self: Box<Rc<Alias>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/assoc-async.rs
+++ b/src/test/ui/self/elision/assoc-async.rs
@@ -1,0 +1,43 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+trait Trait {
+    type AssocType;
+}
+
+struct Struct { }
+
+impl Trait for Struct {
+    type AssocType = Self;
+}
+
+impl Struct {
+    async fn assoc(self: <Struct as Trait>::AssocType, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_AssocType(self: Box<<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn rc_AssocType(self: Rc<<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_box_AssocType(self: Box<Box<<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_rc_AssocType(self: Box<Rc<<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/lt-alias-async.rs
+++ b/src/test/ui/self/elision/lt-alias-async.rs
@@ -1,0 +1,41 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+struct Struct<'a> { x: &'a u32 }
+
+type Alias<'a> = Struct<'a>;
+
+impl<'a> Alias<'a> {
+    async fn take_self(self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Alias(self: Alias<'a>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Alias(self: Box<Alias<'a>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Box_Alias(self: Box<Box<Alias<'a>>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Rc_Alias(self: Rc<Alias<'a>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Rc_Alias(self: Box<Rc<Alias<'a>>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/lt-assoc-async.rs
+++ b/src/test/ui/self/elision/lt-assoc-async.rs
@@ -1,0 +1,53 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+trait Trait {
+    type AssocType;
+}
+
+struct Struct<'a> { x: &'a u32 }
+
+impl<'a> Trait for Struct<'a> {
+    type AssocType = Self;
+}
+
+impl<'a> Struct<'a> {
+    async fn take_self(self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_AssocType(self: <Struct<'a> as Trait>::AssocType, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_AssocType(self: Box<<Struct<'a> as Trait>::AssocType>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Box_AssocType(
+        self: Box<Box<<Struct<'a> as Trait>::AssocType>>,
+        f: &u32
+    ) -> &u32 {
+        f
+    }
+
+    async fn take_Rc_AssocType(self: Rc<<Struct<'a> as Trait>::AssocType>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Rc_AssocType(
+        self: Box<Rc<<Struct<'a> as Trait>::AssocType>>,
+        f: &u32
+    ) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.nll.stderr
@@ -1,0 +1,51 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:15:42
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:23:48
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                                ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:29:57
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:35:57
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:41:66
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:47:62
+   |
+LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                              ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/lt-ref-self-async.rs
+++ b/src/test/ui/self/elision/lt-ref-self-async.rs
@@ -1,0 +1,54 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct<'a> { data: &'a u32 }
+
+impl<'a> Struct<'a> {
+    // Test using `&self` sugar:
+
+    async fn ref_self(&self, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+
+    // Test using `&Self` explicitly:
+
+    async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+
+    async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+
+    async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+
+    async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+
+    async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+        //~^ ERROR cannot infer an appropriate lifetime
+        //~| ERROR missing lifetime specifier
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -1,0 +1,159 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:15:42
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:23:48
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                                ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:29:57
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:35:57
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:41:66
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/lt-ref-self-async.rs:47:62
+   |
+LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                              ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:15:30
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                              ^           ---- this return type evaluates to the `'static` lifetime...
+   |                              |
+   |                              ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:23
+  --> $DIR/lt-ref-self-async.rs:15:23
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:23
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 + '_ {
+   |                                          ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:23:36
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                    ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                    |
+   |                                    ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 23:29
+  --> $DIR/lt-ref-self-async.rs:23:29
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 23:29
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 + '_ {
+   |                                                ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:29:45
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                             ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                             |
+   |                                             ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 29:37
+  --> $DIR/lt-ref-self-async.rs:29:37
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 29:37
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 + '_ {
+   |                                                         ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:35:45
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                             ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                             |
+   |                                             ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 35:37
+  --> $DIR/lt-ref-self-async.rs:35:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 35:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 + '_ {
+   |                                                         ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:41:54
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                      ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                      |
+   |                                                      ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 41:45
+  --> $DIR/lt-ref-self-async.rs:41:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 41:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                  ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/lt-ref-self-async.rs:47:50
+   |
+LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                  ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                  |
+   |                                                  ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 47:41
+  --> $DIR/lt-ref-self-async.rs:47:41
+   |
+LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                         ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 47:41
+   |
+LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 + '_ {
+   |                                                              ^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/lt-self-async.rs
+++ b/src/test/ui/self/elision/lt-self-async.rs
@@ -1,0 +1,52 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+use std::rc::Rc;
+
+struct Struct<'a> {
+    x: &'a u32
+}
+
+impl<'a> Struct<'a> {
+    async fn take_self(self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Self(self: Self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Self(self: Box<Self>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Box_Self(self: Box<Box<Self>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Rc_Self(self: Rc<Self>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Rc_Self(self: Box<Rc<Self>>, f: &u32) -> &u32 {
+        f
+    }
+
+    // N/A
+    //fn take_Pin_Self(self: Pin<Self>, f: &u32) -> &u32 {
+    //    f
+    //}
+
+    // N/A
+    //fn take_Box_Pin_Self(self: Box<Pin<Self>>, f: &u32) -> &u32 {
+    //    f
+    //}
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/lt-struct-async.rs
+++ b/src/test/ui/self/elision/lt-struct-async.rs
@@ -1,0 +1,39 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+struct Struct<'a> { x: &'a u32 }
+
+impl<'a> Struct<'a> {
+    async fn take_self(self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Struct(self: Struct<'a>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Struct(self: Box<Struct<'a>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Box_Struct(self: Box<Box<Struct<'a>>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Rc_Struct(self: Rc<Struct<'a>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Rc_Struct(self: Box<Rc<Struct<'a>>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/multiple-ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/multiple-ref-self-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:24:74
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:30:84
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:36:84
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:42:93
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:48:93
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/multiple-ref-self-async.rs
+++ b/src/test/ui/self/elision/multiple-ref-self-async.rs
@@ -1,0 +1,55 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::pin::Pin;
+
+struct Struct { }
+
+struct Wrap<T, P>(T, PhantomData<P>);
+
+impl<T, P> Deref for Wrap<T, P> {
+    type Target = T;
+    fn deref(&self) -> &T { &self.0 }
+}
+
+impl Struct {
+    // Test using multiple `&Self`:
+
+    async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/multiple-ref-self-async.stderr
+++ b/src/test/ui/self/elision/multiple-ref-self-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:24:74
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:30:84
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:36:84
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:42:93
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/multiple-ref-self-async.rs:48:93
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/multiple-ref-self-async.rs:24:63
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                                               ^          --- this return type evaluates to the `'static` lifetime...
+   |                                                               |
+   |                                                               ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 24:48
+  --> $DIR/multiple-ref-self-async.rs:24:48
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 {
+   |                                                ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 24:48
+   |
+LL |     async fn wrap_ref_Self_ref_Self(self: Wrap<&Self, &Self>, f: &u8) -> &u8 + '_ {
+   |                                                                          ^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/multiple-ref-self-async.rs:30:72
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                        |
+   |                                                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 30:56
+  --> $DIR/multiple-ref-self-async.rs:30:56
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                        ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 30:56
+   |
+LL |     async fn box_wrap_ref_Self_ref_Self(self: Box<Wrap<&Self, &Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                                    ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/multiple-ref-self-async.rs:36:72
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                        |
+   |                                                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 36:56
+  --> $DIR/multiple-ref-self-async.rs:36:56
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 {
+   |                                                        ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 36:56
+   |
+LL |     async fn pin_wrap_ref_Self_ref_Self(self: Pin<Wrap<&Self, &Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                                    ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/multiple-ref-self-async.rs:42:81
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                                 |
+   |                                                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 42:64
+  --> $DIR/multiple-ref-self-async.rs:42:64
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 42:64
+   |
+LL |     async fn box_box_wrap_ref_Self_ref_Self(self: Box<Box<Wrap<&Self, &Self>>>, f: &u32) -> &u32 + '_ {
+   |                                                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/multiple-ref-self-async.rs:48:81
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                                 |
+   |                                                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 48:64
+  --> $DIR/multiple-ref-self-async.rs:48:64
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 {
+   |                                                                ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 48:64
+   |
+LL |     async fn box_pin_wrap_ref_Self_ref_Self(self: Box<Pin<Wrap<&Self, &Self>>>, f: &u32) -> &u32 + '_ {
+   |                                                                                             ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-alias-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-alias-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:20:50
+   |
+LL |     async fn ref_Alias(self: &Alias, f: &u32) -> &u32 {
+   |                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:26:59
+   |
+LL |     async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 {
+   |                                                           ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:32:59
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 {
+   |                                                           ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:38:68
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 {
+   |                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:44:68
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 {
+   |                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-alias-async.rs
+++ b/src/test/ui/self/elision/ref-alias-async.rs
@@ -1,0 +1,51 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct { }
+
+type Alias = Struct;
+
+impl Struct {
+    // Test using an alias for `Struct`:
+    //
+    // FIXME. We currently fail to recognize this as the self type, which
+    // feels like a bug.
+
+    async fn ref_Alias(self: &Alias, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-alias-async.stderr
+++ b/src/test/ui/self/elision/ref-alias-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:20:50
+   |
+LL |     async fn ref_Alias(self: &Alias, f: &u32) -> &u32 {
+   |                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:26:59
+   |
+LL |     async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 {
+   |                                                           ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:32:59
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 {
+   |                                                           ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:38:68
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 {
+   |                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-alias-async.rs:44:68
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 {
+   |                                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-alias-async.rs:20:38
+   |
+LL |     async fn ref_Alias(self: &Alias, f: &u32) -> &u32 {
+   |                                      ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                      |
+   |                                      ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 20:30
+  --> $DIR/ref-alias-async.rs:20:30
+   |
+LL |     async fn ref_Alias(self: &Alias, f: &u32) -> &u32 {
+   |                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 20:30
+   |
+LL |     async fn ref_Alias(self: &Alias, f: &u32) -> &u32 + '_ {
+   |                                                  ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-alias-async.rs:26:47
+   |
+LL |     async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 {
+   |                                               ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                               |
+   |                                               ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 26:38
+  --> $DIR/ref-alias-async.rs:26:38
+   |
+LL |     async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 {
+   |                                      ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 26:38
+   |
+LL |     async fn box_ref_Alias(self: Box<&Alias>, f: &u32) -> &u32 + '_ {
+   |                                                           ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-alias-async.rs:32:47
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 {
+   |                                               ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                               |
+   |                                               ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 32:38
+  --> $DIR/ref-alias-async.rs:32:38
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 {
+   |                                      ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 32:38
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&Alias>, f: &u32) -> &u32 + '_ {
+   |                                                           ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-alias-async.rs:38:56
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 {
+   |                                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                        |
+   |                                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 38:46
+  --> $DIR/ref-alias-async.rs:38:46
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 {
+   |                                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 38:46
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&Alias>>, f: &u32) -> &u32 + '_ {
+   |                                                                    ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-alias-async.rs:44:56
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 {
+   |                                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                        |
+   |                                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 44:46
+  --> $DIR/ref-alias-async.rs:44:46
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 {
+   |                                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 44:46
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&Alias>>, f: &u32) -> &u32 + '_ {
+   |                                                                    ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-assoc-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-assoc-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:21:77
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:27:86
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:33:86
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:39:95
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:45:95
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-assoc-async.rs
+++ b/src/test/ui/self/elision/ref-assoc-async.rs
@@ -1,0 +1,52 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+trait Trait {
+    type AssocType;
+}
+
+struct Struct { }
+
+impl Trait for Struct {
+    type AssocType = Self;
+}
+
+impl Struct {
+    async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-assoc-async.stderr
+++ b/src/test/ui/self/elision/ref-assoc-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:21:77
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:27:86
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:33:86
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:39:95
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-assoc-async.rs:45:95
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-assoc-async.rs:21:65
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                 |
+   |                                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 21:34
+  --> $DIR/ref-assoc-async.rs:21:34
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 {
+   |                                  ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 21:34
+   |
+LL |     async fn ref_AssocType(self: &<Struct as Trait>::AssocType, f: &u32) -> &u32 + '_ {
+   |                                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-assoc-async.rs:27:74
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                          |
+   |                                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 27:42
+  --> $DIR/ref-assoc-async.rs:27:42
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 27:42
+   |
+LL |     async fn box_ref_AssocType(self: Box<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 + '_ {
+   |                                                                                      ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-assoc-async.rs:33:74
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                          |
+   |                                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 33:42
+  --> $DIR/ref-assoc-async.rs:33:42
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 {
+   |                                          ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 33:42
+   |
+LL |     async fn pin_ref_AssocType(self: Pin<&<Struct as Trait>::AssocType>, f: &u32) -> &u32 + '_ {
+   |                                                                                      ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-assoc-async.rs:39:83
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                   ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                                   |
+   |                                                                                   ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 39:50
+  --> $DIR/ref-assoc-async.rs:39:50
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                  ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 39:50
+   |
+LL |     async fn box_box_ref_AssocType(self: Box<Box<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 + '_ {
+   |                                                                                               ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-assoc-async.rs:45:83
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                                                   ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                                                   |
+   |                                                                                   ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 45:50
+  --> $DIR/ref-assoc-async.rs:45:50
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 {
+   |                                                  ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 45:50
+   |
+LL |     async fn box_pin_ref_AssocType(self: Box<Pin<&<Struct as Trait>::AssocType>>, f: &u32) -> &u32 + '_ {
+   |                                                                                               ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-alias-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-alias-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:17:54
+   |
+LL |     async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 {
+   |                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:23:63
+   |
+LL |     async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 {
+   |                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:29:63
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 {
+   |                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:35:72
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:41:72
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-alias-async.rs
+++ b/src/test/ui/self/elision/ref-mut-alias-async.rs
@@ -1,0 +1,48 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct { }
+
+type Alias = Struct;
+
+impl Struct {
+    // Test using an alias for `Struct`:
+
+    async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-mut-alias-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-alias-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:17:54
+   |
+LL |     async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 {
+   |                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:23:63
+   |
+LL |     async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 {
+   |                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:29:63
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 {
+   |                                                               ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:35:72
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-alias-async.rs:41:72
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-alias-async.rs:17:42
+   |
+LL |     async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 {
+   |                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                          |
+   |                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 17:30
+  --> $DIR/ref-mut-alias-async.rs:17:30
+   |
+LL |     async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 {
+   |                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 17:30
+   |
+LL |     async fn ref_Alias(self: &mut Alias, f: &u32) -> &u32 + '_ {
+   |                                                      ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-alias-async.rs:23:51
+   |
+LL |     async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 {
+   |                                                   ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                   |
+   |                                                   ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 23:38
+  --> $DIR/ref-mut-alias-async.rs:23:38
+   |
+LL |     async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 {
+   |                                      ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 23:38
+   |
+LL |     async fn box_ref_Alias(self: Box<&mut Alias>, f: &u32) -> &u32 + '_ {
+   |                                                               ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-alias-async.rs:29:51
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 {
+   |                                                   ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                   |
+   |                                                   ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 29:38
+  --> $DIR/ref-mut-alias-async.rs:29:38
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 {
+   |                                      ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 29:38
+   |
+LL |     async fn pin_ref_Alias(self: Pin<&mut Alias>, f: &u32) -> &u32 + '_ {
+   |                                                               ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-alias-async.rs:35:60
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                            ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                            |
+   |                                                            ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 35:46
+  --> $DIR/ref-mut-alias-async.rs:35:46
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 {
+   |                                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 35:46
+   |
+LL |     async fn box_box_ref_Alias(self: Box<Box<&mut Alias>>, f: &u32) -> &u32 + '_ {
+   |                                                                        ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-alias-async.rs:41:60
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 {
+   |                                                            ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                            |
+   |                                                            ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 41:46
+  --> $DIR/ref-mut-alias-async.rs:41:46
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 {
+   |                                              ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 41:46
+   |
+LL |     async fn box_pin_ref_Alias(self: Box<Pin<&mut Alias>>, f: &u32) -> &u32 + '_ {
+   |                                                                        ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.nll.stderr
@@ -1,0 +1,51 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:15:46
+   |
+LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
+   |                                              ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:23:52
+   |
+LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+   |                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:29:61
+   |
+LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:35:61
+   |
+LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:41:70
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:47:70
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-self-async.rs
+++ b/src/test/ui/self/elision/ref-mut-self-async.rs
@@ -1,0 +1,54 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct { }
+
+impl Struct {
+    // Test using `&mut self` sugar:
+
+    async fn ref_self(&mut self, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    // Test using `&mut Self` explicitly:
+
+    async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -1,0 +1,159 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:15:46
+   |
+LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
+   |                                              ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:23:52
+   |
+LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+   |                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:29:61
+   |
+LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:35:61
+   |
+LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:41:70
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-self-async.rs:47:70
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:15:34
+   |
+LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
+   |                                  ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                  |
+   |                                  ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:23
+  --> $DIR/ref-mut-self-async.rs:15:23
+   |
+LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
+   |                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:23
+   |
+LL |     async fn ref_self(&mut self, f: &u32) -> &u32 + '_ {
+   |                                              ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:23:40
+   |
+LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+   |                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                        |
+   |                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 23:29
+  --> $DIR/ref-mut-self-async.rs:23:29
+   |
+LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
+   |                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 23:29
+   |
+LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 + '_ {
+   |                                                    ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:29:49
+   |
+LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+   |                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                 |
+   |                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 29:37
+  --> $DIR/ref-mut-self-async.rs:29:37
+   |
+LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 29:37
+   |
+LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 + '_ {
+   |                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:35:49
+   |
+LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+   |                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                 |
+   |                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 35:37
+  --> $DIR/ref-mut-self-async.rs:35:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 35:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 + '_ {
+   |                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:41:58
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+   |                                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                          |
+   |                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 41:45
+  --> $DIR/ref-mut-self-async.rs:41:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
+   |                                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 41:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                      ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-self-async.rs:47:58
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+   |                                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                          |
+   |                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 47:45
+  --> $DIR/ref-mut-self-async.rs:47:45
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
+   |                                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 47:45
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                      ^^^^^^^^^
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:15:56
+   |
+LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+   |                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:21:65
+   |
+LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+   |                                                                 ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:27:65
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+   |                                                                 ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:33:74
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:39:74
+   |
+LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-mut-struct-async.rs
+++ b/src/test/ui/self/elision/ref-mut-struct-async.rs
@@ -1,0 +1,46 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct { }
+
+impl Struct {
+    // Test using `&mut Struct` explicitly:
+
+    async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:15:56
+   |
+LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+   |                                                        ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:21:65
+   |
+LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+   |                                                                 ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:27:65
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+   |                                                                 ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:33:74
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-mut-struct-async.rs:39:74
+   |
+LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-struct-async.rs:15:44
+   |
+LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+   |                                            ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                            |
+   |                                            ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:31
+  --> $DIR/ref-mut-struct-async.rs:15:31
+   |
+LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
+   |                               ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:31
+   |
+LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 + '_ {
+   |                                                        ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-struct-async.rs:21:53
+   |
+LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+   |                                                     ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                     |
+   |                                                     ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 21:39
+  --> $DIR/ref-mut-struct-async.rs:21:39
+   |
+LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
+   |                                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 21:39
+   |
+LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 + '_ {
+   |                                                                 ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-struct-async.rs:27:53
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+   |                                                     ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                     |
+   |                                                     ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 27:39
+  --> $DIR/ref-mut-struct-async.rs:27:39
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
+   |                                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 27:39
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 + '_ {
+   |                                                                 ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-struct-async.rs:33:62
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                              ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                              |
+   |                                                              ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 33:47
+  --> $DIR/ref-mut-struct-async.rs:33:47
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
+   |                                               ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 33:47
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 + '_ {
+   |                                                                          ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-mut-struct-async.rs:39:62
+   |
+LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+   |                                                              ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                              |
+   |                                                              ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 39:47
+  --> $DIR/ref-mut-struct-async.rs:39:47
+   |
+LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
+   |                                               ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 39:47
+   |
+LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 + '_ {
+   |                                                                          ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-self-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-self-async.nll.stderr
@@ -1,0 +1,59 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:24:42
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:32:48
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                                ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:38:57
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:44:57
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:50:66
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:56:66
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:62:69
+   |
+LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+   |                                                                     ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 7 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-self-async.rs
+++ b/src/test/ui/self/elision/ref-self-async.rs
@@ -1,0 +1,69 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::pin::Pin;
+
+struct Struct { }
+
+struct Wrap<T, P>(T, PhantomData<P>);
+
+impl<T, P> Deref for Wrap<T, P> {
+    type Target = T;
+    fn deref(&self) -> &T { &self.0 }
+}
+
+impl Struct {
+    // Test using `&self` sugar:
+
+    async fn ref_self(&self, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    // Test using `&Self` explicitly:
+
+    async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -1,0 +1,185 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:24:42
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                                          ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:32:48
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                                ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:38:57
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:44:57
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                                         ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:50:66
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:56:66
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-self-async.rs:62:69
+   |
+LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+   |                                                                     ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:24:30
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                              ^           ---- this return type evaluates to the `'static` lifetime...
+   |                              |
+   |                              ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 24:23
+  --> $DIR/ref-self-async.rs:24:23
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 {
+   |                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 24:23
+   |
+LL |     async fn ref_self(&self, f: &u32) -> &u32 + '_ {
+   |                                          ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:32:36
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                                    ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                    |
+   |                                    ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 32:29
+  --> $DIR/ref-self-async.rs:32:29
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
+   |                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 32:29
+   |
+LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 + '_ {
+   |                                                ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:38:45
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                             ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                             |
+   |                                             ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 38:37
+  --> $DIR/ref-self-async.rs:38:37
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 38:37
+   |
+LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 + '_ {
+   |                                                         ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:44:45
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                             ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                             |
+   |                                             ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 44:37
+  --> $DIR/ref-self-async.rs:44:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
+   |                                     ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 44:37
+   |
+LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 + '_ {
+   |                                                         ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:50:54
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                                      ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                      |
+   |                                                      ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 50:45
+  --> $DIR/ref-self-async.rs:50:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
+   |                                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 50:45
+   |
+LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                  ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:56:54
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                                      ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                      |
+   |                                                      ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 56:45
+  --> $DIR/ref-self-async.rs:56:45
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
+   |                                             ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 56:45
+   |
+LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 + '_ {
+   |                                                                  ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-self-async.rs:62:58
+   |
+LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+   |                                                          ^          --- this return type evaluates to the `'static` lifetime...
+   |                                                          |
+   |                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 62:44
+  --> $DIR/ref-self-async.rs:62:44
+   |
+LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
+   |                                            ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 62:44
+   |
+LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 + '_ {
+   |                                                                     ^^^^^^^^
+
+error: aborting due to 14 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-struct-async.nll.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.nll.stderr
@@ -1,0 +1,43 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:15:52
+   |
+LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:21:61
+   |
+LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:27:61
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:33:70
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:39:66
+   |
+LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/ref-struct-async.rs
+++ b/src/test/ui/self/elision/ref-struct-async.rs
@@ -1,0 +1,46 @@
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::pin::Pin;
+
+struct Struct { }
+
+impl Struct {
+    // Test using `&Struct` explicitly:
+
+    async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+
+    async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
+        //~^ ERROR missing lifetime specifier
+        //~| ERROR cannot infer an appropriate lifetime
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -1,0 +1,133 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:15:52
+   |
+LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                                                    ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:21:61
+   |
+LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:27:61
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
+   |                                                             ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:33:70
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
+   |                                                                      ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/ref-struct-async.rs:39:66
+   |
+LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
+   |                                                                  ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found multiple.
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-struct-async.rs:15:40
+   |
+LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                                        ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                        |
+   |                                        ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 15:31
+  --> $DIR/ref-struct-async.rs:15:31
+   |
+LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
+   |                               ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 15:31
+   |
+LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 + '_ {
+   |                                                    ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-struct-async.rs:21:49
+   |
+LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
+   |                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                 |
+   |                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 21:39
+  --> $DIR/ref-struct-async.rs:21:39
+   |
+LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
+   |                                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 21:39
+   |
+LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 + '_ {
+   |                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-struct-async.rs:27:49
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
+   |                                                 ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                 |
+   |                                                 ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 27:39
+  --> $DIR/ref-struct-async.rs:27:39
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
+   |                                       ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 27:39
+   |
+LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 + '_ {
+   |                                                             ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-struct-async.rs:33:58
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
+   |                                                          ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                          |
+   |                                                          ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 33:47
+  --> $DIR/ref-struct-async.rs:33:47
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
+   |                                               ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 33:47
+   |
+LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 + '_ {
+   |                                                                      ^^^^^^^^^
+
+error: cannot infer an appropriate lifetime
+  --> $DIR/ref-struct-async.rs:39:54
+   |
+LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
+   |                                                      ^           ---- this return type evaluates to the `'static` lifetime...
+   |                                                      |
+   |                                                      ...but this borrow...
+   |
+note: ...can't outlive the lifetime '_ as defined on the method body at 39:43
+  --> $DIR/ref-struct-async.rs:39:43
+   |
+LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
+   |                                           ^
+help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 39:43
+   |
+LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 + '_ {
+   |                                                                  ^^^^^^^^^
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/elision/self-async.rs
+++ b/src/test/ui/self/elision/self-async.rs
@@ -1,0 +1,39 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+struct Struct { }
+
+impl Struct {
+    async fn take_self(self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Self(self: Self, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Self(self: Box<Self>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Box_Self(self: Box<Box<Self>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Rc_Self(self: Rc<Self>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn take_Box_Rc_Self(self: Box<Rc<Self>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/elision/struct-async.rs
+++ b/src/test/ui/self/elision/struct-async.rs
@@ -1,0 +1,35 @@
+// check-pass
+// edition:2018
+
+#![feature(async_await)]
+
+#![feature(arbitrary_self_types)]
+#![allow(non_snake_case)]
+
+use std::rc::Rc;
+
+struct Struct { }
+
+impl Struct {
+    async fn ref_Struct(self: Struct, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_Struct(self: Box<Struct>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn rc_Struct(self: Rc<Struct>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_box_Struct(self: Box<Box<Struct>>, f: &u32) -> &u32 {
+        f
+    }
+
+    async fn box_rc_Struct(self: Box<Rc<Struct>>, f: &u32) -> &u32 {
+        f
+    }
+}
+
+fn main() { }

--- a/src/test/ui/self/self_lifetime-async.nll.stderr
+++ b/src/test/ui/self/self_lifetime-async.nll.stderr
@@ -1,0 +1,11 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/self_lifetime-async.rs:9:44
+   |
+LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
+   |                                            ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found none.
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/self/self_lifetime-async.rs
+++ b/src/test/ui/self/self_lifetime-async.rs
@@ -1,0 +1,20 @@
+// FIXME: Investigate why `self_lifetime.rs` is check-pass but this isn't.
+
+// edition:2018
+
+#![feature(async_await)]
+
+struct Foo<'a>(&'a ());
+impl<'a> Foo<'a> {
+    async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
+    //~^ ERROR missing lifetime specifier
+    //~| ERROR cannot infer an appropriate lifetime
+}
+
+type Alias = Foo<'static>;
+impl Alias {
+    async fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
+    //~^ ERROR lifetime mismatch
+}
+
+fn main() {}

--- a/src/test/ui/self/self_lifetime-async.stderr
+++ b/src/test/ui/self/self_lifetime-async.stderr
@@ -1,0 +1,39 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/self_lifetime-async.rs:9:44
+   |
+LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
+   |                                            ^
+   |
+   = note: return-position elided lifetimes require exactly one input-position elided lifetime, found none.
+
+error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
+  --> $DIR/self_lifetime-async.rs:9:22
+   |
+LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
+   |                      ^^^^
+   |
+note: first, the lifetime cannot outlive the lifetime 'a as defined on the impl at 8:6...
+  --> $DIR/self_lifetime-async.rs:8:6
+   |
+LL | impl<'a> Foo<'a> {
+   |      ^^
+   = note: ...so that the expression is assignable:
+           expected &Foo<'_>
+              found &'b Foo<'a>
+   = note: but, the lifetime must be valid for the static lifetime...
+   = note: ...so that the types are compatible:
+           expected &()
+              found &'static ()
+
+error[E0623]: lifetime mismatch
+  --> $DIR/self_lifetime-async.rs:16:52
+   |
+LL |     async fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
+   |                            ------                  ^^^
+   |                            |                       |
+   |                            |                       ...but data from `arg` is returned here
+   |                            this parameter and the return type are declared with different lifetimes...
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
Successful merges:

 - #62849 (typeck: Prohibit RPIT types that inherit lifetimes)
 - #63383 (`async fn` lifetime elision tests)
 - #63485 (ci: move mirrors to their standalone bucket)

Failed merges:


r? @ghost