### PR TITLE
Hash the remapped sysroot instead of the original.

### DIFF
--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -396,7 +396,6 @@ top_level_options!(
         search_paths: Vec<SearchPath> [UNTRACKED],
         libs: Vec<(String, Option<String>, Option<cstore::NativeLibraryKind>)> [TRACKED],
         maybe_sysroot: Option<PathBuf> [UNTRACKED],
-        maybe_sysroot_remapped: Option<PathBuf> [TRACKED],
 
         target_triple: TargetTriple [TRACKED],
 
@@ -611,7 +610,6 @@ impl Default for Options {
             output_types: OutputTypes(BTreeMap::new()),
             search_paths: vec![],
             maybe_sysroot: None,
-            maybe_sysroot_remapped: None,
             target_triple: TargetTriple::from_triple(host_triple()),
             test: false,
             incremental: None,
@@ -2455,7 +2453,7 @@ pub fn build_session_options_and_crate_config(
 
     let crate_name = matches.opt_str("crate-name");
 
-    let remap_path_prefix: Vec<(PathBuf, PathBuf)> = matches
+    let remap_path_prefix = matches
         .opt_strs("remap-path-prefix")
         .into_iter()
         .map(|remap| {
@@ -2472,10 +2470,6 @@ pub fn build_session_options_and_crate_config(
         })
         .collect();
 
-    let sysroot_remapped_opt = sysroot_opt
-        .clone()
-        .map(|sysroot| FilePathMapping::new(remap_path_prefix.clone()).map_prefix(sysroot).0);
-
     (
         Options {
             crate_types,
@@ -2487,7 +2481,6 @@ pub fn build_session_options_and_crate_config(
             output_types: OutputTypes(output_types),
             search_paths,
             maybe_sysroot: sysroot_opt,
-            maybe_sysroot_remapped: sysroot_remapped_opt,
             target_triple,
             test,
             incremental,

--- a/src/test/run-make-fulldeps/reproducible-build-2/Makefile
+++ b/src/test/run-make-fulldeps/reproducible-build-2/Makefile
@@ -5,7 +5,8 @@
 # Objects are reproducible but their path is not.
 
 all:  \
-	fat_lto
+	fat_lto \
+	sysroot
 
 fat_lto:
 	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
@@ -14,3 +15,12 @@ fat_lto:
 	cp $(TMPDIR)/reproducible-build $(TMPDIR)/reproducible-build-a
 	$(RUSTC) reproducible-build.rs -C lto=fat
 	cmp "$(TMPDIR)/reproducible-build-a" "$(TMPDIR)/reproducible-build" || exit 1
+
+sysroot:
+	rm -rf $(TMPDIR) && mkdir $(TMPDIR)
+	$(RUSTC) reproducible-build-aux.rs
+	$(RUSTC) reproducible-build.rs --crate-type rlib --sysroot $(shell $(RUSTC) --print sysroot) --remap-path-prefix=$(shell $(RUSTC) --print sysroot)=/sysroot
+	cp -r $(shell $(RUSTC) --print sysroot) $(TMPDIR)/sysroot
+	cp $(TMPDIR)/libreproducible_build.rlib $(TMPDIR)/libfoo.rlib
+	$(RUSTC) reproducible-build.rs --crate-type rlib --sysroot $(TMPDIR)/sysroot --remap-path-prefix=$(TMPDIR)/sysroot=/sysroot
+	cmp "$(TMPDIR)/libreproducible_build.rlib" "$(TMPDIR)/libfoo.rlib" || exit 1


### PR DESCRIPTION
One of the reasons that rustc builds are not reproducible is because the --sysroot path is dependent on the current directory.  We can fix this by hashing the remapped sysroot instead of the original when applicable.

Note that with this patch, the hash will stay the same if both the sysroot and the remapped path change.  However, given that if the contents of the sysroot change the hash will also stay the same, this might be acceptable.  I would appreciate feedback on the best way to do this.

This helps #34902, although it does not fix it by itself.