### PR TITLE
Do not ICE when synthesizing spans falling inside unicode chars

### DIFF
--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -519,7 +519,7 @@ impl SourceMap {
     /// extract function takes three arguments: a string slice containing the source, an index in
     /// the slice for the beginning of the span and an index in the slice for the end of the span.
     fn span_to_source<F>(&self, sp: Span, extract_source: F) -> Result<String, SpanSnippetError>
-        where F: Fn(&str, usize, usize) -> String
+        where F: Fn(&str, usize, usize) -> Result<String, SpanSnippetError>
     {
         if sp.lo() > sp.hi() {
             return Err(SpanSnippetError::IllFormedSpan(sp));
@@ -554,15 +554,9 @@ impl SourceMap {
             }
 
             if let Some(ref src) = local_begin.sf.src {
-                if !src.is_char_boundary(start_index) || !src.is_char_boundary(end_index) {
-                    return Err(SpanSnippetError::IllFormedSpan(sp));
-                }
-                return Ok(extract_source(src, start_index, end_index));
+                return extract_source(src, start_index, end_index);
             } else if let Some(src) = local_begin.sf.external_src.borrow().get_source() {
-                if !src.is_char_boundary(start_index) || !src.is_char_boundary(end_index) {
-                    return Err(SpanSnippetError::IllFormedSpan(sp));
-                }
-                return Ok(extract_source(src, start_index, end_index));
+                return extract_source(src, start_index, end_index);
             } else {
                 return Err(SpanSnippetError::SourceNotAvailable {
                     filename: local_begin.sf.name.clone()
@@ -573,8 +567,9 @@ impl SourceMap {
 
     /// Returns the source snippet as `String` corresponding to the given `Span`
     pub fn span_to_snippet(&self, sp: Span) -> Result<String, SpanSnippetError> {
-        self.span_to_source(sp, |src, start_index, end_index| src[start_index..end_index]
-                                                                .to_string())
+        self.span_to_source(sp, |src, start_index, end_index| src.get(start_index..end_index)
+            .map(|s| s.to_string())
+            .ok_or_else(|| SpanSnippetError::IllFormedSpan(sp)))
     }
 
     pub fn span_to_margin(&self, sp: Span) -> Option<usize> {
@@ -588,7 +583,9 @@ impl SourceMap {
 
     /// Returns the source snippet as `String` before the given `Span`
     pub fn span_to_prev_source(&self, sp: Span) -> Result<String, SpanSnippetError> {
-        self.span_to_source(sp, |src, start_index, _| src[..start_index].to_string())
+        self.span_to_source(sp, |src, start_index, _| src.get(..start_index)
+            .map(|s| s.to_string())
+            .ok_or_else(|| SpanSnippetError::IllFormedSpan(sp)))
     }
 
     /// Extend the given `Span` to just after the previous occurrence of `c`. Return the same span

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -554,8 +554,14 @@ impl SourceMap {
             }
 
             if let Some(ref src) = local_begin.sf.src {
+                if !src.is_char_boundary(start_index) || !src.is_char_boundary(end_index) {
+                    return Err(SpanSnippetError::IllFormedSpan(sp));
+                }
                 return Ok(extract_source(src, start_index, end_index));
             } else if let Some(src) = local_begin.sf.external_src.borrow().get_source() {
+                if !src.is_char_boundary(start_index) || !src.is_char_boundary(end_index) {
+                    return Err(SpanSnippetError::IllFormedSpan(sp));
+                }
                 return Ok(extract_source(src, start_index, end_index));
             } else {
                 return Err(SpanSnippetError::SourceNotAvailable {

--- a/src/test/ui/suggestions/issue-61226.rs
+++ b/src/test/ui/suggestions/issue-61226.rs
@@ -1,0 +1,5 @@
+struct X {}
+fn f() {
+    vec![X]; //…
+    //~^ ERROR expected value, found struct `X`
+}

--- a/src/test/ui/suggestions/issue-61226.rs
+++ b/src/test/ui/suggestions/issue-61226.rs
@@ -1,5 +1,5 @@
 struct X {}
-fn f() {
+fn main() {
     vec![X]; //…
     //~^ ERROR expected value, found struct `X`
 }

--- a/src/test/ui/suggestions/issue-61226.stderr
+++ b/src/test/ui/suggestions/issue-61226.stderr
@@ -1,0 +1,17 @@
+error[E0423]: expected value, found struct `X`
+  --> $DIR/issue-61226.rs:3:10
+   |
+LL |     vec![X]; //…
+   |          ^
+   |          |
+   |          did you mean `X { /* fields */ }`?
+   |          help: a function with a similar name exists: `f`
+
+error[E0601]: `main` function not found in crate `issue_61226`
+   |
+   = note: consider adding a `main` function to `$DIR/issue-61226.rs`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0423, E0601.
+For more information about an error, try `rustc --explain E0423`.

--- a/src/test/ui/suggestions/issue-61226.stderr
+++ b/src/test/ui/suggestions/issue-61226.stderr
@@ -2,16 +2,8 @@ error[E0423]: expected value, found struct `X`
   --> $DIR/issue-61226.rs:3:10
    |
 LL |     vec![X]; //…
-   |          ^
-   |          |
-   |          did you mean `X { /* fields */ }`?
-   |          help: a function with a similar name exists: `f`
+   |          ^ did you mean `X { /* fields */ }`?
 
-error[E0601]: `main` function not found in crate `issue_61226`
-   |
-   = note: consider adding a `main` function to `$DIR/issue-61226.rs`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0423, E0601.
-For more information about an error, try `rustc --explain E0423`.
+For more information about this error, try `rustc --explain E0423`.


### PR DESCRIPTION
Fix https://github.com/rust-lang/rust/issues/61226.