### PR TITLE
rustc_mir: use dataflow analysis to determine whether locals were moved out of.

### DIFF
--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -284,6 +284,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
             PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect) |
             PlaceContext::MutatingUse(MutatingUseContext::Store) |
+            PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) |
             PlaceContext::MutatingUse(MutatingUseContext::AsmOutput) |
             PlaceContext::MutatingUse(MutatingUseContext::Borrow) |
             PlaceContext::MutatingUse(MutatingUseContext::Projection) |

--- a/src/librustc_mir/dataflow/impls/maybe_init_locals.rs
+++ b/src/librustc_mir/dataflow/impls/maybe_init_locals.rs
@@ -1,0 +1,126 @@
+pub use super::*;
+
+use crate::dataflow::{BitDenotation, GenKillSet};
+use rustc::mir::visit::{
+    MutatingUseContext, NonMutatingUseContext, NonUseContext, PlaceContext, Visitor,
+};
+use rustc::mir::*;
+
+/// This calculates if any part of a MIR local may still be initialized.
+/// This means that once a local has been written to, its bit will be set
+/// from that point and onwards, until we see an Operand::Move out of, or
+/// StorageDead statement for the local.
+/// This is an approximation of `MaybeInitializedPlaces` for whole locals.
+#[derive(Copy, Clone)]
+pub struct MaybeInitializedLocals<'a, 'tcx> {
+    body: &'a Body<'tcx>,
+}
+
+impl<'a, 'tcx> MaybeInitializedLocals<'a, 'tcx> {
+    pub fn new(body: &'a Body<'tcx>) -> Self {
+        MaybeInitializedLocals { body }
+    }
+
+    pub fn body(&self) -> &Body<'tcx> {
+        self.body
+    }
+}
+
+impl<'a, 'tcx> BitDenotation<'tcx> for MaybeInitializedLocals<'a, 'tcx> {
+    type Idx = Local;
+    fn name() -> &'static str {
+        "has_been_borrowed_locals"
+    }
+    fn bits_per_block(&self) -> usize {
+        self.body.local_decls.len()
+    }
+
+    fn start_block_effect(&self, on_entry: &mut BitSet<Local>) {
+        // Arguments are always initialized on entry.
+        for arg in self.body.args_iter() {
+            on_entry.insert(arg);
+        }
+    }
+
+    fn statement_effect(&self, trans: &mut GenKillSet<Local>, loc: Location) {
+        let stmt = &self.body[loc.block].statements[loc.statement_index];
+        MaybeInitializedLocalsVisitor { trans }.visit_statement(stmt, loc);
+    }
+
+    fn terminator_effect(&self, trans: &mut GenKillSet<Local>, loc: Location) {
+        let terminator = self.body[loc.block].terminator();
+        MaybeInitializedLocalsVisitor { trans }.visit_terminator(terminator, loc);
+    }
+
+    fn propagate_call_return(
+        &self,
+        in_out: &mut BitSet<Local>,
+        _call_bb: mir::BasicBlock,
+        _dest_bb: mir::BasicBlock,
+        dest_place: &mir::Place<'tcx>,
+    ) {
+        // Calls initialize their destination.
+        if let Some(local) = find_local(dest_place) {
+            in_out.insert(local);
+        }
+    }
+}
+
+impl<'a, 'tcx> BottomValue for MaybeInitializedLocals<'a, 'tcx> {
+    // bottom = definitely uninit
+    const BOTTOM_VALUE: bool = false;
+}
+
+struct MaybeInitializedLocalsVisitor<'gk> {
+    trans: &'gk mut GenKillSet<Local>,
+}
+
+fn find_local(place: &Place<'_>) -> Option<Local> {
+    place.iterate(|place_base, place_projection| {
+        for proj in place_projection {
+            if proj.elem == ProjectionElem::Deref {
+                return None;
+            }
+        }
+
+        if let PlaceBase::Local(local) = place_base {
+            Some(*local)
+        } else {
+            None
+        }
+    })
+}
+
+impl<'tcx> Visitor<'tcx> for MaybeInitializedLocalsVisitor<'_> {
+    fn visit_place(
+        &mut self,
+        place: &Place<'tcx>,
+        context: PlaceContext,
+        _location: Location,
+    ) {
+        match context {
+            // Only `Operand::Move` and `StorageDead` can deinitialize a local,
+            // and only if they act on the whole local, not just some part of it.
+            PlaceContext::NonMutatingUse(NonMutatingUseContext::Move)
+            | PlaceContext::NonUse(NonUseContext::StorageDead) => match *place {
+                Place { base: PlaceBase::Local(local), projection: None } => {
+                    self.trans.kill(local)
+                }
+                _ => {}
+            },
+
+            // Handled separately, in `propagate_call_return`.
+            PlaceContext::MutatingUse(MutatingUseContext::Call) => {}
+
+            // Any assignment to any part of the local initializes it
+            // (even if only partially).
+            _ => {
+                if context.is_place_assignment() {
+                    if let Some(local) = find_local(place) {
+                        self.trans.gen(local);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/librustc_mir/dataflow/impls/mod.rs
+++ b/src/librustc_mir/dataflow/impls/mod.rs
@@ -28,6 +28,10 @@ pub use self::borrowed_locals::*;
 
 pub(super) mod borrows;
 
+mod maybe_init_locals;
+
+pub use self::maybe_init_locals::*;
+
 /// `MaybeInitializedPlaces` tracks all places that might be
 /// initialized upon reaching a particular point in the control flow
 /// for a function.

--- a/src/librustc_mir/dataflow/mod.rs
+++ b/src/librustc_mir/dataflow/mod.rs
@@ -23,6 +23,7 @@ pub use self::impls::DefinitelyInitializedPlaces;
 pub use self::impls::EverInitializedPlaces;
 pub use self::impls::borrows::Borrows;
 pub use self::impls::HaveBeenBorrowedLocals;
+pub use self::impls::MaybeInitializedLocals;
 pub use self::at_location::{FlowAtLocation, FlowsAtLocation};
 pub(crate) use self::drop_flag_effects::*;
 

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -284,6 +284,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                         if adt.is_union() {
                             if context == PlaceContext::MutatingUse(MutatingUseContext::Store) ||
                                 context == PlaceContext::MutatingUse(MutatingUseContext::Drop) ||
+                                context ==
+                                    PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) ||
                                 context == PlaceContext::MutatingUse(
                                     MutatingUseContext::AsmOutput
                                 )

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -101,6 +101,10 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
                 "visit_local: context.is_drop={:?} context.is_use={:?}",
                 context.is_drop(), context.is_use(),
             );
+            // Except, `is_drop()` will also be `true` for `DropAndReplace`.
+            if context == PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) {
+                *temp = TempState::Unpromotable;
+            }
             return;
         }
 

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -93,6 +93,9 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
             => return,
         }
 
+        let temp = &mut self.temps[index];
+        debug!("visit_local: temp={:?}", temp);
+
         // Ignore drops, if the temp gets promoted,
         // then it's constant and thus drop is noop.
         // Non-uses are also irrelevent.
@@ -108,8 +111,6 @@ impl<'tcx> Visitor<'tcx> for TempCollector<'tcx> {
             return;
         }
 
-        let temp = &mut self.temps[index];
-        debug!("visit_local: temp={:?}", temp);
         if *temp == TempState::Undefined {
             match context {
                 PlaceContext::MutatingUse(MutatingUseContext::Store) |

--- a/src/librustc_mir/util/liveness.rs
+++ b/src/librustc_mir/util/liveness.rs
@@ -131,6 +131,9 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
 
         PlaceContext::MutatingUse(MutatingUseContext::Store) |
 
+        // FIXME(eddyb) this should probably not even appear here, ever.
+        PlaceContext::MutatingUse(MutatingUseContext::DropAndReplace) |
+
         // This is potentially both a def and a use...
         PlaceContext::MutatingUse(MutatingUseContext::AsmOutput) |
 


### PR DESCRIPTION
This replaces one of the remaining cases where a qualif bit is being unset (which prevent further work in this area), with a more robust dataflow analysis pass.

That is, when a local was moved out of, its `NeedsDrop` bit was unset, to force its eventual `Drop` to be treated as a noop, but now that's handled by the local not being "maybe-initialized" at the `Drop`.

Note that the first commit fixes a preexisting bug, and should be reviewed separately.

r? @matthewjasper cc @ecstatic-morse @oli-obk