### PR TITLE
Update rustfmt to 1.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "annotate-snippets",
  "atty",


### PR DESCRIPTION
This update includes a bug fix that fixes generating invalid code when formatting an impl block with const generics inside a where clause.

**Changes**
https://github.com/rust-lang/rustfmt/compare/0462008de87d2757e8ef1dc26f2c54dd789a59a8...1de58ce46d64b1164a214dc0b7fb7c400576c3a6