### PR TITLE
RELEASES.md: ? is one of three Kleene operators

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,7 +22,7 @@ Language
 - [You can now use `_` as an identifier for consts.][61347] e.g. You can write
   `const _: u32 = 5;`.
 - [You can now use `#[repr(align(X)]` on enums.][61229]
-- [The  `?`/_"Kleene"_ macro operator is now available in the
+- [The  `?` Kleene macro operator is now available in the
   2015 edition.][60932]
 
 Compiler


### PR DESCRIPTION
The slash and quotes in ?/“Kleene” appeared to define “Kleene” as the name for the `?` operator, which is not the case. Rust has three Kleene operators `*`, `+`, `?`.

([Pointed out](https://www.reddit.com/r/rust/comments/cprt0z/rust_1370_prerelease_testing/ewr90y3/) by /u/Sharlinator on Reddit.)