### PR TITLE
Support repr(simd) on ADTs containing a single array field

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -772,7 +772,8 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     // This error isn;t caught in typeck, e.g., if
                     // the element type of the vector is generic.
                     tcx.sess.fatal(&format!(
-                        "monomorphising SIMD type `{}` with a non-primitive-scalar (integer/float/pointer) element type `{}`",
+                        "monomorphising SIMD type `{}` with a non-primitive-scalar \
+                        (integer/float/pointer) element type `{}`",
                         ty, e_ty
                     ))
                 };

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -769,7 +769,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 let e_abi = if let Abi::Scalar(ref scalar) = e_ly.abi {
                     scalar.clone()
                 } else {
-                    // This error isn;t caught in typeck, e.g., if
+                    // This error isn't caught in typeck, e.g., if
                     // the element type of the vector is generic.
                     tcx.sess.fatal(&format!(
                         "monomorphising SIMD type `{}` with a non-primitive-scalar \

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -694,7 +694,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                 // * #[repr(simd)] struct S { x: T, y: T, z: T, w: T }
                 // * #[repr(simd)] struct S([T; 4])
                 //
-                // where T is a "machine type", e.g., `f32`, `i64`, `*mut _`.
+                // where T is a primitive scalar (integer/float/pointer).
 
                 // SIMD vectors with zero fields are not supported.
                 // (should be caught by typeck)
@@ -746,7 +746,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     }) = self.layout_of(f0_ty) {
                         count
                     } else {
-                        unreachable!();
+                        return Err(LayoutError::Unknown(ty));
                     };
 
                     (e_ty, *len, true)
@@ -772,7 +772,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
                     // This error isn;t caught in typeck, e.g., if
                     // the element type of the vector is generic.
                     tcx.sess.fatal(&format!(
-                        "monomorphising SIMD type `{}` with a non-machine element type `{}`",
+                        "monomorphising SIMD type `{}` with a non-primitive-scalar (integer/float/pointer) element type `{}`",
                         ty, e_ty
                     ))
                 };

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1823,22 +1823,6 @@ impl<'tcx> TyS<'tcx> {
         }
     }
 
-    pub fn simd_type(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
-        match self.sty {
-            Adt(def, substs) => {
-                def.non_enum_variant().fields[0].ty(tcx, substs)
-            }
-            _ => bug!("simd_type called on invalid type")
-        }
-    }
-
-    pub fn simd_size(&self, _cx: TyCtxt<'_>) -> usize {
-        match self.sty {
-            Adt(def, _) => def.non_enum_variant().fields.len(),
-            _ => bug!("simd_size called on invalid type")
-        }
-    }
-
     #[inline]
     pub fn is_region_ptr(&self) -> bool {
         match self.sty {

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1041,18 +1041,18 @@ fn generic_simd_intrinsic(
 ) -> Result<&'ll Value, ()> {
     // Given a SIMD vector type `x` return the element type and the number of
     // elements in the vector.
-    fn simd_ty_and_len(bx: &Builder<'a, 'll, 'tcx>, x: Ty<'tcx>) -> (Ty<'tcx>, usize) {
-        let ty = if let ty::Adt(def, substs) = x.sty {
-            let field0_ty = def.non_enum_variant().fields[0].ty(bx.tcx(), substs);
-            if let ty::Array(element_ty, _) = field0_ty.sty {
+    fn simd_ty_and_len(bx: &Builder<'a, 'll, 'tcx>, simd_ty: Ty<'tcx>) -> (Ty<'tcx>, usize) {
+        let ty = if let ty::Adt(def, substs) = simd_ty.sty {
+            let f0_ty = def.non_enum_variant().fields[0].ty(bx.tcx(), substs);
+            if let ty::Array(element_ty, _) = f0_ty.sty {
                 element_ty
             } else {
-                field0_ty
+                f0_ty
             }
         } else {
             bug!("should only be called with a SIMD type")
         };
-        let count = if let ty::layout::Abi::Vector{count, ..} = bx.layout_of(x).abi {
+        let count = if let ty::layout::Abi::Vector{count, ..} = bx.layout_of(simd_ty).abi {
             count
         } else {
             bug!("should only be called with a SIMD type")

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1042,8 +1042,8 @@ fn generic_simd_intrinsic(
     // Given a SIMD vector type `x` return the element type and the number of
     // elements in the vector.
     fn simd_ty_and_len(bx: &Builder<'a, 'll, 'tcx>, simd_ty: Ty<'tcx>) -> (Ty<'tcx>, usize) {
-        let ty = if let ty::Adt(def, substs) = simd_ty.sty {
-            let f0_ty = def.non_enum_variant().fields[0].ty(bx.tcx(), substs);
+        let ty = if let ty::Adt(_def, _substs) = simd_ty.sty {
+            let f0_ty = bx.layout_of(simd_ty).field(bx, 0).ty;
             if let ty::Array(element_ty, _) = f0_ty.sty {
                 element_ty
             } else {

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1043,7 +1043,6 @@ fn generic_simd_intrinsic(
     // elements in the vector.
     fn simd_ty_and_len(bx: &Builder<'a, 'll, 'tcx>, x: Ty<'tcx>) -> (Ty<'tcx>, usize) {
         let ty = if let ty::Adt(def, substs) = x.sty {
-            assert!(def.repr.simd());
             let field0_ty = def.non_enum_variant().fields[0].ty(bx.tcx(), substs);
             if let ty::Array(element_ty, _) = field0_ty.sty {
                 element_ty

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -1098,9 +1098,8 @@ fn generic_simd_intrinsic(
     }
 
     let tcx = bx.tcx();
-    let param_env = ty::ParamEnv::reveal_all();
     let sig = tcx.normalize_erasing_late_bound_regions(
-        param_env,
+        ty::ParamEnv::reveal_all(),
         &callee_ty.fn_sig(tcx),
     );
     let arg_tys = sig.inputs();

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1763,8 +1763,11 @@ pub fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
                 _ if e.is_machine() => { /* struct(u8, u8, u8, u8) is ok */ }
                 ty::Array(ty, _c) if ty.is_machine() => { /* struct([f32; 4]) */ }
                 _ => {
-                    span_err!(tcx.sess, sp, E0077,
-                              "SIMD vector element type should be machine type");
+                    span_err!(
+                        tcx.sess, sp, E0077,
+                        "SIMD vector element type should be a \
+                         primitive scalar (integer/float/pointer) type"
+                    );
                     return;
                 }
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1761,6 +1761,7 @@ pub fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
             match e.sty {
                 ty::Param(_) => { /* struct<T>(T, T, T, T) is ok */ }
                 _ if e.is_machine() => { /* struct(u8, u8, u8, u8) is ok */ }
+                ty::Array(ty, _c) if ty.is_machine() => { /* struct([f32; 4]) */ }
                 _ => {
                     span_err!(tcx.sess, sp, E0077,
                               "SIMD vector element type should be machine type");

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-generic-extract-insert.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-generic-extract-insert.rs
@@ -1,0 +1,47 @@
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+#![feature(repr_simd, platform_intrinsics, const_generics)]
+#![allow(non_camel_case_types, incomplete_features)]
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct M(pub f32, pub f32, pub f32, pub f32);
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct S<const N: usize>([f32; N]);
+
+extern "platform-intrinsic" {
+    fn simd_extract<T, U>(x: T, idx: u32) -> U;
+    fn simd_insert<T, U>(x: T, idx: u32, b: U) -> T;
+}
+
+// CHECK-LABEL: @extract_m
+#[no_mangle]
+pub unsafe fn extract_m(v: M, i: u32) -> f32  {
+    // CHECK: extractelement <4 x float> %0, i32 %i
+    simd_extract(v, i)
+}
+
+// CHECK-LABEL: @extract_s
+#[no_mangle]
+pub unsafe fn extract_s(v: S<4>, i: u32) -> f32  {
+    // CHECK: extractelement <4 x float> %0, i32 %i
+    simd_extract(v, i)
+}
+
+// CHECK-LABEL: @insert_m
+#[no_mangle]
+pub unsafe fn insert_m(v: M, i: u32, j: f32) -> M  {
+    // CHECK: insertelement <4 x float> %1, float %j, i32 %i
+    simd_insert(v, i, j)
+}
+
+// CHECK-LABEL: @insert_s
+#[no_mangle]
+pub unsafe fn insert_s(v: S<4>, i: u32, j: f32) -> S<4>  {
+    // CHECK: insertelement <4 x float> %1, float %j, i32 %i
+    simd_insert(v, i, j)
+}

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -1,5 +1,6 @@
 // ignore-tidy-linelength
 // compile-flags: -C no-prepopulate-passes
+// min-llvm-version 8.0
 
 #![crate_type = "lib"]
 

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -21,23 +21,23 @@ pub struct U(f32, f32, f32, f32);
 // CHECK-LABEL: @build_array_s
 #[no_mangle]
 pub fn build_array_s(x: [f32; 4]) -> S<4> {
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 16 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %6, i64 16, i1 false)
     S::<4>(x)
 }
 
 // CHECK-LABEL: @build_array_t
 #[no_mangle]
 pub fn build_array_t(x: [f32; 4]) -> T {
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 16 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %6, i64 16, i1 false)
     T(x)
 }
 
 // CHECK-LABEL: @build_array_u
 #[no_mangle]
 pub fn build_array_u(x: [f32; 4]) -> U {
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
-    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* {{.*}} %{{[0-9]+}}, i8* {{.*}} %6, i64 16, i1 false)
     unsafe { std::mem::transmute(x) }
 }

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -1,0 +1,18 @@
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+
+#![allow(non_camel_case_types, incomplete_features)]
+#![feature(repr_simd, platform_intrinsics, const_generics)]
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct S<const N: usize>([f32; N]);
+
+// CHECK-LABEL: @build_array
+#[no_mangle]
+pub fn build_array(x: [f32; 4]) -> S<4> {
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 16 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    S::<4>(x)
+}

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-linelength
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]

--- a/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/src/test/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -10,10 +10,34 @@
 #[derive(Copy, Clone)]
 pub struct S<const N: usize>([f32; N]);
 
-// CHECK-LABEL: @build_array
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct T([f32; 4]);
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+pub struct U(f32, f32, f32, f32);
+
+// CHECK-LABEL: @build_array_s
 #[no_mangle]
-pub fn build_array(x: [f32; 4]) -> S<4> {
+pub fn build_array_s(x: [f32; 4]) -> S<4> {
     // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
     // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 16 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
     S::<4>(x)
+}
+
+// CHECK-LABEL: @build_array_t
+#[no_mangle]
+pub fn build_array_t(x: [f32; 4]) -> T {
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 16 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    T(x)
+}
+
+// CHECK-LABEL: @build_array_u
+#[no_mangle]
+pub fn build_array_u(x: [f32; 4]) -> U {
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %3, i64 16, i1 false)
+    // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 4 %{{[0-9]+}}, i8* align 4 %6, i64 16, i1 false)
+    unsafe { std::mem::transmute(x) }
 }

--- a/src/test/ui/error-codes/E0077.stderr
+++ b/src/test/ui/error-codes/E0077.stderr
@@ -1,4 +1,4 @@
-error[E0077]: SIMD vector element type should be machine type
+error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
   --> $DIR/E0077.rs:4:1
    |
 LL | struct Bad(String);

--- a/src/test/ui/simd-type-generic-monomorphisation.rs
+++ b/src/test/ui/simd-type-generic-monomorphisation.rs
@@ -1,6 +1,8 @@
 #![feature(repr_simd, platform_intrinsics)]
 
-// error-pattern:monomorphising SIMD type `Simd2<X>` with a non-machine element type `X`
+// ignore-tidy-linelength
+
+// error-pattern:monomorphising SIMD type `Simd2<X>` with a non-primitive-scalar (integer/float/pointer) element type `X`
 
 struct X(Vec<i32>);
 #[repr(simd)]

--- a/src/test/ui/simd-type-generic-monomorphisation.stderr
+++ b/src/test/ui/simd-type-generic-monomorphisation.stderr
@@ -1,4 +1,4 @@
-error: monomorphising SIMD type `Simd2<X>` with a non-machine element type `X`
+error: monomorphising SIMD type `Simd2<X>` with a non-primitive-scalar (integer/float/pointer) element type `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/simd-type.rs
+++ b/src/test/ui/simd-type.rs
@@ -1,10 +1,20 @@
 #![feature(repr_simd)]
 #![allow(non_camel_case_types)]
 
+// ignore-tidy-linelength
+
 #[repr(simd)]
 struct empty; //~ ERROR SIMD vector cannot be empty
 
 #[repr(simd)]
 struct i64f64(i64, f64); //~ ERROR SIMD vector should be homogeneous
+
+struct Foo;
+
+#[repr(simd)]
+struct FooV(Foo, Foo); //~ ERROR SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+
+#[repr(simd)]
+struct FooV2([Foo; 2]); //~ ERROR SIMD vector element type should be a primitive scalar (integer/float/pointer) type
 
 fn main() {}

--- a/src/test/ui/simd-type.stderr
+++ b/src/test/ui/simd-type.stderr
@@ -1,16 +1,28 @@
 error[E0075]: SIMD vector cannot be empty
-  --> $DIR/simd-type.rs:5:1
+  --> $DIR/simd-type.rs:7:1
    |
 LL | struct empty;
    | ^^^^^^^^^^^^^
 
 error[E0076]: SIMD vector should be homogeneous
-  --> $DIR/simd-type.rs:8:1
+  --> $DIR/simd-type.rs:10:1
    |
 LL | struct i64f64(i64, f64);
    | ^^^^^^^^^^^^^^^^^^^^^^^^ SIMD elements must have the same type
 
-error: aborting due to 2 previous errors
+error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+  --> $DIR/simd-type.rs:15:1
+   |
+LL | struct FooV(Foo, Foo);
+   | ^^^^^^^^^^^^^^^^^^^^^^
 
-Some errors have detailed explanations: E0075, E0076.
+error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+  --> $DIR/simd-type.rs:18:1
+   |
+LL | struct FooV2([Foo; 2]);
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0075, E0076, E0077.
 For more information about an error, try `rustc --explain E0075`.

--- a/src/test/ui/simd/simd-array-type.rs
+++ b/src/test/ui/simd/simd-array-type.rs
@@ -1,0 +1,44 @@
+// run-pass
+#![allow(dead_code, incomplete_features)]
+
+// pretty-expanded FIXME #23616
+
+#![feature(repr_simd)]
+#![feature(platform_intrinsics)]
+#![feature(const_generics)]
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+struct S([i32; 4]);
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+struct T<const N: usize>([i32; N]);
+
+extern "platform-intrinsic" {
+    fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
+    fn simd_extract<T, E>(x: T, idx: u32) -> E;
+}
+
+pub fn main() {
+    let mut s = S([0; 4]);
+
+    unsafe {
+        for i in 0_i32..4 {
+            s = simd_insert(s, i as u32, i);
+        }
+        for i in 0_i32..4 {
+            assert_eq!(i, simd_extract(s, i as u32));
+        }
+    }
+
+    let mut t = T::<4>([0; 4]);
+    unsafe {
+        for i in 0_i32..4 {
+            t = simd_insert(t, i as u32, i);
+        }
+        for i in 0_i32..4 {
+            assert_eq!(i, simd_extract(t, i as u32));
+        }
+    }
+}

--- a/src/test/ui/simd/simd-generics.rs
+++ b/src/test/ui/simd/simd-generics.rs
@@ -1,15 +1,17 @@
 // run-pass
-#![allow(non_camel_case_types)]
-
-
-
-#![feature(repr_simd, platform_intrinsics)]
+#![allow(non_camel_case_types, incomplete_features)]
+#![feature(repr_simd, platform_intrinsics, const_generics)]
 
 use std::ops;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 struct f32x4(f32, f32, f32, f32);
+
+#[repr(simd)]
+#[derive(Copy, Clone)]
+struct S<const N: usize>([f32; N]);
+
 
 extern "platform-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
@@ -27,7 +29,16 @@ impl ops::Add for f32x4 {
     }
 }
 
-pub fn main() {
+impl ops::Add for S<4> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        unsafe {simd_add(self, rhs)}
+    }
+}
+
+
+pub fn main() { unsafe {
     let lr = f32x4(1.0f32, 2.0f32, 3.0f32, 4.0f32);
 
     // lame-o
@@ -36,4 +47,11 @@ pub fn main() {
     assert_eq!(y, 4.0f32);
     assert_eq!(z, 6.0f32);
     assert_eq!(w, 8.0f32);
-}
+
+    let lr2 = S::<4>([1.0f32, 2.0f32, 3.0f32, 4.0f32]);
+    let [x, y, z, w] = add(lr2, lr2).0;
+    assert_eq!(x, 2.0f32);
+    assert_eq!(y, 4.0f32);
+    assert_eq!(z, 6.0f32);
+    assert_eq!(w, 8.0f32);
+}}

--- a/src/test/ui/simd/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -2,16 +2,16 @@
 // ignore-emscripten
 // min-llvm-version 8.0
 
-#![allow(non_camel_case_types)]
-#![feature(repr_simd, platform_intrinsics)]
+#![allow(non_camel_case_types, incomplete_features)]
+#![feature(repr_simd, platform_intrinsics, const_generics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
 struct u32x4(pub u32, pub u32, pub u32, pub u32);
 
 #[repr(simd)]
-#[derive(Copy, Clone, PartialEq, Debug)]
-struct i32x4(pub i32, pub i32, pub i32, pub i32);
+#[derive(Copy, Clone)]
+struct I32<const N: usize>([i32; N]);
 
 extern "platform-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;
@@ -52,41 +52,41 @@ fn main() {
         const MIN: i32 = i32::min_value();
         const MAX: i32 = i32::max_value();
 
-        let a = i32x4(1, 2, 3, 4);
-        let b = i32x4(2, 4, 6, 8);
-        let c = i32x4(-1, -2, -3, -4);
-        let d = i32x4(-2, -4, -6, -8);
+        let a = I32::<4>([1, 2, 3, 4]);
+        let b = I32::<4>([2, 4, 6, 8]);
+        let c = I32::<4>([-1, -2, -3, -4]);
+        let d = I32::<4>([-2, -4, -6, -8]);
 
-        let max = i32x4(MAX, MAX, MAX, MAX);
-        let max1 = i32x4(MAX - 1, MAX - 1, MAX - 1, MAX - 1);
-        let min = i32x4(MIN, MIN, MIN, MIN);
-        let min1 = i32x4(MIN + 1, MIN + 1, MIN + 1, MIN + 1);
+        let max = I32::<4>([MAX, MAX, MAX, MAX]);
+        let max1 = I32::<4>([MAX - 1, MAX - 1, MAX - 1, MAX - 1]);
+        let min = I32::<4>([MIN, MIN, MIN, MIN]);
+        let min1 = I32::<4>([MIN + 1, MIN + 1, MIN + 1, MIN + 1]);
 
-        let z = i32x4(0, 0, 0, 0);
+        let z = I32::<4>([0, 0, 0, 0]);
 
         unsafe {
-            assert_eq!(simd_saturating_add(z, z), z);
-            assert_eq!(simd_saturating_add(z, a), a);
-            assert_eq!(simd_saturating_add(b, z), b);
-            assert_eq!(simd_saturating_add(a, a), b);
-            assert_eq!(simd_saturating_add(a, max), max);
-            assert_eq!(simd_saturating_add(max, b), max);
-            assert_eq!(simd_saturating_add(max1, a), max);
-            assert_eq!(simd_saturating_add(min1, z), min1);
-            assert_eq!(simd_saturating_add(min, z), min);
-            assert_eq!(simd_saturating_add(min1, c), min);
-            assert_eq!(simd_saturating_add(min, c), min);
-            assert_eq!(simd_saturating_add(min1, d), min);
-            assert_eq!(simd_saturating_add(min, d), min);
+            assert_eq!(simd_saturating_add(z, z).0, z.0);
+            assert_eq!(simd_saturating_add(z, a).0, a.0);
+            assert_eq!(simd_saturating_add(b, z).0, b.0);
+            assert_eq!(simd_saturating_add(a, a).0, b.0);
+            assert_eq!(simd_saturating_add(a, max).0, max.0);
+            assert_eq!(simd_saturating_add(max, b).0, max.0);
+            assert_eq!(simd_saturating_add(max1, a).0, max.0);
+            assert_eq!(simd_saturating_add(min1, z).0, min1.0);
+            assert_eq!(simd_saturating_add(min, z).0, min.0);
+            assert_eq!(simd_saturating_add(min1, c).0, min.0);
+            assert_eq!(simd_saturating_add(min, c).0, min.0);
+            assert_eq!(simd_saturating_add(min1, d).0, min.0);
+            assert_eq!(simd_saturating_add(min, d).0, min.0);
 
-            assert_eq!(simd_saturating_sub(b, z), b);
-            assert_eq!(simd_saturating_sub(b, a), a);
-            assert_eq!(simd_saturating_sub(a, a), z);
-            assert_eq!(simd_saturating_sub(a, b), c);
-            assert_eq!(simd_saturating_sub(z, max), min1);
-            assert_eq!(simd_saturating_sub(min1, z), min1);
-            assert_eq!(simd_saturating_sub(min1, a), min);
-            assert_eq!(simd_saturating_sub(min1, b), min);
+            assert_eq!(simd_saturating_sub(b, z).0, b.0);
+            assert_eq!(simd_saturating_sub(b, a).0, a.0);
+            assert_eq!(simd_saturating_sub(a, a).0, z.0);
+            assert_eq!(simd_saturating_sub(a, b).0, c.0);
+            assert_eq!(simd_saturating_sub(z, max).0, min1.0);
+            assert_eq!(simd_saturating_sub(min1, z).0, min1.0);
+            assert_eq!(simd_saturating_sub(min1, a).0, min.0);
+            assert_eq!(simd_saturating_sub(min1, b).0, min.0);
         }
     }
 }

--- a/src/test/ui/simd/simd-intrinsic-generic-arithmetic.rs
+++ b/src/test/ui/simd/simd-intrinsic-generic-arithmetic.rs
@@ -1,9 +1,9 @@
 // run-pass
-#![allow(non_camel_case_types)]
+#![allow(non_camel_case_types, incomplete_features)]
 
 // ignore-emscripten FIXME(#45351) hits an LLVM assert
 
-#![feature(repr_simd, platform_intrinsics)]
+#![feature(repr_simd, platform_intrinsics, const_generics)]
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -11,7 +11,7 @@ struct i32x4(pub i32, pub i32, pub i32, pub i32);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct U32<const N: usize>([u32; N]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -24,6 +24,15 @@ macro_rules! all_eq {
         assert!(a.0 == b.0 && a.1 == b.1 && a.2 == b.2 && a.3 == b.3);
     }}
 }
+
+macro_rules! all_eq_ {
+    ($a: expr, $b: expr) => {{
+        let a = $a;
+        let b = $b;
+        assert!(a.0 == b.0);
+    }}
+}
+
 
 extern "platform-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
@@ -40,81 +49,81 @@ extern "platform-intrinsic" {
 
 fn main() {
     let x1 = i32x4(1, 2, 3, 4);
-    let y1 = u32x4(1, 2, 3, 4);
+    let y1 = U32::<4>([1, 2, 3, 4]);
     let z1 = f32x4(1.0, 2.0, 3.0, 4.0);
     let x2 = i32x4(2, 3, 4, 5);
-    let y2 = u32x4(2, 3, 4, 5);
+    let y2 = U32::<4>([2, 3, 4, 5]);
     let z2 = f32x4(2.0, 3.0, 4.0, 5.0);
 
     unsafe {
         all_eq!(simd_add(x1, x2), i32x4(3, 5, 7, 9));
         all_eq!(simd_add(x2, x1), i32x4(3, 5, 7, 9));
-        all_eq!(simd_add(y1, y2), u32x4(3, 5, 7, 9));
-        all_eq!(simd_add(y2, y1), u32x4(3, 5, 7, 9));
+        all_eq_!(simd_add(y1, y2), U32::<4>([3, 5, 7, 9]));
+        all_eq_!(simd_add(y2, y1), U32::<4>([3, 5, 7, 9]));
         all_eq!(simd_add(z1, z2), f32x4(3.0, 5.0, 7.0, 9.0));
         all_eq!(simd_add(z2, z1), f32x4(3.0, 5.0, 7.0, 9.0));
 
         all_eq!(simd_mul(x1, x2), i32x4(2, 6, 12, 20));
         all_eq!(simd_mul(x2, x1), i32x4(2, 6, 12, 20));
-        all_eq!(simd_mul(y1, y2), u32x4(2, 6, 12, 20));
-        all_eq!(simd_mul(y2, y1), u32x4(2, 6, 12, 20));
+        all_eq_!(simd_mul(y1, y2), U32::<4>([2, 6, 12, 20]));
+        all_eq_!(simd_mul(y2, y1), U32::<4>([2, 6, 12, 20]));
         all_eq!(simd_mul(z1, z2), f32x4(2.0, 6.0, 12.0, 20.0));
         all_eq!(simd_mul(z2, z1), f32x4(2.0, 6.0, 12.0, 20.0));
 
         all_eq!(simd_sub(x2, x1), i32x4(1, 1, 1, 1));
         all_eq!(simd_sub(x1, x2), i32x4(-1, -1, -1, -1));
-        all_eq!(simd_sub(y2, y1), u32x4(1, 1, 1, 1));
-        all_eq!(simd_sub(y1, y2), u32x4(!0, !0, !0, !0));
+        all_eq_!(simd_sub(y2, y1), U32::<4>([1, 1, 1, 1]));
+        all_eq_!(simd_sub(y1, y2), U32::<4>([!0, !0, !0, !0]));
         all_eq!(simd_sub(z2, z1), f32x4(1.0, 1.0, 1.0, 1.0));
         all_eq!(simd_sub(z1, z2), f32x4(-1.0, -1.0, -1.0, -1.0));
 
         all_eq!(simd_div(x1, x1), i32x4(1, 1, 1, 1));
         all_eq!(simd_div(i32x4(2, 4, 6, 8), i32x4(2, 2, 2, 2)), x1);
-        all_eq!(simd_div(y1, y1), u32x4(1, 1, 1, 1));
-        all_eq!(simd_div(u32x4(2, 4, 6, 8), u32x4(2, 2, 2, 2)), y1);
+        all_eq_!(simd_div(y1, y1), U32::<4>([1, 1, 1, 1]));
+        all_eq_!(simd_div(U32::<4>([2, 4, 6, 8]), U32::<4>([2, 2, 2, 2])), y1);
         all_eq!(simd_div(z1, z1), f32x4(1.0, 1.0, 1.0, 1.0));
         all_eq!(simd_div(z1, z2), f32x4(1.0/2.0, 2.0/3.0, 3.0/4.0, 4.0/5.0));
         all_eq!(simd_div(z2, z1), f32x4(2.0/1.0, 3.0/2.0, 4.0/3.0, 5.0/4.0));
 
         all_eq!(simd_rem(x1, x1), i32x4(0, 0, 0, 0));
         all_eq!(simd_rem(x2, x1), i32x4(0, 1, 1, 1));
-        all_eq!(simd_rem(y1, y1), u32x4(0, 0, 0, 0));
-        all_eq!(simd_rem(y2, y1), u32x4(0, 1, 1, 1));
+        all_eq_!(simd_rem(y1, y1), U32::<4>([0, 0, 0, 0]));
+        all_eq_!(simd_rem(y2, y1), U32::<4>([0, 1, 1, 1]));
         all_eq!(simd_rem(z1, z1), f32x4(0.0, 0.0, 0.0, 0.0));
         all_eq!(simd_rem(z1, z2), z1);
         all_eq!(simd_rem(z2, z1), f32x4(0.0, 1.0, 1.0, 1.0));
 
         all_eq!(simd_shl(x1, x2), i32x4(1 << 2, 2 << 3, 3 << 4, 4 << 5));
         all_eq!(simd_shl(x2, x1), i32x4(2 << 1, 3 << 2, 4 << 3, 5 << 4));
-        all_eq!(simd_shl(y1, y2), u32x4(1 << 2, 2 << 3, 3 << 4, 4 << 5));
-        all_eq!(simd_shl(y2, y1), u32x4(2 << 1, 3 << 2, 4 << 3, 5 << 4));
+        all_eq_!(simd_shl(y1, y2), U32::<4>([1 << 2, 2 << 3, 3 << 4, 4 << 5]));
+        all_eq_!(simd_shl(y2, y1), U32::<4>([2 << 1, 3 << 2, 4 << 3, 5 << 4]));
 
         // test right-shift by assuming left-shift is correct
         all_eq!(simd_shr(simd_shl(x1, x2), x2), x1);
         all_eq!(simd_shr(simd_shl(x2, x1), x1), x2);
-        all_eq!(simd_shr(simd_shl(y1, y2), y2), y1);
-        all_eq!(simd_shr(simd_shl(y2, y1), y1), y2);
+        all_eq_!(simd_shr(simd_shl(y1, y2), y2), y1);
+        all_eq_!(simd_shr(simd_shl(y2, y1), y1), y2);
 
         // ensure we get logical vs. arithmetic shifts correct
         let (a, b, c, d) = (-12, -123, -1234, -12345);
         all_eq!(simd_shr(i32x4(a, b, c, d), x1), i32x4(a >> 1, b >> 2, c >> 3, d >> 4));
-        all_eq!(simd_shr(u32x4(a as u32, b as u32, c as u32, d as u32), y1),
-                u32x4((a as u32) >> 1, (b as u32) >> 2, (c as u32) >> 3, (d as u32) >> 4));
+        all_eq_!(simd_shr(U32::<4>([a as u32, b as u32, c as u32, d as u32]), y1),
+                U32::<4>([(a as u32) >> 1, (b as u32) >> 2, (c as u32) >> 3, (d as u32) >> 4]));
 
         all_eq!(simd_and(x1, x2), i32x4(0, 2, 0, 4));
         all_eq!(simd_and(x2, x1), i32x4(0, 2, 0, 4));
-        all_eq!(simd_and(y1, y2), u32x4(0, 2, 0, 4));
-        all_eq!(simd_and(y2, y1), u32x4(0, 2, 0, 4));
+        all_eq_!(simd_and(y1, y2), U32::<4>([0, 2, 0, 4]));
+        all_eq_!(simd_and(y2, y1), U32::<4>([0, 2, 0, 4]));
 
         all_eq!(simd_or(x1, x2), i32x4(3, 3, 7, 5));
         all_eq!(simd_or(x2, x1), i32x4(3, 3, 7, 5));
-        all_eq!(simd_or(y1, y2), u32x4(3, 3, 7, 5));
-        all_eq!(simd_or(y2, y1), u32x4(3, 3, 7, 5));
+        all_eq_!(simd_or(y1, y2), U32::<4>([3, 3, 7, 5]));
+        all_eq_!(simd_or(y2, y1), U32::<4>([3, 3, 7, 5]));
 
         all_eq!(simd_xor(x1, x2), i32x4(3, 1, 7, 1));
         all_eq!(simd_xor(x2, x1), i32x4(3, 1, 7, 1));
-        all_eq!(simd_xor(y1, y2), u32x4(3, 1, 7, 1));
-        all_eq!(simd_xor(y2, y1), u32x4(3, 1, 7, 1));
+        all_eq_!(simd_xor(y1, y2), U32::<4>([3, 1, 7, 1]));
+        all_eq_!(simd_xor(y2, y1), U32::<4>([3, 1, 7, 1]));
 
     }
 }


### PR DESCRIPTION
This PR allows using `#[repr(simd)]` on ADTs containing a
single array field:

```rust
 #[repr(simd)] struct S0([f32; 4]);
 #[repr(simd)] struct S1<const N: usize>([f32; N]);
 #[repr(simd)] struct S2<T, const N: usize>([T; N]);
```

This should allow experimenting with portable packed SIMD
abstractions on nightly that make use of const generics.

It also has a fly-by cleanup that removes `simd_type` and `simd_size` methods.

r? @eddyb