### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -132,10 +132,7 @@ fn main() {
         cmd.arg("-Dwarnings");
         cmd.arg("-Drust_2018_idioms");
         cmd.arg("-Dunused_lifetimes");
-        // cfg(not(bootstrap)): Remove this during the next stage 0 compiler update.
-        // `-Drustc::internal` is a new feature and `rustc_version` mis-reports the `stage`.
-        let cfg_not_bootstrap = stage != "0" && crate_name != Some("rustc_version");
-        if cfg_not_bootstrap && use_internal_lints(crate_name) {
+        if use_internal_lints(crate_name) {
             cmd.arg("-Zunstable-options");
             cmd.arg("-Drustc::internal");
         }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -110,7 +110,11 @@ fn main() {
 
     // Non-zero stages must all be treated uniformly to avoid problems when attempting to uplift
     // compiler libraries and such from stage 1 to 2.
-    if stage == "0" {
+    //
+    // FIXME: the fact that core here is excluded is due to core_arch from our stdarch submodule
+    // being broken on the beta compiler with bootstrap passed, so this is a temporary workaround
+    // (we've just snapped, so there are no cfg(bootstrap) related annotations in core).
+    if stage == "0" && crate_name != Some("core") {
         cmd.arg("--cfg").arg("bootstrap");
     }
 

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -45,18 +45,6 @@ fn main() {
         }
     }
 
-    // Drop `--error-format json` because despite our desire for json messages
-    // from Cargo we don't want any from rustc itself.
-    if let Some(n) = args.iter().position(|n| n == "--error-format") {
-        args.remove(n);
-        args.remove(n);
-    }
-
-    if let Some(s) = env::var_os("RUSTC_ERROR_FORMAT") {
-        args.push("--error-format".into());
-        args.push(s);
-    }
-
     // Detect whether or not we're a build script depending on whether --target
     // is passed (a bit janky...)
     let target = args.windows(2)

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -980,9 +980,6 @@ impl<'a> Builder<'a> {
         if let Some(target_linker) = self.linker(target) {
             cargo.env("RUSTC_TARGET_LINKER", target_linker);
         }
-        if let Some(ref error_format) = self.config.rustc_error_format {
-            cargo.env("RUSTC_ERROR_FORMAT", error_format);
-        }
         if !(["build", "check", "clippy", "fix", "rustc"].contains(&cmd)) && want_rustdoc {
             cargo.env("RUSTDOC_LIBDIR", self.rustc_libdir(compiler));
         }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -145,7 +145,7 @@ impl StepDescription {
             only_hosts: S::ONLY_HOSTS,
             should_run: S::should_run,
             make_run: S::make_run,
-            name: unsafe { ::std::intrinsics::type_name::<S>() },
+            name: std::any::type_name::<S>(),
         }
     }
 

--- a/src/bootstrap/channel.rs
+++ b/src/bootstrap/channel.rs
@@ -13,7 +13,7 @@ use build_helper::output;
 use crate::Build;
 
 // The version number
-pub const CFG_RELEASE_NUM: &str = "1.38.0";
+pub const CFG_RELEASE_NUM: &str = "1.39.0";
 
 pub struct GitInfo {
     inner: Option<Info>,

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -304,3 +304,10 @@ to customize the output:
 
 Note that it is invalid to combine the `--json` argument with the `--color`
 argument, and it is required to combine `--json` with `--error-format=json`.
+
+## `@path`: load command-line flags from a path
+
+If you specify `@path` on the command-line, then it will open `path` and read
+command line options from it. These options are one per line; a blank line indicates
+an empty option. The file can use Unix or Windows style line endings, and must be
+encoded as UTF-8.

--- a/src/liballoc/collections/btree/node.rs
+++ b/src/liballoc/collections/btree/node.rs
@@ -106,8 +106,8 @@ impl<K, V> LeafNode<K, V> {
         LeafNode {
             // As a general policy, we leave fields uninitialized if they can be, as this should
             // be both slightly faster and easier to track in Valgrind.
-            keys: uninit_array![_; CAPACITY],
-            vals: uninit_array![_; CAPACITY],
+            keys: [MaybeUninit::UNINIT; CAPACITY],
+            vals: [MaybeUninit::UNINIT; CAPACITY],
             parent: ptr::null(),
             parent_idx: MaybeUninit::uninit(),
             len: 0
@@ -159,7 +159,7 @@ impl<K, V> InternalNode<K, V> {
     unsafe fn new() -> Self {
         InternalNode {
             data: LeafNode::new(),
-            edges: uninit_array![_; 2*B],
+            edges: [MaybeUninit::UNINIT; 2*B]
         }
     }
 }

--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -69,7 +69,7 @@
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
-#![cfg_attr(not(bootstrap), allow(incomplete_features))]
+#![allow(incomplete_features)]
 
 #![cfg_attr(not(test), feature(generator_trait))]
 #![cfg_attr(test, feature(test))]
@@ -84,7 +84,7 @@
 #![feature(coerce_unsized)]
 #![feature(const_generic_impls_guard)]
 #![feature(const_generics)]
-#![cfg_attr(not(bootstrap), feature(const_in_array_repeat_expressions))]
+#![feature(const_in_array_repeat_expressions)]
 #![feature(dispatch_from_dyn)]
 #![feature(core_intrinsics)]
 #![feature(dropck_eyepatch)]
@@ -118,7 +118,7 @@
 #![feature(rustc_const_unstable)]
 #![feature(const_vec_new)]
 #![feature(slice_partition_dedup)]
-#![feature(maybe_uninit_extra, maybe_uninit_slice, maybe_uninit_array)]
+#![feature(maybe_uninit_extra, maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(mem_take)]

--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -470,10 +470,5 @@ impl TypeId {
 #[stable(feature = "type_name", since = "1.38.0")]
 #[rustc_const_unstable(feature = "const_type_name")]
 pub const fn type_name<T: ?Sized>() -> &'static str {
-    #[cfg(bootstrap)]
-    unsafe {
-        intrinsics::type_name::<T>()
-    }
-    #[cfg(not(bootstrap))]
     intrinsics::type_name::<T>()
 }

--- a/src/libcore/char/methods.rs
+++ b/src/libcore/char/methods.rs
@@ -553,12 +553,7 @@ impl char {
     /// `XID_Start` is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to `ID_Start` but modified for closure under `NFKx`.
-    #[cfg_attr(bootstrap,
-               unstable(feature = "rustc_private",
-                        reason = "mainly needed for compiler internals",
-                        issue = "27812"))]
-    #[cfg_attr(not(bootstrap),
-               unstable(feature = "unicode_internals", issue = "0"))]
+    #[unstable(feature = "unicode_internals", issue = "0")]
     pub fn is_xid_start(self) -> bool {
         derived_property::XID_Start(self)
     }
@@ -569,12 +564,7 @@ impl char {
     /// `XID_Continue` is a Unicode Derived Property specified in
     /// [UAX #31](http://unicode.org/reports/tr31/#NFKC_Modifications),
     /// mostly similar to `ID_Continue` but modified for closure under NFKx.
-    #[cfg_attr(bootstrap,
-               unstable(feature = "rustc_private",
-                        reason = "mainly needed for compiler internals",
-                        issue = "27812"))]
-    #[cfg_attr(not(bootstrap),
-               unstable(feature = "unicode_internals", issue = "0"))]
+    #[unstable(feature = "unicode_internals", issue = "0")]
     #[inline]
     pub fn is_xid_continue(self) -> bool {
         derived_property::XID_Continue(self)

--- a/src/libcore/clone.rs
+++ b/src/libcore/clone.rs
@@ -134,7 +134,6 @@ pub trait Clone : Sized {
 }
 
 /// Derive macro generating an impl of the trait `Clone`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -201,7 +201,6 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
 }
 
 /// Derive macro generating an impl of the trait `PartialEq`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
@@ -265,7 +264,6 @@ pub trait Eq: PartialEq<Self> {
 }
 
 /// Derive macro generating an impl of the trait `Eq`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
@@ -617,7 +615,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
 }
 
 /// Derive macro generating an impl of the trait `Ord`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
@@ -867,7 +864,6 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
 }
 
 /// Derive macro generating an impl of the trait `PartialOrd`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/libcore/default.rs
+++ b/src/libcore/default.rs
@@ -116,7 +116,6 @@ pub trait Default: Sized {
 }
 
 /// Derive macro generating an impl of the trait `Default`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/libcore/fmt/mod.rs
+++ b/src/libcore/fmt/mod.rs
@@ -546,7 +546,6 @@ pub trait Debug {
 }
 
 // Separate module to reexport the macro `Debug` from prelude without the trait `Debug`.
-#[cfg(not(bootstrap))]
 pub(crate) mod macros {
     /// Derive macro generating an impl of the trait `Debug`.
     #[rustc_builtin_macro]
@@ -555,7 +554,6 @@ pub(crate) mod macros {
     #[allow_internal_unstable(core_intrinsics)]
     pub macro Debug($item:item) { /* compiler built-in */ }
 }
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(inline)]
 pub use macros::Debug;

--- a/src/libcore/hash/mod.rs
+++ b/src/libcore/hash/mod.rs
@@ -199,7 +199,6 @@ pub trait Hash {
 }
 
 // Separate module to reexport the macro `Hash` from prelude without the trait `Hash`.
-#[cfg(not(bootstrap))]
 pub(crate) mod macros {
     /// Derive macro generating an impl of the trait `Hash`.
     #[rustc_builtin_macro]
@@ -208,7 +207,6 @@ pub(crate) mod macros {
     #[allow_internal_unstable(core_intrinsics)]
     pub macro Hash($item:item) { /* compiler built-in */ }
 }
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(inline)]
 pub use macros::Hash;

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -63,7 +63,7 @@
 #![warn(missing_debug_implementations)]
 #![deny(intra_doc_link_resolution_failure)] // rustdoc is run without -D warnings
 #![allow(explicit_outlives_requirements)]
-#![cfg_attr(not(bootstrap), allow(incomplete_features))]
+#![allow(incomplete_features)]
 
 #![feature(allow_internal_unstable)]
 #![feature(arbitrary_self_types)]
@@ -129,7 +129,7 @@
 #![feature(structural_match)]
 #![feature(abi_unadjusted)]
 #![feature(adx_target_feature)]
-#![feature(maybe_uninit_slice, maybe_uninit_array)]
+#![feature(maybe_uninit_slice)]
 #![feature(external_doc)]
 #![feature(mem_take)]
 #![feature(associated_type_bounds)]

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -635,46 +635,11 @@ macro_rules! todo {
     ($($arg:tt)+) => (panic!("not yet implemented: {}", format_args!($($arg)+)));
 }
 
-/// Creates an array of [`MaybeUninit`].
-///
-/// This macro constructs an uninitialized array of the type `[MaybeUninit<K>; N]`.
-/// It exists solely because bootstrap does not yet support const array-init expressions.
-///
-/// [`MaybeUninit`]: mem/union.MaybeUninit.html
-// FIXME: Remove both versions of this macro once bootstrap is 1.38.
-#[macro_export]
-#[unstable(feature = "maybe_uninit_array", issue = "53491")]
-#[cfg(bootstrap)]
-macro_rules! uninit_array {
-    // This `assume_init` is safe because an array of `MaybeUninit` does not
-    // require initialization.
-    ($t:ty; $size:expr) => (unsafe {
-        MaybeUninit::<[MaybeUninit<$t>; $size]>::uninit().assume_init()
-    });
-}
-
-/// Creates an array of [`MaybeUninit`].
-///
-/// This macro constructs an uninitialized array of the type `[MaybeUninit<K>; N]`.
-/// It exists solely because bootstrap does not yet support const array-init expressions.
-///
-/// [`MaybeUninit`]: mem/union.MaybeUninit.html
-// FIXME: Just inline this version of the macro once bootstrap is 1.38.
-#[macro_export]
-#[unstable(feature = "maybe_uninit_array", issue = "53491")]
-#[cfg(not(bootstrap))]
-macro_rules! uninit_array {
-    ($t:ty; $size:expr) => (
-        [MaybeUninit::<$t>::UNINIT; $size]
-    );
-}
-
 /// Definitions of built-in macros.
 ///
 /// Most of the macro properties (stability, visibility, etc.) are taken from the source code here,
 /// with exception of expansion functions transforming macro inputs into outputs,
 /// those functions are provided by the compiler.
-#[cfg(not(bootstrap))]
 pub(crate) mod builtin {
 
     /// Causes compilation to fail with the given error message when encountered.

--- a/src/libcore/marker.rs
+++ b/src/libcore/marker.rs
@@ -289,7 +289,6 @@ pub trait Copy : Clone {
 }
 
 /// Derive macro generating an impl of the trait `Copy`.
-#[cfg(not(bootstrap))]
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -213,7 +213,7 @@ use crate::mem::ManuallyDrop;
 #[allow(missing_debug_implementations)]
 #[stable(feature = "maybe_uninit", since = "1.36.0")]
 // Lang item so we can wrap other types in it. This is useful for generators.
-#[cfg_attr(not(bootstrap), lang = "maybe_uninit")]
+#[lang = "maybe_uninit"]
 #[derive(Copy)]
 #[repr(transparent)]
 pub union MaybeUninit<T> {

--- a/src/libcore/mem/mod.rs
+++ b/src/libcore/mem/mod.rs
@@ -453,7 +453,7 @@ pub const fn needs_drop<T>() -> bool {
 /// ```
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(bootstrap, allow(deprecated_in_future))]
+#[allow(deprecated_in_future)]
 #[allow(deprecated)]
 pub unsafe fn zeroed<T>() -> T {
     intrinsics::panic_if_uninhabited::<T>();
@@ -481,7 +481,7 @@ pub unsafe fn zeroed<T>() -> T {
 #[inline]
 #[rustc_deprecated(since = "1.39.0", reason = "use `mem::MaybeUninit` instead")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(bootstrap, allow(deprecated_in_future))]
+#[allow(deprecated_in_future)]
 #[allow(deprecated)]
 pub unsafe fn uninitialized<T>() -> T {
     intrinsics::panic_if_uninhabited::<T>();

--- a/src/libcore/prelude/v1.rs
+++ b/src/libcore/prelude/v1.rs
@@ -46,16 +46,13 @@ pub use crate::option::Option::{self, Some, None};
 pub use crate::result::Result::{self, Ok, Err};
 
 // Re-exported built-in macros
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
 pub use crate::fmt::macros::Debug;
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
 pub use crate::hash::macros::Hash;
 
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
 pub use crate::{
@@ -83,7 +80,6 @@ pub use crate::{
     trace_macros,
 };
 
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(no_inline)]

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -677,6 +677,7 @@ impl LoweringContext<'_> {
         let fn_decl = self.lower_fn_decl(decl, None, false, None);
 
         self.with_new_scopes(|this| {
+            let prev = this.current_item;
             this.current_item = Some(fn_decl_span);
             let mut generator_kind = None;
             let body_id = this.lower_fn_body(decl, |this| {
@@ -690,8 +691,10 @@ impl LoweringContext<'_> {
                 generator_kind,
                 movability,
             );
+            let capture_clause = this.lower_capture_clause(capture_clause);
+            this.current_item = prev;
             hir::ExprKind::Closure(
-                this.lower_capture_clause(capture_clause),
+                capture_clause,
                 fn_decl,
                 body_id,
                 fn_decl_span,

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -1355,7 +1355,7 @@ struct LateLintPassObjects<'a> {
     lints: &'a mut [LateLintPassObject],
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::lint_pass_impl_without_macro))]
+#[allow(rustc::lint_pass_impl_without_macro)]
 impl LintPass for LateLintPassObjects<'_> {
     fn name(&self) -> &'static str {
         panic!()
@@ -1525,7 +1525,7 @@ struct EarlyLintPassObjects<'a> {
     lints: &'a mut [EarlyLintPassObject],
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::lint_pass_impl_without_macro))]
+#[allow(rustc::lint_pass_impl_without_macro)]
 impl LintPass for EarlyLintPassObjects<'_> {
     fn name(&self) -> &'static str {
         panic!()

--- a/src/librustc/lint/internal.rs
+++ b/src/librustc/lint/internal.rs
@@ -23,7 +23,7 @@ pub struct DefaultHashTypes {
 
 impl DefaultHashTypes {
     // we are allowed to use `HashMap` and `HashSet` as identifiers for implementing the lint itself
-    #[cfg_attr(not(bootstrap), allow(rustc::default_hash_types))]
+    #[allow(rustc::default_hash_types)]
     pub fn new() -> Self {
         let mut map = FxHashMap::default();
         map.insert(sym::HashMap, sym::FxHashMap);

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -191,8 +191,11 @@ impl<'tcx, Tag> Pointer<Tag> {
         Pointer { alloc_id: self.alloc_id, offset: self.offset, tag: () }
     }
 
+    /// Test if the pointer is "inbounds" of an allocation of the given size.
+    /// A pointer is "inbounds" even if its offset is equal to the size; this is
+    /// a "one-past-the-end" pointer.
     #[inline(always)]
-    pub fn check_in_alloc(
+    pub fn check_inbounds_alloc(
         self,
         allocation_size: Size,
         msg: CheckInAllocMsg,

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -2197,7 +2197,6 @@ impl<'tcx> Operand<'tcx> {
         let ty = tcx.type_of(def_id).subst(tcx, substs);
         Operand::Constant(box Constant {
             span,
-            ty,
             user_ty: None,
             literal: ty::Const::zero_sized(tcx, ty),
         })
@@ -2476,7 +2475,6 @@ impl<'tcx> Debug for Rvalue<'tcx> {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, HashStable)]
 pub struct Constant<'tcx> {
     pub span: Span,
-    pub ty: Ty<'tcx>,
 
     /// Optional user-given type: for something like
     /// `collect::<Vec<_>>`, this would be present and would
@@ -3385,12 +3383,11 @@ impl<'tcx> TypeFoldable<'tcx> for Constant<'tcx> {
     fn super_fold_with<F: TypeFolder<'tcx>>(&self, folder: &mut F) -> Self {
         Constant {
             span: self.span.clone(),
-            ty: self.ty.fold_with(folder),
             user_ty: self.user_ty.fold_with(folder),
             literal: self.literal.fold_with(folder),
         }
     }
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-        self.ty.visit_with(visitor) || self.literal.visit_with(visitor)
+         self.literal.visit_with(visitor)
     }
 }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -3388,6 +3388,6 @@ impl<'tcx> TypeFoldable<'tcx> for Constant<'tcx> {
         }
     }
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> bool {
-         self.literal.visit_with(visitor)
+        self.literal.visit_with(visitor)
     }
 }

--- a/src/librustc/mir/tcx.rs
+++ b/src/librustc/mir/tcx.rs
@@ -252,7 +252,7 @@ impl<'tcx> Operand<'tcx> {
         match self {
             &Operand::Copy(ref l) |
             &Operand::Move(ref l) => l.ty(local_decls, tcx).ty,
-            &Operand::Constant(ref c) => c.ty,
+            &Operand::Constant(ref c) => c.literal.ty,
         }
     }
 }

--- a/src/librustc/mir/visit.rs
+++ b/src/librustc/mir/visit.rs
@@ -782,13 +782,11 @@ macro_rules! make_mir_visitor {
                               location: Location) {
                 let Constant {
                     span,
-                    ty,
                     user_ty,
                     literal,
                 } = constant;
 
                 self.visit_span(span);
-                self.visit_ty(ty, TyContext::Location(location));
                 drop(user_ty); // no visit method for this
                 self.visit_const(literal, location);
             }

--- a/src/librustc/ty/codec.rs
+++ b/src/librustc/ty/codec.rs
@@ -27,7 +27,7 @@ pub trait EncodableWithShorthand: Clone + Eq + Hash {
     fn variant(&self) -> &Self::Variant;
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+#[allow(rustc::usage_of_ty_tykind)]
 impl<'tcx> EncodableWithShorthand for Ty<'tcx> {
     type Variant = ty::TyKind<'tcx>;
     fn variant(&self) -> &Self::Variant {
@@ -160,7 +160,7 @@ where
     Ok(decoder.map_encoded_cnum_to_current(cnum))
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+#[allow(rustc::usage_of_ty_tykind)]
 #[inline]
 pub fn decode_ty<D>(decoder: &mut D) -> Result<Ty<'tcx>, D::Error>
 where

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -130,7 +130,7 @@ impl<'tcx> CtxtInterners<'tcx> {
     }
 
     /// Intern a type
-    #[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+    #[allow(rustc::usage_of_ty_tykind)]
     #[inline(never)]
     fn intern_ty(&self,
         st: TyKind<'tcx>
@@ -2076,7 +2076,7 @@ impl<'tcx> Hash for Interned<'tcx, TyS<'tcx>> {
     }
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+#[allow(rustc::usage_of_ty_tykind)]
 impl<'tcx> Borrow<TyKind<'tcx>> for Interned<'tcx, TyS<'tcx>> {
     fn borrow<'a>(&'a self) -> &'a TyKind<'tcx> {
         &self.0.sty
@@ -2291,7 +2291,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self.mk_fn_ptr(converted_sig)
     }
 
-    #[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+    #[allow(rustc::usage_of_ty_tykind)]
     #[inline]
     pub fn mk_ty(&self, st: TyKind<'tcx>) -> Ty<'tcx> {
         self.interners.intern_ty(st)

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -18,7 +18,7 @@ impl FlagComputation {
         }
     }
 
-    #[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+    #[allow(rustc::usage_of_ty_tykind)]
     pub fn for_sty(st: &ty::TyKind<'_>) -> FlagComputation {
         let mut result = FlagComputation::new();
         result.add_sty(st);
@@ -62,7 +62,7 @@ impl FlagComputation {
         } // otherwise, this binder captures nothing
     }
 
-    #[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+    #[allow(rustc::usage_of_ty_tykind)]
     fn add_sty(&mut self, st: &ty::TyKind<'_>) {
         match st {
             &ty::Bool |

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -483,7 +483,7 @@ bitflags! {
     }
 }
 
-#[cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+#[allow(rustc::usage_of_ty_tykind)]
 pub struct TyS<'tcx> {
     pub sty: TyKind<'tcx>,
     pub flags: TypeFlags,

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -1,6 +1,6 @@
 //! This module contains `TyKind` and its major components.
 
-#![cfg_attr(not(bootstrap), allow(rustc::usage_of_ty_tykind))]
+#![allow(rustc::usage_of_ty_tykind)]
 
 use crate::hir;
 use crate::hir::def_id::DefId;

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -221,7 +221,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
             mir::TerminatorKind::Call {
                 func: mir::Operand::Constant(ref c),
                 ref args, ..
-            } => match c.ty.sty {
+            } => match c.literal.ty.sty {
                 ty::FnDef(did, _) => Some((did, args)),
                 _ => None,
             },

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -651,7 +651,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             let (llval, ty) = self.simd_shuffle_indices(
                                 &bx,
                                 constant.span,
-                                constant.ty,
+                                constant.literal.ty,
                                 c,
                             );
                             return OperandRef {

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -466,7 +466,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::Operand::Constant(ref constant) => {
-                let ty = self.monomorphize(&constant.ty);
                 self.eval_mir_constant(constant)
                     .map(|c| OperandRef::from_const(bx, c))
                     .unwrap_or_else(|err| {
@@ -481,6 +480,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         // the above error (or silence it under some conditions) will not cause UB
                         bx.abort();
                         // We've errored, so we don't have to produce working code.
+                        let ty = self.monomorphize(&constant.literal.ty);
                         let layout = bx.cx().layout_of(ty);
                         bx.load_operand(PlaceRef::new_sized(
                             bx.cx().const_undef(bx.cx().type_ptr_to(bx.cx().backend_type(layout))),

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -27,7 +27,7 @@
 
 #![cfg_attr(unix, feature(libc))]
 
-#![cfg_attr(not(bootstrap), allow(rustc::default_hash_types))]
+#![allow(rustc::default_hash_types)]
 
 #[macro_use]
 extern crate log;

--- a/src/librustc_driver/args/mod.rs
+++ b/src/librustc_driver/args/mod.rs
@@ -1,0 +1,145 @@
+#![allow(dead_code)]
+
+use std::env;
+use std::error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::str;
+
+#[cfg(test)]
+mod tests;
+
+/// States for parsing text
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum State {
+    Normal, // within normal text
+    Cr,     // just saw \r
+    Lf,     // just saw \n
+}
+
+struct FileArgs {
+    path: String,
+    input: Vec<u8>,
+    offset: usize,
+}
+
+impl FileArgs {
+    pub fn new(path: String, input: Vec<u8>) -> Self {
+        FileArgs { path, input, offset: 0 }
+    }
+}
+
+impl Iterator for FileArgs {
+    type Item = Result<String, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.offset >= self.input.len() {
+            // All done
+            return None;
+        }
+
+        use State::*;
+        let mut state = Normal;
+        let start = self.offset;
+        let mut end = start;
+
+        for (idx, b) in self.input[start..].iter().enumerate() {
+            let idx = start + idx + 1;
+
+            self.offset = idx;
+
+            match (b, state) {
+                (b'\r', Normal) => state = Cr,
+                (b'\n', Normal) => state = Lf,
+
+                (b'\r', Lf) | (b'\n', Cr) => {
+                    // Two-character line break (accept \r\n and \n\r(?)), so consume them both
+                    break;
+                }
+
+                (_, Cr) | (_, Lf) => {
+                    // Peeked at character after single-character line break, so rewind to visit it
+                    // next time around.
+                    self.offset = idx - 1;
+                    break;
+                }
+
+                (_, _) => {
+                    end = idx;
+                    state = Normal;
+                }
+            }
+        }
+
+        Some(
+            String::from_utf8(self.input[start..end].to_vec())
+                .map_err(|_| Error::Utf8Error(Some(self.path.clone()))),
+        )
+    }
+}
+
+pub struct ArgsIter {
+    base: env::ArgsOs,
+    file: Option<FileArgs>,
+}
+
+impl ArgsIter {
+    pub fn new() -> Self {
+        ArgsIter { base: env::args_os(), file: None }
+    }
+}
+
+impl Iterator for ArgsIter {
+    type Item = Result<String, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(ref mut file) = &mut self.file {
+                match file.next() {
+                    Some(res) => return Some(res.map_err(From::from)),
+                    None => self.file = None,
+                }
+            }
+
+            let arg =
+                self.base.next().map(|arg| arg.into_string().map_err(|_| Error::Utf8Error(None)));
+            match arg {
+                Some(Err(err)) => return Some(Err(err)),
+                Some(Ok(ref arg)) if arg.starts_with("@") => {
+                    // can't not be utf-8 now
+                    let path = str::from_utf8(&arg.as_bytes()[1..]).unwrap();
+                    let file = match fs::read(path) {
+                        Ok(file) => file,
+                        Err(err) => return Some(Err(Error::IOError(path.to_string(), err))),
+                    };
+                    self.file = Some(FileArgs::new(path.to_string(), file));
+                }
+                Some(Ok(arg)) => return Some(Ok(arg)),
+                None => return None,
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Utf8Error(Option<String>),
+    IOError(String, io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Utf8Error(None) => write!(fmt, "Utf8 error"),
+            Error::Utf8Error(Some(path)) => write!(fmt, "Utf8 error in {}", path),
+            Error::IOError(path, err) => write!(fmt, "IO Error: {}: {}", path, err),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &'static str {
+        "argument error"
+    }
+}

--- a/src/librustc_driver/args/tests.rs
+++ b/src/librustc_driver/args/tests.rs
@@ -1,11 +1,18 @@
 use super::*;
 
+use std::str;
+
 fn want_args(v: impl IntoIterator<Item = &'static str>) -> Vec<String> {
     v.into_iter().map(String::from).collect()
 }
 
 fn got_args(file: &[u8]) -> Result<Vec<String>, Error> {
-    FileArgs::new(String::new(), file.to_vec()).lines().collect()
+    let ret = str::from_utf8(file)
+        .map_err(|_| Error::Utf8Error(None))?
+        .lines()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    Ok(ret)
 }
 
 #[test]

--- a/src/librustc_driver/args/tests.rs
+++ b/src/librustc_driver/args/tests.rs
@@ -5,7 +5,7 @@ fn want_args(v: impl IntoIterator<Item = &'static str>) -> Vec<String> {
 }
 
 fn got_args(file: &[u8]) -> Result<Vec<String>, Error> {
-    FileArgs::new(String::new(), file.to_vec()).collect()
+    FileArgs::new(String::new(), file.to_vec()).lines().collect()
 }
 
 #[test]
@@ -78,6 +78,7 @@ fn multi_empty_end() {
     assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar", ""]));
 }
 
+#[test]
 fn simple_eol_crlf() {
     let file = b"foo\r\n";
 

--- a/src/librustc_driver/args/tests.rs
+++ b/src/librustc_driver/args/tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+fn want_args(v: impl IntoIterator<Item = &'static str>) -> Vec<String> {
+    v.into_iter().map(String::from).collect()
+}
+
+fn got_args(file: &[u8]) -> Result<Vec<String>, Error> {
+    FileArgs::new(String::new(), file.to_vec()).collect()
+}
+
+#[test]
+fn nothing() {
+    let file = b"";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec![]));
+}
+
+#[test]
+fn empty() {
+    let file = b"\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec![""]));
+}
+
+#[test]
+fn simple() {
+    let file = b"foo";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo"]));
+}
+
+#[test]
+fn simple_eol() {
+    let file = b"foo\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo"]));
+}
+
+#[test]
+fn multi() {
+    let file = b"foo\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar"]));
+}
+
+#[test]
+fn multi_eol() {
+    let file = b"foo\nbar\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar"]));
+}
+
+#[test]
+fn multi_empty() {
+    let file = b"foo\n\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "", "bar"]));
+}
+
+#[test]
+fn multi_empty_eol() {
+    let file = b"foo\n\nbar\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "", "bar"]));
+}
+
+#[test]
+fn multi_empty_start() {
+    let file = b"\nfoo\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["", "foo", "bar"]));
+}
+
+#[test]
+fn multi_empty_end() {
+    let file = b"foo\nbar\n\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar", ""]));
+}
+
+fn simple_eol_crlf() {
+    let file = b"foo\r\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo"]));
+}
+
+#[test]
+fn multi_crlf() {
+    let file = b"foo\r\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar"]));
+}
+
+#[test]
+fn multi_eol_crlf() {
+    let file = b"foo\r\nbar\r\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar"]));
+}
+
+#[test]
+fn multi_empty_crlf() {
+    let file = b"foo\r\n\r\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "", "bar"]));
+}
+
+#[test]
+fn multi_empty_eol_crlf() {
+    let file = b"foo\r\n\r\nbar\r\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "", "bar"]));
+}
+
+#[test]
+fn multi_empty_start_crlf() {
+    let file = b"\r\nfoo\r\nbar";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["", "foo", "bar"]));
+}
+
+#[test]
+fn multi_empty_end_crlf() {
+    let file = b"foo\r\nbar\r\n\r\n";
+
+    assert_eq!(got_args(file).unwrap(), want_args(vec!["foo", "bar", ""]));
+}
+
+#[test]
+fn bad_utf8() {
+    let file = b"foo\x80foo";
+
+    match got_args(file).unwrap_err() {
+        Error::Utf8Error(_) => (),
+        bad => panic!("bad err: {:?}", bad),
+    }
+}

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -783,14 +783,14 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     } else {
         ""
     };
-    println!("{}{}\nAdditional help:
+    println!("{options}{at_path}\nAdditional help:
     -C help             Print codegen options
     -W help             \
-              Print 'lint' options and default settings{}{}\n",
-             options.usage(message),
-             at_path,
-             nightly_help,
-             verbose_help);
+              Print 'lint' options and default settings{nightly}{verbose}\n",
+             options = options.usage(message),
+             at_path = at_path,
+             nightly = nightly_help,
+             verbose = verbose_help);
 }
 
 fn print_wall_help() {

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -778,7 +778,7 @@ fn usage(verbose: bool, include_unstable_options: bool) {
     } else {
         "\n    --help -v           Print the full set of options rustc accepts"
     };
-    let at_path = if verbose {
+    let at_path = if verbose && nightly_options::is_nightly_build() {
         "    @path               Read newline separated options from `path`\n"
     } else {
         ""
@@ -1014,6 +1014,12 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     // * Otherwise, if we're an unstable option then we generate an error
     //   (unstable option being used on stable)
     nightly_options::check_nightly_options(&matches, &config::rustc_optgroups());
+
+    // Late check to see if @file was used without unstable options enabled
+    if crate::args::used_unstable_argsfile() && !nightly_options::is_unstable_enabled(&matches) {
+        early_error(ErrorOutputType::default(),
+            "@path is unstable - use -Z unstable-options to enable its use");
+    }
 
     if matches.opt_present("h") || matches.opt_present("help") {
         // Only show unstable options in --help if we accept unstable options.

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -24,6 +24,7 @@ extern crate rustc;
 
 mod error_codes;
 mod nonstandard_style;
+mod redundant_semicolon;
 pub mod builtin;
 mod types;
 mod unused;
@@ -55,6 +56,7 @@ use session::Session;
 use lint::LintId;
 use lint::FutureIncompatibleInfo;
 
+use redundant_semicolon::*;
 use nonstandard_style::*;
 use builtin::*;
 use types::*;
@@ -98,6 +100,7 @@ macro_rules! early_lint_passes {
             WhileTrue: WhileTrue,
             NonAsciiIdents: NonAsciiIdents,
             IncompleteFeatures: IncompleteFeatures,
+            RedundantSemicolon: RedundantSemicolon,
         ]);
     )
 }

--- a/src/librustc_macros/src/lib.rs
+++ b/src/librustc_macros/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(proc_macro_hygiene)]
-#![cfg_attr(not(bootstrap), allow(rustc::default_hash_types))]
+#![allow(rustc::default_hash_types)]
 
 #![recursion_limit="128"]
 

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -38,6 +38,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         inferred_ty: ty,
                     })
                 });
+                assert_eq!(literal.ty, ty);
                 Constant {
                     span,
                     user_ty,

--- a/src/librustc_mir/build/expr/as_constant.rs
+++ b/src/librustc_mir/build/expr/as_constant.rs
@@ -40,7 +40,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 });
                 Constant {
                     span,
-                    ty,
                     user_ty,
                     literal,
                 }

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -591,7 +591,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let n = (!0u128) >> (128 - bits);
         let literal = ty::Const::from_bits(self.hir.tcx(), n, param_ty);
 
-        self.literal_operand(span, ty, literal)
+        self.literal_operand(span, literal)
     }
 
     // Helper to get the minimum value of the appropriate type
@@ -602,6 +602,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let n = 1 << (bits - 1);
         let literal = ty::Const::from_bits(self.hir.tcx(), n, param_ty);
 
-        self.literal_operand(span, ty, literal)
+        self.literal_operand(span, literal)
     }
 }

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -114,7 +114,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     destination,
                     Constant {
                         span: expr_span,
-                        ty: this.hir.bool_ty(),
                         user_ty: None,
                         literal: this.hir.true_literal(),
                     },
@@ -126,7 +125,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     destination,
                     Constant {
                         span: expr_span,
-                        ty: this.hir.bool_ty(),
                         user_ty: None,
                         literal: this.hir.false_literal(),
                     },

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -108,8 +108,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 Err(match_pair)
             }
 
-            PatternKind::Range(PatternRange { lo, hi, ty, end }) => {
-                let (range, bias) = match ty.sty {
+            PatternKind::Range(PatternRange { lo, hi, end }) => {
+                let (range, bias) = match lo.ty.sty {
                     ty::Char => {
                         (Some(('\u{0000}' as u128, '\u{10FFFF}' as u128, Size::from_bits(32))), 0)
                     }

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -63,7 +63,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             PatternKind::Range(range) => {
-                assert!(range.ty == match_pair.pattern.ty);
                 Test {
                     span: match_pair.pattern.span,
                     kind: TestKind::Range(range),
@@ -270,8 +269,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     );
                 } else {
                     if let [success, fail] = *make_target_blocks(self) {
+                        let expect = self.literal_operand(test.span, value);
                         let val = Operand::Copy(place.clone());
-                        let expect = self.literal_operand(test.span, ty, value);
                         self.compare(block, success, fail, source_info, BinOp::Eq, expect, val);
                     } else {
                         bug!("`TestKind::Eq` should have two target blocks");
@@ -279,13 +278,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 }
             }
 
-            TestKind::Range(PatternRange { ref lo, ref hi, ty, ref end }) => {
+            TestKind::Range(PatternRange { ref lo, ref hi, ref end }) => {
                 let lower_bound_success = self.cfg.start_new_block();
                 let target_blocks = make_target_blocks(self);
 
                 // Test `val` by computing `lo <= val && val <= hi`, using primitive comparisons.
-                let lo = self.literal_operand(test.span, ty, lo);
-                let hi = self.literal_operand(test.span, ty, hi);
+                let lo = self.literal_operand(test.span, lo);
+                let hi = self.literal_operand(test.span, hi);
                 let val = Operand::Copy(place.clone());
 
                 if let [success, fail] = *target_blocks {
@@ -387,7 +386,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) {
         use rustc::middle::lang_items::EqTraitLangItem;
 
-        let mut expect = self.literal_operand(source_info.span, value.ty, value);
+        let mut expect = self.literal_operand(source_info.span, value);
         let mut val = Operand::Copy(place.clone());
 
         // If we're using `b"..."` as a pattern, we need to insert an
@@ -440,7 +439,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         };
 
         let eq_def_id = self.hir.tcx().require_lang_item(EqTraitLangItem);
-        let (mty, method) = self.hir.trait_method(eq_def_id, sym::eq, deref_ty, &[deref_ty.into()]);
+        let method = self.hir.trait_method(eq_def_id, sym::eq, deref_ty, &[deref_ty.into()]);
 
         let bool_ty = self.hir.bool_ty();
         let eq_result = self.temp(bool_ty, source_info.span);
@@ -449,7 +448,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         self.cfg.terminate(block, source_info, TerminatorKind::Call {
             func: Operand::Constant(box Constant {
                 span: source_info.span,
-                ty: mty,
 
                 // FIXME(#54571): This constant comes from user input (a
                 // constant in a pattern).  Are there forms where users can add
@@ -656,8 +654,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let tcx = self.hir.tcx();
 
-                    let lo = compare_const_vals(tcx, test.lo, pat.hi, self.hir.param_env, test.ty)?;
-                    let hi = compare_const_vals(tcx, test.hi, pat.lo, self.hir.param_env, test.ty)?;
+                    let test_ty = test.lo.ty;
+                    let lo = compare_const_vals(tcx, test.lo, pat.hi, self.hir.param_env, test_ty)?;
+                    let hi = compare_const_vals(tcx, test.hi, pat.lo, self.hir.param_env, test_ty)?;
 
                     match (test.end, pat.end, lo, hi) {
                         // pat < test
@@ -774,8 +773,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let tcx = self.hir.tcx();
 
-        let a = compare_const_vals(tcx, range.lo, value, self.hir.param_env, range.ty)?;
-        let b = compare_const_vals(tcx, value, range.hi, self.hir.param_env, range.ty)?;
+        let a = compare_const_vals(tcx, range.lo, value, self.hir.param_env, range.lo.ty)?;
+        let b = compare_const_vals(tcx, value, range.hi, self.hir.param_env, range.lo.ty)?;
 
         match (b, range.end) {
             (Less, _) |

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -63,6 +63,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             PatternKind::Range(range) => {
+                assert_eq!(range.lo.ty, match_pair.pattern.ty);
+                assert_eq!(range.hi.ty, match_pair.pattern.ty);
                 Test {
                     span: match_pair.pattern.span,
                     kind: TestKind::Range(range),
@@ -269,6 +271,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     );
                 } else {
                     if let [success, fail] = *make_target_blocks(self) {
+                        assert_eq!(value.ty, ty);
                         let expect = self.literal_operand(test.span, value);
                         let val = Operand::Copy(place.clone());
                         self.compare(block, success, fail, source_info, BinOp::Eq, expect, val);

--- a/src/librustc_mir/build/misc.rs
+++ b/src/librustc_mir/build/misc.rs
@@ -26,12 +26,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// without any user type annotation.
     pub fn literal_operand(&mut self,
                            span: Span,
-                           ty: Ty<'tcx>,
                            literal: &'tcx ty::Const<'tcx>)
                            -> Operand<'tcx> {
         let constant = box Constant {
             span,
-            ty,
             user_ty: None,
             literal,
         };
@@ -47,7 +45,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn zero_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         let literal = ty::Const::from_bits(self.hir.tcx(), 0, ty::ParamEnv::empty().and(ty));
 
-        self.literal_operand(span, ty, literal)
+        self.literal_operand(span, literal)
     }
 
     pub fn push_usize(&mut self,
@@ -61,7 +59,6 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             block, source_info, &temp,
             Constant {
                 span: source_info.span,
-                ty: self.hir.usize_ty(),
                 user_ty: None,
                 literal: self.hir.usize_literal(value),
             });

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -927,7 +927,7 @@ fn convert_path_expr<'a, 'tcx>(
             ExprKind::Literal {
                 literal: cx.tcx.mk_const(ty::Const {
                     val: ConstValue::Unevaluated(def_id, substs),
-                    ty: cx.tcx.type_of(def_id),
+                    ty: cx.tables().node_type(expr.hir_id),
                 }),
                 user_ty,
             }

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -170,13 +170,13 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
                         method_name: Symbol,
                         self_ty: Ty<'tcx>,
                         params: &[Kind<'tcx>])
-                        -> (Ty<'tcx>, &'tcx ty::Const<'tcx>) {
+                        -> &'tcx ty::Const<'tcx> {
         let substs = self.tcx.mk_substs_trait(self_ty, params);
         for item in self.tcx.associated_items(trait_def_id) {
             if item.kind == ty::AssocKind::Method && item.ident.name == method_name {
                 let method_ty = self.tcx.type_of(item.def_id);
                 let method_ty = method_ty.subst(self.tcx, substs);
-                return (method_ty, ty::Const::zero_sized(self.tcx, method_ty));
+                return ty::Const::zero_sized(self.tcx, method_ty);
             }
         }
 

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -441,6 +441,8 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
 
                 let mut kind = match (lo, hi) {
                     (PatternKind::Constant { value: lo }, PatternKind::Constant { value: hi }) => {
+                        assert_eq!(lo.ty, ty);
+                        assert_eq!(hi.ty, ty);
                         let cmp = compare_const_vals(
                             self.tcx,
                             lo,

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -181,7 +181,6 @@ pub enum PatternKind<'tcx> {
 pub struct PatternRange<'tcx> {
     pub lo: &'tcx ty::Const<'tcx>,
     pub hi: &'tcx ty::Const<'tcx>,
-    pub ty: Ty<'tcx>,
     pub end: RangeEnd,
 }
 
@@ -296,7 +295,7 @@ impl<'tcx> fmt::Display for Pattern<'tcx> {
             PatternKind::Constant { value } => {
                 write!(f, "{}", value)
             }
-            PatternKind::Range(PatternRange { lo, hi, ty: _, end }) => {
+            PatternKind::Range(PatternRange { lo, hi, end }) => {
                 write!(f, "{}", lo)?;
                 match end {
                     RangeEnd::Included => write!(f, "..=")?,
@@ -451,7 +450,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                         );
                         match (end, cmp) {
                             (RangeEnd::Excluded, Some(Ordering::Less)) =>
-                                PatternKind::Range(PatternRange { lo, hi, ty, end }),
+                                PatternKind::Range(PatternRange { lo, hi, end }),
                             (RangeEnd::Excluded, _) => {
                                 span_err!(
                                     self.tcx.sess,
@@ -465,7 +464,7 @@ impl<'a, 'tcx> PatternContext<'a, 'tcx> {
                                 PatternKind::Constant { value: lo }
                             }
                             (RangeEnd::Included, Some(Ordering::Less)) => {
-                                PatternKind::Range(PatternRange { lo, hi, ty, end })
+                                PatternKind::Range(PatternRange { lo, hi, end })
                             }
                             (RangeEnd::Included, _) => {
                                 let mut err = struct_span_err!(
@@ -1416,17 +1415,7 @@ impl<'tcx> PatternFoldable<'tcx> for PatternKind<'tcx> {
             } => PatternKind::Constant {
                 value,
             },
-            PatternKind::Range(PatternRange {
-                lo,
-                hi,
-                ty,
-                end,
-            }) => PatternKind::Range(PatternRange {
-                lo,
-                hi,
-                ty: ty.fold_with(folder),
-                end,
-            }),
+            PatternKind::Range(range) => PatternKind::Range(range),
             PatternKind::Slice {
                 ref prefix,
                 ref slice,

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -357,7 +357,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 // It is sufficient to check this for the end pointer. The addition
                 // checks for overflow.
                 let end_ptr = ptr.offset(size, self)?;
-                end_ptr.check_in_alloc(allocation_size, CheckInAllocMsg::MemoryAccessTest)?;
+                end_ptr.check_inbounds_alloc(allocation_size, CheckInAllocMsg::MemoryAccessTest)?;
                 // Test align. Check this last; if both bounds and alignment are violated
                 // we want the error to be about the bounds.
                 if alloc_align.bytes() < align.bytes() {
@@ -387,7 +387,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
     ) -> bool {
         let (size, _align) = self.get_size_and_align(ptr.alloc_id, AllocCheck::MaybeDead)
             .expect("alloc info with MaybeDead cannot fail");
-        ptr.check_in_alloc(size, CheckInAllocMsg::NullPointerTest).is_err()
+        ptr.check_inbounds_alloc(size, CheckInAllocMsg::NullPointerTest).is_err()
     }
 }
 

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -238,7 +238,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             return Ok(None);
         }
 
-        let ptr = match self.check_mplace_access(mplace, None)? {
+        let ptr = match self.check_mplace_access(mplace, None)
+            .expect("places should be checked on creation")
+        {
             Some(ptr) => ptr,
             None => return Ok(Some(ImmTy { // zero-sized type
                 imm: Immediate::Scalar(Scalar::zst().into()),

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -308,16 +308,8 @@ where
     ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
         let val = self.read_immediate(src)?;
         trace!("deref to {} on {:?}", val.layout.ty, *val);
-        let mut place = self.ref_to_mplace(val)?;
-        let (size, align) = self.size_and_align_of_mplace(place)?
-            .unwrap_or((place.layout.size, place.layout.align.abi));
-        assert!(place.mplace.align <= align, "dynamic alignment less strict than static one?");
-        place.mplace.align = align; // maximally strict checking
-        // When dereferencing a pointer, it must be non-NULL, aligned, and live.
-        if let Some(ptr) = self.check_mplace_access(place, Some(size))? {
-            place.mplace.ptr = ptr.into();
-        }
-        Ok(place)
+        let place = self.ref_to_mplace(val)?;
+        self.mplace_access_checked(place)
     }
 
     /// Check if the given place is good for memory access with the given
@@ -338,6 +330,23 @@ where
             place.layout.size
         });
         self.memory.check_ptr_access(place.ptr, size, place.align)
+    }
+
+    /// Return the "access-checked" version of this `MPlace`, where for non-ZST
+    /// this is definitely a `Pointer`.
+    pub fn mplace_access_checked(
+        &self,
+        mut place: MPlaceTy<'tcx, M::PointerTag>,
+    ) -> InterpResult<'tcx, MPlaceTy<'tcx, M::PointerTag>> {
+        let (size, align) = self.size_and_align_of_mplace(place)?
+            .unwrap_or((place.layout.size, place.layout.align.abi));
+        assert!(place.mplace.align <= align, "dynamic alignment less strict than static one?");
+        place.mplace.align = align; // maximally strict checking
+        // When dereferencing a pointer, it must be non-NULL, aligned, and live.
+        if let Some(ptr) = self.check_mplace_access(place, Some(size))? {
+            place.mplace.ptr = ptr.into();
+        }
+        Ok(place)
     }
 
     /// Force `place.ptr` to a `Pointer`.

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -277,6 +277,10 @@ where
 {
     /// Take a value, which represents a (thin or fat) reference, and make it a place.
     /// Alignment is just based on the type.  This is the inverse of `MemPlace::to_ref()`.
+    ///
+    /// Only call this if you are sure the place is "valid" (aligned and inbounds), or do not
+    /// want to ever use the place for memory access!
+    /// Generally prefer `deref_operand`.
     pub fn ref_to_mplace(
         &self,
         val: ImmTy<'tcx, M::PointerTag>,

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -763,7 +763,9 @@ where
         // to handle padding properly, which is only correct if we never look at this data with the
         // wrong type.
 
-        let ptr = match self.check_mplace_access(dest, None)? {
+        let ptr = match self.check_mplace_access(dest, None)
+            .expect("places should be checked on creation")
+        {
             Some(ptr) => ptr,
             None => return Ok(()), // zero-sized access
         };
@@ -866,8 +868,10 @@ where
         });
         assert_eq!(src.meta, dest.meta, "Can only copy between equally-sized instances");
 
-        let src = self.check_mplace_access(src, Some(size))?;
-        let dest = self.check_mplace_access(dest, Some(size))?;
+        let src = self.check_mplace_access(src, Some(size))
+            .expect("places should be checked on creation");
+        let dest = self.check_mplace_access(dest, Some(size))
+            .expect("places should be checked on creation");
         let (src_ptr, dest_ptr) = match (src, dest) {
             (Some(src_ptr), Some(dest_ptr)) => (src_ptr, dest_ptr),
             (None, None) => return Ok(()), // zero-sized copy

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -240,8 +240,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
             Ref(_, _, ref place) => {
                 let src = self.eval_place(place)?;
-                let val = self.force_allocation(src)?;
-                self.write_immediate(val.to_ref(), dest)?;
+                let place = self.force_allocation(src)?;
+                if place.layout.size.bytes() > 0 {
+                    // definitely not a ZST
+                    assert!(place.ptr.is_ptr(), "non-ZST places should be normalized to `Pointer`");
+                }
+                self.write_immediate(place.to_ref(), dest)?;
             }
 
             NullaryOp(mir::NullOp::Box, _) => {

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -445,7 +445,6 @@ impl CloneShimBuilder<'tcx> {
         let func_ty = tcx.mk_fn_def(self.def_id, substs);
         let func = Operand::Constant(box Constant {
             span: self.span,
-            ty: func_ty,
             user_ty: None,
             literal: ty::Const::zero_sized(tcx, func_ty),
         });
@@ -505,7 +504,6 @@ impl CloneShimBuilder<'tcx> {
     fn make_usize(&self, value: u64) -> Box<Constant<'tcx>> {
         box Constant {
             span: self.span,
-            ty: self.tcx.types.usize,
             user_ty: None,
             literal: ty::Const::from_usize(self.tcx, value),
         }
@@ -745,7 +743,6 @@ fn build_call_shim<'tcx>(
             let ty = tcx.type_of(def_id);
             (Operand::Constant(box Constant {
                 span,
-                ty,
                 user_ty: None,
                 literal: ty::Const::zero_sized(tcx, ty),
              }),

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -539,7 +539,6 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         Operand::Constant(Box::new(
             Constant {
                 span,
-                ty,
                 user_ty: None,
                 literal: self.tcx.mk_const(*ty::Const::from_scalar(
                     self.tcx,

--- a/src/librustc_mir/transform/elaborate_drops.rs
+++ b/src/librustc_mir/transform/elaborate_drops.rs
@@ -527,7 +527,6 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
     fn constant_bool(&self, span: Span, val: bool) -> Rvalue<'tcx> {
         Rvalue::Use(Operand::Constant(Box::new(Constant {
             span,
-            ty: self.tcx.types.bool,
             user_ty: None,
             literal: ty::Const::from_bool(self.tcx, val),
         })))

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -975,7 +975,6 @@ fn insert_panic_block<'tcx>(
     let term = TerminatorKind::Assert {
         cond: Operand::Constant(box Constant {
             span: body.span,
-            ty: tcx.types.bool,
             user_ty: None,
             literal: ty::Const::from_bool(tcx, false),
         }),

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -328,7 +328,7 @@ impl Inliner<'tcx> {
                 }
 
                 TerminatorKind::Call {func: Operand::Constant(ref f), .. } => {
-                    if let ty::FnDef(def_id, _) = f.ty.sty {
+                    if let ty::FnDef(def_id, _) = f.literal.ty.sty {
                         // Don't give intrinsics the extra penalty for calls
                         let f = tcx.fn_sig(def_id);
                         if f.abi() == Abi::RustIntrinsic || f.abi() == Abi::PlatformIntrinsic {

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -97,8 +97,7 @@ impl Visitor<'tcx> for OptimizationFinder<'b, 'tcx> {
             let place_ty = place.ty(&self.body.local_decls, self.tcx).ty;
             if let ty::Array(_, len) = place_ty.sty {
                 let span = self.body.source_info(location).span;
-                let ty = self.tcx.types.usize;
-                let constant = Constant { span, ty, literal: len, user_ty: None };
+                let constant = Constant { span, literal: len, user_ty: None };
                 self.optimizations.arrays_lengths.insert(location, constant);
             }
         }

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -249,7 +249,7 @@ trait Qualif {
                 if let ConstValue::Unevaluated(def_id, _) = constant.literal.val {
                     // Don't peek inside trait associated constants.
                     if cx.tcx.trait_of_item(def_id).is_some() {
-                        Self::in_any_value_of_ty(cx, constant.ty).unwrap_or(false)
+                        Self::in_any_value_of_ty(cx, constant.literal.ty).unwrap_or(false)
                     } else {
                         let (bits, _) = cx.tcx.at(constant.span).mir_const_qualif(def_id);
 
@@ -258,7 +258,7 @@ trait Qualif {
                         // Just in case the type is more specific than
                         // the definition, e.g., impl associated const
                         // with type parameters, take it into account.
-                        qualif && Self::mask_for_ty(cx, constant.ty)
+                        qualif && Self::mask_for_ty(cx, constant.literal.ty)
                     }
                 } else {
                     false

--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -224,7 +224,7 @@ fn is_rustc_peek<'a, 'tcx>(
     if let Some(mir::Terminator { ref kind, source_info, .. }) = *terminator {
         if let mir::TerminatorKind::Call { func: ref oper, ref args, .. } = *kind {
             if let mir::Operand::Constant(ref func) = *oper {
-                if let ty::FnDef(def_id, _) = func.ty.sty {
+                if let ty::FnDef(def_id, _) = func.literal.ty.sty {
                     let abi = tcx.fn_sig(def_id).abi();
                     let name = tcx.item_name(def_id);
                     if abi == Abi::RustIntrinsic && name == sym::rustc_peek {

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -970,7 +970,6 @@ where
     fn constant_usize(&self, val: u16) -> Operand<'tcx> {
         Operand::Constant(box Constant {
             span: self.source_info.span,
-            ty: self.tcx().types.usize,
             user_ty: None,
             literal: ty::Const::from_usize(self.tcx(), val.into()),
         })

--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -397,10 +397,9 @@ impl ExtraComments<'tcx> {
 impl Visitor<'tcx> for ExtraComments<'tcx> {
     fn visit_constant(&mut self, constant: &Constant<'tcx>, location: Location) {
         self.super_constant(constant, location);
-        let Constant { span, ty, user_ty, literal } = constant;
+        let Constant { span, user_ty, literal } = constant;
         self.push("mir::Constant");
         self.push(&format!("+ span: {:?}", span));
-        self.push(&format!("+ ty: {:?}", ty));
         if let Some(user_ty) = user_ty {
             self.push(&format!("+ user_ty: {:?}", user_ty));
         }

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -114,26 +114,20 @@ impl TargetDataLayout {
                 [p] if p.starts_with("P") => {
                     dl.instruction_address_space = parse_address_space(&p[1..], "P")?
                 }
-                // FIXME: Ping cfg(bootstrap) -- Use `ref a @ ..` with new bootstrap compiler.
-                ["a", ..] => {
-                    let a = &spec_parts[1..]; // FIXME inline into pattern.
+                ["a", ref a @ ..] => {
                     dl.aggregate_align = align(a, "a")?
                 }
-                ["f32", ..] => {
-                    let a = &spec_parts[1..]; // FIXME inline into pattern.
+                ["f32", ref a @ ..] => {
                     dl.f32_align = align(a, "f32")?
                 }
-                ["f64", ..] => {
-                    let a = &spec_parts[1..]; // FIXME inline into pattern.
+                ["f64", ref a @ ..] => {
                     dl.f64_align = align(a, "f64")?
                 }
-                [p @ "p", s, ..] | [p @ "p0", s, ..] => {
-                    let a = &spec_parts[2..]; // FIXME inline into pattern.
+                [p @ "p", s, ref a @ ..] | [p @ "p0", s, ref a @ ..] => {
                     dl.pointer_size = size(s, p)?;
                     dl.pointer_align = align(a, p)?;
                 }
-                [s, ..] if s.starts_with("i") => {
-                    let a = &spec_parts[1..]; // FIXME inline into pattern.
+                [s, ref a @ ..] if s.starts_with("i") => {
                     let bits = match s[1..].parse::<u64>() {
                         Ok(bits) => bits,
                         Err(_) => {
@@ -157,8 +151,7 @@ impl TargetDataLayout {
                         dl.i128_align = a;
                     }
                 }
-                [s, ..] if s.starts_with("v") => {
-                    let a = &spec_parts[1..]; // FIXME inline into pattern.
+                [s, ref a @ ..] if s.starts_with("v") => {
                     let v_size = size(&s[1..], "v")?;
                     let a = align(a, s)?;
                     if let Some(v) = dl.vector_align.iter_mut().find(|v| v.0 == v_size) {

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1834,9 +1834,7 @@ fn bad_variant_count<'tcx>(tcx: TyCtxt<'tcx>, adt: &'tcx ty::AdtDef, sp: Span, d
     );
     let mut err = struct_span_err!(tcx.sess, sp, E0731, "transparent enum {}", msg);
     err.span_label(sp, &msg);
-    if let &[.., ref end] = &variant_spans[..] {
-        // FIXME: Ping cfg(bootstrap) -- Use `ref start @ ..` with new bootstrap compiler.
-        let start = &variant_spans[..variant_spans.len() - 1];
+    if let &[ref start @ .., ref end] = &variant_spans[..] {
         for variant_span in start {
             err.span_label(*variant_span, "");
         }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -228,7 +228,7 @@
 // std is implemented with unstable features, many of which are internal
 // compiler details that will never be stable
 // NB: the following list is sorted to minimize merge conflicts.
-#![cfg_attr(not(bootstrap), feature(__rust_unstable_column))]
+#![feature(__rust_unstable_column)]
 #![feature(alloc_error_handler)]
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
@@ -513,7 +513,7 @@ pub use std_detect::detect;
 
 // Re-export macros defined in libcore.
 #[stable(feature = "rust1", since = "1.0.0")]
-#[allow(deprecated_in_future)]
+#[allow(deprecated, deprecated_in_future)]
 pub use core::{
     // Stable
     assert_eq,
@@ -531,7 +531,6 @@ pub use core::{
 };
 
 // Re-export built-in macros defined through libcore.
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 pub use core::{
     // Stable

--- a/src/libstd/os/raw/mod.rs
+++ b/src/libstd/os/raw/mod.rs
@@ -8,8 +8,7 @@
 
 #![stable(feature = "raw_os", since = "1.1.0")]
 
-#[cfg_attr(bootstrap, doc(include = "os/raw/char.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "char.md"))]
+#[doc(include = "char.md")]
 #[cfg(any(all(target_os = "linux", any(target_arch = "aarch64",
                                        target_arch = "arm",
                                        target_arch = "hexagon",
@@ -33,8 +32,7 @@
                                          target_arch = "powerpc")),
           all(target_os = "fuchsia", target_arch = "aarch64")))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = u8;
-#[cfg_attr(bootstrap, doc(include = "os/raw/char.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "char.md"))]
+#[doc(include = "char.md")]
 #[cfg(not(any(all(target_os = "linux", any(target_arch = "aarch64",
                                            target_arch = "arm",
                                            target_arch = "hexagon",
@@ -58,51 +56,37 @@
                                              target_arch = "powerpc")),
               all(target_os = "fuchsia", target_arch = "aarch64"))))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_char = i8;
-#[cfg_attr(bootstrap, doc(include = "os/raw/schar.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "schar.md"))]
+#[doc(include = "schar.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_schar = i8;
-#[cfg_attr(bootstrap, doc(include = "os/raw/uchar.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "uchar.md"))]
+#[doc(include = "uchar.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_uchar = u8;
-#[cfg_attr(bootstrap, doc(include = "os/raw/short.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "short.md"))]
+#[doc(include = "short.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_short = i16;
-#[cfg_attr(bootstrap, doc(include = "os/raw/ushort.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "ushort.md"))]
+#[doc(include = "ushort.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_ushort = u16;
-#[cfg_attr(bootstrap, doc(include = "os/raw/int.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "int.md"))]
+#[doc(include = "int.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_int = i32;
-#[cfg_attr(bootstrap, doc(include = "os/raw/uint.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "uint.md"))]
+#[doc(include = "uint.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_uint = u32;
-#[cfg_attr(bootstrap, doc(include = "os/raw/long.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "long.md"))]
+#[doc(include = "long.md")]
 #[cfg(any(target_pointer_width = "32", windows))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i32;
-#[cfg_attr(bootstrap, doc(include = "os/raw/ulong.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "ulong.md"))]
+#[doc(include = "ulong.md")]
 #[cfg(any(target_pointer_width = "32", windows))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u32;
-#[cfg_attr(bootstrap, doc(include = "os/raw/long.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "long.md"))]
+#[doc(include = "long.md")]
 #[cfg(all(target_pointer_width = "64", not(windows)))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_long = i64;
-#[cfg_attr(bootstrap, doc(include = "os/raw/ulong.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "ulong.md"))]
+#[doc(include = "ulong.md")]
 #[cfg(all(target_pointer_width = "64", not(windows)))]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulong = u64;
-#[cfg_attr(bootstrap, doc(include = "os/raw/longlong.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "longlong.md"))]
+#[doc(include = "longlong.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_longlong = i64;
-#[cfg_attr(bootstrap, doc(include = "os/raw/ulonglong.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "ulonglong.md"))]
+#[doc(include = "ulonglong.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_ulonglong = u64;
-#[cfg_attr(bootstrap, doc(include = "os/raw/float.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "float.md"))]
+#[doc(include = "float.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_float = f32;
-#[cfg_attr(bootstrap, doc(include = "os/raw/double.md"))]
-#[cfg_attr(not(bootstrap), doc(include = "double.md"))]
+#[doc(include = "double.md")]
 #[stable(feature = "raw_os", since = "1.1.0")] pub type c_double = f64;
 
 #[stable(feature = "raw_os", since = "1.1.0")]

--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -7,10 +7,6 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 // Re-exported core operators
-#[cfg(bootstrap)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::marker::Copy;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::marker::{Send, Sized, Sync, Unpin};
@@ -24,21 +20,9 @@ pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 pub use crate::mem::drop;
 
 // Re-exported types and traits
-#[cfg(bootstrap)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::clone::Clone;
-#[cfg(bootstrap)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::cmp::{PartialEq, PartialOrd, Eq, Ord};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::convert::{AsRef, AsMut, Into, From};
-#[cfg(bootstrap)]
-#[stable(feature = "rust1", since = "1.0.0")]
-#[doc(no_inline)]
-pub use crate::default::Default;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
 pub use crate::iter::{Iterator, Extend, IntoIterator};
@@ -53,7 +37,6 @@ pub use crate::option::Option::{self, Some, None};
 pub use crate::result::Result::{self, Ok, Err};
 
 // Re-exported built-in macros
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[doc(no_inline)]
 pub use core::prelude::v1::{
@@ -83,7 +66,6 @@ pub use core::prelude::v1::{
 
 // FIXME: Attribute and derive macros are not documented because for them rustdoc generates
 // dead links which fail link checker testing.
-#[cfg(not(bootstrap))]
 #[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
 #[allow(deprecated)]
 #[doc(hidden)]

--- a/src/libstd/sync/mod.rs
+++ b/src/libstd/sync/mod.rs
@@ -163,7 +163,6 @@ pub use self::condvar::{Condvar, WaitTimeoutResult};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::mutex::{Mutex, MutexGuard};
 #[stable(feature = "rust1", since = "1.0.0")]
-#[cfg_attr(bootstrap, allow(deprecated_in_future))]
 #[allow(deprecated)]
 pub use self::once::{Once, OnceState, ONCE_INIT};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/sys/cloudabi/mod.rs
+++ b/src/libstd/sys/cloudabi/mod.rs
@@ -1,4 +1,4 @@
-#![allow(deprecated_in_future)] // mem::uninitialized; becomes `deprecated` when nightly is 1.39
+#![allow(deprecated)] // mem::uninitialized
 
 use crate::io::ErrorKind;
 use crate::mem;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -608,6 +608,7 @@ pub struct FieldPat {
     pub pat: P<Pat>,
     pub is_shorthand: bool,
     pub attrs: ThinVec<Attribute>,
+    pub id: NodeId,
 }
 
 #[derive(Clone, PartialEq, RustcEncodable, RustcDecodable, Debug, Copy)]
@@ -925,6 +926,7 @@ pub struct Arm {
     pub guard: Option<P<Expr>>,
     pub body: P<Expr>,
     pub span: Span,
+    pub id: NodeId,
 }
 
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
@@ -934,6 +936,7 @@ pub struct Field {
     pub span: Span,
     pub is_shorthand: bool,
     pub attrs: ThinVec<Attribute>,
+    pub id: NodeId,
 }
 
 pub type SpannedIdent = Spanned<Ident>;

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -405,7 +405,6 @@ impl MacResult for MacEager {
 /// after hitting errors.
 #[derive(Copy, Clone)]
 pub struct DummyResult {
-    expr_only: bool,
     is_error: bool,
     span: Span,
 }
@@ -416,21 +415,12 @@ impl DummyResult {
     /// Use this as a return value after hitting any errors and
     /// calling `span_err`.
     pub fn any(span: Span) -> Box<dyn MacResult+'static> {
-        Box::new(DummyResult { expr_only: false, is_error: true, span })
+        Box::new(DummyResult { is_error: true, span })
     }
 
     /// Same as `any`, but must be a valid fragment, not error.
     pub fn any_valid(span: Span) -> Box<dyn MacResult+'static> {
-        Box::new(DummyResult { expr_only: false, is_error: false, span })
-    }
-
-    /// Creates a default MacResult that can only be an expression.
-    ///
-    /// Use this for macros that must expand to an expression, so even
-    /// if an error is encountered internally, the user will receive
-    /// an error that they also used it in the wrong place.
-    pub fn expr(span: Span) -> Box<dyn MacResult+'static> {
-        Box::new(DummyResult { expr_only: true, is_error: true, span })
+        Box::new(DummyResult { is_error: false, span })
     }
 
     /// A plain dummy expression.
@@ -472,36 +462,19 @@ impl MacResult for DummyResult {
     }
 
     fn make_items(self: Box<DummyResult>) -> Option<SmallVec<[P<ast::Item>; 1]>> {
-        // this code needs a comment... why not always just return the Some() ?
-        if self.expr_only {
-            None
-        } else {
-            Some(SmallVec::new())
-        }
+        Some(SmallVec::new())
     }
 
     fn make_impl_items(self: Box<DummyResult>) -> Option<SmallVec<[ast::ImplItem; 1]>> {
-        if self.expr_only {
-            None
-        } else {
-            Some(SmallVec::new())
-        }
+        Some(SmallVec::new())
     }
 
     fn make_trait_items(self: Box<DummyResult>) -> Option<SmallVec<[ast::TraitItem; 1]>> {
-        if self.expr_only {
-            None
-        } else {
-            Some(SmallVec::new())
-        }
+        Some(SmallVec::new())
     }
 
     fn make_foreign_items(self: Box<Self>) -> Option<SmallVec<[ast::ForeignItem; 1]>> {
-        if self.expr_only {
-            None
-        } else {
-            Some(SmallVec::new())
-        }
+        Some(SmallVec::new())
     }
 
     fn make_stmts(self: Box<DummyResult>) -> Option<SmallVec<[ast::Stmt; 1]>> {

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -947,8 +947,10 @@ pub fn expr_to_spanned_string<'a>(
     // Update `expr.span`'s ctxt now in case expr is an `include!` macro invocation.
     expr.span = expr.span.apply_mark(cx.current_expansion.id);
 
-    // we want to be able to handle e.g., `concat!("foo", "bar")`
-    cx.expander().visit_expr(&mut expr);
+    // Perform eager expansion on the expression.
+    // We want to be able to handle e.g., `concat!("foo", "bar")`.
+    let expr = cx.expander().fully_expand_fragment(AstFragment::Expr(expr)).make_expr();
+
     Err(match expr.node {
         ast::ExprKind::Lit(ref l) => match l.node {
             ast::LitKind::Str(s, style) => return Ok(respan(expr.span, (s, style))),
@@ -1013,8 +1015,12 @@ pub fn get_exprs_from_tts(cx: &mut ExtCtxt<'_>,
     let mut p = cx.new_parser_from_tts(tts);
     let mut es = Vec::new();
     while p.token != token::Eof {
-        let mut expr = panictry!(p.parse_expr());
-        cx.expander().visit_expr(&mut expr);
+        let expr = panictry!(p.parse_expr());
+
+        // Perform eager expansion on the expression.
+        // We want to be able to handle e.g., `concat!("foo", "bar")`.
+        let expr = cx.expander().fully_expand_fragment(AstFragment::Expr(expr)).make_expr();
+
         es.push(expr);
         if p.eat(&token::Comma) {
             continue;

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -403,6 +403,7 @@ impl<'a> ExtCtxt<'a> {
             span,
             is_shorthand: false,
             attrs: ThinVec::new(),
+            id: ast::DUMMY_NODE_ID,
         }
     }
     pub fn expr_struct(
@@ -612,6 +613,7 @@ impl<'a> ExtCtxt<'a> {
             guard: None,
             body: expr,
             span,
+            id: ast::DUMMY_NODE_ID,
         }
     }
 

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -116,18 +116,6 @@ macro_rules! ast_fragments {
             }
         }
 
-        impl<'a, 'b> MutVisitor for MacroExpander<'a, 'b> {
-            fn filter_map_expr(&mut self, expr: P<ast::Expr>) -> Option<P<ast::Expr>> {
-                self.fully_expand_fragment(AstFragment::OptExpr(Some(expr))).make_opt_expr()
-            }
-            $($(fn $mut_visit_ast(&mut self, ast: &mut $AstTy) {
-                visit_clobber(ast, |ast| self.fully_expand_fragment(AstFragment::$Kind(ast)).$make_ast());
-            })?)*
-            $($(fn $flat_map_ast_elt(&mut self, ast_elt: <$AstTy as IntoIterator>::Item) -> $AstTy {
-                self.fully_expand_fragment(AstFragment::$Kind(smallvec![ast_elt])).$make_ast()
-            })?)*
-        }
-
         impl<'a> MacResult for crate::ext::tt::macro_rules::ParserAnyMacro<'a> {
             $(fn $make_ast(self: Box<crate::ext::tt::macro_rules::ParserAnyMacro<'a>>)
                            -> Option<$AstTy> {
@@ -286,7 +274,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
     }
 
     // Recursively expand all macro invocations in this AST fragment.
-    fn fully_expand_fragment(&mut self, input_fragment: AstFragment) -> AstFragment {
+    pub fn fully_expand_fragment(&mut self, input_fragment: AstFragment) -> AstFragment {
         let orig_expansion_data = self.cx.current_expansion.clone();
         self.cx.current_expansion.depth = 0;
 

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -383,10 +383,11 @@ pub fn noop_visit_use_tree<T: MutVisitor>(use_tree: &mut UseTree, vis: &mut T) {
 }
 
 pub fn noop_visit_arm<T: MutVisitor>(
-    Arm { attrs, pats, guard, body, span }: &mut Arm,
+    Arm { attrs, pats, guard, body, span, id }: &mut Arm,
     vis: &mut T,
 ) {
     visit_attrs(attrs, vis);
+    vis.visit_id(id);
     visit_vec(pats, |pat| vis.visit_pat(pat));
     visit_opt(guard, |guard| vis.visit_expr(guard));
     vis.visit_expr(body);
@@ -808,9 +809,10 @@ pub fn noop_visit_struct_field<T: MutVisitor>(f: &mut StructField, visitor: &mut
 }
 
 pub fn noop_visit_field<T: MutVisitor>(f: &mut Field, vis: &mut T) {
-    let Field { ident, expr, span, is_shorthand: _, attrs } = f;
+    let Field { ident, expr, span, is_shorthand: _, attrs, id } = f;
     vis.visit_ident(ident);
     vis.visit_expr(expr);
+    vis.visit_id(id);
     vis.visit_span(span);
     visit_thin_attrs(attrs, vis);
 }
@@ -1040,8 +1042,12 @@ pub fn noop_visit_pat<T: MutVisitor>(pat: &mut P<Pat>, vis: &mut T) {
         }
         PatKind::Struct(path, fields, _etc) => {
             vis.visit_path(path);
-            for Spanned { node: FieldPat { ident, pat, is_shorthand: _, attrs }, span } in fields {
+            for Spanned {
+                node: FieldPat { ident, pat, is_shorthand: _, attrs, id },
+                span
+            } in fields {
                 vis.visit_ident(ident);
+                vis.visit_id(id);
                 vis.visit_pat(pat);
                 visit_thin_attrs(attrs, vis);
                 vis.visit_span(span);

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -1444,6 +1444,7 @@ impl<'a> Parser<'a> {
             guard,
             body: expr,
             span: lo.to(hi),
+            id: ast::DUMMY_NODE_ID,
         })
     }
 
@@ -1599,6 +1600,7 @@ impl<'a> Parser<'a> {
                         expr: self.mk_expr(self.token.span, ExprKind::Err, ThinVec::new()),
                         is_shorthand: false,
                         attrs: ThinVec::new(),
+                        id: ast::DUMMY_NODE_ID,
                     });
                 }
             }
@@ -1684,6 +1686,7 @@ impl<'a> Parser<'a> {
             expr,
             is_shorthand,
             attrs: attrs.into(),
+            id: ast::DUMMY_NODE_ID,
         })
     }
 

--- a/src/libsyntax/parse/parser/pat.rs
+++ b/src/libsyntax/parse/parser/pat.rs
@@ -620,6 +620,7 @@ impl<'a> Parser<'a> {
                 pat: subpat,
                 is_shorthand,
                 attrs: attrs.into(),
+                id: ast::DUMMY_NODE_ID,
            }
         })
     }

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -47,10 +47,10 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt<'_>,
                        -> Box<dyn base::MacResult + 'cx> {
     let mut inline_asm = match parse_inline_asm(cx, sp, tts) {
         Ok(Some(inline_asm)) => inline_asm,
-        Ok(None) => return DummyResult::expr(sp),
+        Ok(None) => return DummyResult::any(sp),
         Err(mut err) => {
             err.emit();
-            return DummyResult::expr(sp);
+            return DummyResult::any(sp);
         }
     };
 

--- a/src/libsyntax_ext/assert.rs
+++ b/src/libsyntax_ext/assert.rs
@@ -20,7 +20,7 @@ pub fn expand_assert<'cx>(
         Ok(assert) => assert,
         Err(mut err) => {
             err.emit();
-            return DummyResult::expr(sp);
+            return DummyResult::any(sp);
         }
     };
 

--- a/src/libsyntax_ext/cfg.rs
+++ b/src/libsyntax_ext/cfg.rs
@@ -25,7 +25,7 @@ pub fn expand_cfg(
         }
         Err(mut err) => {
             err.emit();
-            DummyResult::expr(sp)
+            DummyResult::any(sp)
         }
     }
 }

--- a/src/libsyntax_ext/concat.rs
+++ b/src/libsyntax_ext/concat.rs
@@ -1,5 +1,5 @@
 use syntax::ast;
-use syntax::ext::base;
+use syntax::ext::base::{self, DummyResult};
 use syntax::symbol::Symbol;
 use syntax::tokenstream;
 
@@ -12,7 +12,7 @@ pub fn expand_syntax_ext(
 ) -> Box<dyn base::MacResult + 'static> {
     let es = match base::get_exprs_from_tts(cx, sp, tts) {
         Some(e) => e,
-        None => return base::DummyResult::expr(sp),
+        None => return DummyResult::any(sp),
     };
     let mut accumulator = String::new();
     let mut missing_literal = vec![];
@@ -55,9 +55,9 @@ pub fn expand_syntax_ext(
         let mut err = cx.struct_span_err(missing_literal, "expected a literal");
         err.note("only literals (like `\"foo\"`, `42` and `3.14`) can be passed to `concat!()`");
         err.emit();
-        return base::DummyResult::expr(sp);
+        return DummyResult::any(sp);
     } else if has_errors {
-        return base::DummyResult::expr(sp);
+        return DummyResult::any(sp);
     }
     let sp = sp.apply_mark(cx.current_expansion.id);
     base::MacEager::expr(cx.expr_str(sp, Symbol::intern(&accumulator)))

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1613,6 +1613,7 @@ impl<'a> TraitDef<'a> {
                         source_map::Spanned {
                             span: pat.span.with_ctxt(self.span.ctxt()),
                             node: ast::FieldPat {
+                                id: ast::DUMMY_NODE_ID,
                                 ident: ident.unwrap(),
                                 pat,
                                 is_shorthand: false,

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -16,7 +16,7 @@ pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
                               tts: &[tokenstream::TokenTree])
                               -> Box<dyn base::MacResult + 'cx> {
     let var = match get_single_str_from_tts(cx, sp, tts, "option_env!") {
-        None => return DummyResult::expr(sp),
+        None => return DummyResult::any(sp),
         Some(v) => v,
     };
 
@@ -50,21 +50,21 @@ pub fn expand_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
     let mut exprs = match get_exprs_from_tts(cx, sp, tts) {
         Some(ref exprs) if exprs.is_empty() => {
             cx.span_err(sp, "env! takes 1 or 2 arguments");
-            return DummyResult::expr(sp);
+            return DummyResult::any(sp);
         }
-        None => return DummyResult::expr(sp),
+        None => return DummyResult::any(sp),
         Some(exprs) => exprs.into_iter(),
     };
 
     let var = match expr_to_string(cx, exprs.next().unwrap(), "expected string literal") {
-        None => return DummyResult::expr(sp),
+        None => return DummyResult::any(sp),
         Some((v, _style)) => v,
     };
     let msg = match exprs.next() {
         None => Symbol::intern(&format!("environment variable `{}` not defined", var)),
         Some(second) => {
             match expr_to_string(cx, second, "expected string literal") {
-                None => return DummyResult::expr(sp),
+                None => return DummyResult::any(sp),
                 Some((s, _style)) => s,
             }
         }
@@ -72,13 +72,13 @@ pub fn expand_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
 
     if exprs.next().is_some() {
         cx.span_err(sp, "env! takes 1 or 2 arguments");
-        return DummyResult::expr(sp);
+        return DummyResult::any(sp);
     }
 
     let e = match env::var(&*var.as_str()) {
         Err(_) => {
             cx.span_err(sp, &msg.as_str());
-            return DummyResult::expr(sp);
+            return DummyResult::any(sp);
         }
         Ok(s) => cx.expr_str(sp, Symbol::intern(&s)),
     };

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -805,7 +805,7 @@ fn expand_format_args_impl<'cx>(
         }
         Err(mut err) => {
             err.emit();
-            DummyResult::expr(sp)
+            DummyResult::any(sp)
         }
     }
 }

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -1,18 +1,17 @@
 use std::mem;
 
+use smallvec::smallvec;
 use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::source_map::{ExpnInfo, ExpnKind, respan};
 use syntax::ext::base::{ExtCtxt, MacroKind};
-use syntax::ext::expand::ExpansionConfig;
+use syntax::ext::expand::{AstFragment, ExpansionConfig};
 use syntax::ext::hygiene::ExpnId;
 use syntax::ext::proc_macro::is_proc_macro_attr;
-use syntax::mut_visit::MutVisitor;
 use syntax::parse::ParseSess;
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym};
 use syntax::visit::{self, Visitor};
-
 use syntax_pos::{Span, DUMMY_SP};
 
 struct ProcMacroDerive {
@@ -409,5 +408,7 @@ fn mk_decls(
         i
     });
 
-    cx.monotonic_expander().flat_map_item(module).pop().unwrap()
+    // Integrate the new module into existing module structures.
+    let module = AstFragment::Items(smallvec![module]);
+    cx.monotonic_expander().fully_expand_fragment(module).make_items().pop().unwrap()
 }

--- a/src/libsyntax_ext/source_util.rs
+++ b/src/libsyntax_ext/source_util.rs
@@ -111,7 +111,7 @@ pub fn expand_include_str(cx: &mut ExtCtxt<'_>, sp: Span, tts: &[tokenstream::To
                           -> Box<dyn base::MacResult+'static> {
     let file = match get_single_str_from_tts(cx, sp, tts, "include_str!") {
         Some(f) => f,
-        None => return DummyResult::expr(sp)
+        None => return DummyResult::any(sp)
     };
     let file = cx.resolve_path(file, sp);
     match fs::read_to_string(&file) {
@@ -126,11 +126,11 @@ pub fn expand_include_str(cx: &mut ExtCtxt<'_>, sp: Span, tts: &[tokenstream::To
         },
         Err(ref e) if e.kind() == ErrorKind::InvalidData => {
             cx.span_err(sp, &format!("{} wasn't a utf-8 file", file.display()));
-            DummyResult::expr(sp)
+            DummyResult::any(sp)
         }
         Err(e) => {
             cx.span_err(sp, &format!("couldn't read {}: {}", file.display(), e));
-            DummyResult::expr(sp)
+            DummyResult::any(sp)
         }
     }
 }
@@ -139,7 +139,7 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt<'_>, sp: Span, tts: &[tokenstream::
                             -> Box<dyn base::MacResult+'static> {
     let file = match get_single_str_from_tts(cx, sp, tts, "include_bytes!") {
         Some(f) => f,
-        None => return DummyResult::expr(sp)
+        None => return DummyResult::any(sp)
     };
     let file = cx.resolve_path(file, sp);
     match fs::read(&file) {
@@ -158,7 +158,7 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt<'_>, sp: Span, tts: &[tokenstream::
         },
         Err(e) => {
             cx.span_err(sp, &format!("couldn't read {}: {}", file.display(), e));
-            DummyResult::expr(sp)
+            DummyResult::any(sp)
         }
     }
 }

--- a/src/libunwind/build.rs
+++ b/src/libunwind/build.rs
@@ -4,13 +4,11 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
 
-    // FIXME: the not(bootstrap) part is needed because of the issue addressed by #62286,
-    // and could be removed once that change is in beta.
-    if cfg!(all(not(bootstrap), feature = "llvm-libunwind")) &&
+    if cfg!(feature = "llvm-libunwind") &&
         (target.contains("linux") ||
          target.contains("fuchsia")) {
         // Build the unwinding from libunwind C/C++ source code.
-        #[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
+        #[cfg(feature = "llvm-libunwind")]
         llvm_libunwind::compile();
     } else if target.contains("linux") {
         if target.contains("musl") {
@@ -46,7 +44,7 @@ fn main() {
     }
 }
 
-#[cfg(all(not(bootstrap), feature = "llvm-libunwind"))]
+#[cfg(feature = "llvm-libunwind")]
 mod llvm_libunwind {
     use std::env;
     use std::path::Path;

--- a/src/libunwind/libunwind.rs
+++ b/src/libunwind/libunwind.rs
@@ -70,7 +70,7 @@ pub enum _Unwind_Context {}
 
 pub type _Unwind_Exception_Cleanup_Fn = extern "C" fn(unwind_code: _Unwind_Reason_Code,
                                                       exception: *mut _Unwind_Exception);
-#[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+#[cfg_attr(all(feature = "llvm-libunwind",
                any(target_os = "fuchsia", target_os = "linux")),
            link(name = "unwind", kind = "static"))]
 extern "C" {
@@ -97,7 +97,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     }
     pub use _Unwind_Action::*;
 
-    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+    #[cfg_attr(all(feature = "llvm-libunwind",
                    any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
@@ -153,7 +153,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
     pub const UNWIND_POINTER_REG: c_int = 12;
     pub const UNWIND_IP_REG: c_int = 15;
 
-    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+    #[cfg_attr(all(feature = "llvm-libunwind",
                    any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
@@ -218,7 +218,7 @@ if #[cfg(all(any(target_os = "ios", target_os = "netbsd", not(target_arch = "arm
 cfg_if::cfg_if! {
 if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     // Not 32-bit iOS
-    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+    #[cfg_attr(all(feature = "llvm-libunwind",
                    any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {
@@ -230,7 +230,7 @@ if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     }
 } else {
     // 32-bit iOS uses SjLj and does not provide _Unwind_Backtrace()
-    #[cfg_attr(all(not(bootstrap), feature = "llvm-libunwind",
+    #[cfg_attr(all(feature = "llvm-libunwind",
                    any(target_os = "fuchsia", target_os = "linux")),
                link(name = "unwind", kind = "static"))]
     extern "C" {

--- a/src/stage0.txt
+++ b/src/stage0.txt
@@ -12,7 +12,7 @@
 # source tarball for a stable release you'll likely see `1.x.0` for rustc and
 # `0.x.0` for Cargo where they were released on `date`.
 
-date: 2019-07-04
+date: 2019-08-13
 rustc: beta
 cargo: beta
 
@@ -25,7 +25,7 @@ cargo: beta
 #
 # This means that there's a small window of time (a few days) where artifacts
 # are downloaded from dev-static.rust-lang.org instead of static.rust-lang.org.
-# In order to ease this transition we have an extra key which is in the 
+# In order to ease this transition we have an extra key which is in the
 # configuration file below. When uncommented this will instruct the bootstrap.py
 # script to download from dev-static.rust-lang.org.
 #

--- a/src/test/ui/async-await/issues/non-async-enclosing-span.rs
+++ b/src/test/ui/async-await/issues/non-async-enclosing-span.rs
@@ -4,8 +4,9 @@
 async fn do_the_thing() -> u8 {
     8
 }
-
-fn main() {
+// #63398: point at the enclosing scope and not the previously seen closure
+fn main() {  //~ NOTE this is not `async`
     let x = move || {};
     let y = do_the_thing().await; //~ ERROR `await` is only allowed inside `async` functions
+    //~^ NOTE only allowed inside `async` functions and blocks
 }

--- a/src/test/ui/async-await/issues/non-async-enclosing-span.stderr
+++ b/src/test/ui/async-await/issues/non-async-enclosing-span.stderr
@@ -1,5 +1,5 @@
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-63398.rs:10:13
+  --> $DIR/non-async-enclosing-span.rs:10:13
    |
 LL | fn main() {
    |    ---- this is not `async`

--- a/src/test/ui/block-expr-precedence.stderr
+++ b/src/test/ui/block-expr-precedence.stderr
@@ -1,0 +1,8 @@
+warning: unnecessary trailing semicolons
+  --> $DIR/block-expr-precedence.rs:60:21
+   |
+LL |   if (true) { 12; };;; -num;
+   |                     ^^ help: remove these semicolons
+   |
+   = note: `#[warn(redundant_semicolon)]` on by default
+

--- a/src/test/ui/commandline-argfile-badutf8.args
+++ b/src/test/ui/commandline-argfile-badutf8.args
@@ -1,0 +1,2 @@
+--cfg
+unbroken€

--- a/src/test/ui/commandline-argfile-badutf8.rs
+++ b/src/test/ui/commandline-argfile-badutf8.rs
@@ -1,0 +1,13 @@
+// Check to see if we can get parameters from an @argsfile file
+//
+// build-fail
+// compile-flags: --cfg cmdline_set @{{src-base}}/commandline-argfile-badutf8.args
+
+#[cfg(not(cmdline_set))]
+compile_error!("cmdline_set not set");
+
+#[cfg(not(unbroken))]
+compile_error!("unbroken not set");
+
+fn main() {
+}

--- a/src/test/ui/commandline-argfile-badutf8.stderr
+++ b/src/test/ui/commandline-argfile-badutf8.stderr
@@ -1,0 +1,2 @@
+error: Argument 19 is not valid: Utf8 error in $DIR/commandline-argfile-badutf8.args
+

--- a/src/test/ui/commandline-argfile-badutf8.stderr
+++ b/src/test/ui/commandline-argfile-badutf8.stderr
@@ -1,2 +1,2 @@
-error: Argument 19 is not valid: Utf8 error in $DIR/commandline-argfile-badutf8.args
+error: Argument 18 is not valid: Utf8 error in $DIR/commandline-argfile-badutf8.args
 

--- a/src/test/ui/commandline-argfile-missing.rs
+++ b/src/test/ui/commandline-argfile-missing.rs
@@ -1,0 +1,13 @@
+// Check to see if we can get parameters from an @argsfile file
+//
+// build-fail
+// compile-flags: --cfg cmdline_set @{{src-base}}/commandline-argfile-missing.args
+
+#[cfg(not(cmdline_set))]
+compile_error!("cmdline_set not set");
+
+#[cfg(not(unbroken))]
+compile_error!("unbroken not set");
+
+fn main() {
+}

--- a/src/test/ui/commandline-argfile-missing.stderr
+++ b/src/test/ui/commandline-argfile-missing.stderr
@@ -1,0 +1,2 @@
+error: Argument 18 is not valid: IO Error: $DIR/commandline-argfile-missing.args: No such file or directory (os error 2)
+

--- a/src/test/ui/commandline-argfile.args
+++ b/src/test/ui/commandline-argfile.args
@@ -1,0 +1,2 @@
+--cfg
+unbroken

--- a/src/test/ui/commandline-argfile.rs
+++ b/src/test/ui/commandline-argfile.rs
@@ -1,0 +1,13 @@
+// Check to see if we can get parameters from an @argsfile file
+//
+// build-pass
+// compile-flags: --cfg cmdline_set @{{src-base}}/commandline-argfile.args
+
+#[cfg(not(cmdline_set))]
+compile_error!("cmdline_set not set");
+
+#[cfg(not(unbroken))]
+compile_error!("unbroken not set");
+
+fn main() {
+}

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -11,10 +11,11 @@ const NON_NULL_PTR: NonNull<u8> = unsafe { mem::transmute(&1) };
 const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
 //~^ ERROR it is undefined behavior to use this value
 
+#[deny(const_err)] // this triggers a `const_err` so validation does not even happen
 const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
-//~^ ERROR it is undefined behavior to use this value
-    let ptr: &(u8, u8, u8) = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
-    let out_of_bounds_ptr = &ptr.2; // use address-of-field for pointer arithmetic
+    let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+    // Use address-of-element for pointer arithmetic. This could wrap around to NULL!
+    let out_of_bounds_ptr = &ptr[255]; //~ ERROR any use of this value will cause an error
     mem::transmute(out_of_bounds_ptr)
 } };
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.stderr
@@ -6,21 +6,26 @@ LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:14:1
+error: any use of this value will cause an error
+  --> $DIR/ub-nonnull.rs:18:29
    |
 LL | / const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
-LL | |
-LL | |     let ptr: &(u8, u8, u8) = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
-LL | |     let out_of_bounds_ptr = &ptr.2; // use address-of-field for pointer arithmetic
+LL | |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+LL | |     // Use address-of-element for pointer arithmetic. This could wrap around to NULL!
+LL | |     let out_of_bounds_ptr = &ptr[255];
+   | |                             ^^^^^^^^^ Memory access failed: pointer must be in-bounds at offset 256, but is outside bounds of allocation 6 which has size 1
 LL | |     mem::transmute(out_of_bounds_ptr)
 LL | | } };
-   | |____^ type validation failed: encountered a potentially NULL pointer, but expected something that cannot possibly fail to be greater or equal to 1
+   | |____-
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+note: lint level defined here
+  --> $DIR/ub-nonnull.rs:14:8
+   |
+LL | #[deny(const_err)] // this triggers a `const_err` so validation does not even happen
+   |        ^^^^^^^^^
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:21:1
+  --> $DIR/ub-nonnull.rs:22:1
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -28,7 +33,7 @@ LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:23:1
+  --> $DIR/ub-nonnull.rs:24:1
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
@@ -36,7 +41,7 @@ LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:30:1
+  --> $DIR/ub-nonnull.rs:31:1
    |
 LL | const UNINIT: NonZeroU8 = unsafe { Transmute { uninit: () }.out };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected something greater or equal to 1
@@ -44,7 +49,7 @@ LL | const UNINIT: NonZeroU8 = unsafe { Transmute { uninit: () }.out };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:38:1
+  --> $DIR/ub-nonnull.rs:39:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
@@ -52,7 +57,7 @@ LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:44:1
+  --> $DIR/ub-nonnull.rs:45:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30

--- a/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
+++ b/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
@@ -28,7 +28,10 @@ error: expected `{`, found `;`
 LL |     if not  // lack of braces is [sic]
    |     -- this `if` statement has a condition, but no block
 LL |         println!("Then when?");
-   |                               ^ expected `{`
+   |                               ^
+   |                               |
+   |                               expected `{`
+   |                               help: try placing this code inside a block: `{ ; }`
 
 error: unexpected `2` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:26:24

--- a/src/test/ui/dropck/dropck_trait_cycle_checked.stderr
+++ b/src/test/ui/dropck/dropck_trait_cycle_checked.stderr
@@ -2,7 +2,7 @@ error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:111:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                                                                               -------- cast requires that `o2` is borrowed for `'static`
+   |                                                                     -------- cast requires that `o2` is borrowed for `'static`
 LL |     o1.set0(&o2);
    |             ^^^ borrowed value does not live long enough
 ...
@@ -13,7 +13,7 @@ error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:112:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                                                                                         -------- cast requires that `o3` is borrowed for `'static`
+   |                                                                     -------- cast requires that `o3` is borrowed for `'static`
 LL |     o1.set0(&o2);
 LL |     o1.set1(&o3);
    |             ^^^ borrowed value does not live long enough
@@ -37,7 +37,7 @@ error[E0597]: `o3` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:114:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                                                                                         -------- cast requires that `o3` is borrowed for `'static`
+   |                                                                               -------- cast requires that `o3` is borrowed for `'static`
 ...
 LL |     o2.set1(&o3);
    |             ^^^ borrowed value does not live long enough
@@ -49,7 +49,7 @@ error[E0597]: `o1` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:115:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                                                                     -------- cast requires that `o1` is borrowed for `'static`
+   |                                                                                         -------- cast requires that `o1` is borrowed for `'static`
 ...
 LL |     o3.set0(&o1);
    |             ^^^ borrowed value does not live long enough
@@ -61,7 +61,7 @@ error[E0597]: `o2` does not live long enough
   --> $DIR/dropck_trait_cycle_checked.rs:116:13
    |
 LL |     let (o1, o2, o3): (Box<dyn Obj>, Box<dyn Obj>, Box<dyn Obj>) = (O::new(), O::new(), O::new());
-   |                                                                               -------- cast requires that `o2` is borrowed for `'static`
+   |                                                                                         -------- cast requires that `o2` is borrowed for `'static`
 ...
 LL |     o3.set1(&o2);
    |             ^^^ borrowed value does not live long enough

--- a/src/test/ui/issues/issue-63398.rs
+++ b/src/test/ui/issues/issue-63398.rs
@@ -1,0 +1,11 @@
+// edition:2018
+#![feature(async_await)]
+
+async fn do_the_thing() -> u8 {
+    8
+}
+
+fn main() {
+    let x = move || {};
+    let y = do_the_thing().await; //~ ERROR `await` is only allowed inside `async` functions
+}

--- a/src/test/ui/issues/issue-63398.stderr
+++ b/src/test/ui/issues/issue-63398.stderr
@@ -1,0 +1,11 @@
+error[E0728]: `await` is only allowed inside `async` functions and blocks
+  --> $DIR/issue-63398.rs:10:13
+   |
+LL | fn main() {
+   |    ---- this is not `async`
+LL |     let x = move || {};
+LL |     let y = do_the_thing().await;
+   |             ^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-qualification.rs
+++ b/src/test/ui/lint/lint-qualification.rs
@@ -1,5 +1,5 @@
 #![deny(unused_qualifications)]
-#[allow(deprecated)]
+#![allow(deprecated)]
 
 mod foo {
     pub fn bar() {}

--- a/src/test/ui/parser/doc-before-semi.rs
+++ b/src/test/ui/parser/doc-before-semi.rs
@@ -3,4 +3,6 @@ fn main() {
     //~^ ERROR found a documentation comment that doesn't document anything
     //~| HELP maybe a comment was intended
     ;
+    //~^ WARNING unnecessary trailing semicolon
+    //~| HELP remove this semicolon
 }

--- a/src/test/ui/parser/doc-before-semi.stderr
+++ b/src/test/ui/parser/doc-before-semi.stderr
@@ -6,6 +6,14 @@ LL |     /// hi
    |
    = help: doc comments must come before what they document, maybe a comment was intended with `//`?
 
+warning: unnecessary trailing semicolon
+  --> $DIR/doc-before-semi.rs:5:5
+   |
+LL |     ;
+   |     ^ help: remove this semicolon
+   |
+   = note: `#[warn(redundant_semicolon)]` on by default
+
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0585`.

--- a/src/test/ui/proc-macro/span-preservation.rs
+++ b/src/test/ui/proc-macro/span-preservation.rs
@@ -9,7 +9,7 @@ extern crate test_macros;
 
 #[recollect_attr]
 fn a() {
-    let x: usize = "hello";;;;; //~ ERROR mismatched types
+    let x: usize = "hello"; //~ ERROR mismatched types
 }
 
 #[recollect_attr]

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -6,7 +6,7 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> $DIR/span-preservation.rs:12:20
    |
-LL |     let x: usize = "hello";;;;;
+LL |     let x: usize = "hello";
    |                    ^^^^^^^ expected usize, found reference
    |
    = note: expected type `usize`


### PR DESCRIPTION
Successful merges:

 - #62984 (Add lint for excess trailing semicolons)
 - #63075 (Miri: Check that a ptr is aligned and inbounds already when evaluating `*`)
 - #63175 (rustc: implement argsfiles for command line)
 - #63490 (libsyntax: cleanup and refactor `pat.rs`)
 - #63495 ( Remove redundant `ty` fields from `mir::Constant` and `hair::pattern::PatternRange`.)
 - #63509 (Point at the right enclosing scope when using `await` in non-async fn)
 - #63528 (syntax: Remove `DummyResult::expr_only`)
 - #63534 (Bump to 1.39)
 - #63537 (expand: Unimplement `MutVisitor` on `MacroExpander`)
 - #63542 (Add NodeId for Arm, Field and FieldPat)

Failed merges:


r? @ghost