### PR TITLE
Remap paths for proc-macro crates.

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -305,6 +305,16 @@ fn main() {
                 cmd.arg("-C").arg("target-feature=-crt-static");
             }
         }
+
+        let crate_type = args.windows(2)
+            .find(|w| &*w[0] == "--crate-type")
+            .and_then(|w| w[1].to_str());
+
+        if let Some("proc-macro") = crate_type {
+            if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {
+                cmd.arg("--remap-path-prefix").arg(&map);
+            }
+        }
     }
 
     // Force all crates compiled by this compiler to (a) be unstable and (b)

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -287,10 +287,6 @@ fn main() {
                 cmd.arg("-C").arg("target-feature=-crt-static");
             }
         }
-
-        if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {
-            cmd.arg("--remap-path-prefix").arg(&map);
-        }
     } else {
         // Override linker if necessary.
         if let Ok(host_linker) = env::var("RUSTC_HOST_LINKER") {
@@ -305,16 +301,10 @@ fn main() {
                 cmd.arg("-C").arg("target-feature=-crt-static");
             }
         }
+    }
 
-        let crate_type = args.windows(2)
-            .find(|w| &*w[0] == "--crate-type")
-            .and_then(|w| w[1].to_str());
-
-        if let Some("proc-macro") = crate_type {
-            if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {
-                cmd.arg("--remap-path-prefix").arg(&map);
-            }
-        }
+    if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {
+        cmd.arg("--remap-path-prefix").arg(&map);
     }
 
     // Force all crates compiled by this compiler to (a) be unstable and (b)


### PR DESCRIPTION
The remap-debuginfo config option remaps paths in most crates, but it does not apply to proc-macros, so they are still non-reproducible.  This patch fixes that.

I'm not completely sure if this is the best way to do this, but to get reproducible builds we need librustc_macros to be built with --remap-path-prefix.  I was previously modifying Cargo to pass that argument to all child crates, so this seems simpler and more correct.

I did not add a test since there do not seem to be any existing tests for RUSTC_DEBUGINFO_MAP.

r? @alexcrichton