### PR TITLE
move test that shouldn't be in test/run-pass/

### DIFF
--- a/src/test/ui/generator/niche-in-generator.rs
+++ b/src/test/ui/generator/niche-in-generator.rs
@@ -1,5 +1,7 @@
 // Test that niche finding works with captured generator upvars.
 
+// run-pass
+
 #![feature(generators)]
 
 use std::mem::size_of_val;


### PR DESCRIPTION
We no longer test `src/test/run-pass/`; the proper way now is `// run-pass` in `src/test/ui/`

r? @petrochenkov 