### PR TITLE
Make Allocation::bytes private

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -176,15 +176,21 @@ impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::Allocation {
         hasher: &mut StableHasher<W>,
     ) {
         let mir::interpret::Allocation {
-            bytes, relocations, undef_mask, align, mutability,
+            relocations, align, mutability, size,
             extra: _,
+            .. /* private bytes and undef_mask */
         } = self;
+
+        let bytes = self.inspect_with_undef_and_ptr_outside_interpreter(0..self.len());
+        let undef_mask = self.undef_mask();
+
         bytes.hash_stable(hcx, hasher);
         relocations.len().hash_stable(hcx, hasher);
         for reloc in relocations.iter() {
             reloc.hash_stable(hcx, hasher);
         }
         undef_mask.hash_stable(hcx, hasher);
+        size.hash_stable(hcx, hasher);
         align.hash_stable(hcx, hasher);
         mutability.hash_stable(hcx, hasher);
     }

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -13,7 +13,18 @@ use rustc_data_structures::sorted_map::SortedMap;
 use rustc_target::abi::HasDataLayout;
 use std::borrow::Cow;
 
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    RustcEncodable,
+    RustcDecodable,
+    HashStable,
+)]
 pub struct Allocation<Tag=(),Extra=()> {
     /// The actual bytes of the allocation.
     /// Note that the bytes of a pointer represent the offset of the pointer.

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -136,7 +136,7 @@ impl<Tag, Extra> Allocation<Tag, Extra> {
         self.size.bytes() as usize
     }
 
-    /// Look at a slice which may describe undefined bytes or describe a relocation. This differs
+    /// Looks at a slice which may describe undefined bytes or describe a relocation. This differs
     /// from `get_bytes_with_undef_and_ptr` in that it does no relocation checks (even on the
     /// edges) at all. It further ignores `AllocationExtra` callbacks.
     /// This must not be used for reads affecting the interpreter execution.
@@ -144,7 +144,7 @@ impl<Tag, Extra> Allocation<Tag, Extra> {
         &self.bytes[range]
     }
 
-    /// View the undef mask.
+    /// Returns the undef mask.
     pub fn undef_mask(&self) -> &UndefMask {
         &self.undef_mask
     }
@@ -583,7 +583,7 @@ pub struct AllocationDefinedness {
 /// Transferring the definedness mask to other allocations.
 impl<Tag, Extra> Allocation<Tag, Extra> {
     /// Creates a run-length encoding of the undef_mask.
-    pub fn compress_defined_range(
+    pub fn compress_undef_range(
         &self,
         src: Pointer<Tag>,
         size: Size,
@@ -622,7 +622,7 @@ impl<Tag, Extra> Allocation<Tag, Extra> {
     }
 
     /// Apply multiple instances of the run-length encoding to the undef_mask.
-    pub fn mark_compressed_range(
+    pub fn mark_compressed_undef_range(
         &mut self,
         defined: &AllocationDefinedness,
         dest: Pointer<Tag>,

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -581,10 +581,11 @@ impl<'tcx, Tag, Extra> Allocation<Tag, Extra> {
 /// Run-length encoding of the undef mask.
 /// Used to copy parts of a mask multiple times to another allocation.
 pub struct AllocationDefinedness {
-    /// The lengths of ranges that are run-length encoded.
-    ranges: smallvec::SmallVec::<[u64; 1]>,
     /// The definedness of the first range.
     initial: bool,
+    /// The lengths of ranges that are run-length encoded.
+    /// The definedness of the ranges alternate starting with `initial`.
+    ranges: smallvec::SmallVec::<[u64; 1]>,
 }
 
 /// Transferring the definedness mask to other allocations.

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -143,6 +143,11 @@ impl<Tag, Extra> Allocation<Tag, Extra> {
     pub fn inspect_with_undef_and_ptr_outside_interpreter(&self, range: Range<usize>) -> &[u8] {
         &self.bytes[range]
     }
+
+    /// View the undef mask.
+    pub fn undef_mask(&self) -> &UndefMask {
+        &self.undef_mask
+    }
 }
 
 impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx Allocation {}

--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -13,6 +13,8 @@ use rustc_data_structures::sorted_map::SortedMap;
 use rustc_target::abi::HasDataLayout;
 use std::borrow::Cow;
 
+// NOTE: When adding new fields, make sure to adjust the Snapshot impl in
+// `src/librustc_mir/interpret/snapshot.rs`.
 #[derive(
     Clone,
     Debug,

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -944,10 +944,16 @@ pub trait PrettyPrinter<'tcx>:
                         .get_bytes(&self.tcx(), ptr, Size::from_bytes(n)).unwrap())
                 },
                 (ConstValue::Slice { data, start, end }, ty::Slice(t)) if *t == u8 => {
-                    Some(&data.bytes[start..end])
+                    // The `inspect` here is okay since we checked the bounds, and there are no
+                    // relocations (we have an active slice reference here). We don't use this
+                    // result to affect interpreter execution.
+                    Some(data.inspect_with_undef_and_ptr_outside_interpreter(start..end))
                 },
                 (ConstValue::Slice { data, start, end }, ty::Str) => {
-                    let slice = &data.bytes[start..end];
+                    // The `inspect` here is okay since we checked the bounds, and there are no
+                    // relocations (we have an active `str` reference here). We don't use this
+                    // result to affect interpreter execution.
+                    let slice = data.inspect_with_undef_and_ptr_outside_interpreter(start..end);
                     let s = ::std::str::from_utf8(slice)
                         .expect("non utf8 str from miri");
                     p!(write("{:?}", s));

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -35,9 +35,9 @@ pub fn const_alloc_to_llvm(cx: &CodegenCx<'ll, '_>, alloc: &Allocation) -> &'ll 
         assert_eq!(offset as usize as u64, offset);
         let offset = offset as usize;
         if offset > next_offset {
-            // This `inspect` is okay since we have check that it is not within a relocation, it is
-            // within the bounds of the allocation, and it doesn't affect interpreter execution (we
-            // inspect the result after interpreter execution). Any undef byte is replaced with
+            // This `inspect` is okay since we have checked that it is not within a relocation, it
+            // is within the bounds of the allocation, and it doesn't affect interpreter execution
+            // (we inspect the result after interpreter execution). Any undef byte is replaced with
             // some arbitrary byte value.
             //
             // FIXME: relay undef bytes to codegen as undef const bytes

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -25,12 +25,12 @@ use rustc::hir::{self, CodegenFnAttrs, CodegenFnAttrFlags};
 use std::ffi::{CStr, CString};
 
 pub fn const_alloc_to_llvm(cx: &CodegenCx<'ll, '_>, alloc: &Allocation) -> &'ll Value {
-    let mut llvals = Vec::with_capacity(alloc.relocations.len() + 1);
+    let mut llvals = Vec::with_capacity(alloc.relocations().len() + 1);
     let dl = cx.data_layout();
     let pointer_size = dl.pointer_size.bytes() as usize;
 
     let mut next_offset = 0;
-    for &(offset, ((), alloc_id)) in alloc.relocations.iter() {
+    for &(offset, ((), alloc_id)) in alloc.relocations().iter() {
         let offset = offset.bytes();
         assert_eq!(offset as usize as u64, offset);
         let offset = offset as usize;
@@ -455,7 +455,7 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                 //
                 // We could remove this hack whenever we decide to drop macOS 10.10 support.
                 if self.tcx.sess.target.target.options.is_like_osx {
-                    assert_eq!(alloc.relocations.len(), 0);
+                    assert_eq!(alloc.relocations().len(), 0);
 
                     let is_zeroed = {
                         // Treats undefined bytes as if they were defined with the byte value that
@@ -490,7 +490,7 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                         section.as_str().as_ptr() as *const _,
                         section.as_str().len() as c_uint,
                     );
-                    assert!(alloc.relocations.is_empty());
+                    assert!(alloc.relocations().is_empty());
 
                     // The `inspect` method is okay here because we checked relocations, and
                     // because we are doing this access to inspect the final interpreter state (not

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -35,11 +35,21 @@ pub fn const_alloc_to_llvm(cx: &CodegenCx<'ll, '_>, alloc: &Allocation) -> &'ll 
         assert_eq!(offset as usize as u64, offset);
         let offset = offset as usize;
         if offset > next_offset {
-            llvals.push(cx.const_bytes(&alloc.bytes[next_offset..offset]));
+            // This `inspect` is okay since we have check that it is not within a relocation, it is
+            // within the bounds of the allocation, and it doesn't affect interpreter execution (we
+            // inspect the result after interpreter execution). Any undef byte is replaced with
+            // some arbitrary byte value.
+            //
+            // FIXME: relay undef bytes to codegen as undef const bytes
+            let bytes = alloc.inspect_with_undef_and_ptr_outside_interpreter(next_offset..offset);
+            llvals.push(cx.const_bytes(bytes));
         }
         let ptr_offset = read_target_uint(
             dl.endian,
-            &alloc.bytes[offset..(offset + pointer_size)],
+            // This `inspect` is okay since it is within the bounds of the allocation, it doesn't
+            // affect interpreter execution (we inspect the result after interpreter execution),
+            // and we properly interpret the relocation as a relocation pointer offset.
+            alloc.inspect_with_undef_and_ptr_outside_interpreter(offset..(offset + pointer_size)),
         ).expect("const_alloc_to_llvm: could not read relocation pointer") as u64;
         llvals.push(cx.scalar_to_backend(
             Pointer::new(alloc_id, Size::from_bytes(ptr_offset)).into(),
@@ -51,8 +61,16 @@ pub fn const_alloc_to_llvm(cx: &CodegenCx<'ll, '_>, alloc: &Allocation) -> &'ll 
         ));
         next_offset = offset + pointer_size;
     }
-    if alloc.bytes.len() >= next_offset {
-        llvals.push(cx.const_bytes(&alloc.bytes[next_offset ..]));
+    if alloc.len() >= next_offset {
+        let range = next_offset..alloc.len();
+        // This `inspect` is okay since we have check that it is after all relocations, it is
+        // within the bounds of the allocation, and it doesn't affect interpreter execution (we
+        // inspect the result after interpreter execution). Any undef byte is replaced with some
+        // arbitrary byte value.
+        //
+        // FIXME: relay undef bytes to codegen as undef const bytes
+        let bytes = alloc.inspect_with_undef_and_ptr_outside_interpreter(range);
+        llvals.push(cx.const_bytes(bytes));
     }
 
     cx.const_struct(&llvals, true)
@@ -437,7 +455,23 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                 //
                 // We could remove this hack whenever we decide to drop macOS 10.10 support.
                 if self.tcx.sess.target.target.options.is_like_osx {
-                    let sect_name = if alloc.bytes.iter().all(|b| *b == 0) {
+                    assert_eq!(alloc.relocations.len(), 0);
+
+                    let is_zeroed = {
+                        // Treats undefined bytes as if they were defined with the byte value that
+                        // happens to be currently assigned in mir. This is valid since reading
+                        // undef bytes may yield arbitrary values.
+                        //
+                        // FIXME: ignore undef bytes even with representation `!= 0`.
+                        //
+                        // The `inspect` method is okay here because we checked relocations, and
+                        // because we are doing this access to inspect the final interpreter state
+                        // (not as part of the interpreter execution).
+                        alloc.inspect_with_undef_and_ptr_outside_interpreter(0..alloc.len())
+                            .iter()
+                            .all(|b| *b == 0)
+                    };
+                    let sect_name = if is_zeroed {
                         CStr::from_bytes_with_nul_unchecked(b"__DATA,__thread_bss\0")
                     } else {
                         CStr::from_bytes_with_nul_unchecked(b"__DATA,__thread_data\0")
@@ -456,10 +490,17 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
                         section.as_str().as_ptr() as *const _,
                         section.as_str().len() as c_uint,
                     );
+                    assert!(alloc.relocations.is_empty());
+
+                    // The `inspect` method is okay here because we checked relocations, and
+                    // because we are doing this access to inspect the final interpreter state (not
+                    // as part of the interpreter execution).
+                    let bytes = alloc.inspect_with_undef_and_ptr_outside_interpreter(
+                        0..alloc.len());
                     let alloc = llvm::LLVMMDStringInContext(
                         self.llcx,
-                        alloc.bytes.as_ptr() as *const _,
-                        alloc.bytes.len() as c_uint,
+                        bytes.as_ptr() as *const _,
+                        bytes.len() as c_uint,
                     );
                     let data = [section, alloc];
                     let meta = llvm::LLVMMDNodeInContext(self.llcx, data.as_ptr(), 2);

--- a/src/librustc_mir/interpret/intern.rs
+++ b/src/librustc_mir/interpret/intern.rs
@@ -94,7 +94,7 @@ impl<'rt, 'mir, 'tcx> InternVisitor<'rt, 'mir, 'tcx> {
         alloc.mutability = mutability;
         // link the alloc id to the actual allocation
         let alloc = tcx.intern_const_alloc(alloc);
-        self.leftover_relocations.extend(alloc.relocations.iter().map(|&(_, ((), reloc))| reloc));
+        self.leftover_relocations.extend(alloc.relocations().iter().map(|&(_, ((), reloc))| reloc));
         tcx.alloc_map.lock().set_alloc_id_memory(ptr.alloc_id, alloc);
         Ok(None)
     }
@@ -316,7 +316,7 @@ pub fn intern_const_alloc_recursive(
             // So we hand-roll the interning logic here again
             let alloc = tcx.intern_const_alloc(alloc);
             tcx.alloc_map.lock().set_alloc_id_memory(alloc_id, alloc);
-            for &(_, ((), reloc)) in alloc.relocations.iter() {
+            for &(_, ((), reloc)) in alloc.relocations().iter() {
                 if leftover_relocations.insert(reloc) {
                     todo.push(reloc);
                 }

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -81,7 +81,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let alloc = alloc_type_name(self.tcx.tcx, substs.type_at(0));
                 let name_id = self.tcx.alloc_map.lock().create_memory_alloc(alloc);
                 let id_ptr = self.memory.tag_static_base_pointer(name_id.into());
-                let alloc_len = alloc.bytes.len() as u64;
+                let alloc_len = alloc.size.bytes();
                 let name_val = Immediate::new_slice(Scalar::Ptr(id_ptr), alloc_len, self);
                 self.write_immediate(name_val, dest)?;
             }

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -221,7 +221,7 @@ pub fn type_name<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> &'tcx ty::Const<'tcx>
         val: ConstValue::Slice {
             data: alloc,
             start: 0,
-            end: alloc.bytes.len(),
+            end: alloc.len(),
         },
         ty: tcx.mk_static_str(),
     })

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -653,7 +653,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 }
                 relocations.push((i, target_id));
             }
-            if alloc.undef_mask.is_range_defined(i, i + Size::from_bytes(1)).is_ok() {
+            if alloc.undef_mask().is_range_defined(i, i + Size::from_bytes(1)).is_ok() {
                 // this `as usize` is fine, since `i` came from a `usize`
                 let i = i.bytes() as usize;
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -900,11 +900,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         assert_eq!(size.bytes() as usize as u64, size.bytes());
 
         let src_alloc = self.get(src.alloc_id)?;
-        let compressed = src_alloc.compress_defined_range(src, size);
+        let compressed = src_alloc.compress_undef_range(src, size);
 
         // now fill in all the data
         let dest_allocation = self.get_mut(dest.alloc_id)?;
-        dest_allocation.mark_compressed_range(&compressed, dest, size, repeat);
+        dest_allocation.mark_compressed_undef_range(&compressed, dest, size, repeat);
 
         Ok(())
     }

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -647,7 +647,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
 
         for i in 0..alloc.size.bytes() {
             let i = Size::from_bytes(i);
-            if let Some(&(_, target_id)) = alloc.relocations.get(&i) {
+            if let Some(&(_, target_id)) = alloc.relocations().get(&i) {
                 if allocs_seen.insert(target_id) {
                     allocs_to_print.push_back(target_id);
                 }
@@ -809,7 +809,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         // (`get_bytes_with_undef_and_ptr` below checks that there are no
         // relocations overlapping the edges; those would not be handled correctly).
         let relocations = {
-            let relocations = self.get(src.alloc_id)?.relocations(self, src, size);
+            let relocations = self.get(src.alloc_id)?.get_relocations(self, src, size);
             if relocations.is_empty() {
                 // nothing to copy, ignore even the `length` loop
                 Vec::new()

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -15,7 +15,7 @@ use rustc::mir::interpret::{
 };
 
 use rustc::ty::{self, TyCtxt};
-use rustc::ty::layout::Align;
+use rustc::ty::layout::{Align, Size};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -276,6 +276,7 @@ struct AllocationSnapshot<'a> {
     relocations: Relocations<(), AllocIdSnapshot<'a>>,
     undef_mask: &'a UndefMask,
     align: &'a Align,
+    size: &'a Size,
     mutability: &'a Mutability,
 }
 
@@ -285,12 +286,27 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
     type Item = AllocationSnapshot<'a>;
 
     fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
-        let Allocation { bytes, relocations, undef_mask, align, mutability, extra: () } = self;
+        let Allocation {
+            relocations,
+            size,
+            align,
+            mutability,
+            extra: (),
+            ..
+        } = self;
+
+        let all_bytes = 0..self.len();
+        // This 'inspect' is okay since following access respects undef and relocations. This does
+        // influence interpreter exeuction, but only to detect the error of cycles in evalution
+        // dependencies.
+        let bytes = self.inspect_with_undef_and_ptr_outside_interpreter(all_bytes);
+        let undef_mask = self.undef_mask();
 
         AllocationSnapshot {
             bytes,
             undef_mask,
             align,
+            size,
             mutability,
             relocations: relocations.snapshot(ctx),
         }

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -287,7 +287,6 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
 
     fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
         let Allocation {
-            relocations,
             size,
             align,
             mutability,
@@ -300,7 +299,9 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
         // influence interpreter exeuction, but only to detect the error of cycles in evalution
         // dependencies.
         let bytes = self.inspect_with_undef_and_ptr_outside_interpreter(all_bytes);
+
         let undef_mask = self.undef_mask();
+        let relocations = self.relocations();
 
         AllocationSnapshot {
             bytes,

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1202,7 +1202,7 @@ fn collect_miri<'tcx>(tcx: TyCtxt<'tcx>, alloc_id: AllocId, output: &mut Vec<Mon
         }
         Some(GlobalAlloc::Memory(alloc)) => {
             trace!("collecting {:?} with {:#?}", alloc_id, alloc);
-            for &((), inner) in alloc.relocations.values() {
+            for &((), inner) in alloc.relocations().values() {
                 collect_miri(tcx, inner, output);
             }
         },
@@ -1268,7 +1268,7 @@ fn collect_const<'tcx>(
             collect_miri(tcx, ptr.alloc_id, output),
         ConstValue::Slice { data: alloc, start: _, end: _ } |
         ConstValue::ByRef { alloc, .. } => {
-            for &((), id) in alloc.relocations.values() {
+            for &((), id) in alloc.relocations().values() {
                 collect_miri(tcx, id, output);
             }
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -1570,7 +1570,7 @@ fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: DefId, span: Span) 
         } else {
             bug!("Matching on non-ByRef static")
         };
-        if alloc.relocations.len() != 0 {
+        if alloc.relocations().len() != 0 {
             let msg = "statics with a custom `#[link_section]` must be a \
                        simple list of bytes on the wasm target with no \
                        extra levels of indirection such as references";


### PR DESCRIPTION
Fixes #62931.

Direct immutable access to the bytes is still possible but redirected through the new method `raw_bytes_with_undef_and_ptr`, similar to `get_bytes_with_undef_and_ptr` but without requiring an interpretation context and not doing *any* relocation or bounds checks. The `size` of the allocation is stored separately which makes access as `Size` and `usize` more ergonomic.

cc: @RalfJung 
