### PR TITLE
Rust 2018: NLL migrate mode => hard error

### DIFF
--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -259,7 +259,10 @@ fn do_mir_borrowck<'a, 'tcx>(
         move_error_reported: BTreeMap::new(),
         uninitialized_error_reported: Default::default(),
         errors_buffer,
-        disable_error_downgrading: false,
+        // Only downgrade errors on Rust 2015 and refuse to do so on Rust 2018.
+        // FIXME(Centril): In Rust 1.40.0, refuse doing so on 2015 as well and
+        // proceed to throwing out the migration infrastructure.
+        disable_error_downgrading: body.span.rust_2018(),
         nonlexical_regioncx: regioncx,
         used_mut: Default::default(),
         used_mut_upvars: SmallVec::new(),

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -164,8 +164,8 @@ fn do_mir_borrowck<'a, 'tcx>(
         };
 
     let mdpe = MoveDataParamEnv {
-        move_data: move_data,
-        param_env: param_env,
+        move_data,
+        param_env,
     };
 
     let dead_unwinds = BitSet::new_empty(body.basic_blocks().len());

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
@@ -1,15 +1,14 @@
-warning[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-migrate-to-nll.rs:28:21
+error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
+  --> $DIR/borrowck-migrate-to-nll.rs:29:21
    |
 LL |     let x = &mut block;
    |             ---------- mutable borrow occurs here
 LL |     let p: &'a u8 = &*block.current;
    |                     ^^^^^^^^^^^^^^^ immutable borrow occurs here
-LL |     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
+...
 LL |     drop(x);
    |          - mutable borrow later used here
-   |
-   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
-   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
-   = note: for more information, try `rustc --explain E0729`
 
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
@@ -4,6 +4,8 @@
 //
 // Therefore, for backwards-compatiblity, under borrowck=migrate the
 // NLL checks will be emitted as *warnings*.
+//
+// In Rust 2018, no errors will be downgraded to warnings.
 
 // NLL mode makes this compile-fail; we cannot currently encode a
 // test that is run-pass or compile-fail based on compare-mode. So
@@ -16,7 +18,6 @@
 //[zflag]compile-flags: -Z borrowck=migrate
 //[edition]edition:2018
 //[zflag] run-pass
-//[edition] run-pass
 
 pub struct Block<'a> {
     current: &'a u8,
@@ -26,6 +27,7 @@ pub struct Block<'a> {
 fn bump<'a>(mut block: &mut Block<'a>) {
     let x = &mut block;
     let p: &'a u8 = &*block.current;
+    //[edition]~^ ERROR cannot borrow `*block.current` as immutable
     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
     drop(x);
     drop(p);

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
@@ -1,11 +1,11 @@
 warning[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-migrate-to-nll.rs:28:21
+  --> $DIR/borrowck-migrate-to-nll.rs:29:21
    |
 LL |     let x = &mut block;
    |             ---------- mutable borrow occurs here
 LL |     let p: &'a u8 = &*block.current;
    |                     ^^^^^^^^^^^^^^^ immutable borrow occurs here
-LL |     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
+...
 LL |     drop(x);
    |          - mutable borrow later used here
    |


### PR DESCRIPTION
As per decision on a language team meeting as described in https://github.com/rust-lang/rust/pull/63565#issuecomment-528563744, we refuse to downgrade NLL errors, that AST borrowck accepts, into warnings and keep them as hard errors.

cc @rust-lang/lang 
cc @rust-lang/wg-compiler-nll 