### PR TITLE
Add HashMap<K, V> to the prelude

### DIFF
--- a/src/libstd/prelude/v1.rs
+++ b/src/libstd/prelude/v1.rs
@@ -119,6 +119,9 @@ pub use crate::boxed::Box;
 pub use crate::borrow::ToOwned;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]
+pub use crate::collections::HashMap;
+#[stable(feature = "rust1", since = "1.0.0")]
+#[doc(no_inline)]
 pub use crate::string::{String, ToString};
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1020,7 +1020,7 @@ pub fn run_tests<F>(opts: &TestOpts, tests: Vec<TestDescAndFn>, mut callback: F)
 where
     F: FnMut(TestEvent) -> io::Result<()>,
 {
-    use std::collections::{self, HashMap};
+    use std::collections;
     use std::hash::BuildHasherDefault;
     use std::sync::mpsc::RecvTimeoutError;
     // Use a deterministic hasher


### PR DESCRIPTION
As discussed in https://internals.rust-lang.org/t/should-the-future-trait-be-part-of-the-prelude/10669/9.