### PR TITLE
Modify librustc_llvm to pass -DNDEBUG while compiling.

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -795,6 +795,9 @@ pub fn build_codegen_backend(builder: &Builder<'_>,
             if builder.config.llvm_use_libcxx {
                 cargo.env("LLVM_USE_LIBCXX", "1");
             }
+            if builder.config.llvm_optimize && !builder.config.llvm_release_debuginfo {
+                cargo.env("LLVM_NDEBUG", "1");
+            }
         }
         _ => panic!("unknown backend: {}", backend),
     }

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -151,6 +151,10 @@ fn main() {
         cfg.define("LLVM_RUSTLLVM", None);
     }
 
+    if env::var_os("LLVM_NDEBUG").is_some() {
+        cfg.define("NDEBUG", None);
+    }
+
     build_helper::rerun_if_changed_anything_in_dir(Path::new("../rustllvm"));
     cfg.file("../rustllvm/PassWrapper.cpp")
        .file("../rustllvm/RustWrapper.cpp")


### PR DESCRIPTION
Currently, librustc_llvm builds are not reproducible because the LLVM files it compiles use the debug version of llvm_unreachable, which uses __FILE__.  To fix this, we propagate NDEBUG from bootstrap if applicable and use it when compiling librustc_llvm.

r? @alexcrichton