### PR TITLE
A couple of comment fixes.

### DIFF
--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -178,8 +178,7 @@ pub trait MetadataLoader {
                           -> Result<MetadataRef, String>;
 }
 
-/// A store of Rust crates, through with their metadata
-/// can be accessed.
+/// A store of Rust crates, through which their metadata can be accessed.
 ///
 /// Note that this trait should probably not be expanding today. All new
 /// functionality should be driven through queries instead!

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -70,7 +70,7 @@ pub struct CrateMetadata {
     // whichever `TyCtxt` is being used to decode those values.
     pub root: schema::CrateRoot<'static>,
 
-    /// For each public item in this crate, we encode a key. When the
+    /// For each definition in this crate, we encode a key. When the
     /// crate is loaded, we read all the keys and put them in this
     /// hashmap, which gives the reverse mapping. This allows us to
     /// quickly retrace a `DefPath`, which is needed for incremental


### PR DESCRIPTION
This change fixes a couple of comments in the compiler code.

The first change was discussed with @eddyb. This one confused me because I thought only *public* defs were in the table (not so).

The second was a typo I noticed yesterday.

OK to go in?