### PR TITLE
add git keyword to submodule comments in config.example.toml

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -141,10 +141,10 @@
 # library and facade crates.
 #compiler-docs = false
 
-# Indicate whether submodules are managed and updated automatically.
+# Indicate whether git submodules are managed and updated automatically.
 #submodules = true
 
-# Update submodules only when the checked out commit in the submodules differs
+# Update git submodules only when the checked out commit in the submodules differs
 # from what is committed in the main rustc repo.
 #fast-submodules = true
 


### PR DESCRIPTION
I searched over config.example.toml file looking for a place to disable git submodules from being updated, and missed the two options related to this because they did not include the keyword git. This pr simply adds git to the relevant comments so hopefully others won't also miss that these options exist.