### PR TITLE
Crank up invalid value lint

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1914,13 +1914,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                 if let hir::ExprKind::Path(ref qpath) = path_expr.node {
                     let def_id = cx.tables.qpath_res(qpath, path_expr.hir_id).opt_def_id()?;
 
-                    if cx.match_def_path(def_id, &ZEROED_PATH) {
+                    if cx.match_def_path(def_id, ZEROED_PATH) {
                         return Some(InitKind::Zeroed);
                     }
-                    if cx.match_def_path(def_id, &UININIT_PATH) {
+                    if cx.match_def_path(def_id, UININIT_PATH) {
                         return Some(InitKind::Uninit);
                     }
-                    if cx.match_def_path(def_id, &TRANSMUTE_PATH) {
+                    if cx.match_def_path(def_id, TRANSMUTE_PATH) {
                         if is_zero(&args[0]) {
                             return Some(InitKind::Zeroed);
                         }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1949,7 +1949,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                 Adt(..) if ty.is_box() => Some((format!("`Box` must be non-null"), None)),
                 FnPtr(..) => Some((format!("Function pointers must be non-null"), None)),
                 Never => Some((format!("The never type (`!`) has no valid value"), None)),
-                // Primitive types with other constraints
+                // Primitive types with other constraints.
                 Bool if init == InitKind::Uninit =>
                     Some((format!("Booleans must be `true` or `false`"), None)),
                 Char if init == InitKind::Uninit =>

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1912,23 +1912,21 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
 
             if let hir::ExprKind::Call(ref path_expr, ref args) = expr.node {
                 if let hir::ExprKind::Path(ref qpath) = path_expr.node {
-                    if let Some(def_id) = cx.tables.qpath_res(qpath, path_expr.hir_id)
-                        .opt_def_id()
-                    {
-                        if cx.match_def_path(def_id, &ZEROED_PATH) {
+                    let def_id = cx.tables.qpath_res(qpath, path_expr.hir_id).opt_def_id()?;
+
+                    if cx.match_def_path(def_id, &ZEROED_PATH) {
+                        return Some(InitKind::Zeroed);
+                    }
+                    if cx.match_def_path(def_id, &UININIT_PATH) {
+                        return Some(InitKind::Uninit);
+                    }
+                    if cx.match_def_path(def_id, &TRANSMUTE_PATH) {
+                        if is_zero(&args[0]) {
                             return Some(InitKind::Zeroed);
                         }
-                        if cx.match_def_path(def_id, &UININIT_PATH) {
-                            return Some(InitKind::Uninit);
-                        }
-                        if cx.match_def_path(def_id, &TRANSMUTE_PATH) {
-                            if is_zero(&args[0]) {
-                                return Some(InitKind::Zeroed);
-                            }
-                        }
-                        // FIXME: Also detect `MaybeUninit::zeroed().assume_init()` and
-                        // `MaybeUninit::uninit().assume_init()`.
                     }
+                    // FIXME: Also detect `MaybeUninit::zeroed().assume_init()` and
+                    // `MaybeUninit::uninit().assume_init()`.
                 }
             }
 

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1971,6 +1971,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                                 })
                             })
                         }
+                        // Multi-variant enums are tricky: if all but one variant are
+                        // uninhabited, we might actually do layout like for a single-variant
+                        // enum, and then even leaving them uninitialized could be okay.
                         _ => None, // Conservative fallback for multi-variant enum.
                     }
                 }
@@ -1978,7 +1981,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for InvalidValue {
                     // Proceed recursively, check all fields.
                     ty.tuple_fields().find_map(|field| ty_find_init_error(tcx, field, init))
                 }
-                // FIXME: *Only for `mem::uninitialized`*, we could also warn for multivariant enum.
                 // Conservative fallback.
                 _ => None,
             }

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -1,5 +1,5 @@
 #![feature(rustc_attrs, const_transmute)]
-#![allow(const_err)] // make sure we cannot allow away the errors tested here
+#![allow(const_err, invalid_value)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 use std::ptr::NonNull;

--- a/src/test/ui/consts/const-eval/ub-ref.rs
+++ b/src/test/ui/consts/const-eval/ub-ref.rs
@@ -1,6 +1,6 @@
 // ignore-tidy-linelength
 #![feature(const_transmute)]
-#![allow(const_err)] // make sure we cannot allow away the errors tested here
+#![allow(const_err, invalid_value)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 

--- a/src/test/ui/consts/const-eval/ub-upvars.rs
+++ b/src/test/ui/consts/const-eval/ub-upvars.rs
@@ -1,5 +1,5 @@
 #![feature(const_transmute)]
-#![allow(const_err)] // make sure we cannot allow away the errors tested here
+#![allow(const_err, invalid_value)] // make sure we cannot allow away the errors tested here
 
 use std::mem;
 

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -56,6 +56,9 @@ fn main() {
         let _val: Wrap<(RefPair, i32)> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: Wrap<(RefPair, i32)> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
+        let _val: bool = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+        let _val: Wrap<char> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
         // Some types that should work just fine.
         let _val: Option<&'static i32> = mem::zeroed();
         let _val: Option<fn()> = mem::zeroed();

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -7,6 +7,7 @@
 #![deny(invalid_value)]
 
 use std::mem::{self, MaybeUninit};
+use std::num::NonZeroU32;
 
 enum Void {}
 
@@ -74,6 +75,11 @@ fn main() {
 
         let _val: NonBig = mem::zeroed();
         let _val: NonBig = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        // Transmute-from-0
+        let _val: &'static i32 = mem::transmute(0usize); //~ ERROR: does not permit zero-initialization
+        let _val: &'static [i32] = mem::transmute((0usize, 0usize)); //~ ERROR: does not permit zero-initialization
+        let _val: NonZeroU32 = mem::transmute(0); //~ ERROR: does not permit zero-initialization
 
         // Some more types that should work just fine.
         let _val: Option<&'static i32> = mem::zeroed();

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -2,7 +2,7 @@
 // This test checks that calling `mem::{uninitialized,zeroed}` with certain types results
 // in a lint.
 
-#![feature(never_type)]
+#![feature(never_type, rustc_attrs)]
 #![allow(deprecated)]
 #![deny(invalid_value)]
 
@@ -15,6 +15,11 @@ struct RefPair((&'static i32, i32));
 
 struct Wrap<T> { wrapped: T }
 enum WrapEnum<T> { Wrapped(T) }
+
+#[rustc_layout_scalar_valid_range_start(0)]
+#[rustc_layout_scalar_valid_range_end(128)]
+#[repr(transparent)]
+pub(crate) struct NonBig(u64);
 
 #[allow(unused)]
 fn generic<T: 'static>() {
@@ -29,6 +34,7 @@ fn generic<T: 'static>() {
 
 fn main() {
     unsafe {
+        // Things that cannot even be zero.
         let _val: ! = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: ! = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
@@ -56,14 +62,23 @@ fn main() {
         let _val: Wrap<(RefPair, i32)> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: Wrap<(RefPair, i32)> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
+        let _val: Vec<i32> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: Vec<i32> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        // Things that can be zero, but not uninit.
+        let _val: bool = mem::zeroed();
         let _val: bool = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        let _val: Wrap<char> = mem::zeroed();
         let _val: Wrap<char> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
-        // Some types that should work just fine.
+        let _val: NonBig = mem::zeroed();
+        let _val: NonBig = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+
+        // Some more types that should work just fine.
         let _val: Option<&'static i32> = mem::zeroed();
         let _val: Option<fn()> = mem::zeroed();
         let _val: MaybeUninit<&'static i32> = mem::zeroed();
-        let _val: bool = mem::zeroed();
         let _val: i32 = mem::zeroed();
     }
 }

--- a/src/test/ui/lint/uninitialized-zeroed.rs
+++ b/src/test/ui/lint/uninitialized-zeroed.rs
@@ -7,6 +7,7 @@
 #![deny(invalid_value)]
 
 use std::mem::{self, MaybeUninit};
+use std::ptr::NonNull;
 use std::num::NonZeroU32;
 
 enum Void {}
@@ -63,8 +64,8 @@ fn main() {
         let _val: Wrap<(RefPair, i32)> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
         let _val: Wrap<(RefPair, i32)> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
-        let _val: Vec<i32> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
-        let _val: Vec<i32> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
+        let _val: NonNull<i32> = mem::zeroed(); //~ ERROR: does not permit zero-initialization
+        let _val: NonNull<i32> = mem::uninitialized(); //~ ERROR: does not permit being left uninitialized
 
         // Things that can be zero, but not uninit.
         let _val: bool = mem::zeroed();

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -285,5 +285,31 @@ note: References must be non-null (in this struct field)
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 22 previous errors
+error: the type `bool` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:59:26
+   |
+LL |         let _val: bool = mem::uninitialized();
+   |                          ^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          this code causes undefined behavior when executed
+   |                          help: use `MaybeUninit<T>` instead
+   |
+   = note: Booleans must be `true` or `false`
+
+error: the type `Wrap<char>` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:60:32
+   |
+LL |         let _val: Wrap<char> = mem::uninitialized();
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                this code causes undefined behavior when executed
+   |                                help: use `MaybeUninit<T>` instead
+   |
+note: Characters must be a valid unicode codepoint (in this struct field)
+  --> $DIR/uninitialized-zeroed.rs:16:18
+   |
+LL | struct Wrap<T> { wrapped: T }
+   |                  ^^^^^^^^^^
+
+error: aborting due to 24 previous errors
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -1,5 +1,5 @@
 error: the type `&'static T` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:22:32
+  --> $DIR/uninitialized-zeroed.rs:27:32
    |
 LL |         let _val: &'static T = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #![deny(invalid_value)]
    = note: References must be non-null
 
 error: the type `&'static T` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:23:32
+  --> $DIR/uninitialized-zeroed.rs:28:32
    |
 LL |         let _val: &'static T = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |         let _val: &'static T = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Wrap<&'static T>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:25:38
+  --> $DIR/uninitialized-zeroed.rs:30:38
    |
 LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      ^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<&'static T>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:26:38
+  --> $DIR/uninitialized-zeroed.rs:31:38
    |
 LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      ^^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `!` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:32:23
+  --> $DIR/uninitialized-zeroed.rs:38:23
    |
 LL |         let _val: ! = mem::zeroed();
    |                       ^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ LL |         let _val: ! = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `!` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:33:23
+  --> $DIR/uninitialized-zeroed.rs:39:23
    |
 LL |         let _val: ! = mem::uninitialized();
    |                       ^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL |         let _val: ! = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:35:30
+  --> $DIR/uninitialized-zeroed.rs:41:30
    |
 LL |         let _val: (i32, !) = mem::zeroed();
    |                              ^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |         let _val: (i32, !) = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:36:30
+  --> $DIR/uninitialized-zeroed.rs:42:30
    |
 LL |         let _val: (i32, !) = mem::uninitialized();
    |                              ^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |         let _val: (i32, !) = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `Void` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:38:26
+  --> $DIR/uninitialized-zeroed.rs:44:26
    |
 LL |         let _val: Void = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |         let _val: Void = mem::zeroed();
    = note: 0-variant enums have no valid value
 
 error: the type `Void` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:39:26
+  --> $DIR/uninitialized-zeroed.rs:45:26
    |
 LL |         let _val: Void = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |         let _val: Void = mem::uninitialized();
    = note: 0-variant enums have no valid value
 
 error: the type `&'static i32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:41:34
+  --> $DIR/uninitialized-zeroed.rs:47:34
    |
 LL |         let _val: &'static i32 = mem::zeroed();
    |                                  ^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |         let _val: &'static i32 = mem::zeroed();
    = note: References must be non-null
 
 error: the type `&'static i32` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:42:34
+  --> $DIR/uninitialized-zeroed.rs:48:34
    |
 LL |         let _val: &'static i32 = mem::uninitialized();
    |                                  ^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |         let _val: &'static i32 = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Ref` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:44:25
+  --> $DIR/uninitialized-zeroed.rs:50:25
    |
 LL |         let _val: Ref = mem::zeroed();
    |                         ^^^^^^^^^^^^^
@@ -159,7 +159,7 @@ LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `Ref` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:45:25
+  --> $DIR/uninitialized-zeroed.rs:51:25
    |
 LL |         let _val: Ref = mem::uninitialized();
    |                         ^^^^^^^^^^^^^^^^^^^^
@@ -174,7 +174,7 @@ LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `fn()` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:47:26
+  --> $DIR/uninitialized-zeroed.rs:53:26
    |
 LL |         let _val: fn() = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |         let _val: fn() = mem::zeroed();
    = note: Function pointers must be non-null
 
 error: the type `fn()` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:48:26
+  --> $DIR/uninitialized-zeroed.rs:54:26
    |
 LL |         let _val: fn() = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL |         let _val: fn() = mem::uninitialized();
    = note: Function pointers must be non-null
 
 error: the type `Wrap<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:50:32
+  --> $DIR/uninitialized-zeroed.rs:56:32
    |
 LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -211,7 +211,7 @@ LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:51:32
+  --> $DIR/uninitialized-zeroed.rs:57:32
    |
 LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -226,7 +226,7 @@ LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `WrapEnum<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:53:36
+  --> $DIR/uninitialized-zeroed.rs:59:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    ^^^^^^^^^^^^^
@@ -241,7 +241,7 @@ LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `WrapEnum<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:54:36
+  --> $DIR/uninitialized-zeroed.rs:60:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    ^^^^^^^^^^^^^^^^^^^^
@@ -256,7 +256,7 @@ LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:56:42
+  --> $DIR/uninitialized-zeroed.rs:62:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          ^^^^^^^^^^^^^
@@ -271,7 +271,7 @@ LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:57:42
+  --> $DIR/uninitialized-zeroed.rs:63:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          ^^^^^^^^^^^^^^^^^^^^
@@ -285,8 +285,38 @@ note: References must be non-null (in this struct field)
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
+error: the type `std::vec::Vec<i32>` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:65:30
+   |
+LL |         let _val: Vec<i32> = mem::zeroed();
+   |                              ^^^^^^^^^^^^^
+   |                              |
+   |                              this code causes undefined behavior when executed
+   |                              help: use `MaybeUninit<T>` instead
+   |
+note: std::ptr::Unique<i32> must be non-null (in this struct field)
+  --> $SRC_DIR/liballoc/raw_vec.rs:LL:COL
+   |
+LL |     ptr: Unique<T>,
+   |     ^^^^^^^^^^^^^^
+
+error: the type `std::vec::Vec<i32>` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:66:30
+   |
+LL |         let _val: Vec<i32> = mem::uninitialized();
+   |                              ^^^^^^^^^^^^^^^^^^^^
+   |                              |
+   |                              this code causes undefined behavior when executed
+   |                              help: use `MaybeUninit<T>` instead
+   |
+note: std::ptr::Unique<i32> must be non-null (in this struct field)
+  --> $SRC_DIR/liballoc/raw_vec.rs:LL:COL
+   |
+LL |     ptr: Unique<T>,
+   |     ^^^^^^^^^^^^^^
+
 error: the type `bool` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:59:26
+  --> $DIR/uninitialized-zeroed.rs:70:26
    |
 LL |         let _val: bool = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -297,7 +327,7 @@ LL |         let _val: bool = mem::uninitialized();
    = note: Booleans must be `true` or `false`
 
 error: the type `Wrap<char>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:60:32
+  --> $DIR/uninitialized-zeroed.rs:73:32
    |
 LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -311,5 +341,16 @@ note: Characters must be a valid unicode codepoint (in this struct field)
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
-error: aborting due to 24 previous errors
+error: the type `NonBig` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:76:28
+   |
+LL |         let _val: NonBig = mem::uninitialized();
+   |                            ^^^^^^^^^^^^^^^^^^^^
+   |                            |
+   |                            this code causes undefined behavior when executed
+   |                            help: use `MaybeUninit<T>` instead
+   |
+   = note: NonBig must be initialized inside its custom valid range
+
+error: aborting due to 27 previous errors
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -1,5 +1,5 @@
 error: the type `&'static T` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:27:32
+  --> $DIR/uninitialized-zeroed.rs:28:32
    |
 LL |         let _val: &'static T = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #![deny(invalid_value)]
    = note: References must be non-null
 
 error: the type `&'static T` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:28:32
+  --> $DIR/uninitialized-zeroed.rs:29:32
    |
 LL |         let _val: &'static T = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |         let _val: &'static T = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Wrap<&'static T>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:30:38
+  --> $DIR/uninitialized-zeroed.rs:31:38
    |
 LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      ^^^^^^^^^^^^^
@@ -35,13 +35,13 @@ LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:16:18
+  --> $DIR/uninitialized-zeroed.rs:17:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<&'static T>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:31:38
+  --> $DIR/uninitialized-zeroed.rs:32:38
    |
 LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      ^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:16:18
+  --> $DIR/uninitialized-zeroed.rs:17:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `!` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:38:23
+  --> $DIR/uninitialized-zeroed.rs:39:23
    |
 LL |         let _val: ! = mem::zeroed();
    |                       ^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ LL |         let _val: ! = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `!` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:39:23
+  --> $DIR/uninitialized-zeroed.rs:40:23
    |
 LL |         let _val: ! = mem::uninitialized();
    |                       ^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL |         let _val: ! = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:41:30
+  --> $DIR/uninitialized-zeroed.rs:42:30
    |
 LL |         let _val: (i32, !) = mem::zeroed();
    |                              ^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |         let _val: (i32, !) = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:42:30
+  --> $DIR/uninitialized-zeroed.rs:43:30
    |
 LL |         let _val: (i32, !) = mem::uninitialized();
    |                              ^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |         let _val: (i32, !) = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `Void` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:44:26
+  --> $DIR/uninitialized-zeroed.rs:45:26
    |
 LL |         let _val: Void = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |         let _val: Void = mem::zeroed();
    = note: 0-variant enums have no valid value
 
 error: the type `Void` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:45:26
+  --> $DIR/uninitialized-zeroed.rs:46:26
    |
 LL |         let _val: Void = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |         let _val: Void = mem::uninitialized();
    = note: 0-variant enums have no valid value
 
 error: the type `&'static i32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:47:34
+  --> $DIR/uninitialized-zeroed.rs:48:34
    |
 LL |         let _val: &'static i32 = mem::zeroed();
    |                                  ^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |         let _val: &'static i32 = mem::zeroed();
    = note: References must be non-null
 
 error: the type `&'static i32` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:48:34
+  --> $DIR/uninitialized-zeroed.rs:49:34
    |
 LL |         let _val: &'static i32 = mem::uninitialized();
    |                                  ^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |         let _val: &'static i32 = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Ref` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:50:25
+  --> $DIR/uninitialized-zeroed.rs:51:25
    |
 LL |         let _val: Ref = mem::zeroed();
    |                         ^^^^^^^^^^^^^
@@ -153,13 +153,13 @@ LL |         let _val: Ref = mem::zeroed();
    |                         help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:13:12
+  --> $DIR/uninitialized-zeroed.rs:14:12
    |
 LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `Ref` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:51:25
+  --> $DIR/uninitialized-zeroed.rs:52:25
    |
 LL |         let _val: Ref = mem::uninitialized();
    |                         ^^^^^^^^^^^^^^^^^^^^
@@ -168,13 +168,13 @@ LL |         let _val: Ref = mem::uninitialized();
    |                         help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:13:12
+  --> $DIR/uninitialized-zeroed.rs:14:12
    |
 LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `fn()` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:53:26
+  --> $DIR/uninitialized-zeroed.rs:54:26
    |
 LL |         let _val: fn() = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |         let _val: fn() = mem::zeroed();
    = note: Function pointers must be non-null
 
 error: the type `fn()` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:54:26
+  --> $DIR/uninitialized-zeroed.rs:55:26
    |
 LL |         let _val: fn() = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL |         let _val: fn() = mem::uninitialized();
    = note: Function pointers must be non-null
 
 error: the type `Wrap<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:56:32
+  --> $DIR/uninitialized-zeroed.rs:57:32
    |
 LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -205,13 +205,13 @@ LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:16:18
+  --> $DIR/uninitialized-zeroed.rs:17:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:57:32
+  --> $DIR/uninitialized-zeroed.rs:58:32
    |
 LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -220,13 +220,13 @@ LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:16:18
+  --> $DIR/uninitialized-zeroed.rs:17:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `WrapEnum<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:59:36
+  --> $DIR/uninitialized-zeroed.rs:60:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    ^^^^^^^^^^^^^
@@ -235,13 +235,13 @@ LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this enum field)
-  --> $DIR/uninitialized-zeroed.rs:17:28
+  --> $DIR/uninitialized-zeroed.rs:18:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `WrapEnum<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:60:36
+  --> $DIR/uninitialized-zeroed.rs:61:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    ^^^^^^^^^^^^^^^^^^^^
@@ -250,13 +250,13 @@ LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this enum field)
-  --> $DIR/uninitialized-zeroed.rs:17:28
+  --> $DIR/uninitialized-zeroed.rs:18:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:62:42
+  --> $DIR/uninitialized-zeroed.rs:63:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          ^^^^^^^^^^^^^
@@ -265,13 +265,13 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:14:16
+  --> $DIR/uninitialized-zeroed.rs:15:16
    |
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:63:42
+  --> $DIR/uninitialized-zeroed.rs:64:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          ^^^^^^^^^^^^^^^^^^^^
@@ -280,13 +280,13 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:14:16
+  --> $DIR/uninitialized-zeroed.rs:15:16
    |
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
 error: the type `std::vec::Vec<i32>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:65:30
+  --> $DIR/uninitialized-zeroed.rs:66:30
    |
 LL |         let _val: Vec<i32> = mem::zeroed();
    |                              ^^^^^^^^^^^^^
@@ -301,7 +301,7 @@ LL |     ptr: Unique<T>,
    |     ^^^^^^^^^^^^^^
 
 error: the type `std::vec::Vec<i32>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:66:30
+  --> $DIR/uninitialized-zeroed.rs:67:30
    |
 LL |         let _val: Vec<i32> = mem::uninitialized();
    |                              ^^^^^^^^^^^^^^^^^^^^
@@ -316,7 +316,7 @@ LL |     ptr: Unique<T>,
    |     ^^^^^^^^^^^^^^
 
 error: the type `bool` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:70:26
+  --> $DIR/uninitialized-zeroed.rs:71:26
    |
 LL |         let _val: bool = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +327,7 @@ LL |         let _val: bool = mem::uninitialized();
    = note: Booleans must be `true` or `false`
 
 error: the type `Wrap<char>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:73:32
+  --> $DIR/uninitialized-zeroed.rs:74:32
    |
 LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -336,13 +336,13 @@ LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Characters must be a valid unicode codepoint (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:16:18
+  --> $DIR/uninitialized-zeroed.rs:17:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `NonBig` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:76:28
+  --> $DIR/uninitialized-zeroed.rs:77:28
    |
 LL |         let _val: NonBig = mem::uninitialized();
    |                            ^^^^^^^^^^^^^^^^^^^^
@@ -352,5 +352,38 @@ LL |         let _val: NonBig = mem::uninitialized();
    |
    = note: NonBig must be initialized inside its custom valid range
 
-error: aborting due to 27 previous errors
+error: the type `&'static i32` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:80:34
+   |
+LL |         let _val: &'static i32 = mem::transmute(0usize);
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  this code causes undefined behavior when executed
+   |                                  help: use `MaybeUninit<T>` instead
+   |
+   = note: References must be non-null
+
+error: the type `&'static [i32]` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:81:36
+   |
+LL |         let _val: &'static [i32] = mem::transmute((0usize, 0usize));
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    this code causes undefined behavior when executed
+   |                                    help: use `MaybeUninit<T>` instead
+   |
+   = note: References must be non-null
+
+error: the type `std::num::NonZeroU32` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:82:32
+   |
+LL |         let _val: NonZeroU32 = mem::transmute(0);
+   |                                ^^^^^^^^^^^^^^^^^
+   |                                |
+   |                                this code causes undefined behavior when executed
+   |                                help: use `MaybeUninit<T>` instead
+   |
+   = note: std::num::NonZeroU32 must be non-null
+
+error: aborting due to 30 previous errors
 

--- a/src/test/ui/lint/uninitialized-zeroed.stderr
+++ b/src/test/ui/lint/uninitialized-zeroed.stderr
@@ -1,5 +1,5 @@
 error: the type `&'static T` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:28:32
+  --> $DIR/uninitialized-zeroed.rs:29:32
    |
 LL |         let _val: &'static T = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL | #![deny(invalid_value)]
    = note: References must be non-null
 
 error: the type `&'static T` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:29:32
+  --> $DIR/uninitialized-zeroed.rs:30:32
    |
 LL |         let _val: &'static T = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |         let _val: &'static T = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Wrap<&'static T>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:31:38
+  --> $DIR/uninitialized-zeroed.rs:32:38
    |
 LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      ^^^^^^^^^^^^^
@@ -35,13 +35,13 @@ LL |         let _val: Wrap<&'static T> = mem::zeroed();
    |                                      help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:17:18
+  --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<&'static T>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:32:38
+  --> $DIR/uninitialized-zeroed.rs:33:38
    |
 LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      ^^^^^^^^^^^^^^^^^^^^
@@ -50,13 +50,13 @@ LL |         let _val: Wrap<&'static T> = mem::uninitialized();
    |                                      help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:17:18
+  --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `!` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:39:23
+  --> $DIR/uninitialized-zeroed.rs:40:23
    |
 LL |         let _val: ! = mem::zeroed();
    |                       ^^^^^^^^^^^^^
@@ -67,7 +67,7 @@ LL |         let _val: ! = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `!` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:40:23
+  --> $DIR/uninitialized-zeroed.rs:41:23
    |
 LL |         let _val: ! = mem::uninitialized();
    |                       ^^^^^^^^^^^^^^^^^^^^
@@ -78,7 +78,7 @@ LL |         let _val: ! = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:42:30
+  --> $DIR/uninitialized-zeroed.rs:43:30
    |
 LL |         let _val: (i32, !) = mem::zeroed();
    |                              ^^^^^^^^^^^^^
@@ -89,7 +89,7 @@ LL |         let _val: (i32, !) = mem::zeroed();
    = note: The never type (`!`) has no valid value
 
 error: the type `(i32, !)` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:43:30
+  --> $DIR/uninitialized-zeroed.rs:44:30
    |
 LL |         let _val: (i32, !) = mem::uninitialized();
    |                              ^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |         let _val: (i32, !) = mem::uninitialized();
    = note: The never type (`!`) has no valid value
 
 error: the type `Void` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:45:26
+  --> $DIR/uninitialized-zeroed.rs:46:26
    |
 LL |         let _val: Void = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL |         let _val: Void = mem::zeroed();
    = note: 0-variant enums have no valid value
 
 error: the type `Void` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:46:26
+  --> $DIR/uninitialized-zeroed.rs:47:26
    |
 LL |         let _val: Void = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |         let _val: Void = mem::uninitialized();
    = note: 0-variant enums have no valid value
 
 error: the type `&'static i32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:48:34
+  --> $DIR/uninitialized-zeroed.rs:49:34
    |
 LL |         let _val: &'static i32 = mem::zeroed();
    |                                  ^^^^^^^^^^^^^
@@ -133,7 +133,7 @@ LL |         let _val: &'static i32 = mem::zeroed();
    = note: References must be non-null
 
 error: the type `&'static i32` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:49:34
+  --> $DIR/uninitialized-zeroed.rs:50:34
    |
 LL |         let _val: &'static i32 = mem::uninitialized();
    |                                  ^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +144,7 @@ LL |         let _val: &'static i32 = mem::uninitialized();
    = note: References must be non-null
 
 error: the type `Ref` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:51:25
+  --> $DIR/uninitialized-zeroed.rs:52:25
    |
 LL |         let _val: Ref = mem::zeroed();
    |                         ^^^^^^^^^^^^^
@@ -153,13 +153,13 @@ LL |         let _val: Ref = mem::zeroed();
    |                         help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:14:12
+  --> $DIR/uninitialized-zeroed.rs:15:12
    |
 LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `Ref` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:52:25
+  --> $DIR/uninitialized-zeroed.rs:53:25
    |
 LL |         let _val: Ref = mem::uninitialized();
    |                         ^^^^^^^^^^^^^^^^^^^^
@@ -168,13 +168,13 @@ LL |         let _val: Ref = mem::uninitialized();
    |                         help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:14:12
+  --> $DIR/uninitialized-zeroed.rs:15:12
    |
 LL | struct Ref(&'static i32);
    |            ^^^^^^^^^^^^
 
 error: the type `fn()` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:54:26
+  --> $DIR/uninitialized-zeroed.rs:55:26
    |
 LL |         let _val: fn() = mem::zeroed();
    |                          ^^^^^^^^^^^^^
@@ -185,7 +185,7 @@ LL |         let _val: fn() = mem::zeroed();
    = note: Function pointers must be non-null
 
 error: the type `fn()` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:55:26
+  --> $DIR/uninitialized-zeroed.rs:56:26
    |
 LL |         let _val: fn() = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -196,7 +196,7 @@ LL |         let _val: fn() = mem::uninitialized();
    = note: Function pointers must be non-null
 
 error: the type `Wrap<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:57:32
+  --> $DIR/uninitialized-zeroed.rs:58:32
    |
 LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                ^^^^^^^^^^^^^
@@ -205,13 +205,13 @@ LL |         let _val: Wrap<fn()> = mem::zeroed();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:17:18
+  --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `Wrap<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:58:32
+  --> $DIR/uninitialized-zeroed.rs:59:32
    |
 LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -220,13 +220,13 @@ LL |         let _val: Wrap<fn()> = mem::uninitialized();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:17:18
+  --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `WrapEnum<fn()>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:60:36
+  --> $DIR/uninitialized-zeroed.rs:61:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    ^^^^^^^^^^^^^
@@ -235,13 +235,13 @@ LL |         let _val: WrapEnum<fn()> = mem::zeroed();
    |                                    help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this enum field)
-  --> $DIR/uninitialized-zeroed.rs:18:28
+  --> $DIR/uninitialized-zeroed.rs:19:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `WrapEnum<fn()>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:61:36
+  --> $DIR/uninitialized-zeroed.rs:62:36
    |
 LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    ^^^^^^^^^^^^^^^^^^^^
@@ -250,13 +250,13 @@ LL |         let _val: WrapEnum<fn()> = mem::uninitialized();
    |                                    help: use `MaybeUninit<T>` instead
    |
 note: Function pointers must be non-null (in this enum field)
-  --> $DIR/uninitialized-zeroed.rs:18:28
+  --> $DIR/uninitialized-zeroed.rs:19:28
    |
 LL | enum WrapEnum<T> { Wrapped(T) }
    |                            ^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:63:42
+  --> $DIR/uninitialized-zeroed.rs:64:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          ^^^^^^^^^^^^^
@@ -265,13 +265,13 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::zeroed();
    |                                          help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:15:16
+  --> $DIR/uninitialized-zeroed.rs:16:16
    |
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
 error: the type `Wrap<(RefPair, i32)>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:64:42
+  --> $DIR/uninitialized-zeroed.rs:65:42
    |
 LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          ^^^^^^^^^^^^^^^^^^^^
@@ -280,43 +280,35 @@ LL |         let _val: Wrap<(RefPair, i32)> = mem::uninitialized();
    |                                          help: use `MaybeUninit<T>` instead
    |
 note: References must be non-null (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:15:16
+  --> $DIR/uninitialized-zeroed.rs:16:16
    |
 LL | struct RefPair((&'static i32, i32));
    |                ^^^^^^^^^^^^^^^^^^^
 
-error: the type `std::vec::Vec<i32>` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:66:30
+error: the type `std::ptr::NonNull<i32>` does not permit zero-initialization
+  --> $DIR/uninitialized-zeroed.rs:67:34
    |
-LL |         let _val: Vec<i32> = mem::zeroed();
-   |                              ^^^^^^^^^^^^^
-   |                              |
-   |                              this code causes undefined behavior when executed
-   |                              help: use `MaybeUninit<T>` instead
+LL |         let _val: NonNull<i32> = mem::zeroed();
+   |                                  ^^^^^^^^^^^^^
+   |                                  |
+   |                                  this code causes undefined behavior when executed
+   |                                  help: use `MaybeUninit<T>` instead
    |
-note: std::ptr::Unique<i32> must be non-null (in this struct field)
-  --> $SRC_DIR/liballoc/raw_vec.rs:LL:COL
-   |
-LL |     ptr: Unique<T>,
-   |     ^^^^^^^^^^^^^^
+   = note: std::ptr::NonNull<i32> must be non-null
 
-error: the type `std::vec::Vec<i32>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:67:30
+error: the type `std::ptr::NonNull<i32>` does not permit being left uninitialized
+  --> $DIR/uninitialized-zeroed.rs:68:34
    |
-LL |         let _val: Vec<i32> = mem::uninitialized();
-   |                              ^^^^^^^^^^^^^^^^^^^^
-   |                              |
-   |                              this code causes undefined behavior when executed
-   |                              help: use `MaybeUninit<T>` instead
+LL |         let _val: NonNull<i32> = mem::uninitialized();
+   |                                  ^^^^^^^^^^^^^^^^^^^^
+   |                                  |
+   |                                  this code causes undefined behavior when executed
+   |                                  help: use `MaybeUninit<T>` instead
    |
-note: std::ptr::Unique<i32> must be non-null (in this struct field)
-  --> $SRC_DIR/liballoc/raw_vec.rs:LL:COL
-   |
-LL |     ptr: Unique<T>,
-   |     ^^^^^^^^^^^^^^
+   = note: std::ptr::NonNull<i32> must be non-null
 
 error: the type `bool` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:71:26
+  --> $DIR/uninitialized-zeroed.rs:72:26
    |
 LL |         let _val: bool = mem::uninitialized();
    |                          ^^^^^^^^^^^^^^^^^^^^
@@ -327,7 +319,7 @@ LL |         let _val: bool = mem::uninitialized();
    = note: Booleans must be `true` or `false`
 
 error: the type `Wrap<char>` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:74:32
+  --> $DIR/uninitialized-zeroed.rs:75:32
    |
 LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                ^^^^^^^^^^^^^^^^^^^^
@@ -336,13 +328,13 @@ LL |         let _val: Wrap<char> = mem::uninitialized();
    |                                help: use `MaybeUninit<T>` instead
    |
 note: Characters must be a valid unicode codepoint (in this struct field)
-  --> $DIR/uninitialized-zeroed.rs:17:18
+  --> $DIR/uninitialized-zeroed.rs:18:18
    |
 LL | struct Wrap<T> { wrapped: T }
    |                  ^^^^^^^^^^
 
 error: the type `NonBig` does not permit being left uninitialized
-  --> $DIR/uninitialized-zeroed.rs:77:28
+  --> $DIR/uninitialized-zeroed.rs:78:28
    |
 LL |         let _val: NonBig = mem::uninitialized();
    |                            ^^^^^^^^^^^^^^^^^^^^
@@ -353,7 +345,7 @@ LL |         let _val: NonBig = mem::uninitialized();
    = note: NonBig must be initialized inside its custom valid range
 
 error: the type `&'static i32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:80:34
+  --> $DIR/uninitialized-zeroed.rs:81:34
    |
 LL |         let _val: &'static i32 = mem::transmute(0usize);
    |                                  ^^^^^^^^^^^^^^^^^^^^^^
@@ -364,7 +356,7 @@ LL |         let _val: &'static i32 = mem::transmute(0usize);
    = note: References must be non-null
 
 error: the type `&'static [i32]` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:81:36
+  --> $DIR/uninitialized-zeroed.rs:82:36
    |
 LL |         let _val: &'static [i32] = mem::transmute((0usize, 0usize));
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -375,7 +367,7 @@ LL |         let _val: &'static [i32] = mem::transmute((0usize, 0usize));
    = note: References must be non-null
 
 error: the type `std::num::NonZeroU32` does not permit zero-initialization
-  --> $DIR/uninitialized-zeroed.rs:82:32
+  --> $DIR/uninitialized-zeroed.rs:83:32
    |
 LL |         let _val: NonZeroU32 = mem::transmute(0);
    |                                ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
* Warn against uninit `bool` and `char`.
* Warn against 0-init `NonNull` and friends
* Detect transmute-from-0 as zero-initialization ([seen in the wild](https://github.com/glium/glium/issues/1775#issuecomment-522144636))