### PR TITLE
convert \r\n -> \n in include_str! macro

### DIFF
--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -978,7 +978,9 @@ pub(crate) mod builtin {
     /// modules are found)
     ///
     /// This macro will yield an expression of type `&'static str` which is the
-    /// contents of the file.
+    /// contents of the file. The string is normalized:
+    ///   * Byte Order Mark (BOM), if any, is removed,
+    ///   * DOS line endings (`\r\n`) are converted to `\n`.
     ///
     /// # Examples
     ///

--- a/src/test/ui/include-macros/normalization.rs
+++ b/src/test/ui/include-macros/normalization.rs
@@ -7,6 +7,6 @@ fn main() {
     );
     assert_eq!(
         include_str!("data.bin"),
-        "\u{FEFF}This file starts with BOM.\r\nLines are separated by \\r\\n.\r\n",
+        "This file starts with BOM.\nLines are separated by \\r\\n.\n",
     );
 }

--- a/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
+++ b/src/test/ui/lexer-crlf-line-endings-string-literal-doc-comment.rs
@@ -36,6 +36,7 @@ literal";
     assert_eq!(s, "byte string\nliteral".as_bytes());
 
     // validate that our source file has CRLF endings
-    let source = include_str!("lexer-crlf-line-endings-string-literal-doc-comment.rs");
+    let source = include_bytes!("lexer-crlf-line-endings-string-literal-doc-comment.rs");
+    let source = std::str::from_utf8(&source[..]).unwrap();
     assert!(source.contains("string\r\nliteral"));
 }


### PR DESCRIPTION
Edit: lang team response https://github.com/rust-lang/rust/pull/63681#issuecomment-538167844 (after [2019-10-03 meeting](https://internals.rust-lang.org/t/lang-team-meetings/9573/20?u=scottmcm))

---

Ideally, the meaning of the program should be independent of the line
endings used, because, for example, git can change line endings during
a checkout.

We currently do line-ending conversion in almost all cases, with
`include_str` being an exception. This commit removes this exception,
bringing `include_str` closer in behavior to string literals.

Note that this is technically a breaking change.

In case that you really mean to include a string with DOS line
endings, you can use `include_bytes!` macro which is guaranteed to not
do any translation, like this

    pub fn my_text() -> &'static str {
        unsafe {
            std::str::from_utf8_unchecked(MY_TEXT_BYTES);
        }
    }

    const MY_TEXT_BYTES: &[u8] = include_bytes("my_text.bin");

    #[test]
    fn test_encoding() {
        std::str::from_utf8(MY_TEXT_BYTES)
	    .unwrap();
    }

cc @petrochenkov, @rust-lang/lang 

Some preliminary discussion in https://github.com/rust-lang/rust/pull/63525#discussion_r313506636