### PR TITLE
WIP: Initial implementation of or-pattern handling in MIR

### DIFF
--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -1480,8 +1480,14 @@ fn pat_constructors<'tcx>(
                 Some(vec![Slice(pat_len)])
             }
         }
-        PatKind::Or { .. } => {
-            bug!("support for or-patterns has not been fully implemented yet.");
+        PatKind::Or { ref pats } => {
+            let mut v = vec![];
+            for pat in pats {
+                if let Some(ctors) = pat_constructors(cx, pat, pcx) {
+                    v.extend(ctors);
+                }
+            }
+            Some(v)
         }
     }
 }
@@ -2053,8 +2059,14 @@ fn specialize<'p, 'a: 'p, 'tcx>(
             }
         }
 
-        PatKind::Or { .. } => {
-            bug!("support for or-patterns has not been fully implemented yet.");
+        PatKind::Or { ref pats } => {
+            let mut specialized_pats = vec![];
+            for pat in pats {
+                if let Some(s) = specialize(cx, &[pat], constructor, wild_patterns) {
+                    specialized_pats.extend(s);
+                }
+            }
+            Some(SmallVec::from_vec(specialized_pats))
         }
     };
     debug!("specialize({:#?}, {:#?}) = {:#?}", r[0], wild_patterns, head);

--- a/src/test/ui/or-patterns/basic-switch.rs
+++ b/src/test/ui/or-patterns/basic-switch.rs
@@ -1,0 +1,32 @@
+// Test basic or-patterns when the target pattern type will be lowered to a
+// `SwitchInt` (an `enum`).
+// run-pass
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete and may cause the compiler to crash
+
+#[derive(Debug)]
+enum Test {
+    Foo,
+    Bar,
+    Baz,
+    Qux
+}
+
+fn test(x: Option<Test>) -> bool {
+    match x {
+        // most simple case
+        Some(Test::Bar | Test::Qux) => true,
+        // wild case
+        Some(_) => false,
+        // empty case
+        None => false,
+    }
+}
+
+fn main() {
+    assert!(!test(Some(Test::Foo)));
+    assert!(test(Some(Test::Bar)));
+    assert!(!test(Some(Test::Baz)));
+    assert!(test(Some(Test::Qux)));
+    assert!(!test(None))
+}

--- a/src/test/ui/or-patterns/basic-switch.stderr
+++ b/src/test/ui/or-patterns/basic-switch.stderr
@@ -1,0 +1,8 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/basic-switch.rs:4:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/or-patterns/basic-switchint.rs
+++ b/src/test/ui/or-patterns/basic-switchint.rs
@@ -1,0 +1,56 @@
+// Test basic or-patterns when the target pattern type will be lowered to
+// a `Switch`. This will happen when the target type is an integer.
+// run-pass
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete and may cause the compiler to crash
+
+#[derive(Debug, PartialEq)]
+enum MatchArm {
+    Arm(usize),
+    Wild
+}
+
+#[derive(Debug)]
+enum Foo {
+    One(usize),
+    Two(usize, usize),
+}
+
+fn test_foo(x: Foo) -> MatchArm {
+    match x {
+        // normal pattern.
+        Foo::One(0) | Foo::One(1) | Foo::One(2) => MatchArm::Arm(0),
+        // most simple or-pattern.
+        Foo::One(42 | 255) => MatchArm::Arm(1),
+        // multiple or-patterns for one structure.
+        Foo::Two(42 | 255, 1024 | 2048) => MatchArm::Arm(2),
+        // mix of pattern types in one or-pattern (range).
+        //
+        // FIXME(dlrobertson | Nadrieril): Fix or-pattern completeness and
+        // unreachabilitychecks for ranges.
+        Foo::One(100 | 110..=120 | 210..=220) => MatchArm::Arm(3),
+        // multiple or-patterns with wild.
+        Foo::Two(0..=10 | 100..=110, 0 | _) => MatchArm::Arm(4),
+        // wild
+        _ => MatchArm::Wild
+    }
+}
+
+fn main() {
+    // `Foo` tests.
+    assert_eq!(test_foo(Foo::One(0)), MatchArm::Arm(0));
+    assert_eq!(test_foo(Foo::One(42)), MatchArm::Arm(1));
+    assert_eq!(test_foo(Foo::One(43)), MatchArm::Wild);
+    assert_eq!(test_foo(Foo::One(255)), MatchArm::Arm(1));
+    assert_eq!(test_foo(Foo::One(256)), MatchArm::Wild);
+    assert_eq!(test_foo(Foo::Two(42, 1023)), MatchArm::Wild);
+    assert_eq!(test_foo(Foo::Two(255, 2048)), MatchArm::Arm(2));
+    assert_eq!(test_foo(Foo::One(100)), MatchArm::Arm(3));
+    assert_eq!(test_foo(Foo::One(115)), MatchArm::Arm(3));
+    assert_eq!(test_foo(Foo::One(105)), MatchArm::Wild);
+    assert_eq!(test_foo(Foo::One(215)), MatchArm::Arm(3));
+    assert_eq!(test_foo(Foo::One(121)), MatchArm::Wild);
+    assert_eq!(test_foo(Foo::Two(0, 42)), MatchArm::Arm(4));
+    assert_eq!(test_foo(Foo::Two(100, 0)), MatchArm::Arm(4));
+    assert_eq!(test_foo(Foo::Two(42, 0)), MatchArm::Wild);
+}

--- a/src/test/ui/or-patterns/basic-switchint.stderr
+++ b/src/test/ui/or-patterns/basic-switchint.stderr
@@ -1,0 +1,22 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/basic-switchint.rs:4:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: unreachable pattern
+  --> $DIR/basic-switchint.rs:31:9
+   |
+LL |         Foo::One(100 | 110..=120 | 210..=220) => MatchArm::Arm(3),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unreachable_patterns)]` on by default
+
+warning: unreachable pattern
+  --> $DIR/basic-switchint.rs:33:9
+   |
+LL |         Foo::Two(0..=10 | 100..=110, 0 | _) => MatchArm::Arm(4),
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+

--- a/src/test/ui/or-patterns/mix-with-wild.rs
+++ b/src/test/ui/or-patterns/mix-with-wild.rs
@@ -1,0 +1,20 @@
+// Test that an or-pattern works with a wild pattern. This tests two things:
+//
+//  1) The Wild pattern should cause the pattern to always succeed.
+//  2) or-patterns should work with simplifyable patterns.
+//
+// run-pass
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete and may cause the compiler to crash
+
+pub fn test(x: Option<usize>) -> bool {
+    match x {
+        Some(0 | _) => true,
+        _ => false
+    }
+}
+
+fn main() {
+    assert!(test(Some(42)));
+    assert!(!test(None));
+}

--- a/src/test/ui/or-patterns/mix-with-wild.stderr
+++ b/src/test/ui/or-patterns/mix-with-wild.stderr
@@ -1,0 +1,8 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/mix-with-wild.rs:7:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+

--- a/src/test/ui/or-patterns/struct-like.rs
+++ b/src/test/ui/or-patterns/struct-like.rs
@@ -1,0 +1,48 @@
+// run-pass
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete and may cause the compiler to crash
+
+#[derive(Debug)]
+enum Other {
+    One,
+    Two,
+    Three,
+}
+
+#[derive(Debug)]
+enum Test {
+    Foo { first: usize, second: usize },
+    Bar { other: Option<Other> },
+    Baz,
+}
+
+fn test(x: Option<Test>) -> bool {
+    match x {
+        Some(
+            Test::Foo {
+                first: 1024 | 2048,
+                second: 2048 | 4096
+            } |
+            Test::Bar { other: Some(
+                Other::One |
+                Other::Two
+            )}
+        ) => true,
+        // wild case
+        Some(_) => false,
+        // empty case
+        None => false,
+    }
+}
+
+fn main() {
+    assert!(test(Some(Test::Foo { first: 1024, second: 4096 })));
+    assert!(!test(Some(Test::Foo { first: 2048, second: 8192 })));
+    assert!(!test(Some(Test::Foo { first: 42, second: 2048 })));
+    assert!(test(Some(Test::Bar { other: Some(Other::One) })));
+    assert!(test(Some(Test::Bar { other: Some(Other::Two) })));
+    assert!(!test(Some(Test::Bar { other: Some(Other::Three) })));
+    assert!(!test(Some(Test::Bar { other: None })));
+    assert!(!test(Some(Test::Baz)));
+    assert!(!test(None));
+}

--- a/src/test/ui/or-patterns/struct-like.stderr
+++ b/src/test/ui/or-patterns/struct-like.stderr
@@ -1,0 +1,8 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/struct-like.rs:2:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
Building on https://github.com/rust-lang/rust/pull/64508, https://github.com/rust-lang/rust/pull/64111, https://github.com/rust-lang/rust/pull/63693, and https://github.com/rust-lang/rust/pull/61708, this PR adds:

 - Initial implementation of or-pattern lowering to MIR.
 - Basic `ui` tests for or-patterns

CC #54883

r? @matthewjasper 