### PR TITLE
Fix suggestion from incorrect `move async` to `async move`.

### DIFF
--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -1190,7 +1190,16 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         );
 
         let suggestion = match tcx.sess.source_map().span_to_snippet(args_span) {
-            Ok(string) => format!("move {}", string),
+            Ok(mut string) => {
+                if string.starts_with("async ") {
+                    string.insert_str(6, "move ");
+                } else if string.starts_with("async|") {
+                    string.insert_str(5, " move");
+                } else {
+                    string.insert_str(0, "move ");
+                };
+                string
+            },
             Err(_) => "move |<args>| <body>".to_string()
         };
 

--- a/src/test/ui/async-await/async-borrowck-escaping-closure-error.rs
+++ b/src/test/ui/async-await/async-borrowck-escaping-closure-error.rs
@@ -1,0 +1,10 @@
+// edition:2018
+#![feature(async_closure,async_await)]
+fn foo() -> Box<dyn std::future::Future<Output = u32>> {
+    let x = 0u32;
+    Box::new((async || x)())
+    //~^ ERROR E0373
+}
+
+fn main() {
+}

--- a/src/test/ui/async-await/async-borrowck-escaping-closure-error.stderr
+++ b/src/test/ui/async-await/async-borrowck-escaping-closure-error.stderr
@@ -1,0 +1,21 @@
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/async-borrowck-escaping-closure-error.rs:5:15
+   |
+LL |     Box::new((async || x)())
+   |               ^^^^^^^^ - `x` is borrowed here
+   |               |
+   |               may outlive borrowed value `x`
+   |
+note: closure is returned here
+  --> $DIR/async-borrowck-escaping-closure-error.rs:5:5
+   |
+LL |     Box::new((async || x)())
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |     Box::new((async move || x)())
+   |               ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0373`.


### PR DESCRIPTION
PR for #61920. Happy with the test. There must be a better implementation though - possibly a MIR visitor to estabilsh a span that doesn't include the `async` keyword?