### PR TITLE
Expose simple constructor for Comments struct in pretty-printer

### DIFF
--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -130,7 +130,7 @@ impl<'a> State<'a> {
                           -> State<'a> {
         State {
             s: pp::mk_printer(),
-            comments: Some(Comments::new(cm, sess, filename, input)),
+            comments: Some(Comments::gather(cm, sess, filename, input)),
             ann,
         }
     }

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -54,18 +54,23 @@ pub struct Comments<'a> {
 }
 
 impl<'a> Comments<'a> {
-    pub fn new(
+    pub fn new(cm: &'a SourceMap, comments: Vec<comments::Comment>) -> Comments<'a> {
+        Comments {
+            cm,
+            comments,
+            current: 0,
+        }
+    }
+
+    /// Parse comments from `input` into a new `Comments` struct.
+    pub fn gather(
         cm: &'a SourceMap,
         sess: &ParseSess,
         filename: FileName,
         input: String,
     ) -> Comments<'a> {
         let comments = comments::gather_comments(sess, filename, input);
-        Comments {
-            cm,
-            comments,
-            current: 0,
-        }
+        Self::new(cm, comments)
     }
 
     pub fn next(&self) -> Option<comments::Comment> {
@@ -111,7 +116,7 @@ pub fn print_crate<'a>(cm: &'a SourceMap,
                        is_expanded: bool) -> String {
     let mut s = State {
         s: pp::mk_printer(),
-        comments: Some(Comments::new(cm, sess, filename, input)),
+        comments: Some(Comments::gather(cm, sess, filename, input)),
         ann,
         is_expanded,
     };


### PR DESCRIPTION
We use the libsyntax pretty printer to write out Rust AST, and we used to be able to control the placement of new comments by modifying the pretty printer comments vector directly. Since 0eb2e566c1d9ee6526e670802debda9c0afabde5 comments are now stored in a struct, but the only way I can see to generate that struct is by parsing comments out of an input file.

Would a public constructor for `pprust::Comments` be alright so we can generate new, synthetic comments and use our own `SourceMap`?

r? @Mark-Simulacrum 