### PR TITLE
Restore the rustc_plugin crate in the sysroot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "rustc_interface",
  "rustc_metadata",
  "rustc_mir",
+ "rustc_plugin",
  "rustc_plugin_impl",
  "rustc_save_analysis",
  "rustc_target",
@@ -3370,6 +3371,13 @@ dependencies = [
  "rustc_errors",
  "syntax",
  "syntax_pos",
+]
+
+[[package]]
+name = "rustc_plugin"
+version = "0.0.0"
+dependencies = [
+ "rustc_plugin_impl",
 ]
 
 [[package]]

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -20,6 +20,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_mir = { path = "../librustc_mir" }
+rustc_plugin = { path = "../librustc_plugin/deprecated" } # To get this in the sysroot
 rustc_plugin_impl = { path = "../librustc_plugin" }
 rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }

--- a/src/librustc_plugin/deprecated/lib.rs
+++ b/src/librustc_plugin/deprecated/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(staged_api)]
-#![unstable(feature = "rustc_plugin", issue = "29597")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![rustc_deprecated(since = "1.38.0", reason = "\
     import this through `rustc_driver::plugin` instead to make TLS work correctly. \
     See https://github.com/rust-lang/rust/issues/62717")]


### PR DESCRIPTION
It was accidentally removed in a rebase of https://github.com/rust-lang/rust/pull/62727

Fixes https://github.com/rust-lang/rust/issues/63729 (rls build failure)