### PR TITLE
Make the generator-locals debuginfo test resilient to re-ordering.

### DIFF
--- a/src/test/debuginfo/generator-locals.rs
+++ b/src/test/debuginfo/generator-locals.rs
@@ -13,16 +13,9 @@
 // gdb-check:$3 = 7
 // gdb-command:continue
 // gdb-command:print a
-// gdb-check:$4 = 7
+// gdb-check:$4 = 8
 // gdb-command:print c
 // gdb-check:$5 = 6
-// gdb-command:print e
-// gdb-check:$6 = 8
-// gdb-command:continue
-// gdb-command:print a
-// gdb-check:$7 = 8
-// gdb-command:print c
-// gdb-check:$8 = 6
 
 // === LLDB TESTS ==================================================================================
 
@@ -38,20 +31,10 @@
 // lldbr-check:(int) d = 7
 // lldb-command:continue
 // lldb-command:print a
-// lldbg-check:(int) $3 = 7
-// lldbr-check:(int) a = 7
-// lldb-command:print c
-// lldbg-check:(int) $4 = 6
-// lldbr-check:(int) c = 6
-// lldb-command:print e
-// lldbg-check:(int) $5 = 8
-// lldbr-check:(int) e = 8
-// lldb-command:continue
-// lldb-command:print a
-// lldbg-check:(int) $6 = 8
+// lldbg-check:(int) $3 = 8
 // lldbr-check:(int) a = 8
 // lldb-command:print c
-// lldbg-check:(int) $7 = 6
+// lldbg-check:(int) $4 = 6
 // lldbr-check:(int) c = 6
 
 #![feature(omit_gdb_pretty_printer_section, generators, generator_trait)]
@@ -71,7 +54,6 @@ fn main() {
         a = d;
 
         let e = 8; // Live across zero yield points
-        _zzz(); // #break
         a = e;
 
         yield;


### PR DESCRIPTION
Hi,

In my Rust fork a made an unrelated change and found that the `generator-locals` debuginfo test would fail.

The relevant part of the test looks like this:
```
fn main() {
    let mut a = 5;
    let mut b = || {
        let c = 6; // Live across multiple yield points

        let d = 7; // Live across only one yield point
        yield;
        _zzz(); // #break
        a = d;

        let e = 8; // Live across zero yield points
        _zzz(); // #break
        a = e;

        yield;
        _zzz(); // #break
        a = c;
    };
    Pin::new(&mut b).resume();
    Pin::new(&mut b).resume();
    Pin::new(&mut b).resume();
    _zzz(); // #break
}
```

The test asserts that at the second breakpoint `a=7`, but I got `a=5`.

Here's the thing, I believe both `a=7` *and* `a=5` to be valid, as any code between the two yields (including the break point itself) could be re-ordered.

Assuming that is correct, how can we fix this? Here I've opted to remove the "un-anchored" breakpoint (and its associated checks), however, we could have just as easily (I think) called `_zzz()` through a `black_box` (probably passing `(a, c, d, e)` though too).

Thoughts?