### PR TITLE
Allow git to merge `Cargo.lock`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@
 src/etc/installer/gfx/* binary
 *.woff binary
 src/vendor/** -text
-Cargo.lock -merge linguist-generated=false
+Cargo.lock linguist-generated=false
 
 # Older git versions try to fix line endings on images, this prevents it.
 *.png binary


### PR DESCRIPTION
This commit backs out #46539 in order to fully leverage #63579 where
`git` should be able to merge `Cargo.lock` nowadays with only minimal
conflicts.