### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,7 @@
 src/etc/installer/gfx/* binary
 *.woff binary
 src/vendor/** -text
-Cargo.lock -merge linguist-generated=false
+Cargo.lock linguist-generated=false
 
 # Older git versions try to fix line endings on images, this prevents it.
 *.png binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,6 +3189,7 @@ dependencies = [
  "rustc_interface",
  "rustc_metadata",
  "rustc_mir",
+ "rustc_plugin",
  "rustc_plugin_impl",
  "rustc_save_analysis",
  "rustc_target",
@@ -3370,6 +3371,13 @@ dependencies = [
  "rustc_errors",
  "syntax",
  "syntax_pos",
+]
+
+[[package]]
+name = "rustc_plugin"
+version = "0.0.0"
+dependencies = [
+ "rustc_plugin_impl",
 ]
 
 [[package]]

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -859,12 +859,12 @@ impl<'a> Builder<'a> {
             stage = compiler.stage;
         }
 
-        let mut extra_args = env::var(&format!("RUSTFLAGS_STAGE_{}", stage)).unwrap_or_default();
+        let mut extra_args = String::new();
         if stage != 0 {
-            let s = env::var("RUSTFLAGS_STAGE_NOT_0").unwrap_or_default();
-            if !extra_args.is_empty() {
-                extra_args.push_str(" ");
-            }
+            let s = env::var("RUSTFLAGS_NOT_BOOTSTRAP").unwrap_or_default();
+            extra_args.push_str(&s);
+        } else {
+            let s = env::var("RUSTFLAGS_BOOTSTRAP").unwrap_or_default();
             extra_args.push_str(&s);
         }
 

--- a/src/libcore/iter/adapters/chain.rs
+++ b/src/libcore/iter/adapters/chain.rs
@@ -173,17 +173,23 @@ impl<A, B> Iterator for Chain<A, B> where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (a_lower, a_upper) = self.a.size_hint();
-        let (b_lower, b_upper) = self.b.size_hint();
+        match self.state {
+            ChainState::Both => {
+                let (a_lower, a_upper) = self.a.size_hint();
+                let (b_lower, b_upper) = self.b.size_hint();
 
-        let lower = a_lower.saturating_add(b_lower);
+                let lower = a_lower.saturating_add(b_lower);
 
-        let upper = match (a_upper, b_upper) {
-            (Some(x), Some(y)) => x.checked_add(y),
-            _ => None
-        };
+                let upper = match (a_upper, b_upper) {
+                    (Some(x), Some(y)) => x.checked_add(y),
+                    _ => None
+                };
 
-        (lower, upper)
+                (lower, upper)
+            }
+            ChainState::Front => self.a.size_hint(),
+            ChainState::Back => self.b.size_hint(),
+        }
     }
 }
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -4612,6 +4612,22 @@ impl<'a, T> DoubleEndedIterator for ChunksExactMut<'a, T> {
             Some(tail)
         }
     }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let len = self.len();
+        if n >= len {
+            self.v = &mut [];
+            None
+        } else {
+            let start = (len - 1 - n) * self.chunk_size;
+            let end = start + self.chunk_size;
+            let (temp, _tail) = mem::replace(&mut self.v, &mut []).split_at_mut(end);
+            let (head, nth_back) = temp.split_at_mut(start);
+            self.v = head;
+            Some(nth_back)
+        }
+    }
 }
 
 #[stable(feature = "chunks_exact", since = "1.31.0")]

--- a/src/libcore/tests/iter.rs
+++ b/src/libcore/tests/iter.rs
@@ -153,6 +153,54 @@ fn test_iterator_chain_find() {
 }
 
 #[test]
+fn test_iterator_chain_size_hint() {
+    struct Iter {
+        is_empty: bool,
+    }
+
+    impl Iterator for Iter {
+        type Item = ();
+
+        // alternates between `None` and `Some(())`
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.is_empty {
+                self.is_empty = false;
+                None
+            } else {
+                self.is_empty = true;
+                Some(())
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            if self.is_empty {
+                (0, Some(0))
+            } else {
+                (1, Some(1))
+            }
+        }
+    }
+
+    impl DoubleEndedIterator for Iter {
+        fn next_back(&mut self) -> Option<Self::Item> {
+            self.next()
+        }
+    }
+
+    // this chains an iterator of length 0 with an iterator of length 1,
+    // so after calling `.next()` once, the iterator is empty and the
+    // state is `ChainState::Back`. `.size_hint()` should now disregard
+    // the size hint of the left iterator
+    let mut iter = Iter { is_empty: true }.chain(once(()));
+    assert_eq!(iter.next(), Some(()));
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+
+    let mut iter = once(()).chain(Iter { is_empty: true });
+    assert_eq!(iter.next_back(), Some(()));
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test]
 fn test_zip_nth() {
     let xs = [0, 1, 2, 4, 5];
     let ys = [10, 11, 12];

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -375,6 +375,25 @@ fn test_chunks_exact_mut_nth() {
 }
 
 #[test]
+fn test_chunks_exact_mut_nth_back() {
+    let v: &mut [i32] = &mut [0, 1, 2, 3, 4, 5];
+    let mut c = v.chunks_exact_mut(2);
+    assert_eq!(c.nth_back(1).unwrap(), &[2, 3]);
+    assert_eq!(c.next().unwrap(), &[0, 1]);
+    assert_eq!(c.next(), None);
+
+    let v2: &mut [i32] = &mut [0, 1, 2, 3, 4];
+    let mut c2 = v2.chunks_exact_mut(3);
+    assert_eq!(c2.nth_back(0).unwrap(), &[0, 1, 2]);
+    assert_eq!(c2.next(), None);
+    assert_eq!(c2.next_back(), None);
+
+    let v3: &mut [i32] = &mut [0, 1, 2, 3, 4];
+    let mut c3 = v3.chunks_exact_mut(10);
+    assert_eq!(c3.nth_back(0), None);
+}
+
+#[test]
 fn test_chunks_exact_mut_last() {
     let v: &mut [i32] = &mut [0, 1, 2, 3, 4, 5];
     let c = v.chunks_exact_mut(2);

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -20,6 +20,7 @@ rustc_data_structures = { path = "../librustc_data_structures" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_metadata = { path = "../librustc_metadata" }
 rustc_mir = { path = "../librustc_mir" }
+rustc_plugin = { path = "../librustc_plugin/deprecated" } # To get this in the sysroot
 rustc_plugin_impl = { path = "../librustc_plugin" }
 rustc_save_analysis = { path = "../librustc_save_analysis" }
 rustc_codegen_utils = { path = "../librustc_codegen_utils" }

--- a/src/librustc_plugin/deprecated/lib.rs
+++ b/src/librustc_plugin/deprecated/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(staged_api)]
-#![unstable(feature = "rustc_plugin", issue = "29597")]
+#![unstable(feature = "rustc_private", issue = "27812")]
 #![rustc_deprecated(since = "1.38.0", reason = "\
     import this through `rustc_driver::plugin` instead to make TLS work correctly. \
     See https://github.com/rust-lang/rust/issues/62717")]

--- a/src/libstd/sys/unix/process/process_unix.rs
+++ b/src/libstd/sys/unix/process/process_unix.rs
@@ -214,14 +214,7 @@ impl Command {
             // need to clean things up now to avoid confusing the program
             // we're about to run.
             let mut set = MaybeUninit::<libc::sigset_t>::uninit();
-            if cfg!(target_os = "android") {
-                // Implementing sigemptyset allow us to support older Android
-                // versions. See the comment about Android and sig* functions in
-                // process_common.rs
-                set.as_mut_ptr().write_bytes(0u8, 1);
-            } else {
-                cvt(libc::sigemptyset(set.as_mut_ptr()))?;
-            }
+            cvt(sigemptyset(set.as_mut_ptr()))?;
             cvt(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(),
                                          ptr::null_mut()))?;
             let ret = sys::signal(libc::SIGPIPE, libc::SIG_DFL);
@@ -363,10 +356,10 @@ impl Command {
             }
 
             let mut set = MaybeUninit::<libc::sigset_t>::uninit();
-            cvt(libc::sigemptyset(set.as_mut_ptr()))?;
+            cvt(sigemptyset(set.as_mut_ptr()))?;
             cvt(libc::posix_spawnattr_setsigmask(attrs.0.as_mut_ptr(),
                                                  set.as_ptr()))?;
-            cvt(libc::sigaddset(set.as_mut_ptr(), libc::SIGPIPE))?;
+            cvt(sigaddset(set.as_mut_ptr(), libc::SIGPIPE))?;
             cvt(libc::posix_spawnattr_setsigdefault(attrs.0.as_mut_ptr(),
                                                     set.as_ptr()))?;
 


### PR DESCRIPTION
Successful merges:

 - #63216 (avoid unnecessary reservations in std::io::Take::read_to_end)
 - #63265 (Implement `nth_back` for ChunksExactMut)
 - #63691 (Fix bug in iter::Chain::size_hint)
 - #63722 (Don't use stage naming in RUSTFLAGS environment variables)
 - #63723 (Consolidate sigemptyset workarounds)
 - #63736 (Restore the rustc_plugin crate in the sysroot)
 - #63743 (Allow git to merge `Cargo.lock`)

Failed merges:


r? @ghost