### PR TITLE
Expose Linux syscall interface

### DIFF
--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -4,4 +4,5 @@
 
 pub mod raw;
 pub mod fs;
+#[unstable(feature = "linux_syscall", issue = "63748")]
 pub mod syscall;

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod raw;
 pub mod fs;
+pub mod syscall;

--- a/src/libstd/os/linux/mod.rs
+++ b/src/libstd/os/linux/mod.rs
@@ -4,5 +4,4 @@
 
 pub mod raw;
 pub mod fs;
-#[unstable(feature = "linux_syscall", issue = "63748")]
 pub mod syscall;

--- a/src/libstd/os/linux/syscall/aarch64.rs
+++ b/src/libstd/os/linux/syscall/aarch64.rs
@@ -1,4 +1,3 @@
-
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret : usize;

--- a/src/libstd/os/linux/syscall/aarch64.rs
+++ b/src/libstd/os/linux/syscall/aarch64.rs
@@ -1,0 +1,87 @@
+
+#[inline(always)]
+pub unsafe fn syscall0(n: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
+                     "{x4}"(a5)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
+                     "{x4}"(a5), "{x6}"(a6)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall7(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4)
+                     "{x4}"(a5), "{x6}"(a6)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}

--- a/src/libstd/os/linux/syscall/arm.rs
+++ b/src/libstd/os/linux/syscall/arm.rs
@@ -1,8 +1,8 @@
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -11,8 +11,8 @@ pub unsafe fn syscall0(n: usize) -> usize {
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -21,8 +21,8 @@ pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -31,8 +31,8 @@ pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2), "{r2}"(a3)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -42,8 +42,9 @@ pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
                                 a4: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2), "{r2}"(a3),
+                     "{r3}"(a4)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -53,9 +54,9 @@ pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
 pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
                                 a4: usize, a5: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
-                     "{x4}"(a5)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2), "{r2}"(a3),
+                     "{r3}"(a4), "{r4}"(a5)
                    : "memory" "cc"
                    : "volatile");
     ret
@@ -65,9 +66,22 @@ pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
 pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
                                 a4: usize, a5: usize, a6: usize) -> usize {
     let ret : usize;
-    asm!("svc 0"   : "={x0}"(ret)
-                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
-                     "{x4}"(a5), "{x6}"(a6)
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2), "{r2}"(a3),
+                     "{r3}"(a4), "{r4}"(a5), "{r5}"(a6)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall7(n: usize, a1: usize, a2: usize, a3: usize,
+                            a4: usize, a5: usize, a6: usize,
+                            a7: usize) -> usize {
+    let ret : usize;
+    asm!("swi $$0" : "={r0}"(ret)
+                   : "{r7}"(n), "{r0}"(a1), "{r1}"(a2), "{r2}"(a3),
+                     "{r3}"(a4), "{r4}"(a5), "{r5}"(a6), "{r6}"(a7)
                    : "memory" "cc"
                    : "volatile");
     ret

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -2,13 +2,13 @@
 #![unstable(feature = "linux_syscall", issue = "0")]
 #![cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 
-#[cfg(target_arch = "x86")] {
+#[cfg(target_arch = "x86")]
 #[path="x86.rs"] mod platform;
 
-#[cfg(target_arch = "x86_64")] {
+#[cfg(target_arch = "x86_64")]
 #[path="x86_64.rs"] mod platform;
 
-#[cfg(target_arch = "aarch64")] {
+#[cfg(target_arch = "aarch64")]
 #[path="aarch64"] mod platform;
 
 /// Execute syscall with 0 arguments.

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -1,5 +1,5 @@
 //! Raw syscall functions.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#![unstable(feature = "linux_syscall", issue = "63748")]
 #![cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 
 #[cfg(target_arch = "x86")]
@@ -12,35 +12,35 @@
 #[path="aarch64"] mod platform;
 
 /// Execute syscall with 0 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     platform::syscall0(n)
 }
 
 /// Execute syscall with 1 argument.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     platform::syscall1(n, a1)
 }
 
 /// Execute syscall with 2 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     platform::syscall2(n, a1, a2)
 }
 
 /// Execute syscall with 3 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     platform::syscall3(n, a1, a2, a3)
 }
 
 /// Execute syscall with 4 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall4(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize,
@@ -49,7 +49,7 @@ pub unsafe fn syscall4(
 }
 
 /// Execute syscall with 5 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall5(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize,
@@ -58,7 +58,7 @@ pub unsafe fn syscall5(
 }
 
 /// Execute syscall with 6 arguments.
-#[unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
 pub unsafe fn syscall6(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize,

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -63,5 +63,5 @@ pub unsafe fn syscall5(
 pub unsafe fn syscall6(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize,
 ) -> usize {
-    platform::syscall5(n, a1, a2, a3, a4, a5, a6)
+    platform::syscall6(n, a1, a2, a3, a4, a5, a6)
 }

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -12,35 +12,35 @@
 #[path="aarch64"] mod platform;
 
 /// Execute syscall with 0 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     platform::syscall0(n)
 }
 
 /// Execute syscall with 1 argument.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
     platform::syscall1(n, a1)
 }
 
 /// Execute syscall with 2 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
     platform::syscall2(n, a1, a2)
 }
 
 /// Execute syscall with 3 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
     platform::syscall3(n, a1, a2, a3)
 }
 
 /// Execute syscall with 4 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall4(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize,
@@ -49,7 +49,7 @@ pub unsafe fn syscall4(
 }
 
 /// Execute syscall with 5 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall5(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize,
@@ -58,7 +58,7 @@ pub unsafe fn syscall5(
 }
 
 /// Execute syscall with 6 arguments.
-#![unstable(feature = "linux_syscall", issue = "0")]
+#[unstable(feature = "linux_syscall", issue = "0")]
 #[inline(always)]
 pub unsafe fn syscall6(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize,

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -11,6 +11,9 @@
 #[cfg(target_arch = "aarch64")]
 #[path="aarch64"] mod platform;
 
+#[cfg(target_arch = "arm")]
+#[path="arm"] mod platform;
+
 /// Execute syscall with 0 arguments.
 #[unstable(feature = "linux_syscall", issue = "63748")]
 #[inline(always)]
@@ -64,4 +67,17 @@ pub unsafe fn syscall6(
     n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize,
 ) -> usize {
     platform::syscall6(n, a1, a2, a3, a4, a5, a6)
+}
+
+/// Execute syscall with 7 arguments.
+///
+/// Available only on ARM targets.
+#[cfg(target_arch = "arm")]
+#[unstable(feature = "linux_syscall", issue = "63748")]
+#[inline(always)]
+pub unsafe fn syscall7(
+    n: usize, a1: usize, a2: usize, a3: usize, a4: usize,
+    a5: usize, a6: usize,  a7: usize,
+) -> usize {
+    platform::syscall7(n, a1, a2, a3, a4, a5, a6, a7)
 }

--- a/src/libstd/os/linux/syscall/mod.rs
+++ b/src/libstd/os/linux/syscall/mod.rs
@@ -1,0 +1,67 @@
+//! Raw syscall functions.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#![cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
+
+#[cfg(target_arch = "x86")] {
+#[path="x86.rs"] mod platform;
+
+#[cfg(target_arch = "x86_64")] {
+#[path="x86_64.rs"] mod platform;
+
+#[cfg(target_arch = "aarch64")] {
+#[path="aarch64"] mod platform;
+
+/// Execute syscall with 0 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall0(n: usize) -> usize {
+    platform::syscall0(n)
+}
+
+/// Execute syscall with 1 argument.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
+    platform::syscall1(n, a1)
+}
+
+/// Execute syscall with 2 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
+    platform::syscall2(n, a1, a2)
+}
+
+/// Execute syscall with 3 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    platform::syscall3(n, a1, a2, a3)
+}
+
+/// Execute syscall with 4 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall4(
+    n: usize, a1: usize, a2: usize, a3: usize, a4: usize,
+) -> usize {
+    platform::syscall4(n, a1, a2, a3, a4)
+}
+
+/// Execute syscall with 5 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall5(
+    n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize,
+) -> usize {
+    platform::syscall5(n, a1, a2, a3, a4, a5)
+}
+
+/// Execute syscall with 6 arguments.
+#![unstable(feature = "linux_syscall", issue = "0")]
+#[inline(always)]
+pub unsafe fn syscall6(
+    n: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize, a6: usize,
+) -> usize {
+    platform::syscall5(n, a1, a2, a3, a4, a5, a6)
+}

--- a/src/libstd/os/linux/syscall/x86.rs
+++ b/src/libstd/os/linux/syscall/x86.rs
@@ -1,0 +1,116 @@
+
+#[inline(always)]
+pub unsafe fn syscall0(n: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n), "{ebx}"(a1)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3),
+                        "{esi}"(a4)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize) -> usize {
+    let ret : usize;
+    asm!("int $$0x80" : "={eax}"(ret)
+                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3),
+                        "{esi}"(a4), "{edi}"(a5)
+                      : "memory" "cc"
+                      : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+
+    //
+    // XXX: this fails when building without optimizations:
+    //
+    //    asm!("int $$0x80" : "={eax}"(ret)
+    //                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3),
+    //                        "{esi}"(a4), "{edi}"(a5), "{ebp}"(a6)
+    //                      : "memory" "cc"
+    //                      : "volatile");
+    //
+    // error: ran out of registers during register allocation
+    //
+    // XXX: this fails when building with optimizations as the "m"(a6) gets translated to
+    // [esp+offset] but the push ebp moved esp.
+    //
+    //      asm!("push %ebp
+    //            mov $7, %ebp
+    //            int $$0x80
+    //            pop %ebp"
+    //              : "={eax}"(ret)
+    //              : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3),
+    //                "{esi}"(a4), "{edi}"(a5), "m"(a6)
+    //              : "memory" "cc"
+    //              : "volatile");
+    //
+    // XXX: in general putting "ebp" in clobber list seems to not have any effect.
+    //
+    // As workaround only use a single input operand with known memory layout and manually save
+    // restore ebp.
+    let args = [n, a1, a2, a3, a4, a5, a6];
+
+    asm!("push %ebp
+          movl 24(%eax), %ebp
+          movl 20(%eax), %edi
+          movl 16(%eax), %esi
+          movl 12(%eax), %edx
+          movl  8(%eax), %ecx
+          movl  4(%eax), %ebx
+          movl  0(%eax), %eax
+          int $$0x80
+          pop %ebp"
+            : "={eax}"(ret)
+            : "{eax}"(args)
+            : "ebx" "ecx" "edx" "esi" "edi" "ebp" "memory" "cc"
+            : "volatile");
+    ret
+}

--- a/src/libstd/os/linux/syscall/x86.rs
+++ b/src/libstd/os/linux/syscall/x86.rs
@@ -1,4 +1,3 @@
-
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret : usize;
@@ -69,7 +68,7 @@ pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
     let ret : usize;
 
     //
-    // XXX: this fails when building without optimizations:
+    // this fails when building without optimizations:
     //
     //    asm!("int $$0x80" : "={eax}"(ret)
     //                      : "{eax}"(n), "{ebx}"(a1), "{ecx}"(a2), "{edx}"(a3),
@@ -79,7 +78,7 @@ pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
     //
     // error: ran out of registers during register allocation
     //
-    // XXX: this fails when building with optimizations as the "m"(a6) gets translated to
+    // this fails when building with optimizations as the "m"(a6) gets translated to
     // [esp+offset] but the push ebp moved esp.
     //
     //      asm!("push %ebp
@@ -92,7 +91,7 @@ pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
     //              : "memory" "cc"
     //              : "volatile");
     //
-    // XXX: in general putting "ebp" in clobber list seems to not have any effect.
+    // in general putting "ebp" in clobber list seems to not have any effect.
     //
     // As workaround only use a single input operand with known memory layout and manually save
     // restore ebp.

--- a/src/libstd/os/linux/syscall/x86_64.rs
+++ b/src/libstd/os/linux/syscall/x86_64.rs
@@ -1,0 +1,76 @@
+
+#[inline(always)]
+pub unsafe fn syscall0(n: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
+                     "{r10}"(a4)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
+                     "{r10}"(a4), "{r8}"(a5)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+    asm!("syscall" : "={rax}"(ret)
+                   : "{rax}"(n), "{rdi}"(a1), "{rsi}"(a2), "{rdx}"(a3),
+                     "{r10}"(a4), "{r8}"(a5), "{r9}"(a6)
+                   : "rcx", "r11", "memory"
+                   : "volatile");
+    ret
+}

--- a/src/libstd/os/linux/syscall/x86_64.rs
+++ b/src/libstd/os/linux/syscall/x86_64.rs
@@ -1,4 +1,3 @@
-
 #[inline(always)]
 pub unsafe fn syscall0(n: usize) -> usize {
     let ret : usize;


### PR DESCRIPTION
Based on the [`syscall`](https://github.com/kmcallister/syscall.rs) crate. Right now only `x86`, `x86-64`, `arm` and `aarch64` architectures are supported.

This PR adds basic functions which after stabilization will allow usage of Linux syscalls on stable Rust. Syscall constants and a convenience macro imitating a variadic function can reside in third-party crates (e.g. in the aforementioned `syscall`). Since AFAIK only Linux guarantees stability of the syscall API, I've omitted code for FreeBSD and macOS. It was proposed to add those functions to `core::os`, but I think it's worth to start with a more conservative approach.

For an earlier discussion see: https://internals.rust-lang.org/t/10614

cc @kmcallister