### PR TITLE
Parse `default async fn` & Pre-expansion-gate `default`

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -2438,16 +2438,19 @@ pub fn check_crate(krate: &ast::Crate,
     };
 
     macro_rules! gate_all {
+        ($gate:ident, $msg:literal) => { gate_all!($gate, $gate, $msg); };
         ($spans:ident, $gate:ident, $msg:literal) => {
-            for span in &*sess.$spans.borrow() { gate_feature!(&ctx, $gate, *span, $msg); }
+            for span in &*sess.gated_spans.$spans.borrow() {
+                gate_feature!(&ctx, $gate, *span, $msg);
+            }
         }
     }
 
-    gate_all!(param_attr_spans, param_attrs, "attributes on function parameters are unstable");
-    gate_all!(let_chains_spans, let_chains, "`let` expressions in this position are experimental");
-    gate_all!(async_closure_spans, async_closure, "async closures are unstable");
-    gate_all!(yield_spans, generators, "yield syntax is experimental");
-    gate_all!(or_pattern_spans, or_patterns, "or-patterns syntax is experimental");
+    gate_all!(param_attrs, "attributes on function parameters are unstable");
+    gate_all!(let_chains, "`let` expressions in this position are experimental");
+    gate_all!(async_closure, "async closures are unstable");
+    gate_all!(yields, generators, "yield syntax is experimental");
+    gate_all!(or_patterns, "or-patterns syntax is experimental");
 
     let visitor = &mut PostExpansionVisitor {
         context: &ctx,

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -1980,18 +1980,12 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 }
             }
 
-            ast::ItemKind::Impl(_, polarity, defaultness, _, _, _, _) => {
+            ast::ItemKind::Impl(_, polarity, ..) => {
                 if polarity == ast::ImplPolarity::Negative {
                     gate_feature_post!(&self, optin_builtin_traits,
                                        i.span,
                                        "negative trait bounds are not yet fully implemented; \
                                         use marker types for now");
-                }
-
-                if let ast::Defaultness::Default = defaultness {
-                    gate_feature_post!(&self, specialization,
-                                       i.span,
-                                       "specialization is unstable");
                 }
             }
 
@@ -2231,12 +2225,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     }
 
     fn visit_impl_item(&mut self, ii: &'a ast::ImplItem) {
-        if ii.defaultness == ast::Defaultness::Default {
-            gate_feature_post!(&self, specialization,
-                              ii.span,
-                              "specialization is unstable");
-        }
-
         match ii.node {
             ast::ImplItemKind::Method(..) => {}
             ast::ImplItemKind::OpaqueTy(..) => {
@@ -2451,6 +2439,7 @@ pub fn check_crate(krate: &ast::Crate,
     gate_all!(async_closure, "async closures are unstable");
     gate_all!(yields, generators, "yield syntax is experimental");
     gate_all!(or_patterns, "or-patterns syntax is experimental");
+    gate_all!(specialization, "specialization is unstable");
 
     let visitor = &mut PostExpansionVisitor {
         context: &ctx,

--- a/src/libsyntax/parse/attr.rs
+++ b/src/libsyntax/parse/attr.rs
@@ -21,9 +21,8 @@ const DEFAULT_UNEXPECTED_INNER_ATTR_ERR_MSG: &str = "an inner attribute is not \
 impl<'a> Parser<'a> {
     crate fn parse_arg_attributes(&mut self) -> PResult<'a, Vec<ast::Attribute>> {
         let attrs = self.parse_outer_attributes()?;
-        attrs.iter().for_each(|a|
-            self.sess.param_attr_spans.borrow_mut().push(a.span)
-        );
+        self.sess.gated_spans.param_attrs.borrow_mut()
+            .extend(attrs.iter().map(|a| a.span));
         Ok(attrs)
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -53,6 +53,8 @@ pub struct GatedSpans {
     pub yields: Lock<Vec<Span>>,
     /// Spans collected for gating `or_patterns`, e.g. `Some(Foo | Bar)`.
     pub or_patterns: Lock<Vec<Span>>,
+    /// Spans collected for gating the `default` qualifier for `specialization`.
+    pub specialization: Lock<Vec<Span>>,
 }
 
 /// Info about a parsing session.

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -999,7 +999,7 @@ impl<'a> Parser<'a> {
                     }
 
                     let span = lo.to(hi);
-                    self.sess.yield_spans.borrow_mut().push(span);
+                    self.sess.gated_spans.yields.borrow_mut().push(span);
                 } else if self.eat_keyword(kw::Let) {
                     return self.parse_let_expr(attrs);
                 } else if is_span_rust_2018 && self.eat_keyword(kw::Await) {
@@ -1111,7 +1111,7 @@ impl<'a> Parser<'a> {
         };
         if asyncness.is_async() {
             // Feature gate `async ||` closures.
-            self.sess.async_closure_spans.borrow_mut().push(self.prev_span);
+            self.sess.gated_spans.async_closure.borrow_mut().push(self.prev_span);
         }
 
         let capture_clause = self.parse_capture_clause();
@@ -1234,7 +1234,7 @@ impl<'a> Parser<'a> {
 
         if let ExprKind::Let(..) = cond.node {
             // Remove the last feature gating of a `let` expression since it's stable.
-            let last = self.sess.let_chains_spans.borrow_mut().pop();
+            let last = self.sess.gated_spans.let_chains.borrow_mut().pop();
             debug_assert_eq!(cond.span, last.unwrap());
         }
 
@@ -1252,7 +1252,7 @@ impl<'a> Parser<'a> {
             |this| this.parse_assoc_expr_with(1 + prec_let_scrutinee_needs_par(), None.into())
         )?;
         let span = lo.to(expr.span);
-        self.sess.let_chains_spans.borrow_mut().push(span);
+        self.sess.gated_spans.let_chains.borrow_mut().push(span);
         Ok(self.mk_expr(span, ExprKind::Let(pats, expr), attrs))
     }
 

--- a/src/libsyntax/parse/parser/item.rs
+++ b/src/libsyntax/parse/parser/item.rs
@@ -825,6 +825,7 @@ impl<'a> Parser<'a> {
             self.is_keyword_ahead(1, &[
                 kw::Impl,
                 kw::Const,
+                kw::Async,
                 kw::Fn,
                 kw::Unsafe,
                 kw::Extern,

--- a/src/libsyntax/parse/parser/item.rs
+++ b/src/libsyntax/parse/parser/item.rs
@@ -833,6 +833,7 @@ impl<'a> Parser<'a> {
             ])
         {
             self.bump(); // `default`
+            self.sess.gated_spans.specialization.borrow_mut().push(self.prev_span);
             Defaultness::Default
         } else {
             Defaultness::Final

--- a/src/libsyntax/parse/parser/pat.rs
+++ b/src/libsyntax/parse/parser/pat.rs
@@ -123,7 +123,7 @@ impl<'a> Parser<'a> {
 
         let or_pattern_span = lo.to(self.prev_span);
 
-        self.sess.or_pattern_spans.borrow_mut().push(or_pattern_span);
+        self.sess.gated_spans.or_patterns.borrow_mut().push(or_pattern_span);
 
         Ok(self.mk_pat(or_pattern_span, PatKind::Or(pats)))
     }

--- a/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-feature-gate-default.stderr
@@ -1,10 +1,8 @@
 error[E0658]: specialization is unstable
   --> $DIR/specialization-feature-gate-default.rs:7:1
    |
-LL | / default impl<T> Foo for T {
-LL | |     fn foo(&self) {}
-LL | | }
-   | |_^
+LL | default impl<T> Foo for T {
+   | ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31844
    = help: add `#![feature(specialization)]` to the crate attributes to enable

--- a/src/test/ui/specialization/issue-63716-parse-async.rs
+++ b/src/test/ui/specialization/issue-63716-parse-async.rs
@@ -1,0 +1,14 @@
+// Ensure that `default async fn` will parse.
+// See issue #63716 for details.
+
+// check-pass
+// edition:2018
+
+#![feature(specialization)]
+
+fn main() {}
+
+#[cfg(FALSE)]
+impl Foo for Bar {
+    default async fn baz() {}
+}

--- a/src/test/ui/specialization/specialization-feature-gate-default.rs
+++ b/src/test/ui/specialization/specialization-feature-gate-default.rs
@@ -6,8 +6,16 @@ trait Foo {
     fn foo(&self);
 }
 
+#[cfg(FALSE)]
 impl<T> Foo for T {
-    default fn foo(&self) {} //~ ERROR specialization is unstable
+    default //~ ERROR specialization is unstable
+    fn foo(&self) {}
+}
+
+#[cfg(FALSE)]
+default //~ ERROR specialization is unstable
+impl<T> Foo for T {
+    fn foo(&self) {}
 }
 
 fn main() {}

--- a/src/test/ui/specialization/specialization-feature-gate-default.stderr
+++ b/src/test/ui/specialization/specialization-feature-gate-default.stderr
@@ -1,12 +1,21 @@
 error[E0658]: specialization is unstable
-  --> $DIR/specialization-feature-gate-default.rs:10:5
+  --> $DIR/specialization-feature-gate-default.rs:11:5
    |
-LL |     default fn foo(&self) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     default
+   |     ^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/31844
    = help: add `#![feature(specialization)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: specialization is unstable
+  --> $DIR/specialization-feature-gate-default.rs:16:1
+   |
+LL | default
+   | ^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/31844
+   = help: add `#![feature(specialization)]` to the crate attributes to enable
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
- Simplify the overall pre-expansion gating "experience".
- Pre-expansion gate `default` instead of post-expansion.
- Parse `default async fn`. Fixes https://github.com/rust-lang/rust/issues/63716.

r? @petrochenkov 