### PR TITLE
`async_await` was stabilized in 1.39.0, not 1.38.0.

### DIFF
--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -855,7 +855,7 @@ declare_features! (
     // Allows `const _: TYPE = VALUE`.
     (accepted, underscore_const_names, "1.37.0", Some(54912), None),
     // Allows free and inherent `async fn`s, `async` blocks, and `<expr>.await` expressions.
-    (accepted, async_await, "1.38.0", Some(50547), None),
+    (accepted, async_await, "1.39.0", Some(50547), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: accepted features


### PR DESCRIPTION
r? @Mark-Simulacrum 