### PR TITLE
Use more optimal Ord implementation for integers

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1012,6 +1012,8 @@ mod impls {
             impl Ord for $t {
                 #[inline]
                 fn cmp(&self, other: &$t) -> Ordering {
+                    // The order here is important to generate more optimal assembly.
+                    // See <https://github.com/rust-lang/rust/issues/63758> for more info.
                     if *self < *other { Less }
                     else if *self > *other { Greater }
                     else { Equal }

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1012,9 +1012,9 @@ mod impls {
             impl Ord for $t {
                 #[inline]
                 fn cmp(&self, other: &$t) -> Ordering {
-                    if *self == *other { Equal }
-                    else if *self < *other { Less }
-                    else { Greater }
+                    if *self < *other { Less }
+                    else if *self > *other { Greater }
+                    else { Equal }
                 }
             }
         )*)

--- a/src/test/codegen/integer-cmp.rs
+++ b/src/test/codegen/integer-cmp.rs
@@ -1,0 +1,28 @@
+// This is test for more optimal Ord implementation for integers.
+// See <https://github.com/rust-lang/rust/issues/63758> for more info.
+
+// compile-flags: -C opt-level=3
+
+#![crate_type = "lib"]
+
+use std::cmp::Ordering;
+
+// CHECK-LABEL: @cmp_signed
+#[no_mangle]
+pub fn cmp_signed(a: i64, b: i64) -> Ordering {
+// CHECK: icmp slt
+// CHECK: icmp sgt
+// CHECK: zext i1
+// CHECK: select i1
+    a.cmp(&b)
+}
+
+// CHECK-LABEL: @cmp_unsigned
+#[no_mangle]
+pub fn cmp_unsigned(a: u32, b: u32) -> Ordering {
+// CHECK: icmp ult
+// CHECK: icmp ugt
+// CHECK: zext i1
+// CHECK: select i1
+    a.cmp(&b)
+}


### PR DESCRIPTION
Closes #63758
r? @nagisa 

### Compare results

([godbolt link](https://godbolt.org/z/dsbczy))

Old assembly:
```asm
example::cmp1:
  mov eax, dword ptr [rdi]
  mov ecx, dword ptr [rsi]
  cmp eax, ecx
  setae dl
  add dl, dl
  add dl, -1
  xor esi, esi
  cmp eax, ecx
  movzx eax, dl
  cmove eax, esi
  ret
```

New assembly:
```asm
example::cmp2:
  mov eax, dword ptr [rdi]
  xor ecx, ecx
  cmp eax, dword ptr [rsi]
  seta cl
  mov eax, 255
  cmovae eax, ecx
  ret
```

Old llvm-mca statistics:
```
Iterations:        100
Instructions:      1100
Total Cycles:      243
Total uOps:        1300

Dispatch Width:    6
uOps Per Cycle:    5.35
IPC:               4.53
Block RThroughput: 2.2
```

New llvm-mca statistics:
```
Iterations:        100
Instructions:      700
Total Cycles:      217
Total uOps:        1100

Dispatch Width:    6
uOps Per Cycle:    5.07
IPC:               3.23
Block RThroughput: 1.8
```
