### PR TITLE
Fix `window.hashchange is not a function`

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -344,7 +344,7 @@ if (!DOMTokenList.prototype.remove) {
             var set_fragment = function(name) {
                 if (browserSupportsHistoryApi()) {
                     history.replaceState(null, null, "#" + name);
-                    window.hashchange();
+                    highlightSourceLines(null);
                 } else {
                     location.replace("#" + name);
                 }


### PR DESCRIPTION
Closes #63707.