### PR TITLE
Improve diagnostics: break/continue in wrong context

### DIFF
--- a/src/librustc_passes/error_codes.rs
+++ b/src/librustc_passes/error_codes.rs
@@ -131,7 +131,7 @@ be taken. Erroneous code example:
 
 ```compile_fail,E0268
 fn some_func() {
-    break; // error: `break` outside of loop
+    break; // error: `break` outside of a loop
 }
 ```
 

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -16,8 +16,8 @@ use errors::Applicability;
 enum Context {
     Normal,
     Loop(hir::LoopSource),
-    Closure,
-    AsyncClosure,
+    Closure(Span),
+    AsyncClosure(Span),
     LabeledBlock,
     AnonConst,
 }
@@ -58,11 +58,11 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
             hir::ExprKind::Loop(ref b, _, source) => {
                 self.with_context(Loop(source), |v| v.visit_block(&b));
             }
-            hir::ExprKind::Closure(_, ref function_decl, b, _, movability) => {
+            hir::ExprKind::Closure(_, ref function_decl, b, span, movability) => {
                 let cx = if let Some(GeneratorMovability::Static) = movability {
-                    AsyncClosure
+                    AsyncClosure(span)
                 } else {
-                    Closure
+                    Closure(span)
                 };
                 self.visit_fn_decl(&function_decl);
                 self.with_context(cx, |v| v.visit_nested_body(b));
@@ -170,23 +170,22 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
     }
 
     fn require_break_cx(&self, name: &str, span: Span) {
+        let err_inside_of = |article, r#type, closure_span| {
+            struct_span_err!(self.sess, span, E0267, "`{}` inside of {} {}", name, article, r#type)
+                .span_label(span, format!("cannot `{}` inside of {} {}", name, article, r#type))
+                .span_label(closure_span, &format!("enclosing {}", r#type))
+                .emit();
+        };
+
         match self.cx {
-            LabeledBlock | Loop(_) => {}
-            Closure => {
-                struct_span_err!(self.sess, span, E0267, "`{}` inside of a closure", name)
-                .span_label(span, "cannot break inside of a closure")
-                .emit();
-            }
-            AsyncClosure => {
-                struct_span_err!(self.sess, span, E0267, "`{}` inside of an async block", name)
-                    .span_label(span, "cannot break inside of an async block")
-                    .emit();
-            }
+            LabeledBlock | Loop(_) => {},
+            Closure(closure_span) => err_inside_of("a", "closure", closure_span),
+            AsyncClosure(closure_span) => err_inside_of("an", "`async` block", closure_span),
             Normal | AnonConst => {
-                struct_span_err!(self.sess, span, E0268, "`{}` outside of loop", name)
-                .span_label(span, "cannot break outside of a loop")
+                struct_span_err!(self.sess, span, E0268, "`{}` outside of a loop", name)
+                .span_label(span, format!("cannot `{}` outside of a loop", name))
                 .emit();
-            }
+            },
         }
     }
 

--- a/src/librustc_passes/loops.rs
+++ b/src/librustc_passes/loops.rs
@@ -170,10 +170,10 @@ impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
     }
 
     fn require_break_cx(&self, name: &str, span: Span) {
-        let err_inside_of = |article, r#type, closure_span| {
-            struct_span_err!(self.sess, span, E0267, "`{}` inside of {} {}", name, article, r#type)
-                .span_label(span, format!("cannot `{}` inside of {} {}", name, article, r#type))
-                .span_label(closure_span, &format!("enclosing {}", r#type))
+        let err_inside_of = |article, ty, closure_span| {
+            struct_span_err!(self.sess, span, E0267, "`{}` inside of {} {}", name, article, ty)
+                .span_label(span, format!("cannot `{}` inside of {} {}", name, article, ty))
+                .span_label(closure_span, &format!("enclosing {}", ty))
                 .emit();
         };
 

--- a/src/test/ui/array-break-length.rs
+++ b/src/test/ui/array-break-length.rs
@@ -1,11 +1,11 @@
 fn main() {
     loop {
-        |_: [_; break]| {} //~ ERROR: `break` outside of loop
+        |_: [_; break]| {} //~ ERROR: `break` outside of a loop
         //~^ ERROR mismatched types
     }
 
     loop {
-        |_: [_; continue]| {} //~ ERROR: `continue` outside of loop
+        |_: [_; continue]| {} //~ ERROR: `continue` outside of a loop
         //~^ ERROR mismatched types
     }
 }

--- a/src/test/ui/array-break-length.stderr
+++ b/src/test/ui/array-break-length.stderr
@@ -1,14 +1,14 @@
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/array-break-length.rs:3:17
    |
 LL |         |_: [_; break]| {}
-   |                 ^^^^^ cannot break outside of a loop
+   |                 ^^^^^ cannot `break` outside of a loop
 
-error[E0268]: `continue` outside of loop
+error[E0268]: `continue` outside of a loop
   --> $DIR/array-break-length.rs:8:17
    |
 LL |         |_: [_; continue]| {}
-   |                 ^^^^^^^^ cannot break outside of a loop
+   |                 ^^^^^^^^ cannot `continue` outside of a loop
 
 error[E0308]: mismatched types
   --> $DIR/array-break-length.rs:3:9

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.rs
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.rs
@@ -30,14 +30,14 @@ async fn return_targets_async_block_not_async_fn() -> u8 {
 
 fn no_break_in_async_block() {
     async {
-        break 0u8; //~ ERROR `break` inside of an async block
+        break 0u8; //~ ERROR `break` inside of an `async` block
     };
 }
 
 fn no_break_in_async_block_even_with_outer_loop() {
     loop {
         async {
-            break 0u8; //~ ERROR `break` inside of an async block
+            break 0u8; //~ ERROR `break` inside of an `async` block
         };
     }
 }

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -1,4 +1,4 @@
-error[E0267]: `break` inside of an async block
+error[E0267]: `break` inside of an `async` block
   --> $DIR/async-block-control-flow-static-semantics.rs:33:9
    |
 LL |       async {
@@ -8,7 +8,7 @@ LL | |         break 0u8;
 LL | |     };
    | |_____- enclosing `async` block
 
-error[E0267]: `break` inside of an async block
+error[E0267]: `break` inside of an `async` block
   --> $DIR/async-block-control-flow-static-semantics.rs:40:13
    |
 LL |           async {

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -1,14 +1,22 @@
 error[E0267]: `break` inside of an async block
   --> $DIR/async-block-control-flow-static-semantics.rs:33:9
    |
-LL |         break 0u8;
-   |         ^^^^^^^^^ cannot break inside of an async block
+LL |       async {
+   |  ___________-
+LL | |         break 0u8;
+   | |         ^^^^^^^^^ cannot `break` inside of an `async` block
+LL | |     };
+   | |_____- enclosing `async` block
 
 error[E0267]: `break` inside of an async block
   --> $DIR/async-block-control-flow-static-semantics.rs:40:13
    |
-LL |             break 0u8;
-   |             ^^^^^^^^^ cannot break inside of an async block
+LL |           async {
+   |  _______________-
+LL | |             break 0u8;
+   | |             ^^^^^^^^^ cannot `break` inside of an `async` block
+LL | |         };
+   | |_________- enclosing `async` block
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:13:43

--- a/src/test/ui/break-outside-loop.rs
+++ b/src/test/ui/break-outside-loop.rs
@@ -7,8 +7,8 @@ fn cond() -> bool { true }
 fn foo<F>(_: F) where F: FnOnce() {}
 
 fn main() {
-    let pth = break; //~ ERROR: `break` outside of loop
-    if cond() { continue } //~ ERROR: `continue` outside of loop
+    let pth = break; //~ ERROR: `break` outside of a loop
+    if cond() { continue } //~ ERROR: `continue` outside of a loop
 
     while cond() {
         if cond() { break }
@@ -21,5 +21,5 @@ fn main() {
 
     let rs: Foo = Foo{t: pth};
 
-    let unconstrained = break; //~ ERROR: `break` outside of loop
+    let unconstrained = break; //~ ERROR: `break` outside of a loop
 }

--- a/src/test/ui/break-outside-loop.stderr
+++ b/src/test/ui/break-outside-loop.stderr
@@ -1,32 +1,37 @@
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/break-outside-loop.rs:10:15
    |
 LL |     let pth = break;
-   |               ^^^^^ cannot break outside of a loop
+   |               ^^^^^ cannot `break` outside of a loop
 
-error[E0268]: `continue` outside of loop
+error[E0268]: `continue` outside of a loop
   --> $DIR/break-outside-loop.rs:11:17
    |
 LL |     if cond() { continue }
-   |                 ^^^^^^^^ cannot break outside of a loop
+   |                 ^^^^^^^^ cannot `continue` outside of a loop
 
 error[E0267]: `break` inside of a closure
   --> $DIR/break-outside-loop.rs:17:25
    |
+LL |         foo(|| {
+   |             -- enclosing closure
 LL |             if cond() { break }
-   |                         ^^^^^ cannot break inside of a closure
+   |                         ^^^^^ cannot `break` inside of a closure
 
 error[E0267]: `continue` inside of a closure
   --> $DIR/break-outside-loop.rs:18:25
    |
+LL |         foo(|| {
+   |             -- enclosing closure
+LL |             if cond() { break }
 LL |             if cond() { continue }
-   |                         ^^^^^^^^ cannot break inside of a closure
+   |                         ^^^^^^^^ cannot `continue` inside of a closure
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/break-outside-loop.rs:24:25
    |
 LL |     let unconstrained = break;
-   |                         ^^^^^ cannot break outside of a loop
+   |                         ^^^^^ cannot `break` outside of a loop
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/closures/closure-array-break-length.rs
+++ b/src/test/ui/closures/closure-array-break-length.rs
@@ -1,9 +1,9 @@
 fn main() {
-    |_: [_; continue]| {}; //~ ERROR: `continue` outside of loop
+    |_: [_; continue]| {}; //~ ERROR: `continue` outside of a loop
 
-    while |_: [_; continue]| {} {} //~ ERROR: `continue` outside of loop
+    while |_: [_; continue]| {} {} //~ ERROR: `continue` outside of a loop
     //~^ ERROR mismatched types
 
-    while |_: [_; break]| {} {} //~ ERROR: `break` outside of loop
+    while |_: [_; break]| {} {} //~ ERROR: `break` outside of a loop
     //~^ ERROR mismatched types
 }

--- a/src/test/ui/closures/closure-array-break-length.stderr
+++ b/src/test/ui/closures/closure-array-break-length.stderr
@@ -1,20 +1,20 @@
-error[E0268]: `continue` outside of loop
+error[E0268]: `continue` outside of a loop
   --> $DIR/closure-array-break-length.rs:2:13
    |
 LL |     |_: [_; continue]| {};
-   |             ^^^^^^^^ cannot break outside of a loop
+   |             ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0268]: `continue` outside of loop
+error[E0268]: `continue` outside of a loop
   --> $DIR/closure-array-break-length.rs:4:19
    |
 LL |     while |_: [_; continue]| {} {}
-   |                   ^^^^^^^^ cannot break outside of a loop
+   |                   ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/closure-array-break-length.rs:7:19
    |
 LL |     while |_: [_; break]| {} {}
-   |                   ^^^^^ cannot break outside of a loop
+   |                   ^^^^^ cannot `break` outside of a loop
 
 error[E0308]: mismatched types
   --> $DIR/closure-array-break-length.rs:4:11

--- a/src/test/ui/error-codes/E0267.stderr
+++ b/src/test/ui/error-codes/E0267.stderr
@@ -2,7 +2,9 @@ error[E0267]: `break` inside of a closure
   --> $DIR/E0267.rs:2:18
    |
 LL |     let w = || { break; };
-   |                  ^^^^^ cannot break inside of a closure
+   |             --   ^^^^^ cannot `break` inside of a closure
+   |             |
+   |             enclosing closure
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0268.stderr
+++ b/src/test/ui/error-codes/E0268.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/E0268.rs:2:5
    |
 LL |     break;
-   |     ^^^^^ cannot break outside of a loop
+   |     ^^^^^ cannot `break` outside of a loop
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28105.rs
+++ b/src/test/ui/issues/issue-28105.rs
@@ -1,8 +1,8 @@
 // Make sure that a continue span actually contains the keyword.
 
 fn main() {
-    continue //~ ERROR `continue` outside of loop
+    continue //~ ERROR `continue` outside of a loop
     ;
-    break //~ ERROR `break` outside of loop
+    break //~ ERROR `break` outside of a loop
     ;
 }

--- a/src/test/ui/issues/issue-28105.stderr
+++ b/src/test/ui/issues/issue-28105.stderr
@@ -1,14 +1,14 @@
-error[E0268]: `continue` outside of loop
+error[E0268]: `continue` outside of a loop
   --> $DIR/issue-28105.rs:4:5
    |
 LL |     continue
-   |     ^^^^^^^^ cannot break outside of a loop
+   |     ^^^^^^^^ cannot `continue` outside of a loop
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-28105.rs:6:5
    |
 LL |     break
-   |     ^^^^^ cannot break outside of a loop
+   |     ^^^^^ cannot `break` outside of a loop
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-43162.stderr
+++ b/src/test/ui/issues/issue-43162.stderr
@@ -1,14 +1,14 @@
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-43162.rs:3:5
    |
 LL |     break true;
-   |     ^^^^^^^^^^ cannot break outside of a loop
+   |     ^^^^^^^^^^ cannot `break` outside of a loop
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-43162.rs:7:5
    |
 LL |     break {};
-   |     ^^^^^^^^ cannot break outside of a loop
+   |     ^^^^^^^^ cannot `break` outside of a loop
 
 error[E0308]: mismatched types
   --> $DIR/issue-43162.rs:1:13

--- a/src/test/ui/issues/issue-50576.stderr
+++ b/src/test/ui/issues/issue-50576.stderr
@@ -4,17 +4,17 @@ error[E0426]: use of undeclared label `'L`
 LL |     |bool: [u8; break 'L]| 0;
    |                       ^^ undeclared label `'L`
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-50576.rs:2:17
    |
 LL |     |bool: [u8; break 'L]| 0;
-   |                 ^^^^^^^^ cannot break outside of a loop
+   |                 ^^^^^^^^ cannot `break` outside of a loop
 
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-50576.rs:5:16
    |
 LL |     Vec::<[u8; break]>::new();
-   |                ^^^^^ cannot break outside of a loop
+   |                ^^^^^ cannot `break` outside of a loop
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-50581.stderr
+++ b/src/test/ui/issues/issue-50581.stderr
@@ -1,8 +1,8 @@
-error[E0268]: `break` outside of loop
+error[E0268]: `break` outside of a loop
   --> $DIR/issue-50581.rs:2:14
    |
 LL |     |_: [u8; break]| ();
-   |              ^^^^^ cannot break outside of a loop
+   |              ^^^^^ cannot `break` outside of a loop
 
 error: aborting due to previous error
 


### PR DESCRIPTION
- Fix #63712
- Use `` `break` `` or `` `continue` `` instead of always `break` in `cannot _...`
- Show the enclosing closure or async block we're talking about
- `` `break` outside of loop `` -> `` `break` outside of a loop `` for consistency

r? @estebank 