### PR TITLE
Run Clippy without json-rendered flag

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -875,8 +875,7 @@ impl<'a> Builder<'a> {
         }
 
         if cmd == "clippy" {
-            extra_args.push_str("-Zforce-unstable-if-unmarked -Zunstable-options \
-                --json-rendered=termcolor");
+            extra_args.push_str("-Zforce-unstable-if-unmarked");
         }
 
         if !extra_args.is_empty() {


### PR DESCRIPTION
Removed in https://github.com/rust-lang/rust/pull/62766

Replacing it with `--json=diagnostic-rendered-ansi` fails:
```
error: using `--json` requires also using `--error-format=json`
```
Running `./x.py clippy src/libstd` locally works fine (with colors) on Linux so I don't know if there is something to fix.