### PR TITLE
Fix confusion in theme picker functions

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -876,22 +876,22 @@ r#"var themes = document.getElementById("theme-choices");
 var themePicker = document.getElementById("theme-picker");
 
 function showThemeButtonState() {{
-    themes.style.display = "none";
-    themePicker.style.borderBottomRightRadius = "3px";
-    themePicker.style.borderBottomLeftRadius = "3px";
-}}
-
-function hideThemeButtonState() {{
     themes.style.display = "block";
     themePicker.style.borderBottomRightRadius = "0";
     themePicker.style.borderBottomLeftRadius = "0";
 }}
 
+function hideThemeButtonState() {{
+    themes.style.display = "none";
+    themePicker.style.borderBottomRightRadius = "3px";
+    themePicker.style.borderBottomLeftRadius = "3px";
+}}
+
 function switchThemeButtonState() {{
     if (themes.style.display === "block") {{
-        showThemeButtonState();
-    }} else {{
         hideThemeButtonState();
+    }} else {{
+        showThemeButtonState();
     }}
 }};
 

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -105,9 +105,9 @@ if (!DOMTokenList.prototype.remove) {
                 sidebar.appendChild(div);
             }
         }
-        var themePicker = document.getElementsByClassName("theme-picker");
-        if (themePicker && themePicker.length > 0) {
-            themePicker[0].style.display = "none";
+        var themePickers = document.getElementsByClassName("theme-picker");
+        if (themePickers && themePickers.length > 0) {
+            themePickers[0].style.display = "none";
         }
     }
 
@@ -123,9 +123,9 @@ if (!DOMTokenList.prototype.remove) {
             filler.remove();
         }
         document.getElementsByTagName("body")[0].style.marginTop = "";
-        var themePicker = document.getElementsByClassName("theme-picker");
-        if (themePicker && themePicker.length > 0) {
-            themePicker[0].style.display = null;
+        var themePickers = document.getElementsByClassName("theme-picker");
+        if (themePickers && themePickers.length > 0) {
+            themePickers[0].style.display = null;
         }
     }
 


### PR DESCRIPTION
To reproduce the bug currently: click on the theme picker button twice (to show it then hide it). Then click anywhere else: the dropdown menu appears again.

The problem was coming from a confusion of what the `hideThemeButtonState` and `showThemeButtonState` were supposed to do. I switched their codes and updated the `switchThemeButtonState` function. It now works as expected.

r? @kinnison 