### PR TITLE
Tweak E0308 on opaque types

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -1650,7 +1650,7 @@ impl<'tcx> ObligationCause<'tcx> {
                 hir::MatchSource::IfLetDesugar { .. } => "`if let` arms have compatible types",
                 _ => "match arms have compatible types",
             },
-            IfExpression { .. } => "if and else have compatible types",
+            IfExpression { .. } => "if and else have incompatible types",
             IfExpressionWithNoElse => "if missing an else returns ()",
             MainFunctionType => "`main` function has the correct type",
             StartFunctionType => "`start` function has the correct type",

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -247,19 +247,30 @@ impl<'tcx> ty::TyS<'tcx> {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    pub fn note_and_explain_type_err(self,
-                                     db: &mut DiagnosticBuilder<'_>,
-                                     err: &TypeError<'tcx>,
-                                     sp: Span) {
+    pub fn note_and_explain_type_err(
+        self,
+        db: &mut DiagnosticBuilder<'_>,
+        err: &TypeError<'tcx>,
+        sp: Span,
+    ) {
         use self::TypeError::*;
 
-        match err.clone() {
+        match err {
             Sorts(values) => {
                 let expected_str = values.expected.sort_string(self);
                 let found_str = values.found.sort_string(self);
                 if expected_str == found_str && expected_str == "closure" {
                     db.note("no two closures, even if identical, have the same type");
                     db.help("consider boxing your closure and/or using it as a trait object");
+                }
+                if expected_str == found_str && expected_str == "opaque type" { // Issue #63167
+                    db.note("distinct uses of `impl Trait` result in different opaque types");
+                    let e_str = values.expected.to_string();
+                    let f_str = values.found.to_string();
+                    if &e_str == &f_str && &e_str == "impl std::future::Future" {
+                        db.help("if both futures resolve to the same type, consider `await`ing \
+                                 on both of them");
+                    }
                 }
                 if let (ty::Infer(ty::IntVar(_)), ty::Float(_)) =
                        (&values.found.sty, &values.expected.sty) // Issue #53280

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -269,8 +269,8 @@ impl<'tcx> TyCtxt<'tcx> {
                     let f_str = values.found.to_string();
                     if &e_str == &f_str && &e_str == "impl std::future::Future" {
                         // FIXME: use non-string based check.
-                        db.help("if both futures resolve to the same type, consider `await`ing \
-                                 on both of them");
+                        db.help("if both `Future`s have the same `Output` type, consider \
+                                 `.await`ing on both of them");
                     }
                 }
                 if let (ty::Infer(ty::IntVar(_)), ty::Float(_)) =

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -268,6 +268,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     let e_str = values.expected.to_string();
                     let f_str = values.found.to_string();
                     if &e_str == &f_str && &e_str == "impl std::future::Future" {
+                        // FIXME: use non-string based check.
                         db.help("if both futures resolve to the same type, consider `await`ing \
                                  on both of them");
                     }

--- a/src/test/ui/suggestions/opaque-type-error.rs
+++ b/src/test/ui/suggestions/opaque-type-error.rs
@@ -1,0 +1,24 @@
+// edition:2018
+use core::future::Future;
+
+async fn base_thing() -> Result<(), ()> {
+    Ok(())
+}
+
+fn thing_one() -> impl Future<Output = Result<(), ()>> {
+    base_thing()
+}
+
+fn thing_two() -> impl Future<Output = Result<(), ()>> {
+    base_thing()
+}
+
+async fn thing() -> Result<(), ()> {
+    if true {
+        thing_one()
+    } else {
+        thing_two() //~ ERROR if and else have incompatible types
+    }.await
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/opaque-type-error.stderr
+++ b/src/test/ui/suggestions/opaque-type-error.stderr
@@ -1,0 +1,20 @@
+error[E0308]: if and else have incompatible types
+  --> $DIR/opaque-type-error.rs:20:9
+   |
+LL | /     if true {
+LL | |         thing_one()
+   | |         ----------- expected because of this
+LL | |     } else {
+LL | |         thing_two()
+   | |         ^^^^^^^^^^^ expected opaque type, found a different opaque type
+LL | |     }.await
+   | |_____- if and else have incompatible types
+   |
+   = note: expected type `impl std::future::Future` (opaque type)
+              found type `impl std::future::Future` (opaque type)
+   = note: distinct uses of `impl Trait` result in different opaque types
+   = help: if both `Future`s have the same `Output` type, consider `.await`ing on both of them
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
```
error[E0308]: if and else have incompatible types
  --> file.rs:21:9
   |
18 | /     if true {
19 | |         thing_one()
   | |         ----------- expected because of this
20 | |     } else {
21 | |         thing_two()
   | |         ^^^^^^^^^^^ expected opaque type, found a different opaque type
22 | |     }.await
   | |_____- if and else have incompatible types
   |
   = note: expected type `impl std::future::Future` (opaque type)
              found type `impl std::future::Future` (opaque type)
   = note: distinct uses of `impl Trait` result in different opaque types
   = help: if both futures resolve to the same type, consider `await`ing on both of them
```

r? @Centril
CC #63167