### PR TITLE
Do not suggest `.try_into()` on `i32::from(x)`

### DIFF
--- a/src/test/ui/suggestions/mismatched-types-numeric-from.rs
+++ b/src/test/ui/suggestions/mismatched-types-numeric-from.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _: u32 = i32::from(0_u8); //~ ERROR mismatched types
+}

--- a/src/test/ui/suggestions/mismatched-types-numeric-from.stderr
+++ b/src/test/ui/suggestions/mismatched-types-numeric-from.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/mismatched-types-numeric-from.rs:2:18
+   |
+LL |     let _: u32 = i32::from(0_u8);
+   |                  ^^^^^^^^^^^^^^^ expected u32, found i32
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #63697.