### PR TITLE
rustc docs: Update single-use-lifetimes

### DIFF
--- a/src/doc/rustc/src/lints/listing/allowed-by-default.md
+++ b/src/doc/rustc/src/lints/listing/allowed-by-default.md
@@ -208,7 +208,7 @@ error: missing documentation for a function
 
 To fix the lint, add documentation to all items.
 
-## single-use-lifetime
+## single-use-lifetimes
 
 This lint detects lifetimes that are only used once. Some example code that
 triggers this lint:


### PR DESCRIPTION
When using this, rustc emits a warning that the lint has been renamed (to having an 's' at the end)