### PR TITLE
[WIP] rustc_mir: disallow global mutable state in proc macros.

### DIFF
--- a/src/test/ui/proc-macro/global-mut-state.rs
+++ b/src/test/ui/proc-macro/global-mut-state.rs
@@ -1,0 +1,19 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+#![allow(warnings)]
+
+use std::cell::Cell;
+use std::sync::atomic::AtomicBool;
+
+static mut FOO: u8 = 0;
+//~^ ERROR mutable global state in a proc-macro
+
+static BAR: AtomicBool = AtomicBool::new(false);
+//~^ ERROR mutable global state in a proc-macro
+
+thread_local!(static BAZ: Cell<String> = Cell::new(String::new()));
+//~^ ERROR mutable global state in a proc-macro
+
+static FROZEN: &str = "snow";

--- a/src/test/ui/proc-macro/global-mut-state.stderr
+++ b/src/test/ui/proc-macro/global-mut-state.stderr
@@ -1,0 +1,22 @@
+error: mutable global state in a proc-macro
+  --> $DIR/global-mut-state.rs:10:1
+   |
+LL | static mut FOO: u8 = 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: mutable global state in a proc-macro
+  --> $DIR/global-mut-state.rs:13:1
+   |
+LL | static BAR: AtomicBool = AtomicBool::new(false);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: mutable global state in a proc-macro
+  --> $DIR/global-mut-state.rs:16:1
+   |
+LL | thread_local!(static BAZ: Cell<String> = Cell::new(String::new()));
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Along the lines of #63809, this PR attempts to get rid of the main (or only?) place `proc_macro` handles could be leaked to, *and* further disallow/discourage sharing (other) state between invocations.

The approach of banning (interior-)mutable `static`s was most recently mentioned in https://github.com/rust-lang/rust/issues/63804#issuecomment-524181407, but it's likely been brought up several times, we just never tried it.
(Note that this is not foolproof: one would have to scan all dependencies for such `static`s, modulo `proc_macro`/`std`, and even then it's possible there would be a lot of false positives)

So this is mostly for a check-only crater run, to see what (if anything) breaks.