### PR TITLE
Suggest calling closure with resolved return type when appropriate

### DIFF
--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -385,7 +385,8 @@ impl<'tcx> ClosureSubsts<'tcx> {
         let ty = self.closure_sig_ty(def_id, tcx);
         match ty.sty {
             ty::FnPtr(sig) => sig,
-            _ => bug!("closure_sig_ty is not a fn-ptr: {:?}", ty),
+            ty::Infer(_) | ty::Error => ty::Binder::dummy(FnSig::fake()),  // ignore errors
+            _ => bug!("closure_sig_ty is not a fn-ptr: {:?}", ty.sty),
         }
     }
 }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -385,7 +385,6 @@ impl<'tcx> ClosureSubsts<'tcx> {
         let ty = self.closure_sig_ty(def_id, tcx);
         match ty.sty {
             ty::FnPtr(sig) => sig,
-            ty::Infer(_) | ty::Error => ty::Binder::dummy(FnSig::fake()),  // ignore errors
             _ => bug!("closure_sig_ty is not a fn-ptr: {:?}", ty.sty),
         }
     }

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -799,12 +799,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// adjusted type of the expression, if successful.
     /// Adjustments are only recorded if the coercion succeeded.
     /// The expressions *must not* have any pre-existing adjustments.
-    pub fn try_coerce(&self,
-                      expr: &hir::Expr,
-                      expr_ty: Ty<'tcx>,
-                      target: Ty<'tcx>,
-                      allow_two_phase: AllowTwoPhase)
-                      -> RelateResult<'tcx, Ty<'tcx>> {
+    pub fn try_coerce(
+        &self,
+        expr: &hir::Expr,
+        expr_ty: Ty<'tcx>,
+        target: Ty<'tcx>,
+        allow_two_phase: AllowTwoPhase,
+    ) -> RelateResult<'tcx, Ty<'tcx>> {
         let source = self.resolve_type_vars_with_obligations(expr_ty);
         debug!("coercion::try({:?}: {:?} -> {:?})", expr, source, target);
 

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.rs
@@ -42,4 +42,6 @@ fn main() {
     let _: usize = X::bal; //~ ERROR mismatched types
     let _: usize = X.ban; //~ ERROR attempted to take value of method
     let _: usize = X.bal; //~ ERROR attempted to take value of method
+    let closure = || 42;
+    let _: usize = closure; //~ ERROR mismatched types
 }

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -214,7 +214,21 @@ error[E0615]: attempted to take value of method `bal` on type `X`
 LL |     let _: usize = X.bal;
    |                      ^^^ help: use parentheses to call the method: `bal()`
 
-error: aborting due to 16 previous errors
+error[E0308]: mismatched types
+  --> $DIR/fn-or-tuple-struct-without-args.rs:46:20
+   |
+LL |     let closure = || 42;
+   |                   -- closure defined here
+LL |     let _: usize = closure;
+   |                    ^^^^^^^
+   |                    |
+   |                    expected usize, found closure
+   |                    help: use parentheses to call this closure: `closure()`
+   |
+   = note: expected type `usize`
+              found type `[closure@$DIR/fn-or-tuple-struct-without-args.rs:45:19: 45:24]`
+
+error: aborting due to 17 previous errors
 
 Some errors have detailed explanations: E0308, E0423, E0615.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Follow up to #63337. CC #63100.

```
error[E0308]: mismatched types
  --> $DIR/fn-or-tuple-struct-without-args.rs:46:20
   |
LL |     let closure = || 42;
   |                   -- closure defined here
LL |     let _: usize = closure;
   |                    ^^^^^^^
   |                    |
   |                    expected usize, found closure
   |                    help: use parentheses to call this closure: `closure()`
   |
   = note: expected type `usize`
              found type `[closure@$DIR/fn-or-tuple-struct-without-args.rs:45:19: 45:24]`
```