### PR TITLE
VxWorks does not provide a way to set the task name except at creation time

### DIFF
--- a/src/libstd/sys/vxworks/thread.rs
+++ b/src/libstd/sys/vxworks/thread.rs
@@ -77,7 +77,7 @@ impl Thread {
     }
 
     pub fn set_name(_name: &CStr) {
-        assert!(false, "FIXME: set_name");
+        // VxWorks does not provide a way to set the task name except at creation time
     }
 
     pub fn sleep(dur: Duration) {


### PR DESCRIPTION
Make set_name do thing as VxWorks does not provide a way to set the task name except at creation time.

r? @alexcrichton 

cc @n-salim 