### PR TITLE
Removed a confusing FnOnce example

### DIFF
--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -184,6 +184,7 @@ pub trait FnMut<Args> : FnOnce<Args> {
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
+///
 /// ## Using a `FnOnce` parameter
 ///
 /// ```

--- a/src/libcore/ops/function.rs
+++ b/src/libcore/ops/function.rs
@@ -184,15 +184,6 @@ pub trait FnMut<Args> : FnOnce<Args> {
 /// [nomicon]: ../../nomicon/hrtb.html
 ///
 /// # Examples
-///
-/// ## Calling a by-value closure
-///
-/// ```
-/// let x = 5;
-/// let square_x = move || x * x;
-/// assert_eq!(square_x(), 25);
-/// ```
-///
 /// ## Using a `FnOnce` parameter
 ///
 /// ```


### PR DESCRIPTION
# Description
See #47091 for a discussion.

## Changes
- Removed an example that might suggest readers that square_x is (only) FnOnce.

closes #47091