### PR TITLE
[rustdoc] Fix system theme detection

### DIFF
--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -118,7 +118,8 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
 }
 
 function getSystemValue() {
-    return getComputedStyle(document.documentElement).getPropertyValue('content');
+    var property = getComputedStyle(document.documentElement).getPropertyValue('content');
+    return property.replace(/\"\'/g, "");
 }
 
 switchTheme(currentTheme, mainTheme,


### PR DESCRIPTION
Fixes #63830 

The problem is that it returns the property "entirely" (so with the quotes in our case). Removing them fixes the issue.

cc @fenhl

r? @kinnison 