### PR TITLE
HIR: introduce a HirId to DefId map in Definitions

### DIFF
--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -28,7 +28,8 @@ impl<'a> DefCollector<'a> {
                   -> DefIndex {
         let parent_def = self.parent_def;
         debug!("create_def(node_id={:?}, data={:?}, parent_def={:?})", node_id, data, parent_def);
-        self.definitions.create_def_with_parent(parent_def, node_id, data, self.expansion, span)
+        self.definitions.create_def_with_parent(
+            parent_def, node_id, None, data, self.expansion, span)
     }
 
     fn with_parent<F: FnOnce(&mut Self)>(&mut self, parent_def: DefIndex, f: F) {

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -281,8 +281,7 @@ impl<'hir> Map<'hir> {
 
     #[inline]
     pub fn opt_local_def_id(&self, hir_id: HirId) -> Option<DefId> {
-        let node_id = self.hir_to_node_id(hir_id);
-        self.definitions.opt_local_def_id(node_id)
+        self.definitions.opt_local_def_id_from_hir_id(hir_id)
     }
 
     #[inline]


### PR DESCRIPTION
Split out from https://github.com/rust-lang/rust/pull/62975.

Introduce a `HirId` to `DefIndex` map in `map::Definitions`; this introduces a little bit of extra complexity, but could result in a performance win. I'd do a perf run to check if it's worth it.