### PR TITLE
Refactor feature gates

### DIFF
--- a/src/libsyntax/feature_gate/accepted.rs
+++ b/src/libsyntax/feature_gate/accepted.rs
@@ -1,14 +1,24 @@
 //! List of the accepted feature gates.
 
-use crate::symbol::{Symbol, sym};
+use crate::symbol::sym;
+use super::{State, Feature};
 
 macro_rules! declare_features {
     ($(
         $(#[doc = $doc:tt])* (accepted, $feature:ident, $ver:expr, $issue:expr, None),
     )+) => {
         /// Those language feature has since been Accepted (it was once Active)
-        pub const ACCEPTED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
-            $((sym::$feature, $ver, $issue, None)),+
+        pub const ACCEPTED_FEATURES: &[Feature] = &[
+            $(
+                Feature {
+                    state: State::Accepted,
+                    name: sym::$feature,
+                    since: $ver,
+                    issue: $issue,
+                    edition: None,
+                    description: concat!($($doc,)*),
+                }
+            ),+
         ];
     }
 }

--- a/src/libsyntax/feature_gate/accepted.rs
+++ b/src/libsyntax/feature_gate/accepted.rs
@@ -3,7 +3,9 @@
 use crate::symbol::{Symbol, sym};
 
 macro_rules! declare_features {
-    ($((accepted, $feature: ident, $ver: expr, $issue: expr, None),)+) => {
+    ($(
+        $(#[doc = $doc:tt])* (accepted, $feature:ident, $ver:expr, $issue:expr, None),
+    )+) => {
         /// Those language feature has since been Accepted (it was once Active)
         pub const ACCEPTED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
             $((sym::$feature, $ver, $issue, None)),+
@@ -16,11 +18,11 @@ declare_features! (
     // feature-group-start: for testing purposes
     // -------------------------------------------------------------------------
 
-    // A temporary feature gate used to enable parser extensions needed
-    // to bootstrap fix for #5723.
+    /// A temporary feature gate used to enable parser extensions needed
+    /// to bootstrap fix for #5723.
     (accepted, issue_5723_bootstrap, "1.0.0", None, None),
-    // These are used to test this portion of the compiler,
-    // they don't actually mean anything.
+    /// These are used to test this portion of the compiler,
+    /// they don't actually mean anything.
     (accepted, test_accepted_feature, "1.0.0", None, None),
 
     // -------------------------------------------------------------------------
@@ -31,203 +33,203 @@ declare_features! (
     // feature-group-start: accepted features
     // -------------------------------------------------------------------------
 
-    // Allows using associated `type`s in `trait`s.
+    /// Allows using associated `type`s in `trait`s.
     (accepted, associated_types, "1.0.0", None, None),
-    // Allows using assigning a default type to type parameters in algebraic data type definitions.
+    /// Allows using assigning a default type to type parameters in algebraic data type definitions.
     (accepted, default_type_params, "1.0.0", None, None),
     // FIXME: explain `globs`.
     (accepted, globs, "1.0.0", None, None),
-    // Allows `macro_rules!` items.
+    /// Allows `macro_rules!` items.
     (accepted, macro_rules, "1.0.0", None, None),
-    // Allows use of `&foo[a..b]` as a slicing syntax.
+    /// Allows use of `&foo[a..b]` as a slicing syntax.
     (accepted, slicing_syntax, "1.0.0", None, None),
-    // Allows struct variants `Foo { baz: u8, .. }` in enums (RFC 418).
+    /// Allows struct variants `Foo { baz: u8, .. }` in enums (RFC 418).
     (accepted, struct_variant, "1.0.0", None, None),
-    // Allows indexing tuples.
+    /// Allows indexing tuples.
     (accepted, tuple_indexing, "1.0.0", None, None),
-    // Allows the use of `if let` expressions.
+    /// Allows the use of `if let` expressions.
     (accepted, if_let, "1.0.0", None, None),
-    // Allows the use of `while let` expressions.
+    /// Allows the use of `while let` expressions.
     (accepted, while_let, "1.0.0", None, None),
-    // Allows using `#![no_std]`.
+    /// Allows using `#![no_std]`.
     (accepted, no_std, "1.6.0", None, None),
-    // Allows overloading augmented assignment operations like `a += b`.
+    /// Allows overloading augmented assignment operations like `a += b`.
     (accepted, augmented_assignments, "1.8.0", Some(28235), None),
-    // Allows empty structs and enum variants with braces.
+    /// Allows empty structs and enum variants with braces.
     (accepted, braced_empty_structs, "1.8.0", Some(29720), None),
-    // Allows `#[deprecated]` attribute.
+    /// Allows `#[deprecated]` attribute.
     (accepted, deprecated, "1.9.0", Some(29935), None),
-    // Allows macros to appear in the type position.
+    /// Allows macros to appear in the type position.
     (accepted, type_macros, "1.13.0", Some(27245), None),
-    // Allows use of the postfix `?` operator in expressions.
+    /// Allows use of the postfix `?` operator in expressions.
     (accepted, question_mark, "1.13.0", Some(31436), None),
-    // Allows `..` in tuple (struct) patterns.
+    /// Allows `..` in tuple (struct) patterns.
     (accepted, dotdot_in_tuple_patterns, "1.14.0", Some(33627), None),
-    // Allows some increased flexibility in the name resolution rules,
-    // especially around globs and shadowing (RFC 1560).
+    /// Allows some increased flexibility in the name resolution rules,
+    /// especially around globs and shadowing (RFC 1560).
     (accepted, item_like_imports, "1.15.0", Some(35120), None),
-    // Allows using `Self` and associated types in struct expressions and patterns.
+    /// Allows using `Self` and associated types in struct expressions and patterns.
     (accepted, more_struct_aliases, "1.16.0", Some(37544), None),
-    // Allows elision of `'static` lifetimes in `static`s and `const`s.
+    /// Allows elision of `'static` lifetimes in `static`s and `const`s.
     (accepted, static_in_const, "1.17.0", Some(35897), None),
-    // Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
+    /// Allows field shorthands (`x` meaning `x: x`) in struct literal expressions.
     (accepted, field_init_shorthand, "1.17.0", Some(37340), None),
-    // Allows the definition recursive static items.
+    /// Allows the definition recursive static items.
     (accepted, static_recursion, "1.17.0", Some(29719), None),
-    // Allows `pub(restricted)` visibilities (RFC 1422).
+    /// Allows `pub(restricted)` visibilities (RFC 1422).
     (accepted, pub_restricted, "1.18.0", Some(32409), None),
-    // Allows `#![windows_subsystem]`.
+    /// Allows `#![windows_subsystem]`.
     (accepted, windows_subsystem, "1.18.0", Some(37499), None),
-    // Allows `break {expr}` with a value inside `loop`s.
+    /// Allows `break {expr}` with a value inside `loop`s.
     (accepted, loop_break_value, "1.19.0", Some(37339), None),
-    // Allows numeric fields in struct expressions and patterns.
+    /// Allows numeric fields in struct expressions and patterns.
     (accepted, relaxed_adts, "1.19.0", Some(35626), None),
-    // Allows coercing non capturing closures to function pointers.
+    /// Allows coercing non capturing closures to function pointers.
     (accepted, closure_to_fn_coercion, "1.19.0", Some(39817), None),
-    // Allows attributes on struct literal fields.
+    /// Allows attributes on struct literal fields.
     (accepted, struct_field_attributes, "1.20.0", Some(38814), None),
-    // Allows the definition of associated constants in `trait` or `impl` blocks.
+    /// Allows the definition of associated constants in `trait` or `impl` blocks.
     (accepted, associated_consts, "1.20.0", Some(29646), None),
-    // Allows usage of the `compile_error!` macro.
+    /// Allows usage of the `compile_error!` macro.
     (accepted, compile_error, "1.20.0", Some(40872), None),
-    // Allows code like `let x: &'static u32 = &42` to work (RFC 1414).
+    /// Allows code like `let x: &'static u32 = &42` to work (RFC 1414).
     (accepted, rvalue_static_promotion, "1.21.0", Some(38865), None),
-    // Allows `Drop` types in constants (RFC 1440).
+    /// Allows `Drop` types in constants (RFC 1440).
     (accepted, drop_types_in_const, "1.22.0", Some(33156), None),
-    // Allows the sysV64 ABI to be specified on all platforms
-    // instead of just the platforms on which it is the C ABI.
+    /// Allows the sysV64 ABI to be specified on all platforms
+    /// instead of just the platforms on which it is the C ABI.
     (accepted, abi_sysv64, "1.24.0", Some(36167), None),
-    // Allows `repr(align(16))` struct attribute (RFC 1358).
+    /// Allows `repr(align(16))` struct attribute (RFC 1358).
     (accepted, repr_align, "1.25.0", Some(33626), None),
-    // Allows '|' at beginning of match arms (RFC 1925).
+    /// Allows '|' at beginning of match arms (RFC 1925).
     (accepted, match_beginning_vert, "1.25.0", Some(44101), None),
-    // Allows nested groups in `use` items (RFC 2128).
+    /// Allows nested groups in `use` items (RFC 2128).
     (accepted, use_nested_groups, "1.25.0", Some(44494), None),
-    // Allows indexing into constant arrays.
+    /// Allows indexing into constant arrays.
     (accepted, const_indexing, "1.26.0", Some(29947), None),
-    // Allows using `a..=b` and `..=b` as inclusive range syntaxes.
+    /// Allows using `a..=b` and `..=b` as inclusive range syntaxes.
     (accepted, inclusive_range_syntax, "1.26.0", Some(28237), None),
-    // Allows `..=` in patterns (RFC 1192).
+    /// Allows `..=` in patterns (RFC 1192).
     (accepted, dotdoteq_in_patterns, "1.26.0", Some(28237), None),
-    // Allows `fn main()` with return types which implements `Termination` (RFC 1937).
+    /// Allows `fn main()` with return types which implements `Termination` (RFC 1937).
     (accepted, termination_trait, "1.26.0", Some(43301), None),
-    // Allows implementing `Clone` for closures where possible (RFC 2132).
+    /// Allows implementing `Clone` for closures where possible (RFC 2132).
     (accepted, clone_closures, "1.26.0", Some(44490), None),
-    // Allows implementing `Copy` for closures where possible (RFC 2132).
+    /// Allows implementing `Copy` for closures where possible (RFC 2132).
     (accepted, copy_closures, "1.26.0", Some(44490), None),
-    // Allows `impl Trait` in function arguments.
+    /// Allows `impl Trait` in function arguments.
     (accepted, universal_impl_trait, "1.26.0", Some(34511), None),
-    // Allows `impl Trait` in function return types.
+    /// Allows `impl Trait` in function return types.
     (accepted, conservative_impl_trait, "1.26.0", Some(34511), None),
-    // Allows using the `u128` and `i128` types.
+    /// Allows using the `u128` and `i128` types.
     (accepted, i128_type, "1.26.0", Some(35118), None),
-    // Allows default match binding modes (RFC 2005).
+    /// Allows default match binding modes (RFC 2005).
     (accepted, match_default_bindings, "1.26.0", Some(42640), None),
-    // Allows `'_` placeholder lifetimes.
+    /// Allows `'_` placeholder lifetimes.
     (accepted, underscore_lifetimes, "1.26.0", Some(44524), None),
-    // Allows attributes on lifetime/type formal parameters in generics (RFC 1327).
+    /// Allows attributes on lifetime/type formal parameters in generics (RFC 1327).
     (accepted, generic_param_attrs, "1.27.0", Some(48848), None),
-    // Allows `cfg(target_feature = "...")`.
+    /// Allows `cfg(target_feature = "...")`.
     (accepted, cfg_target_feature, "1.27.0", Some(29717), None),
-    // Allows `#[target_feature(...)]`.
+    /// Allows `#[target_feature(...)]`.
     (accepted, target_feature, "1.27.0", None, None),
-    // Allows using `dyn Trait` as a syntax for trait objects.
+    /// Allows using `dyn Trait` as a syntax for trait objects.
     (accepted, dyn_trait, "1.27.0", Some(44662), None),
-    // Allows `#[must_use]` on functions, and introduces must-use operators (RFC 1940).
+    /// Allows `#[must_use]` on functions, and introduces must-use operators (RFC 1940).
     (accepted, fn_must_use, "1.27.0", Some(43302), None),
-    // Allows use of the `:lifetime` macro fragment specifier.
+    /// Allows use of the `:lifetime` macro fragment specifier.
     (accepted, macro_lifetime_matcher, "1.27.0", Some(34303), None),
-    // Allows `#[test]` functions where the return type implements `Termination` (RFC 1937).
+    /// Allows `#[test]` functions where the return type implements `Termination` (RFC 1937).
     (accepted, termination_trait_test, "1.27.0", Some(48854), None),
-    // Allows the `#[global_allocator]` attribute.
+    /// Allows the `#[global_allocator]` attribute.
     (accepted, global_allocator, "1.28.0", Some(27389), None),
-    // Allows `#[repr(transparent)]` attribute on newtype structs.
+    /// Allows `#[repr(transparent)]` attribute on newtype structs.
     (accepted, repr_transparent, "1.28.0", Some(43036), None),
-    // Allows procedural macros in `proc-macro` crates.
+    /// Allows procedural macros in `proc-macro` crates.
     (accepted, proc_macro, "1.29.0", Some(38356), None),
-    // Allows `foo.rs` as an alternative to `foo/mod.rs`.
+    /// Allows `foo.rs` as an alternative to `foo/mod.rs`.
     (accepted, non_modrs_mods, "1.30.0", Some(44660), None),
-    // Allows use of the `:vis` macro fragment specifier
+    /// Allows use of the `:vis` macro fragment specifier
     (accepted, macro_vis_matcher, "1.30.0", Some(41022), None),
-    // Allows importing and reexporting macros with `use`,
-    // enables macro modularization in general.
+    /// Allows importing and reexporting macros with `use`,
+    /// enables macro modularization in general.
     (accepted, use_extern_macros, "1.30.0", Some(35896), None),
-    // Allows keywords to be escaped for use as identifiers.
+    /// Allows keywords to be escaped for use as identifiers.
     (accepted, raw_identifiers, "1.30.0", Some(48589), None),
-    // Allows attributes scoped to tools.
+    /// Allows attributes scoped to tools.
     (accepted, tool_attributes, "1.30.0", Some(44690), None),
-    // Allows multi-segment paths in attributes and derives.
+    /// Allows multi-segment paths in attributes and derives.
     (accepted, proc_macro_path_invoc, "1.30.0", Some(38356), None),
-    // Allows all literals in attribute lists and values of key-value pairs.
+    /// Allows all literals in attribute lists and values of key-value pairs.
     (accepted, attr_literals, "1.30.0", Some(34981), None),
-    // Allows inferring outlives requirements (RFC 2093).
+    /// Allows inferring outlives requirements (RFC 2093).
     (accepted, infer_outlives_requirements, "1.30.0", Some(44493), None),
-    // Allows annotating functions conforming to `fn(&PanicInfo) -> !` with `#[panic_handler]`.
-    // This defines the behavior of panics.
+    /// Allows annotating functions conforming to `fn(&PanicInfo) -> !` with `#[panic_handler]`.
+    /// This defines the behavior of panics.
     (accepted, panic_handler, "1.30.0", Some(44489), None),
-    // Allows `#[used]` to preserve symbols (see llvm.used).
+    /// Allows `#[used]` to preserve symbols (see llvm.used).
     (accepted, used, "1.30.0", Some(40289), None),
-    // Allows `crate` in paths.
+    /// Allows `crate` in paths.
     (accepted, crate_in_paths, "1.30.0", Some(45477), None),
-    // Allows resolving absolute paths as paths from other crates.
+    /// Allows resolving absolute paths as paths from other crates.
     (accepted, extern_absolute_paths, "1.30.0", Some(44660), None),
-    // Allows access to crate names passed via `--extern` through prelude.
+    /// Allows access to crate names passed via `--extern` through prelude.
     (accepted, extern_prelude, "1.30.0", Some(44660), None),
-    // Allows parentheses in patterns.
+    /// Allows parentheses in patterns.
     (accepted, pattern_parentheses, "1.31.0", Some(51087), None),
-    // Allows the definition of `const fn` functions.
+    /// Allows the definition of `const fn` functions.
     (accepted, min_const_fn, "1.31.0", Some(53555), None),
-    // Allows scoped lints.
+    /// Allows scoped lints.
     (accepted, tool_lints, "1.31.0", Some(44690), None),
-    // Allows lifetime elision in `impl` headers. For example:
-    // + `impl<I:Iterator> Iterator for &mut Iterator`
-    // + `impl Debug for Foo<'_>`
+    /// Allows lifetime elision in `impl` headers. For example:
+    /// + `impl<I:Iterator> Iterator for &mut Iterator`
+    /// + `impl Debug for Foo<'_>`
     (accepted, impl_header_lifetime_elision, "1.31.0", Some(15872), None),
-    // Allows `extern crate foo as bar;`. This puts `bar` into extern prelude.
+    /// Allows `extern crate foo as bar;`. This puts `bar` into extern prelude.
     (accepted, extern_crate_item_prelude, "1.31.0", Some(55599), None),
-    // Allows use of the `:literal` macro fragment specifier (RFC 1576).
+    /// Allows use of the `:literal` macro fragment specifier (RFC 1576).
     (accepted, macro_literal_matcher, "1.32.0", Some(35625), None),
-    // Allows use of `?` as the Kleene "at most one" operator in macros.
+    /// Allows use of `?` as the Kleene "at most one" operator in macros.
     (accepted, macro_at_most_once_rep, "1.32.0", Some(48075), None),
-    // Allows `Self` struct constructor (RFC 2302).
+    /// Allows `Self` struct constructor (RFC 2302).
     (accepted, self_struct_ctor, "1.32.0", Some(51994), None),
-    // Allows `Self` in type definitions (RFC 2300).
+    /// Allows `Self` in type definitions (RFC 2300).
     (accepted, self_in_typedefs, "1.32.0", Some(49303), None),
-    // Allows `use x::y;` to search `x` in the current scope.
+    /// Allows `use x::y;` to search `x` in the current scope.
     (accepted, uniform_paths, "1.32.0", Some(53130), None),
-    // Allows integer match exhaustiveness checking (RFC 2591).
+    /// Allows integer match exhaustiveness checking (RFC 2591).
     (accepted, exhaustive_integer_patterns, "1.33.0", Some(50907), None),
-    // Allows `use path as _;` and `extern crate c as _;`.
+    /// Allows `use path as _;` and `extern crate c as _;`.
     (accepted, underscore_imports, "1.33.0", Some(48216), None),
-    // Allows `#[repr(packed(N))]` attribute on structs.
+    /// Allows `#[repr(packed(N))]` attribute on structs.
     (accepted, repr_packed, "1.33.0", Some(33158), None),
-    // Allows irrefutable patterns in `if let` and `while let` statements (RFC 2086).
+    /// Allows irrefutable patterns in `if let` and `while let` statements (RFC 2086).
     (accepted, irrefutable_let_patterns, "1.33.0", Some(44495), None),
-    // Allows calling `const unsafe fn` inside `unsafe` blocks in `const fn` functions.
+    /// Allows calling `const unsafe fn` inside `unsafe` blocks in `const fn` functions.
     (accepted, min_const_unsafe_fn, "1.33.0", Some(55607), None),
-    // Allows let bindings, assignments and destructuring in `const` functions and constants.
-    // As long as control flow is not implemented in const eval, `&&` and `||` may not be used
-    // at the same time as let bindings.
+    /// Allows let bindings, assignments and destructuring in `const` functions and constants.
+    /// As long as control flow is not implemented in const eval, `&&` and `||` may not be used
+    /// at the same time as let bindings.
     (accepted, const_let, "1.33.0", Some(48821), None),
-    // Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
+    /// Allows `#[cfg_attr(predicate, multiple, attributes, here)]`.
     (accepted, cfg_attr_multi, "1.33.0", Some(54881), None),
-    // Allows top level or-patterns (`p | q`) in `if let` and `while let`.
+    /// Allows top level or-patterns (`p | q`) in `if let` and `while let`.
     (accepted, if_while_or_patterns, "1.33.0", Some(48215), None),
-    // Allows `cfg(target_vendor = "...")`.
+    /// Allows `cfg(target_vendor = "...")`.
     (accepted, cfg_target_vendor, "1.33.0", Some(29718), None),
-    // Allows `extern crate self as foo;`.
-    // This puts local crate root into extern prelude under name `foo`.
+    /// Allows `extern crate self as foo;`.
+    /// This puts local crate root into extern prelude under name `foo`.
     (accepted, extern_crate_self, "1.34.0", Some(56409), None),
-    // Allows arbitrary delimited token streams in non-macro attributes.
+    /// Allows arbitrary delimited token streams in non-macro attributes.
     (accepted, unrestricted_attribute_tokens, "1.34.0", Some(55208), None),
-    // Allows paths to enum variants on type aliases including `Self`.
+    /// Allows paths to enum variants on type aliases including `Self`.
     (accepted, type_alias_enum_variants, "1.37.0", Some(49683), None),
-    // Allows using `#[repr(align(X))]` on enums with equivalent semantics
-    // to wrapping an enum in a wrapper struct with `#[repr(align(X))]`.
+    /// Allows using `#[repr(align(X))]` on enums with equivalent semantics
+    /// to wrapping an enum in a wrapper struct with `#[repr(align(X))]`.
     (accepted, repr_align_enum, "1.37.0", Some(57996), None),
-    // Allows `const _: TYPE = VALUE`.
+    /// Allows `const _: TYPE = VALUE`.
     (accepted, underscore_const_names, "1.37.0", Some(54912), None),
-    // Allows free and inherent `async fn`s, `async` blocks, and `<expr>.await` expressions.
+    /// Allows free and inherent `async fn`s, `async` blocks, and `<expr>.await` expressions.
     (accepted, async_await, "1.39.0", Some(50547), None),
 
     // -------------------------------------------------------------------------

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -65,6 +65,16 @@ macro_rules! declare_features {
     };
 }
 
+impl Feature {
+    /// Set this feature in `Features`. Panics if called on a non-active feature.
+    pub fn set(&self, features: &mut Features, span: Span) {
+        match self.state {
+            State::Active { set } => set(features, span),
+            _ => panic!("Called `set` on feature `{}` which is not `active`", self.name)
+        }
+    }
+}
+
 // If you change this, please modify `src/doc/unstable-book` as well.
 //
 // Don't ever remove anything from this list; move them to `removed.rs`.

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -3,6 +3,7 @@
 use crate::edition::Edition;
 use crate::symbol::{Symbol, sym};
 use syntax_pos::Span;
+use super::{State, Feature};
 
 macro_rules! set {
     ($field: ident) => {{
@@ -14,12 +15,24 @@ macro_rules! set {
 }
 
 macro_rules! declare_features {
-    ($((active, $feature: ident, $ver: expr, $issue: expr, $edition: expr),)+) => {
+    ($(
+        $(#[doc = $doc:tt])* (active, $feature:ident, $ver:expr, $issue:expr, $edition:expr),
+    )+) => {
         /// Represents active features that are currently being implemented or
         /// currently being considered for addition/removal.
         pub const ACTIVE_FEATURES:
-            &[(Symbol, &str, Option<u32>, Option<Edition>, fn(&mut Features, Span))] =
-            &[$((sym::$feature, $ver, $issue, $edition, set!($feature))),+];
+            &[Feature] =
+            &[$(
+                // (sym::$feature, $ver, $issue, $edition, set!($feature))
+                Feature {
+                    state: State::Active { set: set!($feature) },
+                    name: sym::$feature,
+                    since: $ver,
+                    issue: $issue,
+                    edition: $edition,
+                    description: concat!($($doc,)*),
+                }
+            ),+];
 
         /// A set of features to be used by later passes.
         #[derive(Clone)]
@@ -28,7 +41,10 @@ macro_rules! declare_features {
             pub declared_lang_features: Vec<(Symbol, Span, Option<Symbol>)>,
             /// `#![feature]` attrs for non-language (library) features
             pub declared_lib_features: Vec<(Symbol, Span)>,
-            $(pub $feature: bool),+
+            $(
+                $(#[doc = $doc])*
+                pub $feature: bool
+            ),+
         }
 
         impl Features {
@@ -58,7 +74,7 @@ macro_rules! declare_features {
 // stable (active).
 //
 // Note that the features are grouped into internal/user-facing and then
-// sorted by version inside those groups. This is inforced with tidy.
+// sorted by version inside those groups. This is enforced with tidy.
 //
 // N.B., `tools/tidy/src/features.rs` parses this information directly out of the
 // source, so take care when modifying it.
@@ -70,127 +86,127 @@ declare_features! (
 
     // no-tracking-issue-start
 
-    // Allows using compiler's own crates.
+    /// Allows using compiler's own crates.
     (active, rustc_private, "1.0.0", Some(27812), None),
 
-    // Allows using the `rust-intrinsic`'s "ABI".
+    /// Allows using the `rust-intrinsic`'s "ABI".
     (active, intrinsics, "1.0.0", None, None),
 
-    // Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
+    /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.
     (active, lang_items, "1.0.0", None, None),
 
-    // Allows using the `#[stable]` and `#[unstable]` attributes.
+    /// Allows using the `#[stable]` and `#[unstable]` attributes.
     (active, staged_api, "1.0.0", None, None),
 
-    // Allows using `#[allow_internal_unstable]`. This is an
-    // attribute on `macro_rules!` and can't use the attribute handling
-    // below (it has to be checked before expansion possibly makes
-    // macros disappear).
+    /// Allows using `#[allow_internal_unstable]`. This is an
+    /// attribute on `macro_rules!` and can't use the attribute handling
+    /// below (it has to be checked before expansion possibly makes
+    /// macros disappear).
     (active, allow_internal_unstable, "1.0.0", None, None),
 
-    // Allows using `#[allow_internal_unsafe]`. This is an
-    // attribute on `macro_rules!` and can't use the attribute handling
-    // below (it has to be checked before expansion possibly makes
-    // macros disappear).
+    /// Allows using `#[allow_internal_unsafe]`. This is an
+    /// attribute on `macro_rules!` and can't use the attribute handling
+    /// below (it has to be checked before expansion possibly makes
+    /// macros disappear).
     (active, allow_internal_unsafe, "1.0.0", None, None),
 
-    // Allows using the macros:
-    // + `__diagnostic_used`
-    // + `__register_diagnostic`
-    // +`__build_diagnostic_array`
+    /// Allows using the macros:
+    /// + `__diagnostic_used`
+    /// + `__register_diagnostic`
+    /// +`__build_diagnostic_array`
     (active, rustc_diagnostic_macros, "1.0.0", None, None),
 
-    // Allows using `#[rustc_const_unstable(feature = "foo", ..)]` which
-    // lets a function to be `const` when opted into with `#![feature(foo)]`.
+    /// Allows using `#[rustc_const_unstable(feature = "foo", ..)]` which
+    /// lets a function to be `const` when opted into with `#![feature(foo)]`.
     (active, rustc_const_unstable, "1.0.0", None, None),
 
-    // no-tracking-issue-end
+    /// no-tracking-issue-end
 
-    // Allows using `#[link_name="llvm.*"]`.
+    /// Allows using `#[link_name="llvm.*"]`.
     (active, link_llvm_intrinsics, "1.0.0", Some(29602), None),
 
-    // Allows using `rustc_*` attributes (RFC 572).
+    /// Allows using `rustc_*` attributes (RFC 572).
     (active, rustc_attrs, "1.0.0", Some(29642), None),
 
-    // Allows using `#[on_unimplemented(..)]` on traits.
+    /// Allows using `#[on_unimplemented(..)]` on traits.
     (active, on_unimplemented, "1.0.0", Some(29628), None),
 
-    // Allows using the `box $expr` syntax.
+    /// Allows using the `box $expr` syntax.
     (active, box_syntax, "1.0.0", Some(49733), None),
 
-    // Allows using `#[main]` to replace the entrypoint `#[lang = "start"]` calls.
+    /// Allows using `#[main]` to replace the entrypoint `#[lang = "start"]` calls.
     (active, main, "1.0.0", Some(29634), None),
 
-    // Allows using `#[start]` on a function indicating that it is the program entrypoint.
+    /// Allows using `#[start]` on a function indicating that it is the program entrypoint.
     (active, start, "1.0.0", Some(29633), None),
 
-    // Allows using the `#[fundamental]` attribute.
+    /// Allows using the `#[fundamental]` attribute.
     (active, fundamental, "1.0.0", Some(29635), None),
 
-    // Allows using the `rust-call` ABI.
+    /// Allows using the `rust-call` ABI.
     (active, unboxed_closures, "1.0.0", Some(29625), None),
 
-    // Allows using the `#[linkage = ".."]` attribute.
+    /// Allows using the `#[linkage = ".."]` attribute.
     (active, linkage, "1.0.0", Some(29603), None),
 
-    // Allows features specific to OIBIT (auto traits).
+    /// Allows features specific to OIBIT (auto traits).
     (active, optin_builtin_traits, "1.0.0", Some(13231), None),
 
-    // Allows using `box` in patterns (RFC 469).
+    /// Allows using `box` in patterns (RFC 469).
     (active, box_patterns, "1.0.0", Some(29641), None),
 
     // no-tracking-issue-start
 
-    // Allows using `#[prelude_import]` on glob `use` items.
+    /// Allows using `#[prelude_import]` on glob `use` items.
     (active, prelude_import, "1.2.0", None, None),
 
     // no-tracking-issue-end
 
     // no-tracking-issue-start
 
-    // Allows using `#[omit_gdb_pretty_printer_section]`.
+    /// Allows using `#[omit_gdb_pretty_printer_section]`.
     (active, omit_gdb_pretty_printer_section, "1.5.0", None, None),
 
-    // Allows using the `vectorcall` ABI.
+    /// Allows using the `vectorcall` ABI.
     (active, abi_vectorcall, "1.7.0", None, None),
 
     // no-tracking-issue-end
 
-    // Allows using `#[structural_match]` which indicates that a type is structurally matchable.
+    /// Allows using `#[structural_match]` which indicates that a type is structurally matchable.
     (active, structural_match, "1.8.0", Some(31434), None),
 
-    // Allows using the `may_dangle` attribute (RFC 1327).
+    /// Allows using the `may_dangle` attribute (RFC 1327).
     (active, dropck_eyepatch, "1.10.0", Some(34761), None),
 
-    // Allows using the `#![panic_runtime]` attribute.
+    /// Allows using the `#![panic_runtime]` attribute.
     (active, panic_runtime, "1.10.0", Some(32837), None),
 
-    // Allows declaring with `#![needs_panic_runtime]` that a panic runtime is needed.
+    /// Allows declaring with `#![needs_panic_runtime]` that a panic runtime is needed.
     (active, needs_panic_runtime, "1.10.0", Some(32837), None),
 
     // no-tracking-issue-start
 
-    // Allows identifying the `compiler_builtins` crate.
+    /// Allows identifying the `compiler_builtins` crate.
     (active, compiler_builtins, "1.13.0", None, None),
 
-    // Allows using the `unadjusted` ABI; perma-unstable.
+    /// Allows using the `unadjusted` ABI; perma-unstable.
     (active, abi_unadjusted, "1.16.0", None, None),
 
-    // Allows identifying crates that contain sanitizer runtimes.
+    /// Allows identifying crates that contain sanitizer runtimes.
     (active, sanitizer_runtime, "1.17.0", None, None),
 
-    // Used to identify crates that contain the profiler runtime.
+    /// Used to identify crates that contain the profiler runtime.
     (active, profiler_runtime, "1.18.0", None, None),
 
-    // Allows using the `thiscall` ABI.
+    /// Allows using the `thiscall` ABI.
     (active, abi_thiscall, "1.19.0", None, None),
 
-    // Allows using `#![needs_allocator]`, an implementation detail of `#[global_allocator]`.
+    /// Allows using `#![needs_allocator]`, an implementation detail of `#[global_allocator]`.
     (active, allocator_internals, "1.20.0", None, None),
 
     // no-tracking-issue-end
 
-    // Added for testing E0705; perma-unstable.
+    /// Added for testing E0705; perma-unstable.
     (active, test_2018_feature, "1.31.0", Some(0), Some(Edition::Edition2018)),
 
     // -------------------------------------------------------------------------
@@ -228,281 +244,282 @@ declare_features! (
     // feature-group-start: actual feature gates
     // -------------------------------------------------------------------------
 
-    // Allows using the `#[link_args]` attribute.
+    /// Allows using the `#[link_args]` attribute.
     (active, link_args, "1.0.0", Some(29596), None),
 
-    // Allows defining identifiers beyond ASCII.
+    /// Allows defining identifiers beyond ASCII.
     (active, non_ascii_idents, "1.0.0", Some(55467), None),
 
-    // Allows using `#[plugin_registrar]` on functions.
+    /// Allows using `#[plugin_registrar]` on functions.
     (active, plugin_registrar, "1.0.0", Some(29597), None),
 
-    // Allows using `#![plugin(myplugin)]`.
+    /// Allows using `#![plugin(myplugin)]`.
     (active, plugin, "1.0.0", Some(29597), None),
 
-    // Allows using `#[thread_local]` on `static` items.
+    /// Allows using `#[thread_local]` on `static` items.
     (active, thread_local, "1.0.0", Some(29594), None),
 
-    // Allows the use of SIMD types in functions declared in `extern` blocks.
+    /// Allows the use of SIMD types in functions declared in `extern` blocks.
     (active, simd_ffi, "1.0.0", Some(27731), None),
 
-    // Allows using custom attributes (RFC 572).
+    /// Allows using custom attributes (RFC 572).
     (active, custom_attribute, "1.0.0", Some(29642), None),
 
-    // Allows using non lexical lifetimes (RFC 2094).
+    /// Allows using non lexical lifetimes (RFC 2094).
     (active, nll, "1.0.0", Some(43234), None),
 
-    // Allows using slice patterns.
+    /// Allows using slice patterns.
     (active, slice_patterns, "1.0.0", Some(62254), None),
 
-    // Allows the definition of `const` functions with some advanced features.
+    /// Allows the definition of `const` functions with some advanced features.
     (active, const_fn, "1.2.0", Some(57563), None),
 
-    // Allows associated type defaults.
+    /// Allows associated type defaults.
     (active, associated_type_defaults, "1.2.0", Some(29661), None),
 
-    // Allows `#![no_core]`.
+    /// Allows `#![no_core]`.
     (active, no_core, "1.3.0", Some(29639), None),
 
-    // Allows default type parameters to influence type inference.
+    /// Allows default type parameters to influence type inference.
     (active, default_type_parameter_fallback, "1.3.0", Some(27336), None),
 
-    // Allows `repr(simd)` and importing the various simd intrinsics.
+    /// Allows `repr(simd)` and importing the various simd intrinsics.
     (active, repr_simd, "1.4.0", Some(27731), None),
 
-    // Allows `extern "platform-intrinsic" { ... }`.
+    /// Allows `extern "platform-intrinsic" { ... }`.
     (active, platform_intrinsics, "1.4.0", Some(27731), None),
 
-    // Allows `#[unwind(..)]`.
-    //
-    // Permits specifying whether a function should permit unwinding or abort on unwind.
+    /// Allows `#[unwind(..)]`.
+    ///
+    /// Permits specifying whether a function should permit unwinding or abort on unwind.
     (active, unwind_attributes, "1.4.0", Some(58760), None),
 
-    // Allows `#[no_debug]`.
+    /// Allows `#[no_debug]`.
     (active, no_debug, "1.5.0", Some(29721), None),
 
-    // Allows attributes on expressions and non-item statements.
+    /// Allows attributes on expressions and non-item statements.
     (active, stmt_expr_attributes, "1.6.0", Some(15701), None),
 
-    // Allows the use of type ascription in expressions.
+    /// Allows the use of type ascription in expressions.
     (active, type_ascription, "1.6.0", Some(23416), None),
 
-    // Allows `cfg(target_thread_local)`.
+    /// Allows `cfg(target_thread_local)`.
     (active, cfg_target_thread_local, "1.7.0", Some(29594), None),
 
-    // Allows specialization of implementations (RFC 1210).
+    /// Allows specialization of implementations (RFC 1210).
     (active, specialization, "1.7.0", Some(31844), None),
 
-    // Allows using `#[naked]` on functions.
+    /// Allows using `#[naked]` on functions.
     (active, naked_functions, "1.9.0", Some(32408), None),
 
-    // Allows `cfg(target_has_atomic = "...")`.
+    /// Allows `cfg(target_has_atomic = "...")`.
     (active, cfg_target_has_atomic, "1.9.0", Some(32976), None),
 
-    // Allows `X..Y` patterns.
+    /// Allows `X..Y` patterns.
     (active, exclusive_range_pattern, "1.11.0", Some(37854), None),
 
-    // Allows the `!` type. Does not imply 'exhaustive_patterns' (below) any more.
+    /// Allows the `!` type. Does not imply 'exhaustive_patterns' (below) any more.
     (active, never_type, "1.13.0", Some(35121), None),
 
-    // Allows exhaustive pattern matching on types that contain uninhabited types.
+    /// Allows exhaustive pattern matching on types that contain uninhabited types.
     (active, exhaustive_patterns, "1.13.0", Some(51085), None),
 
-    // Allows untagged unions `union U { ... }`.
+    /// Allows untagged unions `union U { ... }`.
     (active, untagged_unions, "1.13.0", Some(32836), None),
 
-    // Allows `#[link(..., cfg(..))]`.
+    /// Allows `#[link(..., cfg(..))]`.
     (active, link_cfg, "1.14.0", Some(37406), None),
 
-    // Allows `extern "ptx-*" fn()`.
+    /// Allows `extern "ptx-*" fn()`.
     (active, abi_ptx, "1.15.0", Some(38788), None),
 
-    // Allows the `#[repr(i128)]` attribute for enums.
+    /// Allows the `#[repr(i128)]` attribute for enums.
     (active, repr128, "1.16.0", Some(35118), None),
 
-    // Allows `#[link(kind="static-nobundle"...)]`.
+    /// Allows `#[link(kind="static-nobundle"...)]`.
     (active, static_nobundle, "1.16.0", Some(37403), None),
 
-    // Allows `extern "msp430-interrupt" fn()`.
+    /// Allows `extern "msp430-interrupt" fn()`.
     (active, abi_msp430_interrupt, "1.16.0", Some(38487), None),
 
-    // Allows declarative macros 2.0 (`macro`).
+    /// Allows declarative macros 2.0 (`macro`).
     (active, decl_macro, "1.17.0", Some(39412), None),
 
-    // Allows `extern "x86-interrupt" fn()`.
+    /// Allows `extern "x86-interrupt" fn()`.
     (active, abi_x86_interrupt, "1.17.0", Some(40180), None),
 
-    // Allows overlapping impls of marker traits.
+    /// Allows overlapping impls of marker traits.
     (active, overlapping_marker_traits, "1.18.0", Some(29864), None),
 
-    // Allows a test to fail without failing the whole suite.
+    /// Allows a test to fail without failing the whole suite.
     (active, allow_fail, "1.19.0", Some(46488), None),
 
-    // Allows unsized tuple coercion.
+    /// Allows unsized tuple coercion.
     (active, unsized_tuple_coercion, "1.20.0", Some(42877), None),
 
-    // Allows defining generators.
+    /// Allows defining generators.
     (active, generators, "1.21.0", Some(43122), None),
 
-    // Allows `#[doc(cfg(...))]`.
+    /// Allows `#[doc(cfg(...))]`.
     (active, doc_cfg, "1.21.0", Some(43781), None),
 
-    // Allows `#[doc(masked)]`.
+    /// Allows `#[doc(masked)]`.
     (active, doc_masked, "1.21.0", Some(44027), None),
 
-    // Allows `#[doc(spotlight)]`.
+    /// Allows `#[doc(spotlight)]`.
     (active, doc_spotlight, "1.22.0", Some(45040), None),
 
-    // Allows `#[doc(include = "some-file")]`.
+    /// Allows `#[doc(include = "some-file")]`.
     (active, external_doc, "1.22.0", Some(44732), None),
 
-    // Allows future-proofing enums/structs with the `#[non_exhaustive]` attribute (RFC 2008).
+    /// Allows future-proofing enums/structs with the `#[non_exhaustive]` attribute (RFC 2008).
     (active, non_exhaustive, "1.22.0", Some(44109), None),
 
-    // Allows using `crate` as visibility modifier, synonymous with `pub(crate)`.
+    /// Allows using `crate` as visibility modifier, synonymous with `pub(crate)`.
     (active, crate_visibility_modifier, "1.23.0", Some(53120), None),
 
-    // Allows defining `extern type`s.
+    /// Allows defining `extern type`s.
     (active, extern_types, "1.23.0", Some(43467), None),
 
-    // Allows trait methods with arbitrary self types.
+    /// Allows trait methods with arbitrary self types.
     (active, arbitrary_self_types, "1.23.0", Some(44874), None),
 
-    // Allows in-band quantification of lifetime bindings (e.g., `fn foo(x: &'a u8) -> &'a u8`).
+    /// Allows in-band quantification of lifetime bindings (e.g., `fn foo(x: &'a u8) -> &'a u8`).
     (active, in_band_lifetimes, "1.23.0", Some(44524), None),
 
-    // Allows associated types to be generic, e.g., `type Foo<T>;` (RFC 1598).
+    /// Allows associated types to be generic, e.g., `type Foo<T>;` (RFC 1598).
     (active, generic_associated_types, "1.23.0", Some(44265), None),
 
-    // Allows defining `trait X = A + B;` alias items.
+    /// Allows defining `trait X = A + B;` alias items.
     (active, trait_alias, "1.24.0", Some(41517), None),
 
-    // Allows infering `'static` outlives requirements (RFC 2093).
+    /// Allows infering `'static` outlives requirements (RFC 2093).
     (active, infer_static_outlives_requirements, "1.26.0", Some(54185), None),
 
-    // Allows macro invocations in `extern {}` blocks.
+    /// Allows macro invocations in `extern {}` blocks.
     (active, macros_in_extern, "1.27.0", Some(49476), None),
 
-    // Allows accessing fields of unions inside `const` functions.
+    /// Allows accessing fields of unions inside `const` functions.
     (active, const_fn_union, "1.27.0", Some(51909), None),
 
-    // Allows casting raw pointers to `usize` during const eval.
+    /// Allows casting raw pointers to `usize` during const eval.
     (active, const_raw_ptr_to_usize_cast, "1.27.0", Some(51910), None),
 
-    // Allows dereferencing raw pointers during const eval.
+    /// Allows dereferencing raw pointers during const eval.
     (active, const_raw_ptr_deref, "1.27.0", Some(51911), None),
 
-    // Allows comparing raw pointers during const eval.
+    /// Allows comparing raw pointers during const eval.
     (active, const_compare_raw_pointers, "1.27.0", Some(53020), None),
 
-    // Allows `#[doc(alias = "...")]`.
+    /// Allows `#[doc(alias = "...")]`.
     (active, doc_alias, "1.27.0", Some(50146), None),
 
-    // Allows inconsistent bounds in where clauses.
+    /// Allows inconsistent bounds in where clauses.
     (active, trivial_bounds, "1.28.0", Some(48214), None),
 
-    // Allows `'a: { break 'a; }`.
+    /// Allows `'a: { break 'a; }`.
     (active, label_break_value, "1.28.0", Some(48594), None),
 
-    // Allows using `#[doc(keyword = "...")]`.
+    /// Allows using `#[doc(keyword = "...")]`.
     (active, doc_keyword, "1.28.0", Some(51315), None),
 
-    // Allows reinterpretation of the bits of a value of one type as another type during const eval.
+    /// Allows reinterpretation of the bits of a value of one type as another
+    /// type during const eval.
     (active, const_transmute, "1.29.0", Some(53605), None),
 
-    // Allows using `try {...}` expressions.
+    /// Allows using `try {...}` expressions.
     (active, try_blocks, "1.29.0", Some(31436), None),
 
-    // Allows defining an `#[alloc_error_handler]`.
+    /// Allows defining an `#[alloc_error_handler]`.
     (active, alloc_error_handler, "1.29.0", Some(51540), None),
 
-    // Allows using the `amdgpu-kernel` ABI.
+    /// Allows using the `amdgpu-kernel` ABI.
     (active, abi_amdgpu_kernel, "1.29.0", Some(51575), None),
 
-    // Allows panicking during const eval (producing compile-time errors).
+    /// Allows panicking during const eval (producing compile-time errors).
     (active, const_panic, "1.30.0", Some(51999), None),
 
-    // Allows `#[marker]` on certain traits allowing overlapping implementations.
+    /// Allows `#[marker]` on certain traits allowing overlapping implementations.
     (active, marker_trait_attr, "1.30.0", Some(29864), None),
 
-    // Allows macro invocations on modules expressions and statements and
-    // procedural macros to expand to non-items.
+    /// Allows macro invocations on modules expressions and statements and
+    /// procedural macros to expand to non-items.
     (active, proc_macro_hygiene, "1.30.0", Some(54727), None),
 
-    // Allows unsized rvalues at arguments and parameters.
+    /// Allows unsized rvalues at arguments and parameters.
     (active, unsized_locals, "1.30.0", Some(48055), None),
 
-    // Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
+    /// Allows custom test frameworks with `#![test_runner]` and `#[test_case]`.
     (active, custom_test_frameworks, "1.30.0", Some(50297), None),
 
-    // Allows non-builtin attributes in inner attribute position.
+    /// Allows non-builtin attributes in inner attribute position.
     (active, custom_inner_attributes, "1.30.0", Some(54726), None),
 
-    // Allows mixing bind-by-move in patterns and references to those identifiers in guards.
+    /// Allows mixing bind-by-move in patterns and references to those identifiers in guards.
     (active, bind_by_move_pattern_guards, "1.30.0", Some(15287), None),
 
-    // Allows `impl Trait` in bindings (`let`, `const`, `static`).
+    /// Allows `impl Trait` in bindings (`let`, `const`, `static`).
     (active, impl_trait_in_bindings, "1.30.0", Some(63065), None),
 
-    // Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
+    /// Allows using `reason` in lint attributes and the `#[expect(lint)]` lint check.
     (active, lint_reasons, "1.31.0", Some(54503), None),
 
-    // Allows exhaustive integer pattern matching on `usize` and `isize`.
+    /// Allows exhaustive integer pattern matching on `usize` and `isize`.
     (active, precise_pointer_size_matching, "1.32.0", Some(56354), None),
 
-    // Allows relaxing the coherence rules such that
-    // `impl<T> ForeignTrait<LocalType> for ForeignType<T> is permitted.
+    /// Allows relaxing the coherence rules such that
+    /// `impl<T> ForeignTrait<LocalType> for ForeignType<T> is permitted.
     (active, re_rebalance_coherence, "1.32.0", Some(55437), None),
 
-    // Allows using `#[ffi_returns_twice]` on foreign functions.
+    /// Allows using `#[ffi_returns_twice]` on foreign functions.
     (active, ffi_returns_twice, "1.34.0", Some(58314), None),
 
-    // Allows const generic types (e.g. `struct Foo<const N: usize>(...);`).
+    /// Allows const generic types (e.g. `struct Foo<const N: usize>(...);`).
     (active, const_generics, "1.34.0", Some(44580), None),
 
-    // Allows using `#[optimize(X)]`.
+    /// Allows using `#[optimize(X)]`.
     (active, optimize_attribute, "1.34.0", Some(54882), None),
 
-    // Allows using C-variadics.
+    /// Allows using C-variadics.
     (active, c_variadic, "1.34.0", Some(44930), None),
 
-    // Allows the user of associated type bounds.
+    /// Allows the user of associated type bounds.
     (active, associated_type_bounds, "1.34.0", Some(52662), None),
 
-    // Attributes on formal function params.
+    /// Attributes on formal function params.
     (active, param_attrs, "1.36.0", Some(60406), None),
 
-    // Allows calling constructor functions in `const fn`.
+    /// Allows calling constructor functions in `const fn`.
     (active, const_constructor, "1.37.0", Some(61456), None),
 
-    // Allows `if/while p && let q = r && ...` chains.
+    /// Allows `if/while p && let q = r && ...` chains.
     (active, let_chains, "1.37.0", Some(53667), None),
 
-    // Allows #[repr(transparent)] on enums (RFC 2645).
+    /// Allows #[repr(transparent)] on enums (RFC 2645).
     (active, transparent_enums, "1.37.0", Some(60405), None),
 
-    // Allows #[repr(transparent)] on unions (RFC 2645).
+    /// Allows #[repr(transparent)] on unions (RFC 2645).
     (active, transparent_unions, "1.37.0", Some(60405), None),
 
-    // Allows explicit discriminants on non-unit enum variants.
+    /// Allows explicit discriminants on non-unit enum variants.
     (active, arbitrary_enum_discriminant, "1.37.0", Some(60553), None),
 
-    // Allows `impl Trait` with multiple unrelated lifetimes.
+    /// Allows `impl Trait` with multiple unrelated lifetimes.
     (active, member_constraints, "1.37.0", Some(61977), None),
 
-    // Allows `async || body` closures.
+    /// Allows `async || body` closures.
     (active, async_closure, "1.37.0", Some(62290), None),
 
-    // Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests
+    /// Allows the use of `#[cfg(doctest)]`, set when rustdoc is collecting doctests
     (active, cfg_doctest, "1.37.0", Some(62210), None),
 
-    // Allows `[x; N]` where `x` is a constant (RFC 2203).
+    /// Allows `[x; N]` where `x` is a constant (RFC 2203).
     (active, const_in_array_repeat_expressions, "1.37.0", Some(49147), None),
 
-    // Allows `impl Trait` to be used inside type aliases (RFC 2515).
+    /// Allows `impl Trait` to be used inside type aliases (RFC 2515).
     (active, type_alias_impl_trait, "1.38.0", Some(63063), None),
 
-    // Allows the use of or-patterns, e.g. `0 | 1`.
+    /// Allows the use of or-patterns, e.g. `0 | 1`.
     (active, or_patterns, "1.38.0", Some(54883), None),
 
     // -------------------------------------------------------------------------

--- a/src/libsyntax/feature_gate/mod.rs
+++ b/src/libsyntax/feature_gate/mod.rs
@@ -18,6 +18,39 @@ mod active;
 mod builtin_attrs;
 mod check;
 
+use std::fmt;
+use crate::{edition::Edition, symbol::Symbol};
+use syntax_pos::Span;
+
+#[derive(Clone, Copy)]
+pub enum State {
+    Accepted,
+    Active { set: fn(&mut Features, Span) },
+    Removed { reason: Option<&'static str> },
+    Stabilized { reason: Option<&'static str> },
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            State::Accepted { .. } => write!(f, "accepted"),
+            State::Active { .. } => write!(f, "active"),
+            State::Removed { .. } => write!(f, "removed"),
+            State::Stabilized { .. } => write!(f, "stabilized"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Feature {
+    state: State,
+    name: Symbol,
+    since: &'static str,
+    issue: Option<u32>,
+    edition: Option<Edition>,
+    description: &'static str,
+}
+
 pub use active::{Features, INCOMPLETE_FEATURES};
 pub use builtin_attrs::{
     AttributeGate, AttributeType, GatedCfg,

--- a/src/libsyntax/feature_gate/removed.rs
+++ b/src/libsyntax/feature_gate/removed.rs
@@ -3,14 +3,18 @@
 use crate::symbol::{Symbol, sym};
 
 macro_rules! declare_features {
-    ($((removed, $feature: ident, $ver: expr, $issue: expr, None, $reason: expr),)+) => {
+    ($(
+        $(#[doc = $doc:tt])* (removed, $feature:ident, $ver:expr, $issue:expr, None, $reason:expr),
+    )+) => {
         /// Represents unstable features which have since been removed (it was once Active)
         pub const REMOVED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
             $((sym::$feature, $ver, $issue, $reason)),+
         ];
     };
 
-    ($((stable_removed, $feature: ident, $ver: expr, $issue: expr, None),)+) => {
+    ($(
+        $(#[doc = $doc:tt])* (stable_removed, $feature:ident, $ver:expr, $issue:expr, None),
+    )+) => {
         /// Represents stable features which have since been removed (it was once Accepted)
         pub const STABLE_REMOVED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
             $((sym::$feature, $ver, $issue, None)),+
@@ -25,17 +29,17 @@ declare_features! (
 
     (removed, import_shadowing, "1.0.0", None, None, None),
     (removed, managed_boxes, "1.0.0", None, None, None),
-    // Allows use of unary negate on unsigned integers, e.g., -e for e: u8
+    /// Allows use of unary negate on unsigned integers, e.g., -e for e: u8
     (removed, negate_unsigned, "1.0.0", Some(29645), None, None),
     (removed, reflect, "1.0.0", Some(27749), None, None),
-    // A way to temporarily opt out of opt in copy. This will *never* be accepted.
+    /// A way to temporarily opt out of opt in copy. This will *never* be accepted.
     (removed, opt_out_copy, "1.0.0", None, None, None),
     (removed, quad_precision_float, "1.0.0", None, None, None),
     (removed, struct_inherit, "1.0.0", None, None, None),
     (removed, test_removed_feature, "1.0.0", None, None, None),
     (removed, visible_private_types, "1.0.0", None, None, None),
     (removed, unsafe_no_drop_flag, "1.0.0", None, None, None),
-    // Allows using items which are missing stability attributes
+    /// Allows using items which are missing stability attributes
     (removed, unmarked_api, "1.0.0", None, None, None),
     (removed, allocator, "1.0.0", None, None, None),
     (removed, simd, "1.0.0", Some(27731), None,
@@ -57,18 +61,18 @@ declare_features! (
      Some("subsumed by `#![feature(proc_macro_hygiene)]`")),
     (removed, panic_implementation, "1.28.0", Some(44489), None,
      Some("subsumed by `#[panic_handler]`")),
-    // Allows the use of `#[derive(Anything)]` as sugar for `#[derive_Anything]`.
+    /// Allows the use of `#[derive(Anything)]` as sugar for `#[derive_Anything]`.
     (removed, custom_derive, "1.32.0", Some(29644), None,
      Some("subsumed by `#[proc_macro_derive]`")),
-    // Paths of the form: `extern::foo::bar`
+    /// Paths of the form: `extern::foo::bar`
     (removed, extern_in_paths, "1.33.0", Some(55600), None,
      Some("subsumed by `::foo::bar` paths")),
     (removed, quote, "1.33.0", Some(29601), None, None),
-    // Allows using `#[unsafe_destructor_blind_to_params]` (RFC 1238).
+    /// Allows using `#[unsafe_destructor_blind_to_params]` (RFC 1238).
     (removed, dropck_parametricity, "1.38.0", Some(28498), None, None),
     (removed, await_macro, "1.38.0", Some(50547), None,
      Some("subsumed by `.await` syntax")),
-    // Allows defining `existential type`s.
+    /// Allows defining `existential type`s.
     (removed, existential_type, "1.38.0", Some(63063), None,
      Some("removed in favor of `#![feature(type_alias_impl_trait)]`")),
 

--- a/src/libsyntax/feature_gate/removed.rs
+++ b/src/libsyntax/feature_gate/removed.rs
@@ -1,14 +1,24 @@
 //! List of the removed feature gates.
 
-use crate::symbol::{Symbol, sym};
+use crate::symbol::sym;
+use super::{State, Feature};
 
 macro_rules! declare_features {
     ($(
         $(#[doc = $doc:tt])* (removed, $feature:ident, $ver:expr, $issue:expr, None, $reason:expr),
     )+) => {
         /// Represents unstable features which have since been removed (it was once Active)
-        pub const REMOVED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
-            $((sym::$feature, $ver, $issue, $reason)),+
+        pub const REMOVED_FEATURES: &[Feature] = &[
+            $(
+                Feature {
+                    state: State::Removed { reason: $reason },
+                    name: sym::$feature,
+                    since: $ver,
+                    issue: $issue,
+                    edition: None,
+                    description: concat!($($doc,)*),
+                }
+            ),+
         ];
     };
 
@@ -16,8 +26,17 @@ macro_rules! declare_features {
         $(#[doc = $doc:tt])* (stable_removed, $feature:ident, $ver:expr, $issue:expr, None),
     )+) => {
         /// Represents stable features which have since been removed (it was once Accepted)
-        pub const STABLE_REMOVED_FEATURES: &[(Symbol, &str, Option<u32>, Option<&str>)] = &[
-            $((sym::$feature, $ver, $issue, None)),+
+        pub const STABLE_REMOVED_FEATURES: &[Feature] = &[
+            $(
+                Feature {
+                    state: State::Stabilized { reason: None },
+                    name: sym::$feature,
+                    since: $ver,
+                    issue: $issue,
+                    edition: None,
+                    description: concat!($($doc,)*),
+                }
+            ),+
         ];
     };
 }

--- a/src/tools/tidy/src/features.rs
+++ b/src/tools/tidy/src/features.rs
@@ -176,7 +176,10 @@ pub fn check(path: &Path, bad: &mut bool, verbose: bool) -> CollectedFeatures {
     CollectedFeatures { lib: lib_features, lang: features }
 }
 
-fn format_features<'a>(features: &'a Features, family: &'a str) -> impl Iterator<Item = String> + 'a {
+fn format_features<'a>(
+    features: &'a Features,
+    family: &'a str,
+) -> impl Iterator<Item = String> + 'a {
     features.iter().map(move |(name, feature)| {
         format!("{:<32} {:<8} {:<12} {:<8}",
                 name,
@@ -228,7 +231,8 @@ pub fn collect_lang_features(base_src_path: &Path, bad: &mut bool) -> Features {
 }
 
 fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features {
-    let contents = t!(fs::read_to_string(base.join("libsyntax/feature_gate").join(file)));
+    let path = base.join("libsyntax/feature_gate").join(file);
+    let contents = t!(fs::read_to_string(&path));
 
     // We allow rustc-internal features to omit a tracking issue.
     // To make tidy accept omitting a tracking issue, group the list of features
@@ -259,8 +263,9 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 if in_feature_group {
                     tidy_error!(
                         bad,
-                        // ignore-tidy-linelength
-                        "libsyntax/feature_gate.rs:{}: new feature group is started without ending the previous one",
+                        "{}:{}: \
+                        new feature group is started without ending the previous one",
+                        path.display(),
                         line_number,
                     );
                 }
@@ -289,7 +294,8 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 Err(err) => {
                     tidy_error!(
                         bad,
-                        "libsyntax/feature_gate.rs:{}: failed to parse since: {} ({:?})",
+                        "{}:{}: failed to parse since: {} ({:?})",
+                        path.display(),
                         line_number,
                         since_str,
                         err,
@@ -301,7 +307,8 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                 if prev_since > since {
                     tidy_error!(
                         bad,
-                        "libsyntax/feature_gate.rs:{}: feature {} is not sorted by since",
+                        "{}:{}: feature {} is not sorted by since",
+                        path.display(),
                         line_number,
                         name,
                     );
@@ -315,7 +322,8 @@ fn collect_lang_features_in(base: &Path, file: &str, bad: &mut bool) -> Features
                     *bad = true;
                     tidy_error!(
                         bad,
-                        "libsyntax/feature_gate.rs:{}: no tracking issue for feature {}",
+                        "{}:{}: no tracking issue for feature {}",
+                        path.display(),
                         line_number,
                         name,
                     );


### PR DESCRIPTION
After #63824, this goes a few steps further by

- parsing doc comments in the macros to extract descriptions for feature gates, and
- introducing a common `Feature` type to replace the tuples used previously to improve readability.

The descriptions are not yet used, but I felt like this PR is a useful enough refactoring on its own.

r? @Centril 