### PR TITLE
Fix build failure in case file doesn't exist

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -375,7 +375,7 @@ impl Step for Standalone {
                up_to_date(&footer, &html) &&
                up_to_date(&favicon, &html) &&
                up_to_date(&full_toc, &html) &&
-               up_to_date(&version_info, &html) &&
+               (builder.config.dry_run || up_to_date(&version_info, &html)) &&
                (builder.config.dry_run || up_to_date(&rustdoc, &html)) {
                 continue
             }


### PR DESCRIPTION
It fixes the following issue:

```bash
$ ./x.py test src/tools/linkchecker ./build/x86_64-apple-darwin/doc/ --stage 1
Updating only changed submodules
Submodules updated in 0.05 seconds
    Finished dev [unoptimized] target(s) in 0.15s
thread 'main' panicked at 'source "/Users/imperio/rust/rust/build/x86_64-apple-darwin/doc/version_info.html" failed to get metadata: No such file or directory (os error 2)', src/build_helper/lib.rs:179:19
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
failed to run: /Users/imperio/rust/rust/build/bootstrap/debug/bootstrap test src/tools/linkchecker ./build/x86_64-apple-darwin/doc/ --stage 1
Build completed unsuccessfully in 0:00:01
```

If the file doesn't exist, it makes sense anyway to just run the command in order to generate it.

r? @Mark-Simulacrum 