### PR TITLE
Suggest call fn ctor passed as arg to fn with type param bounds

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -967,10 +967,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let self_ty = trait_ref.self_ty();
         match self_ty.sty {
             ty::FnDef(def_id, _) => {
-                // We tried to apply the bound to an `fn`. Check wether calling it
-                // would evaluate to a type that *would* satisfy the trait binding.
-                // If it would, suggest calling it: `bar(foo)` -> `bar(foo)`. This
-                // case is *very* to hit if `foo` is `async`.
+                // We tried to apply the bound to an `fn`. Check whether calling it would evaluate
+                // to a type that *would* satisfy the trait binding. If it would, suggest calling
+                // it: `bar(foo)` -> `bar(foo)`. This case is *very* likely to be hit if `foo` is
+                // `async`.
                 let output_ty = self_ty.fn_sig(self.tcx).output();
                 let new_trait_ref = ty::TraitRef {
                     def_id: trait_ref.def_id(),

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -657,19 +657,22 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             span,
                             E0277,
                             "{}",
-                            message.unwrap_or_else(||
-                                format!("the trait bound `{}` is not satisfied{}",
-                                        trait_ref.to_predicate(), post_message)
-                            ));
+                            message.unwrap_or_else(|| format!(
+                                "the trait bound `{}` is not satisfied{}",
+                                trait_ref.to_predicate(),
+                                post_message,
+                            )));
 
                         let explanation =
                             if obligation.cause.code == ObligationCauseCode::MainFunctionType {
                                 "consider using `()`, or a `Result`".to_owned()
                             } else {
-                                format!("{}the trait `{}` is not implemented for `{}`",
+                                format!(
+                                    "{}the trait `{}` is not implemented for `{}`",
                                         pre_message,
                                         trait_ref,
-                                        trait_ref.self_ty())
+                                    trait_ref.self_ty(),
+                                )
                             };
 
                         if let Some(ref s) = label {
@@ -1535,17 +1538,23 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 err.note("only the last element of a tuple may have a dynamically sized type");
             }
             ObligationCauseCode::ProjectionWf(data) => {
-                err.note(&format!("required so that the projection `{}` is well-formed",
-                                  data));
+                err.note(&format!(
+                    "required so that the projection `{}` is well-formed",
+                    data,
+                ));
             }
             ObligationCauseCode::ReferenceOutlivesReferent(ref_ty) => {
-                err.note(&format!("required so that reference `{}` does not outlive its referent",
-                                  ref_ty));
+                err.note(&format!(
+                    "required so that reference `{}` does not outlive its referent",
+                    ref_ty,
+                ));
             }
             ObligationCauseCode::ObjectTypeBound(object_ty, region) => {
-                err.note(&format!("required so that the lifetime bound of `{}` for `{}` \
-                                   is satisfied",
-                                  region, object_ty));
+                err.note(&format!(
+                    "required so that the lifetime bound of `{}` for `{}` is satisfied",
+                    region,
+                    object_ty,
+                ));
             }
             ObligationCauseCode::ItemObligation(item_def_id) => {
                 let item_name = tcx.def_path_str(item_def_id);
@@ -1553,7 +1562,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
                 if let Some(sp) = tcx.hir().span_if_local(item_def_id) {
                     let sp = tcx.sess.source_map().def_span(sp);
-                    err.span_note(sp, &msg);
+                    err.span_label(sp, &msg);
                 } else {
                     err.note(&msg);
                 }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -992,8 +992,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         })) = self.tcx.hir().get_if_local(def_id) {
                             let body = self.tcx.hir().body(*body_id);
                             err.help(&format!(
-                                "it looks like you forgot to use parentheses to \
-                                 call the function: `{}({})`",
+                                "use parentheses to call the function: `{}({})`",
                                 ident,
                                 body.params.iter()
                                     .map(|arg| match &arg.pat.node {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -995,7 +995,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                 "it looks like you forgot to use parentheses to \
                                  call the function: `{}({})`",
                                 ident,
-                                body.arguments.iter()
+                                body.params.iter()
                                     .map(|arg| match &arg.pat.node {
                                         hir::PatKind::Binding(_, _, ident, None)
                                         if ident.name != kw::SelfLower => ident.to_string(),

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -5,12 +5,9 @@ LL |     f1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
-   |
-note: required by `f1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:27:1
-   |
+...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------ required by `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:2:5
@@ -19,12 +16,9 @@ LL |     f1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), &()) -> _`
-   |
-note: required by `f1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:27:1
-   |
+...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------ required by `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -33,12 +27,9 @@ LL |     f2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
-   |
-note: required by `f2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:28:1
-   |
+...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------------------- required by `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -47,12 +38,9 @@ LL |     f2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&'a (), &()) -> _`
-   |
-note: required by `f2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:28:1
-   |
+...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------------------- required by `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -61,12 +49,9 @@ LL |     f3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
-   |
-note: required by `f3`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:29:1
-   |
+...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------- required by `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -75,12 +60,9 @@ LL |     f3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), &()) -> _`
-   |
-note: required by `f3`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:29:1
-   |
+...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------- required by `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -89,12 +71,9 @@ LL |     f4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
-   |
-note: required by `f4`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:30:1
-   |
+...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------------------- required by `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -103,12 +82,9 @@ LL |     f4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), &'r ()) -> _`
-   |
-note: required by `f4`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:30:1
-   |
+...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------------------- required by `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -117,12 +93,9 @@ LL |     f5(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
-   |
-note: required by `f5`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:31:1
-   |
+...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------------------- required by `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -131,12 +104,9 @@ LL |     f5(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&'r (), &'r ()) -> _`
-   |
-note: required by `f5`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:31:1
-   |
+...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------------------- required by `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -145,12 +115,9 @@ LL |     g1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>) -> _`
-   |
-note: required by `g1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:34:1
-   |
+...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------------- required by `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -159,12 +126,9 @@ LL |     g1(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
-   |
-note: required by `g1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:34:1
-   |
+...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------------- required by `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
@@ -173,12 +137,9 @@ LL |     g2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
-   |
-note: required by `g2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:35:1
-   |
+...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ---------------------------------------- required by `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
@@ -187,12 +148,9 @@ LL |     g2(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
-   |
-note: required by `g2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:35:1
-   |
+...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ---------------------------------------- required by `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
@@ -201,12 +159,9 @@ LL |     g3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
-   |
-note: required by `g3`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:36:1
-   |
+...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------------------------ required by `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
@@ -215,12 +170,9 @@ LL |     g3(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
-   |
-note: required by `g3`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:36:1
-   |
+...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ------------------------------------------------------------ required by `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
@@ -229,12 +181,9 @@ LL |     g4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
-   |
-note: required by `g4`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:37:1
-   |
+...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | --------------------------------------------------- required by `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
@@ -243,12 +192,9 @@ LL |     g4(|_: (), _: ()| {});
    |     ^^ -------------- found signature of `fn((), ()) -> _`
    |     |
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
-   |
-note: required by `g4`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:37:1
-   |
+...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | --------------------------------------------------- required by `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
@@ -257,12 +203,9 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 's> fn(&'r (), std::boxed::Box<(dyn for<'t0> std::ops::Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
-   |
-note: required by `h1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:40:1
-   |
+...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------------------------------------- required by `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
@@ -271,12 +214,9 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &(), for<'r, 's> fn(&'r (), &'s ())) -> _`
-   |
-note: required by `h1`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:40:1
-   |
+...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------------------------------------------- required by `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
@@ -285,12 +225,9 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `for<'r, 't0> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
-   |
-note: required by `h2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:41:1
-   |
+...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | --------------------------------------------------------------------------------- required by `h2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
@@ -299,12 +236,9 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     ^^ ---------------------------- found signature of `fn((), (), (), ()) -> _`
    |     |
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &'t0 (), for<'r, 's> fn(&'r (), &'s ())) -> _`
-   |
-note: required by `h2`
-  --> $DIR/anonymous-higher-ranked-lifetime.rs:41:1
-   |
+...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | --------------------------------------------------------------------------------- required by `h2`
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/associated-const/associated-const-array-len.stderr
+++ b/src/test/ui/associated-const/associated-const-array-len.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/associated-const-array-len.rs:5:16
    |
+LL |     const ID: usize;
+   |     ---------------- required by `Foo::ID`
+...
 LL | const X: [i32; <i32 as Foo>::ID] = [0, 1, 2];
    |                ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `Foo::ID`
-  --> $DIR/associated-const-array-len.rs:2:5
-   |
-LL |     const ID: usize;
-   |     ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays-2.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `A: Foo` is not satisfied
   --> $DIR/associated-const-type-parameter-arrays-2.rs:16:22
    |
+LL |     const Y: usize;
+   |     --------------- required by `Foo::Y`
+...
 LL |     let _array = [4; <A as Foo>::Y];
    |                      ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
    |
    = help: consider adding a `where A: Foo` bound
-note: required by `Foo::Y`
-  --> $DIR/associated-const-type-parameter-arrays-2.rs:2:5
-   |
-LL |     const Y: usize;
-   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
+++ b/src/test/ui/associated-const/associated-const-type-parameter-arrays.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `A: Foo` is not satisfied
   --> $DIR/associated-const-type-parameter-arrays.rs:16:23
    |
+LL |     const Y: usize;
+   |     --------------- required by `Foo::Y`
+...
 LL |     let _array: [u32; <A as Foo>::Y];
    |                       ^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
    |
    = help: consider adding a `where A: Foo` bound
-note: required by `Foo::Y`
-  --> $DIR/associated-const-type-parameter-arrays.rs:2:5
-   |
-LL |     const Y: usize;
-   |     ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
+++ b/src/test/ui/associated-type-bounds/bad-bounds-on-assoc-in-trait.stderr
@@ -24,6 +24,9 @@ LL | | }
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be sent between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:37:1
    |
+LL |   trait Case1 {
+   |   ----------- required by `Case1`
+...
 LL | / fn assume_case1<T: Case1>() {
 LL | |
 LL | |
@@ -35,15 +38,13 @@ LL | | }
    |
    = help: the trait `std::marker::Send` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
    = help: consider adding a `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Send` bound
-note: required by `Case1`
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:22:1
-   |
-LL | trait Case1 {
-   | ^^^^^^^^^^^
 
 error[E0277]: `<<T as Case1>::C as std::iter::Iterator>::Item` cannot be shared between threads safely
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:37:1
    |
+LL |   trait Case1 {
+   |   ----------- required by `Case1`
+...
 LL | / fn assume_case1<T: Case1>() {
 LL | |
 LL | |
@@ -55,15 +56,13 @@ LL | | }
    |
    = help: the trait `std::marker::Sync` is not implemented for `<<T as Case1>::C as std::iter::Iterator>::Item`
    = help: consider adding a `where <<T as Case1>::C as std::iter::Iterator>::Item: std::marker::Sync` bound
-note: required by `Case1`
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:22:1
-   |
-LL | trait Case1 {
-   | ^^^^^^^^^^^
 
 error[E0277]: `<_ as Lam<&'a u8>>::App` doesn't implement `std::fmt::Debug`
   --> $DIR/bad-bounds-on-assoc-in-trait.rs:37:1
    |
+LL |   trait Case1 {
+   |   ----------- required by `Case1`
+...
 LL | / fn assume_case1<T: Case1>() {
 LL | |
 LL | |
@@ -74,11 +73,6 @@ LL | | }
    | |_^ `<_ as Lam<&'a u8>>::App` cannot be formatted using `{:?}` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `for<'a> std::fmt::Debug` is not implemented for `<_ as Lam<&'a u8>>::App`
-note: required by `Case1`
-  --> $DIR/bad-bounds-on-assoc-in-trait.rs:22:1
-   |
-LL | trait Case1 {
-   | ^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -1,30 +1,26 @@
 error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
    |
+LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
+   | ------------------------------------ required by `blue_car`
+...
 LL | fn b() { blue_car(ModelT); }
    |          ^^^^^^^^ expected struct `Black`, found struct `Blue`
    |
    = note: expected type `Black`
               found type `Blue`
-note: required by `blue_car`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:27:1
-   |
-LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
    |
+LL | fn black_car<C:Car<Color=Black>>(c: C) {
+   | -------------------------------------- required by `black_car`
+...
 LL | fn c() { black_car(ModelU); }
    |          ^^^^^^^^^ expected struct `Blue`, found struct `Black`
    |
    = note: expected type `Blue`
               found type `Black`
-note: required by `black_car`
-  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:24:1
-   |
-LL | fn black_car<C:Car<Color=Black>>(c: C) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-bound-failure.stderr
+++ b/src/test/ui/associated-types/associated-types-bound-failure.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `<G as GetToInt>::R: ToInt` is not satisfied
   --> $DIR/associated-types-bound-failure.rs:17:5
    |
+LL |     fn to_int(&self) -> isize;
+   |     -------------------------- required by `ToInt::to_int`
+...
 LL |     ToInt::to_int(&g.get())
    |     ^^^^^^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
    |
    = help: consider adding a `where <G as GetToInt>::R: ToInt` bound
-note: required by `ToInt::to_int`
-  --> $DIR/associated-types-bound-failure.rs:4:5
-   |
-LL |     fn to_int(&self) -> isize;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -10,16 +10,14 @@ LL |     let _: Bar = x.boo();
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:5
    |
+LL | fn foo1<I: Foo<A=Bar>>(x: I) {
+   | ---------------------------- required by `foo1`
+...
 LL |     foo1(a);
    |     ^^^^ expected usize, found struct `Bar`
    |
    = note: expected type `usize`
               found type `Bar`
-note: required by `foo1`
-  --> $DIR/associated-types-eq-3.rs:18:1
-   |
-LL | fn foo1<I: Foo<A=Bar>>(x: I) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:41:9

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -1,124 +1,108 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:82:5
    |
-LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ expected usize, found isize
-   |
-   = note: expected type `&usize`
-              found type `&isize`
-note: required by `foo`
-  --> $DIR/associated-types-eq-hr.rs:44:1
-   |
 LL | / fn foo<T>()
 LL | |     where T : for<'x> TheTrait<&'x isize, A = &'x isize>
 LL | | {
 LL | |     // ok for IntStruct, but not UintStruct
 LL | | }
-   | |_^
+   | |_- required by `foo`
+...
+LL |       foo::<UintStruct>();
+   |       ^^^^^^^^^^^^^^^^^ expected usize, found isize
+   |
+   = note: expected type `&usize`
+              found type `&isize`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
   --> $DIR/associated-types-eq-hr.rs:86:5
-   |
-LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ expected isize, found usize
-   |
-   = note: expected type `&isize`
-              found type `&usize`
-note: required by `bar`
-  --> $DIR/associated-types-eq-hr.rs:50:1
    |
 LL | / fn bar<T>()
 LL | |     where T : for<'x> TheTrait<&'x isize, A = &'x usize>
 LL | | {
 LL | |     // ok for UintStruct, but not IntStruct
 LL | | }
-   | |_^
+   | |_- required by `bar`
+...
+LL |       bar::<IntStruct>();
+   |       ^^^^^^^^^^^^^^^^ expected isize, found usize
+   |
+   = note: expected type `&isize`
+              found type `&usize`
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:91:5
-   |
-LL |     tuple_one::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
-   |
-   = help: the following implementations were found:
-             <Tuple as TheTrait<(&'a isize, &'a isize)>>
-note: required by `tuple_one`
-  --> $DIR/associated-types-eq-hr.rs:56:1
    |
 LL | / fn tuple_one<T>()
 LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
 LL | | {
 LL | |     // not ok for tuple, two lifetimes and we pick first
 LL | | }
-   | |_^
+   | |_- required by `tuple_one`
+...
+LL |       tuple_one::<Tuple>();
+   |       ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+   |
+   = help: the following implementations were found:
+             <Tuple as TheTrait<(&'a isize, &'a isize)>>
 
 error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize, &'y isize)>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
-LL |     tuple_one::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
-   |
-note: required by `tuple_one`
-  --> $DIR/associated-types-eq-hr.rs:56:1
-   |
 LL | / fn tuple_one<T>()
 LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
 LL | | {
 LL | |     // not ok for tuple, two lifetimes and we pick first
 LL | | }
-   | |_^
+   | |_- required by `tuple_one`
+...
+LL |       tuple_one::<Tuple>();
+   |       ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:97:5
-   |
-LL |     tuple_two::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
-   |
-   = help: the following implementations were found:
-             <Tuple as TheTrait<(&'a isize, &'a isize)>>
-note: required by `tuple_two`
-  --> $DIR/associated-types-eq-hr.rs:62:1
    |
 LL | / fn tuple_two<T>()
 LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
 LL | | {
 LL | |     // not ok for tuple, two lifetimes and we pick second
 LL | | }
-   | |_^
+   | |_- required by `tuple_two`
+...
+LL |       tuple_two::<Tuple>();
+   |       ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+   |
+   = help: the following implementations were found:
+             <Tuple as TheTrait<(&'a isize, &'a isize)>>
 
 error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize, &'y isize)>>::A == &'y isize`
   --> $DIR/associated-types-eq-hr.rs:97:5
    |
-LL |     tuple_two::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
-   |
-note: required by `tuple_two`
-  --> $DIR/associated-types-eq-hr.rs:62:1
-   |
 LL | / fn tuple_two<T>()
 LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
 LL | | {
 LL | |     // not ok for tuple, two lifetimes and we pick second
 LL | | }
-   | |_^
+   | |_- required by `tuple_two`
+...
+LL |       tuple_two::<Tuple>();
+   |       ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:107:5
-   |
-LL |     tuple_four::<Tuple>();
-   |     ^^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
-   |
-   = help: the following implementations were found:
-             <Tuple as TheTrait<(&'a isize, &'a isize)>>
-note: required by `tuple_four`
-  --> $DIR/associated-types-eq-hr.rs:74:1
    |
 LL | / fn tuple_four<T>()
 LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize)>
 LL | | {
 LL | |     // not ok for tuple, two lifetimes, and lifetime matching is invariant
 LL | | }
-   | |_^
+   | |_- required by `tuple_four`
+...
+LL |       tuple_four::<Tuple>();
+   |       ^^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+   |
+   = help: the following implementations were found:
+             <Tuple as TheTrait<(&'a isize, &'a isize)>>
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -1,16 +1,14 @@
 error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == std::option::Option<T>`
   --> $DIR/associated-types-issue-20346.rs:34:5
    |
+LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
+   | ------------------------------------------------ required by `is_iterator_of`
+...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found enum `std::option::Option`
    |
    = note: expected type `T`
               found type `std::option::Option<T>`
-note: required by `is_iterator_of`
-  --> $DIR/associated-types-issue-20346.rs:15:1
-   |
-LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -3,28 +3,24 @@ error[E0271]: type mismatch resolving `<T as Foo>::Y == i32`
    |
 LL |     want_y(t);
    |     ^^^^^^ expected associated type, found i32
+...
+LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
+   | ------------------------------ required by `want_y`
    |
    = note: expected type `<T as Foo>::Y`
               found type `i32`
-note: required by `want_y`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:44:1
-   |
-LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<T as Foo>::X == u32`
   --> $DIR/associated-types-multiple-types-one-trait.rs:18:5
    |
 LL |     want_x(t);
    |     ^^^^^^ expected associated type, found u32
+...
+LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
+   | ------------------------------ required by `want_x`
    |
    = note: expected type `<T as Foo>::X`
               found type `u32`
-note: required by `want_x`
-  --> $DIR/associated-types-multiple-types-one-trait.rs:42:1
-   |
-LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -1,14 +1,10 @@
 error[E0284]: type annotations required: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
   --> $DIR/associated-types-overridden-binding.rs:4:1
    |
+LL | trait Foo: Iterator<Item = i32> {}
+   | ------------------------------- required by `Foo`
 LL | trait Bar: Foo<Item = u32> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: required by `Foo`
-  --> $DIR/associated-types-overridden-binding.rs:3:1
-   |
-LL | trait Foo: Iterator<Item = i32> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -11,14 +11,11 @@ LL |     f1(2i32, 4u32);
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
    |
+LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
+   | -------------------------------- required by `f1`
+...
 LL |     f1(2u32, 4u32);
    |     ^^ the trait `Foo` is not implemented for `u32`
-   |
-note: required by `f1`
-  --> $DIR/associated-types-path-2.rs:13:1
-   |
-LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
@@ -29,14 +26,11 @@ LL |     f1(2u32, 4u32);
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5
    |
+LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
+   | -------------------------------- required by `f1`
+...
 LL |     f1(2u32, 4i32);
    |     ^^ the trait `Foo` is not implemented for `u32`
-   |
-note: required by `f1`
-  --> $DIR/associated-types-path-2.rs:13:1
-   |
-LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5

--- a/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
+++ b/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
@@ -1,16 +1,13 @@
 error[E0271]: type mismatch resolving `for<'a> <&'a _ as Mirror>::Image == _`
   --> $DIR/higher-ranked-projection.rs:25:5
    |
-LL |     foo(());
-   |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime
-   |
-note: required by `foo`
-  --> $DIR/higher-ranked-projection.rs:14:1
-   |
 LL | / fn foo<U, T>(_t: T)
 LL | |     where for<'a> &'a T: Mirror<Image=U>
 LL | | {}
-   | |__^
+   | |__- required by `foo`
+...
+LL |       foo(());
+   |       ^^^ expected bound lifetime parameter 'a, found concrete lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:50:5
    |
+LL | fn assert_send(_: impl Send) {}
+   | ---------------------------- required by `assert_send`
+...
 LL |     assert_send(local_dropped_before_await());
    |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
    |
@@ -11,15 +14,13 @@ LL |     assert_send(local_dropped_before_await());
    = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:21:39: 26:2 {impl std::fmt::Debug, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
-note: required by `assert_send`
-  --> $DIR/async-fn-nonsend.rs:47:1
-   |
-LL | fn assert_send(_: impl Send) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:52:5
    |
+LL | fn assert_send(_: impl Send) {}
+   | ---------------------------- required by `assert_send`
+...
 LL |     assert_send(non_send_temporary_in_match());
    |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
    |
@@ -30,15 +31,13 @@ LL |     assert_send(non_send_temporary_in_match());
    = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 {fn(impl std::fmt::Debug) -> std::option::Option<impl std::fmt::Debug> {std::option::Option::<impl std::fmt::Debug>::Some}, fn() -> impl std::fmt::Debug {non_send}, impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
-note: required by `assert_send`
-  --> $DIR/async-fn-nonsend.rs:47:1
-   |
-LL | fn assert_send(_: impl Send) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dyn std::fmt::Write` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:54:5
    |
+LL | fn assert_send(_: impl Send) {}
+   | ---------------------------- required by `assert_send`
+...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ `dyn std::fmt::Write` cannot be sent between threads safely
    |
@@ -51,15 +50,13 @@ LL |     assert_send(non_sync_with_method_call());
    = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
-note: required by `assert_send`
-  --> $DIR/async-fn-nonsend.rs:47:1
-   |
-LL | fn assert_send(_: impl Send) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
   --> $DIR/async-fn-nonsend.rs:54:5
    |
+LL | fn assert_send(_: impl Send) {}
+   | ---------------------------- required by `assert_send`
+...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
    |
@@ -76,11 +73,6 @@ LL |     assert_send(non_sync_with_method_call());
    = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, impl std::future::Future, ()}]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
-note: required by `assert_send`
-  --> $DIR/async-fn-nonsend.rs:47:1
-   |
-LL | fn assert_send(_: impl Send) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/chalkify/type_inference.stderr
+++ b/src/test/ui/chalkify/type_inference.stderr
@@ -10,17 +10,15 @@ LL |     only_foo(x);
 error[E0277]: the trait bound `{float}: Bar` is not satisfied
   --> $DIR/type_inference.rs:25:5
    |
+LL | fn only_bar<T: Bar>(_x: T) { }
+   | -------------------------- required by `only_bar`
+...
 LL |     only_bar(x);
    |     ^^^^^^^^ the trait `Bar` is not implemented for `{float}`
    |
    = help: the following implementations were found:
              <i32 as Bar>
              <u32 as Bar>
-note: required by `only_bar`
-  --> $DIR/type_inference.rs:12:1
-   |
-LL | fn only_bar<T: Bar>(_x: T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.nll.stderr
@@ -1,53 +1,44 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:30:5
    |
-LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
-   |     |
-   |     expected signature of `fn(fn(&'a u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_free_region`
-  --> $DIR/expect-fn-supply-fn.rs:1:1
-   |
 LL | / fn with_closure_expecting_fn_with_free_region<F>(_: F)
 LL | |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_free_region`
+...
+LL |       with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
+   |       |
+   |       expected signature of `fn(fn(&'a u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:37:5
    |
-LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
-   |     |
-   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_bound_region`
-  --> $DIR/expect-fn-supply-fn.rs:6:1
-   |
 LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
 LL | |     where F: FnOnce(fn(&u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_bound_region`
+...
+LL |       with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
+   |       |
+   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:46:5
    |
-LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
-   |     |
-   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_bound_region`
-  --> $DIR/expect-fn-supply-fn.rs:6:1
-   |
 LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
 LL | |     where F: FnOnce(fn(&u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_bound_region`
+...
+LL |       with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
+   |       |
+   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -39,53 +39,44 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:30:5
    |
-LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
-   |     |
-   |     expected signature of `fn(fn(&'a u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_free_region`
-  --> $DIR/expect-fn-supply-fn.rs:1:1
-   |
 LL | / fn with_closure_expecting_fn_with_free_region<F>(_: F)
 LL | |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_free_region`
+...
+LL |       with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
+   |       |
+   |       expected signature of `fn(fn(&'a u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:37:5
    |
-LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
-   |     |
-   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_bound_region`
-  --> $DIR/expect-fn-supply-fn.rs:6:1
-   |
 LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
 LL | |     where F: FnOnce(fn(&u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_bound_region`
+...
+LL |       with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
+   |       |
+   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:46:5
    |
-LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
-   |     |
-   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
-   |
-note: required by `with_closure_expecting_fn_with_bound_region`
-  --> $DIR/expect-fn-supply-fn.rs:6:1
-   |
 LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
 LL | |     where F: FnOnce(fn(&u32), &i32)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure_expecting_fn_with_bound_region`
+...
+LL |       with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
+   |       |
+   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -1,19 +1,16 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
-LL |     with_closure(|x: u32, y: i32| {
-   |     ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
-   |     |
-   |     expected signature of `fn(_, _) -> _`
-   |
-note: required by `with_closure`
-  --> $DIR/expect-infer-var-appearing-twice.rs:1:1
-   |
 LL | / fn with_closure<F, A>(_: F)
 LL | |     where F: FnOnce(A, A)
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `with_closure`
+...
+LL |       with_closure(|x: u32, y: i32| {
+   |       ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
+   |       |
+   |       expected signature of `fn(_, _) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/src/test/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `F` cannot be sent between threads safely
   --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:5:1
    |
+LL |   struct X<F> where F: FnOnce() + 'static + Send {
+   |   ---------------------------------------------- required by `X`
+...
 LL | / fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static {
 LL | |
 LL | |     return X { field: blk };
@@ -9,11 +12,6 @@ LL | | }
    |
    = help: the trait `std::marker::Send` is not implemented for `F`
    = help: consider adding a `where F: std::marker::Send` bound
-note: required by `X`
-  --> $DIR/closure-bounds-cant-promote-superkind-in-struct.rs:1:1
-   |
-LL | struct X<F> where F: FnOnce() + 'static + Send {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `F` cannot be shared between threads safely
   --> $DIR/closure-bounds-subtype.rs:13:5
    |
+LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
+   | ------------------------------------------------------------ required by `take_const_owned`
+...
 LL |     take_const_owned(f);
    |     ^^^^^^^^^^^^^^^^ `F` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `F`
    = help: consider adding a `where F: std::marker::Sync` bound
-note: required by `take_const_owned`
-  --> $DIR/closure-bounds-subtype.rs:4:1
-   |
-LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/too_generic_eval_ice.stderr
+++ b/src/test/ui/consts/too_generic_eval_ice.stderr
@@ -14,32 +14,28 @@ LL |         [5; Self::HOST_SIZE] == [6; 0]
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
+LL | pub struct Foo<A, B>(A, B);
+   | --------------------------- required by `Foo`
+...
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `A`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where A: std::marker::Sized` bound
-note: required by `Foo`
-  --> $DIR/too_generic_eval_ice.rs:1:1
-   |
-LL | pub struct Foo<A, B>(A, B);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/too_generic_eval_ice.rs:7:13
    |
+LL | pub struct Foo<A, B>(A, B);
+   | --------------------------- required by `Foo`
+...
 LL |         [5; Self::HOST_SIZE] == [6; 0]
    |             ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `B`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where B: std::marker::Sized` bound
-note: required by `Foo`
-  --> $DIR/too_generic_eval_ice.rs:1:1
-   |
-LL | pub struct Foo<A, B>(A, B);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/defaulted-never-note.stderr
+++ b/src/test/ui/defaulted-never-note.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
   --> $DIR/defaulted-never-note.rs:26:5
    |
+LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
+   | ----------------------------------------------- required by `foo`
+...
 LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`
    |
    = note: the trait is implemented for `()`. Possibly this error has been caused by changes to Rust's type-inference algorithm (see: https://github.com/rust-lang/rust/issues/48950 for more info). Consider whether you meant to use the type `()` here instead.
-note: required by `foo`
-  --> $DIR/defaulted-never-note.rs:21:1
-   |
-LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,41 +1,35 @@
 error[E0277]: the trait bound `C: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:5
    |
+LL | fn is_copy<T: Copy>(_: T) {}
+   | ------------------------- required by `is_copy`
+...
 LL |     is_copy(B { a: 1, b: C });
    |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `C`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `B<C>`
-note: required by `is_copy`
-  --> $DIR/deriving-copyclone.rs:18:1
-   |
-LL | fn is_copy<T: Copy>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `C: std::clone::Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:5
    |
+LL | fn is_clone<T: Clone>(_: T) {}
+   | --------------------------- required by `is_clone`
+...
 LL |     is_clone(B { a: 1, b: C });
    |     ^^^^^^^^ the trait `std::clone::Clone` is not implemented for `C`
    |
    = note: required because of the requirements on the impl of `std::clone::Clone` for `B<C>`
-note: required by `is_clone`
-  --> $DIR/deriving-copyclone.rs:19:1
-   |
-LL | fn is_clone<T: Clone>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `D: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:5
    |
+LL | fn is_copy<T: Copy>(_: T) {}
+   | ------------------------- required by `is_copy`
+...
 LL |     is_copy(B { a: 1, b: D });
    |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `D`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `B<D>`
-note: required by `is_copy`
-  --> $DIR/deriving-copyclone.rs:18:1
-   |
-LL | fn is_copy<T: Copy>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `i8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:24:5
    |
+LL |     fn bar(&self){}
+   |     ------------- required by `Foo::bar`
+...
 LL |     Foo::<i32>::bar(&1i8);
    |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `i8`
    |
@@ -10,15 +13,13 @@ LL |     Foo::<i32>::bar(&1i8);
              <i8 as Foo<u32>>
              <i8 as Foo<u64>>
              <i8 as Foo<u8>>
-note: required by `Foo::bar`
-  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
-   |
-LL |     fn bar(&self){}
-   |     ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:25:5
    |
+LL |     fn bar(&self){}
+   |     ------------- required by `Foo::bar`
+...
 LL |     Foo::<i32>::bar(&1u8);
    |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `u8`
    |
@@ -27,15 +28,13 @@ LL |     Foo::<i32>::bar(&1u8);
              <u8 as Foo<u16>>
              <u8 as Foo<u32>>
              <u8 as Foo<u64>>
-note: required by `Foo::bar`
-  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
-   |
-LL |     fn bar(&self){}
-   |     ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
   --> $DIR/issue-39802-show-5-trait-impls.rs:26:5
    |
+LL |     fn bar(&self){}
+   |     ------------- required by `Foo::bar`
+...
 LL |     Foo::<i32>::bar(&true);
    |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `bool`
    |
@@ -45,11 +44,6 @@ LL |     Foo::<i32>::bar(&true);
              <bool as Foo<u16>>
              <bool as Foo<u32>>
            and 2 others
-note: required by `Foo::bar`
-  --> $DIR/issue-39802-show-5-trait-impls.rs:2:5
-   |
-LL |     fn bar(&self){}
-   |     ^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/did_you_mean/recursion_limit.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit.stderr
@@ -1,6 +1,9 @@
 error[E0275]: overflow evaluating the requirement `J: std::marker::Send`
   --> $DIR/recursion_limit.rs:34:5
    |
+LL | fn is_send<T:Send>() { }
+   | -------------------- required by `is_send`
+...
 LL |     is_send::<A>();
    |     ^^^^^^^^^^^^
    |
@@ -14,11 +17,6 @@ LL |     is_send::<A>();
    = note: required because it appears within the type `C`
    = note: required because it appears within the type `B`
    = note: required because it appears within the type `A`
-note: required by `is_send`
-  --> $DIR/recursion_limit.rs:31:1
-   |
-LL | fn is_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -1,16 +1,14 @@
 error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
   --> $DIR/E0271.rs:10:5
    |
+LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
+   | -------------------------------------------------- required by `foo`
+...
 LL |     foo(3_i8);
    |     ^^^ expected reference, found u32
    |
    = note: expected type `&'static str`
               found type `u32`
-note: required by `foo`
-  --> $DIR/E0271.rs:3:1
-   |
-LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0275.stderr
+++ b/src/test/ui/error-codes/E0275.stderr
@@ -1,6 +1,9 @@
 error[E0275]: overflow evaluating the requirement `Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<Bar<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/E0275.rs:5:1
    |
+LL | trait Foo {}
+   | --------- required by `Foo`
+...
 LL | impl<T> Foo for T where Bar<T>: Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
@@ -132,11 +135,6 @@ LL | impl<T> Foo for T where Bar<T>: Foo {}
    = note: required because of the requirements on the impl of `Foo` for `Bar<Bar<Bar<T>>>`
    = note: required because of the requirements on the impl of `Foo` for `Bar<Bar<T>>`
    = note: required because of the requirements on the impl of `Foo` for `Bar<T>`
-note: required by `Foo`
-  --> $DIR/E0275.rs:1:1
-   |
-LL | trait Foo {}
-   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0277-2.stderr
+++ b/src/test/ui/error-codes/E0277-2.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `*const u8` cannot be sent between threads safely
   --> $DIR/E0277-2.rs:16:5
    |
+LL | fn is_send<T: Send>() { }
+   | --------------------- required by `is_send`
+...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^ `*const u8` cannot be sent between threads safely
    |
@@ -8,11 +11,6 @@ LL |     is_send::<Foo>();
    = note: required because it appears within the type `Baz`
    = note: required because it appears within the type `Bar`
    = note: required because it appears within the type `Foo`
-note: required by `is_send`
-  --> $DIR/E0277-2.rs:13:1
-   |
-LL | fn is_send<T: Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -13,14 +13,11 @@ LL | fn f(p: Path) { }
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:17:5
    |
+LL | fn some_func<T: Foo>(foo: T) {
+   | ---------------------------- required by `some_func`
+...
 LL |     some_func(5i32);
    |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `some_func`
-  --> $DIR/E0277.rs:9:1
-   |
-LL | fn some_func<T: Foo>(foo: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0283.stderr
+++ b/src/test/ui/error-codes/E0283.stderr
@@ -1,14 +1,11 @@
 error[E0283]: type annotations required: cannot resolve `_: Generator`
   --> $DIR/E0283.rs:18:21
    |
+LL |     fn create() -> u32;
+   |     ------------------- required by `Generator::create`
+...
 LL |     let cont: u32 = Generator::create();
    |                     ^^^^^^^^^^^^^^^^^
-   |
-note: required by `Generator::create`
-  --> $DIR/E0283.rs:2:5
-   |
-LL |     fn create() -> u32;
-   |     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/error-should-say-copy-not-pod.rs:6:5
    |
+LL | fn check_bound<T:Copy>(_: T) {}
+   | ---------------------------- required by `check_bound`
+...
 LL |     check_bound("nocopy".to_string());
    |     ^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-note: required by `check_bound`
-  --> $DIR/error-should-say-copy-not-pod.rs:3:1
-   |
-LL | fn check_bound<T:Copy>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -1,28 +1,24 @@
 error[E0277]: `A` cannot be shared between threads safely
   --> $DIR/extern-types-not-sync-send.rs:13:5
    |
+LL | fn assert_sync<T: ?Sized + Sync>() { }
+   | ---------------------------------- required by `assert_sync`
+...
 LL |     assert_sync::<A>();
    |     ^^^^^^^^^^^^^^^^ `A` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `A`
-note: required by `assert_sync`
-  --> $DIR/extern-types-not-sync-send.rs:9:1
-   |
-LL | fn assert_sync<T: ?Sized + Sync>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `A` cannot be sent between threads safely
   --> $DIR/extern-types-not-sync-send.rs:16:5
    |
+LL | fn assert_send<T: ?Sized + Send>() { }
+   | ---------------------------------- required by `assert_send`
+...
 LL |     assert_send::<A>();
    |     ^^^^^^^^^^^^^^^^ `A` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `A`
-note: required by `assert_send`
-  --> $DIR/extern-types-not-sync-send.rs:10:1
-   |
-LL | fn assert_send<T: ?Sized + Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -1,50 +1,47 @@
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:22:5
    |
+LL | fn assert_sized<T>() { }
+   | -------------------- required by `assert_sized`
+...
 LL |     assert_sized::<A>();
    |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `A`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-note: required by `assert_sized`
-  --> $DIR/extern-types-unsized.rs:19:1
-   |
-LL | fn assert_sized<T>() { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:25:5
    |
+LL | fn assert_sized<T>() { }
+   | -------------------- required by `assert_sized`
+...
 LL |     assert_sized::<Foo>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Foo`, the trait `std::marker::Sized` is not implemented for `A`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `Foo`
-note: required by `assert_sized`
-  --> $DIR/extern-types-unsized.rs:19:1
-   |
-LL | fn assert_sized<T>() { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:28:5
    |
+LL | fn assert_sized<T>() { }
+   | -------------------- required by `assert_sized`
+...
 LL |     assert_sized::<Bar<A>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `Bar<A>`, the trait `std::marker::Sized` is not implemented for `A`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `Bar<A>`
-note: required by `assert_sized`
-  --> $DIR/extern-types-unsized.rs:19:1
-   |
-LL | fn assert_sized<T>() { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/extern-types-unsized.rs:31:5
    |
+LL | fn assert_sized<T>() { }
+   | -------------------- required by `assert_sized`
+...
 LL |     assert_sized::<Bar<Bar<A>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -52,11 +49,6 @@ LL |     assert_sized::<Bar<Bar<A>>>();
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because it appears within the type `Bar<A>`
    = note: required because it appears within the type `Bar<Bar<A>>`
-note: required by `assert_sized`
-  --> $DIR/extern-types-unsized.rs:19:1
-   |
-LL | fn assert_sized<T>() { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -1,16 +1,14 @@
 error[E0277]: expected a `std::ops::Fn<()>` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:5
    |
+LL | fn is_fn<F>(_: F) where F: Fn() {}
+   | ------------------------------- required by `is_fn`
+...
 LL |     is_fn(f);
    |     ^^^^^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
    |
    = help: the trait `std::ops::Fn<()>` is not implemented for `extern "C" fn() {f}`
    = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }
-note: required by `is_fn`
-  --> $DIR/extern-wrong-value-type.rs:4:1
-   |
-LL | fn is_fn<F>(_: F) where F: Fn() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
   --> $DIR/send-sync.rs:8:5
    |
+LL | fn send<T: Send>(_: T) {}
+   | ---------------------- required by `send`
+...
 LL |     send(format_args!("{:?}", c));
    |     ^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
    |
@@ -12,15 +15,13 @@ LL |     send(format_args!("{:?}", c));
    = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>]`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&[std::fmt::ArgumentV1<'_>]`
    = note: required because it appears within the type `std::fmt::Arguments<'_>`
-note: required by `send`
-  --> $DIR/send-sync.rs:1:1
-   |
-LL | fn send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
   --> $DIR/send-sync.rs:9:5
    |
+LL | fn sync<T: Sync>(_: T) {}
+   | ---------------------- required by `sync`
+...
 LL |     sync(format_args!("{:?}", c));
    |     ^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
    |
@@ -32,11 +33,6 @@ LL |     sync(format_args!("{:?}", c));
    = note: required because it appears within the type `[std::fmt::ArgumentV1<'_>]`
    = note: required because it appears within the type `&[std::fmt::ArgumentV1<'_>]`
    = note: required because it appears within the type `std::fmt::Arguments<'_>`
-note: required by `sync`
-  --> $DIR/send-sync.rs:2:1
-   |
-LL | fn sync<T: Sync>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -28,15 +28,13 @@ LL |     let _: () = (box || -> isize { unimplemented!() }) as Box<dyn FnMut() -
 error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:5
    |
+LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
+   | ------------------------------------------------ required by `needs_fn`
+...
 LL |     needs_fn(1);
    |     ^^^^^^^^ expected an `Fn<(isize,)>` closure, found `{integer}`
    |
    = help: the trait `std::ops::Fn<(isize,)>` is not implemented for `{integer}`
-note: required by `needs_fn`
-  --> $DIR/fn-trait-formatting.rs:3:1
-   |
-LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator-yielding-or-returning-itself.stderr
@@ -16,20 +16,18 @@ LL | |     })
 error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _] as std::ops::Generator>::Yield == [generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _]`
   --> $DIR/generator-yielding-or-returning-itself.rs:28:5
    |
-LL |     want_cyclic_generator_yield(|| {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
-   |
-   = note: closures cannot capture themselves or take themselves as argument;
-           this error may be the result of a recent compiler bug-fix,
-           see https://github.com/rust-lang/rust/issues/46062 for more details
-note: required by `want_cyclic_generator_yield`
-  --> $DIR/generator-yielding-or-returning-itself.rs:22:1
-   |
 LL | / pub fn want_cyclic_generator_yield<T>(_: T)
 LL | |     where T: Generator<Yield = T, Return = ()>
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `want_cyclic_generator_yield`
+...
+LL |       want_cyclic_generator_yield(|| {
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
+   |
+   = note: closures cannot capture themselves or take themselves as argument;
+           this error may be the result of a recent compiler bug-fix,
+           see https://github.com/rust-lang/rust/issues/46062 for more details
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -1,32 +1,28 @@
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:16:5
    |
+LL |     fn assert_send<T: Send>(_: T) {}
+   |     ----------------------------- required by `main::assert_send`
+...
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::cell::Cell<i32>`
    = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:16:17: 20:6 a:&std::cell::Cell<i32> _]`
-note: required by `main::assert_send`
-  --> $DIR/not-send-sync.rs:7:5
-   |
-LL |     fn assert_send<T: Send>(_: T) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:9:5
    |
+LL |     fn assert_sync<T: Sync>(_: T) {}
+   |     ----------------------------- required by `main::assert_sync`
+...
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
    |
    = help: within `[generator@$DIR/not-send-sync.rs:9:17: 13:6 {std::cell::Cell<i32>, ()}]`, the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
    = note: required because it appears within the type `{std::cell::Cell<i32>, ()}`
    = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:9:17: 13:6 {std::cell::Cell<i32>, ()}]`
-note: required by `main::assert_sync`
-  --> $DIR/not-send-sync.rs:6:5
-   |
-LL |     fn assert_sync<T: Sync>(_: T) {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]: std::marker::Unpin` is not satisfied
   --> $DIR/static-not-unpin.rs:14:5
    |
+LL | fn assert_unpin<T: Unpin>(_: T) {
+   | ------------------------------- required by `assert_unpin`
+...
 LL |     assert_unpin(generator);
    |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`
-   |
-note: required by `assert_unpin`
-  --> $DIR/static-not-unpin.rs:7:1
-   |
-LL | fn assert_unpin<T: Unpin>(_: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-conflate-regions.stderr
+++ b/src/test/ui/hrtb/hrtb-conflate-regions.stderr
@@ -1,19 +1,17 @@
 error[E0277]: the trait bound `for<'a, 'b> SomeStruct: Foo<(&'a isize, &'b isize)>` is not satisfied
   --> $DIR/hrtb-conflate-regions.rs:27:10
    |
-LL | fn b() { want_foo2::<SomeStruct>(); }
-   |          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Foo<(&'a isize, &'b isize)>` is not implemented for `SomeStruct`
-   |
-   = help: the following implementations were found:
-             <SomeStruct as Foo<(&'a isize, &'a isize)>>
-note: required by `want_foo2`
-  --> $DIR/hrtb-conflate-regions.rs:8:1
-   |
 LL | / fn want_foo2<T>()
 LL | |     where T : for<'a,'b> Foo<(&'a isize, &'b isize)>
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `want_foo2`
+...
+LL |   fn b() { want_foo2::<SomeStruct>(); }
+   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Foo<(&'a isize, &'b isize)>` is not implemented for `SomeStruct`
+   |
+   = help: the following implementations were found:
+             <SomeStruct as Foo<(&'a isize, &'a isize)>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
@@ -1,20 +1,18 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(&'b u32)>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-contravariant.rs:34:5
    |
-LL |     foo::<()>();
-   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(&'b u32)>` is not implemented for `()`
-   |
-   = help: the following implementations were found:
-             <() as Trait<fn(&'a u32)>>
-note: required by `foo`
-  --> $DIR/hrtb-exists-forall-trait-contravariant.rs:8:1
-   |
 LL | / fn foo<T>()
 LL | | where
 LL | |     T: Trait<for<'b> fn(&'b u32)>,
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `foo`
+...
+LL |       foo::<()>();
+   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(&'b u32)>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as Trait<fn(&'a u32)>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
@@ -1,20 +1,18 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(fn(&'b u32))>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-covariant.rs:36:5
    |
-LL |     foo::<()>();
-   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(fn(&'b u32))>` is not implemented for `()`
-   |
-   = help: the following implementations were found:
-             <() as Trait<fn(fn(&'a u32))>>
-note: required by `foo`
-  --> $DIR/hrtb-exists-forall-trait-covariant.rs:8:1
-   |
 LL | / fn foo<T>()
 LL | | where
 LL | |     T: Trait<for<'b> fn(fn(&'b u32))>,
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `foo`
+...
+LL |       foo::<()>();
+   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(fn(&'b u32))>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as Trait<fn(fn(&'a u32))>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
@@ -1,20 +1,18 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-invariant.rs:28:5
    |
-LL |     foo::<()>();
-   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not implemented for `()`
-   |
-   = help: the following implementations were found:
-             <() as Trait<fn(std::cell::Cell<&'a u32>)>>
-note: required by `foo`
-  --> $DIR/hrtb-exists-forall-trait-invariant.rs:10:1
-   |
 LL | / fn foo<T>()
 LL | | where
 LL | |     T: Trait<for<'b> fn(Cell<&'b u32>)>,
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `foo`
+...
+LL |       foo::<()>();
+   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not implemented for `()`
+   |
+   = help: the following implementations were found:
+             <() as Trait<fn(std::cell::Cell<&'a u32>)>>
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -1,18 +1,16 @@
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:5
    |
-LL |     want_bar_for_any_ccx(b);
-   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
-   |
-   = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
-note: required by `want_bar_for_any_ccx`
-  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:31:1
-   |
 LL | / fn want_bar_for_any_ccx<B>(b: &B)
 LL | |     where B : for<'ccx> Bar<'ccx>
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `want_bar_for_any_ccx`
+...
+LL |       want_bar_for_any_ccx(b);
+   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |
+   = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -1,31 +1,25 @@
 error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:18:5
    |
-LL |     want_foo_for_any_tcx(f);
-   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
-   |
-   = help: consider adding a `where for<'tcx> F: Foo<'tcx>` bound
-note: required by `want_foo_for_any_tcx`
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:21:1
-   |
+LL |       want_foo_for_any_tcx(f);
+   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
+...
 LL | / fn want_foo_for_any_tcx<F>(f: &F)
 LL | |     where F : for<'tcx> Foo<'tcx>
 LL | | {
 LL | |     want_foo_for_some_tcx(f);
 LL | |     want_foo_for_any_tcx(f);
 LL | | }
-   | |_^
+   | |_- required by `want_foo_for_any_tcx`
+   |
+   = help: consider adding a `where for<'tcx> F: Foo<'tcx>` bound
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:5
    |
-LL |     want_bar_for_any_ccx(b);
-   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
-   |
-   = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
-note: required by `want_bar_for_any_ccx`
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:38:1
-   |
+LL |       want_bar_for_any_ccx(b);
+   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+...
 LL | / fn want_bar_for_any_ccx<B>(b: &B)
 LL | |     where B : for<'ccx> Bar<'ccx>
 LL | | {
@@ -33,7 +27,9 @@ LL | |     want_foo_for_some_tcx(b);
 ...  |
 LL | |     want_bar_for_any_ccx(b);
 LL | | }
-   | |_^
+   | |_- required by `want_bar_for_any_ccx`
+   |
+   = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hrtb/hrtb-just-for-static.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.stderr
@@ -1,36 +1,32 @@
 error[E0277]: the trait bound `for<'a> StaticInt: Foo<&'a isize>` is not satisfied
   --> $DIR/hrtb-just-for-static.rs:24:5
    |
-LL |     want_hrtb::<StaticInt>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `StaticInt`
-   |
-   = help: the following implementations were found:
-             <StaticInt as Foo<&'static isize>>
-note: required by `want_hrtb`
-  --> $DIR/hrtb-just-for-static.rs:8:1
-   |
 LL | / fn want_hrtb<T>()
 LL | |     where T : for<'a> Foo<&'a isize>
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `want_hrtb`
+...
+LL |       want_hrtb::<StaticInt>()
+   |       ^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `StaticInt`
+   |
+   = help: the following implementations were found:
+             <StaticInt as Foo<&'static isize>>
 
 error[E0277]: the trait bound `for<'a> &'a u32: Foo<&'a isize>` is not satisfied
   --> $DIR/hrtb-just-for-static.rs:30:5
    |
-LL |     want_hrtb::<&'a u32>()
-   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `&'a u32`
-   |
-   = help: the following implementations were found:
-             <&'a u32 as Foo<&'a isize>>
-note: required by `want_hrtb`
-  --> $DIR/hrtb-just-for-static.rs:8:1
-   |
 LL | / fn want_hrtb<T>()
 LL | |     where T : for<'a> Foo<&'a isize>
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `want_hrtb`
+...
+LL |       want_hrtb::<&'a u32>()
+   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `&'a u32`
+   |
+   = help: the following implementations were found:
+             <&'a u32 as Foo<&'a isize>>
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/hrtb/issue-46989.stderr
+++ b/src/test/ui/hrtb/issue-46989.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `for<'r> fn(&'r i32): Foo` is not satisfied
   --> $DIR/issue-46989.rs:40:5
    |
+LL | fn assert_foo<T: Foo>() {}
+   | ----------------------- required by `assert_foo`
+...
 LL |     assert_foo::<fn(&i32)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `for<'r> fn(&'r i32)`
    |
    = help: the following implementations were found:
              <fn(A) as Foo>
-note: required by `assert_foo`
-  --> $DIR/issue-46989.rs:37:1
-   |
-LL | fn assert_foo<T: Foo>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -72,16 +72,14 @@ LL | | }
 error[E0277]: `std::rc::Rc<std::string::String>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak.rs:15:5
    |
+LL | fn send<T: Send>(_: T) {}
+   | ---------------------- required by `send`
+...
 LL |     send(cycle2().clone());
    |     ^^^^ `std::rc::Rc<std::string::String>` cannot be sent between threads safely
    |
    = help: within `impl std::clone::Clone`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<std::string::String>`
    = note: required because it appears within the type `impl std::clone::Clone`
-note: required by `send`
-  --> $DIR/auto-trait-leak.rs:4:1
-   |
-LL | fn send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/impl-trait/auto-trait-leak2.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak2.stderr
@@ -1,32 +1,28 @@
 error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak2.rs:13:5
    |
+LL | fn send<T: Send>(_: T) {}
+   | ---------------------- required by `send`
+...
 LL |     send(before());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
    |
    = help: within `impl std::ops::Fn<(i32,)>`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<std::cell::Cell<i32>>`
    = note: required because it appears within the type `[closure@$DIR/auto-trait-leak2.rs:7:5: 7:22 p:std::rc::Rc<std::cell::Cell<i32>>]`
    = note: required because it appears within the type `impl std::ops::Fn<(i32,)>`
-note: required by `send`
-  --> $DIR/auto-trait-leak2.rs:10:1
-   |
-LL | fn send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
   --> $DIR/auto-trait-leak2.rs:16:5
    |
+LL | fn send<T: Send>(_: T) {}
+   | ---------------------- required by `send`
+...
 LL |     send(after());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
    |
    = help: within `impl std::ops::Fn<(i32,)>`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<std::cell::Cell<i32>>`
    = note: required because it appears within the type `[closure@$DIR/auto-trait-leak2.rs:24:5: 24:22 p:std::rc::Rc<std::cell::Cell<i32>>]`
    = note: required because it appears within the type `impl std::ops::Fn<(i32,)>`
-note: required by `send`
-  --> $DIR/auto-trait-leak2.rs:10:1
-   |
-LL | fn send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-1920-1.stderr
+++ b/src/test/ui/issues/issue-1920-1.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `foo::issue_1920::S: std::clone::Clone` is not satisfied
   --> $DIR/issue-1920-1.rs:12:5
    |
+LL | fn assert_clone<T>() where T : Clone { }
+   | ------------------------------------ required by `assert_clone`
+...
 LL |     assert_clone::<foo::issue_1920::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `foo::issue_1920::S`
-   |
-note: required by `assert_clone`
-  --> $DIR/issue-1920-1.rs:9:1
-   |
-LL | fn assert_clone<T>() where T : Clone { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-2.stderr
+++ b/src/test/ui/issues/issue-1920-2.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `bar::S: std::clone::Clone` is not satisfied
   --> $DIR/issue-1920-2.rs:10:5
    |
+LL | fn assert_clone<T>() where T : Clone { }
+   | ------------------------------------ required by `assert_clone`
+...
 LL |     assert_clone::<bar::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `bar::S`
-   |
-note: required by `assert_clone`
-  --> $DIR/issue-1920-2.rs:7:1
-   |
-LL | fn assert_clone<T>() where T : Clone { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-3.stderr
+++ b/src/test/ui/issues/issue-1920-3.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `issue_1920::S: std::clone::Clone` is not satisfied
   --> $DIR/issue-1920-3.rs:14:5
    |
+LL | fn assert_clone<T>() where T : Clone { }
+   | ------------------------------------ required by `assert_clone`
+...
 LL |     assert_clone::<foo::issue_1920::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `issue_1920::S`
-   |
-note: required by `assert_clone`
-  --> $DIR/issue-1920-3.rs:11:1
-   |
-LL | fn assert_clone<T>() where T : Clone { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20005.stderr
+++ b/src/test/ui/issues/issue-20005.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/issue-20005.rs:8:5
    |
+LL |   trait From<Src> {
+   |   --------------- required by `From`
+...
 LL | /     fn to<Dst>(
 LL | |         self
 LL | |     ) -> <Dst as From<Self>>::Result where Dst: From<Self> {
@@ -11,11 +14,6 @@ LL | |     }
    = help: the trait `std::marker::Sized` is not implemented for `Self`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where Self: std::marker::Sized` bound
-note: required by `From`
-  --> $DIR/issue-20005.rs:1:1
-   |
-LL | trait From<Src> {
-   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -9,6 +9,9 @@ LL | struct NoData<T>;
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1
    |
+LL |   trait Foo {
+   |   --------- required by `Foo`
+...
 LL | / impl<T> Foo for T where NoData<T>: Foo {
 LL | |
 LL | |   fn answer(self) {
@@ -146,15 +149,13 @@ LL | | }
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<NoData<T>>>`
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<T>>`
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
-note: required by `Foo`
-  --> $DIR/issue-20413.rs:1:1
-   |
-LL | trait Foo {
-   | ^^^^^^^^^
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:10:3
    |
+LL |   trait Foo {
+   |   --------- required by `Foo`
+...
 LL | /   fn answer(self) {
 LL | |
 LL | |     let val: NoData<T> = NoData;
@@ -289,11 +290,6 @@ LL | |   }
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<NoData<T>>>`
    = note: required because of the requirements on the impl of `Foo` for `NoData<NoData<T>>`
    = note: required because of the requirements on the impl of `Foo` for `NoData<T>`
-note: required by `Foo`
-  --> $DIR/issue-20413.rs:1:1
-   |
-LL | trait Foo {
-   | ^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-21763.stderr
+++ b/src/test/ui/issues/issue-21763.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/issue-21763.rs:9:5
    |
+LL | fn foo<T: Send>() {}
+   | ----------------- required by `foo`
+...
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
    |
@@ -9,11 +12,6 @@ LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    = note: required because of the requirements on the impl of `std::marker::Send` for `hashbrown::raw::RawTable<(std::rc::Rc<()>, std::rc::Rc<()>)>`
    = note: required because it appears within the type `hashbrown::map::HashMap<std::rc::Rc<()>, std::rc::Rc<()>, std::collections::hash_map::RandomState>`
    = note: required because it appears within the type `std::collections::HashMap<std::rc::Rc<()>, std::rc::Rc<()>>`
-note: required by `foo`
-  --> $DIR/issue-21763.rs:6:1
-   |
-LL | fn foo<T: Send>() {}
-   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21837.stderr
+++ b/src/test/ui/issues/issue-21837.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: Bound` is not satisfied
   --> $DIR/issue-21837.rs:8:9
    |
+LL | pub struct Foo<T: Bound>(T);
+   | ---------------------------- required by `Foo`
+...
 LL | impl<T> Trait2 for Foo<T> {}
    |         ^^^^^^ the trait `Bound` is not implemented for `T`
    |
    = help: consider adding a `where T: Bound` bound
-note: required by `Foo`
-  --> $DIR/issue-21837.rs:2:1
-   |
-LL | pub struct Foo<T: Bound>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,6 +1,9 @@
 error[E0283]: type annotations required: cannot resolve `&'a T: Foo`
   --> $DIR/issue-21974.rs:10:1
    |
+LL |   trait Foo {
+   |   --------- required by `Foo`
+...
 LL | / fn foo<'a,'b,T>(x: &'a T, y: &'b T)
 LL | |     where &'a T : Foo,
 LL | |           &'b T : Foo
@@ -9,12 +12,6 @@ LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
    | |_^
-   |
-note: required by `Foo`
-  --> $DIR/issue-21974.rs:6:1
-   |
-LL | trait Foo {
-   | ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -1,16 +1,14 @@
 error[E0271]: type mismatch resolving `<<T as Trait>::A as MultiDispatch<i32>>::O == T`
   --> $DIR/issue-24204.rs:14:1
    |
+LL | trait Trait: Sized {
+   | ------------------ required by `Trait`
+...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found type parameter
    |
    = note: expected type `<<T as Trait>::A as MultiDispatch<i32>>::O`
               found type `T`
-note: required by `Trait`
-  --> $DIR/issue-24204.rs:7:1
-   |
-LL | trait Trait: Sized {
-   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,14 +1,11 @@
 error[E0283]: type annotations required: cannot resolve `T0: Trait0<'l0>`
   --> $DIR/issue-24424.rs:4:1
    |
+LL | trait Trait0<'l0>  {}
+   | ----------------- required by `Trait0`
+LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: required by `Trait0`
-  --> $DIR/issue-24424.rs:2:1
-   |
-LL | trait Trait0<'l0>  {}
-   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `(): InOut<_>` is not satisfied
   --> $DIR/issue-25076.rs:10:5
    |
+LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
+   | ------------------------------------------------ required by `do_fold`
+...
 LL |     do_fold(bot(), ());
    |     ^^^^^^^ the trait `InOut<_>` is not implemented for `()`
-   |
-note: required by `do_fold`
-  --> $DIR/issue-25076.rs:5:1
-   |
-LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-29147.stderr
+++ b/src/test/ui/issues/issue-29147.stderr
@@ -1,14 +1,11 @@
 error[E0283]: type annotations required: cannot resolve `S5<_>: Foo`
   --> $DIR/issue-29147.rs:21:13
    |
+LL | trait Foo { fn xxx(&self); }
+   |             -------------- required by `Foo::xxx`
+...
 LL |     let _ = <S5<_>>::xxx;
    |             ^^^^^^^^^^^^
-   |
-note: required by `Foo::xxx`
-  --> $DIR/issue-29147.rs:10:13
-   |
-LL | trait Foo { fn xxx(&self); }
-   |             ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32963.stderr
+++ b/src/test/ui/issues/issue-32963.stderr
@@ -12,14 +12,11 @@ LL |     size_of_copy::<dyn Misc + Copy>();
 error[E0277]: the trait bound `dyn Misc: std::marker::Copy` is not satisfied
   --> $DIR/issue-32963.rs:8:5
    |
+LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
+   | ------------------------------------------ required by `size_of_copy`
+...
 LL |     size_of_copy::<dyn Misc + Copy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `dyn Misc`
-   |
-note: required by `size_of_copy`
-  --> $DIR/issue-32963.rs:5:1
-   |
-LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -1,17 +1,15 @@
 error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
   --> $DIR/issue-39970.rs:19:5
    |
+LL |     fn visit() {}
+   |     ---------- required by `Visit::visit`
+...
 LL |     <() as Visit>::visit();
    |     ^^^^^^^^^^^^^^^^^^^^ expected &(), found ()
    |
    = note: expected type `&()`
               found type `()`
    = note: required because of the requirements on the impl of `Visit` for `()`
-note: required by `Visit::visit`
-  --> $DIR/issue-39970.rs:6:5
-   |
-LL |     fn visit() {}
-   |     ^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-40827.stderr
+++ b/src/test/ui/issues/issue-40827.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `std::rc::Rc<Foo>` cannot be sent between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
+LL | fn f<T: Send>(_: T) {}
+   | ------------------- required by `f`
+...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be sent between threads safely
    |
@@ -8,15 +11,13 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    = note: required because it appears within the type `Bar`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::sync::Arc<Bar>`
    = note: required because it appears within the type `Foo`
-note: required by `f`
-  --> $DIR/issue-40827.rs:11:1
-   |
-LL | fn f<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Rc<Foo>` cannot be shared between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
+LL | fn f<T: Send>(_: T) {}
+   | ------------------- required by `f`
+...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be shared between threads safely
    |
@@ -24,11 +25,6 @@ LL |     f(Foo(Arc::new(Bar::B(None))));
    = note: required because it appears within the type `Bar`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::sync::Arc<Bar>`
    = note: required because it appears within the type `Foo`
-note: required by `f`
-  --> $DIR/issue-40827.rs:11:1
-   |
-LL | fn f<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -1,41 +1,31 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-43623.rs:14:5
    |
-LL |     break_me::<Type, fn(_)>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
-   |     |
-   |     expected signature of `for<'b> fn(<Type as Trait<'b>>::Assoc) -> _`
-   |     found signature of `fn(_) -> _`
-   |
-note: required by `break_me`
-  --> $DIR/issue-43623.rs:11:1
-   |
 LL | / pub fn break_me<T, F>(f: F)
 LL | | where T: for<'b> Trait<'b>,
 LL | |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
 LL | |     break_me::<Type, fn(_)>;
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^
+   | |     |
+   | |     expected signature of `for<'b> fn(<Type as Trait<'b>>::Assoc) -> _`
+   | |     found signature of `fn(_) -> _`
 LL | |
 LL | |
 LL | | }
-   | |_^
+   | |_- required by `break_me`
 
 error[E0271]: type mismatch resolving `for<'b> <fn(_) as std::ops::FnOnce<(<Type as Trait<'b>>::Assoc,)>>::Output == ()`
   --> $DIR/issue-43623.rs:14:5
    |
-LL |     break_me::<Type, fn(_)>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'b, found concrete lifetime
-   |
-note: required by `break_me`
-  --> $DIR/issue-43623.rs:11:1
-   |
 LL | / pub fn break_me<T, F>(f: F)
 LL | | where T: for<'b> Trait<'b>,
 LL | |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
 LL | |     break_me::<Type, fn(_)>;
+   | |     ^^^^^^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'b, found concrete lifetime
 LL | |
 LL | |
 LL | | }
-   | |_^
+   | |_- required by `break_me`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -10,21 +10,18 @@ LL |         self.foo.map(Foo::new)
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
   --> $DIR/issue-47706.rs:27:5
    |
-LL |     Bar(i32),
-   |     -------- takes 1 argument
+LL |       Bar(i32),
+   |       -------- takes 1 argument
 ...
-LL |     foo(Qux::Bar);
-   |     ^^^ expected function that takes 0 arguments
-   |
-note: required by `foo`
-  --> $DIR/issue-47706.rs:20:1
-   |
 LL | / fn foo<F>(f: F)
 LL | | where
 LL | |     F: Fn(),
 LL | | {
 LL | | }
-   | |_^
+   | |_- required by `foo`
+...
+LL |       foo(Qux::Bar);
+   |       ^^^ expected function that takes 0 arguments
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -1,33 +1,27 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-60283.rs:14:5
    |
-LL |     foo((), drop)
-   |     ^^^
-   |     |
-   |     expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
-   |     found signature of `fn(_) -> _`
-   |
-note: required by `foo`
-  --> $DIR/issue-60283.rs:9:1
-   |
 LL | / pub fn foo<T, F>(_: T, _: F)
 LL | | where T: for<'a> Trait<'a>,
 LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
-   | |_________________________________________________^
+   | |_________________________________________________- required by `foo`
+...
+LL |       foo((), drop)
+   |       ^^^
+   |       |
+   |       expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
+   |       found signature of `fn(_) -> _`
 
 error[E0271]: type mismatch resolving `for<'a> <fn(_) {std::mem::drop::<_>} as std::ops::FnOnce<(<() as Trait<'a>>::Item,)>>::Output == ()`
   --> $DIR/issue-60283.rs:14:5
    |
-LL |     foo((), drop)
-   |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime
-   |
-note: required by `foo`
-  --> $DIR/issue-60283.rs:9:1
-   |
 LL | / pub fn foo<T, F>(_: T, _: F)
 LL | | where T: for<'a> Trait<'a>,
 LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
-   | |_________________________________________________^
+   | |_________________________________________________- required by `foo`
+...
+LL |       foo((), drop)
+   |       ^^^ expected bound lifetime parameter 'a, found concrete lifetime
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/iterators/bound.stderr
+++ b/src/test/ui/iterators/bound.stderr
@@ -1,16 +1,13 @@
 error[E0277]: `u8` is not an iterator
   --> $DIR/bound.rs:2:10
    |
+LL | struct S<I: Iterator>(I);
+   | ------------------------- required by `S`
 LL | struct T(S<u8>);
    |          ^^^^^ `u8` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `u8`
    = note: if you want to iterate between `start` until a value `end`, use the exclusive range syntax `start..end` or the inclusive range syntax `start..=end`
-note: required by `S`
-  --> $DIR/bound.rs:1:1
-   |
-LL | struct S<I: Iterator>(I);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -1,138 +1,107 @@
 error[E0277]: the trait bound `&'static mut isize: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:27:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<&'static mut isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'static mut isize`
    |
    = help: the following implementations were found:
              <isize as std::marker::Copy>
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `&'a mut isize: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:28:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<&'a mut isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut isize`
    |
    = help: the following implementations were found:
              <isize as std::marker::Copy>
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::boxed::Box<isize>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:31:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Box<isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<isize>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:32:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<String>();
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::vec::Vec<isize>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:33:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Vec<isize> >();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::vec::Vec<isize>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::boxed::Box<&'a mut isize>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:34:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Box<&'a mut isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<&'a mut isize>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::boxed::Box<dyn Dummy>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:42:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::boxed::Box<dyn Dummy + std::marker::Send>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:43:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Box<dyn Dummy + Send>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy + std::marker::Send>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `&'a mut (dyn Dummy + std::marker::Send + 'a): std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:46:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<&'a mut (dyn Dummy + Send)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut (dyn Dummy + std::marker::Send + 'a)`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `MyNoncopyStruct: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:64:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<MyNoncopyStruct>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `MyNoncopyStruct`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::rc::Rc<isize>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-copy.rs:67:5
    |
+LL | fn assert_copy<T:Copy>() { }
+   | ------------------------ required by `assert_copy`
+...
 LL |     assert_copy::<Rc<isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::rc::Rc<isize>`
-   |
-note: required by `assert_copy`
-  --> $DIR/kindck-copy.rs:5:1
-   |
-LL | fn assert_copy<T:Copy>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-impl-type-params-2.rs:13:5
    |
+LL | fn take_param<T:Foo>(foo: &T) { }
+   | ----------------------------- required by `take_param`
+...
 LL |     take_param(&x);
    |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
    |
    = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<{integer}>`
-note: required by `take_param`
-  --> $DIR/kindck-impl-type-params-2.rs:9:1
-   |
-LL | fn take_param<T:Foo>(foo: &T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is not satisfied
   --> $DIR/kindck-inherited-copy-bound.rs:18:5
    |
+LL | fn take_param<T:Foo>(foo: &T) { }
+   | ----------------------------- required by `take_param`
+...
 LL |     take_param(&x);
    |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
    |
    = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<{integer}>`
-note: required by `take_param`
-  --> $DIR/kindck-inherited-copy-bound.rs:14:1
-   |
-LL | fn take_param<T:Foo>(foo: &T) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/kindck-inherited-copy-bound.rs:24:19

--- a/src/test/ui/kindck/kindck-nonsendable-1.stderr
+++ b/src/test/ui/kindck/kindck-nonsendable-1.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `std::rc::Rc<usize>` cannot be sent between threads safely
   --> $DIR/kindck-nonsendable-1.rs:9:5
    |
+LL | fn bar<F:FnOnce() + Send>(_: F) { }
+   | ------------------------------- required by `bar`
+...
 LL |     bar(move|| foo(x));
    |     ^^^ `std::rc::Rc<usize>` cannot be sent between threads safely
    |
    = help: within `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22 x:std::rc::Rc<usize>]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<usize>`
    = note: required because it appears within the type `[closure@$DIR/kindck-nonsendable-1.rs:9:9: 9:22 x:std::rc::Rc<usize>]`
-note: required by `bar`
-  --> $DIR/kindck-nonsendable-1.rs:5:1
-   |
-LL | fn bar<F:FnOnce() + Send>(_: F) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-send-object.stderr
+++ b/src/test/ui/kindck/kindck-send-object.stderr
@@ -1,31 +1,27 @@
 error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object.rs:12:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn Dummy + 'static)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&'static (dyn Dummy + 'static)`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object.rs:5:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object.rs:17:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dyn Dummy`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dyn Dummy>`
    = note: required because it appears within the type `std::boxed::Box<dyn Dummy>`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object.rs:5:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object1.nll.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.nll.stderr
@@ -1,31 +1,27 @@
 error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
+LL | fn assert_send<T:Send+'static>() { }
+   | -------------------------------- required by `assert_send`
+...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&'a (dyn Dummy + 'a)`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object1.rs:5:1
-   |
-LL | fn assert_send<T:Send+'static>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
+LL | fn assert_send<T:Send+'static>() { }
+   | -------------------------------- required by `assert_send`
+...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn Dummy + 'a)>`
    = note: required because it appears within the type `std::boxed::Box<(dyn Dummy + 'a)>`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object1.rs:5:1
-   |
-LL | fn assert_send<T:Send+'static>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object1.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
+LL | fn assert_send<T:Send+'static>() { }
+   | -------------------------------- required by `assert_send`
+...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&'a (dyn Dummy + 'a)`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object1.rs:5:1
-   |
-LL | fn assert_send<T:Send+'static>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0477]: the type `&'a (dyn Dummy + std::marker::Sync + 'a)` does not fulfill the required lifetime
   --> $DIR/kindck-send-object1.rs:14:5
@@ -23,17 +21,15 @@ LL |     assert_send::<&'a (dyn Dummy + Sync)>();
 error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
+LL | fn assert_send<T:Send+'static>() { }
+   | -------------------------------- required by `assert_send`
+...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `(dyn Dummy + 'a)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn Dummy + 'a)>`
    = note: required because it appears within the type `std::boxed::Box<(dyn Dummy + 'a)>`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object1.rs:5:1
-   |
-LL | fn assert_send<T:Send+'static>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/kindck/kindck-send-object2.stderr
+++ b/src/test/ui/kindck/kindck-send-object2.stderr
@@ -1,31 +1,27 @@
 error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object2.rs:7:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<&'static dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn Dummy + 'static)`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&'static (dyn Dummy + 'static)`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object2.rs:3:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object2.rs:12:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dyn Dummy`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dyn Dummy>`
    = note: required because it appears within the type `std::boxed::Box<dyn Dummy>`
-note: required by `assert_send`
-  --> $DIR/kindck-send-object2.rs:3:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/kindck/kindck-send-owned.stderr
+++ b/src/test/ui/kindck/kindck-send-owned.stderr
@@ -1,17 +1,15 @@
 error[E0277]: `*mut u8` cannot be sent between threads safely
   --> $DIR/kindck-send-owned.rs:12:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<Box<*mut u8>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `*mut u8`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<*mut u8>`
    = note: required because it appears within the type `std::boxed::Box<*mut u8>`
-note: required by `assert_send`
-  --> $DIR/kindck-send-owned.rs:3:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/kindck/kindck-send-unsafe.stderr
+++ b/src/test/ui/kindck/kindck-send-unsafe.stderr
@@ -1,15 +1,13 @@
 error[E0277]: `*mut &'a isize` cannot be sent between threads safely
   --> $DIR/kindck-send-unsafe.rs:6:5
    |
+LL | fn assert_send<T:Send>() { }
+   | ------------------------ required by `assert_send`
+...
 LL |     assert_send::<*mut &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `*mut &'a isize`
-note: required by `assert_send`
-  --> $DIR/kindck-send-unsafe.rs:3:1
-   |
-LL | fn assert_send<T:Send>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:27:5
    |
+LL | fn is_marker<T: Marker>() { }
+   | ------------------------- required by `is_marker`
+...
 LL |     is_marker::<NotDebugOrDisplay>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`
-   |
-note: required by `is_marker`
-  --> $DIR/overlap-marker-trait.rs:15:1
-   |
-LL | fn is_marker<T: Marker>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -1,60 +1,48 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
+LL | fn foo<F: Fn(usize)>(_: F) {}
+   | -------------------------- required by `foo`
+...
 LL |     foo(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
-   |
-note: required by `foo`
-  --> $DIR/E0631.rs:3:1
-   |
-LL | fn foo<F: Fn(usize)>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
+LL | fn bar<F: Fn<usize>>(_: F) {}
+   | -------------------------- required by `bar`
+...
 LL |     bar(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
    |     |
    |     expected signature of `fn(usize) -> _`
-   |
-note: required by `bar`
-  --> $DIR/E0631.rs:4:1
-   |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:5
    |
+LL | fn foo<F: Fn(usize)>(_: F) {}
+   | -------------------------- required by `foo`
+...
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     foo(f);
    |     ^^^ expected signature of `fn(usize) -> _`
-   |
-note: required by `foo`
-  --> $DIR/E0631.rs:3:1
-   |
-LL | fn foo<F: Fn(usize)>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:5
    |
+LL | fn bar<F: Fn<usize>>(_: F) {}
+   | -------------------------- required by `bar`
+LL | fn main() {
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     bar(f);
    |     ^^^ expected signature of `fn(usize) -> _`
-   |
-note: required by `bar`
-  --> $DIR/E0631.rs:4:1
-   |
-LL | fn bar<F: Fn<usize>>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -45,16 +45,13 @@ LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
 error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
+LL | fn f<F: Fn<usize>>(_: F) {}
+   | ------------------------ required by `f`
+...
 LL |     f(|| panic!());
    |     ^ -- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
-   |
-note: required by `f`
-  --> $DIR/closure-arg-count.rs:3:1
-   |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(|_| panic!());
@@ -63,16 +60,13 @@ LL |     f(|_| panic!());
 error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
+LL | fn f<F: Fn<usize>>(_: F) {}
+   | ------------------------ required by `f`
+...
 LL |     f(  move    || panic!());
    |     ^   ---------- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
-   |
-note: required by `f`
-  --> $DIR/closure-arg-count.rs:3:1
-   |
-LL | fn f<F: Fn<usize>>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(  move    |_| panic!());
@@ -148,14 +142,10 @@ error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
 LL |     call(Foo);
    |     ^^^^ expected function that takes 0 arguments
 ...
+LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
+   | ------------------------------------------ required by `call`
 LL | struct Foo(u8);
    | --------------- takes 1 argument
-   |
-note: required by `call`
-  --> $DIR/closure-arg-count.rs:42:1
-   |
-LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -25,29 +25,23 @@ LL |     a.iter().map(|_: (u16, u16)| 45);
 error[E0631]: type mismatch in function arguments
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   | ------------------------------ required by `baz`
+LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^
    |     |
    |     expected signature of `for<'r> fn(*mut &'r u32) -> _`
    |     found signature of `fn(*mut &'a u32) -> _`
-   |
-note: required by `baz`
-  --> $DIR/closure-arg-type-mismatch.rs:8:1
-   |
-LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `for<'r> <fn(*mut &'a u32) as std::ops::FnOnce<(*mut &'r u32,)>>::Output == ()`
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
+LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
+   | ------------------------------ required by `baz`
+LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^ expected bound lifetime parameter, found concrete lifetime
-   |
-note: required by `baz`
-  --> $DIR/closure-arg-type-mismatch.rs:8:1
-   |
-LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -1,30 +1,26 @@
 error[E0271]: type mismatch resolving `for<'r> <[closure@$DIR/closure-mismatch.rs:8:9: 8:15] as std::ops::FnOnce<(&'r (),)>>::Output == ()`
   --> $DIR/closure-mismatch.rs:8:5
    |
+LL | fn baz<T: Foo>(_: T) {}
+   | -------------------- required by `baz`
+...
 LL |     baz(|_| ());
    |     ^^^ expected bound lifetime parameter, found concrete lifetime
    |
    = note: required because of the requirements on the impl of `Foo` for `[closure@$DIR/closure-mismatch.rs:8:9: 8:15]`
-note: required by `baz`
-  --> $DIR/closure-mismatch.rs:5:1
-   |
-LL | fn baz<T: Foo>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-mismatch.rs:8:5
    |
+LL | fn baz<T: Foo>(_: T) {}
+   | -------------------- required by `baz`
+...
 LL |     baz(|_| ());
    |     ^^^ ------ found signature of `fn(_) -> _`
    |     |
    |     expected signature of `for<'r> fn(&'r ()) -> _`
    |
    = note: required because of the requirements on the impl of `Foo` for `[closure@$DIR/closure-mismatch.rs:8:9: 8:15]`
-note: required by `baz`
-  --> $DIR/closure-mismatch.rs:5:1
-   |
-LL | fn baz<T: Foo>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -3,15 +3,12 @@ error[E0631]: type mismatch in function arguments
    |
 LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
+LL | 
+LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
+   | --------------------------------------------- required by `apply`
 ...
 LL |     apply(&3, takes_mut);
    |     ^^^^^ expected signature of `fn(&{integer}) -> _`
-   |
-note: required by `apply`
-  --> $DIR/fn-variance-1.rs:5:1
-   |
-LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0631]: type mismatch in function arguments
   --> $DIR/fn-variance-1.rs:15:5
@@ -19,14 +16,11 @@ error[E0631]: type mismatch in function arguments
 LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
+LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
+   | --------------------------------------------- required by `apply`
+...
 LL |     apply(&mut 3, takes_imm);
    |     ^^^^^ expected signature of `fn(&mut {integer}) -> _`
-   |
-note: required by `apply`
-  --> $DIR/fn-variance-1.rs:5:1
-   |
-LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -1,17 +1,14 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/unboxed-closures-vtable-mismatch.rs:15:13
    |
+LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
+   | -------------------------------------------------------------------- required by `call_it`
+...
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`
 LL |
 LL |     let z = call_it(3, f);
    |             ^^^^^^^ expected signature of `fn(isize, isize) -> _`
-   |
-note: required by `call_it`
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:7:1
-   |
-LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/mut/mutable-enum-indirect.stderr
+++ b/src/test/ui/mut/mutable-enum-indirect.stderr
@@ -1,17 +1,15 @@
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/mutable-enum-indirect.rs:17:5
    |
+LL | fn bar<T: Sync>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(&x);
    |     ^^^ `NoSync` cannot be shared between threads safely
    |
    = help: within `&Foo`, the trait `std::marker::Sync` is not implemented for `NoSync`
    = note: required because it appears within the type `Foo`
    = note: required because it appears within the type `&Foo`
-note: required by `bar`
-  --> $DIR/mutable-enum-indirect.rs:13:1
-   |
-LL | fn bar<T: Sync>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/mutexguard-sync.rs:11:5
    |
+LL | fn test_sync<T: Sync>(_t: T) {}
+   | ---------------------------- required by `test_sync`
+...
 LL |     test_sync(guard);
    |     ^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::marker::Sync` for `std::sync::MutexGuard<'_, std::cell::Cell<i32>>`
-note: required by `test_sync`
-  --> $DIR/mutexguard-sync.rs:5:1
-   |
-LL | fn test_sync<T: Sync>(_t: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -69,530 +69,398 @@ LL | use namespace_mix::xm8::V;
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m1::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m2::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::S`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m2::S);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:39:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm1::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:41:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm2::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:42:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm2::S);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m3::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:56:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m3::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m4::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::TS`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m4::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:61:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm3::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:62:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm3::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:63:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm4::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:64:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm4::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m5::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m5::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m6::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m6::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:83:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm5::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:84:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm5::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:85:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm6::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:86:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm6::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m7::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m8::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m8::V);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:105:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm7::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:107:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm8::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:108:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm8::V);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m9::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:122:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(m9::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mA::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mA::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:127:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm9::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:128:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xm9::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:129:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmA::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:130:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmA::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mB::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mB::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mC::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(mC::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:149:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmB::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:150:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmB::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:151:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmC::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:152:5
    |
+LL | fn check<T: Impossible>(_: T) {}
+   | ----------------------------- required by `check`
+...
 LL |     check(xmC::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
-   |
-note: required by `check`
-  --> $DIR/namespace-mix.rs:21:1
-   |
-LL | fn check<T: Impossible>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/no_send-enum.stderr
+++ b/src/test/ui/no_send-enum.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `NoSend` cannot be sent between threads safely
   --> $DIR/no_send-enum.rs:16:5
    |
+LL | fn bar<T: Send>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(x);
    |     ^^^ `NoSend` cannot be sent between threads safely
    |
    = help: within `Foo`, the trait `std::marker::Send` is not implemented for `NoSend`
    = note: required because it appears within the type `Foo`
-note: required by `bar`
-  --> $DIR/no_send-enum.rs:12:1
-   |
-LL | fn bar<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -1,15 +1,13 @@
 error[E0277]: `std::rc::Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/no_send-rc.rs:7:5
    |
+LL | fn bar<T: Send>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(x);
    |     ^^^ `std::rc::Rc<{integer}>` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `std::rc::Rc<{integer}>`
-note: required by `bar`
-  --> $DIR/no_send-rc.rs:3:1
-   |
-LL | fn bar<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -1,15 +1,13 @@
 error[E0277]: `Foo` cannot be sent between threads safely
   --> $DIR/no_send-struct.rs:15:5
    |
+LL | fn bar<T: Send>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(x);
    |     ^^^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `Foo`
-note: required by `bar`
-  --> $DIR/no_send-struct.rs:11:1
-   |
-LL | fn bar<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_share-enum.stderr
+++ b/src/test/ui/no_share-enum.stderr
@@ -1,16 +1,14 @@
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/no_share-enum.rs:14:5
    |
+LL | fn bar<T: Sync>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(x);
    |     ^^^ `NoSync` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `std::marker::Sync` is not implemented for `NoSync`
    = note: required because it appears within the type `Foo`
-note: required by `bar`
-  --> $DIR/no_share-enum.rs:10:1
-   |
-LL | fn bar<T: Sync>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -1,15 +1,13 @@
 error[E0277]: `Foo` cannot be shared between threads safely
   --> $DIR/no_share-struct.rs:12:5
    |
+LL | fn bar<T: Sync>(_: T) {}
+   | --------------------- required by `bar`
+...
 LL |     bar(x);
    |     ^^^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `Foo`
-note: required by `bar`
-  --> $DIR/no_share-struct.rs:8:1
-   |
-LL | fn bar<T: Sync>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-panic/not-panic-safe-2.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-2.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `std::cell::RefCell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `std::rc::Rc<std::cell::RefCell<i32>>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-2.rs:7:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-2.rs:10:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -23,11 +24,6 @@ LL |     assert::<Rc<RefCell<i32>>>();
    = note: required because it appears within the type `std::cell::Cell<isize>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `std::rc::Rc<std::cell::RefCell<i32>>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-2.rs:7:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-3.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-3.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `std::cell::RefCell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `std::sync::Arc<std::cell::RefCell<i32>>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-3.rs:7:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-3.rs:10:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -23,11 +24,6 @@ LL |     assert::<Arc<RefCell<i32>>>();
    = note: required because it appears within the type `std::cell::Cell<isize>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `std::sync::Arc<std::cell::RefCell<i32>>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-3.rs:7:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-4.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-4.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `std::cell::RefCell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `&std::cell::RefCell<i32>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-4.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-4.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -23,11 +24,6 @@ LL |     assert::<&RefCell<i32>>();
    = note: required because it appears within the type `std::cell::Cell<isize>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `&std::cell::RefCell<i32>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-4.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe-5.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-5.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-5.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<*const UnsafeCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `*const std::cell::UnsafeCell<i32>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-5.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-panic/not-panic-safe-6.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-6.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `std::cell::RefCell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `*mut std::cell::RefCell<i32>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-6.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
   --> $DIR/not-panic-safe-6.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
@@ -23,11 +24,6 @@ LL |     assert::<*mut RefCell<i32>>();
    = note: required because it appears within the type `std::cell::Cell<isize>`
    = note: required because it appears within the type `std::cell::RefCell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `*mut std::cell::RefCell<i32>`
-note: required by `assert`
-  --> $DIR/not-panic-safe-6.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the type `&mut i32` may not be safely transferred across an unwind boundary
   --> $DIR/not-panic-safe.rs:9:5
    |
+LL | fn assert<T: UnwindSafe + ?Sized>() {}
+   | ----------------------------------- required by `assert`
+...
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary
    |
    = help: the trait `std::panic::UnwindSafe` is not implemented for `&mut i32`
-note: required by `assert`
-  --> $DIR/not-panic-safe.rs:6:1
-   |
-LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/not-sync.stderr
+++ b/src/test/ui/not-sync.stderr
@@ -1,80 +1,68 @@
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:8:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<Cell<i32>>();
    |     ^^^^^^^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::cell::RefCell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:10:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::cell::RefCell<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::RefCell<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Rc<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:13:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<Rc<i32>>();
    |     ^^^^^^^^^^^^^^^ `std::rc::Rc<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::rc::Rc<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Weak<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:15:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<Weak<i32>>();
    |     ^^^^^^^^^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::rc::Weak<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:18:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<Receiver<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::sync::mpsc::Sender<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:20:5
    |
+LL | fn test<T: Sync>() {}
+   | ------------------ required by `test`
+...
 LL |     test::<Sender<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^ `std::sync::mpsc::Sender<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<i32>`
-note: required by `test`
-  --> $DIR/not-sync.rs:5:1
-   |
-LL | fn test<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -1,14 +1,10 @@
 error[E0277]: the trait bound `std::boxed::Box<dyn Foo>: Foo` is not satisfied
   --> $DIR/object-does-not-impl-trait.rs:6:35
    |
+LL | fn take_foo<F:Foo>(f: F) {}
+   | ------------------------ required by `take_foo`
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
    |                                   ^^^^^^^^ the trait `Foo` is not implemented for `std::boxed::Box<dyn Foo>`
-   |
-note: required by `take_foo`
-  --> $DIR/object-does-not-impl-trait.rs:5:1
-   |
-LL | fn take_foo<F:Foo>(f: F) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/multiple-impls.stderr
+++ b/src/test/ui/on-unimplemented/multiple-impls.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
    |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
 LL |     Index::index(&[] as &[i32], 2u32);
    |     ^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-note: required by `Index::index`
-  --> $DIR/multiple-impls.rs:12:5
-   |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
@@ -22,15 +20,13 @@ LL |     Index::index(&[] as &[i32], 2u32);
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:5
    |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^ on impl for Foo
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-note: required by `Index::index`
-  --> $DIR/multiple-impls.rs:12:5
-   |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:5
@@ -43,15 +39,13 @@ LL |     Index::index(&[] as &[i32], Foo(2u32));
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:5
    |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^ on impl for Bar
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-note: required by `Index::index`
-  --> $DIR/multiple-impls.rs:12:5
-   |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:5

--- a/src/test/ui/on-unimplemented/on-impl.stderr
+++ b/src/test/ui/on-unimplemented/on-impl.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5
    |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-note: required by `Index::index`
-  --> $DIR/on-impl.rs:9:5
-   |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5

--- a/src/test/ui/on-unimplemented/on-trait.stderr
+++ b/src/test/ui/on-unimplemented/on-trait.stderr
@@ -1,28 +1,24 @@
 error[E0277]: the trait bound `std::option::Option<std::vec::Vec<u8>>: MyFromIterator<&u8>` is not satisfied
   --> $DIR/on-trait.rs:28:30
    |
+LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
+   | -------------------------------------------------------------------- required by `collect`
+...
 LL |     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
    |                              ^^^^^^^ a collection of type `std::option::Option<std::vec::Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
    |
    = help: the trait `MyFromIterator<&u8>` is not implemented for `std::option::Option<std::vec::Vec<u8>>`
-note: required by `collect`
-  --> $DIR/on-trait.rs:22:1
-   |
-LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::string::String: Bar::Foo<u8, _, u32>` is not satisfied
   --> $DIR/on-trait.rs:31:21
    |
+LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
+   | ---------------------------------------------- required by `foobar`
+...
 LL |     let x: String = foobar();
    |                     ^^^^^^ test error `std::string::String` with `u8` `_` `u32` in `Bar::Foo`
    |
    = help: the trait `Bar::Foo<u8, _, u32>` is not implemented for `std::string::String`
-note: required by `foobar`
-  --> $DIR/on-trait.rs:12:1
-   |
-LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/overlap-marker-trait.stderr
+++ b/src/test/ui/overlap-marker-trait.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:30:5
    |
+LL | fn is_marker<T: Marker>() { }
+   | ------------------------- required by `is_marker`
+...
 LL |     is_marker::<NotDebugOrDisplay>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`
-   |
-note: required by `is_marker`
-  --> $DIR/overlap-marker-trait.rs:18:1
-   |
-LL | fn is_marker<T: Marker>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -1,6 +1,9 @@
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:21:5
    |
+LL | fn is_zen<T: Zen>(_: T) {}
+   | ----------------------- required by `is_zen`
+...
 LL |     is_zen(x)
    |     ^^^^^^ `T` cannot be shared between threads safely
    |
@@ -9,15 +12,13 @@ LL |     is_zen(x)
    = note: required because of the requirements on the impl of `Zen` for `&T`
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`
-note: required by `is_zen`
-  --> $DIR/phantom-oibit.rs:18:1
-   |
-LL | fn is_zen<T: Zen>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:26:5
    |
+LL | fn is_zen<T: Zen>(_: T) {}
+   | ----------------------- required by `is_zen`
+...
 LL |     is_zen(x)
    |     ^^^^^^ `T` cannot be shared between threads safely
    |
@@ -27,11 +28,6 @@ LL |     is_zen(x)
    = note: required because it appears within the type `std::marker::PhantomData<&T>`
    = note: required because it appears within the type `Guard<'_, T>`
    = note: required because it appears within the type `Nested<Guard<'_, T>>`
-note: required by `is_zen`
-  --> $DIR/phantom-oibit.rs:18:1
-   |
-LL | fn is_zen<T: Zen>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/recursion/recursive-requirements.stderr
+++ b/src/test/ui/recursion/recursive-requirements.stderr
@@ -1,20 +1,21 @@
 error[E0277]: `*const Bar` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
+LL | struct AssertSync<T: Sync>(PhantomData<T>);
+   | ------------------------------------------- required by `AssertSync`
+...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Bar` cannot be shared between threads safely
    |
    = help: within `Foo`, the trait `std::marker::Sync` is not implemented for `*const Bar`
    = note: required because it appears within the type `Foo`
-note: required by `AssertSync`
-  --> $DIR/recursive-requirements.rs:3:1
-   |
-LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `*const Foo` cannot be shared between threads safely
   --> $DIR/recursive-requirements.rs:16:12
    |
+LL | struct AssertSync<T: Sync>(PhantomData<T>);
+   | ------------------------------------------- required by `AssertSync`
+...
 LL |     let _: AssertSync<Foo> = unimplemented!();
    |            ^^^^^^^^^^^^^^^ `*const Foo` cannot be shared between threads safely
    |
@@ -22,11 +23,6 @@ LL |     let _: AssertSync<Foo> = unimplemented!();
    = note: required because it appears within the type `Bar`
    = note: required because it appears within the type `std::marker::PhantomData<Bar>`
    = note: required because it appears within the type `Foo`
-note: required by `AssertSync`
-  --> $DIR/recursive-requirements.rs:3:1
-   |
-LL | struct AssertSync<T: Sync>(PhantomData<T>);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/span/issue-29595.stderr
+++ b/src/test/ui/span/issue-29595.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `u8: Tr` is not satisfied
   --> $DIR/issue-29595.rs:6:17
    |
+LL |     const C: Self;
+   |     -------------- required by `Tr::C`
+...
 LL |     let a: u8 = Tr::C;
    |                 ^^^^^ the trait `Tr` is not implemented for `u8`
-   |
-note: required by `Tr::C`
-  --> $DIR/issue-29595.rs:2:5
-   |
-LL |     const C: Self;
-   |     ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-mut-idx.rs:4:15
    |
+LL | fn bot<T>() -> T { loop {} }
+   | ---------------- required by `bot`
+...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-note: required by `bot`
-  --> $DIR/str-mut-idx.rs:1:1
-   |
-LL | fn bot<T>() -> T { loop {} }
-   | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/str-mut-idx.rs:4:5

--- a/src/test/ui/structs/struct-path-alias-bounds.stderr
+++ b/src/test/ui/structs/struct-path-alias-bounds.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `NoClone: std::clone::Clone` is not satisfied
   --> $DIR/struct-path-alias-bounds.rs:9:13
    |
+LL | struct S<T: Clone> { a: T }
+   | ------------------ required by `S`
+...
 LL |     let s = A { a: NoClone };
    |             ^ the trait `std::clone::Clone` is not implemented for `NoClone`
-   |
-note: required by `S`
-  --> $DIR/struct-path-alias-bounds.rs:3:1
-   |
-LL | struct S<T: Clone> { a: T }
-   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -61,17 +61,15 @@ LL |     let x: () = foo::<'static>;
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- required by `Foo::bar`
+...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because of the requirements on the impl of `Foo<'_, '_, u8>` for `str`
-note: required by `Foo::bar`
-  --> $DIR/substs-ppaux.rs:7:5
-   |
-LL |     fn bar<'a, T>() where T: 'a {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -61,17 +61,15 @@ LL |     let x: () = foo::<'static>;
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/substs-ppaux.rs:49:5
    |
+LL |     fn bar<'a, T>() where T: 'a {}
+   |     --------------------------- required by `Foo::bar`
+...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `str`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = note: required because of the requirements on the impl of `Foo<'_#0r, '_#1r, u8>` for `str`
-note: required by `Foo::bar`
-  --> $DIR/substs-ppaux.rs:7:5
-   |
-LL |     fn bar<'a, T>() where T: 'a {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs
@@ -1,0 +1,10 @@
+// edition:2018
+use std::future::Future;
+
+async fn foo() {}
+
+fn bar(f: impl Future<Output=()>) {}
+
+fn main() {
+    bar(foo); //~ERROR E0277
+}

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -7,7 +7,7 @@ LL | fn bar(f: impl Future<Output=()>) {}
 LL |     bar(foo);
    |     ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
    |
-   = help: it looks like you forgot to use parentheses to call the function: `foo()`
+   = help: use parentheses to call the function: `foo()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `fn() -> impl std::future::Future {foo}: std::future::Future` is not satisfied
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:5
+   |
+LL | fn bar(f: impl Future<Output=()>) {}
+   | --------------------------------- required by `bar`
+...
+LL |     bar(foo);
+   |     ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
+   |
+   = help: it looks like you forgot to use parentheses to call the function: `foo()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs
@@ -1,0 +1,18 @@
+// edition:2018
+trait T {
+    type O;
+}
+
+struct S;
+
+impl T for S {
+    type O = ();
+}
+
+fn foo() -> impl T<O=()> { S }
+
+fn bar(f: impl T<O=()>) {}
+
+fn main() {
+    bar(foo); //~ERROR E0277
+}

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -7,7 +7,7 @@ LL | fn bar(f: impl T<O=()>) {}
 LL |     bar(foo);
    |     ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
    |
-   = help: it looks like you forgot to use parentheses to call the function: `foo()`
+   = help: use parentheses to call the function: `foo()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,0 +1,14 @@
+error[E0277]: the trait bound `fn() -> impl T {foo}: T` is not satisfied
+  --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:5
+   |
+LL | fn bar(f: impl T<O=()>) {}
+   | ----------------------- required by `bar`
+...
+LL |     bar(foo);
+   |     ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |
+   = help: it looks like you forgot to use parentheses to call the function: `foo()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `&str: std::convert::From<std::string::String>` is not satisfied
   --> $DIR/into-str.rs:4:5
    |
+LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
+   | ------------------------------------------- required by `foo`
+...
 LL |     foo(String::new());
    |     ^^^ the trait `std::convert::From<std::string::String>` is not implemented for `&str`
    |
    = note: to coerce a `std::string::String` into a `&str`, use `&*` as a prefix
    = note: required because of the requirements on the impl of `std::convert::Into<&str>` for `std::string::String`
-note: required by `foo`
-  --> $DIR/into-str.rs:1:1
-   |
-LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
@@ -1,28 +1,24 @@
 error[E0277]: `std::rc::Rc<u32>` cannot be sent between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:5
    |
+LL | fn use_alias<T: SendSync>() {}
+   | --------------------------- required by `use_alias`
+...
 LL |     use_alias::<Rc<u32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<u32>` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `std::rc::Rc<u32>`
-note: required by `use_alias`
-  --> $DIR/trait-alias-cross-crate.rs:10:1
-   |
-LL | fn use_alias<T: SendSync>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::rc::Rc<u32>` cannot be shared between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:5
    |
+LL | fn use_alias<T: SendSync>() {}
+   | --------------------------- required by `use_alias`
+...
 LL |     use_alias::<Rc<u32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<u32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::rc::Rc<u32>`
-note: required by `use_alias`
-  --> $DIR/trait-alias-cross-crate.rs:10:1
-   |
-LL | fn use_alias<T: SendSync>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-wf.stderr
@@ -1,15 +1,12 @@
 error[E0277]: the trait bound `T: Foo` is not satisfied
   --> $DIR/trait-alias-wf.rs:5:1
    |
+LL | trait A<T: Foo> {}
+   | --------------- required by `A`
 LL | trait B<T> = A<T>;
    | ^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `T`
    |
    = help: consider adding a `where T: Foo` bound
-note: required by `A`
-  --> $DIR/trait-alias-wf.rs:4:1
-   |
-LL | trait A<T: Foo> {}
-   | ^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-fns.stderr
@@ -1,26 +1,20 @@
 error[E0277]: the trait bound `u32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:13:1
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL | fn explode(x: Foo<u32>) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u32`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `f32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:16:1
    |
+LL | enum Bar<T:Trait> {
+   | ----------------- required by `Bar`
+...
 LL | fn kaboom(y: Bar<f32>) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `f32`
-   |
-note: required by `Bar`
-  --> $DIR/trait-bounds-on-structs-and-enums-in-fns.rs:7:1
-   |
-LL | enum Bar<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-in-impls.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `u16: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-in-impls.rs:20:6
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL | impl PolyTrait<Foo<u16>> for Struct {
    |      ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u16`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums-in-impls.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-locals.stderr
@@ -1,26 +1,20 @@
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:15:14
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL |     let baz: Foo<usize> = loop { };
    |              ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:5:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `{integer}: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:10:15
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL |     let foo = Foo {
    |               ^^^ the trait `Trait` is not implemented for `{integer}`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums-locals.rs:5:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums-static.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums-static.rs:9:11
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL | static X: Foo<usize> = Foo {
    |           ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums-static.rs:5:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
+++ b/src/test/ui/traits/trait-bounds-on-structs-and-enums.stderr
@@ -1,89 +1,71 @@
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:13:9
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL | impl<T> Foo<T> {
    |         ^^^^^^ the trait `Trait` is not implemented for `T`
    |
    = help: consider adding a `where T: Trait` bound
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `isize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:19:5
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL |     a: Foo<isize>,
    |     ^^^^^^^^^^^^^ the trait `Trait` is not implemented for `isize`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `usize: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:23:10
    |
+LL | enum Bar<T:Trait> {
+   | ----------------- required by `Bar`
+...
 LL |     Quux(Bar<usize>),
    |          ^^^^^^^^^^ the trait `Trait` is not implemented for `usize`
-   |
-note: required by `Bar`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:7:1
-   |
-LL | enum Bar<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `U: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:27:5
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL |     b: Foo<U>,
    |     ^^^^^^^^^ the trait `Trait` is not implemented for `U`
    |
    = help: consider adding a `where U: Trait` bound
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `V: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:31:21
    |
+LL | enum Bar<T:Trait> {
+   | ----------------- required by `Bar`
+...
 LL |     EvenMoreBadness(Bar<V>),
    |                     ^^^^^^ the trait `Trait` is not implemented for `V`
    |
    = help: consider adding a `where V: Trait` bound
-note: required by `Bar`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:7:1
-   |
-LL | enum Bar<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:35:5
    |
+LL | struct Foo<T:Trait> {
+   | ------------------- required by `Foo`
+...
 LL |     Foo<i32>,
    |     ^^^^^^^^ the trait `Trait` is not implemented for `i32`
-   |
-note: required by `Foo`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:3:1
-   |
-LL | struct Foo<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/trait-bounds-on-structs-and-enums.rs:39:22
    |
+LL | enum Bar<T:Trait> {
+   | ----------------- required by `Bar`
+...
 LL |     DictionaryLike { field: Bar<u8> },
    |                      ^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `u8`
-   |
-note: required by `Bar`
-  --> $DIR/trait-bounds-on-structs-and-enums.rs:7:1
-   |
-LL | enum Bar<T:Trait> {
-   | ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/traits/trait-static-method-generic-inference.stderr
+++ b/src/test/ui/traits/trait-static-method-generic-inference.stderr
@@ -1,14 +1,11 @@
 error[E0283]: type annotations required: cannot resolve `_: base::HasNew<base::Foo>`
   --> $DIR/trait-static-method-generic-inference.rs:24:25
    |
+LL |         fn new() -> T;
+   |         -------------- required by `base::HasNew::new`
+...
 LL |     let _f: base::Foo = base::HasNew::new();
    |                         ^^^^^^^^^^^^^^^^^
-   |
-note: required by `base::HasNew::new`
-  --> $DIR/trait-static-method-generic-inference.rs:8:9
-   |
-LL |         fn new() -> T;
-   |         ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
@@ -1,15 +1,13 @@
 error[E0275]: overflow evaluating the requirement `{integer}: Tweedledum`
   --> $DIR/traits-inductive-overflow-simultaneous.rs:18:5
    |
+LL | fn is_ee<T: Combo>(t: T) {
+   | ------------------------ required by `is_ee`
+...
 LL |     is_ee(4);
    |     ^^^^^
    |
    = note: required because of the requirements on the impl of `Combo` for `{integer}`
-note: required by `is_ee`
-  --> $DIR/traits-inductive-overflow-simultaneous.rs:13:1
-   |
-LL | fn is_ee<T: Combo>(t: T) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -7,15 +7,13 @@ LL | auto trait Magic: Copy {}
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:18
    |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   | --------------------------------- required by `copy`
+...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^ the trait `std::marker::Copy` is not implemented for `NoClone`
    |
    = note: required because of the requirements on the impl of `Magic` for `NoClone`
-note: required by `copy`
-  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:9:1
-   |
-LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
@@ -1,15 +1,13 @@
 error[E0275]: overflow evaluating the requirement `NoClone: Magic`
   --> $DIR/traits-inductive-overflow-supertrait.rs:13:18
    |
+LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
+   | --------------------------------- required by `copy`
+...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^
    |
    = note: required because of the requirements on the impl of `Magic` for `NoClone`
-note: required by `copy`
-  --> $DIR/traits-inductive-overflow-supertrait.rs:7:1
-   |
-LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
@@ -1,14 +1,11 @@
 error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/traits-inductive-overflow-two-traits.rs:19:5
    |
+LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
+   | --------------------- required by `wizard`
+...
 LL |     wizard::<*mut ()>();
    |     ^^^^^^^^^^^^^^^^^
-   |
-note: required by `wizard`
-  --> $DIR/traits-inductive-overflow-two-traits.rs:16:1
-   |
-LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-negative-impls.stderr
+++ b/src/test/ui/traits/traits-negative-impls.stderr
@@ -1,74 +1,67 @@
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:23:5
    |
+LL | struct Outer<T: Send>(T);
+   | ------------------------- required by `Outer`
+...
 LL |     Outer(TestType);
    |     ^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy::TestType`
-note: required by `Outer`
-  --> $DIR/traits-negative-impls.rs:10:1
-   |
-LL | struct Outer<T: Send>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:23:5
    |
+LL | struct Outer<T: Send>(T);
+   | ------------------------- required by `Outer`
+...
 LL |     Outer(TestType);
    |     ^^^^^^^^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy::TestType`
-note: required by `Outer`
-  --> $DIR/traits-negative-impls.rs:10:1
-   |
-LL | struct Outer<T: Send>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:32:5
    |
+LL | fn is_send<T: Send>(_: T) {}
+   | ------------------------- required by `is_send`
+...
 LL |     is_send(TestType);
    |     ^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy1b::TestType`
-note: required by `is_send`
-  --> $DIR/traits-negative-impls.rs:16:1
-   |
-LL | fn is_send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:40:5
    |
+LL | fn is_send<T: Send>(_: T) {}
+   | ------------------------- required by `is_send`
+...
 LL |     is_send((8, TestType));
    |     ^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `std::marker::Send` is not implemented for `dummy1c::TestType`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
-note: required by `is_send`
-  --> $DIR/traits-negative-impls.rs:16:1
-   |
-LL | fn is_send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:48:5
    |
+LL | fn is_send<T: Send>(_: T) {}
+   | ------------------------- required by `is_send`
+...
 LL |     is_send(Box::new(TestType));
    |     ^^^^^^^ `dummy2::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy2::TestType`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dummy2::TestType>`
    = note: required because it appears within the type `std::boxed::Box<dummy2::TestType>`
-note: required by `is_send`
-  --> $DIR/traits-negative-impls.rs:16:1
-   |
-LL | fn is_send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `dummy3::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:56:5
    |
+LL | fn is_send<T: Send>(_: T) {}
+   | ------------------------- required by `is_send`
+...
 LL |     is_send(Box::new(Outer2(TestType)));
    |     ^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
    |
@@ -76,25 +69,18 @@ LL |     is_send(Box::new(Outer2(TestType)));
    = note: required because it appears within the type `Outer2<dummy3::TestType>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<Outer2<dummy3::TestType>>`
    = note: required because it appears within the type `std::boxed::Box<Outer2<dummy3::TestType>>`
-note: required by `is_send`
-  --> $DIR/traits-negative-impls.rs:16:1
-   |
-LL | fn is_send<T: Send>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:66:5
    |
+LL | fn is_sync<T: Sync>(_: T) {}
+   | ------------------------- required by `is_sync`
+...
 LL |     is_sync(Outer2(TestType));
    |     ^^^^^^^ `main::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `main::TestType`
    = note: required because of the requirements on the impl of `std::marker::Sync` for `Outer2<main::TestType>`
-note: required by `is_sync`
-  --> $DIR/traits-negative-impls.rs:17:1
-   |
-LL | fn is_sync<T: Sync>(_: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
+++ b/src/test/ui/traits/traits-repeated-supertrait-ambig.stderr
@@ -15,27 +15,22 @@ LL |     c.same_as(22)
 error[E0277]: the trait bound `dyn CompareToInts: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:34:5
    |
+LL |     fn same_as(&self, t: T) -> bool;
+   |     -------------------------------- required by `CompareTo::same_as`
+...
 LL |     CompareToInts::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `dyn CompareToInts`
-   |
-note: required by `CompareTo::same_as`
-  --> $DIR/traits-repeated-supertrait-ambig.rs:9:5
-   |
-LL |     fn same_as(&self, t: T) -> bool;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `C: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:38:5
    |
+LL |     fn same_as(&self, t: T) -> bool;
+   |     -------------------------------- required by `CompareTo::same_as`
+...
 LL |     CompareTo::same_as(c, 22)
    |     ^^^^^^^^^^^^^^^^^^ the trait `CompareTo<i32>` is not implemented for `C`
    |
    = help: consider adding a `where C: CompareTo<i32>` bound
-note: required by `CompareTo::same_as`
-  --> $DIR/traits-repeated-supertrait-ambig.rs:9:5
-   |
-LL |     fn same_as(&self, t: T) -> bool;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i64: CompareTo<i32>` is not satisfied
   --> $DIR/traits-repeated-supertrait-ambig.rs:42:23

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -21,26 +21,20 @@ LL |     3i32.test();
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:25:5
    |
+LL |     fn test(&self);
+   |     --------------- required by `Foo::test`
+...
 LL |     Foo::test(&4i32);
    |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `Foo::test`
-  --> $DIR/trivial-bounds-leak.rs:5:5
-   |
-LL |     fn test(&self);
-   |     ^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/trivial-bounds-leak.rs:26:5
    |
 LL |     generic_function(5i32);
    |     ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
-   |
-note: required by `generic_function`
-  --> $DIR/trivial-bounds-leak.rs:29:1
-   |
+...
 LL | fn generic_function<T: Foo>(t: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | --------------------------------- required by `generic_function`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/try-operator-on-main.stderr
+++ b/src/test/ui/try-operator-on-main.stderr
@@ -21,12 +21,9 @@ error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
    |
 LL |     try_trait_generic::<()>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `()`
-   |
-note: required by `try_trait_generic`
-  --> $DIR/try-operator-on-main.rs:20:1
-   |
+...
 LL | fn try_trait_generic<T: Try>() -> T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ----------------------------------- required by `try_trait_generic`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/try-operator-on-main.rs:22:5

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,14 +1,11 @@
 error[E0283]: type annotations required: cannot resolve `_: std::convert::Into<std::string::String>`
   --> $DIR/type-annotation-needed.rs:5:5
    |
+LL | fn foo<T: Into<String>>(x: i32) {}
+   | ------------------------------- required by `foo`
+...
 LL |     foo(42);
    |     ^^^
-   |
-note: required by `foo`
-  --> $DIR/type-annotation-needed.rs:1:1
-   |
-LL | fn foo<T: Into<String>>(x: i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -1,90 +1,71 @@
 error[E0277]: a collection of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:6:19
    |
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
+   | ---------------------------------------- required by `Foo`
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
    |                   ^ a collection of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
-note: required by `Foo`
-  --> $DIR/type-check-defaults.rs:5:1
-   |
-LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: a collection of type `i32` cannot be built from an iterator over elements of type `i32`
   --> $DIR/type-check-defaults.rs:8:27
    |
+LL | struct Foo<T, U: FromIterator<T>>(T, U);
+   | ---------------------------------------- required by `Foo`
+...
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    |                           ^ a collection of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
-note: required by `Foo`
-  --> $DIR/type-check-defaults.rs:5:1
-   |
-LL | struct Foo<T, U: FromIterator<T>>(T, U);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:11:1
-   |
-LL | struct Bounds<T:Copy=String>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-note: required by `Bounds`
   --> $DIR/type-check-defaults.rs:11:1
    |
 LL | struct Bounds<T:Copy=String>(T);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | required by `Bounds`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:14:1
-   |
-LL | struct WhereClause<T=String>(T) where T: Copy;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-note: required by `WhereClause`
   --> $DIR/type-check-defaults.rs:14:1
    |
 LL | struct WhereClause<T=String>(T) where T: Copy;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | required by `WhereClause`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:17:1
    |
 LL | trait TraitBound<T:Copy=String> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
-   |
-note: required by `TraitBound`
-  --> $DIR/type-check-defaults.rs:17:1
-   |
-LL | trait TraitBound<T:Copy=String> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | -------------------------------^^^
+   | |
+   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | required by `TraitBound`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/type-check-defaults.rs:21:1
    |
+LL | trait Super<T: Copy> { }
+   | -------------------- required by `Super`
 LL | trait Base<T = String>: Super<T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `Super`
-  --> $DIR/type-check-defaults.rs:20:1
-   |
-LL | trait Super<T: Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: cannot add `u8` to `i32`
   --> $DIR/type-check-defaults.rs:24:1
    |
 LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `i32 + u8`
+   | ------------------------------------------------------------------------^^^
+   | |
+   | no implementation for `i32 + u8`
+   | required by `ProjectionPred`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`
-note: required by `ProjectionPred`
-  --> $DIR/type-check-defaults.rs:24:1
-   |
-LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,6 +1,9 @@
 error[E0283]: type annotations required: cannot resolve `&'a T: Foo`
   --> $DIR/issue-40294.rs:5:1
    |
+LL |   trait Foo: Sized {
+   |   ---------------- required by `Foo`
+...
 LL | / fn foo<'a,'b,T>(x: &'a T, y: &'b T)
 LL | |     where &'a T : Foo,
 LL | |           &'b T : Foo
@@ -9,12 +12,6 @@ LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
    | |_^
-   |
-note: required by `Foo`
-  --> $DIR/issue-40294.rs:1:1
-   |
-LL | trait Foo: Sized {
-   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-params-in-different-spaces-2.stderr
+++ b/src/test/ui/type/type-params-in-different-spaces-2.stderr
@@ -1,28 +1,24 @@
 error[E0277]: the trait bound `Self: Tr<U>` is not satisfied
   --> $DIR/type-params-in-different-spaces-2.rs:10:9
    |
+LL |     fn op(_: T) -> Self;
+   |     -------------------- required by `Tr::op`
+...
 LL |         Tr::op(u)
    |         ^^^^^^ the trait `Tr<U>` is not implemented for `Self`
    |
    = help: consider adding a `where Self: Tr<U>` bound
-note: required by `Tr::op`
-  --> $DIR/type-params-in-different-spaces-2.rs:5:5
-   |
-LL |     fn op(_: T) -> Self;
-   |     ^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `Self: Tr<U>` is not satisfied
   --> $DIR/type-params-in-different-spaces-2.rs:16:9
    |
+LL |     fn op(_: T) -> Self;
+   |     -------------------- required by `Tr::op`
+...
 LL |         Tr::op(u)
    |         ^^^^^^ the trait `Tr<U>` is not implemented for `Self`
    |
    = help: consider adding a `where Self: Tr<U>` bound
-note: required by `Tr::op`
-  --> $DIR/type-params-in-different-spaces-2.rs:5:5
-   |
-LL |     fn op(_: T) -> Self;
-   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -3,14 +3,12 @@ error[E0277]: `<T as Trait>::AssocType` cannot be sent between threads safely
    |
 LL |     is_send::<T::AssocType>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
+...
+LL | fn is_send<T:Send>() {
+   | -------------------- required by `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `<T as Trait>::AssocType`
    = help: consider adding a `where <T as Trait>::AssocType: std::marker::Send` bound
-note: required by `is_send`
-  --> $DIR/typeck-default-trait-impl-assoc-type.rs:12:1
-   |
-LL | fn is_send<T:Send>() {
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:16:5
    |
+LL | fn is_mytrait<T: MyTrait>() {}
+   | --------------------------- required by `is_mytrait`
+...
 LL |     is_mytrait::<(MyS2, MyS)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`
    |
    = help: the following implementations were found:
              <MyS2 as MyTrait>
    = note: required because it appears within the type `(MyS2, MyS)`
-note: required by `is_mytrait`
-  --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:11:1
-   |
-LL | fn is_mytrait<T: MyTrait>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:20:5
    |
+LL | fn is_mytrait<T: MyTrait>() {}
+   | --------------------------- required by `is_mytrait`
+...
 LL |     is_mytrait::<MyS2>();
    |     ^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `MyS2`
    |
    = help: the following implementations were found:
              <MyS2 as MyTrait>
-note: required by `is_mytrait`
-  --> $DIR/typeck-default-trait-impl-constituent-types.rs:15:1
-   |
-LL | fn is_mytrait<T: MyTrait>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -1,15 +1,13 @@
 error[E0277]: `MyNotSendable` cannot be sent between threads safely
   --> $DIR/typeck-default-trait-impl-negation-send.rs:19:5
    |
+LL | fn is_send<T: Send>() {}
+   | --------------------- required by `is_send`
+...
 LL |     is_send::<MyNotSendable>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `MyNotSendable`
-note: required by `is_send`
-  --> $DIR/typeck-default-trait-impl-negation-send.rs:15:1
-   |
-LL | fn is_send<T: Send>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -1,43 +1,37 @@
 error[E0277]: `MyNotSync` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:33:5
    |
+LL | fn is_sync<T: Sync>() {}
+   | --------------------- required by `is_sync`
+...
 LL |     is_sync::<MyNotSync>();
    |     ^^^^^^^^^^^^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `MyNotSync`
-note: required by `is_sync`
-  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:1
-   |
-LL | fn is_sync<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::cell::UnsafeCell<u8>` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:36:5
    |
+LL | fn is_sync<T: Sync>() {}
+   | --------------------- required by `is_sync`
+...
 LL |     is_sync::<MyTypeWUnsafe>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<u8>` cannot be shared between threads safely
    |
    = help: within `MyTypeWUnsafe`, the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<u8>`
    = note: required because it appears within the type `MyTypeWUnsafe`
-note: required by `is_sync`
-  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:1
-   |
-LL | fn is_sync<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `Managed` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:39:5
    |
+LL | fn is_sync<T: Sync>() {}
+   | --------------------- required by `is_sync`
+...
 LL |     is_sync::<MyTypeManaged>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely
    |
    = help: within `MyTypeManaged`, the trait `std::marker::Sync` is not implemented for `Managed`
    = note: required because it appears within the type `MyTypeManaged`
-note: required by `is_sync`
-  --> $DIR/typeck-default-trait-impl-negation-sync.rs:29:1
-   |
-LL | fn is_sync<T: Sync>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
@@ -1,30 +1,26 @@
 error[E0277]: the trait bound `ThisImplsUnsafeTrait: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:21:5
    |
+LL | fn is_my_trait<T: MyTrait>() {}
+   | ---------------------------- required by `is_my_trait`
+...
 LL |     is_my_trait::<ThisImplsUnsafeTrait>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
    |
    = help: the following implementations were found:
              <ThisImplsUnsafeTrait as MyTrait>
-note: required by `is_my_trait`
-  --> $DIR/typeck-default-trait-impl-negation.rs:16:1
-   |
-LL | fn is_my_trait<T: MyTrait>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `ThisImplsTrait: MyUnsafeTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:24:5
    |
+LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
+   | ----------------------------------------- required by `is_my_unsafe_trait`
+...
 LL |     is_my_unsafe_trait::<ThisImplsTrait>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`
    |
    = help: the following implementations were found:
              <ThisImplsTrait as MyUnsafeTrait>
-note: required by `is_my_unsafe_trait`
-  --> $DIR/typeck-default-trait-impl-negation.rs:17:1
-   |
-LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `u32: Signed` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:18:5
    |
+LL | fn is_defaulted<T:Defaulted>() { }
+   | ------------------------------ required by `is_defaulted`
+...
 LL |     is_defaulted::<&'static u32>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`
    |
    = note: required because of the requirements on the impl of `Defaulted` for `&'static u32`
-note: required by `is_defaulted`
-  --> $DIR/typeck-default-trait-impl-precedence.rs:11:1
-   |
-LL | fn is_defaulted<T:Defaulted>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -3,14 +3,12 @@ error[E0277]: `T` cannot be sent between threads safely
    |
 LL |     is_send::<T>()
    |     ^^^^^^^^^^^^ `T` cannot be sent between threads safely
+...
+LL | fn is_send<T:Send>() {
+   | -------------------- required by `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Send` bound
-note: required by `is_send`
-  --> $DIR/typeck-default-trait-impl-send-param.rs:8:1
-   |
-LL | fn is_send<T:Send>() {
-   | ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -1,55 +1,47 @@
 error[E0277]: `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:19:5
    |
+LL | fn test<T: Sync>(s: T) {}
+   | ---------------------- required by `test`
+...
 LL |     test(us);
    |     ^^^^ `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<MySync<{integer}>>`
-note: required by `test`
-  --> $DIR/typeck-unsafe-always-share.rs:15:1
-   |
-LL | fn test<T: Sync>(s: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:23:5
    |
+LL | fn test<T: Sync>(s: T) {}
+   | ---------------------- required by `test`
+...
 LL |     test(uns);
    |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<NoSync>`
-note: required by `test`
-  --> $DIR/typeck-unsafe-always-share.rs:15:1
-   |
-LL | fn test<T: Sync>(s: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:27:5
    |
+LL | fn test<T: Sync>(s: T) {}
+   | ---------------------- required by `test`
+...
 LL |     test(ms);
    |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
    |
    = help: within `MySync<NoSync>`, the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<NoSync>`
    = note: required because it appears within the type `MySync<NoSync>`
-note: required by `test`
-  --> $DIR/typeck-unsafe-always-share.rs:15:1
-   |
-LL | fn test<T: Sync>(s: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:30:5
    |
+LL | fn test<T: Sync>(s: T) {}
+   | ---------------------- required by `test`
+...
 LL |     test(NoSync);
    |     ^^^^ `NoSync` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `NoSync`
-note: required by `test`
-  --> $DIR/typeck-unsafe-always-share.rs:15:1
-   |
-LL | fn test<T: Sync>(s: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `dyn Foo<(isize,), isize, Output = ()>: Eq<dyn Foo<(isize,), Output = ()>>` is not satisfied
   --> $DIR/unboxed-closure-sugar-default.rs:21:5
    |
+LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
+   | -------------------------------------------- required by `eq`
+...
 LL |     eq::<dyn Foo<(isize,), isize, Output=()>, dyn Foo(isize)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<dyn Foo<(isize,), Output = ()>>` is not implemented for `dyn Foo<(isize,), isize, Output = ()>`
-   |
-note: required by `eq`
-  --> $DIR/unboxed-closure-sugar-default.rs:14:1
-   |
-LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
@@ -1,15 +1,12 @@
 error[E0277]: the trait bound `dyn Foo<(char,), Output = ()>: Eq<dyn Foo<(), Output = ()>>` is not satisfied
   --> $DIR/unboxed-closure-sugar-equiv.rs:43:5
    |
+LL |   fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
+   |   ----------------------------------- required by `eq`
+...
 LL | /     eq::< dyn Foo<(),Output=()>,
 LL | |           dyn Foo(char)                                               >();
    | |_______________________________________________________________________^ the trait `Eq<dyn Foo<(), Output = ()>>` is not implemented for `dyn Foo<(char,), Output = ()>`
-   |
-note: required by `eq`
-  --> $DIR/unboxed-closure-sugar-equiv.rs:16:1
-   |
-LL | fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,15 +1,13 @@
 error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:13
    |
+LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
+   | -------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&S, 22);
    |             ^^^^^^^ expected an `Fn<(isize,)>` closure, found `S`
    |
    = help: the trait `std::ops::Fn<(isize,)>` is not implemented for `S`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:23:1
-   |
-LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,67 +1,57 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:7:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:7:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:8:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:8:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:24:13
    |
+LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
+   | ----------------------------------------------------------------- required by `call_it_once`
+...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
-note: required by `call_it_once`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:9:1
-   |
-LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,67 +1,57 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:12:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-wrong-abi.rs:7:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:12:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-wrong-abi.rs:7:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:18:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-wrong-abi.rs:8:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:18:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-wrong-abi.rs:8:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-abi.rs:24:13
    |
+LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
+   | ----------------------------------------------------------------- required by `call_it_once`
+...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-note: required by `call_it_once`
-  --> $DIR/unboxed-closures-wrong-abi.rs:9:1
-   |
-LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,67 +1,57 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:8:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
    |
+LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
+   | --------------------------------------------------------- required by `call_it`
+...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
-note: required by `call_it`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:8:1
-   |
-LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:9:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
    |
+LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
+   | -------------------------------------------------------------------- required by `call_it_mut`
+...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
-note: required by `call_it_mut`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:9:1
-   |
-LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:25:13
    |
+LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
+   | ----------------------------------------------------------------- required by `call_it_once`
+...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
-note: required by `call_it_once`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:10:1
-   |
-LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unevaluated_fixed_size_array_len.stderr
+++ b/src/test/ui/unevaluated_fixed_size_array_len.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `[(); 0]: Foo` is not satisfied
   --> $DIR/unevaluated_fixed_size_array_len.rs:12:5
    |
+LL |     fn foo();
+   |     --------- required by `Foo::foo`
+...
 LL |     <[(); 0] as Foo>::foo()
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `[(); 0]`
    |
    = help: the following implementations were found:
              <[(); 1] as Foo>
-note: required by `Foo::foo`
-  --> $DIR/unevaluated_fixed_size_array_len.rs:4:5
-   |
-LL |     fn foo();
-   |     ^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-generic.stderr
+++ b/src/test/ui/union/union-generic.stderr
@@ -1,26 +1,20 @@
 error[E0277]: the trait bound `std::rc::Rc<u32>: std::marker::Copy` is not satisfied
   --> $DIR/union-generic.rs:8:13
    |
+LL | union U<T: Copy> {
+   | ---------------- required by `U`
+...
 LL |     let u = U { a: Rc::new(0u32) };
    |             ^ the trait `std::marker::Copy` is not implemented for `std::rc::Rc<u32>`
-   |
-note: required by `U`
-  --> $DIR/union-generic.rs:3:1
-   |
-LL | union U<T: Copy> {
-   | ^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `std::rc::Rc<u32>: std::marker::Copy` is not satisfied
   --> $DIR/union-generic.rs:10:13
    |
+LL | union U<T: Copy> {
+   | ---------------- required by `U`
+...
 LL |     let u = U::<Rc<u32>> { a: Default::default() };
    |             ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::rc::Rc<u32>`
-   |
-note: required by `U`
-  --> $DIR/union-generic.rs:3:1
-   |
-LL | union U<T: Copy> {
-   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -1,17 +1,14 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-bare-typaram.rs:2:23
    |
+LL | fn bar<T: Sized>() { }
+   | ------------------ required by `bar`
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |                       ^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where T: std::marker::Sized` bound
-note: required by `bar`
-  --> $DIR/unsized-bare-typaram.rs:1:1
-   |
-LL | fn bar<T: Sized>() { }
-   | ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-enum.rs:6:36
    |
+LL | enum Foo<U> { FooSome(U), FooNone }
+   | ----------- required by `Foo`
+LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |                                    ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where T: std::marker::Sized` bound
-note: required by `Foo`
-  --> $DIR/unsized-enum.rs:4:1
-   |
-LL | enum Foo<U> { FooSome(U), FooNone }
-   | ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-inherent-impl-self-type.rs:7:17
    |
+LL | struct S5<Y>(Y);
+   | ---------------- required by `S5`
+LL | 
 LL | impl<X: ?Sized> S5<X> {
    |                 ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
-note: required by `S5`
-  --> $DIR/unsized-inherent-impl-self-type.rs:5:1
-   |
-LL | struct S5<Y>(Y);
-   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -1,21 +1,22 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-struct.rs:6:36
    |
+LL | struct Foo<T> { data: T }
+   | ------------- required by `Foo`
+LL | fn foo1<T>() { not_sized::<Foo<T>>() } // Hunky dory.
 LL | fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
    |                                    ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `T`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where T: std::marker::Sized` bound
-note: required by `Foo`
-  --> $DIR/unsized-struct.rs:4:1
-   |
-LL | struct Foo<T> { data: T }
-   | ^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-struct.rs:13:24
    |
+LL | fn is_sized<T:Sized>() { }
+   | ---------------------- required by `is_sized`
+...
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |                        ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
@@ -23,11 +24,6 @@ LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where T: std::marker::Sized` bound
    = note: required because it appears within the type `Bar<T>`
-note: required by `is_sized`
-  --> $DIR/unsized-struct.rs:1:1
-   |
-LL | fn is_sized<T:Sized>() { }
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized-trait-impl-self-type.rs:10:17
    |
+LL | struct S5<Y>(Y);
+   | ---------------- required by `S5`
+LL | 
 LL | impl<X: ?Sized> T3<X> for S5<X> {
    |                 ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
-note: required by `S5`
-  --> $DIR/unsized-trait-impl-self-type.rs:8:1
-   |
-LL | struct S5<Y>(Y);
-   | ^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -3,34 +3,33 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
    |
 LL |     f2::<X>(x);
    |     ^^^^^^^ doesn't have a size known at compile-time
+...
+LL | fn f2<X>(x: &X) {
+   | --------------- required by `f2`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
-note: required by `f2`
-  --> $DIR/unsized3.rs:10:1
-   |
-LL | fn f2<X>(x: &X) {
-   | ^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:18:5
    |
 LL |     f4::<X>(x);
    |     ^^^^^^^ doesn't have a size known at compile-time
+...
+LL | fn f4<X: T>(x: &X) {
+   | ------------------ required by `f4`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
-note: required by `f4`
-  --> $DIR/unsized3.rs:21:1
-   |
-LL | fn f4<X: T>(x: &X) {
-   | ^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:33:5
    |
+LL | fn f5<Y>(x: &Y) {}
+   | --------------- required by `f5`
+...
 LL |     f5(x1);
    |     ^^ doesn't have a size known at compile-time
    |
@@ -38,11 +37,6 @@ LL |     f5(x1);
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: required because it appears within the type `S<X>`
-note: required by `f5`
-  --> $DIR/unsized3.rs:24:1
-   |
-LL | fn f5<Y>(x: &Y) {}
-   | ^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:40:5
@@ -72,6 +66,9 @@ LL |     f5(&(32, *x1));
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:45:5
    |
+LL | fn f5<Y>(x: &Y) {}
+   | --------------- required by `f5`
+...
 LL |     f5(&(32, *x1));
    |     ^^ doesn't have a size known at compile-time
    |
@@ -80,11 +77,6 @@ LL |     f5(&(32, *x1));
    = help: consider adding a `where X: std::marker::Sized` bound
    = note: required because it appears within the type `S<X>`
    = note: required because it appears within the type `({integer}, S<X>)`
-note: required by `f5`
-  --> $DIR/unsized3.rs:24:1
-   |
-LL | fn f5<Y>(x: &Y) {}
-   | ^^^^^^^^^^^^^^^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-const-type.rs:10:12
    |
+LL | struct IsCopy<T:Copy> { t: T }
+   | --------------------- required by `IsCopy`
+...
 LL | const FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `std::option::Option<NotCopy>`
-note: required by `IsCopy`
-  --> $DIR/wf-const-type.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> { t: T }
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-bound.stderr
+++ b/src/test/ui/wf/wf-enum-bound.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-bound.rs:9:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / enum SomeEnum<T,U>
 LL | |     where T: ExtraCopy<U>
 LL | | {
@@ -9,11 +12,6 @@ LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-enum-bound.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/src/test/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields-struct-variant.rs:13:9
    |
+LL | struct IsCopy<T:Copy> {
+   | --------------------- required by `IsCopy`
+...
 LL |         f: IsCopy<A>
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
    = help: consider adding a `where A: std::marker::Copy` bound
-note: required by `IsCopy`
-  --> $DIR/wf-enum-fields-struct-variant.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-enum-fields.stderr
+++ b/src/test/ui/wf/wf-enum-fields.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-enum-fields.rs:12:17
    |
+LL | struct IsCopy<T:Copy> {
+   | --------------------- required by `IsCopy`
+...
 LL |     SomeVariant(IsCopy<A>)
    |                 ^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
    = help: consider adding a `where A: std::marker::Copy` bound
-note: required by `IsCopy`
-  --> $DIR/wf-enum-fields.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-fn-where-clause.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-fn-where-clause.rs:8:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / fn foo<T,U>() where T: ExtraCopy<U>
 LL | | {
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-fn-where-clause.rs:6:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `(dyn std::marker::Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:1

--- a/src/test/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-impl-associated-type-trait.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: MyHash` is not satisfied
   --> $DIR/wf-impl-associated-type-trait.rs:17:5
    |
+LL | pub struct MySet<T:MyHash> {
+   | -------------------------- required by `MySet`
+...
 LL |     type Bar = MySet<T>;
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `MyHash` is not implemented for `T`
    |
    = help: consider adding a `where T: MyHash` bound
-note: required by `MySet`
-  --> $DIR/wf-impl-associated-type-trait.rs:8:1
-   |
-LL | pub struct MySet<T:MyHash> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-arg.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-arg.rs:10:1
    |
+LL |   struct MustBeCopy<T:Copy> {
+   |   ------------------------- required by `MustBeCopy`
+...
 LL | / fn bar<T>(_: &MustBeCopy<T>)
 LL | | {
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-fn-arg.rs:6:1
-   |
-LL | struct MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-ret.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-ret.rs:10:1
    |
+LL |   struct MustBeCopy<T:Copy> {
+   |   ------------------------- required by `MustBeCopy`
+...
 LL | / fn bar<T>() -> MustBeCopy<T>
 LL | | {
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-fn-ret.rs:6:1
-   |
-LL | struct MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-arg.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-arg.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-arg.rs:9:5
    |
+LL | struct MustBeCopy<T:Copy> {
+   | ------------------------- required by `MustBeCopy`
+...
 LL |     x: fn(MustBeCopy<T>)
    |     ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-fn-type-arg.rs:3:1
-   |
-LL | struct MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-type-ret.stderr
+++ b/src/test/ui/wf/wf-in-fn-type-ret.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-type-ret.rs:9:5
    |
+LL | struct MustBeCopy<T:Copy> {
+   | ------------------------- required by `MustBeCopy`
+...
 LL |     x: fn() -> MustBeCopy<T>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-fn-type-ret.rs:3:1
-   |
-LL | struct MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-in-fn-where-clause.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-fn-where-clause.rs:9:1
    |
+LL |   trait MustBeCopy<T:Copy> {
+   |   ------------------------ required by `MustBeCopy`
+...
 LL | / fn bar<T,U>()
 LL | |     where T: MustBeCopy<U>
 LL | | {
@@ -8,11 +11,6 @@ LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-fn-where-clause.rs:6:1
-   |
-LL | trait MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-obj-type-trait.stderr
+++ b/src/test/ui/wf/wf-in-obj-type-trait.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-in-obj-type-trait.rs:11:5
    |
+LL | struct MustBeCopy<T:Copy> {
+   | ------------------------- required by `MustBeCopy`
+...
 LL |     x: dyn Object<MustBeCopy<T>>
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `MustBeCopy`
-  --> $DIR/wf-in-obj-type-trait.rs:5:1
-   |
-LL | struct MustBeCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-method-where-clause.rs:12:5
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+...
 LL | /     fn foo(self) where T: ExtraCopy<U>
 LL | |     {}
    | |______^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-inherent-impl-method-where-clause.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/src/test/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-inherent-impl-where-clause.rs:11:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+...
 LL | / impl<T,U> Foo<T,U> where T: ExtraCopy<U>
 LL | | {
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-inherent-impl-where-clause.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `NotCopy: std::marker::Copy` is not satisfied
   --> $DIR/wf-static-type.rs:10:13
    |
+LL | struct IsCopy<T:Copy> { t: T }
+   | --------------------- required by `IsCopy`
+...
 LL | static FOO: IsCopy<Option<NotCopy>> = IsCopy { t: None };
    |             ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `NotCopy`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `std::option::Option<NotCopy>`
-note: required by `IsCopy`
-  --> $DIR/wf-static-type.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> { t: T }
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-bound.stderr
+++ b/src/test/ui/wf/wf-struct-bound.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-bound.rs:9:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / struct SomeStruct<T,U>
 LL | |     where T: ExtraCopy<U>
 LL | | {
@@ -9,11 +12,6 @@ LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-struct-bound.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-struct-field.stderr
+++ b/src/test/ui/wf/wf-struct-field.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `A: std::marker::Copy` is not satisfied
   --> $DIR/wf-struct-field.rs:12:5
    |
+LL | struct IsCopy<T:Copy> {
+   | --------------------- required by `IsCopy`
+...
 LL |     data: IsCopy<A>
    |     ^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `A`
    |
    = help: consider adding a `where A: std::marker::Copy` bound
-note: required by `IsCopy`
-  --> $DIR/wf-struct-field.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> {
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-bound.stderr
@@ -1,17 +1,15 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-bound.rs:9:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / trait SomeTrait<T> {
 LL | |     type Type1: ExtraCopy<T>;
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-trait-associated-type-bound.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-associated-type-trait.stderr
+++ b/src/test/ui/wf/wf-trait-associated-type-trait.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `<Self as SomeTrait>::Type1: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-associated-type-trait.rs:11:5
    |
+LL | struct IsCopy<T:Copy> { x: T }
+   | --------------------- required by `IsCopy`
+...
 LL |     type Type2 = IsCopy<Self::Type1>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `<Self as SomeTrait>::Type1`
    |
    = help: consider adding a `where <Self as SomeTrait>::Type1: std::marker::Copy` bound
-note: required by `IsCopy`
-  --> $DIR/wf-trait-associated-type-trait.rs:7:1
-   |
-LL | struct IsCopy<T:Copy> { x: T }
-   | ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-bound.stderr
+++ b/src/test/ui/wf/wf-trait-bound.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `U: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-bound.rs:9:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / trait SomeTrait<T,U>
 LL | |     where T: ExtraCopy<U>
 LL | | {
@@ -8,11 +11,6 @@ LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `U`
    |
    = help: consider adding a `where U: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-trait-bound.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-arg.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-arg.rs:11:5
    |
+LL |   struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |   ----------------------- required by `Bar`
+...
 LL | /     fn bar(&self, x: &Bar<Self>) {
 LL | |
 LL | |         //
@@ -9,11 +12,6 @@ LL | |     }
    | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-default-fn-arg.rs:8:1
-   |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-ret.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-ret.rs:11:5
    |
+LL |   struct Bar<T:Eq+?Sized> { value: Box<T> }
+   |   ----------------------- required by `Bar`
+...
 LL | /     fn bar(&self) -> Bar<Self> {
 LL | |
 LL | |         //
@@ -10,11 +13,6 @@ LL | |     }
    | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-default-fn-ret.rs:8:1
-   |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-default-fn-where-clause.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-default-fn-where-clause.rs:11:5
    |
+LL |   trait Bar<T:Eq+?Sized> { }
+   |   ---------------------- required by `Bar`
+...
 LL | /     fn bar<A>(&self) where A: Bar<Self> {
 LL | |
 LL | |         //
@@ -9,11 +12,6 @@ LL | |     }
    | |_____^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-default-fn-where-clause.rs:8:1
-   |
-LL | trait Bar<T:Eq+?Sized> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-arg.stderr
+++ b/src/test/ui/wf/wf-trait-fn-arg.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-arg.rs:10:5
    |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   | ----------------------- required by `Bar`
+...
 LL |     fn bar(&self, x: &Bar<Self>);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-fn-arg.rs:7:1
-   |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-ret.stderr
+++ b/src/test/ui/wf/wf-trait-fn-ret.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-ret.rs:10:5
    |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   | ----------------------- required by `Bar`
+...
 LL |     fn bar(&self) -> &Bar<Self>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-fn-ret.rs:7:1
-   |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-fn-where-clause.stderr
+++ b/src/test/ui/wf/wf-trait-fn-where-clause.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `Self: std::cmp::Eq` is not satisfied
   --> $DIR/wf-trait-fn-where-clause.rs:10:5
    |
+LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
+   | ----------------------- required by `Bar`
+...
 LL |     fn bar(&self) where Self: Sized, Bar<Self>: Copy;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::cmp::Eq` is not implemented for `Self`
    |
    = help: consider adding a `where Self: std::cmp::Eq` bound
-note: required by `Bar`
-  --> $DIR/wf-trait-fn-where-clause.rs:7:1
-   |
-LL | struct Bar<T:Eq+?Sized> { value: Box<T> }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-trait-superbound.stderr
+++ b/src/test/ui/wf/wf-trait-superbound.stderr
@@ -1,16 +1,14 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/wf-trait-superbound.rs:9:1
    |
+LL |   trait ExtraCopy<T:Copy> { }
+   |   ----------------------- required by `ExtraCopy`
+LL | 
 LL | / trait SomeTrait<T>: ExtraCopy<T> {
 LL | | }
    | |_^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `ExtraCopy`
-  --> $DIR/wf-trait-superbound.rs:7:1
-   |
-LL | trait ExtraCopy<T:Copy> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:9
    |
+LL | fn require_copy<T: Copy>(x: T) {}
+   | ------------------------------ required by `require_copy`
+...
 LL |         require_copy(self.x);
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `require_copy`
-  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:1:1
-   |
-LL | fn require_copy<T: Copy>(x: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -1,15 +1,13 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:9
    |
+LL | fn require_copy<T: Copy>(x: T) {}
+   | ------------------------------ required by `require_copy`
+...
 LL |         require_copy(self.x);
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
-note: required by `require_copy`
-  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:1:1
-   |
-LL | fn require_copy<T: Copy>(x: T) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
@@ -1,14 +1,11 @@
 error[E0277]: the trait bound `Struct: std::cmp::Eq` is not satisfied
   --> $DIR/where-clauses-unsatisfied.rs:6:10
    |
+LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
+   | ---------------------------------------------- required by `equal`
+...
 LL |     drop(equal(&Struct, &Struct))
    |          ^^^^^ the trait `std::cmp::Eq` is not implemented for `Struct`
-   |
-note: required by `equal`
-  --> $DIR/where-clauses-unsatisfied.rs:1:1
-   |
-LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-for-self-2.stderr
+++ b/src/test/ui/where-clauses/where-for-self-2.stderr
@@ -1,18 +1,16 @@
 error[E0277]: the trait bound `for<'a> &'a _: Bar` is not satisfied
   --> $DIR/where-for-self-2.rs:21:5
    |
-LL |     foo(&X);
-   |     ^^^ the trait `for<'a> Bar` is not implemented for `&'a _`
-   |
-   = help: the following implementations were found:
-             <&'static u32 as Bar>
-note: required by `foo`
-  --> $DIR/where-for-self-2.rs:16:1
-   |
 LL | / fn foo<T>(x: &T)
 LL | |     where for<'a> &'a T: Bar
 LL | | {}
-   | |__^
+   | |__- required by `foo`
+...
+LL |       foo(&X);
+   |       ^^^ the trait `for<'a> Bar` is not implemented for `&'a _`
+   |
+   = help: the following implementations were found:
+             <&'static u32 as Bar>
 
 error: aborting due to previous error
 


### PR DESCRIPTION
_Reviewer note: the relevant changes are in the second commit, the first is simple and mechanical, but verbose._

When forgetting to call a fn in an argument position to an fn that has a generic bound:

```rust
async fn foo() {}

fn bar(f: impl Future<Output=()>) {}

fn main() {
    bar(foo); // <- should be `bar(foo());`
} 
```

suggest calling it:

```
error[E0277]: the trait bound `fn() -> impl std::future::Future {foo}: std::future::Future` is not satisfied
  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:5
   |
LL | fn bar(f: impl Future<Output=()>) {}
   | --------------------------------- required by `bar`
...
LL |     bar(foo);
   |     ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
   |
   = help: it looks like you forgot to use parentheses to call the function: `foo()`
```

Fix #63100. Follow up to #63833 and #63337.