### PR TITLE
debuginfo: give unique names to closure and generator types

### DIFF
--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -191,18 +191,16 @@ pub fn push_debuginfo_type_name<'tcx>(
             visited.remove(t);
         },
         ty::Closure(def_id, ..) => {
-            output.push_str("closure");
-            let disambiguator = tcx.def_key(def_id).disambiguated_data.disambiguator;
-            if disambiguator != 0 {
-                output.push_str(&format!("-{}", disambiguator));
-            }
+            output.push_str(&format!(
+                "closure-{}",
+                tcx.def_key(def_id).disambiguated_data.disambiguator
+            ));
         }
         ty::Generator(def_id, ..) => {
-            output.push_str("generator");
-            let disambiguator = tcx.def_key(def_id).disambiguated_data.disambiguator;
-            if disambiguator != 0 {
-                output.push_str(&format!("-{}", disambiguator));
-            }
+            output.push_str(&format!(
+                "generator-{}",
+                tcx.def_key(def_id).disambiguated_data.disambiguator
+            ));
         }
         ty::Error |
         ty::Infer(_) |

--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -190,11 +190,19 @@ pub fn push_debuginfo_type_name<'tcx>(
             // processing
             visited.remove(t);
         },
-        ty::Closure(..) => {
+        ty::Closure(def_id, ..) => {
             output.push_str("closure");
+            let disambiguator = tcx.def_key(def_id).disambiguated_data.disambiguator;
+            if disambiguator != 0 {
+                output.push_str(&format!("-{}", disambiguator));
+            }
         }
-        ty::Generator(..) => {
+        ty::Generator(def_id, ..) => {
             output.push_str("generator");
+            let disambiguator = tcx.def_key(def_id).disambiguated_data.disambiguator;
+            if disambiguator != 0 {
+                output.push_str(&format!("-{}", disambiguator));
+            }
         }
         ty::Error |
         ty::Infer(_) |

--- a/src/test/debuginfo/generator-objects.rs
+++ b/src/test/debuginfo/generator-objects.rs
@@ -10,31 +10,31 @@
 
 // gdb-command:run
 // gdb-command:print b
-// gdb-check:$1 = generator_objects::main::generator {__0: 0x[...], <<variant>>: {__state: 0, 0: generator_objects::main::generator::Unresumed, 1: generator_objects::main::generator::Returned, 2: generator_objects::main::generator::Panicked, 3: generator_objects::main::generator::Suspend0 {[...]}, 4: generator_objects::main::generator::Suspend1 {[...]}}}
+// gdb-check:$1 = generator_objects::main::generator-0 {__0: 0x[...], <<variant>>: {__state: 0, 0: generator_objects::main::generator-0::Unresumed, 1: generator_objects::main::generator-0::Returned, 2: generator_objects::main::generator-0::Panicked, 3: generator_objects::main::generator-0::Suspend0 {[...]}, 4: generator_objects::main::generator-0::Suspend1 {[...]}}}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$2 = generator_objects::main::generator {__0: 0x[...], <<variant>>: {__state: 3, 0: generator_objects::main::generator::Unresumed, 1: generator_objects::main::generator::Returned, 2: generator_objects::main::generator::Panicked, 3: generator_objects::main::generator::Suspend0 {c: 6, d: 7}, 4: generator_objects::main::generator::Suspend1 {[...]}}}
+// gdb-check:$2 = generator_objects::main::generator-0 {__0: 0x[...], <<variant>>: {__state: 3, 0: generator_objects::main::generator-0::Unresumed, 1: generator_objects::main::generator-0::Returned, 2: generator_objects::main::generator-0::Panicked, 3: generator_objects::main::generator-0::Suspend0 {c: 6, d: 7}, 4: generator_objects::main::generator-0::Suspend1 {[...]}}}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$3 = generator_objects::main::generator {__0: 0x[...], <<variant>>: {__state: 4, 0: generator_objects::main::generator::Unresumed, 1: generator_objects::main::generator::Returned, 2: generator_objects::main::generator::Panicked, 3: generator_objects::main::generator::Suspend0 {[...]}, 4: generator_objects::main::generator::Suspend1 {c: 7, d: 8}}}
+// gdb-check:$3 = generator_objects::main::generator-0 {__0: 0x[...], <<variant>>: {__state: 4, 0: generator_objects::main::generator-0::Unresumed, 1: generator_objects::main::generator-0::Returned, 2: generator_objects::main::generator-0::Panicked, 3: generator_objects::main::generator-0::Suspend0 {[...]}, 4: generator_objects::main::generator-0::Suspend1 {c: 7, d: 8}}}
 // gdb-command:continue
 // gdb-command:print b
-// gdb-check:$4 = generator_objects::main::generator {__0: 0x[...], <<variant>>: {__state: 1, 0: generator_objects::main::generator::Unresumed, 1: generator_objects::main::generator::Returned, 2: generator_objects::main::generator::Panicked, 3: generator_objects::main::generator::Suspend0 {[...]}, 4: generator_objects::main::generator::Suspend1 {[...]}}}
+// gdb-check:$4 = generator_objects::main::generator-0 {__0: 0x[...], <<variant>>: {__state: 1, 0: generator_objects::main::generator-0::Unresumed, 1: generator_objects::main::generator-0::Returned, 2: generator_objects::main::generator-0::Panicked, 3: generator_objects::main::generator-0::Suspend0 {[...]}, 4: generator_objects::main::generator-0::Suspend1 {[...]}}}
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 // lldb-command:print b
-// lldbg-check:(generator_objects::main::generator) $0 = generator(&0x[...])
+// lldbg-check:(generator_objects::main::generator-0) $0 = generator-0(&0x[...])
 // lldb-command:continue
 // lldb-command:print b
-// lldbg-check:(generator_objects::main::generator) $1 = generator(&0x[...])
+// lldbg-check:(generator_objects::main::generator-0) $1 = generator-0(&0x[...])
 // lldb-command:continue
 // lldb-command:print b
-// lldbg-check:(generator_objects::main::generator) $2 = generator(&0x[...])
+// lldbg-check:(generator_objects::main::generator-0) $2 = generator-0(&0x[...])
 // lldb-command:continue
 // lldb-command:print b
-// lldbg-check:(generator_objects::main::generator) $3 = generator(&0x[...])
+// lldbg-check:(generator_objects::main::generator-0) $3 = generator-0(&0x[...])
 
 #![feature(omit_gdb_pretty_printer_section, generators, generator_trait)]
 #![omit_gdb_pretty_printer_section]

--- a/src/test/debuginfo/issue-57822.rs
+++ b/src/test/debuginfo/issue-57822.rs
@@ -1,0 +1,55 @@
+// This test makes sure that the LLDB pretty printer does not throw an exception
+// for nested closures and generators.
+
+// Require LLVM with DW_TAG_variant_part and a gdb that can read it.
+// min-system-llvm-version: 8.0
+// min-gdb-version: 8.2
+// ignore-tidy-linelength
+
+// compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print g
+// gdb-check:$1 = issue_57822::main::closure-1 (issue_57822::main::closure (1))
+
+// gdb-command:print b
+// gdb-check:$2 = issue_57822::main::generator-3 {__0: issue_57822::main::generator-2 {__0: 2, <<variant>>: {[...]}}, <<variant>>: {[...]}}
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print g
+// lldbg-check:(issue_57822::main::closure-1) $0 = closure-1(closure(1))
+
+// lldb-command:print b
+// lldbg-check:(issue_57822::main::generator-3) $1 = generator-3(generator-2(2))
+
+#![feature(omit_gdb_pretty_printer_section, generators, generator_trait)]
+#![omit_gdb_pretty_printer_section]
+
+use std::ops::Generator;
+use std::pin::Pin;
+
+fn main() {
+    let mut x = 1;
+    let f = move || x;
+    let g = move || f();
+
+    let mut y = 2;
+    let mut a = move || {
+        y += 1;
+        yield;
+    };
+    let mut b = move || {
+        Pin::new(&mut a).resume();
+        yield;
+    };
+
+    zzz(); // #break
+}
+
+fn zzz() { () }

--- a/src/test/debuginfo/issue-57822.rs
+++ b/src/test/debuginfo/issue-57822.rs
@@ -13,7 +13,7 @@
 // gdb-command:run
 
 // gdb-command:print g
-// gdb-check:$1 = issue_57822::main::closure-1 (issue_57822::main::closure (1))
+// gdb-check:$1 = issue_57822::main::closure-1 (issue_57822::main::closure-0 (1))
 
 // gdb-command:print b
 // gdb-check:$2 = issue_57822::main::generator-3 {__0: issue_57822::main::generator-2 {__0: 2, <<variant>>: {[...]}}, <<variant>>: {[...]}}
@@ -23,7 +23,7 @@
 // lldb-command:run
 
 // lldb-command:print g
-// lldbg-check:(issue_57822::main::closure-1) $0 = closure-1(closure(1))
+// lldbg-check:(issue_57822::main::closure-1) $0 = closure-1(closure-0(1))
 
 // lldb-command:print b
 // lldbg-check:(issue_57822::main::generator-3) $1 = generator-3(generator-2(2))


### PR DESCRIPTION
Closure types have been moved to the namespace where they
are defined, and both closure and generator type names now
include the disambiguator.

This fixes an exception when lldb prints nested closures.

Fixes #57822

I haven't included the `DW_AT_artificial` changes discussed in #57822 because they make the output worse IMO, but I can easily add these if still required. For example, for the new test case the output is now:
```
(lldb) p g
(issue_57822::main::closure-1) $1 = closure-1(closure(1))
```
but adding `DW_AT_artificial` changes this to:
```
(lldb) p g
(issue_57822::main::closure-1) $0 = closure-1 {

}
```

Note that nested generators didn't cause the exception. I haven't determined why, but I think it makes sense to add the disambiguator for them too. It feels like we still don't really understand why closures were causing an error though.

r? @michaelwoerister 