### PR TITLE
refactor(ord_law): updating ord law to be more correct

### DIFF
--- a/src/liballoc/slice.rs
+++ b/src/liballoc/slice.rs
@@ -206,8 +206,9 @@ impl<T> [T] {
     /// the ordering is not total, the order of the elements is unspecified. An order is a
     /// total order if it is (for all `a`, `b` and `c`):
     ///
-    /// * total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true, and
-    /// * transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+    /// * totality: `a < b` or `b < a`
+    /// * antisymmetric: `a < b` and `b < a`, then `a == b`
+    /// * transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
     ///
     /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
     /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.

--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -457,8 +457,9 @@ impl<T: Ord> Ord for Reverse<T> {
 ///
 /// An order is a total order if it is (for all `a`, `b` and `c`):
 ///
-/// - total and antisymmetric: exactly one of `a < b`, `a == b` or `a > b` is true; and
-/// - transitive, `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
+/// - totality: `a < b` or `b < a`
+/// - antisymmetric: `a < b` and `b < a`, then `a == b`
+/// - transitive: `a < b` and `b < c` implies `a < c`. The same must hold for both `==` and `>`.
 ///
 /// ## Derivable
 ///

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1508,8 +1508,9 @@ impl<T> [T] {
     /// the ordering is not total, the order of the elements is unspecified. An order is a
     /// total order if it is (for all a, b and c):
     ///
-    /// * total and antisymmetric: exactly one of a < b, a == b or a > b is true; and
-    /// * transitive, a < b and b < c implies a < c. The same must hold for both == and >.
+    /// * totality: `a < b` or `b < a`
+    /// * antisymmetric: `a < b` and `b < a`, then `a == b`
+    /// * transitive: a < b and b < c implies a < c. The same must hold for both == and >.
     ///
     /// For example, while [`f64`] doesn't implement [`Ord`] because `NaN != NaN`, we can use
     /// `partial_cmp` as our sort function when we know the slice doesn't contain a `NaN`.


### PR DESCRIPTION
I thought it's more correct to split out totality and antisymmetric into different dot points when discussing Ord laws

Some useful references:
- https://github.com/fantasyland/fantasy-land#ord