### PR TITLE
sync adding nounwind attribute with generating abort-on-panic shim

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2646,9 +2646,6 @@ bitflags! {
         /// `#[rustc_allocator]`: a hint to LLVM that the pointer returned from this
         /// function is never null.
         const ALLOCATOR                 = 1 << 1;
-        /// `#[unwind]`: an indicator that this function may unwind despite what
-        /// its ABI signature may otherwise imply.
-        const UNWIND                    = 1 << 2;
         /// `#[rust_allocator_nounwind]`, an indicator that an imported FFI
         /// function will never unwind. Probably obsolete by recent changes with
         /// #[unwind], but hasn't been removed/migrated yet

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -271,11 +271,7 @@ pub fn from_fn_attrs(
         false
     } else if let Some(id) = id {
         let sig = cx.tcx.normalize_erasing_late_bound_regions(ty::ParamEnv::reveal_all(), &sig);
-        if cx.tcx.is_foreign_item(id) {
-            // Foreign items like `extern "C" { fn foo(); }` and `extern "Rust" { fn bar(); }`
-            // are assumed not to unwind.
-            false
-        } else if cx.tcx.abort_on_panic_shim(id, sig.abi) {
+        if cx.tcx.abort_on_panic_shim(id, sig.abi) {
             // Since we are adding a shim to abort on panic, this cannot unwind.
             false
         } else {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2527,8 +2527,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::COLD;
         } else if attr.check_name(sym::rustc_allocator) {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::ALLOCATOR;
-        } else if attr.check_name(sym::unwind) {
-            codegen_fn_attrs.flags |= CodegenFnAttrFlags::UNWIND;
         } else if attr.check_name(sym::ffi_returns_twice) {
             if tcx.is_foreign_item(id) {
                 codegen_fn_attrs.flags |= CodegenFnAttrFlags::FFI_RETURNS_TWICE;

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -4,17 +4,17 @@
 #![feature(unwind_attributes)]
 
 extern {
-// CHECK: Function Attrs: nounwind
-// CHECK-NEXT: declare void @extern_fn
-    fn extern_fn(); // assumed not to unwind
+// CHECK-NOT: nounwind
+// CHECK: declare void @extern_fn
+    fn extern_fn();
 // CHECK-NOT: nounwind
 // CHECK: declare void @unwinding_extern_fn
     #[unwind(allowed)]
     fn unwinding_extern_fn();
-// CHECK-NOT: nounwind
-// CHECK: declare void @aborting_extern_fn
+// CHECK: Function Attrs: nounwind
+// CHECK-NEXT: declare void @aborting_extern_fn
     #[unwind(aborts)]
-    fn aborting_extern_fn(); // FIXME: we don't have the attribute here
+    fn aborting_extern_fn();
 }
 
 extern "Rust" {
@@ -25,10 +25,10 @@ extern "Rust" {
 // CHECK: declare void @rust_unwinding_extern_fn
     #[unwind(allowed)]
     fn rust_unwinding_extern_fn();
-// CHECK-NOT: nounwind
-// CHECK: declare void @rust_aborting_extern_fn
+// CHECK: Function Attrs: nounwind
+// CHECK-NEXT: declare void @rust_aborting_extern_fn
     #[unwind(aborts)]
-    fn rust_aborting_extern_fn(); // FIXME: we don't have the attribute here
+    fn rust_aborting_extern_fn();
 }
 
 pub unsafe fn force_declare() {

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -6,14 +6,36 @@
 extern {
 // CHECK: Function Attrs: nounwind
 // CHECK-NEXT: declare void @extern_fn
-    fn extern_fn();
-// CHECK-NOT: Function Attrs: nounwind
+    fn extern_fn(); // assumed not to unwind
+// CHECK-NOT: nounwind
 // CHECK: declare void @unwinding_extern_fn
     #[unwind(allowed)]
     fn unwinding_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @aborting_extern_fn
+    #[unwind(aborts)]
+    fn aborting_extern_fn(); // FIXME: we don't have the attribute here
+}
+
+extern "Rust" {
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_extern_fn
+    fn rust_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_unwinding_extern_fn
+    #[unwind(allowed)]
+    fn rust_unwinding_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_aborting_extern_fn
+    #[unwind(aborts)]
+    fn rust_aborting_extern_fn(); // FIXME: we don't have the attribute here
 }
 
 pub unsafe fn force_declare() {
     extern_fn();
     unwinding_extern_fn();
+    aborting_extern_fn();
+    rust_extern_fn();
+    rust_unwinding_extern_fn();
+    rust_aborting_extern_fn();
 }

--- a/src/test/codegen/nounwind-extern.rs
+++ b/src/test/codegen/nounwind-extern.rs
@@ -2,5 +2,8 @@
 
 #![crate_type = "lib"]
 
+// The `nounwind` attribute does not get added by rustc; it is present here because LLVM
+// analyses determine that this function does not unwind.
+
 // CHECK: Function Attrs: norecurse nounwind
 pub extern fn foo() {}

--- a/src/test/codegen/unwind-extern.rs
+++ b/src/test/codegen/unwind-extern.rs
@@ -1,0 +1,15 @@
+// compile-flags: -C opt-level=0
+
+#![crate_type = "lib"]
+#![feature(unwind_attributes)]
+
+// make sure these all do *not* get the attribute
+// CHECK-NOT: nounwind
+
+pub extern fn foo() {} // right now we don't abort-on-panic, so we also shouldn't have `nounwind`
+#[unwind(allowed)]
+pub extern fn foo_allowed() {}
+
+pub extern "Rust" fn bar() {}
+#[unwind(allowed)]
+pub extern "Rust" fn bar_allowed() {}


### PR DESCRIPTION
Currently, the code paths for deciding whether to add an abort-on-panic shim, and whether to add the `nounwind` attribute, are separate. This unifies them. As a consequence, we now add a `nounwind` attribute to `#[unwind(aborts)]` functions.

The logic is also changed slightly to not take the call ABI into account any more. Fixes https://github.com/rust-lang/rust/issues/63883.

Based on https://github.com/rust-lang/rust/pull/63909, [relative diff](https://github.com/RalfJung/rust/compare/nounwind...abort-on-panic).