### PR TITLE
Point at method call on missing annotation error

### DIFF
--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -413,7 +413,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ) -> Option<RegionName> {
         let mut highlight = RegionHighlightMode::default();
         highlight.highlighting_region_vid(needle_fr, *counter);
-        let type_name = infcx.extract_type_name(&argument_ty, Some(highlight));
+        let type_name = infcx.extract_type_name(&argument_ty, Some(highlight)).0;
 
         debug!(
             "give_name_if_we_cannot_match_hir_ty: type_name={:?} needle_fr={:?}",
@@ -695,7 +695,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let mut highlight = RegionHighlightMode::default();
         highlight.highlighting_region_vid(fr, *counter);
-        let type_name = infcx.extract_type_name(&return_ty, Some(highlight));
+        let type_name = infcx.extract_type_name(&return_ty, Some(highlight)).0;
 
         let mir_hir_id = tcx.hir().as_local_hir_id(mir_def_id).expect("non-local mir");
 
@@ -758,7 +758,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let mut highlight = RegionHighlightMode::default();
         highlight.highlighting_region_vid(fr, *counter);
-        let type_name = infcx.extract_type_name(&yield_ty, Some(highlight));
+        let type_name = infcx.extract_type_name(&yield_ty, Some(highlight)).0;
 
         let mir_hir_id = tcx.hir().as_local_hir_id(mir_def_id).expect("non-local mir");
 

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -1,10 +1,10 @@
 error[E0282]: type annotations needed for `std::option::Option<_>`
-  --> $DIR/issue-42234-unknown-receiver-type.rs:7:5
+  --> $DIR/issue-42234-unknown-receiver-type.rs:7:7
    |
 LL |     let x: Option<_> = None;
    |         - consider giving `x` the explicit type `std::option::Option<_>`, where the type parameter `T` is specified
 LL |     x.unwrap().method_that_could_exist_on_some_type();
-   |     ^^^^^^^^^^ cannot infer type for `T`
+   |       ^^^^^^ cannot infer type for `T`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/span/type-annotations-needed-expr.rs
+++ b/src/test/ui/span/type-annotations-needed-expr.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let _ = (vec![1,2,3]).into_iter().sum() as f64; //~ ERROR E0282
+}

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/type-annotations-needed-expr.rs:2:39
+   |
+LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
+   |                                       ^^^ cannot infer type for `S`
+   |
+   = note: type must be known at this point
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Make it clearer where the type name that couldn't be inferred comes from.

Before:

```
error[E0282]: type annotations needed
 --> src/test/ui/span/type-annotations-needed-expr.rs:2:13
  |
2 |     let _ = (vec![1,2,3]).into_iter().sum() as f64; //~ ERROR E0282
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `S`
  |
  = note: type must be known at this point
```
after
```
error[E0282]: type annotations needed
 --> src/test/ui/span/type-annotations-needed-expr.rs:2:39
  |
2 |     let _ = (vec![1,2,3]).into_iter().sum() as f64; //~ ERROR E0282
  |                                       ^^^ cannot infer type for `S`
  |
  = note: type must be known at this point
```

CC #63852.