### PR TITLE
 layout: Avoid niches that make things worse.

### DIFF
--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -533,6 +533,16 @@ impl Integer {
         }
         I8
     }
+
+    /// Finds the largest integer with the given size or less.
+    pub fn approximate_size(wanted: Size) -> Option<Integer> {
+        for &candidate in &[I64, I32, I16, I8] {
+            if wanted >= candidate.size() {
+                return Some(candidate);
+            }
+        }
+        None
+    }
 }
 
 

--- a/src/test/codegen/align-enum.rs
+++ b/src/test/codegen/align-enum.rs
@@ -9,7 +9,7 @@ pub enum Align64 {
     A(u32),
     B(u32),
 }
-// CHECK: %Align64 = type { [0 x i32], i32, [15 x i32] }
+// CHECK: %Align64 = type { [0 x i64], i64, [7 x i64] }
 
 pub struct Nested64 {
     a: u8,

--- a/src/test/codegen/align-struct.rs
+++ b/src/test/codegen/align-struct.rs
@@ -26,8 +26,9 @@ pub enum Enum64 {
     A(Align64),
     B(i32),
 }
-// CHECK: %Enum64 = type { [0 x i32], i32, [31 x i32] }
+// CHECK: %Enum64 = type { [0 x i64], i64, [15 x i64] }
 // CHECK: %"Enum64::A" = type { [8 x i64], %Align64, [0 x i64] }
+// CHECK: %"Enum64::B" = type { [2 x i32], i32, [1 x i32] }
 
 // CHECK-LABEL: @align64
 #[no_mangle]
@@ -69,5 +70,13 @@ pub fn enum4(a: i32) -> Enum4 {
 pub fn enum64(a: Align64) -> Enum64 {
 // CHECK: %e64 = alloca %Enum64, align 64
     let e64 = Enum64::A(a);
+    e64
+}
+
+// CHECK-LABEL: @enum64_b
+#[no_mangle]
+pub fn enum64_b(b: i32) -> Enum64 {
+// CHECK: %e64 = alloca %Enum64, align 64
+    let e64 = Enum64::B(b);
     e64
 }

--- a/src/test/ui/print_type_sizes/niche-filling.rs
+++ b/src/test/ui/print_type_sizes/niche-filling.rs
@@ -27,7 +27,7 @@ impl<T> Default for MyOption<T> {
 
 pub enum EmbeddedDiscr {
     None,
-    Record { pre: u8, val: NonZeroU32, post: u16 },
+    Record { pre1: u8, pre2: u8, val: NonZeroU32, post: u16 },
 }
 
 impl Default for EmbeddedDiscr {
@@ -53,6 +53,15 @@ impl Default for NestedNonZero {
     }
 }
 
+pub enum BadNiche {
+    None,
+    Record { pre: u8, val: NonZeroU32, post: u16 },
+}
+
+impl Default for BadNiche {
+    fn default() -> Self { BadNiche::None }
+}
+
 pub enum Enum4<A, B, C, D> {
     One(A),
     Two(B),
@@ -74,6 +83,7 @@ fn start(_: isize, _: *const *const u8) -> isize {
     let _x: MyOption<NonZeroU32> = Default::default();
     let _y: EmbeddedDiscr = Default::default();
     let _z: MyOption<IndirectNonZero> = Default::default();
+    let _w: BadNiche = Default::default();
     let _a: MyOption<bool> = Default::default();
     let _b: MyOption<char> = Default::default();
     let _c: MyOption<std::cmp::Ordering> = Default::default();

--- a/src/test/ui/print_type_sizes/niche-filling.stdout
+++ b/src/test/ui/print_type_sizes/niche-filling.stdout
@@ -7,13 +7,20 @@ print-type-size type: `MyOption<IndirectNonZero>`: 12 bytes, alignment: 4 bytes
 print-type-size     variant `Some`: 12 bytes
 print-type-size         field `.0`: 12 bytes
 print-type-size     variant `None`: 0 bytes
-print-type-size type: `EmbeddedDiscr`: 8 bytes, alignment: 4 bytes
+print-type-size type: `BadNiche`: 8 bytes, alignment: 4 bytes
+print-type-size     discriminant: 1 bytes
 print-type-size     variant `Record`: 7 bytes
+print-type-size         field `.pre`: 1 bytes
+print-type-size         field `.post`: 2 bytes
+print-type-size         field `.val`: 4 bytes
+print-type-size     variant `None`: 0 bytes
+print-type-size type: `EmbeddedDiscr`: 8 bytes, alignment: 4 bytes
+print-type-size     variant `Record`: 8 bytes
 print-type-size         field `.val`: 4 bytes
 print-type-size         field `.post`: 2 bytes
-print-type-size         field `.pre`: 1 bytes
+print-type-size         field `.pre1`: 1 bytes
+print-type-size         field `.pre2`: 1 bytes
 print-type-size     variant `None`: 0 bytes
-print-type-size     end padding: 1 bytes
 print-type-size type: `MyOption<Union1<std::num::NonZeroU32>>`: 8 bytes, alignment: 4 bytes
 print-type-size     discriminant: 4 bytes
 print-type-size     variant `Some`: 4 bytes

--- a/src/test/ui/print_type_sizes/padding.stdout
+++ b/src/test/ui/print_type_sizes/padding.stdout
@@ -1,21 +1,19 @@
 print-type-size type: `E1`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
-print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
+print-type-size     discriminant: 4 bytes
+print-type-size     variant `A`: 8 bytes
 print-type-size         field `.1`: 1 bytes
-print-type-size         padding: 2 bytes
-print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
-print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
-print-type-size     discriminant: 1 bytes
-print-type-size     variant `B`: 11 bytes
 print-type-size         padding: 3 bytes
-print-type-size         field `.0`: 8 bytes, alignment: 4 bytes
-print-type-size     variant `A`: 7 bytes
+print-type-size         field `.0`: 4 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
+print-type-size type: `E2`: 12 bytes, alignment: 4 bytes
+print-type-size     discriminant: 4 bytes
+print-type-size     variant `A`: 8 bytes
 print-type-size         field `.0`: 1 bytes
-print-type-size         padding: 2 bytes
+print-type-size         padding: 3 bytes
 print-type-size         field `.1`: 4 bytes, alignment: 4 bytes
+print-type-size     variant `B`: 8 bytes
+print-type-size         field `.0`: 8 bytes
 print-type-size type: `S`: 8 bytes, alignment: 4 bytes
 print-type-size     field `.g`: 4 bytes
 print-type-size     field `.a`: 1 bytes

--- a/src/test/ui/print_type_sizes/repr-align.stdout
+++ b/src/test/ui/print_type_sizes/repr-align.stdout
@@ -1,7 +1,7 @@
 print-type-size type: `E`: 32 bytes, alignment: 16 bytes
-print-type-size     discriminant: 4 bytes
-print-type-size     variant `B`: 28 bytes
-print-type-size         padding: 12 bytes
+print-type-size     discriminant: 8 bytes
+print-type-size     variant `B`: 24 bytes
+print-type-size         padding: 8 bytes
 print-type-size         field `.0`: 16 bytes, alignment: 16 bytes
 print-type-size     variant `A`: 4 bytes
 print-type-size         field `.0`: 4 bytes


### PR DESCRIPTION
After pull request #63902. Fixes issue #63866.

In cases where adding a tag does not increase the size of the enum, don't use a niche that has fewer values than the tag.