### PR TITLE
fix nounwind attribute logic

### DIFF
--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -268,7 +268,6 @@ pub fn from_fn_attrs(
         false
     } else if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::UNWIND) {
         // If a specific #[unwind] attribute is present, use that.
-        // FIXME: We currently assume it can unwind even with `#[unwind(aborts)]`.
         true
     } else if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::RUSTC_ALLOCATOR_NOUNWIND) {
         // Special attribute for allocator functions, which can't unwind

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2528,6 +2528,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
         } else if attr.check_name(sym::rustc_allocator) {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::ALLOCATOR;
         } else if attr.check_name(sym::unwind) {
+            // FIXME: We currently assume it can unwind even with `#[unwind(aborts)]`.
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::UNWIND;
         } else if attr.check_name(sym::ffi_returns_twice) {
             if tcx.is_foreign_item(id) {

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -4,9 +4,9 @@
 #![feature(unwind_attributes)]
 
 extern {
-// CHECK: Function Attrs: nounwind
-// CHECK-NEXT: declare void @extern_fn
-    fn extern_fn(); // assumed not to unwind
+// CHECK-NOT: nounwind
+// CHECK: declare void @extern_fn
+    fn extern_fn();
 // CHECK-NOT: nounwind
 // CHECK: declare void @unwinding_extern_fn
     #[unwind(allowed)]

--- a/src/test/codegen/extern-functions.rs
+++ b/src/test/codegen/extern-functions.rs
@@ -6,14 +6,36 @@
 extern {
 // CHECK: Function Attrs: nounwind
 // CHECK-NEXT: declare void @extern_fn
-    fn extern_fn();
-// CHECK-NOT: Function Attrs: nounwind
+    fn extern_fn(); // assumed not to unwind
+// CHECK-NOT: nounwind
 // CHECK: declare void @unwinding_extern_fn
     #[unwind(allowed)]
     fn unwinding_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @aborting_extern_fn
+    #[unwind(aborts)]
+    fn aborting_extern_fn(); // FIXME: we don't have the attribute here
+}
+
+extern "Rust" {
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_extern_fn
+    fn rust_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_unwinding_extern_fn
+    #[unwind(allowed)]
+    fn rust_unwinding_extern_fn();
+// CHECK-NOT: nounwind
+// CHECK: declare void @rust_aborting_extern_fn
+    #[unwind(aborts)]
+    fn rust_aborting_extern_fn(); // FIXME: we don't have the attribute here
 }
 
 pub unsafe fn force_declare() {
     extern_fn();
     unwinding_extern_fn();
+    aborting_extern_fn();
+    rust_extern_fn();
+    rust_unwinding_extern_fn();
+    rust_aborting_extern_fn();
 }

--- a/src/test/codegen/nounwind-extern.rs
+++ b/src/test/codegen/nounwind-extern.rs
@@ -1,9 +1,0 @@
-// compile-flags: -O
-
-#![crate_type = "lib"]
-
-// The `nounwind` attribute does not get added by rustc; it is present here because LLVM
-// analyses determine that this function does not unwind.
-
-// CHECK: Function Attrs: norecurse nounwind
-pub extern fn foo() {}

--- a/src/test/codegen/nounwind-extern.rs
+++ b/src/test/codegen/nounwind-extern.rs
@@ -2,5 +2,8 @@
 
 #![crate_type = "lib"]
 
+// The `nounwind` attribute does not get added by rustc; it is present here because LLVM
+// analyses determine that this function does not unwind.
+
 // CHECK: Function Attrs: norecurse nounwind
 pub extern fn foo() {}

--- a/src/test/codegen/unwind-extern.rs
+++ b/src/test/codegen/unwind-extern.rs
@@ -1,0 +1,15 @@
+// compile-flags: -C opt-level=0
+
+#![crate_type = "lib"]
+#![feature(unwind_attributes)]
+
+// make sure these all do *not* get the attribute
+// CHECK-NOT: nounwind
+
+pub extern fn foo() {} // right now we don't abort-on-panic, so we also shouldn't have `nounwind`
+#[unwind(allowed)]
+pub extern fn foo_allowed() {}
+
+pub extern "Rust" fn bar() {}
+#[unwind(allowed)]
+pub extern "Rust" fn bar_allowed() {}


### PR DESCRIPTION
With https://github.com/rust-lang/rust/pull/62603 landed, we no longer add abort-on-panic shims to `extern "C"` functions. However, that means we should also not emit `nounwind` for `extern fn` because we are not actually catching those panics. The comment justifying that `nounwind` in the source is just factually wrong.

I also noticed that we annotate `extern` *declarations* (of any ABI) with `nounwind`, which seems wrong? I removed this. Code like mozjpeg (the code that prompted the removal of the abort-on-panic shim) throws a panic from Rust code that enters C code (meaning the `extern "C"` *definition* must not have `nounwind`, or else we got UB), but then the panic bubbles through the C code and re-enters Rust code (meaning the `extern "C"` *declaration* that gets called from the Rust side must not have `nounwind` either).

This should be beta-backported if https://github.com/rust-lang/rust/pull/62603 gets backported.

TODO: add test case for https://github.com/rust-lang/rust/issues/63943.