### PR TITLE
Add unchecked math inherant impls to integers

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -633,6 +633,18 @@ $EndFeature, "
         }
 
         doc_comment! {
+            concat!("Unchecked integer addition. Computes `self + rhs`, assuming overflow
+cannot occur."),
+            #[unstable(feature = "unchecked_math", issue = "0")]
+            #[must_use = "this returns the result of the operation, \
+                          without modifying the original"]
+            #[inline]
+            pub unsafe fn unchecked_add(self, rhs: Self) -> Self {
+                intrinsics::unchecked_add(self, rhs)
+            }
+        }
+
+        doc_comment! {
             concat!("Checked integer subtraction. Computes `self - rhs`, returning `None` if
 overflow occurred.
 
@@ -653,6 +665,18 @@ $EndFeature, "
             pub fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
+            }
+        }
+
+        doc_comment! {
+            concat!("Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
+cannot occur."),
+            #[unstable(feature = "unchecked_math", issue = "0")]
+            #[must_use = "this returns the result of the operation, \
+                          without modifying the original"]
+            #[inline]
+            pub unsafe fn unchecked_sub(self, rhs: Self) -> Self {
+                intrinsics::unchecked_sub(self, rhs)
             }
         }
 
@@ -2687,6 +2711,18 @@ assert_eq!((", stringify!($SelfT), "::max_value() - 2).checked_add(3), None);", 
         }
 
         doc_comment! {
+            concat!("Unchecked integer addition. Computes `self + rhs`, assuming overflow
+cannot occur."),
+            #[unstable(feature = "unchecked_math", issue = "0")]
+            #[must_use = "this returns the result of the operation, \
+                          without modifying the original"]
+            #[inline]
+            pub unsafe fn unchecked_add(self, rhs: Self) -> Self {
+                intrinsics::unchecked_add(self, rhs)
+            }
+        }
+
+        doc_comment! {
             concat!("Checked integer subtraction. Computes `self - rhs`, returning
 `None` if overflow occurred.
 
@@ -2705,6 +2741,18 @@ assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
             pub fn checked_sub(self, rhs: Self) -> Option<Self> {
                 let (a, b) = self.overflowing_sub(rhs);
                 if b {None} else {Some(a)}
+            }
+        }
+
+        doc_comment! {
+            concat!("Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
+cannot occur."),
+            #[unstable(feature = "unchecked_math", issue = "0")]
+            #[must_use = "this returns the result of the operation, \
+                          without modifying the original"]
+            #[inline]
+            pub unsafe fn unchecked_sub(self, rhs: Self) -> Self {
+                intrinsics::unchecked_sub(self, rhs)
             }
         }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -634,7 +634,10 @@ $EndFeature, "
 
         doc_comment! {
             concat!("Unchecked integer addition. Computes `self + rhs`, assuming overflow
-cannot occur."),
+cannot occur.
+
+This results in undefined behavior when `self + rhs > ", stringify!($SelfT), "::max_value()`
+or `self + rhs < ", stringify!($SelfT), "::min_value()`.),
             #[unstable(feature = "unchecked_math", issue = "0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
@@ -670,7 +673,10 @@ $EndFeature, "
 
         doc_comment! {
             concat!("Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
-cannot occur."),
+cannot occur.
+
+This results in undefined behavior when `self - rhs > ", stringify!($SelfT), "::max_value()`
+or `self - rhs < ", stringify!($SelfT), "::min_value()`."),
             #[unstable(feature = "unchecked_math", issue = "0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
@@ -2712,7 +2718,10 @@ assert_eq!((", stringify!($SelfT), "::max_value() - 2).checked_add(3), None);", 
 
         doc_comment! {
             concat!("Unchecked integer addition. Computes `self + rhs`, assuming overflow
-cannot occur."),
+cannot occur.
+
+This results in undefined behavior when `self + rhs > ", stringify!($SelfT), "::max_value()`
+or `self + rhs < ", stringify!($SelfT), "::min_value()`."),
             #[unstable(feature = "unchecked_math", issue = "0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
@@ -2746,7 +2755,10 @@ assert_eq!(0", stringify!($SelfT), ".checked_sub(1), None);", $EndFeature, "
 
         doc_comment! {
             concat!("Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
-cannot occur."),
+cannot occur.
+
+This results in undefined behavior when `self - rhs > ", stringify!($SelfT), "::max_value()`
+or `self - rhs < ", stringify!($SelfT), "::min_value()`."),
             #[unstable(feature = "unchecked_math", issue = "0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -637,7 +637,7 @@ $EndFeature, "
 cannot occur.
 
 This results in undefined behavior when `self + rhs > ", stringify!($SelfT), "::max_value()`
-or `self + rhs < ", stringify!($SelfT), "::min_value()`.),
+or `self + rhs < ", stringify!($SelfT), "::min_value()`."),
             #[unstable(feature = "unchecked_math", issue = "0")]
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]


### PR DESCRIPTION
This exposes the [`unchecked_add`](https://doc.rust-lang.org/nightly/core/intrinsics/fn.unchecked_add.html) and [`unchecked_sub`](https://doc.rust-lang.org/nightly/core/intrinsics/fn.unchecked_sub.html) intrinsics on integers.

If we agree we want this, I'll make a tracking issue and point the `#[unstable]` attributes at it.

This would be used by #62886 at a minimum.