### PR TITLE
Filter linkcheck spurious failure

### DIFF
--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -60,11 +60,14 @@ fn main() {
                     #[cfg(feature = "linkcheck")]
                     {
                         err.downcast::<BrokenLinks>()
+                            .map(|broken_links| {
+                                broken_links
+                                    .links()
+                                    .iter()
+                                    .inspect(|cause| eprintln!("\tCaused By: {}", cause))
+                                    .any(|cause| !format!("{}", cause).contains("timed out"))
+                            })
                             .unwrap_or(false)
-                            .links()
-                            .iter()
-                            .inspect(|cause| eprintln!("\tCaused By: {}", cause))
-                            .any(|cause| !cause.contains("timed out"));
                     }
 
                     #[cfg(not(feature = "linkcheck"))]

--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -1,18 +1,18 @@
-use clap::{crate_version};
+use clap::crate_version;
 
 use std::env;
 use std::path::{Path, PathBuf};
 
-use clap::{App, ArgMatches, SubCommand, AppSettings};
+use clap::{App, AppSettings, ArgMatches, SubCommand};
 
+use mdbook::errors::Result as Result3;
 use mdbook::MDBook;
-use mdbook::errors::{Result as Result3};
 
+use failure::Error;
 #[cfg(feature = "linkcheck")]
 use mdbook::renderer::RenderContext;
 #[cfg(feature = "linkcheck")]
 use mdbook_linkcheck::{self, errors::BrokenLinks};
-use failure::Error;
 
 fn main() {
     let d_message = "-d, --dest-dir=[dest-dir]
@@ -21,18 +21,22 @@ fn main() {
 'A directory for your book{n}(Defaults to Current Directory when omitted)'";
 
     let matches = App::new("rustbook")
-                    .about("Build a book with mdBook")
-                    .author("Steve Klabnik <steve@steveklabnik.com>")
-                    .version(&*format!("v{}", crate_version!()))
-                    .setting(AppSettings::SubcommandRequired)
-                    .subcommand(SubCommand::with_name("build")
-                        .about("Build the book from the markdown files")
-                        .arg_from_usage(d_message)
-                        .arg_from_usage(dir_message))
-                    .subcommand(SubCommand::with_name("linkcheck")
-                        .about("Run linkcheck with mdBook 3")
-                        .arg_from_usage(dir_message))
-                    .get_matches();
+        .about("Build a book with mdBook")
+        .author("Steve Klabnik <steve@steveklabnik.com>")
+        .version(&*format!("v{}", crate_version!()))
+        .setting(AppSettings::SubcommandRequired)
+        .subcommand(
+            SubCommand::with_name("build")
+                .about("Build the book from the markdown files")
+                .arg_from_usage(d_message)
+                .arg_from_usage(dir_message),
+        )
+        .subcommand(
+            SubCommand::with_name("linkcheck")
+                .about("Run linkcheck with mdBook 3")
+                .arg_from_usage(dir_message),
+        )
+        .get_matches();
 
     // Check which subcomamnd the user ran...
     match matches.subcommand() {
@@ -46,23 +50,35 @@ fn main() {
 
                 ::std::process::exit(101);
             }
-        },
+        }
         ("linkcheck", Some(sub_matches)) => {
             if let Err(err) = linkcheck(sub_matches) {
                 eprintln!("Error: {}", err);
+
+                // HACK: ignore timeouts
+                #[allow(unused_mut)]
+                let mut actually_broken = false;
 
                 #[cfg(feature = "linkcheck")]
                 {
                     if let Ok(broken_links) = err.downcast::<BrokenLinks>() {
                         for cause in broken_links.links().iter() {
                             eprintln!("\tCaused By: {}", cause);
+
+                            if cause.contains("timed out") {
+                                actually_broken = true;
+                            }
                         }
                     }
                 }
 
-                ::std::process::exit(101);
+                if actually_broken {
+                    std::process::exit(101);
+                } else {
+                    std::process::exit(0);
+                }
             }
-        },
+        }
         (_, _) => unreachable!(),
     };
 }


### PR DESCRIPTION
r? @ehuss 

cc @spastorino 

Basically, we filter errors with messages containing "timed out"... a bit of a hack, but hopefully this will be functionality built into linkcheck soon.