### PR TITLE
 Fix ICE in rustdoc when merging generic and where bounds of an Fn with an output

### DIFF
--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -122,9 +122,9 @@ pub fn merge_bounds(
                     },
                 });
             }
-            PP::Parenthesized { ref mut output, .. } => {
-                assert!(output.is_none());
-                if *rhs != clean::Type::Tuple(Vec::new()) {
+            PP::Parenthesized { ref mut output, .. } => match output {
+                Some(o) => assert!(o == rhs),
+                None => if *rhs != clean::Type::Tuple(Vec::new()) {
                     *output = Some(rhs.clone());
                 }
             }

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -35,7 +35,7 @@ pub fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
                 match ty {
                     clean::Generic(s) => params.entry(s).or_default()
                                                .extend(bounds),
-                    t => tybounds.push((t, ty_bounds(bounds))),
+                    t => tybounds.push((t, bounds)),
                 }
             }
             WP::RegionPredicate { lifetime, bounds } => {
@@ -44,11 +44,6 @@ pub fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
             WP::EqPredicate { lhs, rhs } => equalities.push((lhs, rhs)),
         }
     }
-
-    // Simplify the type parameter bounds on all the generics
-    let mut params = params.into_iter().map(|(k, v)| {
-        (k, ty_bounds(v))
-    }).collect::<BTreeMap<_, _>>();
 
     // Look for equality predicates on associated types that can be merged into
     // general bound predicates
@@ -73,7 +68,7 @@ pub fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
     // And finally, let's reassemble everything
     let mut clauses = Vec::new();
     clauses.extend(lifetimes.into_iter().map(|(lt, bounds)| {
-        WP::RegionPredicate { lifetime: lt, bounds: bounds }
+        WP::RegionPredicate { lifetime: lt, bounds }
     }));
     clauses.extend(params.into_iter().map(|(k, v)| {
         WP::BoundPredicate {
@@ -82,10 +77,10 @@ pub fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
         }
     }));
     clauses.extend(tybounds.into_iter().map(|(ty, bounds)| {
-        WP::BoundPredicate { ty: ty, bounds: bounds }
+        WP::BoundPredicate { ty, bounds }
     }));
     clauses.extend(equalities.into_iter().map(|(lhs, rhs)| {
-        WP::EqPredicate { lhs: lhs, rhs: rhs }
+        WP::EqPredicate { lhs, rhs }
     }));
     clauses
 }
@@ -137,16 +132,12 @@ pub fn ty_params(mut params: Vec<clean::GenericParamDef>) -> Vec<clean::GenericP
     for param in &mut params {
         match param.kind {
             clean::GenericParamDefKind::Type { ref mut bounds, .. } => {
-                *bounds = ty_bounds(mem::take(bounds));
+                *bounds = mem::take(bounds);
             }
             _ => panic!("expected only type parameters"),
         }
     }
     params
-}
-
-fn ty_bounds(bounds: Vec<clean::GenericBound>) -> Vec<clean::GenericBound> {
-    bounds
 }
 
 fn trait_is_same_or_supertrait(cx: &DocContext<'_>, child: DefId,

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -118,7 +118,7 @@ pub fn merge_bounds(
                 });
             }
             PP::Parenthesized { ref mut output, .. } => match output {
-                Some(o) => assert!(o == rhs),
+                Some(o) => assert_eq!(o, rhs),
                 None => if *rhs != clean::Type::Tuple(Vec::new()) {
                     *output = Some(rhs.clone());
                 }

--- a/src/test/rustdoc/auxiliary/issue-57180.rs
+++ b/src/test/rustdoc/auxiliary/issue-57180.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Cmetadata=aux
+
+pub trait Trait {
+}
+
+pub struct Struct<F>
+{
+    _p: ::std::marker::PhantomData<F>,
+}
+
+impl<F: Fn() -> u32>
+Trait for Struct<F>
+    where
+        F: Fn() -> u32,
+{
+}

--- a/src/test/rustdoc/issue-57180.rs
+++ b/src/test/rustdoc/issue-57180.rs
@@ -1,0 +1,7 @@
+// aux-build:issue-57180.rs
+
+extern crate issue_57180;
+use issue_57180::Trait;
+
+fn main() {
+}


### PR DESCRIPTION
Fixes #57180
