### PR TITLE
or-pattern: fix typo in error message

### DIFF
--- a/src/libsyntax/parse/parser/pat.rs
+++ b/src/libsyntax/parse/parser/pat.rs
@@ -113,7 +113,7 @@ impl<'a> Parser<'a> {
         let mut pats = vec![first_pat];
         while self.eat_or_separator() {
             let pat = self.parse_pat(expected).map_err(|mut err| {
-                err.span_label(lo, "while parsing this or-pattern staring here");
+                err.span_label(lo, "while parsing this or-pattern starting here");
                 err
             })?;
             self.maybe_recover_unexpected_comma(pat.span, rc)?;

--- a/src/test/ui/or-patterns/while-parsing-this-or-pattern.rs
+++ b/src/test/ui/or-patterns/while-parsing-this-or-pattern.rs
@@ -3,7 +3,7 @@
 fn main() {
     match Some(42) {
         Some(42) | .=. => {} //~ ERROR expected pattern, found `.`
-        //~^ while parsing this or-pattern staring here
+        //~^ while parsing this or-pattern starting here
         //~| NOTE expected pattern
     }
 }

--- a/src/test/ui/or-patterns/while-parsing-this-or-pattern.stderr
+++ b/src/test/ui/or-patterns/while-parsing-this-or-pattern.stderr
@@ -4,7 +4,7 @@ error: expected pattern, found `.`
 LL |         Some(42) | .=. => {}
    |         --------   ^ expected pattern
    |         |
-   |         while parsing this or-pattern staring here
+   |         while parsing this or-pattern starting here
 
 error: aborting due to previous error
 


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/54883.