### PR TITLE
const_prop: only call error_to_const_error if we are actually showing something

### DIFF
--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -519,6 +519,9 @@ pub fn const_variant_index<'tcx>(
     ecx.read_discriminant(op).unwrap().1
 }
 
+/// Turn an interpreter error into something to report to the user.
+/// As a side-effect, if RUSTC_CTFE_BACKTRACE is set, this prints the backtrace.
+/// Should be called only if the error is actually going to to be reported!
 pub fn error_to_const_error<'mir, 'tcx>(
     ecx: &InterpCx<'mir, 'tcx, CompileTimeInterpreter<'mir, 'tcx>>,
     mut error: InterpErrorInfo<'tcx>,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -237,9 +237,8 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
         let r = match f(self) {
             Ok(val) => Some(val),
             Err(error) => {
-                let diagnostic = error_to_const_error(&self.ecx, error);
                 use rustc::mir::interpret::InterpError::*;
-                match diagnostic.error {
+                match error.kind {
                     Exit(_) => bug!("the CTFE program cannot exit"),
                     Unsupported(_)
                     | UndefinedBehavior(_)
@@ -248,6 +247,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                         // Ignore these errors.
                     }
                     Panic(_) => {
+                        let diagnostic = error_to_const_error(&self.ecx, error);
                         diagnostic.report_as_lint(
                             self.ecx.tcx,
                             "this expression will panic at runtime",


### PR DESCRIPTION
This makes `RUSTC_CTFE_BACKTRACE` useful again.

r? @oli-obk 

Fixes https://github.com/rust-lang/rust/issues/63439