### PR TITLE
Update rustfmt to 1.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "rustfmt-nightly"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "annotate-snippets",
  "atty",


### PR DESCRIPTION
This PR updates rustfmt to 1.4.6. [CHANGELOG](https://github.com/rust-lang/rustfmt/blob/v1.4.6/CHANGELOG.md#146-2019-08-28).