### PR TITLE
add missing `#[repr(C)]` on the Slices union

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -2170,6 +2170,7 @@ impl str {
     #[inline(always)]
     #[rustc_const_unstable(feature="const_str_as_bytes")]
     pub const fn as_bytes(&self) -> &[u8] {
+        #[repr(C)]
         union Slices<'a> {
             str: &'a str,
             slice: &'a [u8],


### PR DESCRIPTION
Adds the `#[repr(C)]` attribute to the `Slices` union used to convert an `&str` into a `&[u8]`.
Without the attribute, the union has an unspecified layout: https://doc.rust-lang.org/reference/types/union.html, so performing the 'transmute' is unsound without the attribute (as far as I understand).

The `Repr` union, used for converting a raw ptr + len to a slice has this attribute as well:
https://github.com/rust-lang/rust/blob/master/src/libcore/ptr/mod.rs#L211-#L216