### PR TITLE
When accessing private field of union, do not misidentify it as a struct

### DIFF
--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1396,8 +1396,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.tcx().sess,
             expr.span,
             E0616,
-            "field `{}` of struct `{}` is private",
+            "field `{}` of `{}` `{}` is private",
             field,
+            if let Some(def_kind) = self.tcx().def_kind(base_did){ def_kind.descr(base_did) }
+            else { " " },
             struct_path
         );
         // Also check if an accessible method exists, which is often what is meant.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -1392,14 +1392,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_did: DefId,
     ) {
         let struct_path = self.tcx().def_path_str(base_did);
+        let kind_name = match self.tcx().def_kind(base_did) {
+            Some(def_kind) => def_kind.descr(base_did),
+            _ => " ",
+        };
         let mut err = struct_span_err!(
             self.tcx().sess,
             expr.span,
             E0616,
-            "field `{}` of `{}` `{}` is private",
+            "field `{}` of {} `{}` is private",
             field,
-            if let Some(def_kind) = self.tcx().def_kind(base_did){ def_kind.descr(base_did) }
-            else { " " },
+            kind_name,
             struct_path
         );
         // Also check if an accessible method exists, which is often what is meant.

--- a/src/test/ui/privacy/union-field-privacy-2.rs
+++ b/src/test/ui/privacy/union-field-privacy-2.rs
@@ -11,5 +11,5 @@ fn main() {
 
     let a = u.a; // OK
     let b = u.b; // OK
-    let c = u.c; //~ ERROR field `c` of struct `m::U` is private
+    let c = u.c; //~ ERROR field `c` of union `m::U` is private
 }

--- a/src/test/ui/privacy/union-field-privacy-2.stderr
+++ b/src/test/ui/privacy/union-field-privacy-2.stderr
@@ -1,4 +1,4 @@
-error[E0616]: field `c` of struct `m::U` is private
+error[E0616]: field `c` of union `m::U` is private
   --> $DIR/union-field-privacy-2.rs:14:13
    |
 LL |     let c = u.c;


### PR DESCRIPTION
Fix incorrect error message when accessing private field of union.

Fixes #63976.