### PR TITLE
Small improvement for Ord implementation of integers

### DIFF
--- a/src/libcore/cmp.rs
+++ b/src/libcore/cmp.rs
@@ -1015,8 +1015,8 @@ mod impls {
                     // The order here is important to generate more optimal assembly.
                     // See <https://github.com/rust-lang/rust/issues/63758> for more info.
                     if *self < *other { Less }
-                    else if *self > *other { Greater }
-                    else { Equal }
+                    else if *self == *other { Equal }
+                    else { Greater }
                 }
             }
         )*)

--- a/src/test/codegen/integer-cmp.rs
+++ b/src/test/codegen/integer-cmp.rs
@@ -11,7 +11,7 @@ use std::cmp::Ordering;
 #[no_mangle]
 pub fn cmp_signed(a: i64, b: i64) -> Ordering {
 // CHECK: icmp slt
-// CHECK: icmp sgt
+// CHECK: icmp ne
 // CHECK: zext i1
 // CHECK: select i1
     a.cmp(&b)
@@ -21,7 +21,7 @@ pub fn cmp_signed(a: i64, b: i64) -> Ordering {
 #[no_mangle]
 pub fn cmp_unsigned(a: u32, b: u32) -> Ordering {
 // CHECK: icmp ult
-// CHECK: icmp ugt
+// CHECK: icmp ne
 // CHECK: zext i1
 // CHECK: select i1
     a.cmp(&b)


### PR DESCRIPTION
Godbolt link: https://godbolt.org/z/tuTDOg

### Before

**asm**
```asm
example::cmp:
  mov eax, dword ptr [rdi]
  xor ecx, ecx
  cmp eax, dword ptr [rsi]
  seta cl
  mov eax, 255
  cmovae eax, ecx
  ret
```

**llvm-mca**
```
Iterations:        100
Instructions:      700
Total Cycles:      217
Total uOps:        1100

Dispatch Width:    6
uOps Per Cycle:    5.07
IPC:               3.23
Block RThroughput: 1.8
```

### After

**asm**
```asm
example::cmp:
  mov eax, dword ptr [rdi]
  xor ecx, ecx
  cmp eax, dword ptr [rsi]
  setne cl
  mov eax, 255
  cmovae eax, ecx
  ret
```

**llvm-mca**
```
Iterations:        100
Instructions:      700
Total Cycles:      209
Total uOps:        1000

Dispatch Width:    6
uOps Per Cycle:    4.78
IPC:               3.35
Block RThroughput: 1.7
```

r? @nagisa
