### PR TITLE
Refactor the `MirPass for QualifyAndPromoteConstants`

### DIFF
--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1714,12 +1714,8 @@ impl<'tcx> MirPass<'tcx> for QualifyAndPromoteConstants<'tcx> {
                         },
                         target,
                         ..
-                    } => {
-                        if promoted_temps.contains(index) {
-                            terminator.kind = TerminatorKind::Goto {
-                                target,
-                            };
-                        }
+                    } if promoted_temps.contains(index) => {
+                        terminator.kind = TerminatorKind::Goto { target };
                     }
                     _ => {}
                 }
@@ -1727,7 +1723,7 @@ impl<'tcx> MirPass<'tcx> for QualifyAndPromoteConstants<'tcx> {
         }
 
         // Statics must be Sync.
-        if mode == Mode::Static {
+        if let Mode::Static = mode {
             // `#[thread_local]` statics don't have to be `Sync`.
             for attr in &tcx.get_attrs(def_id)[..] {
                 if attr.check_name(sym::thread_local) {

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1650,16 +1650,10 @@ impl<'tcx> MirPass<'tcx> for QualifyAndPromoteConstants<'tcx> {
                 promote_consts::promote_candidates(def_id, body, tcx, temps, candidates)
             );
         } else {
-            let const_promoted_temps = match mode {
-                Mode::Const => Some(tcx.mir_const_qualif(def_id).1),
-                _ => None,
-            };
-
             check_short_circuiting_in_const_local(tcx, body, mode);
 
             let promoted_temps = match mode {
-                // Already computed by `mir_const_qualif`.
-                Mode::Const => const_promoted_temps.unwrap(),
+                Mode::Const => tcx.mir_const_qualif(def_id).1,
                 _ => Checker::new(tcx, def_id, body, mode).check_const().1,
             };
 


### PR DESCRIPTION
This is an accumulation of drive-by commits while working on `Vec::new` as a stable `const fn`.
The PR is probably easiest read commit-by-commit.

r? @oli-obk 

cc @eddyb @ecstatic-morse -- your two PRs https://github.com/rust-lang/rust/pull/63812 and https://github.com/rust-lang/rust/pull/63860 respectively will conflict with this a tiny bit but it should be trivial to reintegrate your changes atop of this.