### PR TITLE
Make `CStr` an extern type

### DIFF
--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -123,79 +123,82 @@ pub struct CString {
     inner: Box<[u8]>,
 }
 
-extern {
-    /// Representation of a borrowed C string.
-    ///
-    /// This type represents a borrowed reference to a nul-terminated
-    /// array of bytes. It can be constructed safely from a `&[`[`u8`]`]`
-    /// slice, or unsafely from a raw `*const c_char`. It can then be
-    /// converted to a Rust [`&str`] by performing UTF-8 validation, or
-    /// into an owned [`CString`].
-    ///
-    /// `&CStr` is to [`CString`] as [`&str`] is to [`String`]: the former
-    /// in each pair are borrowed references; the latter are owned
-    /// strings.
-    ///
-    /// Note that this structure is `repr(C)` and is can be
-    /// placed in the signatures of FFI functions. A `&CStr` is equivalent to `*const c_char`,
-    /// but offers a much richer API
-    ///
-    /// # Examples
-    ///
-    /// Inspecting a foreign C string:
-    ///
-    /// ```ignore (extern-declaration)
-    /// use std::ffi::CStr;
-    /// use std::os::raw::c_char;
-    ///
-    /// extern { fn my_string() -> *const c_char; }
-    ///
-    /// unsafe {
-    ///     let slice = CStr::from_ptr(my_string());
-    ///     println!("string buffer size without nul terminator: {}", slice.to_bytes().len());
-    /// }
-    /// ```
-    ///
-    /// Passing a Rust-originating C string:
-    ///
-    /// ```ignore (extern-declaration)
-    /// use std::ffi::{CString, CStr};
-    /// use std::os::raw::c_char;
-    ///
-    /// fn work(data: &CStr) {
-    ///     extern { fn work_with(data: *const c_char); }
-    ///
-    ///     unsafe { work_with(data.as_ptr()) }
-    /// }
-    ///
-    /// let s = CString::new("data data data data").expect("CString::new failed");
-    /// work(&s);
-    /// ```
-    ///
-    /// Converting a foreign C string into a Rust [`String`]:
-    ///
-    /// ```ignore (extern-declaration)
-    /// use std::ffi::CStr;
-    /// use std::os::raw::c_char;
-    ///
-    /// extern { fn my_string() -> *const c_char; }
-    ///
-    /// fn my_string_safe() -> String {
-    ///     unsafe {
-    ///         CStr::from_ptr(my_string()).to_string_lossy().into_owned()
-    ///     }
-    /// }
-    ///
-    /// println!("string: {}", my_string_safe());
-    /// ```
-    ///
-    /// [`u8`]: ../primitive.u8.html
-    /// [`&str`]: ../primitive.str.html
-    /// [`String`]: ../string/struct.String.html
-    /// [`CString`]: struct.CString.html
-    /// [`from_ptr`]: #method.from_ptr
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub type CStr;
+/// Representation of a borrowed C string.
+///
+/// This type represents a borrowed reference to a nul-terminated
+/// array of bytes. It can be constructed safely from a `&[`[`u8`]`]`
+/// slice, or unsafely from a raw `*const c_char`. It can then be
+/// converted to a Rust [`&str`] by performing UTF-8 validation, or
+/// into an owned [`CString`].
+///
+/// `&CStr` is to [`CString`] as [`&str`] is to [`String`]: the former
+/// in each pair are borrowed references; the latter are owned
+/// strings.
+///
+/// Note that this structure is `repr(C)` and is can be
+/// placed in the signatures of FFI functions. A `&CStr` is equivalent to `*const c_char`,
+/// but offers a much richer API
+///
+/// # Examples
+///
+/// Inspecting a foreign C string:
+///
+/// ```ignore (extern-declaration)
+/// use std::ffi::CStr;
+/// use std::os::raw::c_char;
+///
+/// extern { fn my_string() -> *const c_char; }
+///
+/// unsafe {
+///     let slice = CStr::from_ptr(my_string());
+///     println!("string buffer size without nul terminator: {}", slice.to_bytes().len());
+/// }
+/// ```
+///
+/// Passing a Rust-originating C string:
+///
+/// ```ignore (extern-declaration)
+/// use std::ffi::{CString, CStr};
+/// use std::os::raw::c_char;
+///
+/// fn work(data: &CStr) {
+///     extern { fn work_with(data: *const c_char); }
+///
+///     unsafe { work_with(data.as_ptr()) }
+/// }
+///
+/// let s = CString::new("data data data data").expect("CString::new failed");
+/// work(&s);
+/// ```
+///
+/// Converting a foreign C string into a Rust [`String`]:
+///
+/// ```ignore (extern-declaration)
+/// use std::ffi::CStr;
+/// use std::os::raw::c_char;
+///
+/// extern { fn my_string() -> *const c_char; }
+///
+/// fn my_string_safe() -> String {
+///     unsafe {
+///         CStr::from_ptr(my_string()).to_string_lossy().into_owned()
+///     }
+/// }
+///
+/// println!("string: {}", my_string_safe());
+/// ```
+///
+/// [`u8`]: ../primitive.u8.html
+/// [`&str`]: ../primitive.str.html
+/// [`String`]: ../string/struct.String.html
+/// [`CString`]: struct.CString.html
+/// [`from_ptr`]: #method.from_ptr
+#[stable(feature = "rust1", since = "1.0.0")]
+pub struct CStr(CStrExtern);
+
+extern "C" {
+    // HACK: workaround for https://github.com/rust-lang/rust/issues/46665
+    type CStrExtern;
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -137,7 +137,7 @@ pub struct CString {
 ///
 /// Note that this structure is `repr(C)` and is can be
 /// placed in the signatures of FFI functions. A `&CStr` is equivalent to `*const c_char`,
-/// but offers a much richer API
+/// but offers a richer API.
 ///
 /// # Examples
 ///
@@ -204,8 +204,8 @@ extern "C" {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Hash for CStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // we also hash a trailing zero in order to make CStr and CString produce the same hash
-        // for the same string
+        // We also hash a trailing zero to make `CStr` and `CString` produce the same hash
+        // for the same string.
         self.to_bytes_with_nul().hash(state);
     }
 }
@@ -1136,7 +1136,7 @@ impl CStr {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn to_bytes_with_nul(&self) -> &[u8] {
-        // safety: safe references to `CStr` can only exist if they point to a memory location
+        // SAFETY: safe references to `CStr` can only exist if they point to a memory location
         // that is terminated by a `\0`.
         unsafe {
             let len = sys::strlen(self as *const CStr as *const c_char);

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -137,7 +137,8 @@ pub struct CString {
 ///
 /// Note that this structure is `repr(C)` and is can be
 /// placed in the signatures of FFI functions. A `&CStr` is equivalent to `*const c_char`,
-/// but offers a richer API.
+/// but offers a richer API. If you want to handle null pointers, too, using an
+/// `Option<&CStr>` will work.
 ///
 /// # Examples
 ///

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -599,7 +599,11 @@ impl CString {
     /// ```
     #[stable(feature = "into_boxed_c_str", since = "1.20.0")]
     pub fn into_boxed_c_str(self) -> Box<CStr> {
-        unsafe { Box::from_raw(Box::into_raw(self.into_inner()) as *mut CStr) }
+        let ptr: *mut [u8] = Box::into_raw(self.into_inner());
+        // SAFETY: Casting away the length information is fine as `CStr`'s length computation works
+        // by counting the elements up to the first null. Since this `CString` must be null
+        // terminated, the `CStr` can properly compute its length
+        unsafe { Box::from_raw(ptr as *mut CStr) }
     }
 
     /// Bypass "move out of struct which implements [`Drop`] trait" restriction.

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -135,7 +135,7 @@ pub struct CString {
 /// in each pair are borrowed references; the latter are owned
 /// strings.
 ///
-/// Note that this structure is `repr(C)` and is can be
+/// Note that this structure is `repr(C)` and can be
 /// placed in the signatures of FFI functions. A `&CStr` is equivalent to `*const c_char`,
 /// but offers a richer API. If you want to handle null pointers, too, using an
 /// `Option<&CStr>` will work.

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -204,7 +204,9 @@ extern "C" {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Hash for CStr {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_bytes().hash(state)
+        // we also hash a trailing zero in order to make CStr and CString produce the same hash
+        // for the same string
+        self.to_bytes_with_nul().hash(state);
     }
 }
 

--- a/src/libstd/ffi/c_str.rs
+++ b/src/libstd/ffi/c_str.rs
@@ -938,13 +938,10 @@ impl CStr {
     /// allows inspection and interoperation of non-owned C strings. This method
     /// is unsafe for a number of reasons:
     ///
-    /// * There is no guarantee to the validity of `ptr`.
-    /// * The returned lifetime is not guaranteed to be the actual lifetime of
-    ///   `ptr`.
-    /// * There is no guarantee that the memory pointed to by `ptr` contains a
-    ///   valid nul terminator byte at the end of the string.
-    /// * It is not guaranteed that the memory pointed by `ptr` won't change
-    ///   before the `CStr` has been destroyed.
+    /// * The pointer must be non-null,
+    /// * The returned lifetime must be actual lifetime of the memory that `ptr` points to,
+    /// * The memory pointed to by `ptr` must have a nul terminator byte within the allocation,
+    /// * The memory pointed by `ptr` must not be modified before the `CStr` has been destroyed.
     ///
     /// # Examples
     ///

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -263,6 +263,7 @@
 #![feature(exact_size_is_empty)]
 #![feature(exhaustive_patterns)]
 #![feature(external_doc)]
+#![feature(extern_types)]
 #![feature(fn_traits)]
 #![feature(format_args_nl)]
 #![feature(generator_trait)]


### PR DESCRIPTION
This shrinks `&CStr` to one word size and is thus equivalent to `*const c_char`, making it possible to use `&CStr` types directly in FFI APIs instead of having to convert from and to at the FFI boundaries