### PR TITLE
Harden `param_attrs` test wrt. usage of a proc macro `#[attr]`

### DIFF
--- a/src/test/ui/rfc-2565-param-attrs/auxiliary/ident-mac.rs
+++ b/src/test/ui/rfc-2565-param-attrs/auxiliary/ident-mac.rs
@@ -1,0 +1,11 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn id(_: TokenStream, input: TokenStream) -> TokenStream { input }

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.rs
@@ -1,0 +1,60 @@
+// aux-build:ident-mac.rs
+
+#![feature(param_attrs)]
+#![feature(c_variadic)]
+
+extern crate ident_mac;
+use ident_mac::id;
+
+struct W(u8);
+
+extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
+//~^ ERROR the attribute `id` is currently unknown to the compiler
+//~| ERROR the attribute `id` is currently unknown to the compiler
+
+unsafe extern "C" fn cvar(arg1: i32, #[id] mut args: ...) {}
+//~^ ERROR the attribute `id` is currently unknown to the compiler
+
+type Alias = extern "C" fn(#[id] u8, #[id] ...);
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+
+fn free(#[id] arg1: u8) {
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    let lam = |#[id] W(x), #[id] y| ();
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+}
+
+impl W {
+    fn inherent1(#[id] self, #[id] arg1: u8) {}
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn inherent2(#[id] &self, #[id] arg1: u8) {}
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+}
+
+trait A {
+    fn trait1(#[id] self, #[id] arg1: u8);
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn trait2(#[id] &self, #[id] arg1: u8);
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
+    //~^ ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+    //~| ERROR the attribute `id` is currently unknown to the compiler
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/proc-macro-cannot-be-used.stderr
@@ -1,0 +1,228 @@
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:11:21
+   |
+LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
+   |                     ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:11:38
+   |
+LL | extern "C" { fn ffi(#[id] arg1: i32, #[id] ...); }
+   |                                      ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:15:38
+   |
+LL | unsafe extern "C" fn cvar(arg1: i32, #[id] mut args: ...) {}
+   |                                      ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:18:28
+   |
+LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
+   |                            ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:18:38
+   |
+LL | type Alias = extern "C" fn(#[id] u8, #[id] ...);
+   |                                      ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:22:9
+   |
+LL | fn free(#[id] arg1: u8) {
+   |         ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:24:16
+   |
+LL |     let lam = |#[id] W(x), #[id] y| ();
+   |                ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:24:28
+   |
+LL |     let lam = |#[id] W(x), #[id] y| ();
+   |                            ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:30:18
+   |
+LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
+   |                  ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:30:30
+   |
+LL |     fn inherent1(#[id] self, #[id] arg1: u8) {}
+   |                              ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:33:18
+   |
+LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
+   |                  ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:33:31
+   |
+LL |     fn inherent2(#[id] &self, #[id] arg1: u8) {}
+   |                               ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:36:22
+   |
+LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
+   |                      ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:36:42
+   |
+LL |     fn inherent3<'a>(#[id] &'a mut self, #[id] arg1: u8) {}
+   |                                          ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:39:22
+   |
+LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
+   |                      ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:39:45
+   |
+LL |     fn inherent4<'a>(#[id] self: Box<Self>, #[id] arg1: u8) {}
+   |                                             ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:45:15
+   |
+LL |     fn trait1(#[id] self, #[id] arg1: u8);
+   |               ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:45:27
+   |
+LL |     fn trait1(#[id] self, #[id] arg1: u8);
+   |                           ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:48:15
+   |
+LL |     fn trait2(#[id] &self, #[id] arg1: u8);
+   |               ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:48:28
+   |
+LL |     fn trait2(#[id] &self, #[id] arg1: u8);
+   |                            ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:51:19
+   |
+LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
+   |                   ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:51:39
+   |
+LL |     fn trait3<'a>(#[id] &'a mut self, #[id] arg1: u8);
+   |                                       ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:54:19
+   |
+LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
+   |                   ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:54:42
+   |
+LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
+   |                                          ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error[E0658]: the attribute `id` is currently unknown to the compiler and may have meaning added to it in the future
+  --> $DIR/proc-macro-cannot-be-used.rs:54:58
+   |
+LL |     fn trait4<'a>(#[id] self: Box<Self>, #[id] arg1: u8, #[id] Vec<u8>);
+   |                                                          ^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(custom_attribute)]` to the crate attributes to enable
+
+error: aborting due to 25 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
The `param-attrs-builtin-attrs.rs` test file uses the `#[test]` attribute which should cover this but `#[test]` isn't a proc macro attribute so we add another test to be on the safe side. This intends to address https://github.com/rust-lang/rust/pull/64010#issuecomment-526564316.

r? @nikomatsakis 

cc @c410-f3r @petrochenkov 
cc https://github.com/rust-lang/rust/issues/60406