### PR TITLE
rustdoc use -Ccodegen-units=1 by default for test compile

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -263,6 +263,7 @@ fn run_test(
     for extern_str in &options.extern_strs {
         compiler.arg("--extern").arg(&extern_str);
     }
+    compiler.arg("-Ccodegen-units=1");
     for codegen_options_str in &options.codegen_options_strs {
         compiler.arg("-C").arg(&codegen_options_str);
     }


### PR DESCRIPTION
as the test is small we do not want split up in multiple codegen units
and also as there is multiple test running at the same time this
will reduce the number of concurrent threads

tested the test time with `./x.py test src/libcore --doc`
for my 16 core 32 thread cpu i get about 6% faster execution
and my 2 core 4 thread cpu I get about 10% faster execution

cc #63638
 r? @Mark-Simulacrum
