### PR TITLE
[WIP] select rustc to run in rustdoc with env var RUSTC

### DIFF
--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -241,7 +241,12 @@ fn run_test(
     };
     let output_file = outdir.path().join("rust_out");
 
-    let mut compiler = Command::new(std::env::current_exe().unwrap().with_file_name("rustc"));
+    let mut compiler = if let Some(rustc) = env::var_os("RUSTC"){
+        Command::new(&rustc)
+    }else {
+        let rustc = std::env::current_exe().unwrap_or_default().with_file_name("rustc");
+        Command::new(&rustc)
+    };
     compiler.arg("--crate-type").arg("bin");
     for cfg in &options.cfgs {
         compiler.arg("--cfg").arg(&cfg);


### PR DESCRIPTION
handle the case that current_exe return none by falling back to calling rustc

I do not understand why the bootstrap have e.g. rustdoc from stage2 and the RUSTC set to stage0

r? @Mark-Simulacrum

