### PR TITLE
Fix word repetition in str documentation

### DIFF
--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -3558,7 +3558,7 @@ impl str {
     /// A string is a sequence of bytes. `start` in this context means the first
     /// position of that byte string; for a left-to-right language like English or
     /// Russian, this will be left side, and for right-to-left languages like
-    /// like Arabic or Hebrew, this will be the right side.
+    /// Arabic or Hebrew, this will be the right side.
     ///
     /// # Examples
     ///
@@ -3595,7 +3595,7 @@ impl str {
     /// A string is a sequence of bytes. `end` in this context means the last
     /// position of that byte string; for a left-to-right language like English or
     /// Russian, this will be right side, and for right-to-left languages like
-    /// like Arabic or Hebrew, this will be the left side.
+    /// Arabic or Hebrew, this will be the left side.
     ///
     /// # Examples
     ///
@@ -3762,7 +3762,7 @@ impl str {
     /// A string is a sequence of bytes. `start` in this context means the first
     /// position of that byte string; for a left-to-right language like English or
     /// Russian, this will be left side, and for right-to-left languages like
-    /// like Arabic or Hebrew, this will be the right side.
+    /// Arabic or Hebrew, this will be the right side.
     ///
     /// # Examples
     ///
@@ -3801,7 +3801,7 @@ impl str {
     /// A string is a sequence of bytes. `end` in this context means the last
     /// position of that byte string; for a left-to-right language like English or
     /// Russian, this will be right side, and for right-to-left languages like
-    /// like Arabic or Hebrew, this will be the left side.
+    /// Arabic or Hebrew, this will be the left side.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Fixes a few repetitions of "like like" in the `trim*` methods documentation of `str`.