### PR TITLE
Add x86_64-linux-kernel target

### DIFF
--- a/src/librustc_target/spec/linux_kernel_base.rs
+++ b/src/librustc_target/spec/linux_kernel_base.rs
@@ -1,0 +1,26 @@
+use crate::spec::{LinkArgs, LinkerFlavor, PanicStrategy, RelroLevel, TargetOptions};
+use std::default::Default;
+
+pub fn opts() -> TargetOptions {
+    let mut pre_link_args = LinkArgs::new();
+    pre_link_args.insert(
+        LinkerFlavor::Gcc,
+        vec!["-Wl,--as-needed".to_string(), "-Wl,-z,noexecstack".to_string()],
+    );
+
+    TargetOptions {
+        disable_redzone: true,
+        panic_strategy: PanicStrategy::Abort,
+        stack_probes: true,
+        eliminate_frame_pointer: false,
+        linker_is_gnu: true,
+        position_independent_executables: true,
+        needs_plt: true,
+        relro_level: RelroLevel::Full,
+        relocation_model: "static".to_string(),
+        target_family: Some("unix".to_string()),
+        pre_link_args,
+
+        ..Default::default()
+    }
+}

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -53,6 +53,7 @@ mod freebsd_base;
 mod haiku_base;
 mod hermit_base;
 mod linux_base;
+mod linux_kernel_base;
 mod linux_musl_base;
 mod openbsd_base;
 mod netbsd_base;
@@ -385,6 +386,8 @@ supported_targets! {
     ("armv7-linux-androideabi", armv7_linux_androideabi),
     ("thumbv7neon-linux-androideabi", thumbv7neon_linux_androideabi),
     ("aarch64-linux-android", aarch64_linux_android),
+
+    ("x86_64-linux-kernel", x86_64_linux_kernel),
 
     ("aarch64-unknown-freebsd", aarch64_unknown_freebsd),
     ("armv6-unknown-freebsd", armv6_unknown_freebsd),

--- a/src/librustc_target/spec/x86_64_linux_kernel.rs
+++ b/src/librustc_target/spec/x86_64_linux_kernel.rs
@@ -1,0 +1,31 @@
+// This defines the amd64 target for the Linux Kernel. See the linux-kernel-base module for
+// generic Linux kernel options.
+
+use crate::spec::{LinkerFlavor, Target, TargetResult};
+
+pub fn target() -> TargetResult {
+    let mut base = super::linux_kernel_base::opts();
+    base.cpu = "x86-64".to_string();
+    base.max_atomic_width = Some(64);
+    base.features =
+        "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float"
+            .to_string();
+    base.code_model = Some("kernel".to_string());
+    base.pre_link_args.get_mut(&LinkerFlavor::Gcc).unwrap().push("-m64".to_string());
+
+    Ok(Target {
+        // FIXME: Some dispute, the linux-on-clang folks think this should use "Linux"
+        llvm_target: "x86_64-elf".to_string(),
+        target_endian: "little".to_string(),
+        target_pointer_width: "64".to_string(),
+        target_c_int_width: "32".to_string(),
+        data_layout: "e-m:e-i64:64-f80:128-n8:16:32:64-S128".to_string(),
+        target_os: "none".to_string(),
+        target_env: "gnu".to_string(),
+        target_vendor: "unknown".to_string(),
+        arch: "x86_64".to_string(),
+        linker_flavor: LinkerFlavor::Gcc,
+
+        options: base,
+    })
+}


### PR DESCRIPTION
This adds a target specification for Linux kernel modules on x86_64, as well as base code that can be shared with other architectures.

I wasn't totally sure about what the best name for this was.

There's one open question on whether we should use the LLVM generic x86_64-elf target, or the same one used for the Linux userspace.

r? @joshtriplett 