### PR TITLE
Rename test locals to work around LLDB bug

### DIFF
--- a/src/test/debuginfo/boxed-struct.rs
+++ b/src/test/debuginfo/boxed-struct.rs
@@ -8,11 +8,11 @@
 
 // gdb-command:run
 
-// gdb-command:print *unique
+// gdb-command:print *boxed_with_padding
 // gdbg-check:$1 = {x = 99, y = 999, z = 9999, w = 99999}
 // gdbr-check:$1 = boxed_struct::StructWithSomePadding {x: 99, y: 999, z: 9999, w: 99999}
 
-// gdb-command:print *unique_dtor
+// gdb-command:print *boxed_with_dtor
 // gdbg-check:$2 = {x = 77, y = 777, z = 7777, w = 77777}
 // gdbr-check:$2 = boxed_struct::StructWithDestructor {x: 77, y: 777, z: 7777, w: 77777}
 
@@ -21,13 +21,13 @@
 
 // lldb-command:run
 
-// lldb-command:print *unique
+// lldb-command:print *boxed_with_padding
 // lldbg-check:[...]$0 = StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 }
-// lldbr-check:(boxed_struct::StructWithSomePadding) *unique = StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 }
+// lldbr-check:(boxed_struct::StructWithSomePadding) *boxed_with_padding = StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 }
 
-// lldb-command:print *unique_dtor
+// lldb-command:print *boxed_with_dtor
 // lldbg-check:[...]$1 = StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 }
-// lldbr-check:(boxed_struct::StructWithDestructor) *unique_dtor = StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 }
+// lldbr-check:(boxed_struct::StructWithDestructor) *boxed_with_dtor = StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 }
 
 #![allow(unused_variables)]
 #![feature(box_syntax)]
@@ -54,9 +54,9 @@ impl Drop for StructWithDestructor {
 
 fn main() {
 
-    let unique: Box<_> = box StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 };
+    let boxed_with_padding: Box<_> = box StructWithSomePadding { x: 99, y: 999, z: 9999, w: 99999 };
 
-    let unique_dtor: Box<_> = box StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 };
+    let boxed_with_dtor: Box<_> = box StructWithDestructor { x: 77, y: 777, z: 7777, w: 77777 };
     zzz(); // #break
 }
 


### PR DESCRIPTION
LLDB's expression parser can't unambiguously resolve local variables in
some cases, as described in #47938. Work around this by using names that
don't shadow direct submodules of `core`.

Closes #64050.