### PR TITLE
librustc_errors: Extract sugg/subst handling into method

### DIFF
--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -30,10 +30,8 @@ pub struct AnnotateSnippetEmitterWriter {
 impl Emitter for AnnotateSnippetEmitterWriter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, db: &DiagnosticBuilder<'_>) {
-        let primary_span = db.span.clone();
         let children = db.children.clone();
-        // FIXME(#59346): Collect suggestions (see emitter.rs)
-        let suggestions: &[_] = &[];
+        let (primary_span, suggestions) = self.primary_span_formatted(&db);
 
         // FIXME(#59346): Add `fix_multispans_in_std_macros` function from emitter.rs
 


### PR DESCRIPTION
An initial refactoring before working on #61809.

This moves the whole block into a method so that it can be reused in the
annotate-snippet emitter. The method is already used in the new emitter, but
there's no UI tests with suggestions included in this PR.

A first look at some UI tests with suggestions showed that there's some
more work to do in [annotate-snippet-rs][annotate-snippet-rs] before the new output is closer to the
current one, so I opted to do that in a second step.

r? @estebank 

[annotate-snippet-rs]: https://github.com/rust-lang/annotate-snippets-rs