### PR TITLE
Stop emitting impls for PartialEq::ne and PartialOrd::{lt, le, gt, ge}

### DIFF
--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -57,9 +57,6 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
     fn cs_eq(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
         cs_op(cx, span, substr, BinOpKind::Eq, BinOpKind::And, true)
     }
-    fn cs_ne(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<Expr> {
-        cs_op(cx, span, substr, BinOpKind::Ne, BinOpKind::Or, false)
-    }
 
     macro_rules! md {
         ($name:expr, $f:ident) => { {
@@ -81,13 +78,7 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
         } }
     }
 
-    // avoid defining `ne` if we can
-    // c-like enums, enums without any fields and structs without fields
-    // can safely define only `eq`.
-    let mut methods = vec![md!("eq", cs_eq)];
-    if !is_type_without_fields(item) {
-        methods.push(md!("ne", cs_ne));
-    }
+    let methods = vec![md!("eq", cs_eq)];
 
     let trait_def = TraitDef {
         span,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1771,19 +1771,3 @@ pub fn cs_fold1<F, B>(use_foldl: bool,
         }
     }
 }
-
-/// Returns `true` if the type has no value fields
-/// (for an enum, no variant has any fields)
-pub fn is_type_without_fields(item: &Annotatable) -> bool {
-    if let Annotatable::Item(ref item) = *item {
-        match item.node {
-            ast::ItemKind::Enum(ref enum_def, _) => {
-                enum_def.variants.iter().all(|v| v.data.fields().is_empty())
-            }
-            ast::ItemKind::Struct(ref variant_data, _) => variant_data.fields().is_empty(),
-            _ => false,
-        }
-    } else {
-        false
-    }
-}


### PR DESCRIPTION
These are never better optimized than calling the main method (eq,
partial_cmp) in the derived case. This makes us generate far less code,
which is a compile time win.

r? @ghost

Mostly opening this so that I can run perf on it to get a loose sense of whether this is worth it or not.