### PR TITLE
Replace file_stem by file_name in rustdoc markdown

### DIFF
--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -43,7 +43,7 @@ pub fn render(
     edition: Edition
 ) -> i32 {
     let mut output = options.output;
-    output.push(input.file_stem().unwrap());
+    output.push(input.file_name().unwrap());
     output.set_extension("html");
 
     let mut css = String::new();


### PR DESCRIPTION
Before this PR, a file name like `some.file.md` will be output to a file named `some.html` with is not correct because the expected output file must be `some.file.html`