### PR TITLE
Even more optimal Ord implementation for integers

### DIFF
--- a/src/test/codegen/integer-cmp.rs
+++ b/src/test/codegen/integer-cmp.rs
@@ -1,5 +1,5 @@
 // This is test for more optimal Ord implementation for integers.
-// See <https://github.com/rust-lang/rust/issues/63758> for more info.
+// See <https://github.com/rust-lang/rust/pull/64082> for more info.
 
 // compile-flags: -C opt-level=3
 
@@ -10,19 +10,59 @@ use std::cmp::Ordering;
 // CHECK-LABEL: @cmp_signed
 #[no_mangle]
 pub fn cmp_signed(a: i64, b: i64) -> Ordering {
-// CHECK: icmp slt
-// CHECK: icmp ne
+// CHECK: icmp sgt
 // CHECK: zext i1
-// CHECK: select i1
+// CHECK: icmp slt
+// CHECK: zext i1
+// CHECK: sub nsw
+// CHECK-NOT: select
     a.cmp(&b)
 }
 
 // CHECK-LABEL: @cmp_unsigned
 #[no_mangle]
 pub fn cmp_unsigned(a: u32, b: u32) -> Ordering {
-// CHECK: icmp ult
-// CHECK: icmp ne
+// CHECK: icmp ugt
 // CHECK: zext i1
-// CHECK: select i1
+// CHECK: icmp ult
+// CHECK: zext i1
+// CHECK: sub nsw
+// CHECK-NOT: select
     a.cmp(&b)
+}
+
+// CHECK-LABEL: @cmp_signed_lt
+#[no_mangle]
+pub fn cmp_signed_lt(a: &i64, b: &i64) -> bool {
+// CHECK: icmp slt
+// CHECK-NOT: sub
+// CHECK-NOT: select
+    Ord::cmp(a, b) < Ordering::Equal
+}
+
+// CHECK-LABEL: @cmp_unsigned_lt
+#[no_mangle]
+pub fn cmp_unsigned_lt(a: &u32, b: &u32) -> bool {
+// CHECK: icmp ult
+// CHECK-NOT: sub
+// CHECK-NOT: select
+    Ord::cmp(a, b) < Ordering::Equal
+}
+
+// CHECK-LABEL: @cmp_signed_eq
+#[no_mangle]
+pub fn cmp_signed_eq(a: &i64, b: &i64) -> bool {
+// CHECK: icmp eq
+// CHECK-NOT: sub
+// CHECK-NOT: select
+    Ord::cmp(a, b) == Ordering::Equal
+}
+
+// CHECK-LABEL: @cmp_unsigned_eq
+#[no_mangle]
+pub fn cmp_unsigned_eq(a: &u32, b: &u32) -> bool {
+// CHECK: icmp eq
+// CHECK-NOT: sub
+// CHECK-NOT: select
+    Ord::cmp(a, b) == Ordering::Equal
 }


### PR DESCRIPTION
When I saw https://github.com/rust-lang/rust/pull/63767 it made me think of https://github.com/rust-lang/rust/pull/61635, and I noticed I could use the same trick from the latter of those for `cmp`: https://godbolt.org/z/XCDDt7

Before:
```asm
  mov eax, dword ptr [rdi]
  xor ecx, ecx
  cmp eax, dword ptr [rsi]
  seta cl
  mov eax, 255
  cmovae eax, ecx
```

After:
```asm
  mov eax, dword ptr [rdi]
  cmp eax, dword ptr [rsi]
  seta al
  sbb al, 0
```

Old llvm-mca statistics:
```
Iterations:        100
Instructions:      700
Total Cycles:      217
Total uOps:        1100

Dispatch Width:    6
uOps Per Cycle:    5.07
IPC:               3.23
Block RThroughput: 1.8
```

New llvm-mca statistics:
```
Iterations:        100
Instructions:      500
Total Cycles:      214
Total uOps:        1000

Dispatch Width:    6
uOps Per Cycle:    4.67
IPC:               2.34
Block RThroughput: 1.7
```

r? @nagisa 
