### PR TITLE
Update xLTO compatibility table in rustc book.

### DIFF
--- a/src/doc/rustc/src/linker-plugin-lto.md
+++ b/src/doc/rustc/src/linker-plugin-lto.md
@@ -105,5 +105,6 @@ The following table shows known good combinations of toolchain versions.
 | Rust 1.34 |     ✗     |     ✓     |
 | Rust 1.35 |     ✗     |     ✓     |
 | Rust 1.36 |     ✗     |     ✓     |
+| Rust 1.37 |     ✗     |     ✓     |
 
 Note that the compatibility policy for this feature might change in the future.


### PR DESCRIPTION
This is a combination known to work reliable when building Firefox on all the major platforms.

r? @alexcrichton 