### PR TITLE
Improve searching in rustdoc and add tests

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -547,6 +547,11 @@ if (!DOMTokenList.prototype.remove) {
                 results.sort(function(aaa, bbb) {
                     var a, b;
 
+                    // sort by exact match with regard to the last word (mismatch goes later)
+                    a = (aaa.word !== val);
+                    b = (bbb.word !== val);
+                    if (a !== b) { return a - b; }
+
                     // Sort by non levenshtein results and then levenshtein results by the distance
                     // (less changes required to match means higher rankings)
                     a = (aaa.lev);
@@ -556,11 +561,6 @@ if (!DOMTokenList.prototype.remove) {
                     // sort by crate (non-current crate goes later)
                     a = (aaa.item.crate !== window.currentCrate);
                     b = (bbb.item.crate !== window.currentCrate);
-                    if (a !== b) { return a - b; }
-
-                    // sort by exact match (mismatch goes later)
-                    a = (aaa.word !== valLower);
-                    b = (bbb.word !== valLower);
                     if (a !== b) { return a - b; }
 
                     // sort by item name length (longer goes later)
@@ -1028,7 +1028,7 @@ if (!DOMTokenList.prototype.remove) {
                         if (lev > MAX_LEV_DISTANCE) {
                             continue;
                         } else if (lev > 0) {
-                            lev_add = 1;
+                            lev_add = lev / 10;
                         }
                     }
 
@@ -1099,10 +1099,6 @@ if (!DOMTokenList.prototype.remove) {
                     if (index !== -1 || lev <= MAX_LEV_DISTANCE) {
                         if (index !== -1 && paths.length < 2) {
                             lev = 0;
-                        } else if (searchWords[j] === val) {
-                            // Small trick to fix when you're looking for a one letter type
-                            // and there are other short named types.
-                            lev = -1;
                         }
                         if (results[fullId] === undefined) {
                             results[fullId] = {

--- a/src/test/rustdoc-js-std/vec-new.js
+++ b/src/test/rustdoc-js-std/vec-new.js
@@ -4,5 +4,6 @@ const EXPECTED = {
     'others': [
         { 'path': 'std::vec::Vec', 'name': 'new' },
         { 'path': 'std::vec::Vec', 'name': 'ne' },
+        { 'path': 'std::rc::Rc', 'name': 'ne' },
     ],
 };

--- a/src/test/rustdoc-js/exact-match.js
+++ b/src/test/rustdoc-js/exact-match.js
@@ -1,0 +1,9 @@
+const QUERY = 'si::pc';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'exact_match::Si', 'name': 'pc' },
+        { 'path': 'exact_match::Psi', 'name': 'pc' },
+        { 'path': 'exact_match::Si', 'name': 'pa' },
+    ],
+};

--- a/src/test/rustdoc-js/exact-match.rs
+++ b/src/test/rustdoc-js/exact-match.rs
@@ -66,9 +66,3 @@ imp!(Dp, Ep, Fp, Gp, Hp, Ip, Jp, Kp, Lp, Mp, Np, Op, Pp, Qp, Rp, Sp, Tp, Up, Vp,
 en!(Place, Plac, Plae, Plce, Pace, Scalar, Scalr, Scaar, Sclar, Salar);
 
 pub struct P;
-
-pub struct VeryLongTypeName;
-impl VeryLongTypeName {
-    pub fn p() {}
-    pub fn ap() {}
-}

--- a/src/test/rustdoc-js/module-substring.js
+++ b/src/test/rustdoc-js/module-substring.js
@@ -1,0 +1,9 @@
+const QUERY = 'ig::pc';
+
+const EXPECTED = {
+    'others': [
+        { 'path': 'module_substring::Sig', 'name': 'pc' },
+        { 'path': 'module_substring::Si', 'name': 'pc' },
+        { 'path': 'module_substring::Si', 'name': 'pa' },
+    ],
+};

--- a/src/test/rustdoc-js/module-substring.rs
+++ b/src/test/rustdoc-js/module-substring.rs
@@ -66,9 +66,3 @@ imp!(Dp, Ep, Fp, Gp, Hp, Ip, Jp, Kp, Lp, Mp, Np, Op, Pp, Qp, Rp, Sp, Tp, Up, Vp,
 en!(Place, Plac, Plae, Plce, Pace, Scalar, Scalr, Scaar, Sclar, Salar);
 
 pub struct P;
-
-pub struct VeryLongTypeName;
-impl VeryLongTypeName {
-    pub fn p() {}
-    pub fn ap() {}
-}

--- a/src/test/rustdoc-js/search-short-types.js
+++ b/src/test/rustdoc-js/search-short-types.js
@@ -3,6 +3,8 @@ const QUERY = 'P';
 const EXPECTED = {
     'others': [
         { 'path': 'search_short_types', 'name': 'P' },
+        { 'path': 'search_short_types::VeryLongTypeName', 'name': 'p' },
         { 'path': 'search_short_types', 'name': 'Ap' },
+        { 'path': 'search_short_types::VeryLongTypeName', 'name': 'ap' },
     ],
 };


### PR DESCRIPTION
👋 I have made searching in rustdoc more intuitive, added a couple more tests and made a little shell script to aid testing. Closes #63005.

It took me quite a while to figure out how to run the tests for rustdoc (instead of running tests for other crates with rustdoc); the only pointer I found was [hidden in the rustc book](https://rust-lang.github.io/rustc-guide/rustdoc.html#cheat-sheet). Maybe this could be better documented? I shall be delighted to help if it is desirable.