### PR TITLE
Fix regex replacement in theme detection

### DIFF
--- a/src/librustdoc/html/static/storage.js
+++ b/src/librustdoc/html/static/storage.js
@@ -119,7 +119,7 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
 
 function getSystemValue() {
     var property = getComputedStyle(document.documentElement).getPropertyValue('content');
-    return property.replace(/\"\'/g, "");
+    return property.replace(/[\"\']/g, "");
 }
 
 switchTheme(currentTheme, mainTheme,


### PR DESCRIPTION
Fixes #64061.

This is sadly a lot of bad luck: after making the changes and re-build the docs, I just forgot to force reload the page. Hence having the old (working) version with two replacements instead of the failing regex. Sorry again about that...

cc @fenhl 
r? @Mark-Simulacrum 