### PR TITLE
Ensure edition lints and internal lints are enabled with deny-warnings=false

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -119,17 +119,18 @@ fn main() {
         cmd.arg(format!("-Cdebuginfo={}", debuginfo_level));
     }
 
-    if env::var_os("RUSTC_DENY_WARNINGS").is_some() &&
-       env::var_os("RUSTC_EXTERNAL_TOOL").is_none() {
+    if env::var_os("RUSTC_EXTERNAL_TOOL").is_none() {
         // When extending this list, add the new lints to the RUSTFLAGS of the
         // build_bootstrap function of src/bootstrap/bootstrap.py as well as
         // some code doesn't go through this `rustc` wrapper.
-        cmd.arg("-Dwarnings");
-        cmd.arg("-Drust_2018_idioms");
-        cmd.arg("-Dunused_lifetimes");
+        cmd.arg("-Wrust_2018_idioms");
+        cmd.arg("-Wunused_lifetimes");
         if use_internal_lints(crate_name) {
             cmd.arg("-Zunstable-options");
-            cmd.arg("-Drustc::internal");
+            cmd.arg("-Wrustc::internal");
+        }
+        if env::var_os("RUSTC_DENY_WARNINGS").is_some() {
+            cmd.arg("-Dwarnings");
         }
     }
 

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -631,8 +631,9 @@ class RustBuild(object):
         target_linker = self.get_toml("linker", build_section)
         if target_linker is not None:
             env["RUSTFLAGS"] += "-C linker=" + target_linker + " "
+        env["RUSTFLAGS"] += " -Wrust_2018_idioms -Wunused_lifetimes "
         if self.get_toml("deny-warnings", "rust") != "false":
-            env["RUSTFLAGS"] += "-Dwarnings -Drust_2018_idioms -Dunused_lifetimes "
+            env["RUSTFLAGS"] += "-Dwarnings "
 
         env["PATH"] = os.path.join(self.bin_root(), "bin") + \
             os.pathsep + env["PATH"]

--- a/src/bootstrap/flags.rs
+++ b/src/bootstrap/flags.rs
@@ -36,7 +36,7 @@ pub struct Flags {
     // This overrides the deny-warnings configuation option,
     // which passes -Dwarnings to the compiler invocations.
     //
-    // true => deny, false => allow
+    // true => deny, false => warn
     pub deny_warnings: Option<bool>,
 }
 
@@ -556,10 +556,10 @@ fn split(s: &[String]) -> Vec<String> {
 fn parse_deny_warnings(matches: &getopts::Matches) -> Option<bool> {
     match matches.opt_str("warnings").as_ref().map(|v| v.as_str()) {
         Some("deny") => Some(true),
-        Some("allow") => Some(false),
+        Some("warn") => Some(false),
         Some(value) => {
             eprintln!(
-                r#"invalid value for --warnings: {:?}, expected "allow" or "deny""#,
+                r#"invalid value for --warnings: {:?}, expected "warn" or "deny""#,
                 value,
                 );
             process::exit(1);


### PR DESCRIPTION
Previously we only passed the deny command line flags if deny-warnings was enabled, but now we either pass -W... or -D... for each of the flags as appropriate.

This is also a breaking change to x.py as it changes `--warnings=allow` to `--warnings=warn` which is what that flag actually did; we don't have an allow warnings mode.