### PR TITLE
Fix const eval bug breaking run-pass tests in Miri

### DIFF
--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -585,8 +585,9 @@ where
         use rustc::mir::StaticKind;
 
         Ok(match place_static.kind {
-            StaticKind::Promoted(promoted, _) => {
-                let instance = self.frame().instance;
+            StaticKind::Promoted(promoted, promoted_substs) => {
+                let substs = self.subst_from_frame_and_normalize_erasing_regions(promoted_substs);
+                let instance = ty::Instance::new(place_static.def_id, substs);
                 self.const_eval_raw(GlobalId {
                     instance,
                     promoted: Some(promoted),


### PR DESCRIPTION
PR #63580 broke miri's ability to run the run-pass test suite with MIR
optimizations enabled. The issue was that we weren't properly handling
the substs and DefId associated with a Promoted value. This didn't break
anything in rustc because in rustc this code runs before the Inliner
pass which is where the DefId and substs can diverge from their initial
values. It broke Miri though because it ran this code again after
running the optimization pass.

r? @oli-obk 
cc @RalfJung 