### PR TITLE
or-patterns: Uniformly use `PatKind::Or` in AST & Fix/Cleanup resolve

### DIFF
--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -772,7 +772,7 @@ impl EarlyLintPass for UnusedDocComment {
     }
 
     fn check_arm(&mut self, cx: &EarlyContext<'_>, arm: &ast::Arm) {
-        let arm_span = arm.pats[0].span.with_hi(arm.body.span.hi());
+        let arm_span = arm.pat.span.with_hi(arm.body.span.hi());
         self.warn_if_doc(cx, arm_span, "match arms", false, &arm.attrs);
     }
 

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -493,10 +493,8 @@ impl EarlyLintPass for UnusedParens {
     fn check_expr(&mut self, cx: &EarlyContext<'_>, e: &ast::Expr) {
         use syntax::ast::ExprKind::*;
         let (value, msg, followed_by_block, left_pos, right_pos) = match e.node {
-            Let(ref pats, ..) => {
-                for p in pats {
-                    self.check_unused_parens_pat(cx, p, false, false);
-                }
+            Let(ref pat, ..) => {
+                self.check_unused_parens_pat(cx, pat, false, false);
                 return;
             }
 
@@ -594,9 +592,7 @@ impl EarlyLintPass for UnusedParens {
     }
 
     fn check_arm(&mut self, cx: &EarlyContext<'_>, arm: &ast::Arm) {
-        for p in &arm.pats {
-            self.check_unused_parens_pat(cx, p, false, false);
-        }
+        self.check_unused_parens_pat(cx, &arm.pat, false, false);
     }
 }
 

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1210,9 +1210,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
     fn resolve_arm(&mut self, arm: &Arm) {
         self.with_rib(ValueNS, NormalRibKind, |this| {
             this.resolve_pats(&arm.pats, PatternSource::Match);
-            if let Some(ref expr) = arm.guard {
-                this.visit_expr(expr)
-            }
+            walk_list!(this, visit_expr, &arm.guard);
             this.visit_expr(&arm.body);
         });
     }

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -35,8 +35,10 @@ mod diagnostics;
 
 type Res = def::Res<NodeId>;
 
+type IdentMap<T> = FxHashMap<Ident, T>;
+
 /// Map from the name in a pattern to its binding mode.
-type BindingMap = FxHashMap<Ident, BindingInfo>;
+type BindingMap = IdentMap<BindingInfo>;
 
 #[derive(Copy, Clone, Debug)]
 struct BindingInfo {
@@ -143,7 +145,7 @@ impl RibKind<'_> {
 /// resolving, the name is looked up from inside out.
 #[derive(Debug)]
 crate struct Rib<'a, R = Res> {
-    pub bindings: FxHashMap<Ident, R>,
+    pub bindings: IdentMap<R>,
     pub kind: RibKind<'a>,
 }
 
@@ -1275,7 +1277,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
                      pat_id: NodeId,
                      outer_pat_id: NodeId,
                      pat_src: PatternSource,
-                     bindings: &mut FxHashMap<Ident, NodeId>)
+                     bindings: &mut IdentMap<NodeId>)
                      -> Res {
         // Add the binding to the local ribs, if it
         // doesn't already exist in the bindings map. (We
@@ -1323,7 +1325,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
         res
     }
 
-    fn innermost_rib_bindings(&mut self, ns: Namespace) -> &mut FxHashMap<Ident, Res> {
+    fn innermost_rib_bindings(&mut self, ns: Namespace) -> &mut IdentMap<Res> {
         &mut self.ribs[ns].last_mut().unwrap().bindings
     }
 
@@ -1332,7 +1334,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
         pat: &Pat,
         pat_src: PatternSource,
         // Maps idents to the node ID for the outermost pattern that binds them.
-        bindings: &mut FxHashMap<Ident, NodeId>,
+        bindings: &mut IdentMap<NodeId>,
     ) {
         // Visit all direct subpatterns of this pattern.
         let outer_pat_id = pat.id;

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -9,6 +9,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(inner_deref)]
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
 #![feature(mem_take)]

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![feature(nll)]
+#![feature(inner_deref)]
 
 #![recursion_limit="256"]
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -563,7 +563,7 @@ impl Pat {
 
     /// Walk top-down and call `it` in each place where a pattern occurs
     /// starting with the root pattern `walk` is called on. If `it` returns
-    /// false then we will decend no further but siblings will be processed.
+    /// false then we will descend no further but siblings will be processed.
     pub fn walk(&self, it: &mut impl FnMut(&Pat) -> bool) {
         if !it(self) {
             return;
@@ -1150,9 +1150,6 @@ pub enum ExprKind {
     Type(P<Expr>, P<Ty>),
     /// A `let pat = expr` expression that is only semantically allowed in the condition
     /// of `if` / `while` expressions. (e.g., `if let 0 = x { .. }`).
-    ///
-    /// The `Vec<P<Pat>>` is for or-patterns at the top level.
-    /// FIXME(54883): Change this to just `P<Pat>`.
     Let(P<Pat>, P<Expr>),
     /// An `if` block, with an optional `else` block.
     ///

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -930,7 +930,7 @@ pub struct Local {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct Arm {
     pub attrs: Vec<Attribute>,
-    pub pats: Vec<P<Pat>>,
+    pub pat: P<Pat>,
     pub guard: Option<P<Expr>>,
     pub body: P<Expr>,
     pub span: Span,
@@ -1148,12 +1148,12 @@ pub enum ExprKind {
     Cast(P<Expr>, P<Ty>),
     /// A type ascription (e.g., `42: usize`).
     Type(P<Expr>, P<Ty>),
-    /// A `let pats = expr` expression that is only semantically allowed in the condition
+    /// A `let pat = expr` expression that is only semantically allowed in the condition
     /// of `if` / `while` expressions. (e.g., `if let 0 = x { .. }`).
     ///
     /// The `Vec<P<Pat>>` is for or-patterns at the top level.
     /// FIXME(54883): Change this to just `P<Pat>`.
-    Let(Vec<P<Pat>>, P<Expr>),
+    Let(P<Pat>, P<Expr>),
     /// An `if` block, with an optional `else` block.
     ///
     /// `if expr { block } else { expr }`

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -537,9 +537,9 @@ impl<'a> ExtCtxt<'a> {
         let err_expr = self.expr(sp, ast::ExprKind::Ret(Some(err_inner_expr)));
 
         // `Ok(__try_var) => __try_var`
-        let ok_arm = self.arm(sp, vec![ok_pat], binding_expr);
+        let ok_arm = self.arm(sp, ok_pat, binding_expr);
         // `Err(__try_var) => return Err(__try_var)`
-        let err_arm = self.arm(sp, vec![err_pat], err_expr);
+        let err_arm = self.arm(sp, err_pat, err_expr);
 
         // `match head { Ok() => ..., Err() => ... }`
         self.expr_match(sp, head, vec![ok_arm, err_arm])
@@ -606,10 +606,10 @@ impl<'a> ExtCtxt<'a> {
         self.pat_tuple_struct(span, path, vec![pat])
     }
 
-    pub fn arm(&self, span: Span, pats: Vec<P<ast::Pat>>, expr: P<ast::Expr>) -> ast::Arm {
+    pub fn arm(&self, span: Span, pat: P<ast::Pat>, expr: P<ast::Expr>) -> ast::Arm {
         ast::Arm {
             attrs: vec![],
-            pats,
+            pat,
             guard: None,
             body: expr,
             span,
@@ -618,7 +618,7 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn arm_unreachable(&self, span: Span) -> ast::Arm {
-        self.arm(span, vec![self.pat_wild(span)], self.expr_unreachable(span))
+        self.arm(span, self.pat_wild(span), self.expr_unreachable(span))
     }
 
     pub fn expr_match(&self, span: Span, arg: P<ast::Expr>, arms: Vec<ast::Arm>) -> P<Expr> {

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -402,14 +402,11 @@ pub fn noop_visit_use_tree<T: MutVisitor>(use_tree: &mut UseTree, vis: &mut T) {
     vis.visit_span(span);
 }
 
-pub fn noop_flat_map_arm<T: MutVisitor>(
-    mut arm: Arm,
-    vis: &mut T,
-) -> SmallVec<[Arm; 1]> {
-    let Arm { attrs, pats, guard, body, span, id } = &mut arm;
+pub fn noop_flat_map_arm<T: MutVisitor>(mut arm: Arm, vis: &mut T) -> SmallVec<[Arm; 1]> {
+    let Arm { attrs, pat, guard, body, span, id } = &mut arm;
     visit_attrs(attrs, vis);
     vis.visit_id(id);
-    visit_vec(pats, |pat| vis.visit_pat(pat));
+    vis.visit_pat(pat);
     visit_opt(guard, |guard| vis.visit_expr(guard));
     vis.visit_expr(body);
     vis.visit_span(span);
@@ -1132,8 +1129,8 @@ pub fn noop_visit_expr<T: MutVisitor>(Expr { node, id, span, attrs }: &mut Expr,
             vis.visit_ty(ty);
         }
         ExprKind::AddrOf(_m, ohs) => vis.visit_expr(ohs),
-        ExprKind::Let(pats, scrutinee) => {
-            visit_vec(pats, |pat| vis.visit_pat(pat));
+        ExprKind::Let(pat, scrutinee) => {
+            vis.visit_pat(pat);
             vis.visit_expr(scrutinee);
         }
         ExprKind::If(cond, tr, fl) => {

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -1250,8 +1250,7 @@ impl<'a> Parser<'a> {
     /// The `let` token has already been eaten.
     fn parse_let_expr(&mut self, attrs: ThinVec<Attribute>) -> PResult<'a, P<Expr>> {
         let lo = self.prev_span;
-        // FIXME(or_patterns, Centril | dlrobertson): use `parse_top_pat` instead.
-        let pat = self.parse_top_pat_unpack(GateOr::No)?;
+        let pat = self.parse_top_pat(GateOr::No)?;
         self.expect(&token::Eq)?;
         let expr = self.with_res(
             Restrictions::NO_STRUCT_LITERAL,
@@ -1393,8 +1392,7 @@ impl<'a> Parser<'a> {
     crate fn parse_arm(&mut self) -> PResult<'a, Arm> {
         let attrs = self.parse_outer_attributes()?;
         let lo = self.token.span;
-        // FIXME(or_patterns, Centril | dlrobertson): use `parse_top_pat` instead.
-        let pat = self.parse_top_pat_unpack(GateOr::No)?;
+        let pat = self.parse_top_pat(GateOr::No)?;
         let guard = if self.eat_keyword(kw::If) {
             Some(self.parse_expr()?)
         } else {
@@ -1455,7 +1453,7 @@ impl<'a> Parser<'a> {
 
         Ok(ast::Arm {
             attrs,
-            pats: pat, // FIXME(or_patterns, Centril | dlrobertson): this should just be `pat,`.
+            pat,
             guard,
             body: expr,
             span: lo.to(hi),

--- a/src/libsyntax/parse/parser/pat.rs
+++ b/src/libsyntax/parse/parser/pat.rs
@@ -36,16 +36,6 @@ impl<'a> Parser<'a> {
         self.parse_pat_with_range_pat(true, expected)
     }
 
-    // FIXME(or_patterns, Centril | dlrobertson):
-    // remove this and use `parse_top_pat` everywhere it is used instead.
-    pub(super) fn parse_top_pat_unpack(&mut self, gate_or: GateOr) -> PResult<'a, Vec<P<Pat>>> {
-        self.parse_top_pat(gate_or)
-            .map(|pat| pat.and_then(|pat| match pat.node {
-                PatKind::Or(pats) => pats,
-                node => vec![self.mk_pat(pat.span, node)],
-            }))
-    }
-
     /// Entry point to the main pattern parser.
     /// Corresponds to `top_pat` in RFC 2535 and allows or-pattern at the top level.
     pub(super) fn parse_top_pat(&mut self, gate_or: GateOr) -> PResult<'a, P<Pat>> {

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1714,11 +1714,11 @@ impl<'a> State<'a> {
         self.ann.post(self, AnnNode::Block(blk))
     }
 
-    /// Print a `let pats = scrutinee` expression.
-    crate fn print_let(&mut self, pats: &[P<ast::Pat>], scrutinee: &ast::Expr) {
+    /// Print a `let pat = scrutinee` expression.
+    crate fn print_let(&mut self, pat: &ast::Pat, scrutinee: &ast::Expr) {
         self.s.word("let ");
 
-        self.print_pats(pats);
+        self.print_pat(pat);
         self.s.space();
 
         self.word_space("=");
@@ -2044,8 +2044,8 @@ impl<'a> State<'a> {
                 self.word_space(":");
                 self.print_type(ty);
             }
-            ast::ExprKind::Let(ref pats, ref scrutinee) => {
-                self.print_let(pats, scrutinee);
+            ast::ExprKind::Let(ref pat, ref scrutinee) => {
+                self.print_let(pat, scrutinee);
             }
             ast::ExprKind::If(ref test, ref blk, ref elseopt) => {
                 self.print_if(test, blk, elseopt.as_ref().map(|e| &**e));
@@ -2455,21 +2455,16 @@ impl<'a> State<'a> {
         self.ann.post(self, AnnNode::Pat(pat))
     }
 
-    fn print_pats(&mut self, pats: &[P<ast::Pat>]) {
-        self.strsep("|", true, Inconsistent, pats, |s, p| s.print_pat(p));
-    }
-
     fn print_arm(&mut self, arm: &ast::Arm) {
-        // I have no idea why this check is necessary, but here it
-        // is :(
+        // I have no idea why this check is necessary, but here it is :(
         if arm.attrs.is_empty() {
             self.s.space();
         }
         self.cbox(INDENT_UNIT);
         self.ibox(0);
-        self.maybe_print_comment(arm.pats[0].span.lo());
+        self.maybe_print_comment(arm.pat.span.lo());
         self.print_outer_attributes(&arm.attrs);
-        self.print_pats(&arm.pats);
+        self.print_pat(&arm.pat);
         self.s.space();
         if let Some(ref e) = arm.guard {
             self.word_space("if");

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -678,9 +678,8 @@ pub fn walk_anon_const<'a, V: Visitor<'a>>(visitor: &mut V, constant: &'a AnonCo
 }
 
 pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
-    for attr in expression.attrs.iter() {
-        visitor.visit_attribute(attr);
-    }
+    walk_list!(visitor, visit_attribute, expression.attrs.iter());
+
     match expression.node {
         ExprKind::Box(ref subexpression) => {
             visitor.visit_expr(subexpression)
@@ -719,8 +718,8 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
             visitor.visit_expr(subexpression);
             visitor.visit_ty(typ)
         }
-        ExprKind::Let(ref pats, ref scrutinee) => {
-            walk_list!(visitor, visit_pat, pats);
+        ExprKind::Let(ref pat, ref scrutinee) => {
+            visitor.visit_pat(pat);
             visitor.visit_expr(scrutinee);
         }
         ExprKind::If(ref head_expression, ref if_block, ref optional_else) => {
@@ -831,10 +830,10 @@ pub fn walk_param<'a, V: Visitor<'a>>(visitor: &mut V, param: &'a Param) {
 }
 
 pub fn walk_arm<'a, V: Visitor<'a>>(visitor: &mut V, arm: &'a Arm) {
-    walk_list!(visitor, visit_pat, &arm.pats);
-    if let Some(ref e) = &arm.guard {
-        visitor.visit_expr(e);
-    }
+    visitor.visit_pat(&arm.pat);
+    // HACK(or_patterns; Centril | dlrobertson):
+    // If you change this, also change the hack in `lowering.rs`.
+    walk_list!(visitor, visit_expr, &arm.guard);
     visitor.visit_expr(&arm.body);
     walk_list!(visitor, visit_attribute, &arm.attrs);
 }

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -831,7 +831,7 @@ pub fn walk_param<'a, V: Visitor<'a>>(visitor: &mut V, param: &'a Param) {
 
 pub fn walk_arm<'a, V: Visitor<'a>>(visitor: &mut V, arm: &'a Arm) {
     visitor.visit_pat(&arm.pat);
-    // HACK(or_patterns; Centril | dlrobertson):
+    // NOTE(or_patterns; Centril | dlrobertson):
     // If you change this, also change the hack in `lowering.rs`.
     walk_list!(visitor, visit_expr, &arm.guard);
     visitor.visit_expr(&arm.body);

--- a/src/libsyntax_ext/deriving/cmp/ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/ord.rs
@@ -95,11 +95,9 @@ pub fn cs_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>) -> P<
                     cx.expr_call_global(span, cmp_path.clone(), args)
                 };
 
-                let eq_arm = cx.arm(span,
-                                    vec![cx.pat_path(span, equals_path.clone())],
-                                    old);
+                let eq_arm = cx.arm(span, cx.pat_path(span, equals_path.clone()), old);
                 let neq_arm = cx.arm(span,
-                                     vec![cx.pat_ident(span, test_id)],
+                                     cx.pat_ident(span, test_id),
                                      cx.expr_ident(span, test_id));
 
                 cx.expr_match(span, new, vec![eq_arm, neq_arm])

--- a/src/libsyntax_ext/deriving/cmp/partial_ord.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_ord.rs
@@ -160,10 +160,10 @@ pub fn cs_partial_cmp(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_
                 };
 
                 let eq_arm = cx.arm(span,
-                                    vec![cx.pat_some(span, cx.pat_path(span, ordering.clone()))],
+                                    cx.pat_some(span, cx.pat_path(span, ordering.clone())),
                                     old);
                 let neq_arm = cx.arm(span,
-                                    vec![cx.pat_ident(span, test_id)],
+                                    cx.pat_ident(span, test_id),
                                     cx.expr_ident(span, test_id));
 
                 cx.expr_match(span, new, vec![eq_arm, neq_arm])

--- a/src/libsyntax_ext/deriving/decodable.rs
+++ b/src/libsyntax_ext/deriving/decodable.rs
@@ -119,9 +119,7 @@ fn decodable_substructure(cx: &mut ExtCtxt<'_>,
                                                     vec![idx, exprdecode.clone()]))
                 });
 
-                arms.push(cx.arm(v_span,
-                                 vec![cx.pat_lit(v_span, cx.expr_usize(v_span, i))],
-                                 decoded));
+                arms.push(cx.arm(v_span, cx.pat_lit(v_span, cx.expr_usize(v_span, i)), decoded));
             }
 
             arms.push(cx.arm_unreachable(trait_span));

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -1071,7 +1071,7 @@ impl<'a> MethodDef<'a> {
         for (arg_expr, pat) in self_args.iter().zip(patterns) {
             body = cx.expr_match(trait_.span,
                                  arg_expr.clone(),
-                                 vec![cx.arm(trait_.span, vec![pat.clone()], body)])
+                                 vec![cx.arm(trait_.span, pat.clone(), body)])
         }
 
         body
@@ -1311,7 +1311,7 @@ impl<'a> MethodDef<'a> {
                                                              nonself_args,
                                                              &substructure);
 
-                cx.arm(sp, vec![single_pat], arm_expr)
+                cx.arm(sp, single_pat, arm_expr)
             })
             .collect();
 
@@ -1337,7 +1337,7 @@ impl<'a> MethodDef<'a> {
             _ => None,
         };
         if let Some(arm) = default {
-            match_arms.push(cx.arm(sp, vec![cx.pat_wild(sp)], arm));
+            match_arms.push(cx.arm(sp, cx.pat_wild(sp), arm));
         }
 
         // We will usually need the catch-all after matching the

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -716,7 +716,7 @@ impl<'a, 'b> Context<'a, 'b> {
         // But the nested match expression is proved to perform not as well
         // as series of let's; the first approach does.
         let pat = self.ecx.pat_tuple(self.fmtsp, pats);
-        let arm = self.ecx.arm(self.fmtsp, vec![pat], args_array);
+        let arm = self.ecx.arm(self.fmtsp, pat, args_array);
         let head = self.ecx.expr(self.fmtsp, ast::ExprKind::Tup(heads));
         let result = self.ecx.expr_match(self.fmtsp, head, vec![arm]);
 

--- a/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/src/test/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -150,12 +150,12 @@ fn iter_exprs(depth: usize, f: &mut dyn FnMut(P<Expr>)) {
                 iter_exprs(depth - 1, &mut |e| g(ExprKind::Try(e)));
             },
             19 => {
-                let ps = vec![P(Pat {
+                let pat = P(Pat {
                     id: DUMMY_NODE_ID,
                     node: PatKind::Wild,
                     span: DUMMY_SP,
-                })];
-                iter_exprs(depth - 1, &mut |e| g(ExprKind::Let(ps.clone(), e)))
+                });
+                iter_exprs(depth - 1, &mut |e| g(ExprKind::Let(pat.clone(), e)))
             },
             _ => panic!("bad counter value in iter_exprs"),
         }

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.rs
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.rs
@@ -33,10 +33,8 @@ fn or_patterns_no_lint() {
     if let &mut (0 | 1) = &mut 0 {} // Same.
 
     fn foo((Ok(a) | Err(a)): Result<u8, u8>) {} // Doesn't parse if we remove parens for now.
-    //~^ ERROR identifier `a` is bound more than once
 
     let _ = |(Ok(a) | Err(a)): Result<u8, u8>| 1; // `|Ok(a) | Err(a)| 1` parses as bit-or.
-    //~^ ERROR identifier `a` is bound more than once
 }
 
 fn or_patterns_will_lint() {

--- a/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
+++ b/src/test/ui/lint/issue-54538-unused-parens-lint.stderr
@@ -1,15 +1,3 @@
-error[E0416]: identifier `a` is bound more than once in the same pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:35:25
-   |
-LL |     fn foo((Ok(a) | Err(a)): Result<u8, u8>) {} // Doesn't parse if we remove parens for now.
-   |                         ^ used in a pattern more than once
-
-error[E0416]: identifier `a` is bound more than once in the same pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:38:27
-   |
-LL |     let _ = |(Ok(a) | Err(a)): Result<u8, u8>| 1; // `|Ok(a) | Err(a)| 1` parses as bit-or.
-   |                           ^ used in a pattern more than once
-
 warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
   --> $DIR/issue-54538-unused-parens-lint.rs:3:12
    |
@@ -61,113 +49,112 @@ LL |     let _ = |(a): u8| 0;
    |              ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:43:12
+  --> $DIR/issue-54538-unused-parens-lint.rs:41:12
    |
 LL |     if let (0 | 1) = 0 {}
    |            ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:44:13
+  --> $DIR/issue-54538-unused-parens-lint.rs:42:13
    |
 LL |     if let ((0 | 1),) = (0,) {}
    |             ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:45:13
+  --> $DIR/issue-54538-unused-parens-lint.rs:43:13
    |
 LL |     if let [(0 | 1)] = [0] {}
    |             ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:46:16
+  --> $DIR/issue-54538-unused-parens-lint.rs:44:16
    |
 LL |     if let 0 | (1 | 2) = 0 {}
    |                ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:48:15
+  --> $DIR/issue-54538-unused-parens-lint.rs:46:15
    |
 LL |     if let TS((0 | 1)) = TS(0) {}
    |               ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:50:20
+  --> $DIR/issue-54538-unused-parens-lint.rs:48:20
    |
 LL |     if let NS { f: (0 | 1) } = (NS { f: 0 }) {}
    |                    ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:60:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:58:9
    |
 LL |         (_) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:61:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:59:9
    |
 LL |         (y) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:62:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:60:9
    |
 LL |         (ref r) => {}
    |         ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:63:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:61:9
    |
 LL |         (e @ 1...2) => {}
    |         ^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:69:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:67:9
    |
 LL |         (e @ &(1...2)) => {}
    |         ^^^^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:70:10
+  --> $DIR/issue-54538-unused-parens-lint.rs:68:10
    |
 LL |         &(_) => {}
    |          ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:81:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:79:9
    |
 LL |         (_) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:82:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:80:9
    |
 LL |         (y) => {}
    |         ^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:83:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:81:9
    |
 LL |         (ref r) => {}
    |         ^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:84:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:82:9
    |
 LL |         (e @ 1..=2) => {}
    |         ^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:90:9
+  --> $DIR/issue-54538-unused-parens-lint.rs:88:9
    |
 LL |         (e @ &(1..=2)) => {}
    |         ^^^^^^^^^^^^^^ help: remove these parentheses
 
 error: unnecessary parentheses around pattern
-  --> $DIR/issue-54538-unused-parens-lint.rs:91:10
+  --> $DIR/issue-54538-unused-parens-lint.rs:89:10
    |
 LL |         &(_) => {}
    |          ^^^ help: remove these parentheses
 
-error: aborting due to 26 previous errors
+error: aborting due to 24 previous errors
 
-For more information about this error, try `rustc --explain E0416`.

--- a/src/test/ui/or-patterns/already-bound-name.rs
+++ b/src/test/ui/or-patterns/already-bound-name.rs
@@ -38,6 +38,7 @@ fn main() {
     let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
     //~^ ERROR identifier `a` is bound more than once in the same pattern
     //~| ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR variable `a` is not bound in all patterns
 
     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
     //~^ ERROR identifier `a` is bound more than once in the same pattern

--- a/src/test/ui/or-patterns/already-bound-name.rs
+++ b/src/test/ui/or-patterns/already-bound-name.rs
@@ -1,0 +1,45 @@
+// This test ensures that the "already bound identifier in a product pattern"
+// correctly accounts for or-patterns.
+
+#![allow(warnings)]
+#![feature(or_patterns)]
+
+enum E<T> { A(T, T), B(T) }
+
+use E::*;
+
+fn main() {
+    let (a, a) = (0, 1); // Standard duplication without an or-pattern.
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+
+    let (a, A(a, _) | B(a)) = (0, A(1, 2));
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR identifier `a` is bound more than once in the same pattern
+
+    let (A(a, _) | B(a), a) = (A(0, 1), 2);
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+
+    let A(a, a) | B(a) = A(0, 1);
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+
+    let B(a) | A(a, a) = A(0, 1);
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+
+    match A(0, 1) {
+        B(a) | A(a, a) => {} // Let's ensure `match` has no funny business.
+        //~^ ERROR identifier `a` is bound more than once in the same pattern
+    }
+
+    let B(A(a, _) | B(a)) | A(a, A(a, _) | B(a)) = B(B(1));
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR mismatched types
+
+    let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR identifier `a` is bound more than once in the same pattern
+
+    let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+    //~^ ERROR identifier `a` is bound more than once in the same pattern
+    //~| ERROR identifier `a` is bound more than once in the same pattern
+}

--- a/src/test/ui/or-patterns/already-bound-name.rs
+++ b/src/test/ui/or-patterns/already-bound-name.rs
@@ -1,8 +1,8 @@
 // This test ensures that the "already bound identifier in a product pattern"
 // correctly accounts for or-patterns.
 
-#![allow(warnings)]
 #![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete
 
 enum E<T> { A(T, T), B(T) }
 

--- a/src/test/ui/or-patterns/already-bound-name.stderr
+++ b/src/test/ui/or-patterns/already-bound-name.stderr
@@ -82,6 +82,14 @@ error[E0416]: identifier `a` is bound more than once in the same pattern
 LL |     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
    |                                                           ^ used in a pattern more than once
 
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/already-bound-name.rs:4:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0308]: mismatched types
   --> $DIR/already-bound-name.rs:33:31
    |

--- a/src/test/ui/or-patterns/already-bound-name.stderr
+++ b/src/test/ui/or-patterns/already-bound-name.stderr
@@ -64,14 +64,20 @@ error[E0416]: identifier `a` is bound more than once in the same pattern
 LL |     let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
    |                                              ^ used in a pattern more than once
 
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/already-bound-name.rs:38:9
+   |
+LL |     let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+   |         ^^^^ pattern doesn't bind `a`        - variable not in all patterns
+
 error[E0416]: identifier `a` is bound more than once in the same pattern
-  --> $DIR/already-bound-name.rs:42:49
+  --> $DIR/already-bound-name.rs:43:49
    |
 LL |     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
    |                                                 ^ used in a pattern more than once
 
 error[E0416]: identifier `a` is bound more than once in the same pattern
-  --> $DIR/already-bound-name.rs:42:59
+  --> $DIR/already-bound-name.rs:43:59
    |
 LL |     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
    |                                                           ^ used in a pattern more than once
@@ -85,7 +91,7 @@ LL |     let B(A(a, _) | B(a)) | A(a, A(a, _) | B(a)) = B(B(1));
    = note: expected type `{integer}`
               found type `E<{integer}>`
 
-error: aborting due to 14 previous errors
+error: aborting due to 15 previous errors
 
-Some errors have detailed explanations: E0308, E0416.
+Some errors have detailed explanations: E0308, E0408, E0416.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/or-patterns/already-bound-name.stderr
+++ b/src/test/ui/or-patterns/already-bound-name.stderr
@@ -1,0 +1,91 @@
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:12:13
+   |
+LL |     let (a, a) = (0, 1); // Standard duplication without an or-pattern.
+   |             ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:15:15
+   |
+LL |     let (a, A(a, _) | B(a)) = (0, A(1, 2));
+   |               ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:15:25
+   |
+LL |     let (a, A(a, _) | B(a)) = (0, A(1, 2));
+   |                         ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:19:26
+   |
+LL |     let (A(a, _) | B(a), a) = (A(0, 1), 2);
+   |                          ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:22:14
+   |
+LL |     let A(a, a) | B(a) = A(0, 1);
+   |              ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:25:21
+   |
+LL |     let B(a) | A(a, a) = A(0, 1);
+   |                     ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:29:21
+   |
+LL |         B(a) | A(a, a) => {} // Let's ensure `match` has no funny business.
+   |                     ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:33:36
+   |
+LL |     let B(A(a, _) | B(a)) | A(a, A(a, _) | B(a)) = B(B(1));
+   |                                    ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:33:46
+   |
+LL |     let B(A(a, _) | B(a)) | A(a, A(a, _) | B(a)) = B(B(1));
+   |                                              ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:38:36
+   |
+LL |     let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+   |                                    ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:38:46
+   |
+LL |     let B(_) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+   |                                              ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:42:49
+   |
+LL |     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+   |                                                 ^ used in a pattern more than once
+
+error[E0416]: identifier `a` is bound more than once in the same pattern
+  --> $DIR/already-bound-name.rs:42:59
+   |
+LL |     let B(A(a, _) | B(a)) | A(A(a, _) | B(a), A(a, _) | B(a)) = B(B(1));
+   |                                                           ^ used in a pattern more than once
+
+error[E0308]: mismatched types
+  --> $DIR/already-bound-name.rs:33:31
+   |
+LL |     let B(A(a, _) | B(a)) | A(a, A(a, _) | B(a)) = B(B(1));
+   |                               ^ expected integer, found enum `E`
+   |
+   = note: expected type `{integer}`
+              found type `E<{integer}>`
+
+error: aborting due to 14 previous errors
+
+Some errors have detailed explanations: E0308, E0416.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/or-patterns/consistent-bindings.rs
+++ b/src/test/ui/or-patterns/consistent-bindings.rs
@@ -1,0 +1,46 @@
+// Check that or-patterns with consistent bindings across arms are allowed.
+
+// edition:2018
+
+#![feature(or_patterns)]
+//~^ WARN the feature `or_patterns` is incomplete
+
+fn main() {
+    // One level:
+    let Ok(a) | Err(a) = Ok(0);
+    let Ok(ref a) | Err(ref a) = Ok(0);
+    let Ok(ref mut a) | Err(ref mut a) = Ok(0);
+
+    // Two levels:
+    enum Tri<S, T, U> { V1(S), V2(T), V3(U) }
+    use Tri::*;
+
+    let Ok((V1(a) | V2(a) | V3(a), b)) | Err(Ok((a, b)) | Err((a, b)))
+        : Result<_, Result<_, _>>
+        = Ok((V1(1), 1));
+
+    let Ok((V1(a) | V2(a) | V3(a), ref b)) | Err(Ok((a, ref b)) | Err((a, ref b)))
+        : Result<_, Result<_, _>>
+        = Ok((V1(1), 1));
+
+    // Three levels:
+    let (
+            a,
+            Err((ref mut b, ref c, d)) |
+            Ok((
+                Ok(
+                    V1((ref c, d)) |
+                    V2((d, ref c)) |
+                    V3((ref c, Ok((_, d)) | Err((d, _))))
+                ) |
+                Err((ref c, d)),
+                ref mut b
+            ))
+        ) =
+        (1, Ok((Ok(V3((1, Ok((1, 1))))), 1)));
+
+    // FIXME(or_patterns; Centril | dlrobertson): remove this line below and
+    // change this test to check-pass once MIR can handle or-patterns with bindings.
+    let () = 0;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/or-patterns/consistent-bindings.stderr
+++ b/src/test/ui/or-patterns/consistent-bindings.stderr
@@ -1,0 +1,20 @@
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/consistent-bindings.rs:5:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/consistent-bindings.rs:44:9
+   |
+LL |     let () = 0;
+   |         ^^ expected integer, found ()
+   |
+   = note: expected type `{integer}`
+              found type `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/or-patterns/inconsistent-modes.rs
+++ b/src/test/ui/or-patterns/inconsistent-modes.rs
@@ -1,0 +1,26 @@
+// This test ensures that or patterns require binding mode consistency across arms.
+
+#![feature(or_patterns)]
+#![allow(incomplete_features, non_camel_case_types)]
+fn main() {
+    // One level:
+    let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
+    //~^ ERROR variable `a` is bound in inconsistent ways
+    let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
+    //~^ ERROR variable `a` is bound in inconsistent ways
+    let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
+    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~| ERROR mismatched types
+    let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
+    //~^ ERROR variable `a` is bound in inconsistent ways
+    //~| ERROR variable `b` is bound in inconsistent ways
+    //~| ERROR mismatched types
+
+    // Two levels:
+    let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
+    //~^ ERROR variable `a` is bound in inconsistent ways
+
+    // Three levels:
+    let Ok([ Ok((Ok(ref a) | Err(a),)) | Err(a) ]) | Err(a) = Err(&1);
+    //~^ ERROR variable `a` is bound in inconsistent ways
+}

--- a/src/test/ui/or-patterns/inconsistent-modes.rs
+++ b/src/test/ui/or-patterns/inconsistent-modes.rs
@@ -1,7 +1,9 @@
 // This test ensures that or patterns require binding mode consistency across arms.
 
 #![feature(or_patterns)]
-#![allow(incomplete_features, non_camel_case_types)]
+//~^ WARN the feature `or_patterns` is incomplete
+
+#![allow(non_camel_case_types)]
 fn main() {
     // One level:
     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);

--- a/src/test/ui/or-patterns/inconsistent-modes.stderr
+++ b/src/test/ui/or-patterns/inconsistent-modes.stderr
@@ -1,0 +1,72 @@
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:7:25
+   |
+LL |     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
+   |            -            ^ bound in different ways
+   |            |
+   |            first binding
+
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:9:29
+   |
+LL |     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
+   |                    -        ^ bound in different ways
+   |                    |
+   |                    first binding
+
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:11:33
+   |
+LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
+   |                - first binding  ^ bound in different ways
+
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:14:39
+   |
+LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
+   |                 - first binding       ^ bound in different ways
+
+error[E0409]: variable `b` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:14:46
+   |
+LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
+   |                    - first binding           ^ bound in different ways
+
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:20:38
+   |
+LL |     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
+   |                        -             ^ bound in different ways
+   |                        |
+   |                        first binding
+
+error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
+  --> $DIR/inconsistent-modes.rs:24:34
+   |
+LL |     let Ok([ Ok((Ok(ref a) | Err(a),)) | Err(a) ]) | Err(a) = Err(&1);
+   |                         -        ^ bound in different ways
+   |                         |
+   |                         first binding
+
+error[E0308]: mismatched types
+  --> $DIR/inconsistent-modes.rs:11:25
+   |
+LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
+   |                         ^^^^^^^^^ types differ in mutability
+   |
+   = note: expected type `&&u8`
+              found type `&mut &mut u8`
+
+error[E0308]: mismatched types
+  --> $DIR/inconsistent-modes.rs:14:31
+   |
+LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
+   |                               ^^^^^^^^^ types differ in mutability
+   |
+   = note: expected type `&{integer}`
+              found type `&mut _`
+
+error: aborting due to 9 previous errors
+
+Some errors have detailed explanations: E0308, E0409.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/or-patterns/inconsistent-modes.stderr
+++ b/src/test/ui/or-patterns/inconsistent-modes.stderr
@@ -1,5 +1,5 @@
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:7:25
+  --> $DIR/inconsistent-modes.rs:9:25
    |
 LL |     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
    |            -            ^ bound in different ways
@@ -7,7 +7,7 @@ LL |     let Ok(a) | Err(ref a): Result<&u8, u8> = Ok(&0);
    |            first binding
 
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:9:29
+  --> $DIR/inconsistent-modes.rs:11:29
    |
 LL |     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
    |                    -        ^ bound in different ways
@@ -15,25 +15,25 @@ LL |     let Ok(ref mut a) | Err(a): Result<u8, &mut u8> = Ok(0);
    |                    first binding
 
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:11:33
+  --> $DIR/inconsistent-modes.rs:13:33
    |
 LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
    |                - first binding  ^ bound in different ways
 
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:14:39
+  --> $DIR/inconsistent-modes.rs:16:39
    |
 LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
    |                 - first binding       ^ bound in different ways
 
 error[E0409]: variable `b` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:14:46
+  --> $DIR/inconsistent-modes.rs:16:46
    |
 LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
    |                    - first binding           ^ bound in different ways
 
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:20:38
+  --> $DIR/inconsistent-modes.rs:22:38
    |
 LL |     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
    |                        -             ^ bound in different ways
@@ -41,15 +41,23 @@ LL |     let Ok(Ok(a) | Err(a)) | Err(ref a) = Err(0);
    |                        first binding
 
 error[E0409]: variable `a` is bound in inconsistent ways within the same match arm
-  --> $DIR/inconsistent-modes.rs:24:34
+  --> $DIR/inconsistent-modes.rs:26:34
    |
 LL |     let Ok([ Ok((Ok(ref a) | Err(a),)) | Err(a) ]) | Err(a) = Err(&1);
    |                         -        ^ bound in different ways
    |                         |
    |                         first binding
 
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/inconsistent-modes.rs:3:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0308]: mismatched types
-  --> $DIR/inconsistent-modes.rs:11:25
+  --> $DIR/inconsistent-modes.rs:13:25
    |
 LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
    |                         ^^^^^^^^^ types differ in mutability
@@ -58,7 +66,7 @@ LL |     let Ok(ref a) | Err(ref mut a): Result<&u8, &mut u8> = Ok(&0);
               found type `&mut &mut u8`
 
 error[E0308]: mismatched types
-  --> $DIR/inconsistent-modes.rs:14:31
+  --> $DIR/inconsistent-modes.rs:16:31
    |
 LL |     let Ok((ref a, b)) | Err((ref mut a, ref b)) = Ok((0, &0));
    |                               ^^^^^^^^^ types differ in mutability

--- a/src/test/ui/or-patterns/missing-bindings.rs
+++ b/src/test/ui/or-patterns/missing-bindings.rs
@@ -1,0 +1,82 @@
+// This test ensures that or patterns do not allow missing bindings in any of the arms.
+
+// edition:2018
+
+#![feature(or_patterns)]
+#![allow(incomplete_features, non_camel_case_types)]
+
+fn main() {}
+
+fn check_handling_of_paths() {
+    mod bar {
+        pub enum foo {
+            alpha,
+            beta,
+            charlie
+        }
+    }
+
+    use bar::foo::{alpha, charlie};
+    let alpha | beta | charlie = alpha; //~  ERROR variable `beta` is not bound in all patterns
+    match Some(alpha) {
+        Some(alpha | beta) => {} //~ ERROR variable `beta` is not bound in all patterns
+    }
+}
+
+fn check_misc_nesting() {
+    enum E<T> { A(T, T), B(T) }
+    use E::*;
+    enum Vars3<S, T, U> { V1(S), V2(T), V3(U) }
+    use Vars3::*;
+
+    // One level:
+    const X: E<u8> = B(0);
+    let A(a, _) | _ = X; //~ ERROR variable `a` is not bound in all patterns
+    let _ | B(a) = X; //~ ERROR variable `a` is not bound in all patterns
+    let A(..) | B(a) = X; //~ ERROR variable `a` is not bound in all patterns
+    let A(a, _) | B(_) = X; //~ ERROR variable `a` is not bound in all patterns
+    let A(_, a) | B(_) = X; //~ ERROR variable `a` is not bound in all patterns
+    let A(a, b) | B(a) = X; //~ ERROR variable `b` is not bound in all patterns
+
+    // Two levels:
+    const Y: E<E<u8>> = B(B(0));
+    let A(A(..) | B(_), _) | B(a) = Y; //~ ERROR variable `a` is not bound in all patterns
+    let A(A(..) | B(a), _) | B(A(a, _) | B(a)) = Y;
+    //~^ ERROR variable `a` is not bound in all patterns
+    let A(A(a, b) | B(c), d) | B(e) = Y;
+    //~^ ERROR variable `a` is not bound in all patterns
+    //~| ERROR variable `a` is not bound in all patterns
+    //~| ERROR variable `b` is not bound in all patterns
+    //~| ERROR variable `b` is not bound in all patterns
+    //~| ERROR variable `c` is not bound in all patterns
+    //~| ERROR variable `c` is not bound in all patterns
+    //~| ERROR variable `d` is not bound in all patterns
+    //~| ERROR variable `e` is not bound in all patterns
+
+    // Three levels:
+    let (
+            V1(
+            //~^ ERROR variable `b` is not bound in all patterns
+            //~| ERROR variable `c` is not bound in all patterns
+                A(
+                    Ok(a) | Err(_), //~ ERROR variable `a` is not bound in all patterns
+                    _
+                ) |
+                B(Ok(a) | Err(a))
+            ) |
+            V2(
+                A(
+                    A(_, a) | //~ ERROR variable `b` is not bound in all patterns
+                    B(b), //~ ERROR variable `a` is not bound in all patterns
+                    _
+                ) |
+                B(_)
+                //~^ ERROR variable `a` is not bound in all patterns
+                //~| ERROR variable `b` is not bound in all patterns
+            ) |
+            V3(c),
+            //~^ ERROR variable `a` is not bound in all patterns
+        )
+        : (Vars3<E<Result<u8, u8>>, E<E<u8>>, u8>,)
+        = (V3(0),);
+}

--- a/src/test/ui/or-patterns/missing-bindings.rs
+++ b/src/test/ui/or-patterns/missing-bindings.rs
@@ -3,7 +3,9 @@
 // edition:2018
 
 #![feature(or_patterns)]
-#![allow(incomplete_features, non_camel_case_types)]
+//~^ WARN the feature `or_patterns` is incomplete
+
+#![allow(non_camel_case_types)]
 
 fn main() {}
 

--- a/src/test/ui/or-patterns/missing-bindings.stderr
+++ b/src/test/ui/or-patterns/missing-bindings.stderr
@@ -1,0 +1,242 @@
+error[E0408]: variable `beta` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:20:9
+   |
+LL |     let alpha | beta | charlie = alpha;
+   |         ^^^^^   ----   ^^^^^^^ pattern doesn't bind `beta`
+   |         |       |
+   |         |       variable not in all patterns
+   |         pattern doesn't bind `beta`
+
+error[E0408]: variable `beta` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:22:14
+   |
+LL |         Some(alpha | beta) => {}
+   |              ^^^^^   ---- variable not in all patterns
+   |              |
+   |              pattern doesn't bind `beta`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:34:19
+   |
+LL |     let A(a, _) | _ = X;
+   |           -       ^ pattern doesn't bind `a`
+   |           |
+   |           variable not in all patterns
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:35:9
+   |
+LL |     let _ | B(a) = X;
+   |         ^     - variable not in all patterns
+   |         |
+   |         pattern doesn't bind `a`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:36:9
+   |
+LL |     let A(..) | B(a) = X;
+   |         ^^^^^     - variable not in all patterns
+   |         |
+   |         pattern doesn't bind `a`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:37:19
+   |
+LL |     let A(a, _) | B(_) = X;
+   |           -       ^^^^ pattern doesn't bind `a`
+   |           |
+   |           variable not in all patterns
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:38:19
+   |
+LL |     let A(_, a) | B(_) = X;
+   |              -    ^^^^ pattern doesn't bind `a`
+   |              |
+   |              variable not in all patterns
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:39:19
+   |
+LL |     let A(a, b) | B(a) = X;
+   |              -    ^^^^ pattern doesn't bind `b`
+   |              |
+   |              variable not in all patterns
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:43:9
+   |
+LL |     let A(A(..) | B(_), _) | B(a) = Y;
+   |         ^^^^^^^^^^^^^^^^^^     - variable not in all patterns
+   |         |
+   |         pattern doesn't bind `a`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:44:11
+   |
+LL |     let A(A(..) | B(a), _) | B(A(a, _) | B(a)) = Y;
+   |           ^^^^^     - variable not in all patterns
+   |           |
+   |           pattern doesn't bind `a`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:21
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |             -       ^^^^ pattern doesn't bind `a`
+   |             |
+   |             variable not in all patterns
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:21
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |                -    ^^^^ pattern doesn't bind `b`
+   |                |
+   |                variable not in all patterns
+
+error[E0408]: variable `c` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:11
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |           ^^^^^^^     - variable not in all patterns
+   |           |
+   |           pattern doesn't bind `c`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:32
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |             -                  ^^^^ pattern doesn't bind `a`
+   |             |
+   |             variable not in all patterns
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:32
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |                -               ^^^^ pattern doesn't bind `b`
+   |                |
+   |                variable not in all patterns
+
+error[E0408]: variable `c` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:32
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |                       -        ^^^^ pattern doesn't bind `c`
+   |                       |
+   |                       variable not in all patterns
+
+error[E0408]: variable `d` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:32
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |                           -    ^^^^ pattern doesn't bind `d`
+   |                           |
+   |                           variable not in all patterns
+
+error[E0408]: variable `e` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:46:9
+   |
+LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
+   |         ^^^^^^^^^^^^^^^^^^^^     - variable not in all patterns
+   |         |
+   |         pattern doesn't bind `e`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:62:29
+   |
+LL |                     Ok(a) | Err(_),
+   |                        -    ^^^^^^ pattern doesn't bind `a`
+   |                        |
+   |                        variable not in all patterns
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:70:21
+   |
+LL |                     A(_, a) |
+   |                          - variable not in all patterns
+LL |                     B(b),
+   |                     ^^^^ pattern doesn't bind `a`
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:69:21
+   |
+LL |                     A(_, a) |
+   |                     ^^^^^^^ pattern doesn't bind `b`
+LL |                     B(b),
+   |                       - variable not in all patterns
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:73:17
+   |
+LL |                     A(_, a) |
+   |                          - variable not in all patterns
+...
+LL |                 B(_)
+   |                 ^^^^ pattern doesn't bind `a`
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:73:17
+   |
+LL |                     B(b),
+   |                       - variable not in all patterns
+...
+LL |                 B(_)
+   |                 ^^^^ pattern doesn't bind `b`
+
+error[E0408]: variable `a` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:77:13
+   |
+LL |                 B(Ok(a) | Err(a))
+   |                               - variable not in all patterns
+...
+LL |                     A(_, a) |
+   |                          - variable not in all patterns
+...
+LL |             V3(c),
+   |             ^^^^^ pattern doesn't bind `a`
+
+error[E0408]: variable `b` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:58:13
+   |
+LL | /             V1(
+LL | |
+LL | |
+LL | |                 A(
+...  |
+LL | |                 B(Ok(a) | Err(a))
+LL | |             ) |
+   | |_____________^ pattern doesn't bind `b`
+...
+LL |                       B(b),
+   |                         - variable not in all patterns
+...
+LL |               V3(c),
+   |               ^^^^^ pattern doesn't bind `b`
+
+error[E0408]: variable `c` is not bound in all patterns
+  --> $DIR/missing-bindings.rs:58:13
+   |
+LL | /             V1(
+LL | |
+LL | |
+LL | |                 A(
+...  |
+LL | |                 B(Ok(a) | Err(a))
+LL | |             ) |
+   | |_____________^ pattern doesn't bind `c`
+LL | /             V2(
+LL | |                 A(
+LL | |                     A(_, a) |
+LL | |                     B(b),
+...  |
+LL | |
+LL | |             ) |
+   | |_____________^ pattern doesn't bind `c`
+LL |               V3(c),
+   |                  - variable not in all patterns
+
+error: aborting due to 26 previous errors
+
+For more information about this error, try `rustc --explain E0408`.

--- a/src/test/ui/or-patterns/missing-bindings.stderr
+++ b/src/test/ui/or-patterns/missing-bindings.stderr
@@ -1,5 +1,5 @@
 error[E0408]: variable `beta` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:20:9
+  --> $DIR/missing-bindings.rs:22:9
    |
 LL |     let alpha | beta | charlie = alpha;
    |         ^^^^^   ----   ^^^^^^^ pattern doesn't bind `beta`
@@ -8,7 +8,7 @@ LL |     let alpha | beta | charlie = alpha;
    |         pattern doesn't bind `beta`
 
 error[E0408]: variable `beta` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:22:14
+  --> $DIR/missing-bindings.rs:24:14
    |
 LL |         Some(alpha | beta) => {}
    |              ^^^^^   ---- variable not in all patterns
@@ -16,7 +16,7 @@ LL |         Some(alpha | beta) => {}
    |              pattern doesn't bind `beta`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:34:19
+  --> $DIR/missing-bindings.rs:36:19
    |
 LL |     let A(a, _) | _ = X;
    |           -       ^ pattern doesn't bind `a`
@@ -24,7 +24,7 @@ LL |     let A(a, _) | _ = X;
    |           variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:35:9
+  --> $DIR/missing-bindings.rs:37:9
    |
 LL |     let _ | B(a) = X;
    |         ^     - variable not in all patterns
@@ -32,7 +32,7 @@ LL |     let _ | B(a) = X;
    |         pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:36:9
+  --> $DIR/missing-bindings.rs:38:9
    |
 LL |     let A(..) | B(a) = X;
    |         ^^^^^     - variable not in all patterns
@@ -40,7 +40,7 @@ LL |     let A(..) | B(a) = X;
    |         pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:37:19
+  --> $DIR/missing-bindings.rs:39:19
    |
 LL |     let A(a, _) | B(_) = X;
    |           -       ^^^^ pattern doesn't bind `a`
@@ -48,7 +48,7 @@ LL |     let A(a, _) | B(_) = X;
    |           variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:38:19
+  --> $DIR/missing-bindings.rs:40:19
    |
 LL |     let A(_, a) | B(_) = X;
    |              -    ^^^^ pattern doesn't bind `a`
@@ -56,7 +56,7 @@ LL |     let A(_, a) | B(_) = X;
    |              variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:39:19
+  --> $DIR/missing-bindings.rs:41:19
    |
 LL |     let A(a, b) | B(a) = X;
    |              -    ^^^^ pattern doesn't bind `b`
@@ -64,7 +64,7 @@ LL |     let A(a, b) | B(a) = X;
    |              variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:43:9
+  --> $DIR/missing-bindings.rs:45:9
    |
 LL |     let A(A(..) | B(_), _) | B(a) = Y;
    |         ^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -72,7 +72,7 @@ LL |     let A(A(..) | B(_), _) | B(a) = Y;
    |         pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:44:11
+  --> $DIR/missing-bindings.rs:46:11
    |
 LL |     let A(A(..) | B(a), _) | B(A(a, _) | B(a)) = Y;
    |           ^^^^^     - variable not in all patterns
@@ -80,7 +80,7 @@ LL |     let A(A(..) | B(a), _) | B(A(a, _) | B(a)) = Y;
    |           pattern doesn't bind `a`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:21
+  --> $DIR/missing-bindings.rs:48:21
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |             -       ^^^^ pattern doesn't bind `a`
@@ -88,7 +88,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |             variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:21
+  --> $DIR/missing-bindings.rs:48:21
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                -    ^^^^ pattern doesn't bind `b`
@@ -96,7 +96,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                variable not in all patterns
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:11
+  --> $DIR/missing-bindings.rs:48:11
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |           ^^^^^^^     - variable not in all patterns
@@ -104,7 +104,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |           pattern doesn't bind `c`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:32
+  --> $DIR/missing-bindings.rs:48:32
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |             -                  ^^^^ pattern doesn't bind `a`
@@ -112,7 +112,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |             variable not in all patterns
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:32
+  --> $DIR/missing-bindings.rs:48:32
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                -               ^^^^ pattern doesn't bind `b`
@@ -120,7 +120,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                variable not in all patterns
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:32
+  --> $DIR/missing-bindings.rs:48:32
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                       -        ^^^^ pattern doesn't bind `c`
@@ -128,7 +128,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                       variable not in all patterns
 
 error[E0408]: variable `d` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:32
+  --> $DIR/missing-bindings.rs:48:32
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                           -    ^^^^ pattern doesn't bind `d`
@@ -136,7 +136,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |                           variable not in all patterns
 
 error[E0408]: variable `e` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:46:9
+  --> $DIR/missing-bindings.rs:48:9
    |
 LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |         ^^^^^^^^^^^^^^^^^^^^     - variable not in all patterns
@@ -144,7 +144,7 @@ LL |     let A(A(a, b) | B(c), d) | B(e) = Y;
    |         pattern doesn't bind `e`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:62:29
+  --> $DIR/missing-bindings.rs:64:29
    |
 LL |                     Ok(a) | Err(_),
    |                        -    ^^^^^^ pattern doesn't bind `a`
@@ -152,7 +152,7 @@ LL |                     Ok(a) | Err(_),
    |                        variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:70:21
+  --> $DIR/missing-bindings.rs:72:21
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -160,7 +160,7 @@ LL |                     B(b),
    |                     ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:69:21
+  --> $DIR/missing-bindings.rs:71:21
    |
 LL |                     A(_, a) |
    |                     ^^^^^^^ pattern doesn't bind `b`
@@ -168,7 +168,7 @@ LL |                     B(b),
    |                       - variable not in all patterns
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:73:17
+  --> $DIR/missing-bindings.rs:75:17
    |
 LL |                     A(_, a) |
    |                          - variable not in all patterns
@@ -177,7 +177,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:73:17
+  --> $DIR/missing-bindings.rs:75:17
    |
 LL |                     B(b),
    |                       - variable not in all patterns
@@ -186,7 +186,7 @@ LL |                 B(_)
    |                 ^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `a` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:77:13
+  --> $DIR/missing-bindings.rs:79:13
    |
 LL |                 B(Ok(a) | Err(a))
    |                               - variable not in all patterns
@@ -198,7 +198,7 @@ LL |             V3(c),
    |             ^^^^^ pattern doesn't bind `a`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:58:13
+  --> $DIR/missing-bindings.rs:60:13
    |
 LL | /             V1(
 LL | |
@@ -216,7 +216,7 @@ LL |               V3(c),
    |               ^^^^^ pattern doesn't bind `b`
 
 error[E0408]: variable `c` is not bound in all patterns
-  --> $DIR/missing-bindings.rs:58:13
+  --> $DIR/missing-bindings.rs:60:13
    |
 LL | /             V1(
 LL | |
@@ -236,6 +236,14 @@ LL | |             ) |
    | |_____________^ pattern doesn't bind `c`
 LL |               V3(c),
    |                  - variable not in all patterns
+
+warning: the feature `or_patterns` is incomplete and may cause the compiler to crash
+  --> $DIR/missing-bindings.rs:5:12
+   |
+LL | #![feature(or_patterns)]
+   |            ^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
 
 error: aborting due to 26 previous errors
 

--- a/src/test/ui/shadowed/shadowing-in-the-same-pattern.stderr
+++ b/src/test/ui/shadowed/shadowing-in-the-same-pattern.stderr
@@ -1,8 +1,8 @@
-error[E0416]: identifier `a` is bound more than once in the same pattern
+error[E0415]: identifier `a` is bound more than once in this parameter list
   --> $DIR/shadowing-in-the-same-pattern.rs:3:10
    |
 LL | fn f((a, a): (isize, isize)) {}
-   |          ^ used in a pattern more than once
+   |          ^ used as parameter more than once
 
 error[E0416]: identifier `a` is bound more than once in the same pattern
   --> $DIR/shadowing-in-the-same-pattern.rs:6:13
@@ -12,4 +12,5 @@ LL |     let (a, a) = (1, 1);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0416`.
+Some errors have detailed explanations: E0415, E0416.
+For more information about an error, try `rustc --explain E0415`.


### PR DESCRIPTION
Following up on work in https://github.com/rust-lang/rust/pull/63693 and https://github.com/rust-lang/rust/pull/61708, in this PR we:

- Uniformly use `PatKind::Or(...)` in AST:

   - Change `ast::Arm.pats: Vec<P<Pat>>` => `ast::Arm.pat: P<Pat>`

   - Change `ast::ExprKind::Let.0: Vec<P<Pat>>` => `ast::ExprKind::Let.0: P<Pat>`

- Adjust `librustc_resolve/late.rs` to correctly handle or-patterns at any level of nesting as a result.

  In particular, the already-bound check which rejects e.g. `let (a, a);` now accounts for or-patterns. The consistency checking (ensures no missing bindings and binding mode consistency) also now accounts for or-patterns. In the process, a bug was found in the current compiler which allowed:

   ```rust
   enum E<T> { A(T, T), B(T) }
   use E::*;
   fn foo() {
       match A(0, 1) {
           B(mut a) | A(mut a, mut a) => {}
       }
   }
   ```

   The new algorithms took a few iterations to get right. I tried several clever schemes but ultimately a version based on a stack of hashsets and recording product/sum contexts was chosen since it is more clearly correct.

- Clean up `librustc_resolve/late.rs` by, among other things, using a new `with_rib` function to better ensure stack dicipline.

- Do not push the change in AST to HIR for now to avoid doing too much in this PR. To cope with  this, we introduce a temporary hack in `rustc::hir::lowering` (clearly marked in the diff).

cc https://github.com/rust-lang/rust/issues/54883
cc @dlrobertson @matthewjasper 
r? @petrochenkov 