### PR TITLE
Added warning around code with reference to uninit bytes

### DIFF
--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -371,6 +371,14 @@ where
     loop {
         if g.len == g.buf.len() {
             unsafe {
+                // FIXME(danielhenrymantilla): #42788
+                //
+                //   - This creates a (mut) reference to a slice of
+                //     _uninitialized integers_.
+                //
+                //   - This having defined behavior is **unstable**:
+                //     it could become UB in the future,
+                //     at which point it would have be changed.
                 g.buf.reserve(reservation_size(r));
                 let capacity = g.buf.capacity();
                 g.buf.set_len(capacity);

--- a/src/libstd/io/mod.rs
+++ b/src/libstd/io/mod.rs
@@ -374,11 +374,11 @@ where
                 // FIXME(danielhenrymantilla): #42788
                 //
                 //   - This creates a (mut) reference to a slice of
-                //     _uninitialized integers_.
+                //     _uninitialized_ integers, which is **undefined behavior**
                 //
-                //   - This having defined behavior is **unstable**:
-                //     it could become UB in the future,
-                //     at which point it would have be changed.
+                //   - Only the standard library gets to soundly "ignore" this,
+                //     based on its privileged knowledge of unstable rustc
+                //     internals;
                 g.buf.reserve(reservation_size(r));
                 let capacity = g.buf.capacity();
                 g.buf.set_len(capacity);


### PR DESCRIPTION
Officially, uninitialized integers, and therefore, Rust references to them are _invalid_ (note that this may evolve into official defined behavior (_c.f._, https://github.com/rust-lang/unsafe-code-guidelines/issues/71)).

However, `::std` uses references to uninitialized integers when working with the `Read::initializer` feature (#42788), since it relies on this unstably having defined behavior with the current implementation of the compiler (IIUC).

Hence the comment to disincentivize people from using this pattern outside the standard library.