### PR TITLE
Custom backtrace output for Fuchsia

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,8 +110,6 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.3.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 dependencies = [
  "backtrace-sys",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ rustc-workspace-hack = { path = 'src/tools/rustc-workspace-hack' }
 rustc-std-workspace-core = { path = 'src/tools/rustc-std-workspace-core' }
 rustc-std-workspace-alloc = { path = 'src/tools/rustc-std-workspace-alloc' }
 rustc-std-workspace-std = { path = 'src/tools/rustc-std-workspace-std' }
+backtrace = { path = "../backtrace-rs" }
+# backtrace-sys = { path = "../backtrace-rs/crates/backtrace-sys" }
 
 [patch."https://github.com/rust-lang/rust-clippy"]
 clippy_lints = { path = "src/tools/clippy/clippy_lints" }

--- a/src/libstd/sys_common/backtrace.rs
+++ b/src/libstd/sys_common/backtrace.rs
@@ -14,7 +14,7 @@ use crate::sys::mutex::Mutex;
 use backtrace::{BytesOrWideString, Frame, Symbol};
 
 #[cfg(not(target_os = "fuchsia"))]
-pub const HEX_WIDTH: usize = 2 + 2 * mem::size_of::<usize>();
+const HEX_WIDTH: usize = 2 + 2 * mem::size_of::<usize>();
 
 /// Max number of frames to print.
 #[cfg(not(target_os = "fuchsia"))]


### PR DESCRIPTION
This is... not my favorite code that I've ever written. This lovely platform-agnostic module is no longer platform-agnostic. I considered breaking it up more, but the public API for other crates has to remain roughly the same in order to fulfill their needs on other platforms, and the actual quantity of cfg'd code here is fairly small-- it seems wrong to introduce a non-sys-common `sys/fuchsia/backtrace.rs` and `sys/everything_but_fuchsia/backtrace.rs`. Let me know if you have better suggestions for organizing this.

r? @alexcrichton 