### PR TITLE
resolve: Do not afraid to set current module to enums and traits

### DIFF
--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -728,9 +728,10 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                                              expansion,
                                              item.span);
                 self.r.define(parent, ident, TypeNS, (module, vis, sp, expansion));
+                self.parent_scope.module = module;
 
                 for variant in &(*enum_definition).variants {
-                    self.build_reduced_graph_for_variant(variant, module, vis);
+                    self.build_reduced_graph_for_variant(variant, vis);
                 }
             }
 
@@ -818,10 +819,8 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
 
     // Constructs the reduced graph for one variant. Variants exist in the
     // type and value namespaces.
-    fn build_reduced_graph_for_variant(&mut self,
-                                       variant: &Variant,
-                                       parent: Module<'a>,
-                                       vis: ty::Visibility) {
+    fn build_reduced_graph_for_variant(&mut self, variant: &Variant, vis: ty::Visibility) {
+        let parent = self.parent_scope.module;
         let expn_id = self.parent_scope.expansion;
         let ident = variant.ident;
 
@@ -1253,9 +1252,7 @@ impl<'a, 'b> Visitor<'b> for BuildReducedGraphVisitor<'a, 'b> {
         let expansion = self.parent_scope.expansion;
         self.r.define(parent, item.ident, ns, (res, vis, item.span, expansion));
 
-        self.parent_scope.module = parent.parent.unwrap(); // nearest normal ancestor
         visit::walk_trait_item(self, item);
-        self.parent_scope.module = parent;
     }
 
     fn visit_token(&mut self, t: Token) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -538,7 +538,11 @@ impl<'a> ModuleData<'a> {
     }
 
     fn nearest_item_scope(&'a self) -> Module<'a> {
-        if self.is_trait() { self.parent.unwrap() } else { self }
+        match self.kind {
+            ModuleKind::Def(DefKind::Enum, ..) | ModuleKind::Def(DefKind::Trait, ..) =>
+                self.parent.expect("enum or trait module without a parent"),
+            _ => self,
+        }
     }
 
     fn is_ancestor_of(&self, mut other: &Self) -> bool {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1644,7 +1644,7 @@ impl<'a> Resolver<'a> {
         }
 
         if let ModuleKind::Block(..) = module.kind {
-            return Some(module.parent.unwrap());
+            return Some(module.parent.unwrap().nearest_item_scope());
         }
 
         None

--- a/src/test/ui/resolve/block-with-trait-parent.rs
+++ b/src/test/ui/resolve/block-with-trait-parent.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+trait Trait {
+    fn method(&self) {
+        // Items inside a block turn it into a module internally.
+        struct S;
+        impl Trait for S {}
+
+        // OK, `Trait` is in scope here from method resolution point of view.
+        S.method();
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/63535/commits/cfbb60bf6d83fbcfcca1f2919131aa39fb997b53 it's ok.

This is likely required for https://github.com/rust-lang/rust/pull/63468 to work correctly, because that PR starts resolving attributes on enum variants.

r? @matthewjasper @c410-f3r 