### PR TITLE
annotate-snippet emitter: Deal with multispans from macros, too

### DIFF
--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -30,10 +30,14 @@ pub struct AnnotateSnippetEmitterWriter {
 impl Emitter for AnnotateSnippetEmitterWriter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, db: &DiagnosticBuilder<'_>) {
-        let children = db.children.clone();
-        let (primary_span, suggestions) = self.primary_span_formatted(&db);
+        let mut children = db.children.clone();
+        let (mut primary_span, suggestions) = self.primary_span_formatted(&db);
 
-        // FIXME(#59346): Add `fix_multispans_in_std_macros` function from emitter.rs
+        self.fix_multispans_in_std_macros(&self.source_map,
+                                          &mut primary_span,
+                                          &mut children,
+                                          &db.level,
+                                          db.handler.flags.external_macro_backtrace);
 
         self.emit_messages_default(&db.level,
                                    db.message(),


### PR DESCRIPTION
This moves the two methods from the `EmitterWriter` impl to trait
default methods in the `Emitter` trait so that they can be re-used by
the `AnnotateSnippetEmitterWriter`.

r? @estebank

Closes #61810