### PR TITLE
fill metadata in rustc_lexer's Cargo.toml

### DIFF
--- a/src/librustc_lexer/Cargo.toml
+++ b/src/librustc_lexer/Cargo.toml
@@ -2,7 +2,13 @@
 authors = ["The Rust Project Developers"]
 name = "rustc_lexer"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
+
+repository = "https://github.com/rust-lang/rust/"
+description = """
+Rust lexer used by rustc. No stability guarantees are provided.
+"""
 
 # Note: do not remove this blank `[lib]` section.
 # This will be used when publishing this crate as `rustc-ap-rustc_lexer`.


### PR DESCRIPTION
We publish this to crates.io, so having non-empty meta is useful