### PR TITLE
Reduce span to function name in unreachable calls

### DIFF
--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -161,6 +161,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Warn for non-block expressions with diverging children.
         match expr.node {
             ExprKind::Block(..) | ExprKind::Loop(..) | ExprKind::Match(..) => {},
+            ExprKind::Call(ref callee, _) =>
+                self.warn_if_unreachable(expr.hir_id, callee.span, "call"),
+            ExprKind::MethodCall(_, ref span, _) =>
+                self.warn_if_unreachable(expr.hir_id, *span, "call"),
             _ => self.warn_if_unreachable(expr.hir_id, expr.span, "expression"),
         }
 

--- a/src/test/ui/never-assign-dead-code.stderr
+++ b/src/test/ui/never-assign-dead-code.stderr
@@ -11,11 +11,11 @@ LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
 
-warning: unreachable expression
+warning: unreachable call
   --> $DIR/never-assign-dead-code.rs:10:5
    |
 LL |     drop(x);
-   |     ^^^^^^^
+   |     ^^^^
 
 warning: unused variable: `x`
   --> $DIR/never-assign-dead-code.rs:9:9

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -10,11 +10,11 @@ note: lint level defined here
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: unreachable expression
+error: unreachable call
   --> $DIR/expr_call.rs:18:5
    |
 LL |     bar(return);
-   |     ^^^^^^^^^^^
+   |     ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -10,11 +10,11 @@ note: lint level defined here
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: unreachable expression
-  --> $DIR/expr_method.rs:21:5
+error: unreachable call
+  --> $DIR/expr_method.rs:21:9
    |
 LL |     Foo.bar(return);
-   |     ^^^^^^^^^^^^^^^
+   |         ^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unreachable/unreachable-in-call.rs
+++ b/src/test/ui/unreachable/unreachable-in-call.rs
@@ -14,7 +14,7 @@ fn diverge_first() {
          get_u8()); //~ ERROR unreachable expression
 }
 fn diverge_second() {
-    call( //~ ERROR unreachable expression
+    call( //~ ERROR unreachable call
         get_u8(),
         diverge());
 }

--- a/src/test/ui/unreachable/unreachable-in-call.stderr
+++ b/src/test/ui/unreachable/unreachable-in-call.stderr
@@ -10,13 +10,11 @@ note: lint level defined here
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
 
-error: unreachable expression
+error: unreachable call
   --> $DIR/unreachable-in-call.rs:17:5
    |
-LL | /     call(
-LL | |         get_u8(),
-LL | |         diverge());
-   | |__________________^
+LL |     call(
+   |     ^^^^
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
As title suggests, this might close #64103. Refer to the updated tests for expected output.

There is potential to further improve usability. In particular, is it favourable that the exact diverging expression/statement be pointed out (not only in this case, but for all unreachable code)? Certainly that would deserve another issue, but I'm interested in the opinions.