### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -668,7 +668,7 @@ class RustBuild(object):
     def update_submodule(self, module, checked_out, recorded_submodules):
         module_path = os.path.join(self.rust_root, module)
 
-        if checked_out != None:
+        if checked_out is not None:
             default_encoding = sys.getdefaultencoding()
             checked_out = checked_out.communicate()[0].decode(default_encoding).strip()
             if recorded_submodules[module] == checked_out:

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -212,6 +212,7 @@ pub fn std_cargo(builder: &Builder<'_>,
                 emscripten: false,
             });
             cargo.env("LLVM_CONFIG", llvm_config);
+            cargo.env("RUSTC_BUILD_SANITIZERS", "1");
         }
 
         cargo.arg("--features").arg(features)

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1110,6 +1110,18 @@ impl<T: Deref> Option<T> {
     /// to the original one, additionally coercing the contents via [`Deref`].
     ///
     /// [`Deref`]: ../../std/ops/trait.Deref.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(inner_deref)]
+    ///
+    /// let x: Option<String> = Some("hey".to_owned());
+    /// assert_eq!(x.as_deref(), Some("hey"));
+    ///
+    /// let x: Option<String> = None;
+    /// assert_eq!(x.as_deref(), None);
+    /// ```
     pub fn as_deref(&self) -> Option<&T::Target> {
         self.as_ref().map(|t| t.deref())
     }
@@ -1121,6 +1133,18 @@ impl<T: DerefMut> Option<T> {
     ///
     /// Leaves the original `Option` in-place, creating a new one containing a mutable reference to
     /// the inner type's `Deref::Target` type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(inner_deref)]
+    ///
+    /// let mut x: Option<String> = Some("hey".to_owned());
+    /// assert_eq!(x.as_deref_mut().map(|x| {
+    ///     x.make_ascii_uppercase();
+    ///     x
+    /// }), Some("HEY".to_owned().as_mut_str()));
+    /// ```
     pub fn as_deref_mut(&mut self) -> Option<&mut T::Target> {
         self.as_mut().map(|t| t.deref_mut())
     }
@@ -1199,6 +1223,13 @@ impl<T: Clone> Clone for Option<T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Default for Option<T> {
     /// Returns [`None`][Option::None].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let opt: Option<u32> = Option::default();
+    /// assert!(opt.is_none());
+    /// ```
     #[inline]
     fn default() -> Option<T> { None }
 }

--- a/src/libcore/unicode/printable.py
+++ b/src/libcore/unicode/printable.py
@@ -60,7 +60,7 @@ def get_codepoints(f):
         yield Codepoint(codepoint, class_)
         prev_codepoint = codepoint
 
-    if class_first != None:
+    if class_first is not None:
         raise ValueError("Missing Last after First")
 
     for c in range(prev_codepoint + 1, NUM_CODEPOINTS):

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -430,13 +430,13 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
         match self {
             PointerOutOfBounds { ptr, msg, allocation_size } => {
                 write!(f, "{} failed: pointer must be in-bounds at offset {}, \
-                          but is outside bounds of allocation {} which has size {}",
+                           but is outside bounds of allocation {} which has size {}",
                     msg, ptr.offset.bytes(), ptr.alloc_id, allocation_size.bytes())
             },
             ValidationFailure(ref err) => {
                 write!(f, "type validation failed: {}", err)
             }
-            NoMirFor(ref func) => write!(f, "no mir for `{}`", func),
+            NoMirFor(ref func) => write!(f, "no MIR for `{}`", func),
             FunctionAbiMismatch(caller_abi, callee_abi) =>
                 write!(f, "tried to call a function with ABI {:?} using caller ABI {:?}",
                     callee_abi, caller_abi),
@@ -451,9 +451,9 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
             FunctionArgCountMismatch =>
                 write!(f, "tried to call a function with incorrect number of arguments"),
             ReallocatedWrongMemoryKind(ref old, ref new) =>
-                write!(f, "tried to reallocate memory from {} to {}", old, new),
+                write!(f, "tried to reallocate memory from `{}` to `{}`", old, new),
             DeallocatedWrongMemoryKind(ref old, ref new) =>
-                write!(f, "tried to deallocate {} memory but gave {} as the kind", old, new),
+                write!(f, "tried to deallocate `{}` memory but gave `{}` as the kind", old, new),
             InvalidChar(c) =>
                 write!(f, "tried to interpret an invalid 32-bit value as a char: {}", c),
             AlignmentCheckFailed { required, has } =>
@@ -462,7 +462,7 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
             TypeNotPrimitive(ty) =>
                 write!(f, "expected primitive type, got {}", ty),
             PathNotFound(ref path) =>
-                write!(f, "Cannot find path {:?}", path),
+                write!(f, "cannot find path {:?}", path),
             IncorrectAllocationInformation(size, size2, align, align2) =>
                 write!(f, "incorrect alloc info: expected size {} and align {}, \
                            got size {} and align {}",
@@ -525,7 +525,7 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
             InvalidBoolOp(_) =>
                 write!(f, "invalid boolean operation"),
             UnterminatedCString(_) =>
-                write!(f, "attempted to get length of a null terminated string, but no null \
+                write!(f, "attempted to get length of a null-terminated string, but no null \
                     found before end of allocation"),
             ReadUndefBytes(_) =>
                 write!(f, "attempted to read undefined bytes"),

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1998,7 +1998,7 @@ pub fn parse_error_format(
             Some(arg) => early_error(
                 ErrorOutputType::HumanReadable(HumanReadableErrorType::Default(color)),
                 &format!(
-                    "argument for --error-format must be `human`, `json` or \
+                    "argument for `--error-format` must be `human`, `json` or \
                      `short` (instead was `{}`)",
                     arg
                 ),
@@ -2037,7 +2037,7 @@ pub fn build_session_options_and_crate_config(
             early_error(
                 ErrorOutputType::default(),
                 &format!(
-                    "argument for --edition must be one of: \
+                    "argument for `--edition` must be one of: \
                      {}. (instead was `{}`)",
                     EDITION_NAME_LIST,
                     arg
@@ -2051,7 +2051,7 @@ pub fn build_session_options_and_crate_config(
         early_error(
                 ErrorOutputType::default(),
                 &format!(
-                    "Edition {} is unstable and only \
+                    "edition {} is unstable and only \
                      available for nightly builds of rustc.",
                     edition,
                 )
@@ -2075,14 +2075,14 @@ pub fn build_session_options_and_crate_config(
         if let ErrorOutputType::Json { pretty: true, json_rendered } = error_format {
             early_error(
                 ErrorOutputType::Json { pretty: false, json_rendered },
-                "--error-format=pretty-json is unstable",
+                "`--error-format=pretty-json` is unstable",
             );
         }
         if let ErrorOutputType::HumanReadable(HumanReadableErrorType::AnnotateSnippet(_)) =
             error_format {
             early_error(
                 ErrorOutputType::Json { pretty: false, json_rendered },
-                "--error-format=human-annotate-rs is unstable",
+                "`--error-format=human-annotate-rs` is unstable",
             );
         }
     }
@@ -2132,8 +2132,8 @@ pub fn build_session_options_and_crate_config(
                         early_warn(
                             error_format,
                             &format!(
-                                "--emit={} with -o incompatible with \
-                                 -C codegen-units=N for N > 1",
+                                "`--emit={}` with `-o` incompatible with \
+                                 `-C codegen-units=N` for N > 1",
                                 ot
                             ),
                         );
@@ -2153,21 +2153,21 @@ pub fn build_session_options_and_crate_config(
     if debugging_opts.threads == Some(0) {
         early_error(
             error_format,
-            "Value for threads must be a positive nonzero integer",
+            "value for threads must be a positive non-zero integer",
         );
     }
 
     if debugging_opts.threads.unwrap_or(1) > 1 && debugging_opts.fuel.is_some() {
         early_error(
             error_format,
-            "Optimization fuel is incompatible with multiple threads",
+            "optimization fuel is incompatible with multiple threads",
         );
     }
 
     if codegen_units == Some(0) {
         early_error(
             error_format,
-            "Value for codegen units must be a positive nonzero integer",
+            "value for codegen units must be a positive non-zero integer",
         );
     }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -368,7 +368,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     match self.layout_of(param_env.and(ty)) {
                         Ok(layout) => &layout.abi,
                         Err(err) => bug!(
-                            "Error: {}\n while computing layout for type {:?}", err, ty
+                            "error: {}\n while computing layout for type {:?}", err, ty
                         )
                     }
                 };
@@ -384,7 +384,7 @@ impl<'tcx> TyCtxt<'tcx> {
                         self.sess.delay_span_bug(
                             self.def_span(method.def_id),
                             &format!(
-                                "Receiver when Self = () should have a Scalar ABI, found {:?}",
+                                "receiver when `Self = ()` should have a Scalar ABI; found {:?}",
                                 abi
                             ),
                         );
@@ -406,7 +406,8 @@ impl<'tcx> TyCtxt<'tcx> {
                         self.sess.delay_span_bug(
                             self.def_span(method.def_id),
                             &format!(
-                                "Receiver when Self = {} should have a ScalarPair ABI, found {:?}",
+                                "receiver when `Self = {}` should have a ScalarPair ABI; \
+                                 found {:?}",
                                 trait_object_ty, abi
                             ),
                         );

--- a/src/librustc_asan/build.rs
+++ b/src/librustc_asan/build.rs
@@ -4,6 +4,9 @@ use build_helper::sanitizer_lib_boilerplate;
 use cmake::Config;
 
 fn main() {
+    if env::var("RUSTC_BUILD_SANITIZERS") != Ok("1".to_string()) {
+        return;
+    }
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
         build_helper::restore_library_path();
 

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -30,10 +30,14 @@ pub struct AnnotateSnippetEmitterWriter {
 impl Emitter for AnnotateSnippetEmitterWriter {
     /// The entry point for the diagnostics generation
     fn emit_diagnostic(&mut self, db: &DiagnosticBuilder<'_>) {
-        let children = db.children.clone();
-        let (primary_span, suggestions) = self.primary_span_formatted(&db);
+        let mut children = db.children.clone();
+        let (mut primary_span, suggestions) = self.primary_span_formatted(&db);
 
-        // FIXME(#59346): Add `fix_multispans_in_std_macros` function from emitter.rs
+        self.fix_multispans_in_std_macros(&self.source_map,
+                                          &mut primary_span,
+                                          &mut children,
+                                          &db.level,
+                                          db.handler.flags.external_macro_backtrace);
 
         self.emit_messages_default(&db.level,
                                    db.message(),

--- a/src/librustc_errors/annotate_snippet_emitter_writer.rs
+++ b/src/librustc_errors/annotate_snippet_emitter_writer.rs
@@ -105,7 +105,7 @@ impl<'a>  DiagnosticConverter<'a> {
         annotated_files: Vec<FileWithAnnotatedLines>,
         primary_lo: Loc
     ) -> Vec<Slice> {
-        // FIXME(#59346): Provide a test case where `annotated_files` is > 1
+        // FIXME(#64205): Provide a test case where `annotated_files` is > 1
         annotated_files.iter().flat_map(|annotated_file| {
             annotated_file.lines.iter().map(|line| {
                 let line_source = Self::source_string(annotated_file.file.clone(), &line);

--- a/src/librustc_lsan/build.rs
+++ b/src/librustc_lsan/build.rs
@@ -4,6 +4,9 @@ use build_helper::sanitizer_lib_boilerplate;
 use cmake::Config;
 
 fn main() {
+    if env::var("RUSTC_BUILD_SANITIZERS") != Ok("1".to_string()) {
+        return;
+    }
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
         build_helper::restore_library_path();
 

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -98,7 +98,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 &self.describe_place_with_options(moved_place, IncludingDowncast(true))
                     .unwrap_or_else(|| "_".to_owned()),
             );
-            err.span_label(span, format!("use of possibly uninitialized {}", item_msg));
+            err.span_label(span, format!("use of possibly-uninitialized {}", item_msg));
 
             use_spans.var_span_label(
                 &mut err,

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -259,7 +259,10 @@ fn do_mir_borrowck<'a, 'tcx>(
         move_error_reported: BTreeMap::new(),
         uninitialized_error_reported: Default::default(),
         errors_buffer,
-        disable_error_downgrading: false,
+        // Only downgrade errors on Rust 2015 and refuse to do so on Rust 2018.
+        // FIXME(Centril): In Rust 1.40.0, refuse doing so on 2015 as well and
+        // proceed to throwing out the migration infrastructure.
+        disable_error_downgrading: body.span.rust_2018(),
         nonlexical_regioncx: regioncx,
         used_mut: Default::default(),
         used_mut_upvars: SmallVec::new(),

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -164,8 +164,8 @@ fn do_mir_borrowck<'a, 'tcx>(
         };
 
     let mdpe = MoveDataParamEnv {
-        move_data: move_data,
-        param_env: param_env,
+        move_data,
+        param_env,
     };
 
     let dead_unwinds = BitSet::new_empty(body.basic_blocks().len());

--- a/src/librustc_mir/const_eval.rs
+++ b/src/librustc_mir/const_eval.rs
@@ -533,8 +533,8 @@ pub fn error_to_const_error<'mir, 'tcx>(
 
 pub fn note_on_undefined_behavior_error() -> &'static str {
     "The rules on what exactly is undefined behavior aren't clear, \
-    so this check might be overzealous. Please open an issue on the rust compiler \
-    repository if you believe it should not be considered undefined behavior"
+     so this check might be overzealous. Please open an issue on the rustc \
+     repository if you believe it should not be considered undefined behavior."
 }
 
 fn validate_and_turn_into_const<'tcx>(

--- a/src/librustc_mir/error_codes.rs
+++ b/src/librustc_mir/error_codes.rs
@@ -748,7 +748,7 @@ It is not allowed to use or capture an uninitialized variable. For example:
 ```compile_fail,E0381
 fn main() {
     let x: i32;
-    let y = x; // error, use of possibly uninitialized variable
+    let y = x; // error, use of possibly-uninitialized variable
 }
 ```
 

--- a/src/librustc_mir/util/borrowck_errors.rs
+++ b/src/librustc_mir/util/borrowck_errors.rs
@@ -50,7 +50,7 @@ impl<'cx, 'tcx> crate::borrow_check::MirBorrowckCtxt<'cx, 'tcx> {
             self,
             span,
             E0381,
-            "{} of possibly uninitialized variable: `{}`",
+            "{} of possibly-uninitialized variable: `{}`",
             verb,
             desc,
         )

--- a/src/librustc_msan/build.rs
+++ b/src/librustc_msan/build.rs
@@ -4,6 +4,9 @@ use build_helper::sanitizer_lib_boilerplate;
 use cmake::Config;
 
 fn main() {
+    if env::var("RUSTC_BUILD_SANITIZERS") != Ok("1".to_string()) {
+        return;
+    }
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
         build_helper::restore_library_path();
 

--- a/src/librustc_tsan/build.rs
+++ b/src/librustc_tsan/build.rs
@@ -4,6 +4,9 @@ use build_helper::sanitizer_lib_boilerplate;
 use cmake::Config;
 
 fn main() {
+    if env::var("RUSTC_BUILD_SANITIZERS") != Ok("1".to_string()) {
+        return;
+    }
     if let Some(llvm_config) = env::var_os("LLVM_CONFIG") {
         build_helper::restore_library_path();
 

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -982,7 +982,7 @@ impl<'a> Parser<'a> {
                 }
                 if self.is_do_catch_block() {
                     let mut db = self.fatal("found removed `do catch` syntax");
-                    db.help("Following RFC #2388, the new non-placeholder syntax is `try`");
+                    db.help("following RFC #2388, the new non-placeholder syntax is `try`");
                     return Err(db);
                 }
                 if self.is_try_block() {

--- a/src/libsyntax/parse/parser/stmt.rs
+++ b/src/libsyntax/parse/parser/stmt.rs
@@ -469,7 +469,7 @@ impl<'a> Parser<'a> {
         self.diagnostic().struct_span_warn(self.token.span, {
             &format!("expected `;`, found {}", self.this_token_descr())
         }).note({
-            "This was erroneously allowed and will become a hard error in a future release"
+            "this was erroneously allowed and will become a hard error in a future release"
         }).emit();
     }
 }

--- a/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
+++ b/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 #![allow(dead_code)]
 
 // check dtor calling order when casting enums.

--- a/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
+++ b/src/test/run-pass-valgrind/cleanup-auto-borrow-obj.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 // This would previously leak the Box<Trait> because we wouldn't
 // schedule cleanups when auto borrowing trait objects.
 // This program should be valgrind clean.

--- a/src/test/run-pass-valgrind/cleanup-stdin.rs
+++ b/src/test/run-pass-valgrind/cleanup-stdin.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 fn main() {
     let _ = std::io::stdin();
     let _ = std::io::stdout();

--- a/src/test/run-pass-valgrind/down-with-thread-dtors.rs
+++ b/src/test/run-pass-valgrind/down-with-thread-dtors.rs
@@ -1,4 +1,3 @@
-// no-prefer-dynamic
 // ignore-emscripten
 
 thread_local!(static FOO: Foo = Foo);

--- a/src/test/run-pass-valgrind/dst-dtor-1.rs
+++ b/src/test/run-pass-valgrind/dst-dtor-1.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 static mut DROP_RAN: bool = false;
 
 struct Foo;

--- a/src/test/run-pass-valgrind/dst-dtor-2.rs
+++ b/src/test/run-pass-valgrind/dst-dtor-2.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 static mut DROP_RAN: isize = 0;
 
 struct Foo;

--- a/src/test/run-pass-valgrind/dst-dtor-3.rs
+++ b/src/test/run-pass-valgrind/dst-dtor-3.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 #![feature(unsized_tuple_coercion)]
 
 static mut DROP_RAN: bool = false;

--- a/src/test/run-pass-valgrind/dst-dtor-4.rs
+++ b/src/test/run-pass-valgrind/dst-dtor-4.rs
@@ -1,5 +1,3 @@
-// no-prefer-dynamic
-
 #![feature(unsized_tuple_coercion)]
 
 static mut DROP_RAN: isize = 0;

--- a/src/test/run-pass-valgrind/exit-flushes.rs
+++ b/src/test/run-pass-valgrind/exit-flushes.rs
@@ -1,4 +1,3 @@
-// no-prefer-dynamic
 // ignore-cloudabi
 // ignore-emscripten
 // ignore-sgx no processes

--- a/src/test/run-pass-valgrind/osx-frameworks.rs
+++ b/src/test/run-pass-valgrind/osx-frameworks.rs
@@ -1,4 +1,3 @@
-// no-prefer-dynamic
 // pretty-expanded FIXME #23616
 
 #![feature(rustc_private)]

--- a/src/test/ui/asm/asm-out-read-uninit.rs
+++ b/src/test/ui/asm/asm-out-read-uninit.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let x: isize;
     unsafe {
         asm!("mov $1, $0" : "=r"(x) : "r"(x));
-        //~^ ERROR use of possibly uninitialized variable: `x`
+        //~^ ERROR use of possibly-uninitialized variable: `x`
     }
     foo(x);
 }

--- a/src/test/ui/asm/asm-out-read-uninit.stderr
+++ b/src/test/ui/asm/asm-out-read-uninit.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/asm-out-read-uninit.rs:22:43
    |
 LL |         asm!("mov $1, $0" : "=r"(x) : "r"(x));
-   |                                           ^ use of possibly uninitialized `x`
+   |                                           ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/no-non-guaranteed-initialization.rs
+++ b/src/test/ui/async-await/no-non-guaranteed-initialization.rs
@@ -8,7 +8,7 @@ async fn no_non_guaranteed_initialization(x: usize) -> usize {
         y = echo(10).await;
     }
     y
-    //~^ use of possibly uninitialized variable: `y`
+    //~^ use of possibly-uninitialized variable: `y`
 }
 
 async fn echo(x: usize) -> usize { x + 1 }

--- a/src/test/ui/async-await/no-non-guaranteed-initialization.stderr
+++ b/src/test/ui/async-await/no-non-guaranteed-initialization.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `y`
+error[E0381]: use of possibly-uninitialized variable: `y`
   --> $DIR/no-non-guaranteed-initialization.rs:10:5
    |
 LL |     y
-   |     ^ use of possibly uninitialized `y`
+   |     ^ use of possibly-uninitialized `y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/partial-initialization-across-await.rs
+++ b/src/test/ui/async-await/partial-initialization-across-await.rs
@@ -11,7 +11,7 @@ async fn noop() {}
 async fn test_tuple() {
     let mut t: (i32, i32);
     t.0 = 42;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     noop().await;
     t.1 = 88;
     let _ = t;
@@ -20,7 +20,7 @@ async fn test_tuple() {
 async fn test_tuple_struct() {
     let mut t: T;
     t.0 = 42;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     noop().await;
     t.1 = 88;
     let _ = t;
@@ -29,7 +29,7 @@ async fn test_tuple_struct() {
 async fn test_struct() {
     let mut t: S;
     t.x = 42;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     noop().await;
     t.y = 88;
     let _ = t;

--- a/src/test/ui/async-await/partial-initialization-across-await.stderr
+++ b/src/test/ui/async-await/partial-initialization-across-await.stderr
@@ -1,20 +1,20 @@
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-await.rs:13:5
    |
 LL |     t.0 = 42;
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-await.rs:22:5
    |
 LL |     t.0 = 42;
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-await.rs:31:5
    |
 LL |     t.x = 42;
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/assign_mutable_fields.stderr
+++ b/src/test/ui/borrowck/assign_mutable_fields.stderr
@@ -1,14 +1,14 @@
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/assign_mutable_fields.rs:9:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/assign_mutable_fields.rs:17:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-and-init.rs
+++ b/src/test/ui/borrowck/borrowck-and-init.rs
@@ -2,5 +2,5 @@ fn main() {
     let i: isize;
 
     println!("{}", false && { i = 5; true });
-    println!("{}", i); //~ ERROR borrow of possibly uninitialized variable: `i`
+    println!("{}", i); //~ ERROR borrow of possibly-uninitialized variable: `i`
 }

--- a/src/test/ui/borrowck/borrowck-and-init.stderr
+++ b/src/test/ui/borrowck/borrowck-and-init.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `i`
+error[E0381]: borrow of possibly-uninitialized variable: `i`
   --> $DIR/borrowck-and-init.rs:5:20
    |
 LL |     println!("{}", i);
-   |                    ^ use of possibly uninitialized `i`
+   |                    ^ use of possibly-uninitialized `i`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-asm.rs
+++ b/src/test/ui/borrowck/borrowck-asm.rs
@@ -57,7 +57,7 @@ mod test_cases {
     fn indirect_is_not_init() {
         let x: i32;
         unsafe {
-            asm!("nop" : "=*r"(x)); //~ ERROR use of possibly uninitialized variable
+            asm!("nop" : "=*r"(x)); //~ ERROR use of possibly-uninitialized variable
         }
     }
 

--- a/src/test/ui/borrowck/borrowck-asm.stderr
+++ b/src/test/ui/borrowck/borrowck-asm.stderr
@@ -46,11 +46,11 @@ LL |         unsafe {
 LL |             asm!("nop" : "+r"(x));
    |                               ^ cannot assign twice to immutable variable
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-asm.rs:60:32
    |
 LL |             asm!("nop" : "=*r"(x));
-   |                                ^ use of possibly uninitialized `x`
+   |                                ^ use of possibly-uninitialized `x`
 
 error[E0506]: cannot assign to `x` because it is borrowed
   --> $DIR/borrowck-asm.rs:68:31

--- a/src/test/ui/borrowck/borrowck-block-unint.rs
+++ b/src/test/ui/borrowck/borrowck-block-unint.rs
@@ -1,7 +1,7 @@
 fn force<F>(f: F) where F: FnOnce() { f(); }
 fn main() {
     let x: isize;
-    force(|| {  //~ ERROR borrow of possibly uninitialized variable: `x`
+    force(|| {  //~ ERROR borrow of possibly-uninitialized variable: `x`
         println!("{}", x);
     });
 }

--- a/src/test/ui/borrowck/borrowck-block-unint.stderr
+++ b/src/test/ui/borrowck/borrowck-block-unint.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-block-unint.rs:4:11
    |
 LL |     force(|| {
-   |           ^^ use of possibly uninitialized `x`
+   |           ^^ use of possibly-uninitialized `x`
 LL |         println!("{}", x);
    |                        - borrow occurs due to use in closure
 

--- a/src/test/ui/borrowck/borrowck-break-uninit-2.rs
+++ b/src/test/ui/borrowck/borrowck-break-uninit-2.rs
@@ -6,7 +6,7 @@ fn foo() -> isize {
         x = 0;
     }
 
-    println!("{}", x); //~ ERROR borrow of possibly uninitialized variable: `x`
+    println!("{}", x); //~ ERROR borrow of possibly-uninitialized variable: `x`
 
     return 17;
 }

--- a/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit-2.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-break-uninit-2.rs:9:20
    |
 LL |     println!("{}", x);
-   |                    ^ use of possibly uninitialized `x`
+   |                    ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-break-uninit.rs
+++ b/src/test/ui/borrowck/borrowck-break-uninit.rs
@@ -6,7 +6,7 @@ fn foo() -> isize {
         x = 0;
     }
 
-    println!("{}", x); //~ ERROR borrow of possibly uninitialized variable: `x`
+    println!("{}", x); //~ ERROR borrow of possibly-uninitialized variable: `x`
 
     return 17;
 }

--- a/src/test/ui/borrowck/borrowck-break-uninit.stderr
+++ b/src/test/ui/borrowck/borrowck-break-uninit.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-break-uninit.rs:9:20
    |
 LL |     println!("{}", x);
-   |                    ^ use of possibly uninitialized `x`
+   |                    ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-field-sensitivity.rs
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity.rs
@@ -78,20 +78,20 @@ fn fu_move_after_fu_move() {
 
 fn copy_after_field_assign_after_uninit() {
     let mut x: A;
-    x.a = 1; //~ ERROR assign to part of possibly uninitialized variable: `x`
+    x.a = 1; //~ ERROR assign to part of possibly-uninitialized variable: `x`
     drop(x.a);
 }
 
 fn borrow_after_field_assign_after_uninit() {
     let mut x: A;
-    x.a = 1; //~ ERROR assign to part of possibly uninitialized variable: `x`
+    x.a = 1; //~ ERROR assign to part of possibly-uninitialized variable: `x`
     let p = &x.a;
     drop(*p);
 }
 
 fn move_after_field_assign_after_uninit() {
     let mut x: A;
-    x.b = box 1; //~ ERROR assign to part of possibly uninitialized variable: `x`
+    x.b = box 1; //~ ERROR assign to part of possibly-uninitialized variable: `x`
     drop(x.b);
 }
 

--- a/src/test/ui/borrowck/borrowck-field-sensitivity.stderr
+++ b/src/test/ui/borrowck/borrowck-field-sensitivity.stderr
@@ -108,23 +108,23 @@ LL |     let _z = A { a: 4, .. x };
    |
    = note: move occurs because `x.b` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-field-sensitivity.rs:81:5
    |
 LL |     x.a = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-field-sensitivity.rs:87:5
    |
 LL |     x.a = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-field-sensitivity.rs:94:5
    |
 LL |     x.b = box 1;
-   |     ^^^ use of possibly uninitialized `x`
+   |     ^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/borrowck/borrowck-if-no-else.rs
+++ b/src/test/ui/borrowck/borrowck-if-no-else.rs
@@ -2,5 +2,5 @@ fn foo(x: isize) { println!("{}", x); }
 
 fn main() {
     let x: isize; if 1 > 2 { x = 10; }
-    foo(x); //~ ERROR use of possibly uninitialized variable: `x`
+    foo(x); //~ ERROR use of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/borrowck/borrowck-if-no-else.stderr
+++ b/src/test/ui/borrowck/borrowck-if-no-else.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-if-no-else.rs:5:9
    |
 LL |     foo(x);
-   |         ^ use of possibly uninitialized `x`
+   |         ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-if-with-else.rs
+++ b/src/test/ui/borrowck/borrowck-if-with-else.rs
@@ -7,5 +7,5 @@ fn main() {
     } else {
         x = 10;
     }
-    foo(x); //~ ERROR use of possibly uninitialized variable: `x`
+    foo(x); //~ ERROR use of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/borrowck/borrowck-if-with-else.stderr
+++ b/src/test/ui/borrowck/borrowck-if-with-else.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-if-with-else.rs:10:9
    |
 LL |     foo(x);
-   |         ^ use of possibly uninitialized `x`
+   |         ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-called-fn-expr.rs
+++ b/src/test/ui/borrowck/borrowck-init-in-called-fn-expr.rs
@@ -1,7 +1,7 @@
 fn main() {
     let j = || -> isize {
         let i: isize;
-        i //~ ERROR use of possibly uninitialized variable: `i`
+        i //~ ERROR use of possibly-uninitialized variable: `i`
     };
     j();
 }

--- a/src/test/ui/borrowck/borrowck-init-in-called-fn-expr.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-called-fn-expr.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `i`
+error[E0381]: use of possibly-uninitialized variable: `i`
   --> $DIR/borrowck-init-in-called-fn-expr.rs:4:9
    |
 LL |         i
-   |         ^ use of possibly uninitialized `i`
+   |         ^ use of possibly-uninitialized `i`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-fn-expr.rs
+++ b/src/test/ui/borrowck/borrowck-init-in-fn-expr.rs
@@ -1,7 +1,7 @@
 fn main() {
     let f  = || -> isize {
         let i: isize;
-        i //~ ERROR use of possibly uninitialized variable: `i`
+        i //~ ERROR use of possibly-uninitialized variable: `i`
     };
     println!("{}", f());
 }

--- a/src/test/ui/borrowck/borrowck-init-in-fn-expr.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-fn-expr.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `i`
+error[E0381]: use of possibly-uninitialized variable: `i`
   --> $DIR/borrowck-init-in-fn-expr.rs:4:9
    |
 LL |         i
-   |         ^ use of possibly uninitialized `i`
+   |         ^ use of possibly-uninitialized `i`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-in-fru.rs
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.rs
@@ -7,6 +7,6 @@ struct Point {
 fn main() {
     let mut origin: Point;
     origin = Point { x: 10, ..origin };
-    //~^ ERROR use of possibly uninitialized variable: `origin` [E0381]
+    //~^ ERROR use of possibly-uninitialized variable: `origin` [E0381]
     origin.clone();
 }

--- a/src/test/ui/borrowck/borrowck-init-in-fru.stderr
+++ b/src/test/ui/borrowck/borrowck-init-in-fru.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `origin`
+error[E0381]: use of possibly-uninitialized variable: `origin`
   --> $DIR/borrowck-init-in-fru.rs:9:5
    |
 LL |     origin = Point { x: 10, ..origin };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `origin.y`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `origin.y`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-op-equal.rs
+++ b/src/test/ui/borrowck/borrowck-init-op-equal.rs
@@ -1,6 +1,6 @@
 fn test() {
     let v: isize;
-    v += 1; //~ ERROR use of possibly uninitialized variable: `v`
+    v += 1; //~ ERROR use of possibly-uninitialized variable: `v`
     v.clone();
 }
 

--- a/src/test/ui/borrowck/borrowck-init-op-equal.stderr
+++ b/src/test/ui/borrowck/borrowck-init-op-equal.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `v`
+error[E0381]: use of possibly-uninitialized variable: `v`
   --> $DIR/borrowck-init-op-equal.rs:3:5
    |
 LL |     v += 1;
-   |     ^^^^^^ use of possibly uninitialized `v`
+   |     ^^^^^^ use of possibly-uninitialized `v`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-init-plus-equal.rs
+++ b/src/test/ui/borrowck/borrowck-init-plus-equal.rs
@@ -1,6 +1,6 @@
 fn test() {
     let mut v: isize;
-    v = v + 1; //~ ERROR use of possibly uninitialized variable: `v`
+    v = v + 1; //~ ERROR use of possibly-uninitialized variable: `v`
     v.clone();
 }
 

--- a/src/test/ui/borrowck/borrowck-init-plus-equal.stderr
+++ b/src/test/ui/borrowck/borrowck-init-plus-equal.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `v`
+error[E0381]: use of possibly-uninitialized variable: `v`
   --> $DIR/borrowck-init-plus-equal.rs:3:9
    |
 LL |     v = v + 1;
-   |         ^ use of possibly uninitialized `v`
+   |         ^ use of possibly-uninitialized `v`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.edition.stderr
@@ -1,15 +1,14 @@
-warning[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-migrate-to-nll.rs:28:21
+error[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
+  --> $DIR/borrowck-migrate-to-nll.rs:29:21
    |
 LL |     let x = &mut block;
    |             ---------- mutable borrow occurs here
 LL |     let p: &'a u8 = &*block.current;
    |                     ^^^^^^^^^^^^^^^ immutable borrow occurs here
-LL |     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
+...
 LL |     drop(x);
    |          - mutable borrow later used here
-   |
-   = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
-   = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
-   = note: for more information, try `rustc --explain E0729`
 
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0502`.

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.rs
@@ -4,6 +4,8 @@
 //
 // Therefore, for backwards-compatiblity, under borrowck=migrate the
 // NLL checks will be emitted as *warnings*.
+//
+// In Rust 2018, no errors will be downgraded to warnings.
 
 // NLL mode makes this compile-fail; we cannot currently encode a
 // test that is run-pass or compile-fail based on compare-mode. So
@@ -16,7 +18,6 @@
 //[zflag]compile-flags: -Z borrowck=migrate
 //[edition]edition:2018
 //[zflag] run-pass
-//[edition] run-pass
 
 pub struct Block<'a> {
     current: &'a u8,
@@ -26,6 +27,7 @@ pub struct Block<'a> {
 fn bump<'a>(mut block: &mut Block<'a>) {
     let x = &mut block;
     let p: &'a u8 = &*block.current;
+    //[edition]~^ ERROR cannot borrow `*block.current` as immutable
     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
     drop(x);
     drop(p);

--- a/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
+++ b/src/test/ui/borrowck/borrowck-migrate-to-nll.zflag.stderr
@@ -1,11 +1,11 @@
 warning[E0502]: cannot borrow `*block.current` as immutable because it is also borrowed as mutable
-  --> $DIR/borrowck-migrate-to-nll.rs:28:21
+  --> $DIR/borrowck-migrate-to-nll.rs:29:21
    |
 LL |     let x = &mut block;
    |             ---------- mutable borrow occurs here
 LL |     let p: &'a u8 = &*block.current;
    |                     ^^^^^^^^^^^^^^^ immutable borrow occurs here
-LL |     // (use `x` and `p` so enabling NLL doesn't assign overly short lifetimes)
+...
 LL |     drop(x);
    |          - mutable borrow later used here
    |

--- a/src/test/ui/borrowck/borrowck-or-init.rs
+++ b/src/test/ui/borrowck/borrowck-or-init.rs
@@ -2,5 +2,5 @@ fn main() {
     let i: isize;
 
     println!("{}", false || { i = 5; true });
-    println!("{}", i); //~ ERROR borrow of possibly uninitialized variable: `i`
+    println!("{}", i); //~ ERROR borrow of possibly-uninitialized variable: `i`
 }

--- a/src/test/ui/borrowck/borrowck-or-init.stderr
+++ b/src/test/ui/borrowck/borrowck-or-init.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `i`
+error[E0381]: borrow of possibly-uninitialized variable: `i`
   --> $DIR/borrowck-or-init.rs:5:20
    |
 LL |     println!("{}", i);
-   |                    ^ use of possibly uninitialized `i`
+   |                    ^ use of possibly-uninitialized `i`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-partial-reinit-4.rs
+++ b/src/test/ui/borrowck/borrowck-partial-reinit-4.rs
@@ -15,7 +15,7 @@ impl Drop for Test2 {
 fn stuff() {
     let mut x : (Test2, Test2);
     (x.0).0 = Some(Test);
-    //~^ ERROR assign of possibly uninitialized variable: `x.0`
+    //~^ ERROR assign of possibly-uninitialized variable: `x.0`
 }
 
 fn main() {

--- a/src/test/ui/borrowck/borrowck-partial-reinit-4.stderr
+++ b/src/test/ui/borrowck/borrowck-partial-reinit-4.stderr
@@ -1,8 +1,8 @@
-error[E0381]: assign of possibly uninitialized variable: `x.0`
+error[E0381]: assign of possibly-uninitialized variable: `x.0`
   --> $DIR/borrowck-partial-reinit-4.rs:17:5
    |
 LL |     (x.0).0 = Some(Test);
-   |     ^^^^^^^ use of possibly uninitialized `x.0`
+   |     ^^^^^^^ use of possibly-uninitialized `x.0`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-return.rs
+++ b/src/test/ui/borrowck/borrowck-return.rs
@@ -1,6 +1,6 @@
 fn f() -> isize {
     let x: isize;
-    return x; //~ ERROR use of possibly uninitialized variable: `x`
+    return x; //~ ERROR use of possibly-uninitialized variable: `x`
 }
 
 fn main() { f(); }

--- a/src/test/ui/borrowck/borrowck-return.stderr
+++ b/src/test/ui/borrowck/borrowck-return.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-return.rs:3:12
    |
 LL |     return x;
-   |            ^ use of possibly uninitialized `x`
+   |            ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-storage-dead.stderr
+++ b/src/test/ui/borrowck/borrowck-storage-dead.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-storage-dead.rs:16:17
    |
 LL |         let _ = x + 1;
-   |                 ^ use of possibly uninitialized `x`
+   |                 ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-uninit-after-item.rs
+++ b/src/test/ui/borrowck/borrowck-uninit-after-item.rs
@@ -1,5 +1,5 @@
 fn main() {
     let bar;
     fn baz(_x: isize) { }
-    baz(bar); //~ ERROR use of possibly uninitialized variable: `bar`
+    baz(bar); //~ ERROR use of possibly-uninitialized variable: `bar`
 }

--- a/src/test/ui/borrowck/borrowck-uninit-after-item.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit-after-item.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `bar`
+error[E0381]: use of possibly-uninitialized variable: `bar`
   --> $DIR/borrowck-uninit-after-item.rs:4:9
    |
 LL |     baz(bar);
-   |         ^^^ use of possibly uninitialized `bar`
+   |         ^^^ use of possibly-uninitialized `bar`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-uninit-field-access.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit-field-access.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `a`
+error[E0381]: use of possibly-uninitialized variable: `a`
   --> $DIR/borrowck-uninit-field-access.rs:21:13
    |
 LL |     let _ = a.x + 1;
-   |             ^^^ use of possibly uninitialized `a.x`
+   |             ^^^ use of possibly-uninitialized `a.x`
 
 error[E0382]: use of moved value: `line1.origin`
   --> $DIR/borrowck-uninit-field-access.rs:25:13

--- a/src/test/ui/borrowck/borrowck-uninit-in-assignop.rs
+++ b/src/test/ui/borrowck/borrowck-uninit-in-assignop.rs
@@ -3,32 +3,32 @@
 
 pub fn main() {
     let x: isize;
-    x += 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x += 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x -= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x -= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x *= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x *= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x /= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x /= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x %= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x %= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x ^= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x ^= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x &= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x &= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x |= 1; //~ ERROR use of possibly uninitialized variable: `x`
+    x |= 1; //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x <<= 1;    //~ ERROR use of possibly uninitialized variable: `x`
+    x <<= 1;    //~ ERROR use of possibly-uninitialized variable: `x`
 
     let x: isize;
-    x >>= 1;    //~ ERROR use of possibly uninitialized variable: `x`
+    x >>= 1;    //~ ERROR use of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/borrowck/borrowck-uninit-in-assignop.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit-in-assignop.stderr
@@ -1,62 +1,62 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:6:5
    |
 LL |     x += 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:9:5
    |
 LL |     x -= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:12:5
    |
 LL |     x *= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:15:5
    |
 LL |     x /= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:18:5
    |
 LL |     x %= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:21:5
    |
 LL |     x ^= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:24:5
    |
 LL |     x &= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:27:5
    |
 LL |     x |= 1;
-   |     ^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:30:5
    |
 LL |     x <<= 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-in-assignop.rs:33:5
    |
 LL |     x >>= 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/borrowck/borrowck-uninit-ref-chain.rs
+++ b/src/test/ui/borrowck/borrowck-uninit-ref-chain.rs
@@ -15,19 +15,19 @@ fn main() {
 
 
     let mut a: S<i32, i32>;
-    a.x = 0;            //~ ERROR assign to part of possibly uninitialized variable: `a` [E0381]
+    a.x = 0;            //~ ERROR assign to part of possibly-uninitialized variable: `a` [E0381]
     let _b = &a.x;
 
     let mut a: S<&&i32, &&i32>;
-    a.x = &&0;          //~ ERROR assign to part of possibly uninitialized variable: `a` [E0381]
+    a.x = &&0;          //~ ERROR assign to part of possibly-uninitialized variable: `a` [E0381]
     let _b = &**a.x;
 
 
     let mut a: S<i32, i32>;
-    a.x = 0;            //~ ERROR assign to part of possibly uninitialized variable: `a` [E0381]
+    a.x = 0;            //~ ERROR assign to part of possibly-uninitialized variable: `a` [E0381]
     let _b = &a.y;
 
     let mut a: S<&&i32, &&i32>;
-    a.x = &&0;          //~ assign to part of possibly uninitialized variable: `a` [E0381]
+    a.x = &&0;          //~ assign to part of possibly-uninitialized variable: `a` [E0381]
     let _b = &**a.y;
 }

--- a/src/test/ui/borrowck/borrowck-uninit-ref-chain.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit-ref-chain.stderr
@@ -1,44 +1,44 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-ref-chain.rs:8:14
    |
 LL |     let _y = &**x;
-   |              ^^^^ use of possibly uninitialized `**x`
+   |              ^^^^ use of possibly-uninitialized `**x`
 
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-ref-chain.rs:11:14
    |
 LL |     let _y = &**x;
-   |              ^^^^ use of possibly uninitialized `**x`
+   |              ^^^^ use of possibly-uninitialized `**x`
 
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit-ref-chain.rs:14:14
    |
 LL |     let _y = &**x;
-   |              ^^^^ use of possibly uninitialized `**x`
+   |              ^^^^ use of possibly-uninitialized `**x`
 
-error[E0381]: assign to part of possibly uninitialized variable: `a`
+error[E0381]: assign to part of possibly-uninitialized variable: `a`
   --> $DIR/borrowck-uninit-ref-chain.rs:18:5
    |
 LL |     a.x = 0;
-   |     ^^^^^^^ use of possibly uninitialized `a`
+   |     ^^^^^^^ use of possibly-uninitialized `a`
 
-error[E0381]: assign to part of possibly uninitialized variable: `a`
+error[E0381]: assign to part of possibly-uninitialized variable: `a`
   --> $DIR/borrowck-uninit-ref-chain.rs:22:5
    |
 LL |     a.x = &&0;
-   |     ^^^^^^^^^ use of possibly uninitialized `a`
+   |     ^^^^^^^^^ use of possibly-uninitialized `a`
 
-error[E0381]: assign to part of possibly uninitialized variable: `a`
+error[E0381]: assign to part of possibly-uninitialized variable: `a`
   --> $DIR/borrowck-uninit-ref-chain.rs:27:5
    |
 LL |     a.x = 0;
-   |     ^^^^^^^ use of possibly uninitialized `a`
+   |     ^^^^^^^ use of possibly-uninitialized `a`
 
-error[E0381]: assign to part of possibly uninitialized variable: `a`
+error[E0381]: assign to part of possibly-uninitialized variable: `a`
   --> $DIR/borrowck-uninit-ref-chain.rs:31:5
    |
 LL |     a.x = &&0;
-   |     ^^^^^^^^^ use of possibly uninitialized `a`
+   |     ^^^^^^^^^ use of possibly-uninitialized `a`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/borrowck/borrowck-uninit.rs
+++ b/src/test/ui/borrowck/borrowck-uninit.rs
@@ -2,5 +2,5 @@ fn foo(x: isize) { println!("{}", x); }
 
 fn main() {
     let x: isize;
-    foo(x); //~ ERROR use of possibly uninitialized variable: `x`
+    foo(x); //~ ERROR use of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/borrowck/borrowck-uninit.stderr
+++ b/src/test/ui/borrowck/borrowck-uninit.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-uninit.rs:5:9
    |
 LL |     foo(x);
-   |         ^ use of possibly uninitialized `x`
+   |         ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-union-uninitialized.rs
+++ b/src/test/ui/borrowck/borrowck-union-uninitialized.rs
@@ -10,8 +10,8 @@ fn main() {
     unsafe {
         let mut s: S;
         let mut u: U;
-        s.a = 0; //~ ERROR assign to part of possibly uninitialized variable: `s`
-        u.a = 0; //~ ERROR assign to part of possibly uninitialized variable: `u`
+        s.a = 0; //~ ERROR assign to part of possibly-uninitialized variable: `s`
+        u.a = 0; //~ ERROR assign to part of possibly-uninitialized variable: `u`
         let sa = s.a;
         let ua = u.a;
     }

--- a/src/test/ui/borrowck/borrowck-union-uninitialized.stderr
+++ b/src/test/ui/borrowck/borrowck-union-uninitialized.stderr
@@ -1,14 +1,14 @@
-error[E0381]: assign to part of possibly uninitialized variable: `s`
+error[E0381]: assign to part of possibly-uninitialized variable: `s`
   --> $DIR/borrowck-union-uninitialized.rs:13:9
    |
 LL |         s.a = 0;
-   |         ^^^^^^^ use of possibly uninitialized `s`
+   |         ^^^^^^^ use of possibly-uninitialized `s`
 
-error[E0381]: assign to part of possibly uninitialized variable: `u`
+error[E0381]: assign to part of possibly-uninitialized variable: `u`
   --> $DIR/borrowck-union-uninitialized.rs:14:9
    |
 LL |         u.a = 0;
-   |         ^^^^^^^ use of possibly uninitialized `u`
+   |         ^^^^^^^ use of possibly-uninitialized `u`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-use-in-index-lvalue.stderr
+++ b/src/test/ui/borrowck/borrowck-use-in-index-lvalue.stderr
@@ -1,14 +1,14 @@
-error[E0381]: use of possibly uninitialized variable: `w`
+error[E0381]: use of possibly-uninitialized variable: `w`
   --> $DIR/borrowck-use-in-index-lvalue.rs:3:5
    |
 LL |     w[5] = 0;
-   |     ^^^^ use of possibly uninitialized `*w`
+   |     ^^^^ use of possibly-uninitialized `*w`
 
-error[E0381]: use of possibly uninitialized variable: `w`
+error[E0381]: use of possibly-uninitialized variable: `w`
   --> $DIR/borrowck-use-in-index-lvalue.rs:6:5
    |
 LL |     w[5] = 0;
-   |     ^^^^ use of possibly uninitialized `*w`
+   |     ^^^^ use of possibly-uninitialized `*w`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
+++ b/src/test/ui/borrowck/borrowck-use-uninitialized-in-cast-trait.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-use-uninitialized-in-cast-trait.rs:9:13
    |
 LL |     let y = x as *const dyn Foo;
-   |             ^ use of possibly uninitialized `*x`
+   |             ^ use of possibly-uninitialized `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
+++ b/src/test/ui/borrowck/borrowck-use-uninitialized-in-cast.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-use-uninitialized-in-cast.rs:7:13
    |
 LL |     let y = x as *const i32;
-   |             ^ use of possibly uninitialized `*x`
+   |             ^ use of possibly-uninitialized `*x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-while-break.rs
+++ b/src/test/ui/borrowck/borrowck-while-break.rs
@@ -4,7 +4,7 @@ fn test(cond: bool) {
         v = 3;
         break;
     }
-    println!("{}", v); //~ ERROR borrow of possibly uninitialized variable: `v`
+    println!("{}", v); //~ ERROR borrow of possibly-uninitialized variable: `v`
 }
 
 fn main() {

--- a/src/test/ui/borrowck/borrowck-while-break.stderr
+++ b/src/test/ui/borrowck/borrowck-while-break.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `v`
+error[E0381]: borrow of possibly-uninitialized variable: `v`
   --> $DIR/borrowck-while-break.rs:7:20
    |
 LL |     println!("{}", v);
-   |                    ^ use of possibly uninitialized `v`
+   |                    ^ use of possibly-uninitialized `v`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-while-cond.rs
+++ b/src/test/ui/borrowck/borrowck-while-cond.rs
@@ -1,4 +1,4 @@
 fn main() {
     let x: bool;
-    while x { } //~ ERROR use of possibly uninitialized variable: `x`
+    while x { } //~ ERROR use of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/borrowck/borrowck-while-cond.stderr
+++ b/src/test/ui/borrowck/borrowck-while-cond.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-while-cond.rs:3:11
    |
 LL |     while x { }
-   |           ^ use of possibly uninitialized `x`
+   |           ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrowck-while.rs
+++ b/src/test/ui/borrowck/borrowck-while.rs
@@ -1,7 +1,7 @@
 fn f() -> isize {
     let mut x: isize;
     while 1 == 1 { x = 10; }
-    return x; //~ ERROR use of possibly uninitialized variable: `x`
+    return x; //~ ERROR use of possibly-uninitialized variable: `x`
 }
 
 fn main() { f(); }

--- a/src/test/ui/borrowck/borrowck-while.stderr
+++ b/src/test/ui/borrowck/borrowck-while.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/borrowck-while.rs:4:12
    |
 LL |     return x;
-   |            ^ use of possibly uninitialized `x`
+   |            ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/disallow-possibly-uninitialized.rs
+++ b/src/test/ui/borrowck/disallow-possibly-uninitialized.rs
@@ -4,19 +4,19 @@
 fn main() {
     let mut t: (u64, u64);
     t.0 = 1;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     t.1 = 1;
 
     let mut t: (u64, u64);
     t.1 = 1;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     t.0 = 1;
 
     let mut t: (u64, u64);
     t.0 = 1;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
 
     let mut t: (u64,);
     t.0 = 1;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
 }

--- a/src/test/ui/borrowck/disallow-possibly-uninitialized.stderr
+++ b/src/test/ui/borrowck/disallow-possibly-uninitialized.stderr
@@ -1,26 +1,26 @@
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/disallow-possibly-uninitialized.rs:6:5
    |
 LL |     t.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/disallow-possibly-uninitialized.rs:11:5
    |
 LL |     t.1 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/disallow-possibly-uninitialized.rs:16:5
    |
 LL |     t.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/disallow-possibly-uninitialized.rs:20:5
    |
 LL |     t.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^ use of possibly-uninitialized `t`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/borrowck/issue-54499-field-mutation-marks-mut-as-used.rs
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-marks-mut-as-used.rs
@@ -10,7 +10,7 @@ fn main() {
     {
         let mut t: Tuple;
         t.0 = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
         t.1 = 2;
         println!("{:?} {:?}", t.0, t.1);
     }
@@ -18,7 +18,7 @@ fn main() {
     {
         let mut u: Tpair;
         u.0 = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `u` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `u` [E0381]
         u.1 = 2;
         println!("{:?} {:?}", u.0, u.1);
     }
@@ -26,7 +26,7 @@ fn main() {
     {
         let mut v: Spair;
         v.x = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `v` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `v` [E0381]
         v.y = 2;
         println!("{:?} {:?}", v.x, v.y);
     }

--- a/src/test/ui/borrowck/issue-54499-field-mutation-marks-mut-as-used.stderr
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-marks-mut-as-used.stderr
@@ -1,20 +1,20 @@
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/issue-54499-field-mutation-marks-mut-as-used.rs:12:9
    |
 LL |         t.0 = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `t`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `u`
+error[E0381]: assign to part of possibly-uninitialized variable: `u`
   --> $DIR/issue-54499-field-mutation-marks-mut-as-used.rs:20:9
    |
 LL |         u.0 = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `u`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `u`
 
-error[E0381]: assign to part of possibly uninitialized variable: `v`
+error[E0381]: assign to part of possibly-uninitialized variable: `v`
   --> $DIR/issue-54499-field-mutation-marks-mut-as-used.rs:28:9
    |
 LL |         v.x = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `v`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `v`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/issue-54499-field-mutation-of-never-init.rs
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-of-never-init.rs
@@ -10,7 +10,7 @@ fn main() {
     {
         let t: Tuple;
         t.0 = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
         t.1 = 2;
         println!("{:?} {:?}", t.0, t.1);
     }
@@ -18,7 +18,7 @@ fn main() {
     {
         let u: Tpair;
         u.0 = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `u` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `u` [E0381]
         u.1 = 2;
         println!("{:?} {:?}", u.0, u.1);
     }
@@ -26,7 +26,7 @@ fn main() {
     {
         let v: Spair;
         v.x = S(1);
-        //~^ ERROR assign to part of possibly uninitialized variable: `v` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `v` [E0381]
         v.y = 2;
         println!("{:?} {:?}", v.x, v.y);
     }

--- a/src/test/ui/borrowck/issue-54499-field-mutation-of-never-init.stderr
+++ b/src/test/ui/borrowck/issue-54499-field-mutation-of-never-init.stderr
@@ -1,20 +1,20 @@
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/issue-54499-field-mutation-of-never-init.rs:12:9
    |
 LL |         t.0 = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `t`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `u`
+error[E0381]: assign to part of possibly-uninitialized variable: `u`
   --> $DIR/issue-54499-field-mutation-of-never-init.rs:20:9
    |
 LL |         u.0 = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `u`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `u`
 
-error[E0381]: assign to part of possibly uninitialized variable: `v`
+error[E0381]: assign to part of possibly-uninitialized variable: `v`
   --> $DIR/issue-54499-field-mutation-of-never-init.rs:28:9
    |
 LL |         v.x = S(1);
-   |         ^^^^^^^^^^ use of possibly uninitialized `v`
+   |         ^^^^^^^^^^ use of possibly-uninitialized `v`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/borrowck/issue-62107-match-arm-scopes.rs
+++ b/src/test/ui/borrowck/issue-62107-match-arm-scopes.rs
@@ -1,7 +1,7 @@
 fn main() {
     let e: i32;
     match e {
-        //~^ ERROR use of possibly uninitialized variable
+        //~^ ERROR use of possibly-uninitialized variable
         ref u if true => {}
         ref v if true => {
             let tx = 0;

--- a/src/test/ui/borrowck/issue-62107-match-arm-scopes.stderr
+++ b/src/test/ui/borrowck/issue-62107-match-arm-scopes.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `e`
+error[E0381]: use of possibly-uninitialized variable: `e`
   --> $DIR/issue-62107-match-arm-scopes.rs:3:11
    |
 LL |     match e {
-   |           ^ use of possibly uninitialized `e`
+   |           ^ use of possibly-uninitialized `e`
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/reassignment_immutable_fields.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields.stderr
@@ -1,14 +1,14 @@
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/reassignment_immutable_fields.rs:7:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/reassignment_immutable_fields.rs:15:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
@@ -1,8 +1,8 @@
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/reassignment_immutable_fields_overlapping.rs:12:5
    |
 LL |     x.a = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
 error[E0594]: cannot assign to `x.b`, as `x` is not declared as mutable
   --> $DIR/reassignment_immutable_fields_overlapping.rs:13:5

--- a/src/test/ui/borrowck/reassignment_immutable_fields_twice.stderr
+++ b/src/test/ui/borrowck/reassignment_immutable_fields_twice.stderr
@@ -7,11 +7,11 @@ LL |     x = (22, 44);
 LL |     x.0 = 1;
    |     ^^^^^^^ cannot assign
 
-error[E0381]: assign to part of possibly uninitialized variable: `x`
+error[E0381]: assign to part of possibly-uninitialized variable: `x`
   --> $DIR/reassignment_immutable_fields_twice.rs:12:5
    |
 LL |     x.0 = 1;
-   |     ^^^^^^^ use of possibly uninitialized `x`
+   |     ^^^^^^^ use of possibly-uninitialized `x`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/borrowck/two-phase-across-loop.rs
+++ b/src/test/ui/borrowck/two-phase-across-loop.rs
@@ -1,4 +1,4 @@
-// Test that a borrow which starts as a 2-phase borrow and gets
+// Test that a borrow which starts as a two-phase borrow and gets
 // carried around a loop winds up conflicting with itself.
 
 struct Foo { x: String }

--- a/src/test/ui/consts/const-err4.stderr
+++ b/src/test/ui/consts/const-err4.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:28:43
@@ -38,7 +38,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:40:5
@@ -46,7 +46,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:43:43
@@ -78,7 +78,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:55:5
@@ -86,7 +86,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:58:45
@@ -102,7 +102,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:64:47
@@ -150,7 +150,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:82:43
@@ -190,7 +190,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:97:43
@@ -214,7 +214,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:106:43

--- a/src/test/ui/consts/const-eval/double_check2.stderr
+++ b/src/test/ui/consts/const-eval/double_check2.stderr
@@ -7,7 +7,7 @@ LL | |     Union { u8: &BAR }.bar,
 LL | | )};
    | |___^ type validation failed: encountered 5 at .1.<deref>, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ref_to_int_match.stderr
+++ b/src/test/ui/consts/const-eval/ref_to_int_match.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: could not evaluate constant pattern
   --> $DIR/ref_to_int_match.rs:7:14

--- a/src/test/ui/consts/const-eval/transmute-const.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | static FOO: bool = unsafe { mem::transmute(3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3, but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ub-enum.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM: Enum = unsafe { TransmuteEnum { in2: 1 }.out1 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 1, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:26:1
@@ -12,7 +12,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM_PTR: Enum = unsafe { TransmuteEnum { in1: &1 }.out1 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:29:1
@@ -20,7 +20,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { TransmuteEnum { in1: &1 }.out2 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected something that cannot possibly fail to be equal to 0
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:48:1
@@ -28,7 +28,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM2: Enum2 = unsafe { TransmuteEnum2 { in1: 0 }.out1 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:50:1
@@ -36,7 +36,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { TransmuteEnum2 { in2: &0 }.out1 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:52:1
@@ -44,7 +44,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { TransmuteEnum2 { in2: &0 }.out2 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected something that cannot possibly fail to be equal to 2
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:56:1
@@ -52,7 +52,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM2_UNDEF : Enum2 = unsafe { TransmuteEnum2 { in3: () }.out1 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
@@ -60,7 +60,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { TransmuteEnum2 { in2: &0 }.out3 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected a valid enum discriminant
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:71:1
@@ -68,7 +68,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { TransmuteChar { a: !0 }.b }));
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 4294967295 at .<downcast-variant(Some)>.0.1, but expected something less or equal to 1114111
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: any use of this value will cause an error
   --> $DIR/ub-nonnull.rs:18:29
@@ -30,7 +30,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:24:1
@@ -38,7 +38,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:32:1
@@ -46,7 +46,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const UNINIT: NonZeroU8 = unsafe { Transmute { uninit: () }.out };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:40:1
@@ -54,7 +54,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-nonnull.rs:46:1
@@ -62,7 +62,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-ref.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned reference (required 2 byte alignment but found 1)
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:11:1
@@ -12,7 +12,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:17:1
@@ -20,7 +20,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:20:1
@@ -28,7 +28,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer at .<deref>, but expected plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref.rs:23:1
@@ -36,7 +36,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling reference (created from integer)
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-uninhabit.stderr
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_BAD_BAD: Bar = unsafe { (TransmuteUnion::<(), Bar> { a: () }).b };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-uninhabit.rs:18:1
@@ -12,7 +12,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-uninhabit.rs:21:1
@@ -20,7 +20,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { (TransmuteUnion::<(), [Bar; 1]> { a: () }).b };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-upvars.stderr
+++ b/src/test/ui/consts/const-eval/ub-upvars.stderr
@@ -8,7 +8,7 @@ LL | |     move || { let _ = bad_ref; let _ = another_var; }
 LL | | };
    | |__^ type validation failed: encountered 0 at .<deref>.<dyn-downcast>.<closure-var(bad_ref)>, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const STR_TOO_LONG: &str = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len: 999 } }.str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling reference (not entirely in bounds)
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:90:1
@@ -12,7 +12,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const STR_LENGTH_PTR: &str = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:93:1
@@ -20,7 +20,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.my_str};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:97:1
@@ -28,7 +28,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const STR_NO_UTF8: &str = unsafe { SliceTransmute { slice: &[0xFF] }.str };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized or non-UTF-8 data in str at .<deref>
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:100:1
@@ -36,7 +36,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const MYSTR_NO_UTF8: &MyStr = unsafe { SliceTransmute { slice: &[0xFF] }.my_str };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized or non-UTF-8 data in str at .<deref>.0
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:107:1
@@ -44,7 +44,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const SLICE_LENGTH_UNINIT: &[u8] = unsafe { SliceTransmute { addr: 42 }.slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized data in wide pointer metadata
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:110:1
@@ -52,7 +52,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { SliceTransmute { repr: SliceRepr { ptr: &42, len: 999 } }.slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling reference (not entirely in bounds)
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:113:1
@@ -60,7 +60,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { SliceTransmute { bad: BadSliceRepr { ptr: &42, len: &3 } }.slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:117:1
@@ -68,7 +68,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { BoolTransmute { val: 3 }.bl }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>[0], but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:123:1
@@ -76,7 +76,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { BoolTransmute { val: 3 }.bl }, [false]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.0, but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:126:1
@@ -84,7 +84,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { BoolTransmute { val: 3 }.bl }]);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.1[0], but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:133:1
@@ -92,7 +92,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe { SliceTransmute { addr: 42 }.raw_slice};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized data in wide pointer metadata
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:138:1
@@ -100,7 +100,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: &dyn Trait = unsafe { DynTransmute { repr: DynRepr { ptr: &92, vtable: &3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling or unaligned vtable pointer in wide pointer or too small vtable
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:141:1
@@ -108,7 +108,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: &dyn Trait = unsafe { DynTransmute { repr2: DynRepr2 { ptr: &92, vtable: &3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling or unaligned vtable pointer in wide pointer or too small vtable
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:144:1
@@ -116,7 +116,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const TRAIT_OBJ_INT_VTABLE: &dyn Trait = unsafe { DynTransmute { bad: BadDynRepr { ptr: &92, vtable: 3 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling or unaligned vtable pointer in wide pointer or too small vtable
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:148:1
@@ -124,7 +124,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = &unsafe { BoolTransmute { val: 3 }.bl };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 3 at .<deref>.<dyn-downcast>, but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:152:1
@@ -132,7 +132,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { DynTransmute { bad: BadDynRepr { ptr: &92, vtable: 0 } }.rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling or unaligned vtable pointer in wide pointer or too small vtable
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:154:1
@@ -140,7 +140,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { DynTransmute { repr2: DynRepr2 { ptr: &92, vtable: &3 } }.raw_rust};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling or unaligned vtable pointer in wide pointer or too small vtable
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/union-ice.stderr
+++ b/src/test/ui/consts/const-eval/union-ice.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const FIELD3: Field3 = unsafe { UNION.field3 };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/union-ice.rs:16:1
@@ -15,7 +15,7 @@ LL | |     b: unsafe { UNION.field3 },
 LL | | };
    | |__^ type validation failed: encountered uninitialized bytes at .b, but expected initialized plain (non-pointer) bytes
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/union-ice.rs:26:1
@@ -29,7 +29,7 @@ LL | |     a: 42,
 LL | | };
    | |__^ type validation failed: encountered undefined bytes at .b[1]
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/union-ub.stderr
+++ b/src/test/ui/consts/const-eval/union-ub.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something less or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_let_refutable.rs
+++ b/src/test/ui/consts/const_let_refutable.rs
@@ -2,6 +2,6 @@ fn main() {}
 
 const fn slice([a, b]: &[i32]) -> i32 { //~ ERROR refutable pattern in function argument
     a + b //~ ERROR can only call other `const fn` within a `const fn`
-    //~^ ERROR use of possibly uninitialized variable: `a`
-    //~| ERROR use of possibly uninitialized variable: `b`
+    //~^ ERROR use of possibly-uninitialized variable: `a`
+    //~| ERROR use of possibly-uninitialized variable: `b`
 }

--- a/src/test/ui/consts/const_let_refutable.stderr
+++ b/src/test/ui/consts/const_let_refutable.stderr
@@ -13,17 +13,17 @@ LL |     a + b
    = note: for more information, see issue https://github.com/rust-lang/rust/issues/57563
    = help: add `#![feature(const_fn)]` to the crate attributes to enable
 
-error[E0381]: use of possibly uninitialized variable: `a`
+error[E0381]: use of possibly-uninitialized variable: `a`
   --> $DIR/const_let_refutable.rs:4:5
    |
 LL |     a + b
-   |     ^ use of possibly uninitialized `a`
+   |     ^ use of possibly-uninitialized `a`
 
-error[E0381]: use of possibly uninitialized variable: `b`
+error[E0381]: use of possibly-uninitialized variable: `b`
   --> $DIR/const_let_refutable.rs:4:9
    |
 LL |     a + b
-   |         ^ use of possibly uninitialized `b`
+   |         ^ use of possibly-uninitialized `b`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/std/alloc.stderr
+++ b/src/test/ui/consts/std/alloc.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const LAYOUT_INVALID: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0 at .align_, but expected something greater or equal to 1
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/validate_never_arrays.stderr
+++ b/src/test/ui/consts/validate_never_arrays.stderr
@@ -4,7 +4,7 @@ error[E0080]: it is undefined behavior to use this value
 LL | const FOO: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of an uninhabited type at .<deref>
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rust compiler repository if you believe it should not be considered undefined behavior
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-never-array.rs
+++ b/src/test/ui/empty/empty-never-array.rs
@@ -10,7 +10,7 @@ fn transmute<T, U>(t: T) -> U {
     let Helper::U(u) = Helper::T(t, []);
     //~^ ERROR refutable pattern in local binding: `T(_, _)` not covered
     u
-    //~^ ERROR use of possibly uninitialized variable: `u`
+    //~^ ERROR use of possibly-uninitialized variable: `u`
 }
 
 fn main() {

--- a/src/test/ui/empty/empty-never-array.stderr
+++ b/src/test/ui/empty/empty-never-array.stderr
@@ -11,11 +11,11 @@ LL | | }
 LL |       let Helper::U(u) = Helper::T(t, []);
    |           ^^^^^^^^^^^^ pattern `T(_, _)` not covered
 
-error[E0381]: use of possibly uninitialized variable: `u`
+error[E0381]: use of possibly-uninitialized variable: `u`
   --> $DIR/empty-never-array.rs:12:5
    |
 LL |     u
-   |     ^ use of possibly uninitialized `u`
+   |     ^ use of possibly-uninitialized `u`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generator/partial-initialization-across-yield.rs
+++ b/src/test/ui/generator/partial-initialization-across-yield.rs
@@ -10,7 +10,7 @@ fn test_tuple() {
     let _ = || {
         let mut t: (i32, i32);
         t.0 = 42;
-        //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
         yield;
         t.1 = 88;
         let _ = t;
@@ -21,7 +21,7 @@ fn test_tuple_struct() {
     let _ = || {
         let mut t: T;
         t.0 = 42;
-        //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
         yield;
         t.1 = 88;
         let _ = t;
@@ -32,7 +32,7 @@ fn test_struct() {
     let _ = || {
         let mut t: S;
         t.x = 42;
-        //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+        //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
         yield;
         t.y = 88;
         let _ = t;

--- a/src/test/ui/generator/partial-initialization-across-yield.stderr
+++ b/src/test/ui/generator/partial-initialization-across-yield.stderr
@@ -1,20 +1,20 @@
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-yield.rs:12:9
    |
 LL |         t.0 = 42;
-   |         ^^^^^^^^ use of possibly uninitialized `t`
+   |         ^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-yield.rs:23:9
    |
 LL |         t.0 = 42;
-   |         ^^^^^^^^ use of possibly uninitialized `t`
+   |         ^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/partial-initialization-across-yield.rs:34:9
    |
 LL |         t.x = 42;
-   |         ^^^^^^^^ use of possibly uninitialized `t`
+   |         ^^^^^^^^ use of possibly-uninitialized `t`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-15381.rs
+++ b/src/test/ui/issues/issue-15381.rs
@@ -4,6 +4,6 @@ fn main() {
     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
         //~^ ERROR refutable pattern in `for` loop binding: `&[]` not covered
         println!("y={}", y);
-        //~^ ERROR borrow of possibly uninitialized variable: `y`
+        //~^ ERROR borrow of possibly-uninitialized variable: `y`
     }
 }

--- a/src/test/ui/issues/issue-15381.stderr
+++ b/src/test/ui/issues/issue-15381.stderr
@@ -4,11 +4,11 @@ error[E0005]: refutable pattern in `for` loop binding: `&[]` not covered
 LL |     for &[x,y,z] in values.chunks(3).filter(|&xs| xs.len() == 3) {
    |         ^^^^^^^^ pattern `&[]` not covered
 
-error[E0381]: borrow of possibly uninitialized variable: `y`
+error[E0381]: borrow of possibly-uninitialized variable: `y`
   --> $DIR/issue-15381.rs:6:26
    |
 LL |         println!("y={}", y);
-   |                          ^ use of possibly uninitialized `y`
+   |                          ^ use of possibly-uninitialized `y`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-24267-flow-exit.rs
+++ b/src/test/ui/issues/issue-24267-flow-exit.rs
@@ -9,11 +9,11 @@ pub fn main() {
 pub fn foo1() {
     let x: i32;
     loop { x = break; }
-    println!("{}", x); //~ ERROR borrow of possibly uninitialized variable: `x`
+    println!("{}", x); //~ ERROR borrow of possibly-uninitialized variable: `x`
 }
 
 pub fn foo2() {
     let x: i32;
     for _ in 0..10 { x = continue; }
-    println!("{}", x); //~ ERROR borrow of possibly uninitialized variable: `x`
+    println!("{}", x); //~ ERROR borrow of possibly-uninitialized variable: `x`
 }

--- a/src/test/ui/issues/issue-24267-flow-exit.stderr
+++ b/src/test/ui/issues/issue-24267-flow-exit.stderr
@@ -1,14 +1,14 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/issue-24267-flow-exit.rs:12:20
    |
 LL |     println!("{}", x);
-   |                    ^ use of possibly uninitialized `x`
+   |                    ^ use of possibly-uninitialized `x`
 
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/issue-24267-flow-exit.rs:18:20
    |
 LL |     println!("{}", x);
-   |                    ^ use of possibly uninitialized `x`
+   |                    ^ use of possibly-uninitialized `x`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/loops/loop-proper-liveness.rs
+++ b/src/test/ui/loops/loop-proper-liveness.rs
@@ -6,7 +6,7 @@ fn test1() {
     'a: loop {
         x = loop { break 'a };
     }
-    println!("{:?}", x); //~ ERROR borrow of possibly uninitialized variable
+    println!("{:?}", x); //~ ERROR borrow of possibly-uninitialized variable
 }
 
 // test2 and test3 should not fail.

--- a/src/test/ui/loops/loop-proper-liveness.stderr
+++ b/src/test/ui/loops/loop-proper-liveness.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `x`
+error[E0381]: borrow of possibly-uninitialized variable: `x`
   --> $DIR/loop-proper-liveness.rs:9:22
    |
 LL |     println!("{:?}", x);
-   |                      ^ use of possibly uninitialized `x`
+   |                      ^ use of possibly-uninitialized `x`
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-semicolon-warning.stderr
+++ b/src/test/ui/missing/missing-semicolon-warning.stderr
@@ -7,7 +7,7 @@ LL |         $( let x = $e1 )*;
 LL | fn main() { m!(0, 0; 0, 0); }
    |             --------------- in this macro invocation
    |
-   = note: This was erroneously allowed and will become a hard error in a future release
+   = note: this was erroneously allowed and will become a hard error in a future release
 
 warning: expected `;`, found `println`
   --> $DIR/missing-semicolon-warning.rs:7:12
@@ -18,5 +18,5 @@ LL |         $( println!("{}", $e2) )*;
 LL | fn main() { m!(0, 0; 0, 0); }
    |             --------------- in this macro invocation
    |
-   = note: This was erroneously allowed and will become a hard error in a future release
+   = note: this was erroneously allowed and will become a hard error in a future release
 

--- a/src/test/ui/moves/move-into-dead-array-1.rs
+++ b/src/test/ui/moves/move-into-dead-array-1.rs
@@ -11,5 +11,5 @@ fn main() {
 
 fn foo(i: usize) {
     let mut a: [D; 4];
-    a[i] = d();        //~ ERROR use of possibly uninitialized variable: `a`
+    a[i] = d();        //~ ERROR use of possibly-uninitialized variable: `a`
 }

--- a/src/test/ui/moves/move-into-dead-array-1.stderr
+++ b/src/test/ui/moves/move-into-dead-array-1.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `a`
+error[E0381]: use of possibly-uninitialized variable: `a`
   --> $DIR/move-into-dead-array-1.rs:14:5
    |
 LL |     a[i] = d();
-   |     ^^^^ use of possibly uninitialized `a`
+   |     ^^^^ use of possibly-uninitialized `a`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.rs
+++ b/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.rs
@@ -26,13 +26,13 @@ impl Drop for D {
 fn cannot_partially_init_adt_with_drop() {
     let d: D;
     d.x = 10;
-    //~^ ERROR assign of possibly uninitialized variable: `d` [E0381]
+    //~^ ERROR assign of possibly-uninitialized variable: `d` [E0381]
 }
 
 fn cannot_partially_init_mutable_adt_with_drop() {
     let mut d: D;
     d.x = 10;
-    //~^ ERROR assign of possibly uninitialized variable: `d` [E0381]
+    //~^ ERROR assign of possibly-uninitialized variable: `d` [E0381]
 }
 
 fn cannot_partially_reinit_adt_with_drop() {
@@ -45,13 +45,13 @@ fn cannot_partially_reinit_adt_with_drop() {
 fn cannot_partially_init_inner_adt_via_outer_with_drop() {
     let d: D;
     d.s.y = 20;
-    //~^ ERROR assign to part of possibly uninitialized variable: `d` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `d` [E0381]
 }
 
 fn cannot_partially_init_inner_adt_via_mutable_outer_with_drop() {
     let mut d: D;
     d.s.y = 20;
-    //~^ ERROR assign to part of possibly uninitialized variable: `d` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `d` [E0381]
 }
 
 fn cannot_partially_reinit_inner_adt_via_outer_with_drop() {

--- a/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.stderr
+++ b/src/test/ui/nll/issue-21232-partial-init-and-erroneous-use.stderr
@@ -1,14 +1,14 @@
-error[E0381]: assign of possibly uninitialized variable: `d`
+error[E0381]: assign of possibly-uninitialized variable: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:28:5
    |
 LL |     d.x = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `d`
+   |     ^^^^^^^^ use of possibly-uninitialized `d`
 
-error[E0381]: assign of possibly uninitialized variable: `d`
+error[E0381]: assign of possibly-uninitialized variable: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:34:5
    |
 LL |     d.x = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `d`
+   |     ^^^^^^^^ use of possibly-uninitialized `d`
 
 error[E0382]: assign of moved value: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:41:5
@@ -20,17 +20,17 @@ LL |     drop(d);
 LL |     d.x = 10;
    |     ^^^^^^^^ value assigned here after move
 
-error[E0381]: assign to part of possibly uninitialized variable: `d`
+error[E0381]: assign to part of possibly-uninitialized variable: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:47:5
    |
 LL |     d.s.y = 20;
-   |     ^^^^^^^^^^ use of possibly uninitialized `d.s`
+   |     ^^^^^^^^^^ use of possibly-uninitialized `d.s`
 
-error[E0381]: assign to part of possibly uninitialized variable: `d`
+error[E0381]: assign to part of possibly-uninitialized variable: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:53:5
    |
 LL |     d.s.y = 20;
-   |     ^^^^^^^^^^ use of possibly uninitialized `d.s`
+   |     ^^^^^^^^^^ use of possibly-uninitialized `d.s`
 
 error[E0382]: assign to part of moved value: `d`
   --> $DIR/issue-21232-partial-init-and-erroneous-use.rs:60:5

--- a/src/test/ui/nll/issue-21232-partial-init-and-use.rs
+++ b/src/test/ui/nll/issue-21232-partial-init-and-use.rs
@@ -97,14 +97,14 @@ macro_rules! use_part {
 fn test_0000_local_fully_init_and_use_struct() {
     let s: S<B>;
     s.x = 10; s.y = Box::new(20);
-    //~^ ERROR assign to part of possibly uninitialized variable: `s` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `s` [E0381]
     use_fully!(struct s);
 }
 
 fn test_0001_local_fully_init_and_use_tuple() {
     let t: T;
     t.0 = 10; t.1 = Box::new(20);
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     use_fully!(tuple t);
 }
 
@@ -125,14 +125,14 @@ fn test_0011_local_fully_reinit_and_use_tuple() {
 fn test_0100_local_partial_init_and_use_struct() {
     let s: S<B>;
     s.x = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `s` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `s` [E0381]
     use_part!(struct s);
 }
 
 fn test_0101_local_partial_init_and_use_tuple() {
     let t: T;
     t.0 = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     use_part!(tuple t);
 }
 
@@ -153,14 +153,14 @@ fn test_0111_local_partial_reinit_and_use_tuple() {
 fn test_0200_local_void_init_and_use_struct() {
     let s: S<Void>;
     s.x = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `s` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `s` [E0381]
     use_part!(struct s);
 }
 
 fn test_0201_local_void_init_and_use_tuple() {
     let t: Tvoid;
     t.0 = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `t` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `t` [E0381]
     use_part!(tuple t);
 }
 
@@ -176,14 +176,14 @@ fn test_0201_local_void_init_and_use_tuple() {
 fn test_1000_field_fully_init_and_use_struct() {
     let q: Q<S<B>>;
     q.r.f.x = 10; q.r.f.y = Box::new(20);
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_fully!(struct q.r.f);
 }
 
 fn test_1001_field_fully_init_and_use_tuple() {
     let q: Q<T>;
     q.r.f.0 = 10; q.r.f.1 = Box::new(20);
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_fully!(tuple q.r.f);
 }
 
@@ -204,14 +204,14 @@ fn test_1011_field_fully_reinit_and_use_tuple() {
 fn test_1100_field_partial_init_and_use_struct() {
     let q: Q<S<B>>;
     q.r.f.x = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_part!(struct q.r.f);
 }
 
 fn test_1101_field_partial_init_and_use_tuple() {
     let q: Q<T>;
     q.r.f.0 = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_part!(tuple q.r.f);
 }
 
@@ -232,14 +232,14 @@ fn test_1111_field_partial_reinit_and_use_tuple() {
 fn test_1200_field_void_init_and_use_struct() {
     let mut q: Q<S<Void>>;
     q.r.f.x = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_part!(struct q.r.f);
 }
 
 fn test_1201_field_void_init_and_use_tuple() {
     let mut q: Q<Tvoid>;
     q.r.f.0 = 10;
-    //~^ ERROR assign to part of possibly uninitialized variable: `q` [E0381]
+    //~^ ERROR assign to part of possibly-uninitialized variable: `q` [E0381]
     use_part!(tuple q.r.f);
 }
 

--- a/src/test/ui/nll/issue-21232-partial-init-and-use.stderr
+++ b/src/test/ui/nll/issue-21232-partial-init-and-use.stderr
@@ -1,14 +1,14 @@
-error[E0381]: assign to part of possibly uninitialized variable: `s`
+error[E0381]: assign to part of possibly-uninitialized variable: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:99:5
    |
 LL |     s.x = 10; s.y = Box::new(20);
-   |     ^^^^^^^^ use of possibly uninitialized `s`
+   |     ^^^^^^^^ use of possibly-uninitialized `s`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/issue-21232-partial-init-and-use.rs:106:5
    |
 LL |     t.0 = 10; t.1 = Box::new(20);
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
 error[E0382]: assign to part of moved value: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:113:5
@@ -30,17 +30,17 @@ LL |     let mut t: T = (0, Box::new(0)); drop(t);
 LL |     t.0 = 10; t.1 = Box::new(20);
    |     ^^^^^^^^ value partially assigned here after move
 
-error[E0381]: assign to part of possibly uninitialized variable: `s`
+error[E0381]: assign to part of possibly-uninitialized variable: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:127:5
    |
 LL |     s.x = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `s`
+   |     ^^^^^^^^ use of possibly-uninitialized `s`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/issue-21232-partial-init-and-use.rs:134:5
    |
 LL |     t.0 = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
 error[E0382]: assign to part of moved value: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:141:5
@@ -62,29 +62,29 @@ LL |     let mut t: T = (0, Box::new(0)); drop(t);
 LL |     t.0 = 10;
    |     ^^^^^^^^ value partially assigned here after move
 
-error[E0381]: assign to part of possibly uninitialized variable: `s`
+error[E0381]: assign to part of possibly-uninitialized variable: `s`
   --> $DIR/issue-21232-partial-init-and-use.rs:155:5
    |
 LL |     s.x = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `s`
+   |     ^^^^^^^^ use of possibly-uninitialized `s`
 
-error[E0381]: assign to part of possibly uninitialized variable: `t`
+error[E0381]: assign to part of possibly-uninitialized variable: `t`
   --> $DIR/issue-21232-partial-init-and-use.rs:162:5
    |
 LL |     t.0 = 10;
-   |     ^^^^^^^^ use of possibly uninitialized `t`
+   |     ^^^^^^^^ use of possibly-uninitialized `t`
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:178:5
    |
 LL |     q.r.f.x = 10; q.r.f.y = Box::new(20);
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:185:5
    |
 LL |     q.r.f.0 = 10; q.r.f.1 = Box::new(20);
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
 error[E0382]: assign to part of moved value: `q.r`
   --> $DIR/issue-21232-partial-init-and-use.rs:192:5
@@ -106,17 +106,17 @@ LL |     q.r.f.0 = 10; q.r.f.1 = Box::new(20);
    |
    = note: move occurs because `q.r` has type `R<(u32, std::boxed::Box<u32>)>`, which does not implement the `Copy` trait
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:206:5
    |
 LL |     q.r.f.x = 10;
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:213:5
    |
 LL |     q.r.f.0 = 10;
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
 error[E0382]: assign to part of moved value: `q.r`
   --> $DIR/issue-21232-partial-init-and-use.rs:220:5
@@ -138,17 +138,17 @@ LL |     q.r.f.0 = 10;
    |
    = note: move occurs because `q.r` has type `R<(u32, std::boxed::Box<u32>)>`, which does not implement the `Copy` trait
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:234:5
    |
 LL |     q.r.f.x = 10;
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
-error[E0381]: assign to part of possibly uninitialized variable: `q`
+error[E0381]: assign to part of possibly-uninitialized variable: `q`
   --> $DIR/issue-21232-partial-init-and-use.rs:241:5
    |
 LL |     q.r.f.0 = 10;
-   |     ^^^^^^^^^^^^ use of possibly uninitialized `q.r.f`
+   |     ^^^^^^^^^^^^ use of possibly-uninitialized `q.r.f`
 
 error[E0382]: assign to part of moved value: `c`
   --> $DIR/issue-21232-partial-init-and-use.rs:259:13

--- a/src/test/ui/nll/match-cfg-fake-edges.rs
+++ b/src/test/ui/nll/match-cfg-fake-edges.rs
@@ -20,7 +20,7 @@ fn guard_may_be_skipped(y: i32) {
     match y {
         _ if { x = 2; true } => 1,
         _ if {
-            x; //~ ERROR use of possibly uninitialized variable: `x`
+            x; //~ ERROR use of possibly-uninitialized variable: `x`
             false
         } => 2,
         _ => 3,

--- a/src/test/ui/nll/match-cfg-fake-edges.stderr
+++ b/src/test/ui/nll/match-cfg-fake-edges.stderr
@@ -1,8 +1,8 @@
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/match-cfg-fake-edges.rs:23:13
    |
 LL |             x;
-   |             ^ use of possibly uninitialized `x`
+   |             ^ use of possibly-uninitialized `x`
 
 error[E0382]: use of moved value: `x`
   --> $DIR/match-cfg-fake-edges.rs:37:13

--- a/src/test/ui/nll/match-on-borrowed.stderr
+++ b/src/test/ui/nll/match-on-borrowed.stderr
@@ -34,11 +34,11 @@ LL |         true => (),
 LL |     x;
    |     - borrow later used here
 
-error[E0381]: use of possibly uninitialized variable: `n`
+error[E0381]: use of possibly-uninitialized variable: `n`
   --> $DIR/match-on-borrowed.rs:92:11
    |
 LL |     match n {}
-   |           ^ use of possibly uninitialized `n`
+   |           ^ use of possibly-uninitialized `n`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/do-catch-suggests-try.rs
+++ b/src/test/ui/parser/do-catch-suggests-try.rs
@@ -1,5 +1,5 @@
 fn main() {
     let _: Option<()> = do catch {};
     //~^ ERROR found removed `do catch` syntax
-    //~^^ HELP Following RFC #2388, the new non-placeholder syntax is `try`
+    //~^^ HELP following RFC #2388, the new non-placeholder syntax is `try`
 }

--- a/src/test/ui/parser/do-catch-suggests-try.stderr
+++ b/src/test/ui/parser/do-catch-suggests-try.stderr
@@ -4,7 +4,7 @@ error: found removed `do catch` syntax
 LL |     let _: Option<()> = do catch {};
    |                         ^^
    |
-   = help: Following RFC #2388, the new non-placeholder syntax is `try`
+   = help: following RFC #2388, the new non-placeholder syntax is `try`
 
 error: aborting due to previous error
 

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.rs
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.rs
@@ -6,7 +6,7 @@ fn foo(res: Result<u32, &R>) -> u32 {
     let Ok(x) = res;
     //~^ ERROR refutable pattern
     x
-    //~^ ERROR use of possibly uninitialized variable: `x`
+    //~^ ERROR use of possibly-uninitialized variable: `x`
 }
 
 fn main() {

--- a/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
+++ b/src/test/ui/recursion/recursive-types-are-not-uninhabited.stderr
@@ -4,11 +4,11 @@ error[E0005]: refutable pattern in local binding: `Err(_)` not covered
 LL |     let Ok(x) = res;
    |         ^^^^^ pattern `Err(_)` not covered
 
-error[E0381]: use of possibly uninitialized variable: `x`
+error[E0381]: use of possibly-uninitialized variable: `x`
   --> $DIR/recursive-types-are-not-uninhabited.rs:8:5
    |
 LL |     x
-   |     ^ use of possibly uninitialized `x`
+   |     ^ use of possibly-uninitialized `x`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/try-block/try-block-opt-init.rs
+++ b/src/test/ui/try-block/try-block-opt-init.rs
@@ -12,5 +12,5 @@ pub fn main() {
         Ok::<(), ()>(())?;
         use_val(cfg_res);
     };
-    assert_eq!(cfg_res, 5); //~ ERROR borrow of possibly uninitialized variable: `cfg_res`
+    assert_eq!(cfg_res, 5); //~ ERROR borrow of possibly-uninitialized variable: `cfg_res`
 }

--- a/src/test/ui/try-block/try-block-opt-init.stderr
+++ b/src/test/ui/try-block/try-block-opt-init.stderr
@@ -1,8 +1,8 @@
-error[E0381]: borrow of possibly uninitialized variable: `cfg_res`
+error[E0381]: borrow of possibly-uninitialized variable: `cfg_res`
   --> $DIR/try-block-opt-init.rs:15:5
    |
 LL |     assert_eq!(cfg_res, 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly uninitialized `cfg_res`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ use of possibly-uninitialized `cfg_res`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 


### PR DESCRIPTION
Successful merges:

 - #63565 (Rust 2018: NLL migrate mode => hard error)
 - #63969 (Add missing examples for Option type)
 - #64067 (Remove no-prefer-dynamic from valgrind tests)
 - #64166 (Better way of conditioning the sanitizer builds)
 - #64189 (annotate-snippet emitter: Deal with multispans from macros, too)
 - #64202 (Fixed grammar/style in some error messages)
 - #64206 (annotate-snippet emitter: Update an issue number)
 - #64208 (it's more pythonic to use 'is not None' in python files)

Failed merges:


r? @ghost