### PR TITLE
Include compiler-rt in the source tarball

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -808,6 +808,7 @@ fn copy_src_dirs(builder: &Builder<'_>, src_dirs: &[&str], exclude_dirs: &[&str]
             "llvm-project/lld", "llvm-project\\lld",
             "llvm-project/lldb", "llvm-project\\lldb",
             "llvm-project/llvm", "llvm-project\\llvm",
+            "llvm-project/compiler-rt", "llvm-project\\compiler-rt",
         ];
         if spath.contains("llvm-project") && !spath.ends_with("llvm-project")
             && !LLVM_PROJECTS.iter().any(|path| spath.contains(path))


### PR DESCRIPTION
In #60981 we switched to using src/llvm-project/compiler-rt inside
compiler-builtins rather than a separate copy of it.
In order to have the "c" feature turn on in builds from the source
tarball, we need to include that path in its creation.

fixes #64239