### PR TITLE
PowerPC C ZST ABI fixes

### DIFF
--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2642,12 +2642,11 @@ where
         };
 
         let target = &cx.tcx().sess.target.target;
-        let win_x64_gnu =
-            target.target_os == "windows" && target.arch == "x86_64" && target.target_env == "gnu";
-        let linux_s390x =
-            target.target_os == "linux" && target.arch == "s390x" && target.target_env == "gnu";
-        let linux_sparc64 =
-            target.target_os == "linux" && target.arch == "sparc64" && target.target_env == "gnu";
+        let indirect_zst = match target.arch.as_ref() {
+            "powerpc" | "s390x" | "sparc64" => true,
+            "x86_64" => target.target_os == "windows" && target.target_env == "gnu",
+            _ => false,
+        };
         let rust_abi = match sig.abi {
             RustIntrinsic | PlatformIntrinsic | Rust | RustCall => true,
             _ => false,
@@ -2709,11 +2708,10 @@ where
             let is_return = arg_idx.is_none();
             let mut arg = mk_arg_type(ty, arg_idx);
             if arg.layout.is_zst() {
-                // For some forsaken reason, x86_64-pc-windows-gnu
-                // doesn't ignore zero-sized struct arguments.
-                // The same is true for s390x-unknown-linux-gnu
-                // and sparc64-unknown-linux-gnu.
-                if is_return || rust_abi || (!win_x64_gnu && !linux_s390x && !linux_sparc64) {
+                // FIXME: The C ABI case should be handled in adjust_for_cabi.
+                // Zero-sized struct arguments cannot be ignored in the C ABI
+                // if they are passed indirectly.
+                if is_return || rust_abi || !indirect_zst {
                     arg.mode = PassMode::Ignore;
                 }
             }


### PR DESCRIPTION
These patches fix some longstanding issues with the PowerPC C ABI that were causing several test failures. With these patches, I get a clean testsuite run on `powerpc-unknown-linux-musl`.

The [PowerPC SVR4 ELF psABI](http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf) specifies that, for parameter passing:

> A struct, union, or long double, any of which shall be treated as
a pointer to the object, or to a copy of the object where necessary to
enforce call-by-value semantics. Only if the caller can ascertain that the
object is "constant" can it pass a pointer to the object itself.

The first commit fixes this for most aggregates; the second commit fixes this for zero-size aggregates.