### PR TITLE
Sidestep bad precedence of closures in `let` bindings

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1729,7 +1729,10 @@ impl<'a> State<'a> {
         self.print_expr_cond_paren(
             scrutinee,
             Self::cond_needs_par(scrutinee)
-            || parser::needs_par_as_let_scrutinee(scrutinee.precedence().order())
+                || parser::needs_par_as_let_scrutinee(scrutinee.precedence().order())
+                // #51635: handle closures correctly, even though they have a really low
+                // precedence, they *don't* need parens for assignment 🤷.
+                && scrutinee.precedence() != parser::ExprPrecedence::Closure
         )
     }
 
@@ -1808,7 +1811,6 @@ impl<'a> State<'a> {
         match expr.node {
             // These cases need parens due to the parse error observed in #26461: `if return {}`
             // parses as the erroneous construct `if (return {})`, not `if (return) {}`.
-            ast::ExprKind::Closure(..) |
             ast::ExprKind::Ret(..) |
             ast::ExprKind::Break(..) => true,
 

--- a/src/libsyntax/util/parser.rs
+++ b/src/libsyntax/util/parser.rs
@@ -242,7 +242,7 @@ pub const PREC_POSTFIX: i8 = 60;
 pub const PREC_PAREN: i8 = 99;
 pub const PREC_FORCE_PAREN: i8 = 100;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ExprPrecedence {
     Closure,
     Break,


### PR DESCRIPTION
Avoid adding unnecessary parentheses around closures in
`if let _ = || ()`.

CC https://github.com/rust-lang/rust/issues/51635.

r? @petrochenkov 