### PR TITLE
Warn if include macro fails to include entire file

### DIFF
--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -368,6 +368,12 @@ pub mod parser {
         Allow,
         "possible meta-variable misuse at macro definition"
     }
+
+    declare_lint! {
+        pub INCOMPLETE_INCLUDE,
+        Deny,
+        "trailing content in included file"
+    }
 }
 
 declare_lint! {

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -28,6 +28,7 @@ use crate::hir::intravisit;
 use crate::hir;
 use crate::lint::builtin::BuiltinLintDiagnostics;
 use crate::lint::builtin::parser::{ILL_FORMED_ATTRIBUTE_INPUT, META_VARIABLE_MISUSE};
+use crate::lint::builtin::parser::INCOMPLETE_INCLUDE;
 use crate::session::{Session, DiagnosticMessageId};
 use crate::ty::TyCtxt;
 use crate::ty::query::Providers;
@@ -83,6 +84,7 @@ impl Lint {
         match lint_id {
             BufferedEarlyLintId::IllFormedAttributeInput => ILL_FORMED_ATTRIBUTE_INPUT,
             BufferedEarlyLintId::MetaVariableMisuse => META_VARIABLE_MISUSE,
+            BufferedEarlyLintId::IncompleteInclude => INCOMPLETE_INCLUDE,
         }
     }
 

--- a/src/libsyntax/early_buffered_lints.rs
+++ b/src/libsyntax/early_buffered_lints.rs
@@ -11,6 +11,7 @@ use syntax_pos::MultiSpan;
 pub enum BufferedEarlyLintId {
     IllFormedAttributeInput,
     MetaVariableMisuse,
+    IncompleteInclude,
 }
 
 /// Stores buffered lint info which can later be passed to `librustc`.

--- a/src/test/ui/include-single-expr-helper-1.rs
+++ b/src/test/ui/include-single-expr-helper-1.rs
@@ -1,0 +1,5 @@
+// ignore-test auxiliary file for include-single-expr.rs
+
+0
+
+// trailing comment permitted

--- a/src/test/ui/include-single-expr-helper.rs
+++ b/src/test/ui/include-single-expr-helper.rs
@@ -1,0 +1,5 @@
+// ignore-test auxiliary file for include-single-expr.rs
+
+0
+10
+100

--- a/src/test/ui/include-single-expr.rs
+++ b/src/test/ui/include-single-expr.rs
@@ -1,0 +1,6 @@
+// error-pattern include macro expected single expression
+
+fn main() {
+    include!("include-single-expr-helper.rs");
+    include!("include-single-expr-helper-1.rs");
+}

--- a/src/test/ui/include-single-expr.stderr
+++ b/src/test/ui/include-single-expr.stderr
@@ -1,0 +1,10 @@
+error: include macro expected single expression in source
+  --> $DIR/include-single-expr-helper.rs:4:1
+   |
+LL | 10
+   | ^^
+   |
+   = note: `#[deny(incomplete_include)]` on by default
+
+error: aborting due to previous error
+

--- a/src/tools/error_index_generator/build.rs
+++ b/src/tools/error_index_generator/build.rs
@@ -15,7 +15,7 @@ fn main() {
             println!("cargo:rerun-if-changed={}", entry.path().to_str().unwrap());
             let file = fs::read_to_string(entry.path()).unwrap()
                 .replace("syntax::register_diagnostics!", "register_diagnostics!");
-            let contents = format!("(|| {{\n{}\n}})();", file);
+            let contents = format!("(|| {{\n{}\n}})()", file);
 
             fs::write(&out_dir.join(&format!("error_{}.rs", idx)), &contents).unwrap();
 


### PR DESCRIPTION
This currently introduces an error, mainly because that was just simpler, and I'm not entirely certain if we can introduce a lint without an RFC and such.

This is primarily to get feedback on the approach and overall aim -- in particular, do we think this is helpful? If so, we probably will need lang-team sign off and decide if it should be an error (as currently introduced by this PR), a lint, or a warning.

r? @petrochenkov 

cc https://github.com/rust-lang/rust/issues/35560