### PR TITLE
Fix `Stdio::piped` example code and lint

### DIFF
--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -935,12 +935,12 @@ impl Stdio {
     ///     .expect("Failed to spawn child process");
     ///
     /// {
-    ///     let mut stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    ///     let stdin = child.stdin.as_mut().expect("Failed to open stdin");
     ///     stdin.write_all("Hello, world!".as_bytes()).expect("Failed to write to stdin");
     /// }
     ///
     /// let output = child.wait_with_output().expect("Failed to read stdout");
-    /// assert_eq!(String::from_utf8_lossy(&output.stdout), "!dlrow ,olleH\n");
+    /// assert_eq!(String::from_utf8_lossy(&output.stdout), "!dlrow ,olleH");
     /// ```
     #[stable(feature = "process", since = "1.0.0")]
     pub fn piped() -> Stdio { Stdio(imp::Stdio::MakePipe) }


### PR DESCRIPTION
Summary:
Invoking `rev` does not add a trailing newline when none is present in
the input (at least on my Debian). Nearby examples use `echo` rather
than `rev`, which probably explains the source of the discrepancy.

Also, a `mut` qualifier is unused.

Test Plan:
Copy the code block into <https://play.rust-lang.org> with a `fn main`
wrapper, and run it. Note that it compiles and runs cleanly; prior to
this commit, it would emit an `unused_mut` warning and then panic.

wchargin-branch: stdio-piped-docs