### PR TITLE
Document the unstable iter_order_by library feature

### DIFF
--- a/src/doc/unstable-book/src/iter-order-by.md
+++ b/src/doc/unstable-book/src/iter-order-by.md
@@ -1,0 +1,9 @@
+# `iter_order_by`
+
+The tracking issue for this feature is: [#64295]
+
+[#64295]: https://github.com/rust-lang/rust/issues/64295
+
+------------------------
+
+Add `cmp_by`, `partial_cmp_by` and `eq_by` methods to `Iterator` in the same vein as `max_by` and `min_by`.

--- a/src/doc/unstable-book/src/iter-order-by.md
+++ b/src/doc/unstable-book/src/iter-order-by.md
@@ -1,9 +1,0 @@
-# `iter_order_by`
-
-The tracking issue for this feature is: [#64295]
-
-[#64295]: https://github.com/rust-lang/rust/issues/64295
-
-------------------------
-
-Add `cmp_by`, `partial_cmp_by` and `eq_by` methods to `Iterator` in the same vein as `max_by` and `min_by`.

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -2585,7 +2585,7 @@ pub trait Iterator {
     /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (x * x).cmp(&y)), Ordering::Equal);
     /// assert_eq!(xs.iter().cmp_by(&ys, |&x, &y| (2 * x).cmp(&y)), Ordering::Greater);
     /// ```
-    #[unstable(feature = "iter_order_by", issue = "0")]
+    #[unstable(feature = "iter_order_by", issue = "64295")]
     fn cmp_by<I, F>(mut self, other: I, mut cmp: F) -> Ordering
     where
         Self: Sized,
@@ -2668,7 +2668,7 @@ pub trait Iterator {
     ///     Some(Ordering::Greater)
     /// );
     /// ```
-    #[unstable(feature = "iter_order_by", issue = "0")]
+    #[unstable(feature = "iter_order_by", issue = "64295")]
     fn partial_cmp_by<I, F>(mut self, other: I, mut partial_cmp: F) -> Option<Ordering>
     where
         Self: Sized,
@@ -2733,7 +2733,7 @@ pub trait Iterator {
     ///
     /// assert!(xs.iter().eq_by(&ys, |&x, &y| x * x == y));
     /// ```
-    #[unstable(feature = "iter_order_by", issue = "0")]
+    #[unstable(feature = "iter_order_by", issue = "64295")]
     fn eq_by<I, F>(mut self, other: I, mut eq: F) -> bool
     where
         Self: Sized,


### PR DESCRIPTION
Tracking issue: #64295

Follow-up for: #62205

References the tracking issue and adds a page to the unstable book for the new unstable `iter_order_by` feature.