### PR TITLE
Create compilation target versions of `::alloc::Layout`

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -5,7 +5,7 @@ use super::{
 };
 
 use crate::mir;
-use crate::ty::layout::{Size, Align};
+use crate::ty::layout::{Size, MemoryPosition, Align};
 
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_target::abi::HasDataLayout;
@@ -116,14 +116,14 @@ impl<Tag> Allocation<Tag> {
         Allocation::from_bytes(slice, Align::from_bytes(1).unwrap())
     }
 
-    pub fn undef(size: Size, align: Align) -> Self {
-        assert_eq!(size.bytes() as usize as u64, size.bytes());
+    pub fn undef(mem_pos: MemoryPosition) -> Self {
+        assert_eq!(mem_pos.size.bytes() as usize as u64, mem_pos.size.bytes());
         Allocation {
-            bytes: vec![0; size.bytes() as usize],
+            bytes: vec![0; mem_pos.size.bytes() as usize],
             relocations: Relocations::new(),
-            undef_mask: UndefMask::new(size, false),
-            size,
-            align,
+            undef_mask: UndefMask::new(mem_pos.size, false),
+            size: mem_pos.size,
+            align: mem_pos.align,
             mutability: Mutability::Mutable,
             extra: (),
         }

--- a/src/librustc/mir/interpret/error.rs
+++ b/src/librustc/mir/interpret/error.rs
@@ -4,7 +4,7 @@ use crate::hir;
 use crate::hir::map::definitions::DefPathData;
 use crate::mir;
 use crate::ty::{self, Ty, layout};
-use crate::ty::layout::{Size, Align, LayoutError};
+use crate::ty::layout::{Size, MemoryPosition, Align, LayoutError};
 use crate::ty::query::TyCtxtAt;
 
 use backtrace::Backtrace;
@@ -438,7 +438,7 @@ pub enum UnsupportedOpInfo<'tcx> {
     DeallocatedWrongMemoryKind(String, String),
     ReallocateNonBasePtr,
     DeallocateNonBasePtr,
-    IncorrectAllocationInformation(Size, Size, Align, Align),
+    IncorrectAllocationInformation(MemoryPosition, MemoryPosition),
     HeapAllocZeroBytes,
     HeapAllocNonPowerOfTwoAlignment(u64),
     ReadFromReturnPointer,
@@ -484,10 +484,10 @@ impl fmt::Debug for UnsupportedOpInfo<'tcx> {
                 write!(f, "expected primitive type, got {}", ty),
             PathNotFound(ref path) =>
                 write!(f, "cannot find path {:?}", path),
-            IncorrectAllocationInformation(size, size2, align, align2) =>
+            IncorrectAllocationInformation(expect, got) =>
                 write!(f, "incorrect alloc info: expected size {} and align {}, \
                            got size {} and align {}",
-                    size.bytes(), align.bytes(), size2.bytes(), align2.bytes()),
+                    expect.size.bytes(), expect.align.bytes(), got.size.bytes(), got.align.bytes()),
             InvalidMemoryAccess =>
                 write!(f, "tried to access memory through an invalid pointer"),
             DanglingPointerDeref =>

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -37,7 +37,7 @@ pub trait PointerArithmetic: layout::HasDataLayout {
 
     #[inline(always)]
     fn pointer_size(&self) -> Size {
-        self.data_layout().pointer_size
+        self.data_layout().pointer_pos.size
     }
 
     /// Helper function: truncate given value-"overflowed flag" pair to pointer size and

--- a/src/librustc/mir/interpret/pointer.rs
+++ b/src/librustc/mir/interpret/pointer.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
 use crate::mir;
-use crate::ty::layout::{self, HasDataLayout, Size};
+use crate::ty::layout::{self, HasDataLayout, LayoutPositionPref, Size};
 use rustc_macros::HashStable;
 
 use super::{AllocId, InterpResult};
@@ -36,8 +36,13 @@ pub trait PointerArithmetic: layout::HasDataLayout {
     // These are not supposed to be overridden.
 
     #[inline(always)]
+    fn pointer_pos(&self) -> LayoutPositionPref {
+        self.data_layout().pointer_pos
+    }
+
+    #[inline(always)]
     fn pointer_size(&self) -> Size {
-        self.data_layout().pointer_pos.size
+        self.pointer_pos().size
     }
 
     /// Helper function: truncate given value-"overflowed flag" pair to pointer size and

--- a/src/librustc/mir/interpret/value.rs
+++ b/src/librustc/mir/interpret/value.rs
@@ -191,7 +191,7 @@ impl<'tcx, Tag> Scalar<Tag> {
     pub fn ptr_null(cx: &impl HasDataLayout) -> Self {
         Scalar::Raw {
             data: 0,
-            size: cx.data_layout().pointer_size.bytes() as u8,
+            size: cx.data_layout().pointer_pos.size.bytes() as u8,
         }
     }
 
@@ -205,7 +205,7 @@ impl<'tcx, Tag> Scalar<Tag> {
         let dl = cx.data_layout();
         match self {
             Scalar::Raw { data, size } => {
-                assert_eq!(size as u64, dl.pointer_size.bytes());
+                assert_eq!(size as u64, dl.pointer_pos.size.bytes());
                 Ok(Scalar::Raw {
                     data: dl.offset(data as u64, i.bytes())? as u128,
                     size,
@@ -220,7 +220,7 @@ impl<'tcx, Tag> Scalar<Tag> {
         let dl = cx.data_layout();
         match self {
             Scalar::Raw { data, size } => {
-                assert_eq!(size as u64, dl.pointer_size.bytes());
+                assert_eq!(size as u64, dl.pointer_pos.size.bytes());
                 Scalar::Raw {
                     data: dl.overflowing_offset(data as u64, i.bytes()).0 as u128,
                     size,
@@ -250,7 +250,7 @@ impl<'tcx, Tag> Scalar<Tag> {
         let dl = cx.data_layout();
         match self {
             Scalar::Raw { data, size } => {
-                assert_eq!(size as u64, dl.pointer_size.bytes());
+                assert_eq!(size as u64, dl.pointer_pos.size.bytes());
                 Scalar::Raw {
                     data: dl.overflowing_signed_offset(data as u64, i128::from(i)).0 as u128,
                     size,
@@ -342,7 +342,7 @@ impl<'tcx, Tag> Scalar<Tag> {
                 Ok(data)
             }
             Scalar::Ptr(ptr) => {
-                assert_eq!(target_size, cx.data_layout().pointer_size);
+                assert_eq!(target_size, cx.data_layout().pointer_pos.size);
                 Err(ptr)
             }
         }
@@ -440,7 +440,7 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     pub fn to_machine_usize(self, cx: &impl HasDataLayout) -> InterpResult<'static, u64> {
-        let b = self.to_bits(cx.data_layout().pointer_size)?;
+        let b = self.to_bits(cx.data_layout().pointer_pos.size)?;
         Ok(b as u64)
     }
 
@@ -466,7 +466,7 @@ impl<'tcx, Tag> Scalar<Tag> {
     }
 
     pub fn to_machine_isize(self, cx: &impl HasDataLayout) -> InterpResult<'static, i64> {
-        let sz = cx.data_layout().pointer_size;
+        let sz = cx.data_layout().pointer_pos.size;
         let b = self.to_bits(sz)?;
         let b = sign_extend(b, sz) as i128;
         Ok(b as i64)

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1502,7 +1502,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             SwitchInt { ref values, switch_ty, .. } => ty::tls::with(|tcx| {
                 let param_env = ty::ParamEnv::empty();
                 let switch_ty = tcx.lift(&switch_ty).unwrap();
-                let size = tcx.layout_of(param_env.and(switch_ty)).unwrap().size;
+                let size = tcx.layout_of(param_env.and(switch_ty)).unwrap().pref_pos.size;
                 values
                     .iter()
                     .map(|&u| {

--- a/src/librustc/session/code_stats.rs
+++ b/src/librustc/session/code_stats.rs
@@ -1,4 +1,4 @@
-use rustc_target::abi::{Align, Size};
+use rustc_target::abi::{MemoryPosition, Size};
 use rustc_data_structures::fx::{FxHashSet};
 use std::cmp::{self, Ordering};
 use rustc_data_structures::sync::Lock;
@@ -54,8 +54,7 @@ impl CodeStats {
     pub fn record_type_size<S: ToString>(&self,
                                          kind: DataTypeKind,
                                          type_desc: S,
-                                         align: Align,
-                                         overall_size: Size,
+                                         mem_pos: MemoryPosition,
                                          packed: bool,
                                          opt_discr_size: Option<Size>,
                                          mut variants: Vec<VariantInfo>) {
@@ -68,8 +67,8 @@ impl CodeStats {
         let info = TypeSizeInfo {
             kind,
             type_description: type_desc.to_string(),
-            align: align.bytes(),
-            overall_size: overall_size.bytes(),
+            align: mem_pos.align.bytes(),
+            overall_size: mem_pos.size.bytes(),
             packed: packed,
             opt_discr_size: opt_discr_size.map(|s| s.bytes()),
             variants,

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2205,8 +2205,7 @@ where
             ty::RawPtr(mt) if offset.bytes() == 0 => {
                 cx.layout_of(mt.ty).to_result().ok()
                     .map(|layout| PointeeInfo {
-                        size: layout.pref_pos.size,
-                        align: layout.pref_pos.align.abi,
+                        mem_pos: layout.pref_pos.mem_pos(),
                         safe: None,
                     })
             }
@@ -2244,8 +2243,7 @@ where
 
                 cx.layout_of(ty).to_result().ok()
                     .map(|layout| PointeeInfo {
-                        size: layout.pref_pos.size,
-                        align: layout.pref_pos.align.abi,
+                        mem_pos: layout.pref_pos.mem_pos(),
                         safe: Some(kind),
                     })
             }
@@ -2681,8 +2679,8 @@ where
 
             if let Some(pointee) = layout.pointee_info_at(cx, offset) {
                 if let Some(kind) = pointee.safe {
-                    attrs.pointee_size = pointee.size;
-                    attrs.pointee_align = Some(pointee.align);
+                    attrs.pointee_size = pointee.mem_pos.size;
+                    attrs.pointee_align = Some(pointee.mem_pos.align);
 
                     // `Box` pointer parameters never alias because ownership is transferred
                     // `&mut` pointer parameters never alias other parameters,

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2466,6 +2466,11 @@ impl_stable_hash_for!(struct crate::ty::layout::LayoutPositionPref {
     align
 });
 
+impl_stable_hash_for!(struct crate::ty::layout::MemoryPosition {
+    size,
+    align
+});
+
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for Align {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         self.bytes().hash_stable(hcx, hasher);

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -1612,8 +1612,7 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
             let type_desc = format!("{:?}", layout.ty);
             self.tcx.sess.code_stats.record_type_size(kind,
                                                       type_desc,
-                                                      layout.pref_pos.align.abi,
-                                                      layout.pref_pos.size,
+                                                      layout.pref_pos.mem_pos(),
                                                       packed,
                                                       opt_discr_size,
                                                       variants);

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -910,6 +910,7 @@ pub trait PrettyPrinter<'tcx>:
                 let ty = self.tcx().lift(&ct.ty).unwrap();
                 let size = self.tcx().layout_of(ty::ParamEnv::empty().and(ty))
                     .unwrap()
+                    .pref_pos
                     .size;
                 let i_str = i.name_str();
                 match data {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2276,7 +2276,7 @@ impl<'tcx> Const<'tcx> {
     pub fn from_bits(tcx: TyCtxt<'tcx>, bits: u128, ty: ParamEnvAnd<'tcx, Ty<'tcx>>) -> &'tcx Self {
         let size = tcx.layout_of(ty).unwrap_or_else(|e| {
             panic!("could not compute layout for {:?}: {:?}", ty, e)
-        }).size;
+        }).pref_pos.size;
         Self::from_scalar(tcx, Scalar::from_uint(bits, size), ty.value)
     }
 
@@ -2303,7 +2303,7 @@ impl<'tcx> Const<'tcx> {
         ty: Ty<'tcx>,
     ) -> Option<u128> {
         assert_eq!(self.ty, ty);
-        let size = tcx.layout_of(param_env.with_reveal_all().and(ty)).ok()?.size;
+        let size = tcx.layout_of(param_env.with_reveal_all().and(ty)).ok()?.pref_pos.size;
         // if `ty` does not depend on generic parameters, use an empty param_env
         self.eval(tcx, param_env).val.try_to_bits(size)
     }

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -546,7 +546,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         let keep_going = header_bx.icmp(IntPredicate::IntNE, current, end);
         header_bx.cond_br(keep_going, body_bx.llbb(), next_bx.llbb());
 
-        let align = dest.align.restrict_for_offset(dest.layout.field(self.cx(), 0).size);
+        let align = dest.align.restrict_for_offset(dest.layout.field(self.cx(), 0).pref_pos.size);
         cg_elem.val.store(&mut body_bx,
             PlaceRef::new_sized_aligned(current, cg_elem.layout, align));
 

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -202,7 +202,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     }
 
     fn const_usize(&self, i: u64) -> &'ll Value {
-        let bit_size = self.data_layout().pointer_size.bits();
+        let bit_size = self.data_layout().pointer_pos.size.bits();
         if bit_size < 64 {
             // make sure it doesn't overflow
             assert!(i < (1<<bit_size));

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -314,9 +314,9 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         alloc: &Allocation,
         offset: Size,
     ) -> PlaceRef<'tcx, &'ll Value> {
-        assert_eq!(alloc.align, layout.align.abi);
+        assert_eq!(alloc.align, layout.pref_pos.align.abi);
         let llty = self.type_ptr_to(layout.llvm_type(self));
-        let llval = if layout.size == Size::ZERO {
+        let llval = if layout.pref_pos.size == Size::ZERO {
             let llval = self.const_usize(alloc.align.bytes());
             unsafe { llvm::LLVMConstIntToPtr(llval, llty) }
         } else {

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -26,7 +26,7 @@ use std::ffi::{CStr, CString};
 pub fn const_alloc_to_llvm(cx: &CodegenCx<'ll, '_>, alloc: &Allocation) -> &'ll Value {
     let mut llvals = Vec::with_capacity(alloc.relocations().len() + 1);
     let dl = cx.data_layout();
-    let pointer_size = dl.pointer_size.bytes() as usize;
+    let pointer_size = dl.pointer_pos.size.bytes() as usize;
 
     let mut next_offset = 0;
     for &(offset, ((), alloc_id)) in alloc.relocations().iter() {

--- a/src/librustc_codegen_llvm/context.rs
+++ b/src/librustc_codegen_llvm/context.rs
@@ -288,7 +288,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             None
         };
 
-        let isize_ty = Type::ix_llcx(llcx, tcx.data_layout.pointer_size.bits());
+        let isize_ty = Type::ix_llcx(llcx, tcx.data_layout.pointer_pos.size.bits());
 
         CodegenCx {
             tcx,

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -2304,7 +2304,7 @@ pub fn create_vtable_metadata(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>, vtable: &
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
             Size::ZERO.bits(),
-            cx.tcx.data_layout.pointer_align.abi.bits() as u32,
+            cx.tcx.data_layout.pointer_pos.align.abi.bits() as u32,
             DIFlags::FlagArtificial,
             None,
             empty_array,

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -496,8 +496,8 @@ fn trait_pointer_metadata(
                 cx.tcx.mk_mut_ptr(cx.tcx.types.u8),
                 syntax_pos::DUMMY_SP),
             offset: layout.fields.offset(0),
-            size: data_ptr_field.size,
-            align: data_ptr_field.align.abi,
+            size: data_ptr_field.pref_pos.size,
+            align: data_ptr_field.pref_pos.align.abi,
             flags: DIFlags::FlagArtificial,
             discriminant: None,
         },
@@ -505,8 +505,8 @@ fn trait_pointer_metadata(
             name: "vtable".to_owned(),
             type_metadata: type_metadata(cx, vtable_field.ty, syntax_pos::DUMMY_SP),
             offset: layout.fields.offset(1),
-            size: vtable_field.size,
-            align: vtable_field.align.abi,
+            size: vtable_field.pref_pos.size,
+            align: vtable_field.pref_pos.align.abi,
             flags: DIFlags::FlagArtificial,
             discriminant: None,
         },
@@ -1128,8 +1128,8 @@ impl<'tcx> StructMemberDescriptionFactory<'tcx> {
                 name,
                 type_metadata: type_metadata(cx, field.ty, self.span),
                 offset: layout.fields.offset(i),
-                size: field.size,
-                align: field.align.abi,
+                size: field.pref_pos.size,
+                align: field.pref_pos.align.abi,
                 flags: DIFlags::FlagZero,
                 discriminant: None,
             }
@@ -1252,8 +1252,8 @@ impl<'tcx> UnionMemberDescriptionFactory<'tcx> {
                 name: f.ident.to_string(),
                 type_metadata: type_metadata(cx, field.ty, self.span),
                 offset: Size::ZERO,
-                size: field.size,
-                align: field.align.abi,
+                size: field.pref_pos.size,
+                align: field.pref_pos.align.abi,
                 flags: DIFlags::FlagZero,
                 discriminant: None,
             }
@@ -1386,8 +1386,8 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         },
                         type_metadata: variant_type_metadata,
                         offset: Size::ZERO,
-                        size: self.layout.size,
-                        align: self.layout.align.abi,
+                        size: self.layout.pref_pos.size,
+                        align: self.layout.pref_pos.align.abi,
                         flags: DIFlags::FlagZero,
                         discriminant: None,
                     }
@@ -1435,8 +1435,8 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                         },
                         type_metadata: variant_type_metadata,
                         offset: Size::ZERO,
-                        size: self.layout.size,
-                        align: self.layout.align.abi,
+                        size: self.layout.pref_pos.size,
+                        align: self.layout.pref_pos.align.abi,
                         flags: DIFlags::FlagZero,
                         discriminant: Some(
                             self.layout.ty.discriminant_for_variant(cx.tcx, i).unwrap().val as u64
@@ -1490,7 +1490,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                             }
                             let inner_offset = offset - field_offset;
                             let field = layout.field(cx, i);
-                            if inner_offset + size <= field.size {
+                            if inner_offset + size <= field.pref_pos.size {
                                 write!(name, "{}$", i).unwrap();
                                 compute_field_path(cx, name, field, inner_offset, size);
                             }
@@ -1499,7 +1499,7 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                     compute_field_path(cx, &mut name,
                                        self.layout,
                                        self.layout.fields.offset(discr_index),
-                                       self.layout.field(cx, discr_index).size);
+                                       self.layout.field(cx, discr_index).pref_pos.size);
                     variant_info_for(*niche_variants.start()).map_struct_name(|variant_name| {
                         name.push_str(variant_name);
                     });
@@ -1510,8 +1510,8 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                             name,
                             type_metadata: variant_type_metadata,
                             offset: Size::ZERO,
-                            size: variant.size,
-                            align: variant.align.abi,
+                            size: variant.pref_pos.size,
+                            align: variant.pref_pos.align.abi,
                             flags: DIFlags::FlagZero,
                             discriminant: None,
                         }
@@ -1554,8 +1554,8 @@ impl EnumMemberDescriptionFactory<'ll, 'tcx> {
                             name: variant_info.variant_name(),
                             type_metadata: variant_type_metadata,
                             offset: Size::ZERO,
-                            size: self.layout.size,
-                            align: self.layout.align.abi,
+                            size: self.layout.pref_pos.size,
+                            align: self.layout.pref_pos.align.abi,
                             flags: DIFlags::FlagZero,
                             discriminant: niche_value,
                         }
@@ -1859,8 +1859,8 @@ fn prepare_enum_metadata(
                 enum_name.as_ptr(),
                 file_metadata,
                 UNKNOWN_LINE_NUMBER,
-                layout.size.bits(),
-                layout.align.abi.bits() as u32,
+                layout.pref_pos.size.bits(),
+                layout.pref_pos.align.abi.bits() as u32,
                 DIFlags::FlagZero,
                 None,
                 0, // RuntimeLang
@@ -1980,8 +1980,8 @@ fn prepare_enum_metadata(
             ptr::null_mut(),
             file_metadata,
             UNKNOWN_LINE_NUMBER,
-            layout.size.bits(),
-            layout.align.abi.bits() as u32,
+            layout.pref_pos.size.bits(),
+            layout.pref_pos.align.abi.bits() as u32,
             DIFlags::FlagZero,
             discriminator_metadata,
             empty_array,
@@ -1998,8 +1998,8 @@ fn prepare_enum_metadata(
             enum_name.as_ptr(),
             file_metadata,
             UNKNOWN_LINE_NUMBER,
-            layout.size.bits(),
-            layout.align.abi.bits() as u32,
+            layout.pref_pos.size.bits(),
+            layout.pref_pos.align.abi.bits() as u32,
             DIFlags::FlagZero,
             None,
             type_array,

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -654,12 +654,11 @@ pub fn type_metadata(
                     // type is going to see *somthing* weird - the only
                     // question is what exactly it will see
                     let mem_pos = cx.mem_pos_of(t);
-                    let (size, align) = (mem_pos.size, mem_pos.align);
                     llvm::LLVMRustDIBuilderCreateBasicType(
                         DIB(cx),
                         SmallCStr::new("<recur_type>").as_ptr(),
-                        size.bits(),
-                        align.bits() as u32,
+                        mem_pos.size.bits(),
+                        mem_pos.align.bits() as u32,
                         DW_ATE_unsigned)
                 }
             };
@@ -853,14 +852,13 @@ fn basic_type_metadata(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'ll DIType {
     };
 
     let mem_pos = cx.mem_pos_of(t);
-    let (size, align) = (mem_pos.size, mem_pos.align);
     let name = SmallCStr::new(name);
     let ty_metadata = unsafe {
         llvm::LLVMRustDIBuilderCreateBasicType(
             DIB(cx),
             name.as_ptr(),
-            size.bits(),
-            align.bits() as u32,
+            mem_pos.size.bits(),
+            mem_pos.align.bits() as u32,
             encoding)
     };
 
@@ -1923,8 +1921,6 @@ fn prepare_enum_metadata(
         } => {
             let discr_type = discr.value.to_ty(cx.tcx);
             let mem_pos = cx.mem_pos_of(discr_type);
-            let (size, align) = (mem_pos.size, mem_pos.align);
-
 
             let discr_metadata = basic_type_metadata(cx, discr_type);
             unsafe {
@@ -1934,8 +1930,8 @@ fn prepare_enum_metadata(
                     discriminator_name,
                     file_metadata,
                     UNKNOWN_LINE_NUMBER,
-                    size.bits(),
-                    align.bits() as u32,
+                    mem_pos.size.bits(),
+                    mem_pos.align.bits() as u32,
                     layout.fields.offset(discr_index).bits(),
                     DIFlags::FlagArtificial,
                     discr_metadata))
@@ -2137,7 +2133,6 @@ fn create_struct_stub(
     containing_scope: Option<&'ll DIScope>,
 ) -> &'ll DICompositeType {
     let struct_mem_pos = cx.mem_pos_of(struct_type);
-    let (struct_size, struct_align) = (struct_mem_pos.size, struct_mem_pos.align);
 
     let name = SmallCStr::new(struct_type_name);
     let unique_type_id = SmallCStr::new(
@@ -2155,8 +2150,8 @@ fn create_struct_stub(
             name.as_ptr(),
             unknown_file_metadata(cx),
             UNKNOWN_LINE_NUMBER,
-            struct_size.bits(),
-            struct_align.bits() as u32,
+            struct_mem_pos.size.bits(),
+            struct_mem_pos.align.bits() as u32,
             DIFlags::FlagZero,
             None,
             empty_array,

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -769,17 +769,17 @@ fn copy_intrinsic(
     src: &'ll Value,
     count: &'ll Value,
 ) {
-    let (size, align) = bx.size_and_align_of(ty);
-    let size = bx.mul(bx.const_usize(size.bytes()), count);
+    let mem_pos = bx.mem_pos_of(ty);
+    let size = bx.mul(bx.const_usize(mem_pos.size.bytes()), count);
     let flags = if volatile {
         MemFlags::VOLATILE
     } else {
         MemFlags::empty()
     };
     if allow_overlap {
-        bx.memmove(dst, align, src, align, size, flags);
+        bx.memmove(dst, mem_pos.align, src, mem_pos.align, size, flags);
     } else {
-        bx.memcpy(dst, align, src, align, size, flags);
+        bx.memcpy(dst, mem_pos.align, src, mem_pos.align, size, flags);
     }
 }
 
@@ -791,14 +791,14 @@ fn memset_intrinsic(
     val: &'ll Value,
     count: &'ll Value
 ) {
-    let (size, align) = bx.size_and_align_of(ty);
-    let size = bx.mul(bx.const_usize(size.bytes()), count);
+    let mem_pos = bx.mem_pos_of(ty);
+    let size = bx.mul(bx.const_usize(mem_pos.size.bytes()), count);
     let flags = if volatile {
         MemFlags::VOLATILE
     } else {
         MemFlags::empty()
     };
-    bx.memset(dst, val, size, align, flags);
+    bx.memset(dst, val, size, mem_pos.align, flags);
 }
 
 fn try_intrinsic(

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -810,7 +810,7 @@ fn try_intrinsic(
 ) {
     if bx.sess().no_landing_pads() {
         bx.call(func, &[data], None);
-        let ptr_align = bx.tcx().data_layout.pointer_align.abi;
+        let ptr_align = bx.tcx().data_layout.pointer_pos.align.abi;
         bx.store(bx.const_null(bx.type_i8p()), dest, ptr_align);
     } else if wants_msvc_seh(bx.sess()) {
         codegen_msvc_try(bx, func, data, local_ptr, dest);
@@ -984,7 +984,7 @@ fn codegen_gnu_try(
         };
         catch.add_clause(vals, tydesc);
         let ptr = catch.extract_value(vals, 0);
-        let ptr_align = bx.tcx().data_layout.pointer_align.abi;
+        let ptr_align = bx.tcx().data_layout.pointer_pos.align.abi;
         let bitcast = catch.bitcast(local_ptr, bx.type_ptr_to(bx.type_i8p()));
         catch.store(ptr, bitcast, ptr_align);
         catch.ret(bx.const_i32(1));
@@ -1262,11 +1262,11 @@ fn generic_simd_intrinsic(
         let (i_xn, in_elem_bitwidth) = match in_elem.kind {
             ty::Int(i) => (
                 args[0].immediate(),
-                i.bit_width().unwrap_or(bx.data_layout().pointer_size.bits() as _)
+                i.bit_width().unwrap_or(bx.data_layout().pointer_pos.size.bits() as _)
             ),
             ty::Uint(i) => (
                 args[0].immediate(),
-                i.bit_width().unwrap_or(bx.data_layout().pointer_size.bits() as _)
+                i.bit_width().unwrap_or(bx.data_layout().pointer_pos.size.bits() as _)
             ),
             _ => return_error!(
                 "vector argument `{}`'s element type `{}`, expected integer element type",
@@ -1876,7 +1876,7 @@ unsupported {} from `{}` with element `{}` of size `{}` to `{}`"#,
         let lhs = args[0].immediate();
         let rhs = args[1].immediate();
         let is_add = name == "simd_saturating_add";
-        let ptr_bits = bx.tcx().data_layout.pointer_size.bits() as _;
+        let ptr_bits = bx.tcx().data_layout.pointer_pos.size.bits() as _;
         let (signed, elem_width, elem_ty) = match in_elem.kind {
             ty::Int(i) =>
                 (

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -306,7 +306,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyLayout<'tcx> {
             layout::Pointer => {
                 // If we know the alignment, pick something better than i8.
                 let pointee = if let Some(pointee) = self.pointee_info_at(cx, offset) {
-                    cx.type_pointee_for_align(pointee.align)
+                    cx.type_pointee_for_align(pointee.mem_pos.align)
                 } else {
                     cx.type_i8()
                 };

--- a/src/librustc_codegen_llvm/type_of.rs
+++ b/src/librustc_codegen_llvm/type_of.rs
@@ -2,7 +2,9 @@ use crate::abi::{FnAbi};
 use crate::common::*;
 use crate::type_::Type;
 use rustc::ty::{self, Ty, TypeFoldable};
-use rustc::ty::layout::{self, Align, LayoutOf, FnAbiExt, PointeeInfo, Size, TyLayout};
+use rustc::ty::layout::{
+    self, Align, MemoryPosition, LayoutOf, FnAbiExt, PointeeInfo, Size, TyLayout
+};
 use rustc_target::abi::TyLayoutMethods;
 use rustc::ty::print::obsolete::DefPathBasedNames;
 use rustc_codegen_ssa::traits::*;
@@ -167,9 +169,8 @@ impl<'a, 'tcx> CodegenCx<'a, 'tcx> {
         self.layout_of(ty).pref_pos.size
     }
 
-    pub fn size_and_align_of(&self, ty: Ty<'tcx>) -> (Size, Align) {
-        let layout = self.layout_of(ty);
-        (layout.pref_pos.size, layout.pref_pos.align.abi)
+    pub fn mem_pos_of(&self, ty: Ty<'tcx>) -> MemoryPosition {
+        self.layout_of(ty).pref_pos.mem_pos()
     }
 }
 

--- a/src/librustc_codegen_llvm/va_arg.rs
+++ b/src/librustc_codegen_llvm/va_arg.rs
@@ -75,8 +75,8 @@ fn emit_ptr_va_arg(
          bx.cx.data_layout().pointer_pos.align)
     } else {
         (layout.llvm_type(bx.cx),
-         layout.size,
-         layout.align)
+         layout.pref_pos.size,
+         layout.pref_pos.align)
     };
     let (addr, addr_align) = emit_direct_ptr_va_arg(bx, list, llty, size, align.abi,
                                                     slot_size, allow_higher_align);

--- a/src/librustc_codegen_llvm/va_arg.rs
+++ b/src/librustc_codegen_llvm/va_arg.rs
@@ -36,7 +36,7 @@ fn emit_direct_ptr_va_arg(
         list.immediate()
     };
 
-    let ptr = bx.load(va_list_addr, bx.tcx().data_layout.pointer_align.abi);
+    let ptr = bx.load(va_list_addr, bx.tcx().data_layout.pointer_pos.align.abi);
 
     let (addr, addr_align) = if allow_higher_align && align > slot_size {
         (round_pointer_up_to_alignment(bx, ptr, align, bx.cx().type_i8p()), align)
@@ -48,7 +48,7 @@ fn emit_direct_ptr_va_arg(
     let aligned_size = size.align_to(slot_size).bytes() as i32;
     let full_direct_size = bx.cx().const_i32(aligned_size);
     let next = bx.inbounds_gep(addr, &[full_direct_size]);
-    bx.store(next, va_list_addr, bx.tcx().data_layout.pointer_align.abi);
+    bx.store(next, va_list_addr, bx.tcx().data_layout.pointer_pos.align.abi);
 
     if size.bytes() < slot_size.bytes() &&
             &*bx.tcx().sess.target.target.target_endian == "big" {
@@ -71,8 +71,8 @@ fn emit_ptr_va_arg(
     let layout = bx.cx.layout_of(target_ty);
     let (llty, size, align) = if indirect {
         (bx.cx.layout_of(bx.cx.tcx.mk_imm_ptr(target_ty)).llvm_type(bx.cx),
-         bx.cx.data_layout().pointer_size,
-         bx.cx.data_layout().pointer_align)
+         bx.cx.data_layout().pointer_pos.size,
+         bx.cx.data_layout().pointer_pos.align)
     } else {
         (layout.llvm_type(bx.cx),
          layout.size,

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -181,7 +181,7 @@ pub fn unsize_thin_ptr<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 if src_f.is_zst() {
                     continue;
                 }
-                assert_eq!(src_layout.size, src_f.size);
+                assert_eq!(src_layout.pref_pos.size, src_f.pref_pos.size);
 
                 let dst_f = dst_layout.field(bx.cx(), i);
                 assert_ne!(src_f.ty, dst_f.ty);
@@ -348,7 +348,7 @@ pub fn memcpy_ty<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     layout: TyLayout<'tcx>,
     flags: MemFlags,
 ) {
-    let size = layout.size.bytes();
+    let size = layout.pref_pos.size.bytes();
     if size == 0 {
         return;
     }

--- a/src/librustc_codegen_ssa/glue.rs
+++ b/src/librustc_codegen_ssa/glue.rs
@@ -16,8 +16,8 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     debug!("size_and_align_of_dst(ty={}, info={:?}): layout: {:?}",
            t, info, layout);
     if !layout.is_unsized() {
-        let size = bx.const_usize(layout.size.bytes());
-        let align = bx.const_usize(layout.align.abi.bytes());
+        let size = bx.const_usize(layout.pref_pos.size.bytes());
+        let align = bx.const_usize(layout.pref_pos.align.abi.bytes());
         return (size, align);
     }
     match t.kind {
@@ -30,8 +30,8 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let unit = layout.field(bx, 0);
             // The info in this case is the length of the str, so the size is that
             // times the unit size.
-            (bx.mul(info.unwrap(), bx.const_usize(unit.size.bytes())),
-             bx.const_usize(unit.align.abi.bytes()))
+            (bx.mul(info.unwrap(), bx.const_usize(unit.pref_pos.size.bytes())),
+             bx.const_usize(unit.pref_pos.align.abi.bytes()))
         }
         _ => {
             // First get the size of all statically known fields.
@@ -42,7 +42,7 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
             let i = layout.fields.count() - 1;
             let sized_size = layout.fields.offset(i).bytes();
-            let sized_align = layout.align.abi.bytes();
+            let sized_align = layout.pref_pos.align.abi.bytes();
             debug!("DST {} statically sized prefix size: {} align: {}",
                    t, sized_size, sized_align);
             let sized_size = bx.const_usize(sized_size);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -29,7 +29,7 @@ impl<'a, 'tcx> VirtualIndex {
             llvtable,
             bx.type_ptr_to(bx.fn_ptr_backend_type(fn_abi))
         );
-        let ptr_align = bx.tcx().data_layout.pointer_align.abi;
+        let ptr_align = bx.tcx().data_layout.pointer_pos.align.abi;
         let gep = bx.inbounds_gep(llvtable, &[bx.const_usize(self.0)]);
         let ptr = bx.load(gep, ptr_align);
         bx.nonnull_metadata(ptr);
@@ -47,7 +47,7 @@ impl<'a, 'tcx> VirtualIndex {
         debug!("get_int({:?}, {:?})", llvtable, self);
 
         let llvtable = bx.pointercast(llvtable, bx.type_ptr_to(bx.type_isize()));
-        let usize_align = bx.tcx().data_layout.pointer_align.abi;
+        let usize_align = bx.tcx().data_layout.pointer_pos.align.abi;
         let gep = bx.inbounds_gep(llvtable, &[bx.const_usize(self.0)]);
         let ptr = bx.load(gep, usize_align);
         // Vtable loads are invariant
@@ -114,7 +114,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     ].iter().cloned().chain(methods).collect();
 
     let vtable_const = cx.const_struct(&components, false);
-    let align = cx.data_layout().pointer_align.abi;
+    let align = cx.data_layout().pointer_pos.align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));
 
     cx.create_vtable_metadata(ty, vtable);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -109,8 +109,8 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     // /////////////////////////////////////////////////////////////////////////////////////////////
     let components: Vec<_> = [
         cx.get_fn_addr(Instance::resolve_drop_in_place(cx.tcx(), ty)),
-        cx.const_usize(layout.size.bytes()),
-        cx.const_usize(layout.align.abi.bytes())
+        cx.const_usize(layout.pref_pos.size.bytes()),
+        cx.const_usize(layout.pref_pos.align.abi.bytes())
     ].iter().cloned().chain(methods).collect();
 
     let vtable_const = cx.const_struct(&components, false);

--- a/src/librustc_codegen_ssa/mir/operand.rs
+++ b/src/librustc_codegen_ssa/mir/operand.rs
@@ -146,7 +146,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             llval: llptr,
             llextra,
             layout,
-            align: layout.align.abi,
+            align: layout.pref_pos.align.abi,
         }
     }
 
@@ -210,7 +210,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
 
             // Newtype of a scalar, scalar pair or vector.
             (OperandValue::Immediate(_), _) |
-            (OperandValue::Pair(..), _) if field.size == self.layout.size => {
+            (OperandValue::Pair(..), _) if field.pref_pos.size == self.layout.pref_pos.size => {
                 assert_eq!(offset.bytes(), 0);
                 self.val
             }
@@ -218,12 +218,12 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             // Extract a scalar component from a pair.
             (OperandValue::Pair(a_llval, b_llval), &layout::Abi::ScalarPair(ref a, ref b)) => {
                 if offset.bytes() == 0 {
-                    assert_eq!(field.size, a.value.size(bx.cx()));
+                    assert_eq!(field.pref_pos.size, a.value.size(bx.cx()));
                     OperandValue::Immediate(a_llval)
                 } else {
                     assert_eq!(offset, a.value.size(bx.cx())
                         .align_to(b.value.align(bx.cx()).abi));
-                    assert_eq!(field.size, b.value.size(bx.cx()));
+                    assert_eq!(field.pref_pos.size, b.value.size(bx.cx()));
                     OperandValue::Immediate(b_llval)
                 }
             }

--- a/src/librustc_codegen_ssa/mir/place.rs
+++ b/src/librustc_codegen_ssa/mir/place.rs
@@ -399,7 +399,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
         // as this will yield the lowest alignment.
         let layout = self.layout.field(bx, 0);
         let offset = if let Some(llindex) = bx.const_to_opt_uint(llindex) {
-            layout.pref_pos.size.checked_mul(llindex, bx).unwrap_or(layout.pref_pos.size)
+            layout.pref_pos.checked_mul(llindex, bx).unwrap_or(layout.pref_pos).size
         } else {
             layout.pref_pos.size
         };

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -91,7 +91,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 if let OperandValue::Immediate(v) = cg_elem.val {
                     let zero = bx.const_usize(0);
                     let start = dest.project_index(&mut bx, zero).llval;
-                    let size = bx.const_usize(dest.layout.size.bytes());
+                    let size = bx.const_usize(dest.layout.pref_pos.size.bytes());
 
                     // Use llvm.memset.p0i8.* to initialize all zero arrays
                     if bx.cx().const_to_opt_uint(v) == Some(0) {
@@ -472,7 +472,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             mir::Rvalue::NullaryOp(mir::NullOp::SizeOf, ty) => {
                 assert!(bx.cx().type_is_sized(ty));
-                let val = bx.cx().const_usize(bx.cx().layout_of(ty).size.bytes());
+                let val = bx.cx().const_usize(bx.cx().layout_of(ty).pref_pos.size.bytes());
                 let tcx = self.cx.tcx();
                 (bx, OperandRef {
                     val: OperandValue::Immediate(val),
@@ -483,8 +483,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::Rvalue::NullaryOp(mir::NullOp::Box, content_ty) => {
                 let content_ty = self.monomorphize(&content_ty);
                 let content_layout = bx.cx().layout_of(content_ty);
-                let llsize = bx.cx().const_usize(content_layout.size.bytes());
-                let llalign = bx.cx().const_usize(content_layout.align.abi.bytes());
+                let llsize = bx.cx().const_usize(content_layout.pref_pos.size.bytes());
+                let llalign = bx.cx().const_usize(content_layout.pref_pos.align.abi.bytes());
                 let box_layout = bx.cx().layout_of(bx.tcx().mk_box(content_ty));
                 let llty_ptr = bx.cx().backend_type(box_layout);
 

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -1077,14 +1077,14 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for VariantSizeDifferences {
             let discr_size = tag.value.size(&cx.tcx).bytes();
 
             debug!("enum `{}` is {} bytes large with layout:\n{:#?}",
-                   t, layout.size.bytes(), layout);
+                   t, layout.pref_pos.size.bytes(), layout);
 
             let (largest, slargest, largest_index) = enum_definition.variants
                 .iter()
                 .zip(variants)
                 .map(|(variant, variant_layout)| {
                     // Subtract the size of the enum discriminant.
-                    let bytes = variant_layout.size.bytes().saturating_sub(discr_size);
+                    let bytes = variant_layout.pref_pos.size.bytes().saturating_sub(discr_size);
 
                     debug!("- variant `{}` is {} bytes large",
                            variant.ident,

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -583,7 +583,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     // Helper to get a `-1` value of the appropriate type
     fn neg_1_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         let param_ty = ty::ParamEnv::empty().and(ty);
-        let bits = self.hir.tcx().layout_of(param_ty).unwrap().size.bits();
+        let bits = self.hir.tcx().layout_of(param_ty).unwrap().pref_pos.size.bits();
         let n = (!0u128) >> (128 - bits);
         let literal = ty::Const::from_bits(self.hir.tcx(), n, param_ty);
 
@@ -594,7 +594,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     fn minval_literal(&mut self, span: Span, ty: Ty<'tcx>) -> Operand<'tcx> {
         assert!(ty.is_signed());
         let param_ty = ty::ParamEnv::empty().and(ty);
-        let bits = self.hir.tcx().layout_of(param_ty).unwrap().size.bits();
+        let bits = self.hir.tcx().layout_of(param_ty).unwrap().pref_pos.size.bits();
         let n = 1 << (bits - 1);
         let literal = ty::Const::from_bits(self.hir.tcx(), n, param_ty);
 

--- a/src/librustc_mir/hair/constant.rs
+++ b/src/librustc_mir/hair/constant.rs
@@ -19,7 +19,7 @@ crate fn lit_to_const<'tcx>(
 
     let trunc = |n| {
         let param_ty = ParamEnv::reveal_all().and(ty);
-        let width = tcx.layout_of(param_ty).map_err(|_| LitToConstError::Reported)?.size;
+        let width = tcx.layout_of(param_ty).map_err(|_| LitToConstError::Reported)?.pref_pos.size;
         trace!("trunc {} with size {} and shift {}", n, width.bits(), 128 - width.bits());
         let result = truncate(n, width);
         trace!("trunc result: {}", result);

--- a/src/librustc_mir/hair/pattern/_match.rs
+++ b/src/librustc_mir/hair/pattern/_match.rs
@@ -2287,8 +2287,8 @@ fn specialize_one_pattern<'p, 'a: 'p, 'q: 'p, 'tcx>(
                 let ptr = Pointer::new(AllocId(0), offset);
                 (0..n)
                     .map(|i| {
-                        let ptr = ptr.offset(layout.size * i, &cx.tcx).ok()?;
-                        let scalar = alloc.read_scalar(&cx.tcx, ptr, layout.size).ok()?;
+                        let ptr = ptr.offset((layout.pref_pos * i).size, &cx.tcx).ok()?;
+                        let scalar = alloc.read_scalar(&cx.tcx, ptr, layout.pref_pos.size).ok()?;
                         let scalar = scalar.not_undef().ok()?;
                         let value = ty::Const::from_scalar(cx.tcx, scalar, ty);
                         let pattern =

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -140,7 +140,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         if src.layout.ty.is_unsafe_ptr() && dest_layout.ty.is_unsafe_ptr() &&
             dest_layout.pref_pos.size != src.layout.pref_pos.size
         {
-            assert_eq!(src.layout.pref_pos.size, 2*self.memory.pointer_size());
+            assert_eq!(src.layout.pref_pos.size, (2*self.memory.pointer_pos()).size);
             assert_eq!(dest_layout.pref_pos.size, self.memory.pointer_size());
             assert!(dest_layout.ty.is_unsafe_ptr());
             match *src {

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -448,8 +448,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             ty::Dynamic(..) => {
                 let vtable = metadata.expect("dyn trait fat ptr must have vtable");
                 // Read size and align from vtable (already checks size).
-                let (size, align) = self.read_size_and_align_from_vtable(vtable)?;
-                let mem_pos = MemoryPosition::new(size, align);
+                let mem_pos = self.read_mem_pos_from_vtable(vtable)?;
+
                 Ok(Some(mem_pos))
             }
 

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -70,7 +70,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
             let n = match name {
                 "pref_align_of" => layout.pref_pos.align.pref.bytes(),
                 "min_align_of" => layout.pref_pos.align.abi.bytes(),
-                "size_of" => layout.pref_pos.size.bytes(),
+                "size_of" => layout.pref_pos.stride().bytes(),
                 _ => bug!(),
             };
             ty::Const::from_usize(tcx, n)

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -693,7 +693,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 let target = format!("({})", target_id);
                 // this `as usize` is fine, since we can't print more chars than `usize::MAX`
                 write!(msg, "└{0:─^1$}┘ ", target, relocation_width as usize).unwrap();
-                pos = i + self.pointer_size();
+                pos = i + self.pointer_pos().stride();
             }
             trace!("{}", msg);
         }

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -168,7 +168,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         mem_pos: MemoryPosition,
         kind: MemoryKind<M::MemoryKinds>,
     ) -> Pointer<M::PointerTag> {
-        let alloc = Allocation::undef(mem_pos.size, mem_pos.align);
+        let alloc = Allocation::undef(mem_pos);
         self.allocate_with(alloc, kind)
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -268,10 +268,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 format!("{:?}", kind),
             ))
         }
-        if let Some(MemoryPosition {size, align}) = old_mem_pos {
-            if size != alloc.size || align != alloc.align {
-                let bytes = alloc.size;
-                throw_unsup!(IncorrectAllocationInformation(size, bytes, align, alloc.align))
+        if let Some(mem_pos) = old_mem_pos {
+            if mem_pos != MemoryPosition::new(alloc.size, alloc.align) {
+                let got_mem_pos = MemoryPosition::new(alloc.size, alloc.align);
+                throw_unsup!(IncorrectAllocationInformation(mem_pos, got_mem_pos))
             }
         }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -586,7 +586,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
                 // Use size and align of the type.
                 let ty = self.tcx.type_of(did);
                 let layout = self.tcx.layout_of(ParamEnv::empty().and(ty)).unwrap();
-                Ok((layout.size, layout.align.abi))
+                Ok((layout.pref_pos.size, layout.pref_pos.align.abi))
             },
             Some(GlobalAlloc::Memory(alloc)) =>
                 // Need to duplicate the logic here, because the global allocations have

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -54,7 +54,7 @@ impl<'tcx, Tag> Immediate<Tag> {
     ) -> Self {
         Immediate::ScalarPair(
             val.into(),
-            Scalar::from_uint(len, cx.data_layout().pointer_size).into(),
+            Scalar::from_uint(len, cx.data_layout().pointer_pos.size).into(),
         )
     }
 

--- a/src/librustc_mir/interpret/operator.rs
+++ b/src/librustc_mir/interpret/operator.rs
@@ -128,7 +128,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             let signed = left_layout.abi.is_signed();
             let mut oflo = (r as u32 as u128) != r;
             let mut r = r as u32;
-            let size = left_layout.size;
+            let size = left_layout.pref_pos.size;
             oflo |= r >= size.bits() as u32;
             if oflo {
                 r %= size.bits() as u32;
@@ -189,7 +189,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             if let Some(op) = op {
                 let l128 = self.sign_extend(l, left_layout) as i128;
                 let r = self.sign_extend(r, right_layout) as i128;
-                let size = left_layout.size;
+                let size = left_layout.pref_pos.size;
                 match bin_op {
                     Rem | Div => {
                         // int_min / -1
@@ -213,7 +213,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
         }
 
-        let size = left_layout.size;
+        let size = left_layout.pref_pos.size;
 
         let (val, ty) = match bin_op {
             Eq => (Scalar::from_bool(l == r), self.tcx.types.bool),
@@ -307,8 +307,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     left.layout.ty, bin_op, right.layout.ty
                 );
 
-                let l = self.force_bits(left.to_scalar()?, left.layout.size)?;
-                let r = self.force_bits(right.to_scalar()?, right.layout.size)?;
+                let l = self.force_bits(left.to_scalar()?, left.layout.pref_pos.size)?;
+                let r = self.force_bits(right.to_scalar()?, right.layout.pref_pos.size)?;
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
@@ -367,7 +367,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             _ => {
                 assert!(layout.ty.is_integral());
-                let val = self.force_bits(val, layout.size)?;
+                let val = self.force_bits(val, layout.pref_pos.size)?;
                 let res = match un_op {
                     Not => !val,
                     Neg => {

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -1130,10 +1130,9 @@ where
 
         // More sanity checks
         if cfg!(debug_assertions) {
-            let (size, align) = self.read_size_and_align_from_vtable(vtable)?;
-            assert_eq!(size, layout.pref_pos.size);
+            let mem_pos = self.read_mem_pos_from_vtable(vtable)?;
             // only ABI alignment is preserved
-            assert_eq!(align, layout.pref_pos.align.abi);
+            assert_eq!(mem_pos, layout.pref_pos.mem_pos());
         }
 
         let mplace = MPlaceTy {

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -508,7 +508,7 @@ where
                 let layout = self.layout_of(self.tcx.types.usize)?;
                 let n = self.access_local(self.frame(), local, Some(layout))?;
                 let n = self.read_scalar(n)?;
-                let n = self.force_bits(n.not_undef()?, self.tcx.data_layout.pointer_size)?;
+                let n = self.force_bits(n.not_undef()?, self.tcx.data_layout.pointer_pos.size)?;
                 self.mplace_field(base, u64::try_from(n).unwrap())?
             }
 

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -993,7 +993,7 @@ where
                         let mem_pos = self.mem_pos_of(meta, local_layout)?
                             .expect("Cannot allocate for non-dyn-sized type");
                         let (size, align) = (mem_pos.size, mem_pos.align);
-                        let ptr = self.memory.allocate(size, align, MemoryKind::Stack);
+                        let ptr = self.memory.allocate(mem_pos, MemoryKind::Stack);
                         let mplace = MemPlace { ptr: ptr.into(), align, meta };
                         if let Some(value) = old_val {
                             // Preserve old value.
@@ -1030,7 +1030,7 @@ where
         layout: TyLayout<'tcx>,
         kind: MemoryKind<M::MemoryKinds>,
     ) -> MPlaceTy<'tcx, M::PointerTag> {
-        let ptr = self.memory.allocate(layout.pref_pos.size, layout.pref_pos.align.abi, kind);
+        let ptr = self.memory.allocate(layout.pref_pos.mem_pos(), kind);
         MPlaceTy::from_aligned_ptr(ptr, layout)
     }
 

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -15,7 +15,7 @@ use rustc::mir::interpret::{
 };
 
 use rustc::ty::{self, TyCtxt};
-use rustc::ty::layout::{Align, Size};
+use rustc::ty::layout::MemoryPosition;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_index::vec::IndexVec;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -275,8 +275,7 @@ struct AllocationSnapshot<'a> {
     bytes: &'a [u8],
     relocations: Relocations<(), AllocIdSnapshot<'a>>,
     undef_mask: &'a UndefMask,
-    align: &'a Align,
-    size: &'a Size,
+    mem_pos: &'a MemoryPosition,
     mutability: &'a Mutability,
 }
 
@@ -287,8 +286,7 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
 
     fn snapshot(&self, ctx: &'a Ctx) -> Self::Item {
         let Allocation {
-            size,
-            align,
+            mem_pos,
             mutability,
             extra: (),
             ..
@@ -306,8 +304,7 @@ impl<'a, Ctx> Snapshot<'a, Ctx> for &'a Allocation
         AllocationSnapshot {
             bytes,
             undef_mask,
-            align,
-            size,
+            mem_pos,
             mutability,
             relocations: relocations.snapshot(ctx),
         }

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -216,7 +216,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     self.copy_op(op, first.into())?;
 
                     if length > 1 {
-                        let elem_size = first.layout.size;
+                        let elem_size = first.layout.pref_pos.size;
                         // Copy the rest. This is performance-sensitive code
                         // for big static/const arrays!
                         let rest_ptr = first_ptr.offset(elem_size, self)?;
@@ -242,7 +242,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Ref(_, _, ref place) => {
                 let src = self.eval_place(place)?;
                 let place = self.force_allocation(src)?;
-                if place.layout.size.bytes() > 0 {
+                if place.layout.pref_pos.size.bytes() > 0 {
                     // definitely not a ZST
                     assert!(place.ptr.is_ptr(), "non-ZST places should be normalized to `Pointer`");
                 }
@@ -260,7 +260,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         "SizeOf nullary MIR operator called for unsized type");
                 let size = self.pointer_size();
                 self.write_scalar(
-                    Scalar::from_uint(layout.size.bytes(), size),
+                    Scalar::from_uint(layout.pref_pos.size.bytes(), size),
                     dest,
                 )?;
             }
@@ -273,7 +273,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             Discriminant(ref place) => {
                 let op = self.eval_place_to_op(place, None)?;
                 let discr_val = self.read_discriminant(op)?.0;
-                let size = dest.layout.size;
+                let size = dest.layout.pref_pos.size;
                 self.write_scalar(Scalar::from_uint(discr_val, size), dest)?;
             }
         }

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -443,7 +443,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let vtable_slot = self.memory.check_ptr_access(
                     vtable_slot,
                     ptr_size,
-                    self.tcx.data_layout.pointer_align.abi,
+                    self.tcx.data_layout.pointer_pos.align.abi,
                 )?.expect("cannot be a ZST");
                 let fn_ptr = self.memory.get_raw(vtable_slot.alloc_id)?
                     .read_ptr_sized(self, vtable_slot)?.not_undef()?;

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -422,7 +422,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // cannot use the shim here, because that will only result in infinite recursion
             ty::InstanceDef::Virtual(_, idx) => {
                 let mut args = args.to_vec();
-                let ptr_size = self.pointer_size();
+                let ptr_pos = self.pointer_pos();
                 // We have to implement all "object safe receivers".  Currently we
                 // support built-in pointers (&, &mut, Box) as well as unsized-self.  We do
                 // not yet support custom self types.
@@ -439,11 +439,11 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 };
                 // Find and consult vtable
                 let vtable = receiver_place.vtable();
-                let vtable_slot = vtable.ptr_offset(ptr_size * (idx as u64 + 3), self)?;
+                let vtable_slot = vtable.ptr_offset((ptr_pos * (idx as u64 + 3)).size, self)?;
                 let vtable_slot = self.memory.check_ptr_access(
                     vtable_slot,
-                    ptr_size,
-                    self.tcx.data_layout.pointer_pos.align.abi,
+                    ptr_pos.size,
+                    ptr_pos.align.abi,
                 )?.expect("cannot be a ZST");
                 let fn_ptr = self.memory.get_raw(vtable_slot.alloc_id)?
                     .read_ptr_sized(self, vtable_slot)?.not_undef()?;

--- a/src/librustc_mir/interpret/terminator.rs
+++ b/src/librustc_mir/interpret/terminator.rs
@@ -422,7 +422,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             // cannot use the shim here, because that will only result in infinite recursion
             ty::InstanceDef::Virtual(_, idx) => {
                 let mut args = args.to_vec();
-                let ptr_pos = self.pointer_pos();
+                let ptr_pos = self.pointer_pos().mem_pos();
                 // We have to implement all "object safe receivers".  Currently we
                 // support built-in pointers (&, &mut, Box) as well as unsized-self.  We do
                 // not yet support custom self types.
@@ -442,8 +442,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let vtable_slot = vtable.ptr_offset((ptr_pos * (idx as u64 + 3)).size, self)?;
                 let vtable_slot = self.memory.check_ptr_access(
                     vtable_slot,
-                    ptr_pos.size,
-                    ptr_pos.align.abi,
+                    ptr_pos,
                 )?.expect("cannot be a ZST");
                 let fn_ptr = self.memory.get_raw(vtable_slot.alloc_id)?
                     .read_ptr_sized(self, vtable_slot)?.not_undef()?;

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -44,8 +44,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
 
         let layout = self.layout_of(ty)?;
         assert!(!layout.is_unsized(), "can't create a vtable for an unsized type");
-        let size = layout.size.bytes();
-        let align = layout.align.abi.bytes();
+        let size = layout.pref_pos.size.bytes();
+        let align = layout.pref_pos.align.abi.bytes();
 
         let ptr_size = self.pointer_size();
         let ptr_align = self.tcx.data_layout.pointer_pos.align.abi;

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -106,8 +106,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // we don't care about the pointee type, we just want a pointer
         let vtable = self.memory.check_ptr_access(
             vtable,
-            self.tcx.data_layout.pointer_pos.size,
-            self.tcx.data_layout.pointer_pos.align.abi,
+            self.tcx.data_layout.pointer_pos.mem_pos(),
         )?.expect("cannot be a ZST");
         let drop_fn = self.memory
             .get_raw(vtable.alloc_id)?
@@ -128,13 +127,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         &self,
         vtable: Scalar<M::PointerTag>,
     ) -> InterpResult<'tcx, (Size, Align)> {
-        let ptr_pos = self.pointer_pos();
+        let ptr_pos = self.pointer_pos().mem_pos();
         // We check for size = 3*ptr_size, that covers the drop fn (unused here),
         // the size, and the align (which we read below).
         let vtable = self.memory.check_ptr_access(
             vtable,
-            (3 * ptr_pos).size,
-            self.tcx.data_layout.pointer_pos.align.abi,
+            3 * ptr_pos,
         )?.expect("cannot be a ZST");
         let alloc = self.memory.get_raw(vtable.alloc_id)?;
         let size = alloc.read_ptr_sized(

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -1,5 +1,5 @@
 use rustc::ty::{self, Ty, Instance, TypeFoldable};
-use rustc::ty::layout::{Size, Align, LayoutOf, HasDataLayout};
+use rustc::ty::layout::{Size, MemoryPosition, Align, LayoutOf, HasDataLayout};
 use rustc::mir::interpret::{Scalar, Pointer, InterpResult, PointerArithmetic,};
 
 use super::{InterpCx, Machine, MemoryKind, FnVal};
@@ -123,10 +123,10 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok((drop_instance, ty))
     }
 
-    pub fn read_size_and_align_from_vtable(
+    pub fn read_mem_pos_from_vtable(
         &self,
         vtable: Scalar<M::PointerTag>,
-    ) -> InterpResult<'tcx, (Size, Align)> {
+    ) -> InterpResult<'tcx, MemoryPosition> {
         let ptr_pos = self.pointer_pos().mem_pos();
         // We check for size = 3*ptr_size, that covers the drop fn (unused here),
         // the size, and the align (which we read below).
@@ -150,6 +150,6 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             throw_ub_format!("invalid vtable: \
                 size is bigger than largest supported object");
         }
-        Ok((Size::from_bytes(size), Align::from_bytes(align).unwrap()))
+        Ok(MemoryPosition::new(Size::from_bytes(size), Align::from_bytes(align).unwrap()))
     }
 }

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -48,7 +48,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let align = layout.align.abi.bytes();
 
         let ptr_size = self.pointer_size();
-        let ptr_align = self.tcx.data_layout.pointer_align.abi;
+        let ptr_align = self.tcx.data_layout.pointer_pos.align.abi;
         // /////////////////////////////////////////////////////////////////////////////////////////
         // If you touch this code, be sure to also make the corresponding changes to
         // `get_vtable` in rust_codegen_llvm/meth.rs
@@ -105,8 +105,8 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         // we don't care about the pointee type, we just want a pointer
         let vtable = self.memory.check_ptr_access(
             vtable,
-            self.tcx.data_layout.pointer_size,
-            self.tcx.data_layout.pointer_align.abi,
+            self.tcx.data_layout.pointer_pos.size,
+            self.tcx.data_layout.pointer_pos.align.abi,
         )?.expect("cannot be a ZST");
         let drop_fn = self.memory
             .get_raw(vtable.alloc_id)?
@@ -133,7 +133,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let vtable = self.memory.check_ptr_access(
             vtable,
             3*pointer_size,
-            self.tcx.data_layout.pointer_align.abi,
+            self.tcx.data_layout.pointer_pos.align.abi,
         )?.expect("cannot be a ZST");
         let alloc = self.memory.get_raw(vtable.alloc_id)?;
         let size = alloc.read_ptr_sized(

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -269,8 +269,8 @@ impl<'rt, 'mir, 'tcx, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, 'tcx, M
                 try_validation!(
                     self.ecx.memory.check_ptr_access(
                         vtable,
-                        3*self.ecx.tcx.data_layout.pointer_size, // drop, size, align
-                        self.ecx.tcx.data_layout.pointer_align.abi,
+                        3*self.ecx.tcx.data_layout.pointer_pos.size, // drop, size, align
+                        self.ecx.tcx.data_layout.pointer_pos.align.abi,
                     ),
                     "dangling or unaligned vtable pointer in wide pointer or too small vtable",
                     self.path

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -276,7 +276,7 @@ impl<'rt, 'mir, 'tcx, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, 'tcx, M
                 );
                 try_validation!(self.ecx.read_drop_type_from_vtable(vtable),
                     "invalid drop fn in vtable", self.path);
-                try_validation!(self.ecx.read_size_and_align_from_vtable(vtable),
+                try_validation!(self.ecx.read_mem_pos_from_vtable(vtable),
                     "invalid size or align in vtable", self.path);
                 // FIXME: More checks for the vtable.
             }

--- a/src/librustc_mir/interpret/validity.rs
+++ b/src/librustc_mir/interpret/validity.rs
@@ -269,8 +269,7 @@ impl<'rt, 'mir, 'tcx, M: Machine<'mir, 'tcx>> ValidityVisitor<'rt, 'mir, 'tcx, M
                 try_validation!(
                     self.ecx.memory.check_ptr_access(
                         vtable,
-                        3*self.ecx.tcx.data_layout.pointer_pos.size, // drop, size, align
-                        self.ecx.tcx.data_layout.pointer_pos.align.abi,
+                        3 * self.ecx.tcx.data_layout.pointer_pos.mem_pos(), // drop, size, align
                     ),
                     "dangling or unaligned vtable pointer in wide pointer or too small vtable",
                     self.path

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -480,7 +480,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                         let prim = this.ecx.read_immediate(arg)?;
                         // Need to do overflow check here: For actual CTFE, MIR
                         // generation emits code that does this before calling the op.
-                        if prim.to_bits()? == (1 << (prim.layout.size.bits() - 1)) {
+                        if prim.to_bits()? == (1 << (prim.layout.pref_pos.size.bits() - 1)) {
                             throw_panic!(OverflowNeg)
                         }
                     }
@@ -498,8 +498,8 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                     this.ecx.read_immediate(this.ecx.eval_operand(right, None)?)
                 })?;
                 if *op == BinOp::Shr || *op == BinOp::Shl {
-                    let left_bits = place_layout.size.bits();
-                    let right_size = r.layout.size;
+                    let left_bits = place_layout.pref_pos.size.bits();
+                    let right_size = r.layout.pref_pos.size;
                     let r_bits = r.to_scalar().and_then(|r| r.to_bits(right_size));
                     if r_bits.ok().map_or(false, |b| b >= left_bits as u128) {
                         let source_scope_local_data = match self.source_scope_local_data {

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -621,7 +621,7 @@ fn type_size_of<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
 ) -> Option<u64> {
-    tcx.layout_of(param_env.and(ty)).ok().map(|layout| layout.size.bytes())
+    tcx.layout_of(param_env.and(ty)).ok().map(|layout| layout.pref_pos.size.bytes())
 }
 
 /**

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -354,7 +354,7 @@ impl Inliner<'tcx> {
         // Count up the cost of local variables and temps, if we know the size
         // use that, otherwise we use a moderately-large dummy cost.
 
-        let ptr_size = tcx.data_layout.pointer_size.bytes();
+        let ptr_size = tcx.data_layout.pointer_pos.size.bytes();
 
         for v in callee_body.vars_and_temps_iter() {
             let v = &callee_body.local_decls[v];

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -21,7 +21,7 @@ where
 
     let ty = place.ty(local_decls, tcx).ty;
     match tcx.layout_raw(param_env.and(ty)) {
-        Ok(layout) if layout.align.abi.bytes() == 1 => {
+        Ok(layout) if layout.pref_pos.align.abi.bytes() == 1 => {
             // if the alignment is 1, the type can't be further
             // disaligned.
             debug!("is_disaligned({:?}) - align = 1", place);

--- a/src/librustc_passes/layout_test.rs
+++ b/src/librustc_passes/layout_test.rs
@@ -65,13 +65,15 @@ impl VarianceTest<'tcx> {
                         sym::align => {
                             self.tcx
                                 .sess
-                                .span_err(item.span, &format!("align: {:?}", ty_layout.align));
+                                .span_err(item.span, &format!("align: {:?}",
+                                    ty_layout.pref_pos.align));
                         }
 
                         sym::size => {
                             self.tcx
                                 .sess
-                                .span_err(item.span, &format!("size: {:?}", ty_layout.size));
+                                .span_err(item.span, &format!("size: {:?}",
+                                    ty_layout.pref_pos.size));
                         }
 
                         sym::homogeneous_aggregate => {

--- a/src/librustc_target/abi/call/aarch64.rs
+++ b/src/librustc_target/abi/call/aarch64.rs
@@ -7,7 +7,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
           C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout
 {
     arg.layout.homogeneous_aggregate(cx).unit().and_then(|unit| {
-        let size = arg.layout.size;
+        let size = arg.layout.pref_pos.size;
 
         // Ensure we have at most four uniquely addressable members.
         if size > unit.size.checked_mul(4, cx).unwrap() {
@@ -43,7 +43,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>)
         ret.cast_to(uniform);
         return;
     }
-    let size = ret.layout.size;
+    let size = ret.layout.pref_pos.size;
     let bits = size.bits();
     if bits <= 128 {
         let unit = if bits <= 8 {
@@ -77,7 +77,7 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
         arg.cast_to(uniform);
         return;
     }
-    let size = arg.layout.size;
+    let size = arg.layout.pref_pos.size;
     let bits = size.bits();
     if bits <= 128 {
         let unit = if bits <= 8 {

--- a/src/librustc_target/abi/call/arm.rs
+++ b/src/librustc_target/abi/call/arm.rs
@@ -8,7 +8,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
           C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout
 {
     arg.layout.homogeneous_aggregate(cx).unit().and_then(|unit| {
-        let size = arg.layout.size;
+        let size = arg.layout.pref_pos.size;
 
         // Ensure we have at most four uniquely addressable members.
         if size > unit.size.checked_mul(4, cx).unwrap() {
@@ -48,7 +48,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>, vfp: bool)
         }
     }
 
-    let size = ret.layout.size;
+    let size = ret.layout.pref_pos.size;
     let bits = size.bits();
     if bits <= 32 {
         let unit = if bits <= 8 {
@@ -83,8 +83,8 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, vfp: bool)
         }
     }
 
-    let align = arg.layout.align.abi.bytes();
-    let total = arg.layout.size;
+    let align = arg.layout.pref_pos.align.abi.bytes();
+    let total = arg.layout.pref_pos.size;
     arg.cast_to(Uniform {
         unit: if align <= 4 { Reg::i32() } else { Reg::i64() },
         total

--- a/src/librustc_target/abi/call/hexagon.rs
+++ b/src/librustc_target/abi/call/hexagon.rs
@@ -1,7 +1,7 @@
 use crate::abi::call::{FnAbi, ArgAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
+    if ret.layout.is_aggregate() && ret.layout.pref_pos.size.bits() > 64 {
         ret.make_indirect();
     } else {
         ret.extend_integer_width_to(32);
@@ -9,7 +9,7 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
+    if arg.layout.is_aggregate() && arg.layout.pref_pos.size.bits() > 64 {
         arg.make_indirect();
     } else {
         arg.extend_integer_width_to(32);

--- a/src/librustc_target/abi/call/mips.rs
+++ b/src/librustc_target/abi/call/mips.rs
@@ -16,8 +16,8 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let dl = cx.data_layout();
-    let size = arg.layout.size;
-    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align).abi;
+    let size = arg.layout.pref_pos.size;
+    let align = arg.layout.pref_pos.align.max(dl.i32_align).min(dl.i64_align).abi;
 
     if arg.layout.is_aggregate() {
         arg.cast_to(Uniform {

--- a/src/librustc_target/abi/call/mips.rs
+++ b/src/librustc_target/abi/call/mips.rs
@@ -8,7 +8,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'_, Ty>, offset: &mut Size)
         ret.extend_integer_width_to(32);
     } else {
         ret.make_indirect();
-        *offset += cx.data_layout().pointer_size;
+        *offset += cx.data_layout().pointer_pos.size;
     }
 }
 

--- a/src/librustc_target/abi/call/mips64.rs
+++ b/src/librustc_target/abi/call/mips64.rs
@@ -40,7 +40,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>)
         return;
     }
 
-    let size = ret.layout.size;
+    let size = ret.layout.pref_pos.size;
     let bits = size.bits();
     if bits <= 128 {
         // Unlike other architectures which return aggregates in registers, MIPS n64 limits the
@@ -83,7 +83,7 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
     }
 
     let dl = cx.data_layout();
-    let size = arg.layout.size;
+    let size = arg.layout.pref_pos.size;
     let mut prefix = [None; 8];
     let mut prefix_index = 0;
 

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -291,7 +291,7 @@ impl<'a, Ty> TyLayout<'a, Ty> {
                 };
                 HomogeneousAggregate::Homogeneous(Reg {
                     kind,
-                    size: self.size
+                    size: self.pref_pos.size
                 })
             }
 
@@ -299,7 +299,7 @@ impl<'a, Ty> TyLayout<'a, Ty> {
                 assert!(!self.is_zst());
                 HomogeneousAggregate::Homogeneous(Reg {
                     kind: RegKind::Vector,
-                    size: self.size
+                    size: self.pref_pos.size
                 })
             }
 
@@ -348,7 +348,7 @@ impl<'a, Ty> TyLayout<'a, Ty> {
                     }
 
                     // Keep track of the offset (without padding).
-                    let size = field.size;
+                    let size = field.pref_pos.size;
                     if is_union {
                         total = total.max(size);
                     } else {
@@ -357,7 +357,7 @@ impl<'a, Ty> TyLayout<'a, Ty> {
                 }
 
                 // There needs to be no padding.
-                if total != self.size {
+                if total != self.pref_pos.size {
                     HomogeneousAggregate::Heterogeneous
                 } else {
                     match result {
@@ -409,10 +409,10 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
         attrs.set(ArgAttribute::NoAlias)
              .set(ArgAttribute::NoCapture)
              .set(ArgAttribute::NonNull);
-        attrs.pointee_size = self.layout.size;
+        attrs.pointee_size = self.layout.pref_pos.size;
         // FIXME(eddyb) We should be doing this, but at least on
         // i686-pc-windows-msvc, it results in wrong stack offsets.
-        // attrs.pointee_align = Some(self.layout.align.abi);
+        // attrs.pointee_align = Some(self.layout.pref_pos.align.abi);
 
         let extra_attrs = if self.layout.is_unsized() {
             Some(ArgAttributes::new())

--- a/src/librustc_target/abi/call/msp430.rs
+++ b/src/librustc_target/abi/call/msp430.rs
@@ -10,7 +10,7 @@ use crate::abi::call::{ArgAbi, FnAbi};
 // places its address in the appropriate location: either in a register or on
 // the stack, according to its position in the argument list. (..)"
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 32 {
+    if ret.layout.is_aggregate() && ret.layout.pref_pos.size.bits() > 32 {
         ret.make_indirect();
     } else {
         ret.extend_integer_width_to(16);
@@ -18,7 +18,7 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 32 {
+    if arg.layout.is_aggregate() && arg.layout.pref_pos.size.bits() > 32 {
         arg.make_indirect();
     } else {
         arg.extend_integer_width_to(16);

--- a/src/librustc_target/abi/call/nvptx.rs
+++ b/src/librustc_target/abi/call/nvptx.rs
@@ -4,7 +4,7 @@
 use crate::abi::call::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 32 {
+    if ret.layout.is_aggregate() && ret.layout.pref_pos.size.bits() > 32 {
         ret.make_indirect();
     } else {
         ret.extend_integer_width_to(32);
@@ -12,7 +12,7 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 32 {
+    if arg.layout.is_aggregate() && arg.layout.pref_pos.size.bits() > 32 {
         arg.make_indirect();
     } else {
         arg.extend_integer_width_to(32);

--- a/src/librustc_target/abi/call/nvptx64.rs
+++ b/src/librustc_target/abi/call/nvptx64.rs
@@ -4,7 +4,7 @@
 use crate::abi::call::{ArgAbi, FnAbi};
 
 fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
-    if ret.layout.is_aggregate() && ret.layout.size.bits() > 64 {
+    if ret.layout.is_aggregate() && ret.layout.pref_pos.size.bits() > 64 {
         ret.make_indirect();
     } else {
         ret.extend_integer_width_to(64);
@@ -12,7 +12,7 @@ fn classify_ret<Ty>(ret: &mut ArgAbi<'_, Ty>) {
 }
 
 fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
-    if arg.layout.is_aggregate() && arg.layout.size.bits() > 64 {
+    if arg.layout.is_aggregate() && arg.layout.pref_pos.size.bits() > 64 {
         arg.make_indirect();
     } else {
         arg.extend_integer_width_to(64);

--- a/src/librustc_target/abi/call/riscv.rs
+++ b/src/librustc_target/abi/call/riscv.rs
@@ -9,7 +9,7 @@ fn classify_ret<Ty>(arg: &mut ArgAbi<'_, Ty>, xlen: u64) {
     // "Aggregates larger than 2✕XLEN bits are passed by reference and are
     // replaced in the argument list with the address, as are C++ aggregates
     // with nontrivial copy constructors, destructors, or vtables."
-    if arg.layout.size.bits() > 2 * xlen {
+    if arg.layout.pref_pos.size.bits() > 2 * xlen {
         arg.make_indirect();
     }
 
@@ -25,7 +25,7 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>, xlen: u64) {
     // "Aggregates larger than 2✕XLEN bits are passed by reference and are
     // replaced in the argument list with the address, as are C++ aggregates
     // with nontrivial copy constructors, destructors, or vtables."
-    if arg.layout.size.bits() > 2 * xlen {
+    if arg.layout.pref_pos.size.bits() > 2 * xlen {
         arg.make_indirect();
     }
 

--- a/src/librustc_target/abi/call/s390x.rs
+++ b/src/librustc_target/abi/call/s390x.rs
@@ -7,7 +7,7 @@ use crate::abi::{self, HasDataLayout, LayoutOf, TyLayout, TyLayoutMethods};
 fn classify_ret<'a, Ty, C>(ret: &mut ArgAbi<'_, Ty>)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
-    if !ret.layout.is_aggregate() && ret.layout.size.bits() <= 64 {
+    if !ret.layout.is_aggregate() && ret.layout.pref_pos.size.bits() <= 64 {
         ret.extend_integer_width_to(64);
     } else {
         ret.make_indirect();
@@ -35,19 +35,19 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
     where Ty: TyLayoutMethods<'a, C> + Copy,
           C: LayoutOf<Ty = Ty, TyLayout = TyLayout<'a, Ty>> + HasDataLayout
 {
-    if !arg.layout.is_aggregate() && arg.layout.size.bits() <= 64 {
+    if !arg.layout.is_aggregate() && arg.layout.pref_pos.size.bits() <= 64 {
         arg.extend_integer_width_to(64);
         return;
     }
 
     if is_single_fp_element(cx, arg.layout) {
-        match arg.layout.size.bytes() {
+        match arg.layout.pref_pos.size.bytes() {
             4 => arg.cast_to(Reg::f32()),
             8 => arg.cast_to(Reg::f64()),
             _ => arg.make_indirect()
         }
     } else {
-        match arg.layout.size.bytes() {
+        match arg.layout.pref_pos.size.bytes() {
             1 => arg.cast_to(Reg::i8()),
             2 => arg.cast_to(Reg::i16()),
             4 => arg.cast_to(Reg::i32()),

--- a/src/librustc_target/abi/call/sparc.rs
+++ b/src/librustc_target/abi/call/sparc.rs
@@ -16,8 +16,8 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'_, Ty>, offset: &mut Size)
     where Ty: TyLayoutMethods<'a, C>, C: LayoutOf<Ty = Ty> + HasDataLayout
 {
     let dl = cx.data_layout();
-    let size = arg.layout.size;
-    let align = arg.layout.align.max(dl.i32_align).min(dl.i64_align).abi;
+    let size = arg.layout.pref_pos.size;
+    let align = arg.layout.pref_pos.align.max(dl.i32_align).min(dl.i64_align).abi;
 
     if arg.layout.is_aggregate() {
         arg.cast_to(Uniform {

--- a/src/librustc_target/abi/call/sparc.rs
+++ b/src/librustc_target/abi/call/sparc.rs
@@ -8,7 +8,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'_, Ty>, offset: &mut Size)
         ret.extend_integer_width_to(32);
     } else {
         ret.make_indirect();
-        *offset += cx.data_layout().pointer_size;
+        *offset += cx.data_layout().pointer_pos.size;
     }
 }
 

--- a/src/librustc_target/abi/call/sparc64.rs
+++ b/src/librustc_target/abi/call/sparc64.rs
@@ -10,20 +10,20 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
 {
     arg.layout.homogeneous_aggregate(cx).unit().and_then(|unit| {
         // Ensure we have at most eight uniquely addressable members.
-        if arg.layout.size > unit.size.checked_mul(8, cx).unwrap() {
+        if arg.layout.pref_pos.size > unit.size.checked_mul(8, cx).unwrap() {
             return None;
         }
 
         let valid_unit = match unit.kind {
             RegKind::Integer => false,
             RegKind::Float => true,
-            RegKind::Vector => arg.layout.size.bits() == 128
+            RegKind::Vector => arg.layout.pref_pos.size.bits() == 128
         };
 
         if valid_unit {
             Some(Uniform {
                 unit,
-                total: arg.layout.size
+                total: arg.layout.pref_pos.size
             })
         } else {
             None
@@ -44,7 +44,7 @@ fn classify_ret<'a, Ty, C>(cx: &C, ret: &mut ArgAbi<'a, Ty>)
         ret.cast_to(uniform);
         return;
     }
-    let size = ret.layout.size;
+    let size = ret.layout.pref_pos.size;
     let bits = size.bits();
     if bits <= 256 {
         let unit = Reg::i64();
@@ -73,7 +73,7 @@ fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
         return;
     }
 
-    let total = arg.layout.size;
+    let total = arg.layout.pref_pos.size;
     if total.bits() > 128 {
         arg.make_indirect();
         return;

--- a/src/librustc_target/abi/call/wasm32.rs
+++ b/src/librustc_target/abi/call/wasm32.rs
@@ -7,7 +7,7 @@ fn unwrap_trivial_aggregate<'a, Ty, C>(cx: &C, val: &mut ArgAbi<'a, Ty>) -> bool
 {
     if val.layout.is_aggregate() {
         if let Some(unit) = val.layout.homogeneous_aggregate(cx).unit() {
-            let size = val.layout.size;
+            let size = val.layout.pref_pos.size;
             if unit.size == size {
                 val.cast_to(Uniform {
                     unit,

--- a/src/librustc_target/abi/call/x86.rs
+++ b/src/librustc_target/abi/call/x86.rs
@@ -43,13 +43,13 @@ pub fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>, flavor: F
                 // According to Clang, everyone but MSVC returns single-element
                 // float aggregates directly in a floating-point register.
                 if !t.options.is_like_msvc && is_single_fp_element(cx, fn_abi.ret.layout) {
-                    match fn_abi.ret.layout.size.bytes() {
+                    match fn_abi.ret.layout.pref_pos.size.bytes() {
                         4 => fn_abi.ret.cast_to(Reg::f32()),
                         8 => fn_abi.ret.cast_to(Reg::f64()),
                         _ => fn_abi.ret.make_indirect()
                     }
                 } else {
-                    match fn_abi.ret.layout.size.bytes() {
+                    match fn_abi.ret.layout.pref_pos.size.bytes() {
                         1 => fn_abi.ret.cast_to(Reg::i8()),
                         2 => fn_abi.ret.cast_to(Reg::i16()),
                         4 => fn_abi.ret.cast_to(Reg::i32()),
@@ -100,12 +100,12 @@ pub fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>, flavor: F
 
             // At this point we know this must be a primitive of sorts.
             let unit = arg.layout.homogeneous_aggregate(cx).unit().unwrap();
-            assert_eq!(unit.size, arg.layout.size);
+            assert_eq!(unit.size, arg.layout.pref_pos.size);
             if unit.kind == RegKind::Float {
                 continue;
             }
 
-            let size_in_regs = (arg.layout.size.bits() + 31) / 32;
+            let size_in_regs = (arg.layout.pref_pos.size.bits() + 31) / 32;
 
             if size_in_regs == 0 {
                 continue;
@@ -117,7 +117,7 @@ pub fn compute_abi_info<'a, Ty, C>(cx: &C, fn_abi: &mut FnAbi<'a, Ty>, flavor: F
 
             free_regs -= size_in_regs;
 
-            if arg.layout.size.bits() <= 32 && unit.kind == RegKind::Integer {
+            if arg.layout.pref_pos.size.bits() <= 32 && unit.kind == RegKind::Integer {
                 attrs.set(ArgAttribute::InReg);
             }
 

--- a/src/librustc_target/abi/call/x86_win64.rs
+++ b/src/librustc_target/abi/call/x86_win64.rs
@@ -9,7 +9,7 @@ pub fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
             Abi::Uninhabited => {}
             Abi::ScalarPair(..) |
             Abi::Aggregate { .. } => {
-                match a.layout.size.bits() {
+                match a.layout.pref_pos.size.bits() {
                     8 => a.cast_to(Reg::i8()),
                     16 => a.cast_to(Reg::i16()),
                     32 => a.cast_to(Reg::i32()),
@@ -22,7 +22,7 @@ pub fn compute_abi_info<Ty>(fn_abi: &mut FnAbi<'_, Ty>) {
                 // (probably what clang calls "illegal vectors").
             }
             Abi::Scalar(_) => {
-                if a.layout.size.bytes() > 8 {
+                if a.layout.pref_pos.size.bytes() > 8 {
                     a.make_indirect();
                 } else {
                     a.extend_integer_width_to(32);

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -1282,8 +1282,7 @@ pub enum PointerKind {
 
 #[derive(Copy, Clone)]
 pub struct PointeeInfo {
-    pub size: Size,
-    pub align: Align,
+    pub mem_pos: MemoryPosition,
     pub safe: Option<PointerKind>,
 }
 

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -601,6 +601,8 @@ impl AddAssign for LayoutPositionPref {
 /// An aligned size.
 /// Better name appreciated.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, RustcEncodable, RustcDecodable)]
+// I am opposed to adding these, therefore they are in a separate section, and this note.
+#[derive(PartialOrd, Ord)]
 pub struct MemoryPosition {
     /// A size not rounded up to alignment
     pub size: Size,

--- a/src/librustc_target/abi/mod.rs
+++ b/src/librustc_target/abi/mod.rs
@@ -1063,8 +1063,7 @@ pub struct LayoutDetails {
     /// (i.e. outside of its `valid_range`), if it exists.
     pub largest_niche: Option<Niche>,
 
-    pub align: AbiAndPrefAlign,
-    pub size: Size
+    pub pref_pos: LayoutPositionPref
 }
 
 impl LayoutDetails {
@@ -1072,13 +1071,13 @@ impl LayoutDetails {
         let largest_niche = Niche::from_scalar(cx, Size::ZERO, scalar.clone());
         let size = scalar.value.size(cx);
         let align = scalar.value.align(cx);
+        let pref_pos = LayoutPositionPref::new(size, align);
         LayoutDetails {
             variants: Variants::Single { index: VariantIdx::new(0) },
             fields: FieldPlacement::Union(0),
             abi: Abi::Scalar(scalar),
             largest_niche,
-            size,
-            align,
+            pref_pos,
         }
     }
 }
@@ -1176,8 +1175,8 @@ impl<'a, Ty> TyLayout<'a, Ty> {
             Abi::Scalar(_) |
             Abi::ScalarPair(..) |
             Abi::Vector { .. } => false,
-            Abi::Uninhabited => self.size.bytes() == 0,
-            Abi::Aggregate { sized } => sized && self.size.bytes() == 0
+            Abi::Uninhabited => self.pref_pos.size.bytes() == 0,
+            Abi::Aggregate { sized } => sized && self.pref_pos.size.bytes() == 0
         }
     }
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2252,7 +2252,7 @@ fn check_transparent(tcx: TyCtxt<'_>, sp: Span, def_id: DefId) {
         // We are currently checking the type this field came from, so it must be local
         let span = tcx.hir().span_if_local(field.did).unwrap();
         let zst = layout.map(|layout| layout.is_zst()).unwrap_or(false);
-        let align1 = layout.map(|layout| layout.align.abi.bytes() == 1).unwrap_or(false);
+        let align1 = layout.map(|layout| layout.pref_pos.align.abi.bytes() == 1).unwrap_or(false);
         (span, zst, align1)
     });
 

--- a/src/librustc_typeck/coherence/builtin.rs
+++ b/src/librustc_typeck/coherence/builtin.rs
@@ -225,7 +225,7 @@ fn visit_implementation_of_dispatch_from_dyn(tcx: TyCtxt<'_>, impl_did: DefId) {
                         let ty_b = field.ty(tcx, substs_b);
 
                         if let Ok(layout) = tcx.layout_of(param_env.and(ty_a)) {
-                            if layout.is_zst() && layout.details.align.abi.bytes() == 1 {
+                            if layout.is_zst() && layout.details.pref_pos.align.abi.bytes() == 1 {
                                 // ignore ZST fields with alignment of 1 byte
                                 return None;
                             }


### PR DESCRIPTION
This PR adds 2 types `LayoutPositionPref` and `MemoryPosition` which are like `::alloc::Layout` but use `layout::Size` and `layout::{AbiAndPrefAlign, Align}`, and replaces most pairs of `Size` and `*Align` with one of them.

Most of the commits are semi-minimal changes after changing a single (group of) APIs, which is why there are so many of them. If desired they could be squashed.

Edit: also, each commit (in order) satisfies at least “./x.py check -i”.

Overall, other than API breakage, this is almost a pure refactoring, the only difference should be that I changed many places to be more correct for non-stride (`.size != .size.aligned_to(.align)`) sizes, which IIRC Rust currently does not allow anyway.