### PR TITLE
lldb: avoid mixing "Hit breakpoint" message with other output.

### DIFF
--- a/src/etc/lldb_batchmode.py
+++ b/src/etc/lldb_batchmode.py
@@ -45,7 +45,10 @@ def normalize_whitespace(s):
 
 def breakpoint_callback(frame, bp_loc, dict):
     """This callback is registered with every breakpoint and makes sure that the
-    frame containing the breakpoint location is selected"""
+    frame containing the breakpoint location is selected """
+
+    # HACK(eddyb) print a newline to avoid continuing an unfinished line.
+    print("")
     print("Hit breakpoint " + str(bp_loc))
 
     # Select the frame and the thread containing it


### PR DESCRIPTION
This is to get `src/test/debuginfo/lexical-scopes-in-block-expression.rs` working.
It used to work like a week ago, and the main change that happened was I switched from Python 2 to Python 3 (I don't remember why, but I did get rid of the build dir entirely, and it fixed something else).

The error was:
```
error: line not found in debugger output: [...]$27 = 10
```

Relevant part of the output:
```
print val
(long) $26 = 15 
print ten
(long) $27 = 10 Hit breakpoint 15.1: where = a`lexical_scopes_in_block_expression::main::hcdd5c3caa9166e73 + 1223 at lexical-scopes-in-block-expression.rs:504:4, address = 0x00005555555556e7, resolved, hit count = 1 
Hit breakpoint 16.1: where = a`lexical_scopes_in_block_expression::main::hcdd5c3caa9166e73 + 631 at lexical-scopes-in-block-expression.rs:510:8, address = 0x0000555555555497, resolved, hit count = 1 
```

There are most `print` commands and their outputs before, and more `Hit breakpoint` messages afterwards, so I assume what happens is the `Hit breakpoint` messages should be interleaved but somehow they ended up being buffered after all of the other output.

As a stopgap measure I'm adding a newline before each `Hit breakpoint` so they don't end up on the same line as the last `print` output (which breaks our pattern-matching).

r? @michaelwoerister