### PR TITLE
Fixes soundness bug 18510 by aborting on unwind from safe extern "C" functions only

### DIFF
--- a/src/test/incremental/hashes/function_interfaces.rs
+++ b/src/test/incremental/hashes/function_interfaces.rs
@@ -94,7 +94,7 @@ pub unsafe fn make_unsafe() {}
 pub fn make_extern() {}
 
 #[cfg(not(cfail1))]
-#[rustc_clean(cfg = "cfail2", except = "Hir, HirBody, typeck_tables_of, fn_sig")]
+#[rustc_clean(cfg = "cfail2", except = "Hir, HirBody, mir_built, typeck_tables_of, fn_sig")]
 #[rustc_clean(cfg = "cfail3")]
 pub extern "C" fn make_extern() {}
 

--- a/src/test/incremental/hashes/inherent_impls.rs
+++ b/src/test/incremental/hashes/inherent_impls.rs
@@ -269,7 +269,7 @@ impl Foo {
 #[rustc_clean(cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
 impl Foo {
-    #[rustc_clean(cfg="cfail2", except="Hir,HirBody,fn_sig,typeck_tables_of")]
+    #[rustc_clean(cfg="cfail2", except="Hir,HirBody,mir_built,fn_sig,typeck_tables_of")]
     #[rustc_clean(cfg="cfail3")]
     pub extern fn make_method_extern(&self) { }
 }

--- a/src/test/ui/abi/abort-on-c-abi.rs
+++ b/src/test/ui/abi/abort-on-c-abi.rs
@@ -14,14 +14,19 @@ use std::io::prelude::*;
 use std::io;
 use std::process::{Command, Stdio};
 
-#[unwind(aborts)] // FIXME(#58794)
+unsafe extern "C" fn unsafe_panic_in_ffi() {
+    panic!("Test");
+}
+
 extern "C" fn panic_in_ffi() {
     panic!("Test");
 }
 
 fn test() {
-    let _ = panic::catch_unwind(|| { panic_in_ffi(); });
-    // The process should have aborted by now.
+    // A safe extern "C" function that panics should abort the process:
+    let _ = panic::catch_unwind(|| panic_in_ffi() );
+
+    // If the process did not abort, the panic escaped FFI:
     io::stdout().write(b"This should never be printed.\n");
     let _ = io::stdout().flush();
 }
@@ -37,4 +42,7 @@ fn main() {
                         .stdin(Stdio::piped())
                         .arg("test").spawn().unwrap();
     assert!(!p.wait().unwrap().success());
+
+    // An unsafe extern "C" function that panics should let the panic escape:
+    assert!(panic::catch_unwind(|| unsafe { unsafe_panic_in_ffi() }).is_err());
 }

--- a/src/test/ui/abi/abort-on-c-abi.rs
+++ b/src/test/ui/abi/abort-on-c-abi.rs
@@ -22,6 +22,26 @@ extern "C" fn panic_in_ffi() {
     panic!("Test");
 }
 
+#[unwind(allowed)]
+unsafe extern "C" fn unsafe_panic_allow_in_ffi() {
+    panic!("Test");
+}
+
+#[unwind(aborts)]
+unsafe extern "C" fn unsafe_abort_in_ffi() {
+    panic!("Test");
+}
+
+#[unwind(allowed)]
+extern "C" fn nopanic_in_ffi() {
+    panic!("Test");
+}
+
+#[unwind(aborts)]
+extern "C" fn abort_in_ffi() {
+    panic!("Test");
+}
+
 fn test() {
     // A safe extern "C" function that panics should abort the process:
     let _ = panic::catch_unwind(|| panic_in_ffi() );
@@ -31,10 +51,36 @@ fn test() {
     let _ = io::stdout().flush();
 }
 
+fn test2() {
+    // A safe extern "C" function that panics should abort the process:
+    let _ = panic::catch_unwind(|| abort_in_ffi() );
+
+    // If the process did not abort, the panic escaped FFI:
+    io::stdout().write(b"This should never be printed.\n");
+    let _ = io::stdout().flush();
+}
+
+fn test3() {
+    // An unsafe #[unwind(abort)] extern "C" function that panics should abort the process:
+    let _ = panic::catch_unwind(|| unsafe { unsafe_abort_in_ffi() });
+
+    // If the process did not abort, the panic escaped FFI:
+    io::stdout().write(b"This should never be printed.\n");
+    let _ = io::stdout().flush();
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() > 1 && args[1] == "test" {
-        return test();
+    if args.len() > 1 {
+        if args[1] == "test" {
+            return test();
+        }
+        if args[1] == "test2" {
+            return test2();
+        }
+        if args[1] == "test3" {
+            return test3();
+        }
     }
 
     let mut p = Command::new(&args[0])
@@ -43,6 +89,22 @@ fn main() {
                         .arg("test").spawn().unwrap();
     assert!(!p.wait().unwrap().success());
 
+    let mut p = Command::new(&args[0])
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped())
+        .arg("test2").spawn().unwrap();
+    assert!(!p.wait().unwrap().success());
+
+    let mut p = Command::new(&args[0])
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped())
+        .arg("test3").spawn().unwrap();
+    assert!(!p.wait().unwrap().success());
+
     // An unsafe extern "C" function that panics should let the panic escape:
     assert!(panic::catch_unwind(|| unsafe { unsafe_panic_in_ffi() }).is_err());
+    assert!(panic::catch_unwind(|| unsafe { unsafe_panic_allow_in_ffi() }).is_err());
+
+    // A safe extern "C" unwind(allows) that panics should let the panic escape:
+    assert!(panic::catch_unwind(|| nopanic_in_ffi()).is_err());
 }


### PR DESCRIPTION
This fixes the soundness bug #18510 from November 2014 which allows safe Rust code to invoke undefined behavior:

```rust
extern "C" fn foo() { panic!() }
fn main() { foo() } // UB: a panic escapes an extern "C" function
```

by implementing the behavior defined in the reference for all `extern "C"` functions, which is to abort when a panic! tries to unwind out of them, for safe extern "C" functions only.

That is, unlike previous attempts at fixing this soundness hole, this PR does not make `unsafe extern "C"` functions abort, since that is not required for soundness, and has been shown to break a lot of code (see #52652 top comment for a brief history of the breakage).

That is, after this PR, it is still possible to invoke undefined behavior by unwinding out of an `unsafe extern "C"` function like here:

```rust
unsafe extern "C" fn foo() { panic!() }
fn main() { unsafe { foo() } } // UB: a panic escapes an unsafe extern "C" function
```

but doing so requires unsafe code, and is an implementation-bug, but not a soundness bug.

There is a PR open (#63909) that removes the `nounwind` attribute from `unsafe extern "C"` functions to try to prevent them from being optimized if they exhibit undefined behavior. 

Note: this PR only closes #18510, which has been closed and and then re-opened as #52652. It was pointed out, that a lot of people do not interpret #52652 to be about a soundness bug, even though the top comment points to 18510, and the first couple of comments in the issue clarify that. It was also pointed out that people would prefer to re-purpose #52652 for discussing future language features instead.