### PR TITLE
Update version of `rustc-std-workspace-*` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3046,21 +3046,21 @@ checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc-std-workspace-alloc"
-version = "1.0.0"
+version = "1.99.0"
 dependencies = [
  "alloc",
 ]
 
 [[package]]
 name = "rustc-std-workspace-core"
-version = "1.0.0"
+version = "1.99.0"
 dependencies = [
  "core",
 ]
 
 [[package]]
 name = "rustc-std-workspace-std"
-version = "1.0.0"
+version = "1.99.0"
 dependencies = [
  "std",
 ]

--- a/src/tools/rustc-std-workspace-alloc/Cargo.toml
+++ b/src/tools/rustc-std-workspace-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-std-workspace-alloc"
-version = "1.0.0"
+version = "1.99.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """

--- a/src/tools/rustc-std-workspace-core/Cargo.toml
+++ b/src/tools/rustc-std-workspace-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-std-workspace-core"
-version = "1.0.0"
+version = "1.99.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """

--- a/src/tools/rustc-std-workspace-std/Cargo.toml
+++ b/src/tools/rustc-std-workspace-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-std-workspace-std"
-version = "1.0.0"
+version = "1.99.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = 'MIT OR Apache-2.0'
 description = """


### PR DESCRIPTION
This commit updates the version of the `rustc-std-workspace-*` crates
in-tree which are used in `[patch]`. This will guarantee that Cargo will
select these versions even if minor updates are published to crates.io
because otherwise a newer version on crates.io would be preferred which
misses the point of `[patch]`!