### PR TITLE
Expand upper bounds on RangeBounds impls

### DIFF
--- a/src/liballoc/collections/btree/map.rs
+++ b/src/liballoc/collections/btree/map.rs
@@ -845,7 +845,7 @@ impl<K: Ord, V> BTreeMap<K, V> {
     ///     .iter()
     ///     .map(|&s| (s, 0))
     ///     .collect();
-    /// for (_, balance) in map.range_mut("B".."Cheryl") {
+    /// for (_, balance) in map.range_mut::<str, _>("B".."Cheryl") {
     ///     *balance += 100;
     /// }
     /// for (name, balance) in &map {

--- a/src/libcore/ops/range.rs
+++ b/src/libcore/ops/range.rs
@@ -884,7 +884,7 @@ impl<'a, T: ?Sized + 'a> RangeBounds<T> for (Bound<&'a T>, Bound<&'a T>) {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeFrom<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeFrom<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }
@@ -894,7 +894,7 @@ impl<T> RangeBounds<T> for RangeFrom<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for RangeTo<&T> {
+impl<T: ?Sized> RangeBounds<T> for RangeTo<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Unbounded
     }
@@ -904,7 +904,7 @@ impl<T> RangeBounds<T> for RangeTo<&T> {
 }
 
 #[stable(feature = "collections_range", since = "1.28.0")]
-impl<T> RangeBounds<T> for Range<&T> {
+impl<T: ?Sized> RangeBounds<T> for Range<&T> {
     fn start_bound(&self) -> Bound<&T> {
         Included(self.start)
     }


### PR DESCRIPTION
Per issue #64027 adds `?Sized` to all `RangeBounds<&T>` impls. 