### PR TITLE
rustc_mir: buffer -Zdump-mir output instead of pestering the kernel constantly.

### DIFF
--- a/src/librustc_mir/util/pretty.rs
+++ b/src/librustc_mir/util/pretty.rs
@@ -227,12 +227,12 @@ pub(crate) fn create_dump_file(
     pass_name: &str,
     disambiguator: &dyn Display,
     source: MirSource<'tcx>,
-) -> io::Result<fs::File> {
+) -> io::Result<io::BufWriter<fs::File>> {
     let file_path = dump_path(tcx, extension, pass_num, pass_name, disambiguator, source);
     if let Some(parent) = file_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::File::create(&file_path)
+    Ok(io::BufWriter::new(fs::File::create(&file_path)?))
 }
 
 /// Write out a human-readable textual representation for the given MIR.


### PR DESCRIPTION
This brings `mir-opt` tests from `197s` (over 3 minutes!) to `2.85s`, on my build server.
That's a nice speedup of about `69x` and so it definitely fixes #58485, for me.

It's such a beginner mistake I feel like maybe `clippy` should lint against it?
(cc @Manishearth @oli-obk)