### PR TITLE
Make lower-level versions of some `Span` methods.

### DIFF
--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -256,35 +256,16 @@ pub struct MultiSpan {
 
 impl Span {
     #[inline]
-    pub fn lo(self) -> BytePos {
-        self.data().lo
-    }
-    #[inline]
     pub fn with_lo(self, lo: BytePos) -> Span {
         self.data().with_lo(lo)
-    }
-    #[inline]
-    pub fn hi(self) -> BytePos {
-        self.data().hi
     }
     #[inline]
     pub fn with_hi(self, hi: BytePos) -> Span {
         self.data().with_hi(hi)
     }
     #[inline]
-    pub fn ctxt(self) -> SyntaxContext {
-        self.data().ctxt
-    }
-    #[inline]
     pub fn with_ctxt(self, ctxt: SyntaxContext) -> Span {
         self.data().with_ctxt(ctxt)
-    }
-
-    /// Returns `true` if this is a dummy span with any hygienic context.
-    #[inline]
-    pub fn is_dummy(self) -> bool {
-        let span = self.data();
-        span.lo.0 == 0 && span.hi.0 == 0
     }
 
     /// Returns `true` if this span comes from a macro or desugaring.

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -27,12 +27,12 @@ use rustc_data_structures::fx::FxHashMap;
 /// Inline (compressed) format:
 /// - `span.base_or_index == span_data.lo`
 /// - `span.len_or_tag == len == span_data.hi - span_data.lo` (must be `<= MAX_LEN`)
-/// - `span.ctxt == span_data.ctxt` (must be `<= MAX_CTXT`)
+/// - `span.ctxt_or_zero == span_data.ctxt` (may be 0, must be `<= MAX_CTXT`)
 ///
 /// Interned format:
 /// - `span.base_or_index == index` (indexes into the interner table)
 /// - `span.len_or_tag == LEN_TAG` (high bit set, all other bits are zero)
-/// - `span.ctxt == 0`
+/// - `span.ctxt_or_zero == 0`
 ///
 /// The inline form uses 0 for the tag value (rather than 1) so that we don't
 /// need to mask out the tag bit when getting the length, and so that the

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -113,6 +113,44 @@ impl Span {
             with_span_interner(|interner| *interner.get(self.base_or_index))
         }
     }
+
+    #[inline]
+    pub fn lo(self) -> BytePos {
+        if self.is_inline() {
+            BytePos(self.base_or_index)
+        } else {
+            with_span_interner(|interner| *interner.get(self.base_or_index)).lo
+        }
+    }
+
+    #[inline]
+    pub fn hi(self) -> BytePos {
+        if self.is_inline() {
+            BytePos(self.base_or_index + self.len_or_tag as u32)
+        } else {
+            with_span_interner(|interner| *interner.get(self.base_or_index)).hi
+        }
+    }
+
+    #[inline]
+    pub fn ctxt(self) -> SyntaxContext {
+        if self.is_inline() {
+            SyntaxContext::from_u32(self.ctxt_or_zero as u32)
+        } else {
+            with_span_interner(|interner| *interner.get(self.base_or_index)).ctxt
+        }
+    }
+
+    /// Returns `true` if this is a dummy span with any hygienic context.
+    #[inline]
+    pub fn is_dummy(self) -> bool {
+        if self.is_inline() {
+            self.base_or_index == 0 && self.len_or_tag == 0
+        } else {
+            let span = with_span_interner(|interner| *interner.get(self.base_or_index));
+            span.lo.0 == 0 && span.hi.0 == 0
+        }
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
In theory, the compiler should be able to optimize the old definitions to give the same results. But in practice it doesn't, and these versions are faster.
    
In principle, all `Span` methods that call `data()` could be converted. This commit converts some that are simple and hot.
