### PR TITLE
Fix redundant semicolon lint interaction with proc macro attributes

### DIFF
--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1657,9 +1657,18 @@ impl<'a> State<'a> {
                 }
             }
             ast::StmtKind::Semi(ref expr) => {
-                self.space_if_not_bol();
-                self.print_expr_outer_attr_style(expr, false);
-                self.s.word(";");
+                match expr.kind {
+                    // Filter out empty `Tup` exprs created for the `redundant_semicolon`
+                    // lint, as they shouldn't be visible and interact poorly
+                    // with proc macros.
+                    ast::ExprKind::Tup(ref exprs) if exprs.is_empty()
+                      && expr.attrs.is_empty() => (),
+                    _ => {
+                        self.space_if_not_bol();
+                        self.print_expr_outer_attr_style(expr, false);
+                        self.s.word(";");
+                    }
+                }
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, style, ref attrs) = **mac;

--- a/src/test/ui/lint/redundant-semicolon/auxiliary/redundant-semi-proc-macro-def.rs
+++ b/src/test/ui/lint/redundant-semicolon/auxiliary/redundant-semi-proc-macro-def.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+#![crate_type="proc-macro"]
+#![crate_name="redundant_semi_proc_macro"]
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn should_preserve_spans(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    eprintln!("{:?}", item);
+    item
+}

--- a/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.rs
+++ b/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.rs
@@ -1,0 +1,19 @@
+// aux-build:redundant-semi-proc-macro-def.rs
+
+#![deny(redundant_semicolon)]
+extern crate redundant_semi_proc_macro;
+use redundant_semi_proc_macro::should_preserve_spans;
+
+#[should_preserve_spans]
+fn span_preservation()  {
+    let tst = 123;; //~ ERROR unnecessary trailing semicolon
+    match tst {
+        // Redundant semicolons are parsed as empty tuple exprs
+        // for the lint, so ensure the lint doesn't affect
+        // empty tuple exprs explicitly in source.
+        123 => (),
+        _ => ()
+    };;; //~ ERROR unnecessary trailing semicolons
+}
+
+fn main() {}

--- a/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
+++ b/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
@@ -1,0 +1,21 @@
+TokenStream [Ident { ident: "fn", span: #0 bytes(197..199) }, Ident { ident: "span_preservation", span: #0 bytes(200..217) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(217..219) }, Group { delimiter: Brace, stream: TokenStream [Ident { ident: "let", span: #0 bytes(227..230) }, Ident { ident: "tst", span: #0 bytes(231..234) }, Punct { ch: '=', spacing: Alone, span: #0 bytes(235..236) }, Literal { lit: Lit { kind: Integer, symbol: 123, suffix: None }, span: Span { lo: BytePos(237), hi: BytePos(240), ctxt: #0 } }, Punct { ch: ';', spacing: Joint, span: #0 bytes(240..241) }, Punct { ch: ';', spacing: Alone, span: #0 bytes(241..242) }, Ident { ident: "match", span: #0 bytes(288..293) }, Ident { ident: "tst", span: #0 bytes(294..297) }, Group { delimiter: Brace, stream: TokenStream [Literal { lit: Lit { kind: Integer, symbol: 123, suffix: None }, span: Span { lo: BytePos(482), hi: BytePos(485), ctxt: #0 } }, Punct { ch: '=', spacing: Joint, span: #0 bytes(486..488) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(486..488) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(489..491) }, Punct { ch: ',', spacing: Alone, span: #0 bytes(491..492) }, Ident { ident: "_", span: #0 bytes(501..502) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(503..505) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(503..505) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(506..508) }], span: #0 bytes(298..514) }, Punct { ch: ';', spacing: Joint, span: #0 bytes(514..515) }, Punct { ch: ';', spacing: Joint, span: #0 bytes(515..516) }, Punct { ch: ';', spacing: Alone, span: #0 bytes(516..517) }], span: #0 bytes(221..561) }]
+error: unnecessary trailing semicolon
+  --> $DIR/redundant-semi-proc-macro.rs:9:19
+   |
+LL |     let tst = 123;;
+   |                   ^ help: remove this semicolon
+   |
+note: lint level defined here
+  --> $DIR/redundant-semi-proc-macro.rs:3:9
+   |
+LL | #![deny(redundant_semicolon)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: unnecessary trailing semicolons
+  --> $DIR/redundant-semi-proc-macro.rs:16:7
+   |
+LL |     };;;
+   |       ^^ help: remove these semicolons
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #63967 and fixes #63947, both of which were caused by the lint's changes to the parser interacting poorly with proc macro attributes and causing span information to be lost

r? @varkor 