### PR TITLE
Two `ObligationForest` micro-optimizations

### DIFF
--- a/src/librustc_data_structures/obligation_forest/mod.rs
+++ b/src/librustc_data_structures/obligation_forest/mod.rs
@@ -569,14 +569,10 @@ impl<O: ForestObligation> ObligationForest<O> {
     /// Marks all nodes that depend on a pending node as `NodeState::Waiting`.
     fn mark_as_waiting(&self) {
         for node in &self.nodes {
-            if node.state.get() == NodeState::Waiting {
-                node.state.set(NodeState::Success);
-            }
-        }
-
-        for node in &self.nodes {
-            if node.state.get() == NodeState::Pending {
-                self.mark_neighbors_as_waiting_from(node);
+            match node.state.get() {
+                NodeState::Pending => self.mark_neighbors_as_waiting_from(node),
+                NodeState::Waiting => node.state.set(NodeState::Success),
+                _ => {}
             }
         }
     }


### PR DESCRIPTION
These reduce instruction counts for a few benchmarks by up to 4%.

r? @nikomatsakis 