### PR TITLE
Remove raw string literal quotes from error index descriptions

### DIFF
--- a/src/tools/error_index_generator/build.rs
+++ b/src/tools/error_index_generator/build.rs
@@ -35,7 +35,7 @@ fn register_all() -> Vec<(&'static str, Option<&'static str>)> {
         ($($ecode:ident: $message:expr,)* ; $($code:ident,)*) => (
             $(
                 {long_codes.extend([
-                    (stringify!($ecode), Some(stringify!($message))),
+                    (stringify!($ecode), Some($message)),
                 ].iter());}
             )*
             $(


### PR DESCRIPTION
The error index has unnecessary `r##"` and `"##` around the descriptions from #63721. Removing the `stringify` call removes them.

r? @Mark-Simulacrum