### PR TITLE
Pure-Rust implementation of WASI's open_parent

### DIFF
--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -628,7 +628,7 @@ fn get_paths() -> Result<Vec<(PathBuf, WasiFd)>, wasi::Error> {
                 let mut buf = vec![0; name_len];
                 wasi::fd_prestat_dir_name(fd, &mut buf)?;
                 let buf = Buf { inner: buf };
-                let path = PathBuf::from(OsString { inner: buf );
+                let path = PathBuf::from(OsString { inner: buf });
                 paths.push((path, WasiFd::from_raw(fd)));
             },
             Ok(_) => (),

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -618,8 +618,6 @@ fn open_at(fd: &WasiFd, path: &Path, opts: &OpenOptions) -> io::Result<File> {
 
 /// Get pre-opened file descriptors and their paths.
 fn get_paths() -> Result<Box<[(PathBuf, WasiFd)]>, wasi::Error> {
-    use crate::sys::os_str::Buf;
-
     let mut paths = Vec::new();
     for fd in 3.. {
         match wasi::fd_prestat_get(fd) {

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -617,7 +617,7 @@ fn open_at(fd: &WasiFd, path: &Path, opts: &OpenOptions) -> io::Result<File> {
 }
 
 /// Get pre-opened file descriptors and their paths.
-fn get_paths() -> Result<Vec<(PathBuf, WasiFd)>, wasi::Error> {
+fn get_paths() -> Result<Box<[(PathBuf, WasiFd)]>, wasi::Error> {
     use crate::sys::os_str::Buf;
 
     let mut paths = Vec::new();
@@ -636,8 +636,7 @@ fn get_paths() -> Result<Vec<(PathBuf, WasiFd)>, wasi::Error> {
             Err(err) => return Err(err),
         }
     }
-    paths.shrink_to_fit();
-    Ok(paths)
+    Ok(paths.into_boxed_slice())
 }
 
 /// Attempts to open a bare path `p`.
@@ -673,7 +672,7 @@ fn open_parent(
 ) -> io::Result<(ManuallyDrop<WasiFd>, &Path)> {
     use crate::sync::Once;
 
-    static mut PATHS: Result<Vec<(PathBuf, WasiFd)>, wasi::Error> = unsafe {
+    static mut PATHS: Result<Box<[(PathBuf, WasiFd)]>, wasi::Error> = unsafe {
         Err(wasi::Error::new_unchecked(1))
     };
     static PATHS_INIT: Once = Once::new();

--- a/src/libstd/sys/wasi/fs.rs
+++ b/src/libstd/sys/wasi/fs.rs
@@ -627,8 +627,7 @@ fn get_paths() -> Result<Box<[(PathBuf, WasiFd)]>, wasi::Error> {
                 let name_len = u.dir.pr_name_len;
                 let mut buf = vec![0; name_len];
                 wasi::fd_prestat_dir_name(fd, &mut buf)?;
-                let buf = Buf { inner: buf };
-                let path = PathBuf::from(OsString { inner: buf });
+                let path = PathBuf::from(OsString::from_vec(buf));
                 paths.push((path, WasiFd::from_raw(fd)));
             },
             Ok(_) => (),


### PR DESCRIPTION
`__wasilibc_find_relpath` is not needed for interoperability with C/C++, so we can replace it with a pure-Rust code. I am not sure if I understood everything correctly, so I hope @sunfishcode will review this PR. For example I _think_ we can remove the `rights` argument, since error should happen later either way and there is no reason to check access rights in `open_parent`.

r? @alexcrichton 