### PR TITLE
Make any::TypeId repr(transparent)

### DIFF
--- a/src/libcore/any.rs
+++ b/src/libcore/any.rs
@@ -418,6 +418,7 @@ impl dyn Any+Send+Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {


### PR DESCRIPTION
Currently, `any::TypeId` has default-layout and uses the`Abi::Scalar` class (same as `u64`). The field of `any::TypeId` is private, so users cannot rely on this not changing. In practice, I don't see us maxing out `u64::max_value()` type-ids anytime soon.

This commit makes `any::TypeId` `repr(transparent)`. The `transparent` flag is only a guarantee if the fields of the type are public, which is not the case here. If we were to ever change the fields of `TypeId` we can just remove the annotation and fall-back to having default-layout.

In the meantime, `repr(transparent)` allows those who want to use the unspecified implementation-detail that `TypeId` is just a `u64` on FFI to do so more comfortably, without having to inspect the compiler internals `Abi` classes (they can just use an `uint64_t` on FFI), and without raising the `improper_ctypes` lint. 

Passing `any::TypeId` through FFI is useful, e.g., to communicate with a memory allocator that allows tracking the type of an allocation as an identifier. 