### PR TITLE
Enable test-compare-mode on PR builder

### DIFF
--- a/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-llvm-6.0/Dockerfile
@@ -25,7 +25,8 @@ RUN sh /scripts/sccache.sh
 ENV RUST_CONFIGURE_ARGS \
       --build=x86_64-unknown-linux-gnu \
       --llvm-root=/usr/lib/llvm-6.0 \
-      --enable-llvm-link-shared
+      --enable-llvm-link-shared \
+      --set rust.test-compare-mode
 ENV SCRIPT python2.7 ../x.py test src/tools/tidy && python2.7 ../x.py test
 
 # The purpose of this container isn't to test with debug assertions and

--- a/src/ci/docker/x86_64-gnu-nopt/Dockerfile
+++ b/src/ci/docker/x86_64-gnu-nopt/Dockerfile
@@ -19,6 +19,5 @@ COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
 ENV RUST_CONFIGURE_ARGS --build=x86_64-unknown-linux-gnu \
-  --disable-optimize-tests \
-  --set rust.test-compare-mode
+  --disable-optimize-tests
 ENV SCRIPT python2.7 ../x.py test


### PR DESCRIPTION
This moves it over from the nopt builder (taking ~3 hours) to the PR builder (taking ~2 hours).

Primarily this is done so that we can get early warning for changes to the compare-mode output before we hit bors.