### PR TITLE
Hide diagnostics emitted during --cfg parsing

### DIFF
--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-6.rs
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-6.rs
@@ -1,0 +1,3 @@
+// compile-flags: --cfg a{
+// error-pattern: invalid `--cfg` argument: `a{` (expected `key` or `key="value"`)
+fn main() {}

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-6.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-6.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `a{` (expected `key` or `key="value"`)
+


### PR DESCRIPTION
The early error is more than sufficient for fixing the problem.

Fixes https://github.com/rust-lang/rust/issues/31496.