### PR TITLE
Permit impls referencing errors to overlap

### DIFF
--- a/src/test/ui/coherence/conflicting-impl-with-err.rs
+++ b/src/test/ui/coherence/conflicting-impl-with-err.rs
@@ -1,0 +1,16 @@
+struct ErrorKind;
+struct Error(ErrorKind);
+
+impl From<nope::Thing> for Error { //~ ERROR failed to resolve
+    fn from(_: nope::Thing) -> Self { //~ ERROR failed to resolve
+        unimplemented!()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(_: ErrorKind) -> Self {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/coherence/conflicting-impl-with-err.stderr
+++ b/src/test/ui/coherence/conflicting-impl-with-err.stderr
@@ -1,0 +1,15 @@
+error[E0433]: failed to resolve: use of undeclared type or module `nope`
+  --> $DIR/conflicting-impl-with-err.rs:4:11
+   |
+LL | impl From<nope::Thing> for Error {
+   |           ^^^^ use of undeclared type or module `nope`
+
+error[E0433]: failed to resolve: use of undeclared type or module `nope`
+  --> $DIR/conflicting-impl-with-err.rs:5:16
+   |
+LL |     fn from(_: nope::Thing) -> Self {
+   |                ^^^^ use of undeclared type or module `nope`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Fixes #43400; previously this would emit an overlapping impls error, but no longer does.