### PR TITLE
A more explanatory thread local storage panic message

### DIFF
--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -236,8 +236,8 @@ impl<T: 'static> LocalKey<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn with<F, R>(&'static self, f: F) -> R
                       where F: FnOnce(&T) -> R {
-        self.try_with(f).expect("cannot access a TLS value during or \
-                                 after it is destroyed")
+        self.try_with(f).expect("cannot access a Thread Local Storage value \
+                                 during or after it is destroyed")
     }
 
     /// Acquires a reference to the value in this TLS key.

--- a/src/libstd/thread/local.rs
+++ b/src/libstd/thread/local.rs
@@ -237,7 +237,7 @@ impl<T: 'static> LocalKey<T> {
     pub fn with<F, R>(&'static self, f: F) -> R
                       where F: FnOnce(&T) -> R {
         self.try_with(f).expect("cannot access a Thread Local Storage value \
-                                 during or after it is destroyed")
+                                 during or after destruction")
     }
 
     /// Acquires a reference to the value in this TLS key.


### PR DESCRIPTION
Outside rust-std internals, TLS is usually understood as Transport Layer Security, so the existing message could be a bit puzzling when one has TLS sessions in `thread_local!`.