### PR TITLE
rename Allocation::retag -> with_tags_and_extra

### DIFF
--- a/src/librustc/mir/interpret/allocation.rs
+++ b/src/librustc/mir/interpret/allocation.rs
@@ -130,9 +130,9 @@ impl<Tag> Allocation<Tag> {
     }
 }
 
-impl Allocation<()> {
+impl Allocation<(), ()> {
     /// Add Tag and Extra fields
-    pub fn retag<T, E>(
+    pub fn with_tags_and_extra<T, E>(
         self,
         mut tagger: impl FnMut(AllocId) -> T,
         extra: E,


### PR DESCRIPTION
This is more consistent with `Pointer::with_tag`. Also, "retag" is a [term from Stacked Borrows](https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md#retagging) with a [corresponding Machine hook](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_mir/interpret/machine/trait.Machine.html#method.retag), and this function has nothing to do with that other use of the term.

r? @oli-obk 