### PR TITLE
Rename `subst::Kind` to `subst::GenericArg`

### DIFF
--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::Kind<'tcx> {
+impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArg<'tcx> {
     fn hash_stable<W: StableHasherResult>(&self,
                                           hcx: &mut StableHashingContext<'a>,
                                           hasher: &mut StableHasher<W>) {

--- a/src/librustc/infer/canonical/canonicalizer.rs
+++ b/src/librustc/infer/canonical/canonicalizer.rs
@@ -13,7 +13,7 @@ use crate::infer::InferCtxt;
 use crate::mir::interpret::ConstValue;
 use std::sync::atomic::Ordering;
 use crate::ty::fold::{TypeFoldable, TypeFolder};
-use crate::ty::subst::Kind;
+use crate::ty::subst::GenericArg;
 use crate::ty::{self, BoundVar, InferConst, List, Ty, TyCtxt, TypeFlags};
 use crate::ty::flags::FlagComputation;
 
@@ -282,7 +282,7 @@ struct Canonicalizer<'cx, 'tcx> {
     query_state: &'cx mut OriginalQueryValues<'tcx>,
     // Note that indices is only used once `var_values` is big enough to be
     // heap-allocated.
-    indices: FxHashMap<Kind<'tcx>, BoundVar>,
+    indices: FxHashMap<GenericArg<'tcx>, BoundVar>,
     canonicalize_region_mode: &'cx dyn CanonicalizeRegionMode,
     needs_canonical_flags: TypeFlags,
 
@@ -566,7 +566,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
     /// or returns an existing variable if `kind` has already been
     /// seen. `kind` is expected to be an unbound variable (or
     /// potentially a free region).
-    fn canonical_var(&mut self, info: CanonicalVarInfo, kind: Kind<'tcx>) -> BoundVar {
+    fn canonical_var(&mut self, info: CanonicalVarInfo, kind: GenericArg<'tcx>) -> BoundVar {
         let Canonicalizer {
             variables,
             query_state,

--- a/src/librustc/infer/canonical/substitute.rs
+++ b/src/librustc/infer/canonical/substitute.rs
@@ -8,7 +8,7 @@
 
 use crate::infer::canonical::{Canonical, CanonicalVarValues};
 use crate::ty::fold::TypeFoldable;
-use crate::ty::subst::UnpackedKind;
+use crate::ty::subst::GenericArgKind;
 use crate::ty::{self, TyCtxt};
 
 impl<'tcx, V> Canonical<'tcx, V> {
@@ -58,21 +58,21 @@ where
     } else {
         let fld_r = |br: ty::BoundRegion| {
             match var_values.var_values[br.assert_bound_var()].unpack() {
-                UnpackedKind::Lifetime(l) => l,
+                GenericArgKind::Lifetime(l) => l,
                 r => bug!("{:?} is a region but value is {:?}", br, r),
             }
         };
 
         let fld_t = |bound_ty: ty::BoundTy| {
             match var_values.var_values[bound_ty.var].unpack() {
-                UnpackedKind::Type(ty) => ty,
+                GenericArgKind::Type(ty) => ty,
                 r => bug!("{:?} is a type but value is {:?}", bound_ty, r),
             }
         };
 
         let fld_c = |bound_ct: ty::BoundVar, _| {
             match var_values.var_values[bound_ct].unpack() {
-                UnpackedKind::Const(ct) => ct,
+                GenericArgKind::Const(ct) => ct,
                 c => bug!("{:?} is a const but value is {:?}", bound_ct, c),
             }
         };

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -464,7 +464,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         use hir::def_id::CrateNum;
         use hir::map::DisambiguatedDefPathData;
         use ty::print::Printer;
-        use ty::subst::Kind;
+        use ty::subst::GenericArg;
 
         struct AbsolutePathPrinter<'tcx> {
             tcx: TyCtxt<'tcx>,
@@ -548,7 +548,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             fn path_generic_args(
                 self,
                 print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-                _args: &[Kind<'tcx>],
+                _args: &[GenericArg<'tcx>],
             ) -> Result<Self::Path, Self::Error> {
                 print_prefix(self)
             }

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -20,7 +20,7 @@ use crate::traits::{self, ObligationCause, PredicateObligations, TraitEngine};
 use crate::ty::error::{ExpectedFound, TypeError, UnconstrainedNumeric};
 use crate::ty::fold::{TypeFolder, TypeFoldable};
 use crate::ty::relate::RelateResult;
-use crate::ty::subst::{Kind, InternalSubsts, SubstsRef};
+use crate::ty::subst::{GenericArg, InternalSubsts, SubstsRef};
 use crate::ty::{self, GenericParamDefKind, Ty, TyCtxt, InferConst};
 use crate::ty::{FloatVid, IntVid, TyVid, ConstVid};
 use crate::util::nodemap::FxHashMap;
@@ -1110,7 +1110,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         self.next_region_var_in_universe(RegionVariableOrigin::NLL(origin), universe)
     }
 
-    pub fn var_for_def(&self, span: Span, param: &ty::GenericParamDef) -> Kind<'tcx> {
+    pub fn var_for_def(&self, span: Span, param: &ty::GenericParamDef) -> GenericArg<'tcx> {
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 // Create a region inference variable for the given

--- a/src/librustc/infer/nll_relate/mod.rs
+++ b/src/librustc/infer/nll_relate/mod.rs
@@ -26,7 +26,7 @@ use crate::traits::DomainGoal;
 use crate::ty::error::TypeError;
 use crate::ty::fold::{TypeFoldable, TypeVisitor};
 use crate::ty::relate::{self, Relate, RelateResult, TypeRelation};
-use crate::ty::subst::Kind;
+use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt, InferConst};
 use crate::mir::interpret::ConstValue;
 use rustc_data_structures::fx::FxHashMap;
@@ -124,7 +124,7 @@ pub trait TypeRelatingDelegate<'tcx> {
 #[derive(Clone, Debug)]
 struct ScopesAndKind<'tcx> {
     scopes: Vec<BoundRegionScope<'tcx>>,
-    kind: Kind<'tcx>,
+    kind: GenericArg<'tcx>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/librustc/infer/outlives/obligations.rs
+++ b/src/librustc/infer/outlives/obligations.rs
@@ -67,7 +67,7 @@ use crate::hir;
 use crate::traits::ObligationCause;
 use crate::ty::outlives::Component;
 use crate::ty::{self, Region, Ty, TyCtxt, TypeFoldable};
-use crate::ty::subst::UnpackedKind;
+use crate::ty::subst::GenericArgKind;
 
 impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
     /// Registers that the given region obligation must be resolved
@@ -433,13 +433,13 @@ where
 
             for k in projection_ty.substs {
                 match k.unpack() {
-                    UnpackedKind::Lifetime(lt) => {
+                    GenericArgKind::Lifetime(lt) => {
                         self.delegate.push_sub_region_constraint(origin.clone(), region, lt);
                     }
-                    UnpackedKind::Type(ty) => {
+                    GenericArgKind::Type(ty) => {
                         self.type_must_outlive(origin.clone(), ty, region);
                     }
-                    UnpackedKind::Const(_) => {
+                    GenericArgKind::Const(_) => {
                         // Const parameters don't impose constraints.
                     }
                 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -27,7 +27,7 @@ use crate::lint::builtin::BuiltinLintDiagnostics;
 use crate::lint::levels::{LintLevelSets, LintLevelsBuilder};
 use crate::middle::privacy::AccessLevels;
 use crate::session::{config, early_error, Session};
-use crate::ty::{self, print::Printer, subst::Kind, TyCtxt, Ty};
+use crate::ty::{self, print::Printer, subst::GenericArg, TyCtxt, Ty};
 use crate::ty::layout::{LayoutError, LayoutOf, TyLayout};
 use crate::util::nodemap::FxHashMap;
 use crate::util::common::time;
@@ -882,7 +882,7 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
             fn path_generic_args(
                 self,
                 print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-                _args: &[Kind<'tcx>],
+                _args: &[GenericArg<'tcx>],
             ) -> Result<Self::Path, Self::Error> {
                 print_prefix(self)
             }

--- a/src/librustc/mir/interpret/mod.rs
+++ b/src/librustc/mir/interpret/mod.rs
@@ -109,7 +109,7 @@ pub use self::pointer::{Pointer, PointerArithmetic, CheckInAllocMsg};
 
 use crate::mir;
 use crate::hir::def_id::DefId;
-use crate::ty::{self, TyCtxt, Instance, subst::UnpackedKind};
+use crate::ty::{self, TyCtxt, Instance, subst::GenericArgKind};
 use crate::ty::codec::TyDecoder;
 use crate::ty::layout::{self, Size};
 use std::io;
@@ -426,7 +426,7 @@ impl<'tcx> AllocMap<'tcx> {
         // this for generic functions.  Lifetime parameters are ignored.
         let is_generic = instance.substs.into_iter().any(|kind| {
             match kind.unpack() {
-                UnpackedKind::Lifetime(_) => false,
+                GenericArgKind::Lifetime(_) => false,
                 _ => true,
             }
         });

--- a/src/librustc/traits/query/dropck_outlives.rs
+++ b/src/librustc/traits/query/dropck_outlives.rs
@@ -3,7 +3,7 @@ use crate::infer::InferOk;
 use crate::infer::canonical::OriginalQueryValues;
 use std::iter::FromIterator;
 use syntax::source_map::Span;
-use crate::ty::subst::Kind;
+use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
 
 impl<'cx, 'tcx> At<'cx, 'tcx> {
@@ -24,7 +24,7 @@ impl<'cx, 'tcx> At<'cx, 'tcx> {
     ///
     /// [#1238]: https://github.com/rust-lang/rfcs/blob/master/text/1238-nonparametric-dropck.md
     /// [#1327]: https://github.com/rust-lang/rfcs/blob/master/text/1327-dropck-param-eyepatch.md
-    pub fn dropck_outlives(&self, ty: Ty<'tcx>) -> InferOk<'tcx, Vec<Kind<'tcx>>> {
+    pub fn dropck_outlives(&self, ty: Ty<'tcx>) -> InferOk<'tcx, Vec<GenericArg<'tcx>>> {
         debug!(
             "dropck_outlives(ty={:?}, param_env={:?})",
             ty, self.param_env,
@@ -80,7 +80,7 @@ impl<'cx, 'tcx> At<'cx, 'tcx> {
 
 #[derive(Clone, Debug, Default)]
 pub struct DropckOutlivesResult<'tcx> {
-    pub kinds: Vec<Kind<'tcx>>,
+    pub kinds: Vec<GenericArg<'tcx>>,
     pub overflows: Vec<Ty<'tcx>>,
 }
 
@@ -104,7 +104,7 @@ impl<'tcx> DropckOutlivesResult<'tcx> {
         tcx: TyCtxt<'tcx>,
         span: Span,
         ty: Ty<'tcx>,
-    ) -> Vec<Kind<'tcx>> {
+    ) -> Vec<GenericArg<'tcx>> {
         self.report_overflows(tcx, span, ty);
         let DropckOutlivesResult { kinds, overflows: _ } = self;
         kinds
@@ -117,7 +117,7 @@ impl<'tcx> DropckOutlivesResult<'tcx> {
 pub struct DtorckConstraint<'tcx> {
     /// Types that are required to be alive in order for this
     /// type to be valid for destruction.
-    pub outlives: Vec<ty::subst::Kind<'tcx>>,
+    pub outlives: Vec<ty::subst::GenericArg<'tcx>>,
 
     /// Types that could not be resolved: projections and params.
     pub dtorck_types: Vec<Ty<'tcx>>,

--- a/src/librustc/traits/util.rs
+++ b/src/librustc/traits/util.rs
@@ -7,7 +7,7 @@ use crate::hir::def_id::DefId;
 use crate::traits::specialize::specialization_graph::NodeItem;
 use crate::ty::{self, Ty, TyCtxt, ToPredicate, ToPolyTraitRef};
 use crate::ty::outlives::Component;
-use crate::ty::subst::{Kind, Subst, SubstsRef};
+use crate::ty::subst::{GenericArg, Subst, SubstsRef};
 use crate::util::nodemap::FxHashSet;
 
 use super::{Obligation, ObligationCause, PredicateObligation, SelectionContext, Normalized};
@@ -551,7 +551,7 @@ impl<'tcx> TyCtxt<'tcx> {
                                    trait_def_id: DefId,
                                    recursion_depth: usize,
                                    self_ty: Ty<'tcx>,
-                                   params: &[Kind<'tcx>])
+                                   params: &[GenericArg<'tcx>])
         -> PredicateObligation<'tcx>
     {
         let trait_ref = ty::TraitRef {

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -23,7 +23,7 @@ use crate::middle::resolve_lifetime::{self, ObjectLifetimeDefault};
 use crate::middle::stability;
 use crate::mir::{Body, interpret, ProjectionKind, Promoted};
 use crate::mir::interpret::{ConstValue, Allocation, Scalar};
-use crate::ty::subst::{Kind, InternalSubsts, SubstsRef, Subst};
+use crate::ty::subst::{GenericArg, InternalSubsts, SubstsRef, Subst};
 use crate::ty::ReprOptions;
 use crate::traits;
 use crate::traits::{Clause, Clauses, GoalKind, Goal, Goals};
@@ -39,7 +39,7 @@ use crate::ty::GenericParamDefKind;
 use crate::ty::layout::{LayoutDetails, TargetDataLayout, VariantIdx};
 use crate::ty::query;
 use crate::ty::steal::Steal;
-use crate::ty::subst::{UserSubsts, UnpackedKind};
+use crate::ty::subst::{UserSubsts, GenericArgKind};
 use crate::ty::{BoundVar, BindingMode};
 use crate::ty::CanonicalPolyFnSig;
 use crate::util::common::ErrorReported;
@@ -828,7 +828,7 @@ impl CanonicalUserType<'tcx> {
 
                 user_substs.substs.iter().zip(BoundVar::new(0)..).all(|(kind, cvar)| {
                     match kind.unpack() {
-                        UnpackedKind::Type(ty) => match ty.kind {
+                        GenericArgKind::Type(ty) => match ty.kind {
                             ty::Bound(debruijn, b) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(debruijn, ty::INNERMOST);
@@ -837,7 +837,7 @@ impl CanonicalUserType<'tcx> {
                             _ => false,
                         },
 
-                        UnpackedKind::Lifetime(r) => match r {
+                        GenericArgKind::Lifetime(r) => match r {
                             ty::ReLateBound(debruijn, br) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(*debruijn, ty::INNERMOST);
@@ -846,7 +846,7 @@ impl CanonicalUserType<'tcx> {
                             _ => false,
                         },
 
-                        UnpackedKind::Const(ct) => match ct.val {
+                        GenericArgKind::Const(ct) => match ct.val {
                             ConstValue::Infer(InferConst::Canonical(debruijn, b)) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(debruijn, ty::INNERMOST);
@@ -1701,7 +1701,7 @@ nop_list_lift!{CanonicalVarInfo => CanonicalVarInfo}
 nop_list_lift!{ProjectionKind => ProjectionKind}
 
 // This is the impl for `&'a InternalSubsts<'a>`.
-nop_list_lift!{Kind<'a> => Kind<'tcx>}
+nop_list_lift!{GenericArg<'a> => GenericArg<'tcx>}
 
 pub mod tls {
     use super::{GlobalCtxt, TyCtxt, ptr_eq};
@@ -2129,8 +2129,8 @@ impl<'tcx> Borrow<[CanonicalVarInfo]> for Interned<'tcx, List<CanonicalVarInfo>>
     }
 }
 
-impl<'tcx> Borrow<[Kind<'tcx>]> for Interned<'tcx, InternalSubsts<'tcx>> {
-    fn borrow<'a>(&'a self) -> &'a [Kind<'tcx>] {
+impl<'tcx> Borrow<[GenericArg<'tcx>]> for Interned<'tcx, InternalSubsts<'tcx>> {
+    fn borrow<'a>(&'a self) -> &'a [GenericArg<'tcx>] {
         &self.0[..]
     }
 }
@@ -2250,7 +2250,7 @@ slice_interners!(
     existential_predicates: _intern_existential_predicates(ExistentialPredicate<'tcx>),
     predicates: _intern_predicates(Predicate<'tcx>),
     type_list: _intern_type_list(Ty<'tcx>),
-    substs: _intern_substs(Kind<'tcx>),
+    substs: _intern_substs(GenericArg<'tcx>),
     clauses: _intern_clauses(Clause<'tcx>),
     goal_list: _intern_goals(Goal<'tcx>),
     projs: _intern_projs(ProjectionKind)
@@ -2452,13 +2452,13 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn intern_tup(self, ts: &[Ty<'tcx>]) -> Ty<'tcx> {
-        let kinds: Vec<_> = ts.into_iter().map(|&t| Kind::from(t)).collect();
+        let kinds: Vec<_> = ts.into_iter().map(|&t| GenericArg::from(t)).collect();
         self.mk_ty(Tuple(self.intern_substs(&kinds)))
     }
 
     pub fn mk_tup<I: InternAs<[Ty<'tcx>], Ty<'tcx>>>(self, iter: I) -> I::Output {
         iter.intern_with(|ts| {
-            let kinds: Vec<_> = ts.into_iter().map(|&t| Kind::from(t)).collect();
+            let kinds: Vec<_> = ts.into_iter().map(|&t| GenericArg::from(t)).collect();
             self.mk_ty(Tuple(self.intern_substs(&kinds)))
         })
     }
@@ -2592,7 +2592,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
 
-    pub fn mk_param_from_def(self, param: &ty::GenericParamDef) -> Kind<'tcx> {
+    pub fn mk_param_from_def(self, param: &ty::GenericParamDef) -> GenericArg<'tcx> {
         match param.kind {
             GenericParamDefKind::Lifetime => {
                 self.mk_region(ty::ReEarlyBound(param.to_early_bound_region_data())).into()
@@ -2637,7 +2637,7 @@ impl<'tcx> TyCtxt<'tcx> {
         }
     }
 
-    pub fn intern_substs(self, ts: &[Kind<'tcx>]) -> &'tcx List<Kind<'tcx>> {
+    pub fn intern_substs(self, ts: &[GenericArg<'tcx>]) -> &'tcx List<GenericArg<'tcx>> {
         if ts.len() == 0 {
             List::empty()
         } else {
@@ -2710,14 +2710,14 @@ impl<'tcx> TyCtxt<'tcx> {
         iter.intern_with(|xs| self.intern_type_list(xs))
     }
 
-    pub fn mk_substs<I: InternAs<[Kind<'tcx>],
-                     &'tcx List<Kind<'tcx>>>>(self, iter: I) -> I::Output {
+    pub fn mk_substs<I: InternAs<[GenericArg<'tcx>],
+                     &'tcx List<GenericArg<'tcx>>>>(self, iter: I) -> I::Output {
         iter.intern_with(|xs| self.intern_substs(xs))
     }
 
     pub fn mk_substs_trait(self,
                      self_ty: Ty<'tcx>,
-                     rest: &[Kind<'tcx>])
+                     rest: &[GenericArg<'tcx>])
                     -> SubstsRef<'tcx>
     {
         self.mk_substs(iter::once(self_ty.into()).chain(rest.iter().cloned()))

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -132,13 +132,13 @@ impl<'tcx> CtxtInterners<'tcx> {
     #[allow(rustc::usage_of_ty_tykind)]
     #[inline(never)]
     fn intern_ty(&self,
-        st: TyKind<'tcx>
+        kind: TyKind<'tcx>
     ) -> Ty<'tcx> {
-        self.type_.intern(st, |st| {
-            let flags = super::flags::FlagComputation::for_sty(&st);
+        self.type_.intern(kind, |kind| {
+            let flags = super::flags::FlagComputation::for_kind(&kind);
 
             let ty_struct = TyS {
-                kind: st,
+                kind,
                 flags: flags.flags,
                 outer_exclusive_binder: flags.outer_exclusive_binder,
             };

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -19,9 +19,9 @@ impl FlagComputation {
     }
 
     #[allow(rustc::usage_of_ty_tykind)]
-    pub fn for_sty(st: &ty::TyKind<'_>) -> FlagComputation {
+    pub fn for_kind(kind: &ty::TyKind<'_>) -> FlagComputation {
         let mut result = FlagComputation::new();
-        result.add_sty(st);
+        result.add_kind(kind);
         result
     }
 
@@ -63,8 +63,8 @@ impl FlagComputation {
     }
 
     #[allow(rustc::usage_of_ty_tykind)]
-    fn add_sty(&mut self, st: &ty::TyKind<'_>) {
-        match st {
+    fn add_kind(&mut self, kind: &ty::TyKind<'_>) {
+        match kind {
             &ty::Bool |
             &ty::Char |
             &ty::Int(_) |

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -1,4 +1,4 @@
-use crate::ty::subst::{SubstsRef, UnpackedKind};
+use crate::ty::subst::{SubstsRef, GenericArgKind};
 use crate::ty::{self, Ty, TypeFlags, InferConst};
 use crate::mir::interpret::ConstValue;
 
@@ -266,9 +266,9 @@ impl FlagComputation {
     fn add_substs(&mut self, substs: SubstsRef<'_>) {
         for kind in substs {
             match kind.unpack() {
-                UnpackedKind::Type(ty) => self.add_ty(ty),
-                UnpackedKind::Lifetime(lt) => self.add_region(lt),
-                UnpackedKind::Const(ct) => self.add_const(ct),
+                GenericArgKind::Type(ty) => self.add_ty(ty),
+                GenericArgKind::Lifetime(lt) => self.add_region(lt),
+                GenericArgKind::Const(ct) => self.add_const(ct),
             }
         }
     }

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -5,7 +5,7 @@
 //! subtyping, type equality, etc.
 
 use crate::hir::def_id::DefId;
-use crate::ty::subst::{Kind, UnpackedKind, SubstsRef};
+use crate::ty::subst::{GenericArg, GenericArgKind, SubstsRef};
 use crate::ty::{self, Ty, TyCtxt, TypeFoldable};
 use crate::ty::error::{ExpectedFound, TypeError};
 use crate::mir::interpret::{ConstValue, Scalar};
@@ -711,29 +711,29 @@ impl<'tcx, T: Relate<'tcx>> Relate<'tcx> for Box<T> {
     }
 }
 
-impl<'tcx> Relate<'tcx> for Kind<'tcx> {
+impl<'tcx> Relate<'tcx> for GenericArg<'tcx> {
     fn relate<R: TypeRelation<'tcx>>(
         relation: &mut R,
-        a: &Kind<'tcx>,
-        b: &Kind<'tcx>,
-    ) -> RelateResult<'tcx, Kind<'tcx>> {
+        a: &GenericArg<'tcx>,
+        b: &GenericArg<'tcx>,
+    ) -> RelateResult<'tcx, GenericArg<'tcx>> {
         match (a.unpack(), b.unpack()) {
-            (UnpackedKind::Lifetime(a_lt), UnpackedKind::Lifetime(b_lt)) => {
+            (GenericArgKind::Lifetime(a_lt), GenericArgKind::Lifetime(b_lt)) => {
                 Ok(relation.relate(&a_lt, &b_lt)?.into())
             }
-            (UnpackedKind::Type(a_ty), UnpackedKind::Type(b_ty)) => {
+            (GenericArgKind::Type(a_ty), GenericArgKind::Type(b_ty)) => {
                 Ok(relation.relate(&a_ty, &b_ty)?.into())
             }
-            (UnpackedKind::Const(a_ct), UnpackedKind::Const(b_ct)) => {
+            (GenericArgKind::Const(a_ct), GenericArgKind::Const(b_ct)) => {
                 Ok(relation.relate(&a_ct, &b_ct)?.into())
             }
-            (UnpackedKind::Lifetime(unpacked), x) => {
+            (GenericArgKind::Lifetime(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
-            (UnpackedKind::Type(unpacked), x) => {
+            (GenericArgKind::Type(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
-            (UnpackedKind::Const(unpacked), x) => {
+            (GenericArgKind::Const(unpacked), x) => {
                 bug!("impossible case reached: can't relate: {:?} with {:?}", unpacked, x)
             }
         }

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -10,7 +10,7 @@ use crate::middle::region;
 use polonius_engine::Atom;
 use rustc_data_structures::indexed_vec::Idx;
 use rustc_macros::HashStable;
-use crate::ty::subst::{InternalSubsts, Subst, SubstsRef, Kind, UnpackedKind};
+use crate::ty::subst::{InternalSubsts, Subst, SubstsRef, GenericArg, GenericArgKind};
 use crate::ty::{self, AdtDef, Discr, DefIdTree, TypeFlags, Ty, TyCtxt, TypeFoldable};
 use crate::ty::{List, TyS, ParamEnvAnd, ParamEnv};
 use crate::ty::layout::VariantIdx;
@@ -320,7 +320,7 @@ pub struct ClosureSubsts<'tcx> {
 struct SplitClosureSubsts<'tcx> {
     closure_kind_ty: Ty<'tcx>,
     closure_sig_ty: Ty<'tcx>,
-    upvar_kinds: &'tcx [Kind<'tcx>],
+    upvar_kinds: &'tcx [GenericArg<'tcx>],
 }
 
 impl<'tcx> ClosureSubsts<'tcx> {
@@ -345,7 +345,7 @@ impl<'tcx> ClosureSubsts<'tcx> {
     ) -> impl Iterator<Item = Ty<'tcx>> + 'tcx {
         let SplitClosureSubsts { upvar_kinds, .. } = self.split(def_id, tcx);
         upvar_kinds.iter().map(|t| {
-            if let UnpackedKind::Type(ty) = t.unpack() {
+            if let GenericArgKind::Type(ty) = t.unpack() {
                 ty
             } else {
                 bug!("upvar should be type")
@@ -402,7 +402,7 @@ struct SplitGeneratorSubsts<'tcx> {
     yield_ty: Ty<'tcx>,
     return_ty: Ty<'tcx>,
     witness: Ty<'tcx>,
-    upvar_kinds: &'tcx [Kind<'tcx>],
+    upvar_kinds: &'tcx [GenericArg<'tcx>],
 }
 
 impl<'tcx> GeneratorSubsts<'tcx> {
@@ -434,7 +434,7 @@ impl<'tcx> GeneratorSubsts<'tcx> {
     ) -> impl Iterator<Item = Ty<'tcx>> + 'tcx {
         let SplitGeneratorSubsts { upvar_kinds, .. } = self.split(def_id, tcx);
         upvar_kinds.iter().map(|t| {
-            if let UnpackedKind::Type(ty) = t.unpack() {
+            if let GenericArgKind::Type(ty) = t.unpack() {
                 ty
             } else {
                 bug!("upvar should be type")
@@ -584,7 +584,7 @@ impl<'tcx> UpvarSubsts<'tcx> {
             UpvarSubsts::Generator(substs) => substs.split(def_id, tcx).upvar_kinds,
         };
         upvar_kinds.iter().map(|t| {
-            if let UnpackedKind::Type(ty) = t.unpack() {
+            if let GenericArgKind::Type(ty) = t.unpack() {
                 ty
             } else {
                 bug!("upvar should be type")

--- a/src/librustc_codegen_llvm/builder.rs
+++ b/src/librustc_codegen_llvm/builder.rs
@@ -324,7 +324,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         use syntax::ast::UintTy::*;
         use rustc::ty::{Int, Uint};
 
-        let new_sty = match ty.kind {
+        let new_kind = match ty.kind {
             Int(Isize) => Int(self.tcx.sess.target.isize_ty),
             Uint(Usize) => Uint(self.tcx.sess.target.usize_ty),
             ref t @ Uint(_) | ref t @ Int(_) => t.clone(),
@@ -332,7 +332,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         };
 
         let name = match oop {
-            OverflowOp::Add => match new_sty {
+            OverflowOp::Add => match new_kind {
                 Int(I8) => "llvm.sadd.with.overflow.i8",
                 Int(I16) => "llvm.sadd.with.overflow.i16",
                 Int(I32) => "llvm.sadd.with.overflow.i32",
@@ -347,7 +347,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
                 _ => unreachable!(),
             },
-            OverflowOp::Sub => match new_sty {
+            OverflowOp::Sub => match new_kind {
                 Int(I8) => "llvm.ssub.with.overflow.i8",
                 Int(I16) => "llvm.ssub.with.overflow.i16",
                 Int(I32) => "llvm.ssub.with.overflow.i32",
@@ -362,7 +362,7 @@ impl BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
                 _ => unreachable!(),
             },
-            OverflowOp::Mul => match new_sty {
+            OverflowOp::Mul => match new_kind {
                 Int(I8) => "llvm.smul.with.overflow.i8",
                 Int(I16) => "llvm.smul.with.overflow.i16",
                 Int(I32) => "llvm.smul.with.overflow.i32",

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -30,7 +30,7 @@ use rustc::ty::Instance;
 use rustc::ty::{self, AdtKind, ParamEnv, Ty, TyCtxt};
 use rustc::ty::layout::{self, Align, Integer, IntegerExt, LayoutOf,
                         PrimitiveExt, Size, TyLayout, VariantIdx};
-use rustc::ty::subst::UnpackedKind;
+use rustc::ty::subst::GenericArgKind;
 use rustc::session::config::{self, DebugInfo};
 use rustc::util::nodemap::FxHashMap;
 use rustc_fs_util::path_to_c_string;
@@ -2096,7 +2096,7 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'
             let generics = cx.tcx.generics_of(def.did);
             let names = get_parameter_names(cx, generics);
             let template_params: Vec<_> = substs.iter().zip(names).filter_map(|(kind, name)| {
-                if let UnpackedKind::Type(ty) = kind.unpack() {
+                if let GenericArgKind::Type(ty) = kind.unpack() {
                     let actual_type = cx.tcx.normalize_erasing_regions(ParamEnv::reveal_all(), ty);
                     let actual_type_metadata =
                         type_metadata(cx, actual_type, syntax_pos::DUMMY_SP);

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -15,7 +15,7 @@ use crate::llvm::debuginfo::{DIFile, DIType, DIScope, DIBuilder, DISubprogram, D
     DISPFlags, DILexicalBlock};
 use rustc::hir::CodegenFnAttrFlags;
 use rustc::hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
-use rustc::ty::subst::{SubstsRef, UnpackedKind};
+use rustc::ty::subst::{SubstsRef, GenericArgKind};
 
 use crate::abi::Abi;
 use crate::common::CodegenCx;
@@ -460,7 +460,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             let template_params: Vec<_> = if cx.sess().opts.debuginfo == DebugInfo::Full {
                 let names = get_parameter_names(cx, generics);
                 substs.iter().zip(names).filter_map(|(kind, name)| {
-                    if let UnpackedKind::Type(ty) = kind.unpack() {
+                    if let GenericArgKind::Type(ty) = kind.unpack() {
                         let actual_type =
                             cx.tcx.normalize_erasing_regions(ParamEnv::reveal_all(), ty);
                         let actual_type_metadata =

--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -3,7 +3,7 @@ use rustc::hir::map::{DefPathData, DisambiguatedDefPathData};
 use rustc::ich::NodeIdHashingMode;
 use rustc::mir::interpret::{ConstValue, Scalar};
 use rustc::ty::print::{PrettyPrinter, Printer, Print};
-use rustc::ty::subst::{Kind, UnpackedKind};
+use rustc::ty::subst::{GenericArg, GenericArgKind};
 use rustc::ty::{self, Ty, TyCtxt, TypeFoldable, Instance};
 use rustc::util::common::record_time;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -341,13 +341,13 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
     fn path_generic_args(
         mut self,
         print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-        args: &[Kind<'tcx>],
+        args: &[GenericArg<'tcx>],
     )  -> Result<Self::Path, Self::Error> {
         self = print_prefix(self)?;
 
         let args = args.iter().cloned().filter(|arg| {
             match arg.unpack() {
-                UnpackedKind::Lifetime(_) => false,
+                GenericArgKind::Lifetime(_) => false,
                 _ => true,
             }
         });

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -12,7 +12,7 @@ use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::DefId;
 use rustc::infer::InferCtxt;
 use rustc::mir::Body;
-use rustc::ty::subst::{SubstsRef, UnpackedKind};
+use rustc::ty::subst::{SubstsRef, GenericArgKind};
 use rustc::ty::{self, RegionKind, RegionVid, Ty, TyCtxt};
 use rustc::ty::print::RegionHighlightMode;
 use rustc_errors::DiagnosticBuilder;
@@ -667,24 +667,24 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ) -> Option<&'hir hir::Lifetime> {
         for (kind, hir_arg) in substs.iter().zip(&args.args) {
             match (kind.unpack(), hir_arg) {
-                (UnpackedKind::Lifetime(r), hir::GenericArg::Lifetime(lt)) => {
+                (GenericArgKind::Lifetime(r), hir::GenericArg::Lifetime(lt)) => {
                     if r.to_region_vid() == needle_fr {
                         return Some(lt);
                     }
                 }
 
-                (UnpackedKind::Type(ty), hir::GenericArg::Type(hir_ty)) => {
+                (GenericArgKind::Type(ty), hir::GenericArg::Type(hir_ty)) => {
                     search_stack.push((ty, hir_ty));
                 }
 
-                (UnpackedKind::Const(_ct), hir::GenericArg::Const(_hir_ct)) => {
+                (GenericArgKind::Const(_ct), hir::GenericArg::Const(_hir_ct)) => {
                     // Lifetimes cannot be found in consts, so we don't need
                     // to search anything here.
                 }
 
-                (UnpackedKind::Lifetime(_), _)
-                | (UnpackedKind::Type(_), _)
-                | (UnpackedKind::Const(_), _) => {
+                (GenericArgKind::Lifetime(_), _)
+                | (GenericArgKind::Type(_), _)
+                | (GenericArgKind::Const(_), _) => {
                     // I *think* that HIR lowering should ensure this
                     // doesn't happen, even in erroneous
                     // programs. Else we should use delay-span-bug.

--- a/src/librustc_mir/borrow_check/nll/type_check/constraint_conversion.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/constraint_conversion.rs
@@ -10,7 +10,7 @@ use rustc::infer::outlives::obligations::{TypeOutlives, TypeOutlivesDelegate};
 use rustc::infer::region_constraints::{GenericKind, VerifyBound};
 use rustc::infer::{self, InferCtxt, SubregionOrigin};
 use rustc::mir::ConstraintCategory;
-use rustc::ty::subst::UnpackedKind;
+use rustc::ty::subst::GenericArgKind;
 use rustc::ty::{self, TyCtxt};
 use syntax_pos::DUMMY_SP;
 
@@ -101,13 +101,13 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
             });
 
         match k1.unpack() {
-            UnpackedKind::Lifetime(r1) => {
+            GenericArgKind::Lifetime(r1) => {
                 let r1_vid = self.to_region_vid(r1);
                 let r2_vid = self.to_region_vid(r2);
                 self.add_outlives(r1_vid, r2_vid);
             }
 
-            UnpackedKind::Type(t1) => {
+            GenericArgKind::Type(t1) => {
                 // we don't actually use this for anything, but
                 // the `TypeOutlives` code needs an origin.
                 let origin = infer::RelateParamBound(DUMMY_SP, t1);
@@ -121,7 +121,7 @@ impl<'a, 'tcx> ConstraintConversion<'a, 'tcx> {
                 ).type_must_outlive(origin, t1, r2);
             }
 
-            UnpackedKind::Const(_) => {
+            GenericArgKind::Const(_) => {
                 // Consts cannot outlive one another, so we
                 // don't need to handle any relations here.
             }

--- a/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/liveness/polonius.rs
@@ -4,7 +4,7 @@ use crate::dataflow::move_paths::{LookupResult, MoveData};
 use crate::util::liveness::{categorize, DefUse};
 use rustc::mir::visit::{MutatingUseContext, PlaceContext, Visitor};
 use rustc::mir::{Body, Local, Location, Place};
-use rustc::ty::subst::Kind;
+use rustc::ty::subst::GenericArg;
 use rustc::ty::Ty;
 
 use super::TypeChecker;
@@ -125,7 +125,7 @@ pub(super) fn populate_access_facts(
 pub(super) fn add_var_drops_regions(
     typeck: &mut TypeChecker<'_, 'tcx>,
     local: Local,
-    kind: &Kind<'tcx>,
+    kind: &GenericArg<'tcx>,
 ) {
     debug!("add_var_drops_region(local={:?}, kind={:?}", local, kind);
     let tcx = typeck.tcx();

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -36,7 +36,7 @@ use rustc::traits::query::{Fallible, NoSolution};
 use rustc::traits::{self, ObligationCause, PredicateObligations};
 use rustc::ty::adjustment::{PointerCast};
 use rustc::ty::fold::TypeFoldable;
-use rustc::ty::subst::{Subst, SubstsRef, UnpackedKind, UserSubsts};
+use rustc::ty::subst::{Subst, SubstsRef, GenericArgKind, UserSubsts};
 use rustc::ty::{
     self, RegionVid, ToPolyTraitRef, Ty, TyCtxt, UserType,
     CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations,
@@ -2575,7 +2575,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                         });
 
                     match k1.unpack() {
-                        UnpackedKind::Lifetime(r1) => {
+                        GenericArgKind::Lifetime(r1) => {
                             // constraint is r1: r2
                             let r1_vid = self.borrowck_context.universal_regions.to_region_vid(r1);
                             let r2_vid = self.borrowck_context.universal_regions.to_region_vid(r2);
@@ -2589,7 +2589,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                                 ),
                             ))
                         }
-                        UnpackedKind::Type(_) | UnpackedKind::Const(_) => None,
+                        GenericArgKind::Type(_) | GenericArgKind::Const(_) => None,
                     }
                 })
                 .collect();

--- a/src/librustc_mir/hair/cx/mod.rs
+++ b/src/librustc_mir/hair/cx/mod.rs
@@ -12,7 +12,7 @@ use rustc::middle::region;
 use rustc::infer::InferCtxt;
 use rustc::ty::subst::Subst;
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::subst::{Kind, InternalSubsts};
+use rustc::ty::subst::{GenericArg, InternalSubsts};
 use rustc::ty::layout::VariantIdx;
 use syntax::ast;
 use syntax::attr;
@@ -169,7 +169,7 @@ impl<'a, 'tcx> Cx<'a, 'tcx> {
                         trait_def_id: DefId,
                         method_name: Symbol,
                         self_ty: Ty<'tcx>,
-                        params: &[Kind<'tcx>])
+                        params: &[GenericArg<'tcx>])
                         -> &'tcx ty::Const<'tcx> {
         let substs = self.tcx.mk_substs_trait(self_ty, params);
         for item in self.tcx.associated_items(trait_def_id) {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -17,7 +17,7 @@ use rustc::mir::interpret::{GlobalId, ConstValue, sign_extend, AllocId, Pointer}
 use rustc::traits::{ObligationCause, PredicateObligation};
 use rustc::ty::{self, Region, TyCtxt, AdtDef, Ty, UserType, DefIdTree};
 use rustc::ty::{CanonicalUserType, CanonicalUserTypeAnnotation, CanonicalUserTypeAnnotations};
-use rustc::ty::subst::{SubstsRef, Kind};
+use rustc::ty::subst::{SubstsRef, GenericArg};
 use rustc::ty::layout::{VariantIdx, Size};
 use rustc::hir::{self, PatKind, RangeEnd};
 use rustc::hir::def::{CtorOf, Res, DefKind, CtorKind};
@@ -1357,7 +1357,7 @@ macro_rules! CloneImpls {
 CloneImpls!{ <'tcx>
     Span, Field, Mutability, ast::Name, hir::HirId, usize, ty::Const<'tcx>,
     Region<'tcx>, Ty<'tcx>, BindingMode, &'tcx AdtDef,
-    SubstsRef<'tcx>, &'tcx Kind<'tcx>, UserType<'tcx>,
+    SubstsRef<'tcx>, &'tcx GenericArg<'tcx>, UserType<'tcx>,
     UserTypeProjection, PatternTypeProjection<'tcx>
 }
 

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -1,6 +1,6 @@
 use rustc::ty::{
     TyCtxt, Ty,
-    subst::{UnpackedKind, Kind},
+    subst::{GenericArgKind, GenericArg},
     print::{Printer, PrettyPrinter, Print},
     self,
 };
@@ -156,12 +156,12 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
     fn path_generic_args(
         mut self,
         print_prefix: impl FnOnce(Self) -> Result<Self::Path, Self::Error>,
-        args: &[Kind<'tcx>],
+        args: &[GenericArg<'tcx>],
     ) -> Result<Self::Path, Self::Error> {
         self = print_prefix(self)?;
         let args = args.iter().cloned().filter(|arg| {
             match arg.unpack() {
-                UnpackedKind::Lifetime(_) => false,
+                GenericArgKind::Lifetime(_) => false,
                 _ => true,
             }
         });

--- a/src/librustc_traits/chalk_context/program_clauses/builtin.rs
+++ b/src/librustc_traits/chalk_context/program_clauses/builtin.rs
@@ -5,7 +5,7 @@ use rustc::traits::{
     ProgramClauseCategory,
 };
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::subst::{Kind, InternalSubsts, Subst};
+use rustc::ty::subst::{GenericArg, InternalSubsts, Subst};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use crate::lowering::Lower;
@@ -17,7 +17,7 @@ use crate::generic_types;
 fn builtin_impl_clause(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
-    nested: &[Kind<'tcx>],
+    nested: &[GenericArg<'tcx>],
     trait_def_id: DefId,
 ) -> ProgramClause<'tcx> {
     ProgramClause {
@@ -124,7 +124,7 @@ crate fn assemble_builtin_sized_impls<'tcx>(
     ty: Ty<'tcx>,
     clauses: &mut Vec<Clause<'tcx>>,
 ) {
-    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[Kind<'tcx>]| {
+    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[GenericArg<'tcx>]| {
         let clause = builtin_impl_clause(tcx, ty, nested, sized_def_id);
         // Bind innermost bound vars that may exist in `ty` and `nested`.
         clauses.push(Clause::ForAll(ty::Binder::bind(clause)));
@@ -185,7 +185,7 @@ crate fn assemble_builtin_sized_impls<'tcx>(
             let adt = tcx.mk_ty(ty::Adt(adt_def, substs));
             let sized_constraint = adt_def.sized_constraint(tcx)
                 .iter()
-                .map(|ty| Kind::from(ty.subst(tcx, substs)))
+                .map(|ty| GenericArg::from(ty.subst(tcx, substs)))
                 .collect::<Vec<_>>();
             push_builtin_impl(adt, &sized_constraint);
         }
@@ -228,7 +228,7 @@ crate fn assemble_builtin_copy_clone_impls<'tcx>(
     ty: Ty<'tcx>,
     clauses: &mut Vec<Clause<'tcx>>,
 ) {
-    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[Kind<'tcx>]| {
+    let mut push_builtin_impl = |ty: Ty<'tcx>, nested: &[GenericArg<'tcx>]| {
         let clause = builtin_impl_clause(tcx, ty, nested, trait_def_id);
         // Bind innermost bound vars that may exist in `ty` and `nested`.
         clauses.push(Clause::ForAll(ty::Binder::bind(clause)));
@@ -255,7 +255,7 @@ crate fn assemble_builtin_copy_clone_impls<'tcx>(
             let element_ty = generic_types::bound(tcx, 0);
             push_builtin_impl(
                 tcx.mk_ty(ty::Array(element_ty, length)),
-                &[Kind::from(element_ty)],
+                &[GenericArg::from(element_ty)],
             );
         }
         &ty::Tuple(type_list) => {
@@ -266,7 +266,7 @@ crate fn assemble_builtin_copy_clone_impls<'tcx>(
             let closure_ty = generic_types::closure(tcx, def_id);
             let upvar_tys: Vec<_> = match &closure_ty.kind {
                 ty::Closure(_, substs) => {
-                    substs.upvar_tys(def_id, tcx).map(|ty| Kind::from(ty)).collect()
+                    substs.upvar_tys(def_id, tcx).map(|ty| GenericArg::from(ty)).collect()
                 },
                 _ => bug!(),
             };

--- a/src/librustc_traits/chalk_context/resolvent_ops.rs
+++ b/src/librustc_traits/chalk_context/resolvent_ops.rs
@@ -17,7 +17,7 @@ use rustc::traits::{
     InEnvironment,
 };
 use rustc::ty::{self, Ty, TyCtxt, InferConst};
-use rustc::ty::subst::Kind;
+use rustc::ty::subst::GenericArg;
 use rustc::ty::relate::{Relate, RelateResult, TypeRelation};
 use rustc::mir::interpret::ConstValue;
 use syntax_pos::DUMMY_SP;
@@ -151,7 +151,7 @@ impl AnswerSubstitutor<'cx, 'tcx> {
     fn unify_free_answer_var(
         &mut self,
         answer_var: ty::BoundVar,
-        pending: Kind<'tcx>
+        pending: GenericArg<'tcx>
     ) -> RelateResult<'tcx, ()> {
         let answer_param = &self.answer_subst.var_values[answer_var];
         let pending = &ty::fold::shift_out_vars(

--- a/src/librustc_traits/generic_types.rs
+++ b/src/librustc_traits/generic_types.rs
@@ -1,7 +1,7 @@
 //! Utilities for creating generic types with bound vars in place of parameter values.
 
 use rustc::ty::{self, Ty, TyCtxt};
-use rustc::ty::subst::{Kind, SubstsRef, InternalSubsts};
+use rustc::ty::subst::{GenericArg, SubstsRef, InternalSubsts};
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc_target::spec::abi;
@@ -49,7 +49,7 @@ crate fn type_list(tcx: TyCtxt<'tcx>, arity: usize) -> SubstsRef<'tcx> {
         (0..arity).into_iter()
             .map(|i| ty::BoundVar::from(i))
             .map(|var| tcx.mk_ty(ty::Bound(ty::INNERMOST, var.into())))
-            .map(|ty| Kind::from(ty))
+            .map(|ty| GenericArg::from(ty))
     )
 }
 

--- a/src/librustc_traits/type_op.rs
+++ b/src/librustc_traits/type_op.rs
@@ -13,7 +13,7 @@ use rustc::traits::{
     Normalized, Obligation, ObligationCause, TraitEngine, TraitEngineExt,
 };
 use rustc::ty::query::Providers;
-use rustc::ty::subst::{Kind, Subst, UserSubsts, UserSelfTy};
+use rustc::ty::subst::{GenericArg, Subst, UserSubsts, UserSelfTy};
 use rustc::ty::{
     FnSig, Lift, ParamEnv, ParamEnvAnd, PolyFnSig, Predicate, Ty, TyCtxt, TypeFoldable, Variance,
 };
@@ -98,7 +98,7 @@ impl AscribeUserTypeCx<'me, 'tcx> {
         self.infcx.tcx
     }
 
-    fn subst<T>(&self, value: T, substs: &[Kind<'tcx>]) -> T
+    fn subst<T>(&self, value: T, substs: &[GenericArg<'tcx>]) -> T
     where
         T: TypeFoldable<'tcx>,
     {

--- a/src/librustc_typeck/check/dropck.rs
+++ b/src/librustc_typeck/check/dropck.rs
@@ -6,7 +6,7 @@ use rustc::infer::outlives::env::OutlivesEnvironment;
 use rustc::infer::{self, InferOk, SuppressRegionErrors};
 use rustc::middle::region;
 use rustc::traits::{ObligationCause, TraitEngine, TraitEngineExt};
-use rustc::ty::subst::{Subst, SubstsRef, UnpackedKind};
+use rustc::ty::subst::{Subst, SubstsRef, GenericArgKind};
 use rustc::ty::{self, Ty, TyCtxt};
 use crate::util::common::ErrorReported;
 
@@ -308,9 +308,9 @@ pub fn check_safety_of_destructor_if_necessary<'a, 'tcx>(
     let kinds = rcx.fcx.register_infer_ok_obligations(infer_ok);
     for kind in kinds {
         match kind.unpack() {
-            UnpackedKind::Lifetime(r) => rcx.sub_regions(origin(), parent_scope, r),
-            UnpackedKind::Type(ty) => rcx.type_must_outlive(origin(), ty, parent_scope),
-            UnpackedKind::Const(_) => {
+            GenericArgKind::Lifetime(r) => rcx.sub_regions(origin(), parent_scope, r),
+            GenericArgKind::Type(ty) => rcx.type_must_outlive(origin(), ty, parent_scope),
+            GenericArgKind::Const(_) => {
                 // Generic consts don't add constraints.
             }
         }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -116,7 +116,9 @@ use rustc::ty::adjustment::{
 };
 use rustc::ty::fold::TypeFoldable;
 use rustc::ty::query::Providers;
-use rustc::ty::subst::{UnpackedKind, Subst, InternalSubsts, SubstsRef, UserSelfTy, UserSubsts};
+use rustc::ty::subst::{
+    GenericArgKind, Subst, InternalSubsts, SubstsRef, UserSelfTy, UserSubsts,
+};
 use rustc::ty::util::{Representability, IntTypeExt, Discr};
 use rustc::ty::layout::VariantIdx;
 use syntax_pos::{self, BytePos, Span, MultiSpan};
@@ -2213,7 +2215,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
 
     fn ty_infer(&self, param: Option<&ty::GenericParamDef>, span: Span) -> Ty<'tcx> {
         if let Some(param) = param {
-            if let UnpackedKind::Type(ty) = self.var_for_def(span, param).unpack() {
+            if let GenericArgKind::Type(ty) = self.var_for_def(span, param).unpack() {
                 return ty;
             }
             unreachable!()
@@ -2232,7 +2234,7 @@ impl<'a, 'tcx> AstConv<'tcx> for FnCtxt<'a, 'tcx> {
         span: Span,
     ) -> &'tcx Const<'tcx> {
         if let Some(param) = param {
-            if let UnpackedKind::Const(ct) = self.var_for_def(span, param).unpack() {
+            if let GenericArgKind::Const(ct) = self.var_for_def(span, param).unpack() {
                 return ct;
             }
             unreachable!()

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -8,7 +8,7 @@ use rustc::hir::ptr::P;
 use rustc::infer;
 use rustc::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use rustc::ty::{self, Ty, BindingMode, TypeFoldable};
-use rustc::ty::subst::Kind;
+use rustc::ty::subst::GenericArg;
 use syntax::ast;
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax_pos::Span;
@@ -797,7 +797,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let max_len = cmp::max(expected_len, elements.len());
 
         let element_tys_iter = (0..max_len).map(|_| {
-            Kind::from(self.next_ty_var(
+            GenericArg::from(self.next_ty_var(
                 // FIXME: `MiscVariable` for now -- obtaining the span and name information
                 // from all tuple elements isn't trivial.
                 TypeVariableOrigin {

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -81,7 +81,7 @@ use rustc::hir::def_id::DefId;
 use rustc::infer::outlives::env::OutlivesEnvironment;
 use rustc::infer::{self, RegionObligation, SuppressRegionErrors};
 use rustc::ty::adjustment;
-use rustc::ty::subst::{SubstsRef, UnpackedKind};
+use rustc::ty::subst::{SubstsRef, GenericArgKind};
 use rustc::ty::{self, Ty};
 
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
@@ -1401,14 +1401,14 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
 
         for kind in substs {
             match kind.unpack() {
-                UnpackedKind::Lifetime(lt) => {
+                GenericArgKind::Lifetime(lt) => {
                     self.sub_regions(origin.clone(), expr_region, lt);
                 }
-                UnpackedKind::Type(ty) => {
+                GenericArgKind::Type(ty) => {
                     let ty = self.resolve_type(ty);
                     self.type_must_outlive(origin.clone(), ty, expr_region);
                 }
-                UnpackedKind::Const(_) => {
+                GenericArgKind::Const(_) => {
                     // Const parameters don't impose constraints.
                 }
             }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -646,7 +646,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                         let mut seen: FxHashMap<_, Vec<_>> = FxHashMap::default();
                         for (subst, param) in substs.iter().zip(&generics.params) {
                             match subst.unpack() {
-                                ty::subst::UnpackedKind::Type(ty) => match ty.kind {
+                                ty::subst::GenericArgKind::Type(ty) => match ty.kind {
                                     ty::Param(..) => {}
                                     // Prevent `fn foo() -> Foo<u32>` from being defining.
                                     _ => {
@@ -668,7 +668,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                                     }
                                 }
 
-                                ty::subst::UnpackedKind::Lifetime(region) => {
+                                ty::subst::GenericArgKind::Lifetime(region) => {
                                     let param_span = tcx.def_span(param.def_id);
                                     if let ty::ReStatic = region {
                                         tcx
@@ -690,7 +690,7 @@ fn check_opaque_types<'fcx, 'tcx>(
                                     }
                                 }
 
-                                ty::subst::UnpackedKind::Const(ct) => match ct.val {
+                                ty::subst::GenericArgKind::Const(ct) => match ct.val {
                                     ConstValue::Param(_) => {}
                                     _ => {
                                         tcx.sess

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -25,7 +25,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::subst::{Subst, InternalSubsts};
 use rustc::ty::util::Discr;
 use rustc::ty::util::IntTypeExt;
-use rustc::ty::subst::UnpackedKind;
+use rustc::ty::subst::GenericArgKind;
 use rustc::ty::{self, AdtKind, DefIdTree, ToPolyTraitRef, Ty, TyCtxt, Const};
 use rustc::ty::{ReprOptions, ToPredicate};
 use rustc::util::captures::Captures;
@@ -1580,7 +1580,7 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: DefId) -> Ty<'_> {
                 // Skipping binder is ok, since we only use this to find generic parameters and
                 // their positions.
                 for (idx, subst) in substs.iter().enumerate() {
-                    if let UnpackedKind::Type(ty) = subst.unpack() {
+                    if let GenericArgKind::Type(ty) = subst.unpack() {
                         if let ty::Param(p) = ty.kind {
                             if index_map.insert(p, idx).is_some() {
                                 // There was already an entry for `p`, meaning a generic parameter

--- a/src/librustc_typeck/outlives/implicit_infer.rs
+++ b/src/librustc_typeck/outlives/implicit_infer.rs
@@ -1,7 +1,7 @@
 use rustc::hir::{self, Node};
 use rustc::hir::def_id::DefId;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
-use rustc::ty::subst::{Kind, Subst, UnpackedKind};
+use rustc::ty::subst::{GenericArg, Subst, GenericArgKind};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::util::nodemap::FxHashMap;
 
@@ -253,7 +253,7 @@ fn insert_required_predicates_to_be_wf<'tcx>(
 pub fn check_explicit_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     def_id: DefId,
-    substs: &[Kind<'tcx>],
+    substs: &[GenericArg<'tcx>],
     required_predicates: &mut RequiredPredicates<'tcx>,
     explicit_map: &mut ExplicitPredicatesMap<'tcx>,
     ignored_self_ty: Option<Ty<'tcx>>,
@@ -310,7 +310,7 @@ pub fn check_explicit_predicates<'tcx>(
         // binding) and thus infer an outlives requirement that `X:
         // 'b`.
         if let Some(self_ty) = ignored_self_ty {
-            if let UnpackedKind::Type(ty) = outlives_predicate.0.unpack() {
+            if let GenericArgKind::Type(ty) = outlives_predicate.0.unpack() {
                 if ty.walk().any(|ty| ty == self_ty) {
                     debug!("skipping self ty = {:?}", &ty);
                     continue;

--- a/src/librustc_typeck/outlives/mod.rs
+++ b/src/librustc_typeck/outlives/mod.rs
@@ -2,7 +2,7 @@ use hir::Node;
 use rustc::hir;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::ty::query::Providers;
-use rustc::ty::subst::UnpackedKind;
+use rustc::ty::subst::GenericArgKind;
 use rustc::ty::{self, CratePredicatesMap, TyCtxt};
 use syntax::symbol::sym;
 
@@ -100,17 +100,17 @@ fn inferred_outlives_crate(
                 .iter()
                 .filter_map(
                     |ty::OutlivesPredicate(kind1, region2)| match kind1.unpack() {
-                        UnpackedKind::Type(ty1) => {
+                        GenericArgKind::Type(ty1) => {
                             Some(ty::Predicate::TypeOutlives(ty::Binder::bind(
                                 ty::OutlivesPredicate(ty1, region2)
                             )))
                         }
-                        UnpackedKind::Lifetime(region1) => {
+                        GenericArgKind::Lifetime(region1) => {
                             Some(ty::Predicate::RegionOutlives(
                                 ty::Binder::bind(ty::OutlivesPredicate(region1, region2))
                             ))
                         }
-                        UnpackedKind::Const(_) => {
+                        GenericArgKind::Const(_) => {
                             // Generic consts don't impose any constraints.
                             None
                         }

--- a/src/librustc_typeck/variance/constraints.rs
+++ b/src/librustc_typeck/variance/constraints.rs
@@ -4,7 +4,7 @@
 //! We walk the set of items and, for each member, generate new constraints.
 
 use hir::def_id::DefId;
-use rustc::ty::subst::{SubstsRef, UnpackedKind};
+use rustc::ty::subst::{SubstsRef, GenericArgKind};
 use rustc::ty::{self, Ty, TyCtxt};
 use rustc::hir;
 use rustc::hir::itemlikevisit::ItemLikeVisitor;
@@ -232,13 +232,13 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
 
         for k in substs {
             match k.unpack() {
-                UnpackedKind::Lifetime(lt) => {
+                GenericArgKind::Lifetime(lt) => {
                     self.add_constraints_from_region(current, lt, variance_i)
                 }
-                UnpackedKind::Type(ty) => {
+                GenericArgKind::Type(ty) => {
                     self.add_constraints_from_ty(current, ty, variance_i)
                 }
-                UnpackedKind::Const(_) => {
+                GenericArgKind::Const(_) => {
                     // Consts impose no constraints.
                 }
             }
@@ -387,13 +387,13 @@ impl<'a, 'tcx> ConstraintContext<'a, 'tcx> {
                    variance_decl,
                    variance_i);
             match k.unpack() {
-                UnpackedKind::Lifetime(lt) => {
+                GenericArgKind::Lifetime(lt) => {
                     self.add_constraints_from_region(current, lt, variance_i)
                 }
-                UnpackedKind::Type(ty) => {
+                GenericArgKind::Type(ty) => {
                     self.add_constraints_from_ty(current, ty, variance_i)
                 }
-                UnpackedKind::Const(_) => {
+                GenericArgKind::Const(_) => {
                     // Consts impose no constraints.
                 }
             }

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -21,7 +21,7 @@ use rustc::hir;
 use rustc::hir::def::{CtorKind, DefKind, Res};
 use rustc::hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc::hir::ptr::P;
-use rustc::ty::subst::{InternalSubsts, SubstsRef, UnpackedKind};
+use rustc::ty::subst::{InternalSubsts, SubstsRef, GenericArgKind};
 use rustc::ty::{self, DefIdTree, TyCtxt, Region, RegionVid, Ty, AdtKind};
 use rustc::ty::fold::TypeFolder;
 use rustc::ty::layout::VariantIdx;
@@ -1100,18 +1100,18 @@ fn external_generic_args(
     let mut skip_self = has_self;
     let mut ty_sty = None;
     let args: Vec<_> = substs.iter().filter_map(|kind| match kind.unpack() {
-        UnpackedKind::Lifetime(lt) => {
+        GenericArgKind::Lifetime(lt) => {
             lt.clean(cx).and_then(|lt| Some(GenericArg::Lifetime(lt)))
         }
-        UnpackedKind::Type(_) if skip_self => {
+        GenericArgKind::Type(_) if skip_self => {
             skip_self = false;
             None
         }
-        UnpackedKind::Type(ty) => {
+        GenericArgKind::Type(ty) => {
             ty_sty = Some(&ty.kind);
             Some(GenericArg::Type(ty.clean(cx)))
         }
-        UnpackedKind::Const(ct) => Some(GenericArg::Const(ct.clean(cx))),
+        GenericArgKind::Const(ct) => Some(GenericArg::Const(ct.clean(cx))),
     }).collect();
 
     match trait_did {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1098,7 +1098,7 @@ fn external_generic_args(
     substs: SubstsRef<'_>,
 ) -> GenericArgs {
     let mut skip_self = has_self;
-    let mut ty_sty = None;
+    let mut ty_kind = None;
     let args: Vec<_> = substs.iter().filter_map(|kind| match kind.unpack() {
         GenericArgKind::Lifetime(lt) => {
             lt.clean(cx).and_then(|lt| Some(GenericArg::Lifetime(lt)))
@@ -1108,7 +1108,7 @@ fn external_generic_args(
             None
         }
         GenericArgKind::Type(ty) => {
-            ty_sty = Some(&ty.kind);
+            ty_kind = Some(&ty.kind);
             Some(GenericArg::Type(ty.clean(cx)))
         }
         GenericArgKind::Const(ct) => Some(GenericArg::Const(ct.clean(cx))),
@@ -1117,8 +1117,8 @@ fn external_generic_args(
     match trait_did {
         // Attempt to sugar an external path like Fn<(A, B,), C> to Fn(A, B) -> C
         Some(did) if cx.tcx.lang_items().fn_trait_kind(did).is_some() => {
-            assert!(ty_sty.is_some());
-            let inputs = match ty_sty {
+            assert!(ty_kind.is_some());
+            let inputs = match ty_kind {
                 Some(ty::Tuple(ref tys)) => tys.iter().map(|t| t.expect_ty().clean(cx)).collect(),
                 _ => return GenericArgs::AngleBracketed { args, bindings },
             };


### PR DESCRIPTION
And `subst::UnpackedKind` to `subst::GenericArgKind`. Individual variable names (e.g. `kind`) are not renamed, which would be an infeasible mission.

Fixes https://github.com/rust-lang/rust/issues/64352.

r? @eddyb