### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/etc/generate-deriving-span-tests.py
+++ b/src/etc/generate-deriving-span-tests.py
@@ -14,6 +14,8 @@ TEST_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '../test/ui/derives/'))
 
 TEMPLATE = """\
+// ignore-musl
+// ^ due to stderr output differences
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 {error_deriving}

--- a/src/libcore/convert.rs
+++ b/src/libcore/convert.rs
@@ -42,11 +42,11 @@
 
 use crate::fmt;
 
-/// An identity function.
+/// The identity function.
 ///
 /// Two things are important to note about this function:
 ///
-/// - It is not always equivalent to a closure like `|x| x` since the
+/// - It is not always equivalent to a closure like `|x| x`, since the
 ///   closure may coerce `x` into a different type.
 ///
 /// - It moves the input `x` passed to the function.
@@ -56,31 +56,32 @@ use crate::fmt;
 ///
 /// # Examples
 ///
-/// Using `identity` to do nothing among other interesting functions:
+/// Using `identity` to do nothing in a sequence of other, interesting,
+/// functions:
 ///
 /// ```rust
 /// use std::convert::identity;
 ///
 /// fn manipulation(x: u32) -> u32 {
-///     // Let's assume that this function does something interesting.
+///     // Let's pretend that adding one is an interesting function.
 ///     x + 1
 /// }
 ///
 /// let _arr = &[identity, manipulation];
 /// ```
 ///
-/// Using `identity` to get a function that changes nothing in a conditional:
+/// Using `identity` as a "do nothing" base case in a conditional:
 ///
 /// ```rust
 /// use std::convert::identity;
 ///
 /// # let condition = true;
-///
+/// #
 /// # fn manipulation(x: u32) -> u32 { x + 1 }
-///
+/// #
 /// let do_stuff = if condition { manipulation } else { identity };
 ///
-/// // do more interesting stuff..
+/// // Do more interesting stuff...
 ///
 /// let _results = do_stuff(42);
 /// ```

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1893,10 +1893,13 @@ impl<'a> LoweringContext<'a> {
                         if let Ok(snippet) = self.sess.source_map().span_to_snippet(data.span) {
                             // Do not suggest going from `Trait()` to `Trait<>`
                             if data.inputs.len() > 0 {
+                                let split = snippet.find('(').unwrap();
+                                let trait_name = &snippet[0..split];
+                                let args = &snippet[split + 1 .. snippet.len() - 1];
                                 err.span_suggestion(
                                     data.span,
                                     "use angle brackets instead",
-                                    format!("<{}>", &snippet[1..snippet.len() - 1]),
+                                    format!("{}<{}>", trait_name, args),
                                     Applicability::MaybeIncorrect,
                                 );
                             }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2751,9 +2751,8 @@ pub enum Node<'hir> {
     Crate,
 }
 
-impl<'hir> Node<'hir> {
+impl Node<'_> {
     pub fn ident(&self) -> Option<Ident> {
-
         match self {
             Node::TraitItem(TraitItem { ident, .. }) |
             Node::ImplItem(ImplItem { ident, .. }) |

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2750,3 +2750,16 @@ pub enum Node<'hir> {
 
     Crate,
 }
+
+impl<'hir> Node<'hir> {
+    pub fn ident(&self) -> Option<Ident> {
+
+        match self {
+            Node::TraitItem(TraitItem { ident, .. }) |
+            Node::ImplItem(ImplItem { ident, .. }) |
+            Node::ForeignItem(ForeignItem { ident, .. }) |
+            Node::Item(Item { ident, .. }) => Some(*ident),
+            _ => None,
+        }
+    }
+}

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -171,6 +171,9 @@ pub enum ObligationCauseCode<'tcx> {
     /// also implement all supertraits of `X`.
     ItemObligation(DefId),
 
+    /// Like `ItemObligation`, but with extra detail on the source of the obligation.
+    BindingObligation(DefId, Span),
+
     /// A type like `&'a T` is WF only if `T: 'a`.
     ReferenceOutlivesReferent(Ty<'tcx>),
 

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -472,6 +472,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::TupleElem => Some(super::TupleElem),
             super::ProjectionWf(proj) => tcx.lift(&proj).map(super::ProjectionWf),
             super::ItemObligation(def_id) => Some(super::ItemObligation(def_id)),
+            super::BindingObligation(def_id, span) => Some(super::BindingObligation(def_id, span)),
             super::ReferenceOutlivesReferent(ty) => {
                 tcx.lift(&ty).map(super::ReferenceOutlivesReferent)
             }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -1938,9 +1938,15 @@ pub struct FieldDef {
     pub vis: Visibility,
 }
 
-/// The definition of an abstract data type -- a struct or enum.
+/// The definition of a user-defined type, e.g., a `struct`, `enum`, or `union`.
 ///
 /// These are all interned (by `intern_adt_def`) into the `adt_defs` table.
+///
+/// The initialism *"Adt"* stands for an [*algebraic data type (ADT)*][adt].
+/// This is slightly wrong because `union`s are not ADTs.
+/// Moreover, Rust only allows recursive data types through indirection.
+///
+/// [adt]: https://en.wikipedia.org/wiki/Algebraic_data_type
 pub struct AdtDef {
     /// `DefId` of the struct, enum or union item.
     pub did: DefId,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2791,6 +2791,10 @@ impl<'tcx> TyCtxt<'tcx> {
         })
     }
 
+    pub fn opt_item_name(self, def_id: DefId) -> Option<Ident> {
+        self.hir().as_local_hir_id(def_id).and_then(|hir_id| self.hir().get(hir_id).ident())
+    }
+
     pub fn opt_associated_item(self, def_id: DefId) -> Option<AssocItem> {
         let is_associated_item = if let Some(hir_id) = self.hir().as_local_hir_id(def_id) {
             match self.hir().get(hir_id) {

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -614,8 +614,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     projection,
                 } = first_borrowed_place;
 
-                for (i, elem) in projection.iter().enumerate().rev() {
-                    let proj_base = &projection[..i];
+                let mut cursor = &**projection;
+                while let [proj_base @ .., elem] = cursor {
+                    cursor = proj_base;
 
                     match elem {
                         ProjectionElem::Field(field, _) if union_ty(base, proj_base).is_some() => {
@@ -637,8 +638,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     projection,
                 } = second_borrowed_place;
 
-                for (i, elem) in projection.iter().enumerate().rev() {
-                    let proj_base = &projection[..i];
+                let mut cursor = &**projection;
+                while let [proj_base @ .., elem] = cursor {
+                    cursor = proj_base;
 
                     if let ProjectionElem::Field(field, _) = elem {
                         if let Some(union_ty) = union_ty(base, proj_base) {

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -13,7 +13,7 @@ use rustc::infer::NLLRegionVariableOrigin;
 use rustc::mir::{ConstraintCategory, Location, Body};
 use rustc::ty::{self, RegionVid};
 use rustc_data_structures::indexed_vec::IndexVec;
-use rustc_errors::{Diagnostic, DiagnosticBuilder};
+use rustc_errors::DiagnosticBuilder;
 use std::collections::VecDeque;
 use syntax::errors::Applicability;
 use syntax::symbol::kw;
@@ -22,7 +22,7 @@ use syntax_pos::Span;
 mod region_name;
 mod var_name;
 
-crate use self::region_name::{RegionName, RegionNameSource};
+crate use self::region_name::{RegionName, RegionNameSource, RegionErrorNamingCtx};
 
 impl ConstraintDescription for ConstraintCategory {
     fn description(&self) -> &'static str {
@@ -52,6 +52,30 @@ enum Trace {
     StartRegion,
     FromOutlivesConstraint(OutlivesConstraint),
     NotVisited,
+}
+
+/// Various pieces of state used when reporting borrow checker errors.
+pub struct ErrorReportingCtx<'a, 'b, 'tcx> {
+    rinfcx: &'b RegionInferenceContext<'tcx>,
+    infcx: &'b InferCtxt<'a, 'tcx>,
+
+    mir_def_id: DefId,
+    body: &'b Body<'tcx>,
+    upvars: &'b [Upvar],
+}
+
+/// Information about the various region constraints involved in a borrow checker error.
+#[derive(Clone, Debug)]
+pub struct ErrorConstraintInfo {
+    // fr: outlived_fr
+    fr: RegionVid,
+    fr_is_local: bool,
+    outlived_fr: RegionVid,
+    outlived_fr_is_local: bool,
+
+    // Category and span for best blame constraint
+    category: ConstraintCategory,
+    span: Span,
 }
 
 impl<'tcx> RegionInferenceContext<'tcx> {
@@ -257,16 +281,16 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// ```
     ///
     /// Here we would be invoked with `fr = 'a` and `outlived_fr = `'b`.
-    pub(super) fn report_error(
-        &self,
+    pub(super) fn report_error<'a>(
+        &'a self,
         body: &Body<'tcx>,
         upvars: &[Upvar],
-        infcx: &InferCtxt<'_, 'tcx>,
+        infcx: &'a InferCtxt<'a, 'tcx>,
         mir_def_id: DefId,
         fr: RegionVid,
         outlived_fr: RegionVid,
-        errors_buffer: &mut Vec<Diagnostic>,
-    ) {
+        renctx: &mut RegionErrorNamingCtx,
+    ) -> DiagnosticBuilder<'a> {
         debug!("report_error(fr={:?}, outlived_fr={:?})", fr, outlived_fr);
 
         let (category, _, span) = self.best_blame_constraint(body, fr, |r| {
@@ -279,8 +303,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let tables = infcx.tcx.typeck_tables_of(mir_def_id);
             let nice = NiceRegionError::new_from_span(infcx, span, o, f, Some(tables));
             if let Some(diag) = nice.try_report_from_nll() {
-                diag.buffer(errors_buffer);
-                return;
+                return diag;
             }
         }
 
@@ -293,45 +316,35 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             "report_error: fr_is_local={:?} outlived_fr_is_local={:?} category={:?}",
             fr_is_local, outlived_fr_is_local, category
         );
+
+        let errctx = ErrorReportingCtx {
+            rinfcx: self,
+            infcx,
+            mir_def_id,
+            body,
+            upvars,
+        };
+
+        let errci = ErrorConstraintInfo {
+            fr, outlived_fr, fr_is_local, outlived_fr_is_local, category, span
+        };
+
         match (category, fr_is_local, outlived_fr_is_local) {
             (ConstraintCategory::Return, true, false) if self.is_closure_fn_mut(infcx, fr) => {
-                self.report_fnmut_error(
-                    body,
-                    upvars,
-                    infcx,
-                    mir_def_id,
-                    fr,
-                    outlived_fr,
-                    span,
-                    errors_buffer,
-                )
+                self.report_fnmut_error(&errctx, &errci, renctx)
             }
             (ConstraintCategory::Assignment, true, false)
-            | (ConstraintCategory::CallArgument, true, false) => self.report_escaping_data_error(
-                body,
-                upvars,
-                infcx,
-                mir_def_id,
-                fr,
-                outlived_fr,
-                category,
-                span,
-                errors_buffer,
-            ),
-            _ => self.report_general_error(
-                body,
-                upvars,
-                infcx,
-                mir_def_id,
-                fr,
-                fr_is_local,
-                outlived_fr,
-                outlived_fr_is_local,
-                category,
-                span,
-                errors_buffer,
-            ),
-        };
+            | (ConstraintCategory::CallArgument, true, false) => {
+                let mut db = self.report_escaping_data_error(&errctx, &errci, renctx);
+
+                db
+            }
+            _ => {
+                let mut db = self.report_general_error(&errctx, &errci, renctx);
+
+                db
+            }
+        }
     }
 
     /// We have a constraint `fr1: fr2` that is not satisfied, where
@@ -379,19 +392,19 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// ```
     fn report_fnmut_error(
         &self,
-        body: &Body<'tcx>,
-        upvars: &[Upvar],
-        infcx: &InferCtxt<'_, 'tcx>,
-        mir_def_id: DefId,
-        _fr: RegionVid,
-        outlived_fr: RegionVid,
-        span: Span,
-        errors_buffer: &mut Vec<Diagnostic>,
-    ) {
-        let mut diag = infcx
+        errctx: &ErrorReportingCtx<'_, '_, 'tcx>,
+        errci: &ErrorConstraintInfo,
+        renctx: &mut RegionErrorNamingCtx,
+    ) -> DiagnosticBuilder<'_> {
+        let ErrorConstraintInfo {
+            outlived_fr, span, ..
+        } = errci;
+
+        let mut diag = errctx
+            .infcx
             .tcx
             .sess
-            .struct_span_err(span, "captured variable cannot escape `FnMut` closure body");
+            .struct_span_err(*span, "captured variable cannot escape `FnMut` closure body");
 
         // We should check if the return type of this closure is in fact a closure - in that
         // case, we can special case the error further.
@@ -403,11 +416,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             "returns a reference to a captured variable which escapes the closure body"
         };
 
-        diag.span_label(span, message);
+        diag.span_label(*span, message);
 
-        match self.give_region_a_name(infcx, body, upvars, mir_def_id, outlived_fr, &mut 1)
-            .unwrap().source
-        {
+        match self.give_region_a_name(errctx, renctx, *outlived_fr).unwrap().source {
             RegionNameSource::NamedEarlyBoundRegion(fr_span)
             | RegionNameSource::NamedFreeRegion(fr_span)
             | RegionNameSource::SynthesizedFreeEnvRegion(fr_span, _)
@@ -427,7 +438,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         );
         diag.note("...therefore, they cannot allow references to captured variables to escape");
 
-        diag.buffer(errors_buffer);
+        diag
     }
 
     /// Reports a error specifically for when data is escaping a closure.
@@ -444,20 +455,22 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// ```
     fn report_escaping_data_error(
         &self,
-        body: &Body<'tcx>,
-        upvars: &[Upvar],
-        infcx: &InferCtxt<'_, 'tcx>,
-        mir_def_id: DefId,
-        fr: RegionVid,
-        outlived_fr: RegionVid,
-        category: ConstraintCategory,
-        span: Span,
-        errors_buffer: &mut Vec<Diagnostic>,
-    ) {
+        errctx: &ErrorReportingCtx<'_, '_, 'tcx>,
+        errci: &ErrorConstraintInfo,
+        renctx: &mut RegionErrorNamingCtx,
+    ) -> DiagnosticBuilder<'_> {
+        let ErrorReportingCtx {
+            infcx, body, upvars, ..
+        } = errctx;
+
+        let ErrorConstraintInfo {
+            span, category, ..
+        } = errci;
+
         let fr_name_and_span =
-            self.get_var_name_and_span_for_region(infcx.tcx, body, upvars, fr);
+            self.get_var_name_and_span_for_region(infcx.tcx, body, upvars, errci.fr);
         let outlived_fr_name_and_span =
-            self.get_var_name_and_span_for_region(infcx.tcx, body, upvars, outlived_fr);
+            self.get_var_name_and_span_for_region(infcx.tcx, body, upvars, errci.outlived_fr);
 
         let escapes_from = match self.universal_regions.defining_ty {
             DefiningTy::Closure(..) => "closure",
@@ -469,27 +482,23 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // Revert to the normal error in these cases.
         // Assignments aren't "escapes" in function items.
         if (fr_name_and_span.is_none() && outlived_fr_name_and_span.is_none())
-            || (category == ConstraintCategory::Assignment && escapes_from == "function")
+            || (*category == ConstraintCategory::Assignment && escapes_from == "function")
             || escapes_from == "const"
         {
             return self.report_general_error(
-                body,
-                upvars,
-                infcx,
-                mir_def_id,
-                fr,
-                true,
-                outlived_fr,
-                false,
-                category,
-                span,
-                errors_buffer,
+                errctx,
+                &ErrorConstraintInfo {
+                    fr_is_local: true,
+                    outlived_fr_is_local: false,
+                    .. *errci
+                },
+                renctx,
             );
         }
 
         let mut diag = borrowck_errors::borrowed_data_escapes_closure(
             infcx.tcx,
-            span,
+            *span,
             escapes_from,
         );
 
@@ -513,12 +522,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             );
 
             diag.span_label(
-                span,
+                *span,
                 format!("`{}` escapes the {} body here", fr_name, escapes_from),
             );
         }
 
-        diag.buffer(errors_buffer);
+        diag
     }
 
     /// Reports a region inference error for the general case with named/synthesized lifetimes to
@@ -538,41 +547,37 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     /// ```
     fn report_general_error(
         &self,
-        body: &Body<'tcx>,
-        upvars: &[Upvar],
-        infcx: &InferCtxt<'_, 'tcx>,
-        mir_def_id: DefId,
-        fr: RegionVid,
-        fr_is_local: bool,
-        outlived_fr: RegionVid,
-        outlived_fr_is_local: bool,
-        category: ConstraintCategory,
-        span: Span,
-        errors_buffer: &mut Vec<Diagnostic>,
-    ) {
+        errctx: &ErrorReportingCtx<'_, '_, 'tcx>,
+        errci: &ErrorConstraintInfo,
+        renctx: &mut RegionErrorNamingCtx,
+    ) -> DiagnosticBuilder<'_> {
+        let ErrorReportingCtx {
+            infcx, mir_def_id, ..
+        } = errctx;
+        let ErrorConstraintInfo {
+            fr, fr_is_local, outlived_fr, outlived_fr_is_local, span, category, ..
+        } = errci;
+
         let mut diag = infcx.tcx.sess.struct_span_err(
-            span,
+            *span,
             "lifetime may not live long enough"
         );
 
-        let counter = &mut 1;
-        let fr_name = self.give_region_a_name(
-            infcx, body, upvars, mir_def_id, fr, counter).unwrap();
-        fr_name.highlight_region_name(&mut diag);
-        let outlived_fr_name =
-            self.give_region_a_name(infcx, body, upvars, mir_def_id, outlived_fr, counter).unwrap();
-        outlived_fr_name.highlight_region_name(&mut diag);
-
-        let mir_def_name = if infcx.tcx.is_closure(mir_def_id) {
+        let mir_def_name = if infcx.tcx.is_closure(*mir_def_id) {
             "closure"
         } else {
             "function"
         };
 
+        let fr_name = self.give_region_a_name(errctx, renctx, *fr).unwrap();
+        fr_name.highlight_region_name(&mut diag);
+        let outlived_fr_name = self.give_region_a_name(errctx, renctx, *outlived_fr).unwrap();
+        outlived_fr_name.highlight_region_name(&mut diag);
+
         match (category, outlived_fr_is_local, fr_is_local) {
             (ConstraintCategory::Return, true, _) => {
                 diag.span_label(
-                    span,
+                    *span,
                     format!(
                         "{} was supposed to return data with lifetime `{}` but it is returning \
                          data with lifetime `{}`",
@@ -582,7 +587,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
             _ => {
                 diag.span_label(
-                    span,
+                    *span,
                     format!(
                         "{}requires that `{}` must outlive `{}`",
                         category.description(),
@@ -593,9 +598,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
         }
 
-        self.add_static_impl_trait_suggestion(infcx, &mut diag, fr, fr_name, outlived_fr);
+        self.add_static_impl_trait_suggestion(infcx, &mut diag, *fr, fr_name, *outlived_fr);
 
-        diag.buffer(errors_buffer);
+        diag
     }
 
     /// Adds a suggestion to errors where a `impl Trait` is returned.
@@ -704,8 +709,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             borrow_region,
             |r| self.provides_universal_region(r, borrow_region, outlived_region)
         );
-        let outlived_fr_name =
-            self.give_region_a_name(infcx, body, upvars, mir_def_id, outlived_region, &mut 1);
+
+        let mut renctx = RegionErrorNamingCtx::new();
+        let errctx = ErrorReportingCtx {
+            infcx, body, upvars, mir_def_id,
+            rinfcx: self,
+        };
+        let outlived_fr_name = self.give_region_a_name(&errctx, &mut renctx, outlived_region);
+
         (category, from_closure, span, outlived_fr_name)
     }
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -56,6 +56,7 @@ enum Trace {
 
 /// Various pieces of state used when reporting borrow checker errors.
 pub struct ErrorReportingCtx<'a, 'b, 'tcx> {
+    #[allow(dead_code)] // FIXME(mark-i-m): used by outlives suggestions
     rinfcx: &'b RegionInferenceContext<'tcx>,
     infcx: &'b InferCtxt<'a, 'tcx>,
 
@@ -335,12 +336,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
             (ConstraintCategory::Assignment, true, false)
             | (ConstraintCategory::CallArgument, true, false) => {
-                let mut db = self.report_escaping_data_error(&errctx, &errci, renctx);
+                let db = self.report_escaping_data_error(&errctx, &errci, renctx);
 
                 db
             }
             _ => {
-                let mut db = self.report_general_error(&errctx, &errci, renctx);
+                let db = self.report_general_error(&errctx, &errci, renctx);
 
                 db
             }

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -11,7 +11,6 @@ use crate::borrow_check::nll::{
     region_infer::values::{
         PlaceholderIndices, RegionElement, ToElementIndex
     },
-    region_infer::error_reporting::outlives_suggestion::OutlivesSuggestionBuilder,
     type_check::{free_region_relations::UniversalRegionRelations, Locations},
 };
 use crate::borrow_check::Upvar;
@@ -1340,6 +1339,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         mir_def_id,
                         fr,
                         &mut propagated_outlives_requirements,
+                        errors_buffer,
                         region_naming,
                     );
                 }
@@ -1371,6 +1371,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         mir_def_id: DefId,
         longer_fr: RegionVid,
         propagated_outlives_requirements: &mut Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
+        errors_buffer: &mut Vec<Diagnostic>,
         region_naming: &mut RegionErrorNamingCtx,
     ) {
         debug!("check_universal_region(fr={:?})", longer_fr);
@@ -1398,6 +1399,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 upvars,
                 mir_def_id,
                 propagated_outlives_requirements,
+                errors_buffer,
                 region_naming,
             );
             return;
@@ -1414,6 +1416,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 upvars,
                 mir_def_id,
                 propagated_outlives_requirements,
+                errors_buffer,
                 region_naming,
             ) {
                 // continuing to iterate just reports more errors than necessary
@@ -1435,6 +1438,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         upvars: &[Upvar],
         mir_def_id: DefId,
         propagated_outlives_requirements: &mut Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
+        errors_buffer: &mut Vec<Diagnostic>,
         region_naming: &mut RegionErrorNamingCtx,
     ) -> Option<ErrorReported> {
         // If it is known that `fr: o`, carry on.

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1,15 +1,21 @@
-use super::universal_regions::UniversalRegions;
-use crate::borrow_check::nll::constraints::graph::NormalConstraintGraph;
-use crate::borrow_check::nll::constraints::{
-    ConstraintSccIndex, OutlivesConstraint, OutlivesConstraintSet,
+use std::rc::Rc;
+
+use crate::borrow_check::nll::{
+    constraints::{
+        graph::NormalConstraintGraph,
+        ConstraintSccIndex,
+        OutlivesConstraint,
+        OutlivesConstraintSet,
+    },
+    member_constraints::{MemberConstraintSet, NllMemberConstraintIndex},
+    region_infer::values::{
+        PlaceholderIndices, RegionElement, ToElementIndex
+    },
+    region_infer::error_reporting::outlives_suggestion::OutlivesSuggestionBuilder,
+    type_check::{free_region_relations::UniversalRegionRelations, Locations},
 };
-use crate::borrow_check::nll::member_constraints::{MemberConstraintSet, NllMemberConstraintIndex};
-use crate::borrow_check::nll::region_infer::values::{
-    PlaceholderIndices, RegionElement, ToElementIndex,
-};
-use crate::borrow_check::nll::type_check::free_region_relations::UniversalRegionRelations;
-use crate::borrow_check::nll::type_check::Locations;
 use crate::borrow_check::Upvar;
+
 use rustc::hir::def_id::DefId;
 use rustc::infer::canonical::QueryOutlivesConstraint;
 use rustc::infer::opaque_types;
@@ -31,16 +37,16 @@ use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_errors::{Diagnostic, DiagnosticBuilder};
 use syntax_pos::Span;
 
-use std::rc::Rc;
+crate use self::error_reporting::{RegionName, RegionNameSource, RegionErrorNamingCtx};
+use self::values::{LivenessValues, RegionValueElements, RegionValues};
+use super::universal_regions::UniversalRegions;
+use super::ToRegionVid;
 
 mod dump_mir;
 mod error_reporting;
-crate use self::error_reporting::{RegionName, RegionNameSource};
 mod graphviz;
-pub mod values;
-use self::values::{LivenessValues, RegionValueElements, RegionValues};
 
-use super::ToRegionVid;
+pub mod values;
 
 pub struct RegionInferenceContext<'tcx> {
     /// Contains the definition for every region variable. Region
@@ -487,6 +493,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             errors_buffer,
         );
 
+        // If we produce any errors, we keep track of the names of all regions, so that we can use
+        // the same error names in any suggestions we produce. Note that we need names to be unique
+        // across different errors for the same MIR def so that we can make suggestions that fix
+        // multiple problems.
+        let mut region_naming = RegionErrorNamingCtx::new();
+
         self.check_universal_regions(
             infcx,
             body,
@@ -494,6 +506,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             mir_def_id,
             outlives_requirements.as_mut(),
             errors_buffer,
+            &mut region_naming,
         );
 
         self.check_member_constraints(infcx, mir_def_id, errors_buffer);
@@ -1312,6 +1325,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         mir_def_id: DefId,
         mut propagated_outlives_requirements: Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
         errors_buffer: &mut Vec<Diagnostic>,
+        region_naming: &mut RegionErrorNamingCtx,
     ) {
         for (fr, fr_definition) in self.definitions.iter_enumerated() {
             match fr_definition.origin {
@@ -1326,7 +1340,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                         mir_def_id,
                         fr,
                         &mut propagated_outlives_requirements,
-                        errors_buffer,
+                        region_naming,
                     );
                 }
 
@@ -1357,7 +1371,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         mir_def_id: DefId,
         longer_fr: RegionVid,
         propagated_outlives_requirements: &mut Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
-        errors_buffer: &mut Vec<Diagnostic>,
+        region_naming: &mut RegionErrorNamingCtx,
     ) {
         debug!("check_universal_region(fr={:?})", longer_fr);
 
@@ -1384,7 +1398,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 upvars,
                 mir_def_id,
                 propagated_outlives_requirements,
-                errors_buffer,
+                region_naming,
             );
             return;
         }
@@ -1400,9 +1414,13 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 upvars,
                 mir_def_id,
                 propagated_outlives_requirements,
-                errors_buffer,
+                region_naming,
             ) {
                 // continuing to iterate just reports more errors than necessary
+                //
+                // FIXME It would also allow us to report more Outlives Suggestions, though, so
+                // it's not clear that that's a bad thing. Somebody should try commenting out this
+                // line and see it is actually a regression.
                 return;
             }
         }
@@ -1417,7 +1435,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         upvars: &[Upvar],
         mir_def_id: DefId,
         propagated_outlives_requirements: &mut Option<&mut Vec<ClosureOutlivesRequirement<'tcx>>>,
-        errors_buffer: &mut Vec<Diagnostic>,
+        region_naming: &mut RegionErrorNamingCtx,
     ) -> Option<ErrorReported> {
         // If it is known that `fr: o`, carry on.
         if self.universal_region_relations.outlives(longer_fr, shorter_fr) {
@@ -1466,7 +1484,18 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         //
         // Note: in this case, we use the unapproximated regions to report the
         // error. This gives better error messages in some cases.
-        self.report_error(body, upvars, infcx, mir_def_id, longer_fr, shorter_fr, errors_buffer);
+        let db = self.report_error(
+            body,
+            upvars,
+            infcx,
+            mir_def_id,
+            longer_fr,
+            shorter_fr,
+            region_naming,
+        );
+
+        db.buffer(errors_buffer);
+
         Some(ErrorReported)
     }
 

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -2417,9 +2417,12 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             "add_reborrow_constraint({:?}, {:?}, {:?})",
             location, borrow_region, borrowed_place
         );
-        for (i, elem) in borrowed_place.projection.iter().enumerate().rev() {
+
+        let mut cursor = &*borrowed_place.projection;
+        while let [proj_base @ .., elem] = cursor {
+            cursor = proj_base;
+
             debug!("add_reborrow_constraint - iteration {:?}", elem);
-            let proj_base = &borrowed_place.projection[..i];
 
             match elem {
                 ProjectionElem::Deref => {

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1296,8 +1296,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Insert a Shallow borrow of the prefixes of any fake borrows.
         for place in fake_borrows
         {
-            for (i, elem) in place.projection.iter().enumerate().rev() {
-                let proj_base = &place.projection[..i];
+            let mut cursor = &*place.projection;
+            while let [proj_base @ .., elem] = cursor {
+                cursor = proj_base;
 
                 if let ProjectionElem::Deref = elem {
                     // Insert a shallow borrow after a deref. For other

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -407,8 +407,9 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
         place: &Place<'tcx>,
         is_mut_use: bool,
     ) {
-        for (i, elem) in place.projection.iter().enumerate().rev() {
-            let proj_base = &place.projection[..i];
+        let mut cursor = &*place.projection;
+        while let [proj_base @ .., elem] = cursor {
+            cursor = proj_base;
 
             match elem {
                 ProjectionElem::Field(..) => {

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -38,8 +38,9 @@ fn is_within_packed<'tcx, L>(tcx: TyCtxt<'tcx>, local_decls: &L, place: &Place<'
 where
     L: HasLocalDecls<'tcx>,
 {
-    for (i, elem) in place.projection.iter().enumerate().rev() {
-        let proj_base = &place.projection[..i];
+    let mut cursor = &*place.projection;
+    while let [proj_base @ .., elem] = cursor {
+        cursor = proj_base;
 
         match elem {
             // encountered a Deref, which is ABI-aligned

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2548,16 +2548,24 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     /// As `instantiate_type_scheme`, but for the bounds found in a
     /// generic type scheme.
-    fn instantiate_bounds(&self, span: Span, def_id: DefId, substs: SubstsRef<'tcx>)
-                          -> ty::InstantiatedPredicates<'tcx> {
+    fn instantiate_bounds(
+        &self,
+        span: Span,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+    ) -> (ty::InstantiatedPredicates<'tcx>, Vec<Span>) {
         let bounds = self.tcx.predicates_of(def_id);
+        let spans: Vec<Span> = bounds.predicates.iter().map(|(_, span)| *span).collect();
         let result = bounds.instantiate(self.tcx, substs);
         let result = self.normalize_associated_types_in(span, &result);
-        debug!("instantiate_bounds(bounds={:?}, substs={:?}) = {:?}",
+        debug!(
+            "instantiate_bounds(bounds={:?}, substs={:?}) = {:?}, {:?}",
                bounds,
                substs,
-               result);
-        result
+            result,
+            spans,
+        );
+        (result, spans)
     }
 
     /// Replaces the opaque types from the given value with type variables,
@@ -3120,8 +3128,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // All the input types from the fn signature must outlive the call
         // so as to validate implied bounds.
-        for &fn_input_ty in fn_inputs {
-            self.register_wf_obligation(fn_input_ty, sp, traits::MiscObligation);
+        for (fn_input_ty, arg_expr) in fn_inputs.iter().zip(args.iter()) {
+            self.register_wf_obligation(fn_input_ty, arg_expr.span, traits::MiscObligation);
         }
 
         let expected_arg_count = fn_inputs.len();
@@ -3482,7 +3490,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self.write_user_type_annotation_from_substs(hir_id, did, substs, None);
 
             // Check bounds on type arguments used in the path.
-            let bounds = self.instantiate_bounds(path_span, did, substs);
+            let (bounds, _) = self.instantiate_bounds(path_span, did, substs);
             let cause = traits::ObligationCause::new(path_span, self.body_id,
                                                      traits::ItemObligation(did));
             self.add_obligations_for_parameters(cause, &bounds);
@@ -4605,10 +4613,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Add all the obligations that are required, substituting and
         // normalized appropriately.
-        let bounds = self.instantiate_bounds(span, def_id, &substs);
-        self.add_obligations_for_parameters(
-            traits::ObligationCause::new(span, self.body_id, traits::ItemObligation(def_id)),
-            &bounds);
+        let (bounds, spans) = self.instantiate_bounds(span, def_id, &substs);
+
+        for (i, mut obligation) in traits::predicates_for_generics(
+            traits::ObligationCause::new(
+                span,
+                self.body_id,
+                traits::ItemObligation(def_id),
+            ),
+            self.param_env,
+            &bounds,
+        ).into_iter().enumerate() {
+            // This makes the error point at the bound, but we want to point at the argument
+            if let Some(span) = spans.get(i) {
+                obligation.cause.code = traits::BindingObligation(def_id, *span);
+            }
+            self.register_predicate(obligation);
+        }
 
         // Substitute the values for the type parameters into the type of
         // the referenced item.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4611,25 +4611,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // First, store the "user substs" for later.
         self.write_user_type_annotation_from_substs(hir_id, def_id, substs, user_self_ty);
 
-        // Add all the obligations that are required, substituting and
-        // normalized appropriately.
-        let (bounds, spans) = self.instantiate_bounds(span, def_id, &substs);
-
-        for (i, mut obligation) in traits::predicates_for_generics(
-            traits::ObligationCause::new(
-                span,
-                self.body_id,
-                traits::ItemObligation(def_id),
-            ),
-            self.param_env,
-            &bounds,
-        ).into_iter().enumerate() {
-            // This makes the error point at the bound, but we want to point at the argument
-            if let Some(span) = spans.get(i) {
-                obligation.cause.code = traits::BindingObligation(def_id, *span);
-            }
-            self.register_predicate(obligation);
-        }
+        self.add_required_obligations(span, def_id, &substs);
 
         // Substitute the values for the type parameters into the type of
         // the referenced item.
@@ -4664,6 +4646,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.write_substs(hir_id, substs);
 
         (ty_substituted, res)
+    }
+
+    /// Add all the obligations that are required, substituting and normalized appropriately.
+    fn add_required_obligations(&self, span: Span, def_id: DefId, substs: &SubstsRef<'tcx>) {
+        let (bounds, spans) = self.instantiate_bounds(span, def_id, &substs);
+
+        for (i, mut obligation) in traits::predicates_for_generics(
+            traits::ObligationCause::new(
+                span,
+                self.body_id,
+                traits::ItemObligation(def_id),
+            ),
+            self.param_env,
+            &bounds,
+        ).into_iter().enumerate() {
+            // This makes the error point at the bound, but we want to point at the argument
+            if let Some(span) = spans.get(i) {
+                obligation.cause.code = traits::BindingObligation(def_id, *span);
+            }
+            self.register_predicate(obligation);
+        }
     }
 
     fn check_rustc_args_require_const(&self,

--- a/src/libsyntax/parse/parser/path.rs
+++ b/src/libsyntax/parse/parser/path.rs
@@ -197,7 +197,7 @@ impl<'a> Parser<'a> {
                 let (args, constraints) =
                     self.parse_generic_args_with_leaning_angle_bracket_recovery(style, lo)?;
                 self.expect_gt()?;
-                let span = ident.span.to(self.prev_span);
+                let span = lo.to(self.prev_span);
                 AngleBracketedArgs { args, constraints, span }.into()
             } else {
                 // `(T, U) -> R`

--- a/src/libsyntax/parse/parser/path.rs
+++ b/src/libsyntax/parse/parser/path.rs
@@ -129,10 +129,11 @@ impl<'a> Parser<'a> {
         self.parse_path(style)
     }
 
-    crate fn parse_path_segments(&mut self,
-                           segments: &mut Vec<PathSegment>,
-                           style: PathStyle)
-                           -> PResult<'a, ()> {
+    crate fn parse_path_segments(
+        &mut self,
+        segments: &mut Vec<PathSegment>,
+        style: PathStyle,
+    ) -> PResult<'a, ()> {
         loop {
             let segment = self.parse_path_segment(style)?;
             if style == PathStyle::Expr {
@@ -196,12 +197,12 @@ impl<'a> Parser<'a> {
                 let (args, constraints) =
                     self.parse_generic_args_with_leaning_angle_bracket_recovery(style, lo)?;
                 self.expect_gt()?;
-                let span = lo.to(self.prev_span);
+                let span = ident.span.to(self.prev_span);
                 AngleBracketedArgs { args, constraints, span }.into()
             } else {
                 // `(T, U) -> R`
                 let (inputs, _) = self.parse_paren_comma_seq(|p| p.parse_ty())?;
-                let span = lo.to(self.prev_span);
+                let span = ident.span.to(self.prev_span);
                 let output = if self.eat(&token::RArrow) {
                     Some(self.parse_ty_common(false, false, false)?)
                 } else {

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -7,7 +7,7 @@ LL |     f1(|_: (), _: ()| {});
    |     expected signature of `for<'r, 's> fn(&'r (), &'s ()) -> _`
 ...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   | ------------------------------------ required by `f1`
+   |    --                   ------------ required by this bound in `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:2:5
@@ -18,7 +18,7 @@ LL |     f1(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &()) -> _`
 ...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   | ------------------------------------ required by `f1`
+   |    --                     ---------- required by this bound in `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -29,7 +29,7 @@ LL |     f2(|_: (), _: ()| {});
    |     expected signature of `for<'a, 'r> fn(&'a (), &'r ()) -> _`
 ...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   | ----------------------------------------------- required by `f2`
+   |    --                   ----------------------- required by this bound in `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -40,7 +40,7 @@ LL |     f2(|_: (), _: ()| {});
    |     expected signature of `fn(&'a (), &()) -> _`
 ...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   | ----------------------------------------------- required by `f2`
+   |    --                             ------------- required by this bound in `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -51,7 +51,7 @@ LL |     f3(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&(), &'r ()) -> _`
 ...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   | ------------------------------------------- required by `f3`
+   |    --                       --------------- required by this bound in `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -62,7 +62,7 @@ LL |     f3(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &()) -> _`
 ...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   | ------------------------------------------- required by `f3`
+   |    --                         ------------- required by this bound in `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -73,7 +73,7 @@ LL |     f4(|_: (), _: ()| {});
    |     expected signature of `for<'s, 'r> fn(&'s (), &'r ()) -> _`
 ...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   | ----------------------------------------------- required by `f4`
+   |    --                   ----------------------- required by this bound in `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -84,7 +84,7 @@ LL |     f4(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &'r ()) -> _`
 ...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   | ----------------------------------------------- required by `f4`
+   |    --                             ------------- required by this bound in `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -95,7 +95,7 @@ LL |     f5(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), &'r ()) -> _`
 ...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   | -------------------------------------------------- required by `f5`
+   |    --                   -------------------------- required by this bound in `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -106,7 +106,7 @@ LL |     f5(|_: (), _: ()| {});
    |     expected signature of `fn(&'r (), &'r ()) -> _`
 ...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   | -------------------------------------------------- required by `f5`
+   |    --                             ---------------- required by this bound in `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -117,7 +117,7 @@ LL |     g1(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>) -> _`
 ...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   | ------------------------------------------------- required by `g1`
+   |    --                   ------------------------- required by this bound in `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -128,7 +128,7 @@ LL |     g1(|_: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   | ------------------------------------------------- required by `g1`
+   |    --                     ----------------------- required by this bound in `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
@@ -139,7 +139,7 @@ LL |     g2(|_: (), _: ()| {});
    |     expected signature of `for<'r> fn(&'r (), for<'s> fn(&'s ())) -> _`
 ...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   | ---------------------------------------- required by `g2`
+   |    --                   ---------------- required by this bound in `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
@@ -150,7 +150,7 @@ LL |     g2(|_: (), _: ()| {});
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   | ---------------------------------------- required by `g2`
+   |    --                     -------------- required by this bound in `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
@@ -161,7 +161,7 @@ LL |     g3(|_: (), _: ()| {});
    |     expected signature of `for<'s> fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   | ------------------------------------------------------------ required by `g3`
+   |    --                   ------------------------------------ required by this bound in `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
@@ -172,7 +172,7 @@ LL |     g3(|_: (), _: ()| {});
    |     expected signature of `fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   | ------------------------------------------------------------ required by `g3`
+   |    --                             -------------------------- required by this bound in `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
@@ -183,7 +183,7 @@ LL |     g4(|_: (), _: ()| {});
    |     expected signature of `for<'s> fn(&'s (), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   | --------------------------------------------------- required by `g4`
+   |    --                   --------------------------- required by this bound in `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
@@ -194,7 +194,7 @@ LL |     g4(|_: (), _: ()| {});
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   | --------------------------------------------------- required by `g4`
+   |    --                     ------------------------- required by this bound in `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
@@ -205,7 +205,7 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `for<'r, 's> fn(&'r (), std::boxed::Box<(dyn for<'t0> std::ops::Fn(&'t0 ()) + 'static)>, &'s (), for<'t0, 't1> fn(&'t0 (), &'t1 ())) -> _`
 ...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   | -------------------------------------------------------------------- required by `h1`
+   |    --                   -------------------------------------------- required by this bound in `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
@@ -216,7 +216,7 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &(), for<'r, 's> fn(&'r (), &'s ())) -> _`
 ...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   | -------------------------------------------------------------------- required by `h1`
+   |    --                     ------------------------------------------ required by this bound in `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
@@ -227,7 +227,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `for<'r, 't0> fn(&'r (), std::boxed::Box<(dyn for<'s> std::ops::Fn(&'s ()) + 'static)>, &'t0 (), for<'s, 't1> fn(&'s (), &'t1 ())) -> _`
 ...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   | --------------------------------------------------------------------------------- required by `h2`
+   |    --                   --------------------------------------------------------- required by this bound in `h2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
@@ -238,7 +238,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &'t0 (), for<'r, 's> fn(&'r (), &'s ())) -> _`
 ...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   | --------------------------------------------------------------------------------- required by `h2`
+   |    --                              ---------------------------------------------- required by this bound in `h2`
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/anonymous-higher-ranked-lifetime.stderr
+++ b/src/test/ui/anonymous-higher-ranked-lifetime.stderr
@@ -18,7 +18,7 @@ LL |     f1(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &()) -> _`
 ...
 LL | fn f1<F>(_: F) where F: Fn(&(), &()) {}
-   |    --                     ---------- required by this bound in `f1`
+   |    --                   ------------ required by this bound in `f1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:4:5
@@ -40,7 +40,7 @@ LL |     f2(|_: (), _: ()| {});
    |     expected signature of `fn(&'a (), &()) -> _`
 ...
 LL | fn f2<F>(_: F) where F: for<'a> Fn(&'a (), &()) {}
-   |    --                             ------------- required by this bound in `f2`
+   |    --                           --------------- required by this bound in `f2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:6:5
@@ -62,7 +62,7 @@ LL |     f3(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &()) -> _`
 ...
 LL | fn f3<'a, F>(_: F) where F: Fn(&'a (), &()) {}
-   |    --                         ------------- required by this bound in `f3`
+   |    --                       --------------- required by this bound in `f3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:8:5
@@ -84,7 +84,7 @@ LL |     f4(|_: (), _: ()| {});
    |     expected signature of `fn(&(), &'r ()) -> _`
 ...
 LL | fn f4<F>(_: F) where F: for<'r> Fn(&(), &'r ()) {}
-   |    --                             ------------- required by this bound in `f4`
+   |    --                           --------------- required by this bound in `f4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:10:5
@@ -106,7 +106,7 @@ LL |     f5(|_: (), _: ()| {});
    |     expected signature of `fn(&'r (), &'r ()) -> _`
 ...
 LL | fn f5<F>(_: F) where F: for<'r> Fn(&'r (), &'r ()) {}
-   |    --                             ---------------- required by this bound in `f5`
+   |    --                           ------------------ required by this bound in `f5`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:12:5
@@ -128,7 +128,7 @@ LL |     g1(|_: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>) {}
-   |    --                     ----------------------- required by this bound in `g1`
+   |    --                   ------------------------- required by this bound in `g1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:14:5
@@ -150,7 +150,7 @@ LL |     g2(|_: (), _: ()| {});
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g2<F>(_: F) where F: Fn(&(), fn(&())) {}
-   |    --                     -------------- required by this bound in `g2`
+   |    --                   ---------------- required by this bound in `g2`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:16:5
@@ -172,7 +172,7 @@ LL |     g3(|_: (), _: ()| {});
    |     expected signature of `fn(&'s (), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>) -> _`
 ...
 LL | fn g3<F>(_: F) where F: for<'s> Fn(&'s (), Box<dyn Fn(&())>) {}
-   |    --                             -------------------------- required by this bound in `g3`
+   |    --                           ---------------------------- required by this bound in `g3`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:18:5
@@ -194,7 +194,7 @@ LL |     g4(|_: (), _: ()| {});
    |     expected signature of `fn(&(), for<'r> fn(&'r ())) -> _`
 ...
 LL | fn g4<F>(_: F) where F: Fn(&(), for<'r> fn(&'r ())) {}
-   |    --                     ------------------------- required by this bound in `g4`
+   |    --                   --------------------------- required by this bound in `g4`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:20:5
@@ -216,7 +216,7 @@ LL |     h1(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &(), for<'r, 's> fn(&'r (), &'s ())) -> _`
 ...
 LL | fn h1<F>(_: F) where F: Fn(&(), Box<dyn Fn(&())>, &(), fn(&(), &())) {}
-   |    --                     ------------------------------------------ required by this bound in `h1`
+   |    --                   -------------------------------------------- required by this bound in `h1`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/anonymous-higher-ranked-lifetime.rs:22:5
@@ -238,7 +238,7 @@ LL |     h2(|_: (), _: (), _: (), _: ()| {});
    |     expected signature of `fn(&(), std::boxed::Box<(dyn for<'r> std::ops::Fn(&'r ()) + 'static)>, &'t0 (), for<'r, 's> fn(&'r (), &'s ())) -> _`
 ...
 LL | fn h2<F>(_: F) where F: for<'t0> Fn(&(), Box<dyn Fn(&())>, &'t0 (), fn(&(), &())) {}
-   |    --                              ---------------------------------------------- required by this bound in `h2`
+   |    --                            ------------------------------------------------ required by this bound in `h2`
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
    |
 LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
-   | ------------------------------------ required by `blue_car`
+   |    --------       ---------- required by this bound in `blue_car`
 ...
 LL | fn b() { blue_car(ModelT); }
    |          ^^^^^^^^ expected struct `Black`, found struct `Blue`
@@ -14,7 +14,7 @@ error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
    |
 LL | fn black_car<C:Car<Color=Black>>(c: C) {
-   | -------------------------------------- required by `black_car`
+   |    ---------       ----------- required by this bound in `black_car`
 ...
 LL | fn c() { black_car(ModelU); }
    |          ^^^^^^^^^ expected struct `Blue`, found struct `Black`

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -11,7 +11,7 @@ error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:5
    |
 LL | fn foo1<I: Foo<A=Bar>>(x: I) {
-   | ---------------------------- required by `foo1`
+   |    ----        ----- required by this bound in `foo1`
 ...
 LL |     foo1(a);
    |     ^^^^ expected usize, found struct `Bar`

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -1,15 +1,13 @@
 error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:82:5
    |
-LL | / fn foo<T>()
-LL | |     where T : for<'x> TheTrait<&'x isize, A = &'x isize>
-LL | | {
-LL | |     // ok for IntStruct, but not UintStruct
-LL | | }
-   | |_- required by `foo`
+LL | fn foo<T>()
+   |    ---
+LL |     where T : for<'x> TheTrait<&'x isize, A = &'x isize>
+   |                                           ------------- required by this bound in `foo`
 ...
-LL |       foo::<UintStruct>();
-   |       ^^^^^^^^^^^^^^^^^ expected usize, found isize
+LL |     foo::<UintStruct>();
+   |     ^^^^^^^^^^^^^^^^^ expected usize, found isize
    |
    = note: expected type `&usize`
               found type `&isize`
@@ -17,15 +15,13 @@ LL |       foo::<UintStruct>();
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
   --> $DIR/associated-types-eq-hr.rs:86:5
    |
-LL | / fn bar<T>()
-LL | |     where T : for<'x> TheTrait<&'x isize, A = &'x usize>
-LL | | {
-LL | |     // ok for UintStruct, but not IntStruct
-LL | | }
-   | |_- required by `bar`
+LL | fn bar<T>()
+   |    ---
+LL |     where T : for<'x> TheTrait<&'x isize, A = &'x usize>
+   |                                           ------------- required by this bound in `bar`
 ...
-LL |       bar::<IntStruct>();
-   |       ^^^^^^^^^^^^^^^^ expected isize, found usize
+LL |     bar::<IntStruct>();
+   |     ^^^^^^^^^^^^^^^^ expected isize, found usize
    |
    = note: expected type `&isize`
               found type `&usize`
@@ -33,15 +29,13 @@ LL |       bar::<IntStruct>();
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
-LL | / fn tuple_one<T>()
-LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
-LL | | {
-LL | |     // not ok for tuple, two lifetimes and we pick first
-LL | | }
-   | |_- required by `tuple_one`
+LL | fn tuple_one<T>()
+   |    ---------
+LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
+   |               ---------------------------------------------------------- required by this bound in `tuple_one`
 ...
-LL |       tuple_one::<Tuple>();
-   |       ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
    |
    = help: the following implementations were found:
              <Tuple as TheTrait<(&'a isize, &'a isize)>>
@@ -49,28 +43,24 @@ LL |       tuple_one::<Tuple>();
 error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize, &'y isize)>>::A == &'x isize`
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
-LL | / fn tuple_one<T>()
-LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
-LL | | {
-LL | |     // not ok for tuple, two lifetimes and we pick first
-LL | | }
-   | |_- required by `tuple_one`
+LL | fn tuple_one<T>()
+   |    ---------
+LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'x isize>
+   |                                                           ------------- required by this bound in `tuple_one`
 ...
-LL |       tuple_one::<Tuple>();
-   |       ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
+LL |     tuple_one::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:97:5
    |
-LL | / fn tuple_two<T>()
-LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
-LL | | {
-LL | |     // not ok for tuple, two lifetimes and we pick second
-LL | | }
-   | |_- required by `tuple_two`
+LL | fn tuple_two<T>()
+   |    ---------
+LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
+   |               ---------------------------------------------------------- required by this bound in `tuple_two`
 ...
-LL |       tuple_two::<Tuple>();
-   |       ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
    |
    = help: the following implementations were found:
              <Tuple as TheTrait<(&'a isize, &'a isize)>>
@@ -78,28 +68,24 @@ LL |       tuple_two::<Tuple>();
 error[E0271]: type mismatch resolving `for<'x, 'y> <Tuple as TheTrait<(&'x isize, &'y isize)>>::A == &'y isize`
   --> $DIR/associated-types-eq-hr.rs:97:5
    |
-LL | / fn tuple_two<T>()
-LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
-LL | | {
-LL | |     // not ok for tuple, two lifetimes and we pick second
-LL | | }
-   | |_- required by `tuple_two`
+LL | fn tuple_two<T>()
+   |    ---------
+LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize), A = &'y isize>
+   |                                                           ------------- required by this bound in `tuple_two`
 ...
-LL |       tuple_two::<Tuple>();
-   |       ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
+LL |     tuple_two::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'x, found concrete lifetime
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:107:5
    |
-LL | / fn tuple_four<T>()
-LL | |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize)>
-LL | | {
-LL | |     // not ok for tuple, two lifetimes, and lifetime matching is invariant
-LL | | }
-   | |_- required by `tuple_four`
+LL | fn tuple_four<T>()
+   |    ----------
+LL |     where T : for<'x,'y> TheTrait<(&'x isize, &'y isize)>
+   |               ------------------------------------------- required by this bound in `tuple_four`
 ...
-LL |       tuple_four::<Tuple>();
-   |       ^^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
+LL |     tuple_four::<Tuple>();
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `for<'x, 'y> TheTrait<(&'x isize, &'y isize)>` is not implemented for `Tuple`
    |
    = help: the following implementations were found:
              <Tuple as TheTrait<(&'a isize, &'a isize)>>

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<Adapter<I> as Iterator>::Item == std::op
   --> $DIR/associated-types-issue-20346.rs:34:5
    |
 LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
-   | ------------------------------------------------ required by `is_iterator_of`
+   |    --------------                ------ required by this bound in `is_iterator_of`
 ...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found enum `std::option::Option`

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -5,7 +5,7 @@ LL |     want_y(t);
    |     ^^^^^^ expected associated type, found i32
 ...
 LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
-   | ------------------------------ required by `want_y`
+   |    ------       ----- required by this bound in `want_y`
    |
    = note: expected type `<T as Foo>::Y`
               found type `i32`
@@ -17,7 +17,7 @@ LL |     want_x(t);
    |     ^^^^^^ expected associated type, found u32
 ...
 LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
-   | ------------------------------ required by `want_x`
+   |    ------       ----- required by this bound in `want_x`
    |
    = note: expected type `<T as Foo>::X`
               found type `u32`

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:29:5
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   | -------------------------------- required by `f1`
+   |        --    --- required by this bound in `f1`
 ...
 LL |     f1(2u32, 4u32);
    |     ^^ the trait `Foo` is not implemented for `u32`
@@ -27,7 +27,7 @@ error[E0277]: the trait bound `u32: Foo` is not satisfied
   --> $DIR/associated-types-path-2.rs:35:5
    |
 LL | pub fn f1<T: Foo>(a: T, x: T::A) {}
-   | -------------------------------- required by `f1`
+   |        --    --- required by this bound in `f1`
 ...
 LL |     f1(2u32, 4i32);
    |     ^^ the trait `Foo` is not implemented for `u32`

--- a/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
+++ b/src/test/ui/associated-types/higher-ranked-projection.bad.stderr
@@ -1,13 +1,13 @@
 error[E0271]: type mismatch resolving `for<'a> <&'a _ as Mirror>::Image == _`
   --> $DIR/higher-ranked-projection.rs:25:5
    |
-LL | / fn foo<U, T>(_t: T)
-LL | |     where for<'a> &'a T: Mirror<Image=U>
-LL | | {}
-   | |__- required by `foo`
+LL | fn foo<U, T>(_t: T)
+   |    ---
+LL |     where for<'a> &'a T: Mirror<Image=U>
+   |                                 ------- required by this bound in `foo`
 ...
-LL |       foo(());
-   |       ^^^ expected bound lifetime parameter 'a, found concrete lifetime
+LL |     foo(());
+   |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:50:5
    |
 LL | fn assert_send(_: impl Send) {}
-   | ---------------------------- required by `assert_send`
+   |    -----------         ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(local_dropped_before_await());
    |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
@@ -19,7 +19,7 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:52:5
    |
 LL | fn assert_send(_: impl Send) {}
-   | ---------------------------- required by `assert_send`
+   |    -----------         ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(non_send_temporary_in_match());
    |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
@@ -36,7 +36,7 @@ error[E0277]: `dyn std::fmt::Write` cannot be sent between threads safely
   --> $DIR/async-fn-nonsend.rs:54:5
    |
 LL | fn assert_send(_: impl Send) {}
-   | ---------------------------- required by `assert_send`
+   |    -----------         ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ `dyn std::fmt::Write` cannot be sent between threads safely
@@ -55,7 +55,7 @@ error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between thr
   --> $DIR/async-fn-nonsend.rs:54:5
    |
 LL | fn assert_send(_: impl Send) {}
-   | ---------------------------- required by `assert_send`
+   |    -----------         ---- required by this bound in `assert_send`
 ...
 LL |     assert_send(non_sync_with_method_call());
    |     ^^^^^^^^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely

--- a/src/test/ui/async-await/issues/issue-62009-1.rs
+++ b/src/test/ui/async-await/issues/issue-62009-1.rs
@@ -1,4 +1,6 @@
 // edition:2018
+// ignore-musl
+// ^ due to stderr output differences
 
 async fn print_dur() {}
 

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -32,8 +32,11 @@ error[E0277]: the trait bound `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]: std:
    |
 LL |     (|_| 2333).await;
    |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]`
+   | 
+  ::: $SRC_DIR/libstd/future.rs:LL:COL
    |
-   = note: required by `std::future::poll_with_tls_context`
+LL |     F: Future
+   |        ------ required by this bound in `std::future::poll_with_tls_context`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -1,5 +1,5 @@
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009-1.rs:6:5
+  --> $DIR/issue-62009-1.rs:8:5
    |
 LL | fn main() {
    |    ---- this is not `async`
@@ -7,7 +7,7 @@ LL |     async { let (); }.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009-1.rs:8:5
+  --> $DIR/issue-62009-1.rs:10:5
    |
 LL |   fn main() {
    |      ---- this is not `async`
@@ -19,7 +19,7 @@ LL | |     }.await;
    | |___________^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/issue-62009-1.rs:12:5
+  --> $DIR/issue-62009-1.rs:14:5
    |
 LL | fn main() {
    |    ---- this is not `async`
@@ -27,11 +27,11 @@ LL | fn main() {
 LL |     (|_| 2333).await;
    |     ^^^^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
-error[E0277]: the trait bound `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]: std::future::Future` is not satisfied
-  --> $DIR/issue-62009-1.rs:12:5
+error[E0277]: the trait bound `[closure@$DIR/issue-62009-1.rs:14:5: 14:15]: std::future::Future` is not satisfied
+  --> $DIR/issue-62009-1.rs:14:5
    |
 LL |     (|_| 2333).await;
-   |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:12:5: 12:15]`
+   |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:14:5: 14:15]`
    | 
   ::: $SRC_DIR/libstd/future.rs:LL:COL
    |

--- a/src/test/ui/c-variadic/variadic-ffi-4.nll.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.nll.stderr
@@ -37,11 +37,11 @@ error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:20:5
    |
 LL | pub unsafe extern "C" fn no_escape3(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `core::ffi::VaListImpl<'1>`
+   |                                               -------                   ------- has type `core::ffi::VaListImpl<'2>`
    |                                               |
-   |                                               has type `&mut core::ffi::VaListImpl<'2>`
+   |                                               has type `&mut core::ffi::VaListImpl<'1>`
 LL |     *ap0 = ap1;
-   |     ^^^^ assignment requires that `'1` must outlive `'2`
+   |     ^^^^ assignment requires that `'2` must outlive `'1`
 
 error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:25:5
@@ -57,11 +57,11 @@ error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:25:5
    |
 LL | pub unsafe extern "C" fn no_escape4(_: usize, ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               ---                   ------- has type `core::ffi::VaListImpl<'1>`
+   |                                               ---                   ------- has type `core::ffi::VaListImpl<'2>`
    |                                               |
-   |                                               has type `&mut core::ffi::VaListImpl<'2>`
+   |                                               has type `&mut core::ffi::VaListImpl<'1>`
 LL |     ap0 = &mut ap1;
-   |     ^^^^^^^^^^^^^^ assignment requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^^^^^^ assignment requires that `'2` must outlive `'1`
 
 error[E0384]: cannot assign to immutable argument `ap0`
   --> $DIR/variadic-ffi-4.rs:25:5
@@ -99,11 +99,11 @@ error: lifetime may not live long enough
   --> $DIR/variadic-ffi-4.rs:33:12
    |
 LL | pub unsafe extern "C" fn no_escape5(_: usize, mut ap0: &mut VaListImpl, mut ap1: ...) {
-   |                                               -------                   ------- has type `core::ffi::VaListImpl<'1>`
+   |                                               -------                   ------- has type `core::ffi::VaListImpl<'2>`
    |                                               |
-   |                                               has type `&mut core::ffi::VaListImpl<'2>`
+   |                                               has type `&mut core::ffi::VaListImpl<'1>`
 LL |     *ap0 = ap1.clone();
-   |            ^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |            ^^^^^^^^^^^ argument requires that `'2` must outlive `'1`
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/chalkify/type_inference.stderr
+++ b/src/test/ui/chalkify/type_inference.stderr
@@ -11,7 +11,7 @@ error[E0277]: the trait bound `{float}: Bar` is not satisfied
   --> $DIR/type_inference.rs:25:5
    |
 LL | fn only_bar<T: Bar>(_x: T) { }
-   | -------------------------- required by `only_bar`
+   |    --------    --- required by this bound in `only_bar`
 ...
 LL |     only_bar(x);
    |     ^^^^^^^^ the trait `Bar` is not implemented for `{float}`

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -39,44 +39,41 @@ LL |     with_closure_expecting_fn_with_free_region(|x: fn(&'x u32), y| {});
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:30:5
    |
-LL | / fn with_closure_expecting_fn_with_free_region<F>(_: F)
-LL | |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
-LL | | {
-LL | | }
-   | |_- required by `with_closure_expecting_fn_with_free_region`
+LL | fn with_closure_expecting_fn_with_free_region<F>(_: F)
+   |    ------------------------------------------
+LL |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
+   |                            ------------------- required by this bound in `with_closure_expecting_fn_with_free_region`
 ...
-LL |       with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
-   |       |
-   |       expected signature of `fn(fn(&'a u32), &i32) -> _`
+LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
+   |     |
+   |     expected signature of `fn(fn(&'a u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:37:5
    |
-LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-LL | |     where F: FnOnce(fn(&u32), &i32)
-LL | | {
-LL | | }
-   | |_- required by `with_closure_expecting_fn_with_bound_region`
+LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
+   |    -------------------------------------------
+LL |     where F: FnOnce(fn(&u32), &i32)
+   |                    ---------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
-LL |       with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
-   |       |
-   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
+LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
+   |     |
+   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-fn-supply-fn.rs:46:5
    |
-LL | / fn with_closure_expecting_fn_with_bound_region<F>(_: F)
-LL | |     where F: FnOnce(fn(&u32), &i32)
-LL | | {
-LL | | }
-   | |_- required by `with_closure_expecting_fn_with_bound_region`
+LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
+   |    -------------------------------------------
+LL |     where F: FnOnce(fn(&u32), &i32)
+   |                    ---------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
-LL |       with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
-   |       |
-   |       expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
+LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`
+   |     |
+   |     expected signature of `fn(for<'r> fn(&'r u32), &i32) -> _`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
+++ b/src/test/ui/closure-expected-type/expect-fn-supply-fn.stderr
@@ -42,7 +42,7 @@ error[E0631]: type mismatch in closure arguments
 LL | fn with_closure_expecting_fn_with_free_region<F>(_: F)
    |    ------------------------------------------
 LL |     where F: for<'a> FnOnce(fn(&'a u32), &i32)
-   |                            ------------------- required by this bound in `with_closure_expecting_fn_with_free_region`
+   |                      ------------------------- required by this bound in `with_closure_expecting_fn_with_free_region`
 ...
 LL |     with_closure_expecting_fn_with_free_region(|x: fn(&u32), y| {});
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---------------- found signature of `fn(for<'r> fn(&'r u32), _) -> _`
@@ -55,7 +55,7 @@ error[E0631]: type mismatch in closure arguments
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
    |    -------------------------------------------
 LL |     where F: FnOnce(fn(&u32), &i32)
-   |                    ---------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
+   |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
 LL |     with_closure_expecting_fn_with_bound_region(|x: fn(&'x u32), y| {});
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------- found signature of `fn(fn(&'x u32), _) -> _`
@@ -68,7 +68,7 @@ error[E0631]: type mismatch in closure arguments
 LL | fn with_closure_expecting_fn_with_bound_region<F>(_: F)
    |    -------------------------------------------
 LL |     where F: FnOnce(fn(&u32), &i32)
-   |                    ---------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
+   |              ---------------------- required by this bound in `with_closure_expecting_fn_with_bound_region`
 ...
 LL |     with_closure_expecting_fn_with_bound_region(|x: Foo<'_>, y| {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --------------- found signature of `for<'r> fn(fn(&'r u32), _) -> _`

--- a/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
+++ b/src/test/ui/closure-expected-type/expect-infer-var-appearing-twice.stderr
@@ -1,16 +1,15 @@
 error[E0631]: type mismatch in closure arguments
   --> $DIR/expect-infer-var-appearing-twice.rs:14:5
    |
-LL | / fn with_closure<F, A>(_: F)
-LL | |     where F: FnOnce(A, A)
-LL | | {
-LL | | }
-   | |_- required by `with_closure`
+LL | fn with_closure<F, A>(_: F)
+   |    ------------
+LL |     where F: FnOnce(A, A)
+   |              ------------ required by this bound in `with_closure`
 ...
-LL |       with_closure(|x: u32, y: i32| {
-   |       ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
-   |       |
-   |       expected signature of `fn(_, _) -> _`
+LL |     with_closure(|x: u32, y: i32| {
+   |     ^^^^^^^^^^^^ ---------------- found signature of `fn(u32, i32) -> _`
+   |     |
+   |     expected signature of `fn(_, _) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -2,7 +2,7 @@ error[E0277]: `F` cannot be shared between threads safely
   --> $DIR/closure-bounds-subtype.rs:13:5
    |
 LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
-   | ------------------------------------------------------------ required by `take_const_owned`
+   |    ----------------                              ---- required by this bound in `take_const_owned`
 ...
 LL |     take_const_owned(f);
    |     ^^^^^^^^^^^^^^^^ `F` cannot be shared between threads safely

--- a/src/test/ui/closures/closure-move-sync.rs
+++ b/src/test/ui/closures/closure-move-sync.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 use std::thread;
 use std::sync::mpsc::channel;
 

--- a/src/test/ui/closures/closure-move-sync.stderr
+++ b/src/test/ui/closures/closure-move-sync.stderr
@@ -3,22 +3,30 @@ error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads s
    |
 LL |     let t = thread::spawn(|| {
    |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
+   | 
+  ::: $SRC_DIR/libstd/thread/mod.rs:LL:COL
+   |
+LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
+   |                          ---- required by this bound in `std::thread::spawn`
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Receiver<()>`
    = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:6:27: 9:6 recv:&std::sync::mpsc::Receiver<()>]`
-   = note: required by `std::thread::spawn`
 
 error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
   --> $DIR/closure-move-sync.rs:18:5
    |
 LL |     thread::spawn(|| tx.send(()).unwrap());
    |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
+   | 
+  ::: $SRC_DIR/libstd/thread/mod.rs:LL:COL
+   |
+LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
+   |                          ---- required by this bound in `std::thread::spawn`
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Sender<()>`
    = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:18:19: 18:42 tx:&std::sync::mpsc::Sender<()>]`
-   = note: required by `std::thread::spawn`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/closures/closure-move-sync.stderr
+++ b/src/test/ui/closures/closure-move-sync.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
-  --> $DIR/closure-move-sync.rs:6:13
+  --> $DIR/closure-move-sync.rs:8:13
    |
 LL |     let t = thread::spawn(|| {
    |             ^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<()>` cannot be shared between threads safely
@@ -11,10 +11,10 @@ LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Receiver<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Receiver<()>`
-   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:6:27: 9:6 recv:&std::sync::mpsc::Receiver<()>]`
+   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:8:27: 11:6 recv:&std::sync::mpsc::Receiver<()>]`
 
 error[E0277]: `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
-  --> $DIR/closure-move-sync.rs:18:5
+  --> $DIR/closure-move-sync.rs:20:5
    |
 LL |     thread::spawn(|| tx.send(()).unwrap());
    |     ^^^^^^^^^^^^^ `std::sync::mpsc::Sender<()>` cannot be shared between threads safely
@@ -26,7 +26,7 @@ LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::sync::mpsc::Sender<()>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::sync::mpsc::Sender<()>`
-   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:18:19: 18:42 tx:&std::sync::mpsc::Sender<()>]`
+   = note: required because it appears within the type `[closure@$DIR/closure-move-sync.rs:20:19: 20:42 tx:&std::sync::mpsc::Sender<()>]`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/defaulted-never-note.rs
+++ b/src/test/ui/defaulted-never-note.rs
@@ -19,7 +19,8 @@ trait ImplementedForUnitButNotNever {}
 impl ImplementedForUnitButNotNever for () {}
 
 fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-//~^ NOTE required by `foo`
+//~^ NOTE required by this bound in `foo`
+//~| NOTE
 
 fn smeg() {
     let _x = return;

--- a/src/test/ui/defaulted-never-note.stderr
+++ b/src/test/ui/defaulted-never-note.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `!: ImplementedForUnitButNotNever` is not satisfied
-  --> $DIR/defaulted-never-note.rs:26:5
+  --> $DIR/defaulted-never-note.rs:27:5
    |
 LL | fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
-   | ----------------------------------------------- required by `foo`
+   |    ---    ----------------------------- required by this bound in `foo`
 ...
 LL |     foo(_x);
    |     ^^^ the trait `ImplementedForUnitButNotNever` is not implemented for `!`

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.rs
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
    |
 LL |      x: Error
    |      ^^^^^^^^ the trait `std::hash::Hash` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/hash/mod.rs:LL:COL
    |
-   = note: required by `std::hash::Hash::hash`
+LL |     fn hash<H: Hasher>(&self, state: &mut H);
+   |             - required by this bound in `std::hash::Hash::hash`
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
-  --> $DIR/derives-span-Hash-enum-struct-variant.rs:9:6
+  --> $DIR/derives-span-Hash-enum-struct-variant.rs:11:6
    |
 LL |      x: Error
    |      ^^^^^^^^ the trait `std::hash::Hash` is not implemented for `Error`

--- a/src/test/ui/derives/derives-span-Hash-enum.rs
+++ b/src/test/ui/derives/derives-span-Hash-enum.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
    |
 LL |      Error
    |      ^^^^^ the trait `std::hash::Hash` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/hash/mod.rs:LL:COL
    |
-   = note: required by `std::hash::Hash::hash`
+LL |     fn hash<H: Hasher>(&self, state: &mut H);
+   |             - required by this bound in `std::hash::Hash::hash`
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
-  --> $DIR/derives-span-Hash-enum.rs:9:6
+  --> $DIR/derives-span-Hash-enum.rs:11:6
    |
 LL |      Error
    |      ^^^^^ the trait `std::hash::Hash` is not implemented for `Error`

--- a/src/test/ui/derives/derives-span-Hash-struct.rs
+++ b/src/test/ui/derives/derives-span-Hash-struct.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
    |
 LL |     x: Error
    |     ^^^^^^^^ the trait `std::hash::Hash` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/hash/mod.rs:LL:COL
    |
-   = note: required by `std::hash::Hash::hash`
+LL |     fn hash<H: Hasher>(&self, state: &mut H);
+   |             - required by this bound in `std::hash::Hash::hash`
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
-  --> $DIR/derives-span-Hash-struct.rs:8:5
+  --> $DIR/derives-span-Hash-struct.rs:10:5
    |
 LL |     x: Error
    |     ^^^^^^^^ the trait `std::hash::Hash` is not implemented for `Error`

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.rs
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 // This file was auto-generated using 'src/etc/generate-deriving-span-tests.py'
 
 

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
    |
 LL |     Error
    |     ^^^^^ the trait `std::hash::Hash` is not implemented for `Error`
+   | 
+  ::: $SRC_DIR/libcore/hash/mod.rs:LL:COL
    |
-   = note: required by `std::hash::Hash::hash`
+LL |     fn hash<H: Hasher>(&self, state: &mut H);
+   |             - required by this bound in `std::hash::Hash::hash`
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Error: std::hash::Hash` is not satisfied
-  --> $DIR/derives-span-Hash-tuple-struct.rs:8:5
+  --> $DIR/derives-span-Hash-tuple-struct.rs:10:5
    |
 LL |     Error
    |     ^^^^^ the trait `std::hash::Hash` is not implemented for `Error`

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `C: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:31:5
    |
 LL | fn is_copy<T: Copy>(_: T) {}
-   | ------------------------- required by `is_copy`
+   |    -------    ---- required by this bound in `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: C });
    |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `C`
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `C: std::clone::Clone` is not satisfied
   --> $DIR/deriving-copyclone.rs:32:5
    |
 LL | fn is_clone<T: Clone>(_: T) {}
-   | --------------------------- required by `is_clone`
+   |    --------    ----- required by this bound in `is_clone`
 ...
 LL |     is_clone(B { a: 1, b: C });
    |     ^^^^^^^^ the trait `std::clone::Clone` is not implemented for `C`
@@ -24,7 +24,7 @@ error[E0277]: the trait bound `D: std::marker::Copy` is not satisfied
   --> $DIR/deriving-copyclone.rs:35:5
    |
 LL | fn is_copy<T: Copy>(_: T) {}
-   | ------------------------- required by `is_copy`
+   |    -------    ---- required by this bound in `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: D });
    |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `D`

--- a/src/test/ui/did_you_mean/recursion_limit.stderr
+++ b/src/test/ui/did_you_mean/recursion_limit.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `J: std::marker::Send`
   --> $DIR/recursion_limit.rs:34:5
    |
 LL | fn is_send<T:Send>() { }
-   | -------------------- required by `is_send`
+   |    -------   ---- required by this bound in `is_send`
 ...
 LL |     is_send::<A>();
    |     ^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -1,11 +1,11 @@
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/E0214.rs:2:15
+  --> $DIR/E0214.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!["foo"];
-   |               ^^^^^^
-   |               |
-   |               only `Fn` traits may use parentheses
-   |               help: use angle brackets instead: `<&str>`
+   |            ^^^^^^^^^
+   |            |
+   |            only `Fn` traits may use parentheses
+   |            help: use angle brackets instead: `Vec<&str>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
   --> $DIR/E0271.rs:10:5
    |
 LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
-   | -------------------------------------------------- required by `foo`
+   |    ---                         ------------------ required by this bound in `foo`
 ...
 LL |     foo(3_i8);
    |     ^^^ expected reference, found u32

--- a/src/test/ui/error-codes/E0277-2.stderr
+++ b/src/test/ui/error-codes/E0277-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*const u8` cannot be sent between threads safely
   --> $DIR/E0277-2.rs:16:5
    |
 LL | fn is_send<T: Send>() { }
-   | --------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send::<Foo>();
    |     ^^^^^^^^^^^^^^ `*const u8` cannot be sent between threads safely

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `i32: Foo` is not satisfied
   --> $DIR/E0277.rs:17:5
    |
 LL | fn some_func<T: Foo>(foo: T) {
-   | ---------------------------- required by `some_func`
+   |    ---------    --- required by this bound in `some_func`
 ...
 LL |     some_func(5i32);
    |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
   --> $DIR/error-should-say-copy-not-pod.rs:6:5
    |
 LL | fn check_bound<T:Copy>(_: T) {}
-   | ---------------------------- required by `check_bound`
+   |    -----------   ---- required by this bound in `check_bound`
 ...
 LL |     check_bound("nocopy".to_string());
    |     ^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -2,7 +2,7 @@ error[E0277]: `A` cannot be shared between threads safely
   --> $DIR/extern-types-not-sync-send.rs:13:5
    |
 LL | fn assert_sync<T: ?Sized + Sync>() { }
-   | ---------------------------------- required by `assert_sync`
+   |    -----------             ---- required by this bound in `assert_sync`
 ...
 LL |     assert_sync::<A>();
    |     ^^^^^^^^^^^^^^^^ `A` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `A` cannot be sent between threads safely
   --> $DIR/extern-types-not-sync-send.rs:16:5
    |
 LL | fn assert_send<T: ?Sized + Send>() { }
-   | ---------------------------------- required by `assert_send`
+   |    -----------             ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<A>();
    |     ^^^^^^^^^^^^^^^^ `A` cannot be sent between threads safely

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:22:5
    |
 LL | fn assert_sized<T>() { }
-   | -------------------- required by `assert_sized`
+   |    ------------ - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<A>();
    |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -14,7 +14,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:25:5
    |
 LL | fn assert_sized<T>() { }
-   | -------------------- required by `assert_sized`
+   |    ------------ - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Foo>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -27,7 +27,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:28:5
    |
 LL | fn assert_sized<T>() { }
-   | -------------------- required by `assert_sized`
+   |    ------------ - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<A>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -40,7 +40,7 @@ error[E0277]: the size for values of type `A` cannot be known at compilation tim
   --> $DIR/extern-types-unsized.rs:31:5
    |
 LL | fn assert_sized<T>() { }
-   | -------------------- required by `assert_sized`
+   |    ------------ - required by this bound in `assert_sized`
 ...
 LL |     assert_sized::<Bar<Bar<A>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<()>` closure, found `extern "C" fn() {f}`
   --> $DIR/extern-wrong-value-type.rs:9:5
    |
 LL | fn is_fn<F>(_: F) where F: Fn() {}
-   | ------------------------------- required by `is_fn`
+   |    -----                   ---- required by this bound in `is_fn`
 ...
 LL |     is_fn(f);
    |     ^^^^^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -44,10 +44,10 @@ LL | impl Fn<()> for Foo {
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:12
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:15:6
    |
 LL | impl FnOnce() for Foo1 {
-   |            ^^ associated type not allowed here
+   |      ^^^^^^^^ associated type not allowed here
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change. Use parenthetical notation (Fn(Foo, Bar) -> Baz) instead
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:21:6

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between thr
   --> $DIR/send-sync.rs:8:5
    |
 LL | fn send<T: Send>(_: T) {}
-   | ---------------------- required by `send`
+   |    ----    ---- required by this bound in `send`
 ...
 LL |     send(format_args!("{:?}", c));
    |     ^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
@@ -20,7 +20,7 @@ error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between thr
   --> $DIR/send-sync.rs:9:5
    |
 LL | fn sync<T: Sync>(_: T) {}
-   | ---------------------- required by `sync`
+   |    ----    ---- required by this bound in `sync`
 ...
 LL |     sync(format_args!("{:?}", c));
    |     ^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -29,7 +29,7 @@ error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `{integer}`
   --> $DIR/fn-trait-formatting.rs:19:5
    |
 LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
-   | ------------------------------------------------ required by `needs_fn`
+   |    --------                   ------------------ required by this bound in `needs_fn`
 ...
 LL |     needs_fn(1);
    |     ^^^^^^^^ expected an `Fn<(isize,)>` closure, found `{integer}`

--- a/src/test/ui/generator-yielding-or-returning-itself.stderr
+++ b/src/test/ui/generator-yielding-or-returning-itself.stderr
@@ -16,14 +16,13 @@ LL | |     })
 error[E0271]: type mismatch resolving `<[generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _] as std::ops::Generator>::Yield == [generator@$DIR/generator-yielding-or-returning-itself.rs:28:33: 32:6 _]`
   --> $DIR/generator-yielding-or-returning-itself.rs:28:5
    |
-LL | / pub fn want_cyclic_generator_yield<T>(_: T)
-LL | |     where T: Generator<Yield = T, Return = ()>
-LL | | {
-LL | | }
-   | |_- required by `want_cyclic_generator_yield`
+LL | pub fn want_cyclic_generator_yield<T>(_: T)
+   |        ---------------------------
+LL |     where T: Generator<Yield = T, Return = ()>
+   |                        --------- required by this bound in `want_cyclic_generator_yield`
 ...
-LL |       want_cyclic_generator_yield(|| {
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
+LL |     want_cyclic_generator_yield(|| {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ cyclic type of infinite size
    |
    = note: closures cannot capture themselves or take themselves as argument;
            this error may be the result of a recent compiler bug-fix,

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:16:5
    |
 LL |     fn assert_send<T: Send>(_: T) {}
-   |     ----------------------------- required by `main::assert_send`
+   |        -----------    ---- required by this bound in `main::assert_send`
 ...
 LL |     assert_send(|| {
    |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
@@ -15,7 +15,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-send-sync.rs:9:5
    |
 LL |     fn assert_sync<T: Sync>(_: T) {}
-   |     ----------------------------- required by `main::assert_sync`
+   |        -----------    ---- required by this bound in `main::assert_sync`
 ...
 LL |     assert_sync(|| {
    |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:11:25:
   --> $DIR/static-not-unpin.rs:14:5
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
-   | ------------------------------- required by `assert_unpin`
+   |    ------------    ----- required by this bound in `assert_unpin`
 ...
 LL |     assert_unpin(generator);
    |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`

--- a/src/test/ui/hrtb/hrtb-conflate-regions.stderr
+++ b/src/test/ui/hrtb/hrtb-conflate-regions.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `for<'a, 'b> SomeStruct: Foo<(&'a isize, &'b isize)>` is not satisfied
   --> $DIR/hrtb-conflate-regions.rs:27:10
    |
-LL | / fn want_foo2<T>()
-LL | |     where T : for<'a,'b> Foo<(&'a isize, &'b isize)>
-LL | | {
-LL | | }
-   | |_- required by `want_foo2`
+LL | fn want_foo2<T>()
+   |    ---------
+LL |     where T : for<'a,'b> Foo<(&'a isize, &'b isize)>
+   |               -------------------------------------- required by this bound in `want_foo2`
 ...
-LL |   fn b() { want_foo2::<SomeStruct>(); }
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Foo<(&'a isize, &'b isize)>` is not implemented for `SomeStruct`
+LL | fn b() { want_foo2::<SomeStruct>(); }
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Foo<(&'a isize, &'b isize)>` is not implemented for `SomeStruct`
    |
    = help: the following implementations were found:
              <SomeStruct as Foo<(&'a isize, &'a isize)>>

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-contravariant.stderr
@@ -1,15 +1,14 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(&'b u32)>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-contravariant.rs:34:5
    |
-LL | / fn foo<T>()
-LL | | where
-LL | |     T: Trait<for<'b> fn(&'b u32)>,
-LL | | {
-LL | | }
-   | |_- required by `foo`
+LL | fn foo<T>()
+   |    ---
+LL | where
+LL |     T: Trait<for<'b> fn(&'b u32)>,
+   |        -------------------------- required by this bound in `foo`
 ...
-LL |       foo::<()>();
-   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(&'b u32)>` is not implemented for `()`
+LL |     foo::<()>();
+   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(&'b u32)>` is not implemented for `()`
    |
    = help: the following implementations were found:
              <() as Trait<fn(&'a u32)>>

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-covariant.stderr
@@ -1,15 +1,14 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(fn(&'b u32))>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-covariant.rs:36:5
    |
-LL | / fn foo<T>()
-LL | | where
-LL | |     T: Trait<for<'b> fn(fn(&'b u32))>,
-LL | | {
-LL | | }
-   | |_- required by `foo`
+LL | fn foo<T>()
+   |    ---
+LL | where
+LL |     T: Trait<for<'b> fn(fn(&'b u32))>,
+   |        ------------------------------ required by this bound in `foo`
 ...
-LL |       foo::<()>();
-   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(fn(&'b u32))>` is not implemented for `()`
+LL |     foo::<()>();
+   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(fn(&'b u32))>` is not implemented for `()`
    |
    = help: the following implementations were found:
              <() as Trait<fn(fn(&'a u32))>>

--- a/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-trait-invariant.stderr
@@ -1,15 +1,14 @@
 error[E0277]: the trait bound `(): Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not satisfied
   --> $DIR/hrtb-exists-forall-trait-invariant.rs:28:5
    |
-LL | / fn foo<T>()
-LL | | where
-LL | |     T: Trait<for<'b> fn(Cell<&'b u32>)>,
-LL | | {
-LL | | }
-   | |_- required by `foo`
+LL | fn foo<T>()
+   |    ---
+LL | where
+LL |     T: Trait<for<'b> fn(Cell<&'b u32>)>,
+   |        -------------------------------- required by this bound in `foo`
 ...
-LL |       foo::<()>();
-   |       ^^^^^^^^^ the trait `Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not implemented for `()`
+LL |     foo::<()>();
+   |     ^^^^^^^^^ the trait `Trait<for<'b> fn(std::cell::Cell<&'b u32>)>` is not implemented for `()`
    |
    = help: the following implementations were found:
              <() as Trait<fn(std::cell::Cell<&'a u32>)>>

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:5
    |
-LL | / fn want_bar_for_any_ccx<B>(b: &B)
-LL | |     where B : for<'ccx> Bar<'ccx>
-LL | | {
-LL | | }
-   | |_- required by `want_bar_for_any_ccx`
+LL | fn want_bar_for_any_ccx<B>(b: &B)
+   |    --------------------
+LL |     where B : for<'ccx> Bar<'ccx>
+   |               ------------------- required by this bound in `want_bar_for_any_ccx`
 ...
-LL |       want_bar_for_any_ccx(b);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+LL |     want_bar_for_any_ccx(b);
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
    |
    = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -1,33 +1,26 @@
 error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:18:5
    |
-LL |       want_foo_for_any_tcx(f);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
+LL |     want_foo_for_any_tcx(f);
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
 ...
-LL | / fn want_foo_for_any_tcx<F>(f: &F)
-LL | |     where F : for<'tcx> Foo<'tcx>
-LL | | {
-LL | |     want_foo_for_some_tcx(f);
-LL | |     want_foo_for_any_tcx(f);
-LL | | }
-   | |_- required by `want_foo_for_any_tcx`
+LL | fn want_foo_for_any_tcx<F>(f: &F)
+   |    --------------------
+LL |     where F : for<'tcx> Foo<'tcx>
+   |               ------------------- required by this bound in `want_foo_for_any_tcx`
    |
    = help: consider adding a `where for<'tcx> F: Foo<'tcx>` bound
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
   --> $DIR/hrtb-higher-ranker-supertraits.rs:35:5
    |
-LL |       want_bar_for_any_ccx(b);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+LL |     want_bar_for_any_ccx(b);
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
 ...
-LL | / fn want_bar_for_any_ccx<B>(b: &B)
-LL | |     where B : for<'ccx> Bar<'ccx>
-LL | | {
-LL | |     want_foo_for_some_tcx(b);
-...  |
-LL | |     want_bar_for_any_ccx(b);
-LL | | }
-   | |_- required by `want_bar_for_any_ccx`
+LL | fn want_bar_for_any_ccx<B>(b: &B)
+   |    --------------------
+LL |     where B : for<'ccx> Bar<'ccx>
+   |               ------------------- required by this bound in `want_bar_for_any_ccx`
    |
    = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
 

--- a/src/test/ui/hrtb/hrtb-just-for-static.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.stderr
@@ -1,14 +1,13 @@
 error[E0277]: the trait bound `for<'a> StaticInt: Foo<&'a isize>` is not satisfied
   --> $DIR/hrtb-just-for-static.rs:24:5
    |
-LL | / fn want_hrtb<T>()
-LL | |     where T : for<'a> Foo<&'a isize>
-LL | | {
-LL | | }
-   | |_- required by `want_hrtb`
+LL | fn want_hrtb<T>()
+   |    ---------
+LL |     where T : for<'a> Foo<&'a isize>
+   |               ---------------------- required by this bound in `want_hrtb`
 ...
-LL |       want_hrtb::<StaticInt>()
-   |       ^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `StaticInt`
+LL |     want_hrtb::<StaticInt>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `StaticInt`
    |
    = help: the following implementations were found:
              <StaticInt as Foo<&'static isize>>
@@ -16,14 +15,13 @@ LL |       want_hrtb::<StaticInt>()
 error[E0277]: the trait bound `for<'a> &'a u32: Foo<&'a isize>` is not satisfied
   --> $DIR/hrtb-just-for-static.rs:30:5
    |
-LL | / fn want_hrtb<T>()
-LL | |     where T : for<'a> Foo<&'a isize>
-LL | | {
-LL | | }
-   | |_- required by `want_hrtb`
+LL | fn want_hrtb<T>()
+   |    ---------
+LL |     where T : for<'a> Foo<&'a isize>
+   |               ---------------------- required by this bound in `want_hrtb`
 ...
-LL |       want_hrtb::<&'a u32>()
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `&'a u32`
+LL |     want_hrtb::<&'a u32>()
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Foo<&'a isize>` is not implemented for `&'a u32`
    |
    = help: the following implementations were found:
              <&'a u32 as Foo<&'a isize>>

--- a/src/test/ui/hrtb/issue-46989.stderr
+++ b/src/test/ui/hrtb/issue-46989.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `for<'r> fn(&'r i32): Foo` is not satisfied
   --> $DIR/issue-46989.rs:40:5
    |
 LL | fn assert_foo<T: Foo>() {}
-   | ----------------------- required by `assert_foo`
+   |    ----------    --- required by this bound in `assert_foo`
 ...
 LL |     assert_foo::<fn(&i32)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `for<'r> fn(&'r i32)`

--- a/src/test/ui/impl-trait/auto-trait-leak.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak.stderr
@@ -73,7 +73,7 @@ error[E0277]: `std::rc::Rc<std::string::String>` cannot be sent between threads 
   --> $DIR/auto-trait-leak.rs:15:5
    |
 LL | fn send<T: Send>(_: T) {}
-   | ---------------------- required by `send`
+   |    ----    ---- required by this bound in `send`
 ...
 LL |     send(cycle2().clone());
    |     ^^^^ `std::rc::Rc<std::string::String>` cannot be sent between threads safely

--- a/src/test/ui/impl-trait/auto-trait-leak2.stderr
+++ b/src/test/ui/impl-trait/auto-trait-leak2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads
   --> $DIR/auto-trait-leak2.rs:13:5
    |
 LL | fn send<T: Send>(_: T) {}
-   | ---------------------- required by `send`
+   |    ----    ---- required by this bound in `send`
 ...
 LL |     send(before());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely
@@ -15,7 +15,7 @@ error[E0277]: `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads
   --> $DIR/auto-trait-leak2.rs:16:5
    |
 LL | fn send<T: Send>(_: T) {}
-   | ---------------------- required by `send`
+   |    ----    ---- required by this bound in `send`
 ...
 LL |     send(after());
    |     ^^^^ `std::rc::Rc<std::cell::Cell<i32>>` cannot be sent between threads safely

--- a/src/test/ui/interior-mutability/interior-mutability.rs
+++ b/src/test/ui/interior-mutability/interior-mutability.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 use std::cell::Cell;
 use std::panic::catch_unwind;
 fn main() {

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
-  --> $DIR/interior-mutability.rs:5:5
+  --> $DIR/interior-mutability.rs:7:5
    |
 LL |     catch_unwind(|| { x.set(23); });
    |     ^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -12,7 +12,7 @@ LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    = help: within `std::cell::Cell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `&std::cell::Cell<i32>`
-   = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:5:18: 5:35 x:&std::cell::Cell<i32>]`
+   = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:7:18: 7:35 x:&std::cell::Cell<i32>]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/interior-mutability/interior-mutability.stderr
+++ b/src/test/ui/interior-mutability/interior-mutability.stderr
@@ -3,12 +3,16 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
    |
 LL |     catch_unwind(|| { x.set(23); });
    |     ^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
+   | 
+  ::: $SRC_DIR/libstd/panic.rs:LL:COL
+   |
+LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+   |                                        ---------- required by this bound in `std::panic::catch_unwind`
    |
    = help: within `std::cell::Cell<i32>`, the trait `std::panic::RefUnwindSafe` is not implemented for `std::cell::UnsafeCell<i32>`
    = note: required because it appears within the type `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::panic::UnwindSafe` for `&std::cell::Cell<i32>`
    = note: required because it appears within the type `[closure@$DIR/interior-mutability.rs:5:18: 5:35 x:&std::cell::Cell<i32>]`
-   = note: required by `std::panic::catch_unwind`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-1920-1.stderr
+++ b/src/test/ui/issues/issue-1920-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `foo::issue_1920::S: std::clone::Clone` is not sat
   --> $DIR/issue-1920-1.rs:12:5
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   | ------------------------------------ required by `assert_clone`
+   |    ------------                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<foo::issue_1920::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `foo::issue_1920::S`

--- a/src/test/ui/issues/issue-1920-2.stderr
+++ b/src/test/ui/issues/issue-1920-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `bar::S: std::clone::Clone` is not satisfied
   --> $DIR/issue-1920-2.rs:10:5
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   | ------------------------------------ required by `assert_clone`
+   |    ------------                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<bar::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `bar::S`

--- a/src/test/ui/issues/issue-1920-3.stderr
+++ b/src/test/ui/issues/issue-1920-3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `issue_1920::S: std::clone::Clone` is not satisfie
   --> $DIR/issue-1920-3.rs:14:5
    |
 LL | fn assert_clone<T>() where T : Clone { }
-   | ------------------------------------ required by `assert_clone`
+   |    ------------                ----- required by this bound in `assert_clone`
 ...
 LL |     assert_clone::<foo::issue_1920::S>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `issue_1920::S`

--- a/src/test/ui/issues/issue-21160.rs
+++ b/src/test/ui/issues/issue-21160.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 struct Bar;
 
 impl Bar {

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -3,8 +3,11 @@ error[E0277]: the trait bound `Bar: std::hash::Hash` is not satisfied
    |
 LL | struct Foo(Bar);
    |            ^^^ the trait `std::hash::Hash` is not implemented for `Bar`
+   | 
+  ::: $SRC_DIR/libcore/hash/mod.rs:LL:COL
    |
-   = note: required by `std::hash::Hash::hash`
+LL |     fn hash<H: Hasher>(&self, state: &mut H);
+   |             - required by this bound in `std::hash::Hash::hash`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Bar: std::hash::Hash` is not satisfied
-  --> $DIR/issue-21160.rs:8:12
+  --> $DIR/issue-21160.rs:10:12
    |
 LL | struct Foo(Bar);
    |            ^^^ the trait `std::hash::Hash` is not implemented for `Bar`

--- a/src/test/ui/issues/issue-21763.stderr
+++ b/src/test/ui/issues/issue-21763.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
   --> $DIR/issue-21763.rs:9:5
    |
 LL | fn foo<T: Send>() {}
-   | ----------------- required by `foo`
+   |    ---    ---- required by this bound in `foo`
 ...
 LL |     foo::<HashMap<Rc<()>, Rc<()>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -1,11 +1,11 @@
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-23589.rs:2:15
+  --> $DIR/issue-23589.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |               ^^^^^^
-   |               |
-   |               only `Fn` traits may use parentheses
-   |               help: use angle brackets instead: `<&str>`
+   |            ^^^^^^^^^
+   |            |
+   |            only `Fn` traits may use parentheses
+   |            help: use angle brackets instead: `Vec<&str>`
 
 error[E0308]: mismatched types
   --> $DIR/issue-23589.rs:2:29

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `(): InOut<_>` is not satisfied
   --> $DIR/issue-25076.rs:10:5
    |
 LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
-   | ------------------------------------------------ required by `do_fold`
+   |    -------       --------------- required by this bound in `do_fold`
 ...
 LL |     do_fold(bot(), ());
    |     ^^^^^^^ the trait `InOut<_>` is not implemented for `()`

--- a/src/test/ui/issues/issue-32963.stderr
+++ b/src/test/ui/issues/issue-32963.stderr
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `dyn Misc: std::marker::Copy` is not satisfied
   --> $DIR/issue-32963.rs:8:5
    |
 LL | fn size_of_copy<T: Copy+?Sized>() -> usize { mem::size_of::<T>() }
-   | ------------------------------------------ required by `size_of_copy`
+   |    ------------    ---- required by this bound in `size_of_copy`
 ...
 LL |     size_of_copy::<dyn Misc + Copy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `dyn Misc`

--- a/src/test/ui/issues/issue-32995-2.stderr
+++ b/src/test/ui/issues/issue-32995-2.stderr
@@ -1,27 +1,27 @@
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995-2.rs:4:28
+  --> $DIR/issue-32995-2.rs:4:22
    |
 LL |     { fn f<X: ::std::marker()::Send>() {} }
-   |                            ^^
+   |                      ^^^^^^^^
    |
    = note: `#[deny(parenthesized_params_in_types_and_modules)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995-2.rs:8:35
+  --> $DIR/issue-32995-2.rs:8:29
    |
 LL |     { fn f() -> impl ::std::marker()::Send { } }
-   |                                   ^^
+   |                             ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995-2.rs:16:19
+  --> $DIR/issue-32995-2.rs:16:13
    |
 LL | impl ::std::marker()::Copy for X {}
-   |                   ^^
+   |             ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>

--- a/src/test/ui/issues/issue-32995.stderr
+++ b/src/test/ui/issues/issue-32995.stderr
@@ -1,63 +1,63 @@
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:4:17
+  --> $DIR/issue-32995.rs:4:12
    |
 LL |     let x: usize() = 1;
-   |                 ^^
+   |            ^^^^^^^
    |
    = note: `#[deny(parenthesized_params_in_types_and_modules)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:8:24
+  --> $DIR/issue-32995.rs:8:19
    |
 LL |     let b: ::std::boxed()::Box<_> = Box::new(1);
-   |                        ^^
+   |                   ^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:12:25
+  --> $DIR/issue-32995.rs:12:20
    |
 LL |     let p = ::std::str::()::from_utf8(b"foo").unwrap();
-   |                         ^^
+   |                    ^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:16:36
+  --> $DIR/issue-32995.rs:16:25
    |
 LL |     let p = ::std::str::from_utf8::()(b"foo").unwrap();
-   |                                    ^^
+   |                         ^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:20:35
+  --> $DIR/issue-32995.rs:20:29
    |
 LL |     let o : Box<dyn (::std::marker()::Send)> = Box::new(1);
-   |                                   ^^
+   |                             ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:24:41
+  --> $DIR/issue-32995.rs:24:35
    |
 LL |     let o : Box<dyn Send + ::std::marker()::Sync> = Box::new(1);
-   |                                         ^^
+   |                                   ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-32995.rs:30:14
+  --> $DIR/issue-32995.rs:30:13
    |
 LL |     let d : X() = Default::default();
-   |              ^^
+   |             ^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #42238 <https://github.com/rust-lang/rust/issues/42238>

--- a/src/test/ui/issues/issue-39687.stderr
+++ b/src/test/ui/issues/issue-39687.stderr
@@ -1,8 +1,8 @@
 error[E0229]: associated type bindings are not allowed here
-  --> $DIR/issue-39687.rs:4:16
+  --> $DIR/issue-39687.rs:4:14
    |
 LL |     <fn() as Fn()>::call;
-   |                ^^ associated type not allowed here
+   |              ^^^^ associated type not allowed here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-40827.stderr
+++ b/src/test/ui/issues/issue-40827.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<Foo>` cannot be sent between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
 LL | fn f<T: Send>(_: T) {}
-   | ------------------- required by `f`
+   |    -    ---- required by this bound in `f`
 ...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be sent between threads safely
@@ -16,7 +16,7 @@ error[E0277]: `std::rc::Rc<Foo>` cannot be shared between threads safely
   --> $DIR/issue-40827.rs:14:5
    |
 LL | fn f<T: Send>(_: T) {}
-   | ------------------- required by `f`
+   |    -    ---- required by this bound in `f`
 ...
 LL |     f(Foo(Arc::new(Bar::B(None))));
    |     ^ `std::rc::Rc<Foo>` cannot be shared between threads safely

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -1,31 +1,27 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-43623.rs:14:5
    |
-LL | / pub fn break_me<T, F>(f: F)
-LL | | where T: for<'b> Trait<'b>,
-LL | |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
-LL | |     break_me::<Type, fn(_)>;
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^
-   | |     |
-   | |     expected signature of `for<'b> fn(<Type as Trait<'b>>::Assoc) -> _`
-   | |     found signature of `fn(_) -> _`
-LL | |
-LL | |
-LL | | }
-   | |_- required by `break_me`
+LL | pub fn break_me<T, F>(f: F)
+   |        --------
+LL | where T: for<'b> Trait<'b>,
+LL |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
+   |          -------------------------------------- required by this bound in `break_me`
+LL |     break_me::<Type, fn(_)>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     expected signature of `for<'b> fn(<Type as Trait<'b>>::Assoc) -> _`
+   |     found signature of `fn(_) -> _`
 
 error[E0271]: type mismatch resolving `for<'b> <fn(_) as std::ops::FnOnce<(<Type as Trait<'b>>::Assoc,)>>::Output == ()`
   --> $DIR/issue-43623.rs:14:5
    |
-LL | / pub fn break_me<T, F>(f: F)
-LL | | where T: for<'b> Trait<'b>,
-LL | |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
-LL | |     break_me::<Type, fn(_)>;
-   | |     ^^^^^^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'b, found concrete lifetime
-LL | |
-LL | |
-LL | | }
-   | |_- required by `break_me`
+LL | pub fn break_me<T, F>(f: F)
+   |        --------
+LL | where T: for<'b> Trait<'b>,
+LL |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
+   |                       ------------------------- required by this bound in `break_me`
+LL |     break_me::<Type, fn(_)>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'b, found concrete lifetime
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-43623.stderr
+++ b/src/test/ui/issues/issue-43623.stderr
@@ -19,7 +19,7 @@ LL | pub fn break_me<T, F>(f: F)
    |        --------
 LL | where T: for<'b> Trait<'b>,
 LL |       F: for<'b> FnMut(<T as Trait<'b>>::Assoc) {
-   |                       ------------------------- required by this bound in `break_me`
+   |                  ------------------------------ required by this bound in `break_me`
 LL |     break_me::<Type, fn(_)>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^ expected bound lifetime parameter 'b, found concrete lifetime
 

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -10,18 +10,17 @@ LL |         self.foo.map(Foo::new)
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
   --> $DIR/issue-47706.rs:27:5
    |
-LL |       Bar(i32),
-   |       -------- takes 1 argument
+LL |     Bar(i32),
+   |     -------- takes 1 argument
 ...
-LL | / fn foo<F>(f: F)
-LL | | where
-LL | |     F: Fn(),
-LL | | {
-LL | | }
-   | |_- required by `foo`
+LL | fn foo<F>(f: F)
+   |    ---
+LL | where
+LL |     F: Fn(),
+   |        ---- required by this bound in `foo`
 ...
-LL |       foo(Qux::Bar);
-   |       ^^^ expected function that takes 0 arguments
+LL |     foo(Qux::Bar);
+   |     ^^^ expected function that takes 0 arguments
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -1,27 +1,29 @@
 error[E0631]: type mismatch in function arguments
   --> $DIR/issue-60283.rs:14:5
    |
-LL | / pub fn foo<T, F>(_: T, _: F)
-LL | | where T: for<'a> Trait<'a>,
-LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
-   | |_________________________________________________- required by `foo`
+LL | pub fn foo<T, F>(_: T, _: F)
+   |        ---
+LL | where T: for<'a> Trait<'a>,
+LL |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
+   |          ------------------------------------- required by this bound in `foo`
 ...
-LL |       foo((), drop)
-   |       ^^^
-   |       |
-   |       expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
-   |       found signature of `fn(_) -> _`
+LL |     foo((), drop)
+   |     ^^^
+   |     |
+   |     expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
+   |     found signature of `fn(_) -> _`
 
 error[E0271]: type mismatch resolving `for<'a> <fn(_) {std::mem::drop::<_>} as std::ops::FnOnce<(<() as Trait<'a>>::Item,)>>::Output == ()`
   --> $DIR/issue-60283.rs:14:5
    |
-LL | / pub fn foo<T, F>(_: T, _: F)
-LL | | where T: for<'a> Trait<'a>,
-LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
-   | |_________________________________________________- required by `foo`
+LL | pub fn foo<T, F>(_: T, _: F)
+   |        ---
+LL | where T: for<'a> Trait<'a>,
+LL |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
+   |                       ------------------------ required by this bound in `foo`
 ...
-LL |       foo((), drop)
-   |       ^^^ expected bound lifetime parameter 'a, found concrete lifetime
+LL |     foo((), drop)
+   |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -20,7 +20,7 @@ LL | pub fn foo<T, F>(_: T, _: F)
    |        ---
 LL | where T: for<'a> Trait<'a>,
 LL |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
-   |                       ------------------------ required by this bound in `foo`
+   |                  ----------------------------- required by this bound in `foo`
 ...
 LL |     foo((), drop)
    |     ^^^ expected bound lifetime parameter 'a, found concrete lifetime

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&'static mut isize: std::marker::Copy` is not sat
   --> $DIR/kindck-copy.rs:27:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'static mut isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'static mut isize`
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `&'a mut isize: std::marker::Copy` is not satisfie
   --> $DIR/kindck-copy.rs:28:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'a mut isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut isize`
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `std::boxed::Box<isize>: std::marker::Copy` is not
   --> $DIR/kindck-copy.rs:31:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<isize>`
@@ -35,7 +35,7 @@ error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not sa
   --> $DIR/kindck-copy.rs:32:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<String>();
    |     ^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
@@ -44,7 +44,7 @@ error[E0277]: the trait bound `std::vec::Vec<isize>: std::marker::Copy` is not s
   --> $DIR/kindck-copy.rs:33:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Vec<isize> >();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::vec::Vec<isize>`
@@ -53,7 +53,7 @@ error[E0277]: the trait bound `std::boxed::Box<&'a mut isize>: std::marker::Copy
   --> $DIR/kindck-copy.rs:34:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<&'a mut isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<&'a mut isize>`
@@ -62,7 +62,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Dummy>: std::marker::Copy` is
   --> $DIR/kindck-copy.rs:42:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy>`
@@ -71,7 +71,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Dummy + std::marker::Send>: s
   --> $DIR/kindck-copy.rs:43:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Box<dyn Dummy + Send>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<dyn Dummy + std::marker::Send>`
@@ -80,7 +80,7 @@ error[E0277]: the trait bound `&'a mut (dyn Dummy + std::marker::Send + 'a): std
   --> $DIR/kindck-copy.rs:46:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<&'a mut (dyn Dummy + Send)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `&'a mut (dyn Dummy + std::marker::Send + 'a)`
@@ -89,7 +89,7 @@ error[E0277]: the trait bound `MyNoncopyStruct: std::marker::Copy` is not satisf
   --> $DIR/kindck-copy.rs:64:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<MyNoncopyStruct>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `MyNoncopyStruct`
@@ -98,7 +98,7 @@ error[E0277]: the trait bound `std::rc::Rc<isize>: std::marker::Copy` is not sat
   --> $DIR/kindck-copy.rs:67:5
    |
 LL | fn assert_copy<T:Copy>() { }
-   | ------------------------ required by `assert_copy`
+   |    -----------   ---- required by this bound in `assert_copy`
 ...
 LL |     assert_copy::<Rc<isize>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::rc::Rc<isize>`

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is
   --> $DIR/kindck-impl-type-params-2.rs:13:5
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
-   | ----------------------------- required by `take_param`
+   |    ----------   --- required by this bound in `take_param`
 ...
 LL |     take_param(&x);
    |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is
   --> $DIR/kindck-inherited-copy-bound.rs:18:5
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
-   | ----------------------------- required by `take_param`
+   |    ----------   --- required by this bound in `take_param`
 ...
 LL |     take_param(&x);
    |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`

--- a/src/test/ui/kindck/kindck-nonsendable-1.stderr
+++ b/src/test/ui/kindck/kindck-nonsendable-1.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<usize>` cannot be sent between threads safely
   --> $DIR/kindck-nonsendable-1.rs:9:5
    |
 LL | fn bar<F:FnOnce() + Send>(_: F) { }
-   | ------------------------------- required by `bar`
+   |    ---              ---- required by this bound in `bar`
 ...
 LL |     bar(move|| foo(x));
    |     ^^^ `std::rc::Rc<usize>` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object.stderr
+++ b/src/test/ui/kindck/kindck-send-object.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'static (dyn Dummy + 'static)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object.rs:17:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object1.stderr
+++ b/src/test/ui/kindck/kindck-send-object1.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be shared between threads safely
   --> $DIR/kindck-send-object1.rs:10:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   | -------------------------------- required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'a dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be shared between threads safely
@@ -22,7 +22,7 @@ error[E0277]: `(dyn Dummy + 'a)` cannot be sent between threads safely
   --> $DIR/kindck-send-object1.rs:29:5
    |
 LL | fn assert_send<T:Send+'static>() { }
-   | -------------------------------- required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy + 'a>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'a)` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-object2.stderr
+++ b/src/test/ui/kindck/kindck-send-object2.stderr
@@ -2,7 +2,7 @@ error[E0277]: `(dyn Dummy + 'static)` cannot be shared between threads safely
   --> $DIR/kindck-send-object2.rs:7:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<&'static dyn Dummy>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `(dyn Dummy + 'static)` cannot be shared between threads safely
@@ -14,7 +14,7 @@ error[E0277]: `dyn Dummy` cannot be sent between threads safely
   --> $DIR/kindck-send-object2.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<dyn Dummy>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `dyn Dummy` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-owned.stderr
+++ b/src/test/ui/kindck/kindck-send-owned.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*mut u8` cannot be sent between threads safely
   --> $DIR/kindck-send-owned.rs:12:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<Box<*mut u8>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut u8` cannot be sent between threads safely

--- a/src/test/ui/kindck/kindck-send-unsafe.stderr
+++ b/src/test/ui/kindck/kindck-send-unsafe.stderr
@@ -2,7 +2,7 @@ error[E0277]: `*mut &'a isize` cannot be sent between threads safely
   --> $DIR/kindck-send-unsafe.rs:6:5
    |
 LL | fn assert_send<T:Send>() { }
-   | ------------------------ required by `assert_send`
+   |    -----------   ---- required by this bound in `assert_send`
 ...
 LL |     assert_send::<*mut &'a isize>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut &'a isize` cannot be sent between threads safely

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-3.nll.stderr
@@ -12,11 +12,11 @@ error: lifetime may not live long enough
   --> $DIR/ex3-both-anon-regions-3.rs:2:5
    |
 LL | fn foo(z: &mut Vec<(&u8,&u8)>, (x, y): (&u8, &u8)) {
-   |                         -                    - let's call the lifetime of this reference `'1`
+   |                         -                    - let's call the lifetime of this reference `'3`
    |                         |
-   |                         let's call the lifetime of this reference `'2`
+   |                         let's call the lifetime of this reference `'4`
 LL |     z.push((x,y));
-   |     ^^^^^^^^^^^^^ argument requires that `'1` must outlive `'2`
+   |     ^^^^^^^^^^^^^ argument requires that `'3` must outlive `'4`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:27:5
    |
 LL | fn is_marker<T: Marker>() { }
-   | ------------------------- required by `is_marker`
+   |    ---------    ------ required by this bound in `is_marker`
 ...
 LL |     is_marker::<NotDebugOrDisplay>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -2,7 +2,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:7:5
    |
 LL | fn foo<F: Fn(usize)>(_: F) {}
-   | -------------------------- required by `foo`
+   |    ---    --------- required by this bound in `foo`
 ...
 LL |     foo(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
@@ -13,7 +13,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/E0631.rs:8:5
    |
 LL | fn bar<F: Fn<usize>>(_: F) {}
-   | -------------------------- required by `bar`
+   |    ---    --------- required by this bound in `bar`
 ...
 LL |     bar(|_: isize| {});
    |     ^^^ ---------- found signature of `fn(isize) -> _`
@@ -24,7 +24,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:9:5
    |
 LL | fn foo<F: Fn(usize)>(_: F) {}
-   | -------------------------- required by `foo`
+   |    ---    --------- required by this bound in `foo`
 ...
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
@@ -36,7 +36,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/E0631.rs:10:5
    |
 LL | fn bar<F: Fn<usize>>(_: F) {}
-   | -------------------------- required by `bar`
+   |    ---    --------- required by this bound in `bar`
 LL | fn main() {
 LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -46,7 +46,7 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:13:5
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
-   | ------------------------ required by `f`
+   |    -    --------- required by this bound in `f`
 ...
 LL |     f(|| panic!());
    |     ^ -- takes 0 arguments
@@ -61,7 +61,7 @@ error[E0593]: closure is expected to take 1 argument, but it takes 0 arguments
   --> $DIR/closure-arg-count.rs:15:5
    |
 LL | fn f<F: Fn<usize>>(_: F) {}
-   | ------------------------ required by `f`
+   |    -    --------- required by this bound in `f`
 ...
 LL |     f(  move    || panic!());
    |     ^   ---------- takes 0 arguments
@@ -143,7 +143,7 @@ LL |     call(Foo);
    |     ^^^^ expected function that takes 0 arguments
 ...
 LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
-   | ------------------------------------------ required by `call`
+   |    ----                      ------------- required by this bound in `call`
 LL | struct Foo(u8);
    | --------------- takes 1 argument
 

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -26,7 +26,7 @@ error[E0631]: type mismatch in function arguments
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   | ------------------------------ required by `baz`
+   |    ---    ------------- required by this bound in `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^
@@ -38,7 +38,7 @@ error[E0271]: type mismatch resolving `for<'r> <fn(*mut &'a u32) as std::ops::Fn
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   | ------------------------------ required by `baz`
+   |    ---      ----------- required by this bound in `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^ expected bound lifetime parameter, found concrete lifetime

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -38,7 +38,7 @@ error[E0271]: type mismatch resolving `for<'r> <fn(*mut &'a u32) as std::ops::Fn
   --> $DIR/closure-arg-type-mismatch.rs:10:5
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   |    ---      ----------- required by this bound in `baz`
+   |    ---    ------------- required by this bound in `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
    |     ^^^ expected bound lifetime parameter, found concrete lifetime

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -2,7 +2,7 @@ error[E0271]: type mismatch resolving `for<'r> <[closure@$DIR/closure-mismatch.r
   --> $DIR/closure-mismatch.rs:8:5
    |
 LL | fn baz<T: Foo>(_: T) {}
-   | -------------------- required by `baz`
+   |    ---    --- required by this bound in `baz`
 ...
 LL |     baz(|_| ());
    |     ^^^ expected bound lifetime parameter, found concrete lifetime
@@ -13,7 +13,7 @@ error[E0631]: type mismatch in closure arguments
   --> $DIR/closure-mismatch.rs:8:5
    |
 LL | fn baz<T: Foo>(_: T) {}
-   | -------------------- required by `baz`
+   |    ---    --- required by this bound in `baz`
 ...
 LL |     baz(|_| ());
    |     ^^^ ------ found signature of `fn(_) -> _`

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -5,7 +5,7 @@ LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
 LL | 
 LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   | --------------------------------------------- required by `apply`
+   |    -----                            --------- required by this bound in `apply`
 ...
 LL |     apply(&3, takes_mut);
    |     ^^^^^ expected signature of `fn(&{integer}) -> _`
@@ -17,7 +17,7 @@ LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
 ...
 LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
-   | --------------------------------------------- required by `apply`
+   |    -----                            --------- required by this bound in `apply`
 ...
 LL |     apply(&mut 3, takes_imm);
    |     ^^^^^ expected signature of `fn(&mut {integer}) -> _`

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.rs
@@ -5,7 +5,8 @@ use std::ops::FnMut;
 fn to_fn_mut<A,F:FnMut<A>>(f: F) -> F { f }
 
 fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-//~^ NOTE required by `call_it`
+//~^ NOTE required by this bound in `call_it`
+//~| NOTE
     f(2, y)
 }
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0631]: type mismatch in closure arguments
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:15:13
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:16:13
    |
 LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
-   | -------------------------------------------------------------------- required by `call_it`
+   |    -------   ------------------------- required by this bound in `call_it`
 ...
 LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`

--- a/src/test/ui/mut/mutable-enum-indirect.stderr
+++ b/src/test/ui/mut/mutable-enum-indirect.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/mutable-enum-indirect.rs:17:5
    |
 LL | fn bar<T: Sync>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(&x);
    |     ^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/mutexguard-sync.rs:11:5
    |
 LL | fn test_sync<T: Sync>(_t: T) {}
-   | ---------------------------- required by `test_sync`
+   |    ---------    ---- required by this bound in `test_sync`
 ...
 LL |     test_sync(guard);
    |     ^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -70,7 +70,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m1::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -79,7 +79,7 @@ error[E0277]: the trait bound `c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:35:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m2::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::S`
@@ -88,7 +88,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:36:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m2::S);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -97,7 +97,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:39:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm1::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -106,7 +106,7 @@ error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:41:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm2::S{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
@@ -115,7 +115,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:42:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm2::S);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -124,7 +124,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:55:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m3::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -133,7 +133,7 @@ error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfi
   --> $DIR/namespace-mix.rs:56:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m3::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
@@ -142,7 +142,7 @@ error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:57:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m4::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::TS`
@@ -151,7 +151,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:58:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m4::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -160,7 +160,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:61:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm3::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -169,7 +169,7 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::T
   --> $DIR/namespace-mix.rs:62:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm3::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
@@ -178,7 +178,7 @@ error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:63:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm4::TS{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
@@ -187,7 +187,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:64:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm4::TS);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -196,7 +196,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:77:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m5::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -205,7 +205,7 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:78:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m5::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
@@ -214,7 +214,7 @@ error[E0277]: the trait bound `c::US: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:79:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m6::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
@@ -223,7 +223,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:80:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m6::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -232,7 +232,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:83:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm5::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -241,7 +241,7 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:84:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm5::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
@@ -250,7 +250,7 @@ error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfie
   --> $DIR/namespace-mix.rs:85:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm6::US{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
@@ -259,7 +259,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:86:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm6::US);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -268,7 +268,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:99:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m7::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -277,7 +277,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:101:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m8::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -286,7 +286,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:102:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m8::V);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -295,7 +295,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:105:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm7::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -304,7 +304,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:107:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm8::V{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -313,7 +313,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:108:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm8::V);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -322,7 +322,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:121:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m9::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -331,7 +331,7 @@ error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satis
   --> $DIR/namespace-mix.rs:122:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(m9::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
@@ -340,7 +340,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:123:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mA::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -349,7 +349,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:124:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mA::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -358,7 +358,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:127:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm9::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -367,7 +367,7 @@ error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::
   --> $DIR/namespace-mix.rs:128:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xm9::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
@@ -376,7 +376,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:129:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmA::TV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -385,7 +385,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:130:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmA::TV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -394,7 +394,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:143:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mB::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -403,7 +403,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:144:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mB::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -412,7 +412,7 @@ error[E0277]: the trait bound `c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:145:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mC::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
@@ -421,7 +421,7 @@ error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:146:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(mC::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
@@ -430,7 +430,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:149:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmB::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
@@ -439,7 +439,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:150:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmB::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -448,7 +448,7 @@ error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:151:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmC::UV{});
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
@@ -457,7 +457,7 @@ error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisf
   --> $DIR/namespace-mix.rs:152:5
    |
 LL | fn check<T: Impossible>(_: T) {}
-   | ----------------------------- required by `check`
+   |    -----    ---------- required by this bound in `check`
 ...
 LL |     check(xmC::UV);
    |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`

--- a/src/test/ui/no-send-res-ports.rs
+++ b/src/test/ui/no-send-res-ports.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 use std::thread;
 use std::rc::Rc;
 

--- a/src/test/ui/no-send-res-ports.stderr
+++ b/src/test/ui/no-send-res-ports.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
-  --> $DIR/no-send-res-ports.rs:25:5
+  --> $DIR/no-send-res-ports.rs:27:5
    |
 LL |     thread::spawn(move|| {
    |     ^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
@@ -9,10 +9,10 @@ LL |     thread::spawn(move|| {
 LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
    |                          ---- required by this bound in `std::thread::spawn`
    |
-   = help: within `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6 x:main::Foo]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
+   = help: within `[closure@$DIR/no-send-res-ports.rs:27:19: 31:6 x:main::Foo]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
    = note: required because it appears within the type `Port<()>`
    = note: required because it appears within the type `main::Foo`
-   = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6 x:main::Foo]`
+   = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:27:19: 31:6 x:main::Foo]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no-send-res-ports.stderr
+++ b/src/test/ui/no-send-res-ports.stderr
@@ -3,12 +3,16 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
    |
 LL |     thread::spawn(move|| {
    |     ^^^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
+   | 
+  ::: $SRC_DIR/libstd/thread/mod.rs:LL:COL
+   |
+LL |     F: FnOnce() -> T, F: Send + 'static, T: Send + 'static
+   |                          ---- required by this bound in `std::thread::spawn`
    |
    = help: within `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6 x:main::Foo]`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
    = note: required because it appears within the type `Port<()>`
    = note: required because it appears within the type `main::Foo`
    = note: required because it appears within the type `[closure@$DIR/no-send-res-ports.rs:25:19: 29:6 x:main::Foo]`
-   = note: required by `std::thread::spawn`
 
 error: aborting due to previous error
 

--- a/src/test/ui/no_send-enum.stderr
+++ b/src/test/ui/no_send-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSend` cannot be sent between threads safely
   --> $DIR/no_send-enum.rs:16:5
    |
 LL | fn bar<T: Send>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `NoSend` cannot be sent between threads safely

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<{integer}>` cannot be sent between threads safely
   --> $DIR/no_send-rc.rs:7:5
    |
 LL | fn bar<T: Send>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `std::rc::Rc<{integer}>` cannot be sent between threads safely

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Foo` cannot be sent between threads safely
   --> $DIR/no_send-struct.rs:15:5
    |
 LL | fn bar<T: Send>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `Foo` cannot be sent between threads safely

--- a/src/test/ui/no_share-enum.stderr
+++ b/src/test/ui/no_share-enum.stderr
@@ -2,7 +2,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/no_share-enum.rs:14:5
    |
 LL | fn bar<T: Sync>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -2,7 +2,7 @@ error[E0277]: `Foo` cannot be shared between threads safely
   --> $DIR/no_share-struct.rs:12:5
    |
 LL | fn bar<T: Sync>(_: T) {}
-   | --------------------- required by `bar`
+   |    ---    ---- required by this bound in `bar`
 ...
 LL |     bar(x);
    |     ^^^ `Foo` cannot be shared between threads safely

--- a/src/test/ui/not-panic/not-panic-safe-2.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-2.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-2.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<Rc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-3.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-3.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-3.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-3.rs:10:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<Arc<RefCell<i32>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-4.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-4.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-4.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-4.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<&RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-5.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-5.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-5.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<*const UnsafeCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe-6.stderr
+++ b/src/test/ui/not-panic/not-panic-safe-6.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `std::cell::UnsafeCell<i32>` may contain interior mutabil
   --> $DIR/not-panic-safe-6.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<i32>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
@@ -15,7 +15,7 @@ error[E0277]: the type `std::cell::UnsafeCell<isize>` may contain interior mutab
   --> $DIR/not-panic-safe-6.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<*mut RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<isize>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -2,7 +2,7 @@ error[E0277]: the type `&mut i32` may not be safely transferred across an unwind
   --> $DIR/not-panic-safe.rs:9:5
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
-   | ----------------------------------- required by `assert`
+   |    ------    ---------- required by this bound in `assert`
 ...
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary

--- a/src/test/ui/not-sync.stderr
+++ b/src/test/ui/not-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:8:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<Cell<i32>>();
    |     ^^^^^^^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::RefCell<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:10:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<RefCell<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::cell::RefCell<i32>` cannot be shared between threads safely
@@ -24,7 +24,7 @@ error[E0277]: `std::rc::Rc<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:13:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<Rc<i32>>();
    |     ^^^^^^^^^^^^^^^ `std::rc::Rc<i32>` cannot be shared between threads safely
@@ -35,7 +35,7 @@ error[E0277]: `std::rc::Weak<i32>` cannot be shared between threads safely
   --> $DIR/not-sync.rs:15:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<Weak<i32>>();
    |     ^^^^^^^^^^^^^^^^^ `std::rc::Weak<i32>` cannot be shared between threads safely
@@ -46,7 +46,7 @@ error[E0277]: `std::sync::mpsc::Receiver<i32>` cannot be shared between threads 
   --> $DIR/not-sync.rs:18:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<Receiver<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^^^ `std::sync::mpsc::Receiver<i32>` cannot be shared between threads safely
@@ -57,7 +57,7 @@ error[E0277]: `std::sync::mpsc::Sender<i32>` cannot be shared between threads sa
   --> $DIR/not-sync.rs:20:5
    |
 LL | fn test<T: Sync>() {}
-   | ------------------ required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test::<Sender<i32>>();
    |     ^^^^^^^^^^^^^^^^^^^ `std::sync::mpsc::Sender<i32>` cannot be shared between threads safely

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::boxed::Box<dyn Foo>: Foo` is not satisfied
   --> $DIR/object-does-not-impl-trait.rs:6:35
    |
 LL | fn take_foo<F:Foo>(f: F) {}
-   | ------------------------ required by `take_foo`
+   |    --------   --- required by this bound in `take_foo`
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
    |                                   ^^^^^^^^ the trait `Foo` is not implemented for `std::boxed::Box<dyn Foo>`
 

--- a/src/test/ui/on-unimplemented/on-trait.stderr
+++ b/src/test/ui/on-unimplemented/on-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `std::option::Option<std::vec::Vec<u8>>: MyFromIte
   --> $DIR/on-trait.rs:28:30
    |
 LL | fn collect<A, I: Iterator<Item=A>, B: MyFromIterator<A>>(it: I) -> B {
-   | -------------------------------------------------------------------- required by `collect`
+   |    -------                            ----------------- required by this bound in `collect`
 ...
 LL |     let y: Option<Vec<u8>> = collect(x.iter()); // this should give approximately the same error for x.iter().collect()
    |                              ^^^^^^^ a collection of type `std::option::Option<std::vec::Vec<u8>>` cannot be built from an iterator over elements of type `&u8`
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `std::string::String: Bar::Foo<u8, _, u32>` is not
   --> $DIR/on-trait.rs:31:21
    |
 LL | fn foobar<U: Clone, T: Foo<u8, U, u32>>() -> T {
-   | ---------------------------------------------- required by `foobar`
+   |    ------              --------------- required by this bound in `foobar`
 ...
 LL |     let x: String = foobar();
    |                     ^^^^^^ test error `std::string::String` with `u8` `_` `u32` in `Bar::Foo`

--- a/src/test/ui/overlap-marker-trait.stderr
+++ b/src/test/ui/overlap-marker-trait.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
   --> $DIR/overlap-marker-trait.rs:30:5
    |
 LL | fn is_marker<T: Marker>() { }
-   | ------------------------- required by `is_marker`
+   |    ---------    ------ required by this bound in `is_marker`
 ...
 LL |     is_marker::<NotDebugOrDisplay>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`

--- a/src/test/ui/parser/type-parameters-in-field-exprs.stderr
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.stderr
@@ -1,14 +1,14 @@
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:13:7
+  --> $DIR/type-parameters-in-field-exprs.rs:13:10
    |
 LL |     f.x::<isize>;
-   |       ^^^^^^^^^^
+   |          ^^^^^^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:15:7
+  --> $DIR/type-parameters-in-field-exprs.rs:15:10
    |
 LL |     f.x::<>;
-   |       ^^^^^
+   |          ^^
 
 error: field expressions may not have generic arguments
   --> $DIR/type-parameters-in-field-exprs.rs:17:7

--- a/src/test/ui/parser/type-parameters-in-field-exprs.stderr
+++ b/src/test/ui/parser/type-parameters-in-field-exprs.stderr
@@ -1,20 +1,20 @@
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:13:10
+  --> $DIR/type-parameters-in-field-exprs.rs:13:7
    |
 LL |     f.x::<isize>;
-   |          ^^^^^^^
+   |       ^^^^^^^^^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:15:10
+  --> $DIR/type-parameters-in-field-exprs.rs:15:7
    |
 LL |     f.x::<>;
-   |          ^^
+   |       ^^^^^
 
 error: field expressions may not have generic arguments
-  --> $DIR/type-parameters-in-field-exprs.rs:17:10
+  --> $DIR/type-parameters-in-field-exprs.rs:17:7
    |
 LL |     f.x::();
-   |          ^^
+   |       ^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -2,7 +2,7 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:21:5
    |
 LL | fn is_zen<T: Zen>(_: T) {}
-   | ----------------------- required by `is_zen`
+   |    ------    --- required by this bound in `is_zen`
 ...
 LL |     is_zen(x)
    |     ^^^^^^ `T` cannot be shared between threads safely
@@ -17,7 +17,7 @@ error[E0277]: `T` cannot be shared between threads safely
   --> $DIR/phantom-oibit.rs:26:5
    |
 LL | fn is_zen<T: Zen>(_: T) {}
-   | ----------------------- required by `is_zen`
+   |    ------    --- required by this bound in `is_zen`
 ...
 LL |     is_zen(x)
    |     ^^^^^^ `T` cannot be shared between threads safely

--- a/src/test/ui/regions/regions-close-object-into-object-5.stderr
+++ b/src/test/ui/regions/regions-close-object-into-object-5.stderr
@@ -52,26 +52,26 @@ LL |     // oh dear!
 LL |     box B(&*v) as Box<X>
    |         ^^^^^^
    |
-note: ...so that the reference type `&dyn A<T>` does not outlive the data it points at
+note: ...so that the type `T` will meet its required lifetime bounds
   --> $DIR/regions-close-object-into-object-5.rs:17:9
    |
 LL |     box B(&*v) as Box<X>
    |         ^^^^^^
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/regions-close-object-into-object-5.rs:17:9
+  --> $DIR/regions-close-object-into-object-5.rs:17:11
    |
 LL | fn f<'a, T, U>(v: Box<A<T>+'static>) -> Box<X+'static> {
    |          - help: consider adding an explicit lifetime bound `T: 'static`...
 LL |     // oh dear!
 LL |     box B(&*v) as Box<X>
-   |         ^^^^^^
+   |           ^^^
    |
-note: ...so that the type `T` will meet its required lifetime bounds
-  --> $DIR/regions-close-object-into-object-5.rs:17:9
+note: ...so that the reference type `&dyn A<T>` does not outlive the data it points at
+  --> $DIR/regions-close-object-into-object-5.rs:17:11
    |
 LL |     box B(&*v) as Box<X>
-   |         ^^^^^^
+   |           ^^^
 
 error[E0310]: the parameter type `T` may not live long enough
   --> $DIR/regions-close-object-into-object-5.rs:17:11

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.rs
@@ -1,4 +1,6 @@
 // compile-flags: --test
+// ignore-musl
+// ^ due to stderr output differences
 
 use std::num::ParseFloatError;
 

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `main` has invalid return type `std::result::Result<f32, std::num::ParseFloatError>`
-  --> $DIR/termination-trait-test-wrong-type.rs:6:1
+  --> $DIR/termination-trait-test-wrong-type.rs:8:1
    |
 LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -5,9 +5,13 @@ LL | / fn can_parse_zero_as_f32() -> Result<f32, ParseFloatError> {
 LL | |     "0".parse()
 LL | | }
    | |_^ `main` can only return types that implement `std::process::Termination`
+   | 
+  ::: $SRC_DIR/libtest/lib.rs:LL:COL
+   |
+LL |   pub fn assert_test_result<T: Termination>(result: T) {
+   |                                ----------- required by this bound in `test::assert_test_result`
    |
    = help: the trait `std::process::Termination` is not implemented for `std::result::Result<f32, std::num::ParseFloatError>`
-   = note: required by `test::assert_test_result`
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -1,14 +1,14 @@
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:10:5
+  --> $DIR/macro-ty-params.rs:10:10
    |
 LL |     foo::<T>!();
-   |     ^^^^^^^^
+   |          ^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:11:5
+  --> $DIR/macro-ty-params.rs:11:10
    |
 LL |     foo::<>!();
-   |     ^^^^^^^
+   |          ^^
 
 error: unexpected generic arguments in path
   --> $DIR/macro-ty-params.rs:12:8
@@ -17,10 +17,10 @@ LL |     m!(Default<>);
    |        ^^^^^^^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:12:8
+  --> $DIR/macro-ty-params.rs:12:15
    |
 LL |     m!(Default<>);
-   |        ^^^^^^^^^
+   |               ^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/span/macro-ty-params.stderr
+++ b/src/test/ui/span/macro-ty-params.stderr
@@ -1,14 +1,14 @@
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:10:10
+  --> $DIR/macro-ty-params.rs:10:5
    |
 LL |     foo::<T>!();
-   |          ^^^
+   |     ^^^^^^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:11:10
+  --> $DIR/macro-ty-params.rs:11:5
    |
 LL |     foo::<>!();
-   |          ^^
+   |     ^^^^^^^
 
 error: unexpected generic arguments in path
   --> $DIR/macro-ty-params.rs:12:8
@@ -17,10 +17,10 @@ LL |     m!(Default<>);
    |        ^^^^^^^^^
 
 error: generic arguments in macro path
-  --> $DIR/macro-ty-params.rs:12:15
+  --> $DIR/macro-ty-params.rs:12:8
    |
 LL |     m!(Default<>);
-   |               ^^
+   |        ^^^^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/str-mut-idx.rs:4:15
    |
 LL | fn bot<T>() -> T { loop {} }
-   | ---------------- required by `bot`
+   |    --- - required by this bound in `bot`
 ...
 LL |     s[1..2] = bot();
    |               ^^^ doesn't have a size known at compile-time

--- a/src/test/ui/substs-ppaux.normal.stderr
+++ b/src/test/ui/substs-ppaux.normal.stderr
@@ -62,7 +62,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/substs-ppaux.rs:49:5
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- required by `Foo::bar`
+   |        ---                   -- required by this bound in `Foo::bar`
 ...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/substs-ppaux.verbose.stderr
+++ b/src/test/ui/substs-ppaux.verbose.stderr
@@ -62,7 +62,7 @@ error[E0277]: the size for values of type `str` cannot be known at compilation t
   --> $DIR/substs-ppaux.rs:49:5
    |
 LL |     fn bar<'a, T>() where T: 'a {}
-   |     --------------------------- required by `Foo::bar`
+   |        ---                   -- required by this bound in `Foo::bar`
 ...
 LL |     <str as Foo<u8>>::bar;
    |     ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `fn() -> impl std::future::Future {foo}: std::futu
   --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:5
    |
 LL | fn bar(f: impl Future<Output=()>) {}
-   | --------------------------------- required by `bar`
+   |    ---         ----------------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |     ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `fn() -> impl T {foo}: T` is not satisfied
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:5
    |
 LL | fn bar(f: impl T<O=()>) {}
-   | ----------------------- required by `bar`
+   |    ---         ------- required by this bound in `bar`
 ...
 LL |     bar(foo);
    |     ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`

--- a/src/test/ui/suggestions/into-str.stderr
+++ b/src/test/ui/suggestions/into-str.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&str: std::convert::From<std::string::String>` is
   --> $DIR/into-str.rs:4:5
    |
 LL | fn foo<'a, T>(_t: T) where T: Into<&'a str> {}
-   | ------------------------------------------- required by `foo`
+   |    ---                        ------------- required by this bound in `foo`
 ...
 LL |     foo(String::new());
    |     ^^^ the trait `std::convert::From<std::string::String>` is not implemented for `&str`

--- a/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
+++ b/src/test/ui/traits/trait-alias/trait-alias-cross-crate.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::rc::Rc<u32>` cannot be sent between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:5
    |
 LL | fn use_alias<T: SendSync>() {}
-   | --------------------------- required by `use_alias`
+   |    ---------    -------- required by this bound in `use_alias`
 ...
 LL |     use_alias::<Rc<u32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<u32>` cannot be sent between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::rc::Rc<u32>` cannot be shared between threads safely
   --> $DIR/trait-alias-cross-crate.rs:14:5
    |
 LL | fn use_alias<T: SendSync>() {}
-   | --------------------------- required by `use_alias`
+   |    ---------    -------- required by this bound in `use_alias`
 ...
 LL |     use_alias::<Rc<u32>>();
    |     ^^^^^^^^^^^^^^^^^^^^ `std::rc::Rc<u32>` cannot be shared between threads safely

--- a/src/test/ui/traits/trait-suggest-where-clause.rs
+++ b/src/test/ui/traits/trait-suggest-where-clause.rs
@@ -1,3 +1,5 @@
+// ignore-musl
+// ^ due to stderr output differences
 use std::mem;
 
 struct Misc<T:?Sized>(T);

--- a/src/test/ui/traits/trait-suggest-where-clause.stderr
+++ b/src/test/ui/traits/trait-suggest-where-clause.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `U` cannot be known at compilation time
-  --> $DIR/trait-suggest-where-clause.rs:7:5
+  --> $DIR/trait-suggest-where-clause.rs:9:5
    |
 LL |     mem::size_of::<U>();
    |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -14,7 +14,7 @@ LL | pub const fn size_of<T>() -> usize {
    = help: consider adding a `where U: std::marker::Sized` bound
 
 error[E0277]: the size for values of type `U` cannot be known at compilation time
-  --> $DIR/trait-suggest-where-clause.rs:10:5
+  --> $DIR/trait-suggest-where-clause.rs:12:5
    |
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -30,7 +30,7 @@ LL | pub const fn size_of<T>() -> usize {
    = note: required because it appears within the type `Misc<U>`
 
 error[E0277]: the trait bound `u64: std::convert::From<T>` is not satisfied
-  --> $DIR/trait-suggest-where-clause.rs:15:5
+  --> $DIR/trait-suggest-where-clause.rs:17:5
    |
 LL |     <u64 as From<T>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<T>` is not implemented for `u64`
@@ -39,7 +39,7 @@ LL |     <u64 as From<T>>::from;
    = note: required by `std::convert::From::from`
 
 error[E0277]: the trait bound `u64: std::convert::From<<T as std::iter::Iterator>::Item>` is not satisfied
-  --> $DIR/trait-suggest-where-clause.rs:18:5
+  --> $DIR/trait-suggest-where-clause.rs:20:5
    |
 LL |     <u64 as From<<T as Iterator>::Item>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<<T as std::iter::Iterator>::Item>` is not implemented for `u64`
@@ -48,7 +48,7 @@ LL |     <u64 as From<<T as Iterator>::Item>>::from;
    = note: required by `std::convert::From::from`
 
 error[E0277]: the trait bound `Misc<_>: std::convert::From<T>` is not satisfied
-  --> $DIR/trait-suggest-where-clause.rs:23:5
+  --> $DIR/trait-suggest-where-clause.rs:25:5
    |
 LL |     <Misc<_> as From<T>>::from;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<T>` is not implemented for `Misc<_>`
@@ -56,7 +56,7 @@ LL |     <Misc<_> as From<T>>::from;
    = note: required by `std::convert::From::from`
 
 error[E0277]: the size for values of type `[T]` cannot be known at compilation time
-  --> $DIR/trait-suggest-where-clause.rs:28:5
+  --> $DIR/trait-suggest-where-clause.rs:30:5
    |
 LL |     mem::size_of::<[T]>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
@@ -70,7 +70,7 @@ LL | pub const fn size_of<T>() -> usize {
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
 
 error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
-  --> $DIR/trait-suggest-where-clause.rs:31:5
+  --> $DIR/trait-suggest-where-clause.rs:33:5
    |
 LL |     mem::size_of::<[&U]>();
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/traits/trait-suggest-where-clause.stderr
+++ b/src/test/ui/traits/trait-suggest-where-clause.stderr
@@ -3,23 +3,31 @@ error[E0277]: the size for values of type `U` cannot be known at compilation tim
    |
 LL |     mem::size_of::<U>();
    |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/libcore/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
    |
    = help: the trait `std::marker::Sized` is not implemented for `U`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where U: std::marker::Sized` bound
-   = note: required by `std::mem::size_of`
 
 error[E0277]: the size for values of type `U` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:10:5
    |
 LL |     mem::size_of::<Misc<U>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/libcore/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
    |
    = help: within `Misc<U>`, the trait `std::marker::Sized` is not implemented for `U`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
    = help: consider adding a `where U: std::marker::Sized` bound
    = note: required because it appears within the type `Misc<U>`
-   = note: required by `std::mem::size_of`
 
 error[E0277]: the trait bound `u64: std::convert::From<T>` is not satisfied
   --> $DIR/trait-suggest-where-clause.rs:15:5
@@ -52,20 +60,28 @@ error[E0277]: the size for values of type `[T]` cannot be known at compilation t
    |
 LL |     mem::size_of::<[T]>();
    |     ^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/libcore/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
    |
    = help: the trait `std::marker::Sized` is not implemented for `[T]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::mem::size_of`
 
 error[E0277]: the size for values of type `[&U]` cannot be known at compilation time
   --> $DIR/trait-suggest-where-clause.rs:31:5
    |
 LL |     mem::size_of::<[&U]>();
    |     ^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   | 
+  ::: $SRC_DIR/libcore/mem/mod.rs:LL:COL
+   |
+LL | pub const fn size_of<T>() -> usize {
+   |                      - required by this bound in `std::mem::size_of`
    |
    = help: the trait `std::marker::Sized` is not implemented for `[&U]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::mem::size_of`
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-simultaneous.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `{integer}: Tweedledum`
   --> $DIR/traits-inductive-overflow-simultaneous.rs:18:5
    |
 LL | fn is_ee<T: Combo>(t: T) {
-   | ------------------------ required by `is_ee`
+   |    -----    ----- required by this bound in `is_ee`
 ...
 LL |     is_ee(4);
    |     ^^^^^

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
   --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:18
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   | --------------------------------- required by `copy`
+   |    ----    ----- required by this bound in `copy`
 ...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^ the trait `std::marker::Copy` is not implemented for `NoClone`

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `NoClone: Magic`
   --> $DIR/traits-inductive-overflow-supertrait.rs:13:18
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
-   | --------------------------------- required by `copy`
+   |    ----    ----- required by this bound in `copy`
 ...
 LL |     let (a, b) = copy(NoClone);
    |                  ^^^^

--- a/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-two-traits.stderr
@@ -2,7 +2,7 @@ error[E0275]: overflow evaluating the requirement `*mut (): Magic`
   --> $DIR/traits-inductive-overflow-two-traits.rs:19:5
    |
 LL | fn wizard<T: Magic>() { check::<<T as Magic>::X>(); }
-   | --------------------- required by `wizard`
+   |    ------    ----- required by this bound in `wizard`
 ...
 LL |     wizard::<*mut ()>();
    |     ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/traits/traits-negative-impls.stderr
+++ b/src/test/ui/traits/traits-negative-impls.stderr
@@ -24,7 +24,7 @@ error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:32:5
    |
 LL | fn is_send<T: Send>(_: T) {}
-   | ------------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send(TestType);
    |     ^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
@@ -35,7 +35,7 @@ error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:40:5
    |
 LL | fn is_send<T: Send>(_: T) {}
-   | ------------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send((8, TestType));
    |     ^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
@@ -47,7 +47,7 @@ error[E0277]: `dummy2::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:48:5
    |
 LL | fn is_send<T: Send>(_: T) {}
-   | ------------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send(Box::new(TestType));
    |     ^^^^^^^ `dummy2::TestType` cannot be sent between threads safely
@@ -60,7 +60,7 @@ error[E0277]: `dummy3::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:56:5
    |
 LL | fn is_send<T: Send>(_: T) {}
-   | ------------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send(Box::new(Outer2(TestType)));
    |     ^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
@@ -74,7 +74,7 @@ error[E0277]: `main::TestType` cannot be sent between threads safely
   --> $DIR/traits-negative-impls.rs:66:5
    |
 LL | fn is_sync<T: Sync>(_: T) {}
-   | ------------------------- required by `is_sync`
+   |    -------    ---- required by this bound in `is_sync`
 ...
 LL |     is_sync(Outer2(TestType));
    |     ^^^^^^^ `main::TestType` cannot be sent between threads safely

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -34,7 +34,7 @@ LL |     generic_function(5i32);
    |     ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
 ...
 LL | fn generic_function<T: Foo>(t: T) {}
-   | --------------------------------- required by `generic_function`
+   |    ----------------    --- required by this bound in `generic_function`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/try-operator-on-main.stderr
+++ b/src/test/ui/try-operator-on-main.stderr
@@ -23,7 +23,7 @@ LL |     try_trait_generic::<()>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `()`
 ...
 LL | fn try_trait_generic<T: Try>() -> T {
-   | ----------------------------------- required by `try_trait_generic`
+   |    -----------------    --- required by this bound in `try_trait_generic`
 
 error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/try-operator-on-main.rs:22:5

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -5,10 +5,10 @@ LL |         input_cells: Vec::new()
    |         ^^^^^^^^^^^ a field by this name exists in `Self`
 
 error: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/issue-34255-1.rs:7:30
+  --> $DIR/issue-34255-1.rs:7:27
    |
 LL |         input_cells: Vec::new()
-   |                              ^^
+   |                           ^^^^^
    |
    = note: `#[deny(parenthesized_params_in_types_and_modules)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/type/type-annotation-needed.rs
+++ b/src/test/ui/type/type-annotation-needed.rs
@@ -1,5 +1,6 @@
 fn foo<T: Into<String>>(x: i32) {}
 //~^ NOTE required by
+//~| NOTE
 
 fn main() {
     foo(42);

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,8 +1,8 @@
 error[E0283]: type annotations required: cannot resolve `_: std::convert::Into<std::string::String>`
-  --> $DIR/type-annotation-needed.rs:5:5
+  --> $DIR/type-annotation-needed.rs:6:5
    |
 LL | fn foo<T: Into<String>>(x: i32) {}
-   | ------------------------------- required by `foo`
+   |    ---    ------------ required by this bound in `foo`
 ...
 LL |     foo(42);
    |     ^^^

--- a/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-assoc-type.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<T::AssocType>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ `<T as Trait>::AssocType` cannot be sent between threads safely
 ...
 LL | fn is_send<T:Send>() {
-   | -------------------- required by `is_send`
+   |    -------   ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `<T as Trait>::AssocType`
    = help: consider adding a `where <T as Trait>::AssocType: std::marker::Send` bound

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types-2.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied in `(MyS2, MyS)`
   --> $DIR/typeck-default-trait-impl-constituent-types-2.rs:16:5
    |
 LL | fn is_mytrait<T: MyTrait>() {}
-   | --------------------------- required by `is_mytrait`
+   |    ----------    ------- required by this bound in `is_mytrait`
 ...
 LL |     is_mytrait::<(MyS2, MyS)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ within `(MyS2, MyS)`, the trait `MyTrait` is not implemented for `MyS2`

--- a/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-constituent-types.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `MyS2: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-constituent-types.rs:20:5
    |
 LL | fn is_mytrait<T: MyTrait>() {}
-   | --------------------------- required by `is_mytrait`
+   |    ----------    ------- required by this bound in `is_mytrait`
 ...
 LL |     is_mytrait::<MyS2>();
    |     ^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `MyS2`

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-send.stderr
@@ -2,7 +2,7 @@ error[E0277]: `MyNotSendable` cannot be sent between threads safely
   --> $DIR/typeck-default-trait-impl-negation-send.rs:19:5
    |
 LL | fn is_send<T: Send>() {}
-   | --------------------- required by `is_send`
+   |    -------    ---- required by this bound in `is_send`
 ...
 LL |     is_send::<MyNotSendable>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `MyNotSendable` cannot be sent between threads safely

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation-sync.stderr
@@ -2,7 +2,7 @@ error[E0277]: `MyNotSync` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:33:5
    |
 LL | fn is_sync<T: Sync>() {}
-   | --------------------- required by `is_sync`
+   |    -------    ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyNotSync>();
    |     ^^^^^^^^^^^^^^^^^^^^ `MyNotSync` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::UnsafeCell<u8>` cannot be shared between threads safel
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:36:5
    |
 LL | fn is_sync<T: Sync>() {}
-   | --------------------- required by `is_sync`
+   |    -------    ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyTypeWUnsafe>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `std::cell::UnsafeCell<u8>` cannot be shared between threads safely
@@ -25,7 +25,7 @@ error[E0277]: `Managed` cannot be shared between threads safely
   --> $DIR/typeck-default-trait-impl-negation-sync.rs:39:5
    |
 LL | fn is_sync<T: Sync>() {}
-   | --------------------- required by `is_sync`
+   |    -------    ---- required by this bound in `is_sync`
 ...
 LL |     is_sync::<MyTypeManaged>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Managed` cannot be shared between threads safely

--- a/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-negation.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `ThisImplsUnsafeTrait: MyTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:21:5
    |
 LL | fn is_my_trait<T: MyTrait>() {}
-   | ---------------------------- required by `is_my_trait`
+   |    -----------    ------- required by this bound in `is_my_trait`
 ...
 LL |     is_my_trait::<ThisImplsUnsafeTrait>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyTrait` is not implemented for `ThisImplsUnsafeTrait`
@@ -14,7 +14,7 @@ error[E0277]: the trait bound `ThisImplsTrait: MyUnsafeTrait` is not satisfied
   --> $DIR/typeck-default-trait-impl-negation.rs:24:5
    |
 LL | fn is_my_unsafe_trait<T: MyUnsafeTrait>() {}
-   | ----------------------------------------- required by `is_my_unsafe_trait`
+   |    ------------------    ------------- required by this bound in `is_my_unsafe_trait`
 ...
 LL |     is_my_unsafe_trait::<ThisImplsTrait>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyUnsafeTrait` is not implemented for `ThisImplsTrait`

--- a/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-precedence.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: Signed` is not satisfied
   --> $DIR/typeck-default-trait-impl-precedence.rs:18:5
    |
 LL | fn is_defaulted<T:Defaulted>() { }
-   | ------------------------------ required by `is_defaulted`
+   |    ------------   --------- required by this bound in `is_defaulted`
 ...
 LL |     is_defaulted::<&'static u32>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Signed` is not implemented for `u32`

--- a/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -5,7 +5,7 @@ LL |     is_send::<T>()
    |     ^^^^^^^^^^^^ `T` cannot be sent between threads safely
 ...
 LL | fn is_send<T:Send>() {
-   | -------------------- required by `is_send`
+   |    -------   ---- required by this bound in `is_send`
    |
    = help: the trait `std::marker::Send` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Send` bound

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -2,7 +2,7 @@ error[E0277]: `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared betwee
   --> $DIR/typeck-unsafe-always-share.rs:19:5
    |
 LL | fn test<T: Sync>(s: T) {}
-   | ---------------------- required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test(us);
    |     ^^^^ `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
@@ -13,7 +13,7 @@ error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads s
   --> $DIR/typeck-unsafe-always-share.rs:23:5
    |
 LL | fn test<T: Sync>(s: T) {}
-   | ---------------------- required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test(uns);
    |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
@@ -24,7 +24,7 @@ error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads s
   --> $DIR/typeck-unsafe-always-share.rs:27:5
    |
 LL | fn test<T: Sync>(s: T) {}
-   | ---------------------- required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test(ms);
    |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
@@ -36,7 +36,7 @@ error[E0277]: `NoSync` cannot be shared between threads safely
   --> $DIR/typeck-unsafe-always-share.rs:30:5
    |
 LL | fn test<T: Sync>(s: T) {}
-   | ---------------------- required by `test`
+   |    ----    ---- required by this bound in `test`
 ...
 LL |     test(NoSync);
    |     ^^^^ `NoSync` cannot be shared between threads safely

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-default.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `dyn Foo<(isize,), isize, Output = ()>: Eq<dyn Foo
   --> $DIR/unboxed-closure-sugar-default.rs:21:5
    |
 LL | fn eq<A: ?Sized,B: ?Sized>() where A : Eq<B> { }
-   | -------------------------------------------- required by `eq`
+   |    --                                  ----- required by this bound in `eq`
 ...
 LL |     eq::<dyn Foo<(isize,), isize, Output=()>, dyn Foo(isize)>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Eq<dyn Foo<(isize,), Output = ()>>` is not implemented for `dyn Foo<(isize,), isize, Output = ()>`

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-equiv.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `dyn Foo<(char,), Output = ()>: Eq<dyn Foo<(), Out
   --> $DIR/unboxed-closure-sugar-equiv.rs:43:5
    |
 LL |   fn eq<A: ?Sized,B: ?Sized +Eq<A>>() { }
-   |   ----------------------------------- required by `eq`
+   |      --                      ----- required by this bound in `eq`
 ...
 LL | /     eq::< dyn Foo<(),Output=()>,
 LL | |           dyn Foo(char)                                               >();

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-1.stderr
@@ -1,8 +1,8 @@
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:19
+  --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16
    |
 LL |     let x: Box<Bar()> = panic!();
-   |                   ^^ only `Fn` traits may use parentheses
+   |                ^^^^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct-1.rs:8:16

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -1,11 +1,11 @@
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:18
+  --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |                  ^^^^^^^^^^^^^^
-   |                  |
-   |                  only `Fn` traits may use parentheses
-   |                  help: use angle brackets instead: `<isize, usize>`
+   |             ^^^^^^^^^^^^^^^^^^^
+   |             |
+   |             only `Fn` traits may use parentheses
+   |             help: use angle brackets instead: `Bar::<isize, usize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct.stderr
@@ -1,8 +1,8 @@
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:18
+  --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15
    |
 LL | fn foo(b: Box<Bar()>) {
-   |                  ^^ only `Fn` traits may use parentheses
+   |               ^^^^^ only `Fn` traits may use parentheses
 
 error[E0107]: wrong number of type arguments: expected 1, found 0
   --> $DIR/unboxed-closure-sugar-used-on-struct.rs:7:15

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-1.stderr
@@ -1,8 +1,8 @@
 error[E0220]: associated type `Output` not found for `One<()>`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-1.rs:5:19
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-1.rs:5:16
    |
 LL | fn foo(_: &dyn One())
-   |                   ^^ associated type `Output` not found
+   |                ^^^^^ associated type `Output` not found
 
 error: aborting due to previous error
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters-3.stderr
@@ -5,10 +5,10 @@ LL | fn foo(_: &dyn Three())
    |                ^^^^^^^ expected 3 type arguments
 
 error[E0220]: associated type `Output` not found for `Three<(), [type error], [type error]>`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs:5:21
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters-3.rs:5:16
    |
 LL | fn foo(_: &dyn Three())
-   |                     ^^ associated type `Output` not found
+   |                ^^^^^^^ associated type `Output` not found
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -1,14 +1,14 @@
 error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:19
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:15
    |
 LL | fn foo(_: dyn Zero())
-   |                   ^^ unexpected type argument
+   |               ^^^^^^ unexpected type argument
 
 error[E0220]: associated type `Output` not found for `Zero`
-  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:19
+  --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:15
    |
 LL | fn foo(_: dyn Zero())
-   |                   ^^ associated type `Output` not found
+   |               ^^^^^^ associated type `Output` not found
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -1,8 +1,8 @@
 error[E0107]: wrong number of type arguments: expected 0, found 1
-  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:13
+  --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}
-   |             ^^^^^^^ unexpected type argument
+   |        ^^^^^^^^^^^^ unexpected type argument
 
 error[E0220]: associated type `Output` not found for `Trait`
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:24

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `S`
   --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:13
    |
 LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
-   | -------------------------------------------------------- required by `call_it`
+   |    -------   ---------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&S, 22);
    |             ^^^^^^^ expected an `Fn<(isize,)>` closure, found `S`

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> unsaf
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------   ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------               ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> un
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------   -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------                  ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> u
   --> $DIR/unboxed-closures-unsafe-extern-fn.rs:24:13
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ----------------------------------------------------------------- required by `call_it_once`
+   |    ------------                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> exter
   --> $DIR/unboxed-closures-wrong-abi.rs:12:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------   ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:12:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------               ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> ex
   --> $DIR/unboxed-closures-wrong-abi.rs:18:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------   -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:18:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------                  ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> e
   --> $DIR/unboxed-closures-wrong-abi.rs:24:13
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ----------------------------------------------------------------- required by `call_it_once`
+   |    ------------                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -2,7 +2,7 @@ error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `unsafe fn(isi
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------   ----------------- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -13,7 +13,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
-   | --------------------------------------------------------- required by `call_it`
+   |    -------               ----- required by this bound in `call_it`
 ...
 LL |     let x = call_it(&square, 22);
    |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -24,7 +24,7 @@ error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `unsafe fn(
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------   -------------------- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -35,7 +35,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
-   | -------------------------------------------------------------------- required by `call_it_mut`
+   |    -----------                  ----- required by this bound in `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
    |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
@@ -46,7 +46,7 @@ error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn
   --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:25:13
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
-   | ----------------------------------------------------------------- required by `call_it_once`
+   |    ------------                   ----- required by this bound in `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
    |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -2,7 +2,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-bare-typaram.rs:2:23
    |
 LL | fn bar<T: Sized>() { }
-   | ------------------ required by `bar`
+   |    --- - required by this bound in `bar`
 LL | fn foo<T: ?Sized>() { bar::<T>() }
    |                       ^^^^^^^^ doesn't have a size known at compile-time
    |

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -15,7 +15,7 @@ error[E0277]: the size for values of type `T` cannot be known at compilation tim
   --> $DIR/unsized-struct.rs:13:24
    |
 LL | fn is_sized<T:Sized>() { }
-   | ---------------------- required by `is_sized`
+   |    -------- - required by this bound in `is_sized`
 ...
 LL | fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
    |                        ^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -5,7 +5,7 @@ LL |     f2::<X>(x);
    |     ^^^^^^^ doesn't have a size known at compile-time
 ...
 LL | fn f2<X>(x: &X) {
-   | --------------- required by `f2`
+   |    -- - required by this bound in `f2`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -18,7 +18,7 @@ LL |     f4::<X>(x);
    |     ^^^^^^^ doesn't have a size known at compile-time
 ...
 LL | fn f4<X: T>(x: &X) {
-   | ------------------ required by `f4`
+   |    -- - required by this bound in `f4`
    |
    = help: the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -28,7 +28,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:33:5
    |
 LL | fn f5<Y>(x: &Y) {}
-   | --------------- required by `f5`
+   |    -- - required by this bound in `f5`
 ...
 LL |     f5(x1);
    |     ^^ doesn't have a size known at compile-time
@@ -67,7 +67,7 @@ error[E0277]: the size for values of type `X` cannot be known at compilation tim
   --> $DIR/unsized3.rs:45:5
    |
 LL | fn f5<Y>(x: &Y) {}
-   | --------------- required by `f5`
+   |    -- - required by this bound in `f5`
 ...
 LL |     f5(&(32, *x1));
    |     ^^ doesn't have a size known at compile-time

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:9
    |
 LL | fn require_copy<T: Copy>(x: T) {}
-   | ------------------------------ required by `require_copy`
+   |    ------------    ---- required by this bound in `require_copy`
 ...
 LL |         require_copy(self.x);
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
   --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:9
    |
 LL | fn require_copy<T: Copy>(x: T) {}
-   | ------------------------------ required by `require_copy`
+   |    ------------    ---- required by this bound in `require_copy`
 ...
 LL |         require_copy(self.x);
    |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`

--- a/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `Struct: std::cmp::Eq` is not satisfied
   --> $DIR/where-clauses-unsatisfied.rs:6:10
    |
 LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
-   | ---------------------------------------------- required by `equal`
+   |    -----                                    -- required by this bound in `equal`
 ...
 LL |     drop(equal(&Struct, &Struct))
    |          ^^^^^ the trait `std::cmp::Eq` is not implemented for `Struct`

--- a/src/test/ui/where-clauses/where-for-self-2.stderr
+++ b/src/test/ui/where-clauses/where-for-self-2.stderr
@@ -1,13 +1,13 @@
 error[E0277]: the trait bound `for<'a> &'a _: Bar` is not satisfied
   --> $DIR/where-for-self-2.rs:21:5
    |
-LL | / fn foo<T>(x: &T)
-LL | |     where for<'a> &'a T: Bar
-LL | | {}
-   | |__- required by `foo`
+LL | fn foo<T>(x: &T)
+   |    ---
+LL |     where for<'a> &'a T: Bar
+   |                          --- required by this bound in `foo`
 ...
-LL |       foo(&X);
-   |       ^^^ the trait `for<'a> Bar` is not implemented for `&'a _`
+LL |     foo(&X);
+   |     ^^^ the trait `for<'a> Bar` is not implemented for `&'a _`
    |
    = help: the following implementations were found:
              <&'static u32 as Bar>


### PR DESCRIPTION
Successful merges:

 - #64151 (On obligation errors point at the unfulfilled binding when possible)
 - #64357 (`AdtDef` is an algebraic data type, not abstract data type)
 - #64416 (Various refactorings to clean up nll diagnostics)
 - #64509 (Make some adjustments to the documentation for `std::convert::identity`)
 - #64516 (update Nomicon and Reference)
 - #64518 (Use while let slice_pattern instead of carrying an index around)

Failed merges:


r? @ghost