### PR TITLE
Use `vec![]` instead of `Vec::new` to test when miri unleashed

### DIFF
--- a/src/test/ui/consts/miri_unleashed/assoc_const.rs
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.rs
@@ -16,7 +16,9 @@ impl Foo<u32> for () {
     const X: u32 = 42;
 }
 impl Foo<Vec<u32>> for String {
-    const X: Vec<u32> = Vec::new();
+    const X: Vec<u32> = vec![1];
+    //~^ WARN skipping const checks
+    //~| WARN skipping const checks
 }
 
 impl Bar<u32, ()> for () {}

--- a/src/test/ui/consts/miri_unleashed/assoc_const.stderr
+++ b/src/test/ui/consts/miri_unleashed/assoc_const.stderr
@@ -4,8 +4,24 @@ warning: skipping const checks
 LL |     const F: u32 = (U::X, 42).1;
    |                               ^
 
+warning: skipping const checks
+  --> $DIR/assoc_const.rs:19:25
+   |
+LL |     const X: Vec<u32> = vec![1];
+   |                         ^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/assoc_const.rs:19:25
+   |
+LL |     const X: Vec<u32> = vec![1];
+   |                         ^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
 error[E0080]: erroneous constant used
-  --> $DIR/assoc_const.rs:29:13
+  --> $DIR/assoc_const.rs:31:13
    |
 LL |     let y = <String as Bar<Vec<u32>, String>>::F;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors

--- a/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.rs
+++ b/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.rs
@@ -16,7 +16,10 @@ impl Foo<u32> for () {
 }
 
 impl Foo<Vec<u32>> for String {
-    const X: Vec<u32> = Vec::new();
+    const X: Vec<u32> = vec![1];
+    //~^ allocations are not allowed in constants
+    //~| constant contains unimplemented expression type
+    //~| calls in constants are limited to constant functions, tuple structs and tuple variants
 }
 
 impl Bar<u32, ()> for () {}

--- a/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
+++ b/src/test/ui/consts/miri_unleashed/feature-gate-unleash_the_miri_inside_of_you.stderr
@@ -4,5 +4,31 @@ error[E0493]: destructors cannot be evaluated at compile-time
 LL |     const F: u32 = (U::X, 42).1;
    |                    ^^^^^^^^^^ constants cannot evaluate destructors
 
-error: aborting due to previous error
+error[E0010]: allocations are not allowed in constants
+  --> $DIR/feature-gate-unleash_the_miri_inside_of_you.rs:19:25
+   |
+LL |     const X: Vec<u32> = vec![1];
+   |                         ^^^^^^^ allocation not allowed in constants
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/feature-gate-unleash_the_miri_inside_of_you.rs:19:25
+   |
+LL |     const X: Vec<u32> = vec![1];
+   |                         ^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/feature-gate-unleash_the_miri_inside_of_you.rs:19:25
+   |
+LL |     const X: Vec<u32> = vec![1];
+   |                         ^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0010, E0015, E0019.
+For more information about an error, try `rustc --explain E0010`.


### PR DESCRIPTION
Now that the latter is `const`, we need something more complex for `-Zunleash-the-miri-inside-you` to have an effect.