### PR TITLE
Fix accidental stabilization in feature-detection macros

### DIFF
--- a/src/libstd/tests/run-time-detect.rs
+++ b/src/libstd/tests/run-time-detect.rs
@@ -1,14 +1,6 @@
 //! These tests just check that the macros are available in libstd.
 
-#![cfg_attr(
-    any(
-        all(target_arch = "arm", any(target_os = "linux", target_os = "android")),
-        all(target_arch = "aarch64", any(target_os = "linux", target_os = "android")),
-        all(target_arch = "powerpc", target_os = "linux"),
-        all(target_arch = "powerpc64", target_os = "linux"),
-    ),
-    feature(stdsimd)
-)]
+#![feature(stdsimd)]
 
 #[test]
 #[cfg(all(target_arch = "arm",

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-asimd.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-asimd.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-asimd.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-asimd.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("asimd");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-crc.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-crc.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-crc.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-crc.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("crc");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-crypto.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-crypto.rs
@@ -1,16 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
-
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-crypto.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-crypto.rs
@@ -1,0 +1,22 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("crypto");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-dotprod.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-dotprod.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-dotprod.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-dotprod.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("dotprod");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-error.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-error.rs
@@ -1,0 +1,23 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    // test for unknown features
+    is_aarch64_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-fp.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-fp.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-fp.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-fp.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("fp");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-fp16.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-fp16.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("fp16");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-fp16.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-fp16.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-lse.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-lse.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-lse.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-lse.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("lse");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-ras.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-ras.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-ras.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-ras.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("ras");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-rcpc.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-rcpc.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-rcpc.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-rcpc.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("rcpc");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-rdm.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-rdm.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-rdm.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-rdm.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("rdm");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-sve.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-sve.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-sve.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-sve.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("sve");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v81a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v81a.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v81a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v81a.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("v8.1a");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v82a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v82a.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("v8.2a");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v82a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v82a.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v83a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v83a.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detected-v83a.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detected-v83a.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("v8.3a");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detection-neon.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detection-neon.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detection-neon.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detection-neon.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("neon");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_aarch64_feature_detection-pmull.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detection-pmull.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-x86
-// ignore-x86_64
+// only-aarch64
 
 #[cfg(target_arch = "aarch64")]
 fn main() {

--- a/src/test/ui/stdarch/is_aarch64_feature_detection-pmull.rs
+++ b/src/test/ui/stdarch/is_aarch64_feature_detection-pmull.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    is_aarch64_feature_detected!("pmull");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-error.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-error.rs
@@ -1,0 +1,23 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    // test for unknown features
+    is_arm_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-neon.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-neon.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-neon.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-neon.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("neon");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-pmull.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-pmull.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("pmull");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-pmull.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-pmull.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-v7.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-v7.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-v7.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-v7.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("v7");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp2.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp2.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp2.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp2.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("vfp2");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp3.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp3.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("vfp3");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp3.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp3.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp4.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp4.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-arm
 
 #[cfg(target_arch = "arm")]
 fn main() {

--- a/src/test/ui/stdarch/is_arm_feature_detected-vfp4.rs
+++ b/src/test/ui/stdarch/is_arm_feature_detected-vfp4.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "arm")]
+fn main() {
+    is_arm_feature_detected!("vfp4");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "arm"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_mips64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_mips64_feature_detected-error.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-mips64
 
 #[cfg(target_arch = "mips64")]
 fn main() {

--- a/src/test/ui/stdarch/is_mips64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_mips64_feature_detected-error.rs
@@ -1,0 +1,23 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "mips64")]
+fn main() {
+    // test for unknown features
+    is_mips64_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+
+#[cfg(not(target_arch = "mips64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_mips64_feature_detected-msa.rs
+++ b/src/test/ui/stdarch/is_mips64_feature_detected-msa.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "mips64")]
+fn main() {
+    is_mips_feature_detected!("msa");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "mips64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_mips64_feature_detected-msa.rs
+++ b/src/test/ui/stdarch/is_mips64_feature_detected-msa.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-mips64
 
 #[cfg(target_arch = "mips64")]
 fn main() {

--- a/src/test/ui/stdarch/is_mips_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_mips_feature_detected-error.rs
@@ -1,0 +1,23 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "mips")]
+fn main() {
+    // test for unknown features
+    is_mips_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+
+#[cfg(not(target_arch = "mips"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_mips_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_mips_feature_detected-error.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-mips
 
 #[cfg(target_arch = "mips")]
 fn main() {

--- a/src/test/ui/stdarch/is_mips_feature_detected-msa.rs
+++ b/src/test/ui/stdarch/is_mips_feature_detected-msa.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "mips")]
+fn main() {
+    is_mips_feature_detected!("msa");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "mips"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_mips_feature_detected-msa.rs
+++ b/src/test/ui/stdarch/is_mips_feature_detected-msa.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-mips
 
 #[cfg(target_arch = "mips")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-altivec.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-altivec.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc64")]
+fn main() {
+    is_powerpc64_feature_detected!("altivec");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-altivec.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-altivec.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc64|powerpc64le
 
 #[cfg(target_arch = "powerpc64")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-error.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc64|powerpc64le
 
 #[cfg(any(target_arch = "powerpc64", target_arch = "powerpc64le"))]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-error.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(any(target_arch = "powerpc64", target_arch = "powerpc64le"))]
+fn main() {
+    // test for unknown features
+    is_powerpc64_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(any(target_arch = "powerpc64", target_arch = "powerpc64le"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-power8.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-power8.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc64|powerpc64le
 
 #[cfg(target_arch = "powerpc64")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-power8.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-power8.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc64")]
+fn main() {
+    is_powerpc64_feature_detected!("power8");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-vsx.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-vsx.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc64|powerpc64le
 
 #[cfg(target_arch = "powerpc64")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc64_feature_detected-vsx.rs
+++ b/src/test/ui/stdarch/is_powerpc64_feature_detected-vsx.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc64")]
+fn main() {
+    is_powerpc64_feature_detected!("vsx");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc64"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-altivec.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-altivec.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc
 
 #[cfg(target_arch = "powerpc")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-altivec.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-altivec.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc")]
+fn main() {
+    is_powerpc_feature_detected!("altivec");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-error.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc
 
 #[cfg(target_arch = "powerpc")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-error.rs
@@ -1,0 +1,22 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc")]
+fn main() {
+    // test for unknown features
+    is_powerpc_feature_detected!("foobar");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-power8.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-power8.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc
 
 #[cfg(target_arch = "powerpc")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-power8.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-power8.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc")]
+fn main() {
+    is_powerpc_feature_detected!("power8");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-vsx.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-vsx.rs
@@ -1,15 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
-// ignore-x86
-// ignore-x86_64
+// only-powerpc
 
 #[cfg(target_arch = "powerpc")]
 fn main() {

--- a/src/test/ui/stdarch/is_powerpc_feature_detected-vsx.rs
+++ b/src/test/ui/stdarch/is_powerpc_feature_detected-vsx.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+// ignore-x86
+// ignore-x86_64
+
+#[cfg(target_arch = "powerpc")]
+fn main() {
+    is_powerpc_feature_detected!("vsx");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(target_arch = "powerpc"))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512bw");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512bw.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512bw");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512bw.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512bw.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512bw.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512bw");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512cd");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512cd.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512cd.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512cd");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512cd.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512cd.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512cd");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512dq");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512dq.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512dq.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512dq");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512dq.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512dq.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512dq");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512er.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512er.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512er");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512er.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512er.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512er.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512er.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512er.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512er.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512er");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512er.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512er.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512er.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512er");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512f.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512f.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512f");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512f.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512f.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512f.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512f.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512f.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512f");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512f.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512f.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512f.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512f.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512f");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512ifma");
+    //~^ ERROR use of unstable library feature
+ }
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512ifma.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512ifma");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512ifma.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512ifma.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512ifma.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512ifma");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512pf");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512pf.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512pf.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512pf");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512pf.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512pf.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512pf");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512vbmi");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512vbmi.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512vbmi");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vbmi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512vbmi.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512vbmi.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512vbmi");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512vl");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512vl.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512vl");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vl.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512vl.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512vl.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512vl");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("avx512vpopcntdq");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-avx512vpopcntdq.rs:15:5
+   |
+LL |     is_x86_feature_detected!("avx512vpopcntdq");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-avx512vpopcntdq.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-avx512vpopcntdq.rs:15:5
+  --> $DIR/is_x86_feature_detected-avx512vpopcntdq.rs:5:5
    |
 LL |     is_x86_feature_detected!("avx512vpopcntdq");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("cmpxchg16b");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-cmpxchg16b.rs:15:5
+   |
+LL |     is_x86_feature_detected!("cmpxchg16b");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-cmpxchg16b.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-cmpxchg16b.rs:15:5
+  --> $DIR/is_x86_feature_detected-cmpxchg16b.rs:5:5
    |
 LL |     is_x86_feature_detected!("cmpxchg16b");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-error.rs
@@ -1,0 +1,21 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    // test for unknown features
+    is_x86_feature_detected!("foobar");
+    //~^ ERROR unknown x86 target feature: foobar
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-error.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-error.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-error.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-error.stderr
@@ -1,0 +1,10 @@
+error: unknown x86 target feature: foobar
+  --> $DIR/is_x86_feature_detected-error.rs:16:5
+   |
+LL |     is_x86_feature_detected!("foobar");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+

--- a/src/test/ui/stdarch/is_x86_feature_detected-error.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-error.stderr
@@ -1,5 +1,5 @@
 error: unknown x86 target feature: foobar
-  --> $DIR/is_x86_feature_detected-error.rs:16:5
+  --> $DIR/is_x86_feature_detected-error.rs:6:5
    |
 LL |     is_x86_feature_detected!("foobar");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-f16c.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-f16c.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("f16c");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-f16c.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-f16c.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-f16c.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-f16c.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-f16c.rs:15:5
+  --> $DIR/is_x86_feature_detected-f16c.rs:5:5
    |
 LL |     is_x86_feature_detected!("f16c");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-f16c.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-f16c.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-f16c.rs:15:5
+   |
+LL |     is_x86_feature_detected!("f16c");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-mmx.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-mmx.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("mmx");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-mmx.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-mmx.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-mmx.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-mmx.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-mmx.rs:15:5
+   |
+LL |     is_x86_feature_detected!("mmx");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-mmx.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-mmx.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-mmx.rs:15:5
+  --> $DIR/is_x86_feature_detected-mmx.rs:5:5
    |
 LL |     is_x86_feature_detected!("mmx");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-rtm.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-rtm.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("rtm");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-rtm.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-rtm.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-rtm.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-rtm.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-rtm.rs:15:5
+   |
+LL |     is_x86_feature_detected!("rtm");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-rtm.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-rtm.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-rtm.rs:15:5
+  --> $DIR/is_x86_feature_detected-rtm.rs:5:5
    |
 LL |     is_x86_feature_detected!("rtm");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-sse4a.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-sse4a.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("sse4a");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-sse4a.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-sse4a.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-sse4a.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-sse4a.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-sse4a.rs:15:5
+   |
+LL |     is_x86_feature_detected!("sse4a");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stdarch/is_x86_feature_detected-sse4a.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-sse4a.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-sse4a.rs:15:5
+  --> $DIR/is_x86_feature_detected-sse4a.rs:5:5
    |
 LL |     is_x86_feature_detected!("sse4a");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-stable.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-stable.rs
@@ -1,0 +1,33 @@
+// run-pass
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    // stable target features:
+    is_x86_feature_detected!("pclmulqdq");
+    is_x86_feature_detected!("rdrand");
+    is_x86_feature_detected!("rdseed");
+    is_x86_feature_detected!("tsc");
+    is_x86_feature_detected!("sse");
+    is_x86_feature_detected!("sse2");
+    is_x86_feature_detected!("sse3");
+    is_x86_feature_detected!("ssse3");
+    is_x86_feature_detected!("sse4.1");
+    is_x86_feature_detected!("sse4.2");
+    is_x86_feature_detected!("sha");
+    is_x86_feature_detected!("avx");
+    is_x86_feature_detected!("avx2");
+    is_x86_feature_detected!("fma");
+    is_x86_feature_detected!("bmi1");
+    is_x86_feature_detected!("bmi2");
+    is_x86_feature_detected!("lzcnt");
+    is_x86_feature_detected!("popcnt");
+    is_x86_feature_detected!("fxsr");
+    is_x86_feature_detected!("xsave");
+    is_x86_feature_detected!("xsaveopt");
+    is_x86_feature_detected!("xsaves");
+    is_x86_feature_detected!("xsavec");
+    is_x86_feature_detected!("adx");
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-tbm.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-tbm.rs
@@ -1,0 +1,20 @@
+// ignore-s390x
+// ignore-emscripten
+// ignore-powerpc
+// ignore-powerpc64
+// ignore-powerpc64le
+// ignore-sparc
+// ignore-sparc64
+// ignore-mips
+// ignore-mips64
+// ignore-arm
+// ignore-aarch64
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn main() {
+    is_x86_feature_detected!("tbm");
+    //~^ ERROR use of unstable library feature
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/src/test/ui/stdarch/is_x86_feature_detected-tbm.rs
+++ b/src/test/ui/stdarch/is_x86_feature_detected-tbm.rs
@@ -1,14 +1,4 @@
-// ignore-s390x
-// ignore-emscripten
-// ignore-powerpc
-// ignore-powerpc64
-// ignore-powerpc64le
-// ignore-sparc
-// ignore-sparc64
-// ignore-mips
-// ignore-mips64
-// ignore-arm
-// ignore-aarch64
+// only-x86|x86_64
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn main() {

--- a/src/test/ui/stdarch/is_x86_feature_detected-tbm.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-tbm.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'stdsimd'
-  --> $DIR/is_x86_feature_detected-tbm.rs:15:5
+  --> $DIR/is_x86_feature_detected-tbm.rs:5:5
    |
 LL |     is_x86_feature_detected!("tbm");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stdarch/is_x86_feature_detected-tbm.stderr
+++ b/src/test/ui/stdarch/is_x86_feature_detected-tbm.stderr
@@ -1,0 +1,13 @@
+error[E0658]: use of unstable library feature 'stdsimd'
+  --> $DIR/is_x86_feature_detected-tbm.rs:15:5
+   |
+LL |     is_x86_feature_detected!("tbm");
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/27731
+   = help: add `#![feature(stdsimd)]` to the crate attributes to enable
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This commit updates stdarch and fix the accidental stabilization
of unstable target-features in the stable is_x86_feature_detected
macros.

For example, the "mmx" feature is unstable, but
is_x86_feature_detected!("mmx") works on stable Rust.