### PR TITLE
Dump all accessed environment variables when rustc fails

### DIFF
--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -390,7 +390,7 @@ fn main() {
     }
 
     let code = exec_cmd(&mut cmd).unwrap_or_else(|_| {
-        panic!("\n\n failed to run {:?}\n\n with env: {}", cmd, env.to_string())
+        panic!("\n\n failed to run {}{:?}\n\n", env.to_string(), cmd)
     });
     std::process::exit(code);
 }

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -389,7 +389,9 @@ fn main() {
         }
     }
 
-    let code = exec_cmd(&mut cmd).unwrap_or_else(|_| panic!("\n\n failed to run {:?}\n\n with env: {}", cmd, env.to_string()));
+    let code = exec_cmd(&mut cmd).unwrap_or_else(|_| {
+        panic!("\n\n failed to run {:?}\n\n with env: {}", cmd, env.to_string())
+    });
     std::process::exit(code);
 }
 


### PR DESCRIPTION
When reading environment variables in boostrap/bin/rustc, this PR caches the read environment variable, and prints them on failure, to allow users to c&p them before the rustc invocation when trying to reproduce.

r? @oli-obk 