### PR TITLE
ci: split aws credentials in two separate users with scoped perms

### DIFF
--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -7,7 +7,7 @@ trigger:
   - auto
 
 variables:
-- group: real-prod-credentials
+- group: prod-credentials
 
 jobs:
 - job: Linux

--- a/src/ci/azure-pipelines/master.yml
+++ b/src/ci/azure-pipelines/master.yml
@@ -7,7 +7,7 @@ trigger:
   - master
 
 variables:
-- group: real-prod-credentials
+- group: prod-credentials
 
 pool:
   vmImage: ubuntu-16.04

--- a/src/ci/azure-pipelines/steps/run.yml
+++ b/src/ci/azure-pipelines/steps/run.yml
@@ -175,7 +175,8 @@ steps:
   env:
     CI: true
     SRC: .
-    AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+    AWS_ACCESS_KEY_ID: $(SCCACHE_AWS_ACCESS_KEY_ID)
+    AWS_SECRET_ACCESS_KEY: $(SCCACHE_AWS_SECRET_ACCESS_KEY)
     TOOLSTATE_REPO_ACCESS_TOKEN: $(TOOLSTATE_REPO_ACCESS_TOKEN)
   condition: and(succeeded(), not(variables.SKIP_JOB))
   displayName: Run build
@@ -199,7 +200,8 @@ steps:
     fi
     retry aws s3 cp --no-progress --recursive --acl public-read ./$upload_dir s3://$DEPLOY_BUCKET/$deploy_dir/$BUILD_SOURCEVERSION
   env:
-    AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+    AWS_ACCESS_KEY_ID: $(UPLOAD_AWS_ACCESS_KEY_ID)
+    AWS_SECRET_ACCESS_KEY: $(UPLOAD_AWS_SECRET_ACCESS_KEY)
   condition: and(succeeded(), not(variables.SKIP_JOB), or(eq(variables.DEPLOY, '1'), eq(variables.DEPLOY_ALT, '1')))
   displayName: Upload artifacts
 
@@ -208,7 +210,8 @@ steps:
 # errors here ever fail the build since this is just informational.
 - bash: aws s3 cp --acl public-read cpu-usage.csv s3://$DEPLOY_BUCKET/rustc-builds/$BUILD_SOURCEVERSION/cpu-$CI_JOB_NAME.csv
   env:
-    AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
-  condition: variables['AWS_SECRET_ACCESS_KEY']
+    AWS_ACCESS_KEY_ID: $(UPLOAD_AWS_ACCESS_KEY_ID)
+    AWS_SECRET_ACCESS_KEY: $(UPLOAD_AWS_SECRET_ACCESS_KEY)
+  condition: variables['UPLOAD_AWS_SECRET_ACCESS_KEY']
   continueOnError: true
   displayName: Upload CPU usage statistics

--- a/src/ci/azure-pipelines/try.yml
+++ b/src/ci/azure-pipelines/try.yml
@@ -3,7 +3,7 @@ trigger:
 - try
 
 variables:
-- group: real-prod-credentials
+- group: prod-credentials
 
 jobs:
 - job: Linux


### PR DESCRIPTION
This commit changes our CI to use two separate IAM users to authenticate with AWS:

* `ci--rust-lang--rust--sccache`: has access to the `rust-lang-ci-sccache2` S3 bucket and its credentials are available during the whole build.
* `ci--rust-lang--rust--upload`: has access to the `rust-lang-ci2` S3 bucket and its credentials are available just during the upload step.

The new tokens are available in the `prod-credentials` library.

r? @alexcrichton