### PR TITLE
record fewer adjustment types in generator witnesses, avoid spurious drops in MIR construction

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1917,6 +1917,15 @@ impl<'tcx> Place<'tcx> {
         }
     }
 
+    /// If this place represents a local variable like `_X` with no
+    /// projections, return `Some(_X)`.
+    pub fn as_local(&self) -> Option<Local> {
+        match self {
+            Place { projection: box [], base: PlaceBase::Local(l) } => Some(*l),
+            _ => None,
+        }
+    }
+
     pub fn as_ref(&self) -> PlaceRef<'_, 'tcx> {
         PlaceRef {
             base: &self.base,

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -244,6 +244,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     let success = this.cfg.start_new_block();
                     let cleanup = this.diverge_cleanup();
+
+                    this.record_operands_moved(&args);
+
                     this.cfg.terminate(
                         block,
                         source_info,

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -189,8 +189,7 @@ pub enum BreakableTarget {
 
 impl CachedBlock {
     fn invalidate(&mut self) {
-        self.generator_drop = None;
-        self.unwind = None;
+        *self = CachedBlock::default();
     }
 
     fn get(&self, generator_drop: bool) -> Option<BasicBlock> {

--- a/src/librustc_mir/build/scope.rs
+++ b/src/librustc_mir/build/scope.rs
@@ -1123,16 +1123,16 @@ fn build_scope_drops<'tcx>(
         let source_info = scope.source_info(drop_data.span);
         let local = drop_data.local;
 
-        // If the operand has been moved, and we are not on an unwind
-        // path, then don't generate the drop. (We only take this into
-        // account for non-unwind paths so as not to disturb the
-        // caching mechanism.)
-        if !is_cached_path && scope.moved_locals.iter().any(|&o| o == local) {
-            continue;
-        }
-
         match drop_data.kind {
             DropKind::Value => {
+                // If the operand has been moved, and we are not on an unwind
+                // path, then don't generate the drop. (We only take this into
+                // account for non-unwind paths so as not to disturb the
+                // caching mechanism.)
+                if !is_cached_path && scope.moved_locals.iter().any(|&o| o == local) {
+                    continue;
+                }
+
                 let unwind_to = get_unwind_to(scope, is_generator, drop_idx, generator_drop)
                     .unwrap_or(last_unwind_to);
 

--- a/src/test/mir-opt/box_expr.rs
+++ b/src/test/mir-opt/box_expr.rs
@@ -57,25 +57,18 @@ impl Drop for S {
 //     }
 //
 //     bb5: {
-//         drop(_4) -> [return: bb8, unwind: bb6];
-//     }
-//
-//     bb6 (cleanup): {
-//         drop(_1) -> bb1;
-//     }
-//
-//     bb7 (cleanup): {
-//         drop(_4) -> bb6;
-//     }
-//
-//     bb8: {
 //         StorageDead(_4);
 //         StorageDead(_3);
 //         _0 = ();
-//         drop(_1) -> bb9;
+//         drop(_1) -> bb8;
 //     }
-//
-//     bb9: {
+//     bb6 (cleanup): {
+//         drop(_1) -> bb1;
+//     }
+//     bb7 (cleanup): {
+//         drop(_4) -> bb6;
+//     }
+//     bb8: {
 //         StorageDead(_1);
 //         return;
 //     }

--- a/src/test/mir-opt/generator-storage-dead-unwind.rs
+++ b/src/test/mir-opt/generator-storage-dead-unwind.rs
@@ -57,7 +57,7 @@ fn main() {
 //     StorageLive(_6);
 //     StorageLive(_7);
 //     _7 = move _2;
-//     _6 = const take::<Foo>(move _7) -> [return: bb9, unwind: bb8];
+//     _6 = const take::<Foo>(move _7) -> [return: bb7, unwind: bb9];
 // }
 // bb3 (cleanup): {
 //     StorageDead(_2);
@@ -75,23 +75,23 @@ fn main() {
 // bb6: {
 //     generator_drop;
 // }
-// bb7 (cleanup): {
-//     StorageDead(_3);
-//     StorageDead(_2);
-//     drop(_1) -> bb1;
-// }
-// bb8 (cleanup): {
-//     StorageDead(_7);
-//     StorageDead(_6);
-//     goto -> bb7;
-// }
-// bb9: {
+// bb7: {
 //     StorageDead(_7);
 //     StorageDead(_6);
 //     StorageLive(_8);
 //     StorageLive(_9);
 //     _9 = move _3;
 //     _8 = const take::<Bar>(move _9) -> [return: bb10, unwind: bb11];
+// }
+// bb8 (cleanup): {
+//     StorageDead(_3);
+//     StorageDead(_2);
+//     drop(_1) -> bb1;
+// }
+// bb9 (cleanup): {
+//     StorageDead(_7);
+//     StorageDead(_6);
+//     goto -> bb8;
 // }
 // bb10: {
 //     StorageDead(_9);
@@ -104,7 +104,7 @@ fn main() {
 // bb11 (cleanup): {
 //     StorageDead(_9);
 //     StorageDead(_8);
-//     goto -> bb7;
+//     goto -> bb8;
 // }
 // bb12: {
 //     return;

--- a/src/test/mir-opt/no-spurious-drop-after-call.rs
+++ b/src/test/mir-opt/no-spurious-drop-after-call.rs
@@ -1,0 +1,24 @@
+// ignore-wasm32-bare compiled with panic=abort by default
+
+// Test that after the call to `std::mem::drop` we do not generate a
+// MIR drop of the argument. (We used to have a `DROP(_2)` in the code
+// below, as part of bb3.)
+
+fn main() {
+    std::mem::drop("".to_string());
+}
+
+// END RUST SOURCE
+// START rustc.main.ElaborateDrops.before.mir
+//    bb2: {
+//        StorageDead(_3);
+//        _1 = const std::mem::drop::<std::string::String>(move _2) -> [return: bb3, unwind: bb4];
+//    }
+//    bb3: {
+//        StorageDead(_2);
+//        StorageDead(_4);
+//        StorageDead(_1);
+//        _0 = ();
+//        return;
+//    }
+// END rustc.main.ElaborateDrops.before.mir

--- a/src/test/ui/async-await/issues/issue-64391-2.rs
+++ b/src/test/ui/async-await/issues/issue-64391-2.rs
@@ -1,0 +1,17 @@
+// Regression test for #64391
+//
+// As described on the issue, the (spurious) `DROP` inserted for the
+// `"".to_string()` value was causing a (spurious) unwind path that
+// led us to believe that the future might be dropped after `config`
+// had been dropped. This cannot, in fact, happen.
+
+async fn connect() {
+    let config = 666;
+    connect2(&config, "".to_string()).await
+}
+
+async fn connect2(_config: &u32, _tls: String) {
+    unimplemented!()
+}
+
+fn main() { }

--- a/src/test/ui/async-await/issues/issue-64391-2.rs
+++ b/src/test/ui/async-await/issues/issue-64391-2.rs
@@ -4,6 +4,9 @@
 // `"".to_string()` value was causing a (spurious) unwind path that
 // led us to believe that the future might be dropped after `config`
 // had been dropped. This cannot, in fact, happen.
+//
+// check-pass
+// edition:2018
 
 async fn connect() {
     let config = 666;

--- a/src/test/ui/async-await/issues/issue-64433.rs
+++ b/src/test/ui/async-await/issues/issue-64433.rs
@@ -4,6 +4,7 @@
 // same PR.
 //
 // check-pass
+// edition:2018
 
 #[derive(Debug)]
 struct A<'a> {

--- a/src/test/ui/async-await/issues/issue-64433.rs
+++ b/src/test/ui/async-await/issues/issue-64433.rs
@@ -1,0 +1,29 @@
+// Regression test for issue #64433.
+//
+// See issue-64391-2.rs for more details, as that was fixed by the
+// same PR.
+//
+// check-pass
+
+#[derive(Debug)]
+struct A<'a> {
+    inner: Vec<&'a str>,
+}
+
+struct B {}
+
+impl B {
+    async fn something_with_a(&mut self, a: A<'_>) -> Result<(), String> {
+        println!("{:?}", a);
+        Ok(())
+    }
+}
+
+async fn can_error(some_string: &str) -> Result<(), String> {
+    let a = A { inner: vec![some_string, "foo"] };
+    let mut b = B {};
+    Ok(b.something_with_a(a).await.map(|_| ())?)
+}
+
+fn main() {
+}

--- a/src/test/ui/async-await/issues/issue-64477.rs
+++ b/src/test/ui/async-await/issues/issue-64477.rs
@@ -1,0 +1,20 @@
+// Regression test for #64477.
+//
+// We were incorrectly claiming that the `f(x).await` future captured
+// a value of type `T`, and hence that `T: Send` would have to hold.
+//
+// check-pass
+// edition:2018
+
+use std::future::Future;
+use std::pin::Pin;
+
+fn f<T>(_: &T) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    unimplemented!()
+}
+
+pub fn g<T: Sync>(x: &'static T) -> impl Future<Output = ()> + Send {
+    async move { f(x).await }
+}
+
+fn main() { }


### PR DESCRIPTION
Don't record all intermediate adjustment types -- That's way more than is needed, and winds up recording types that will never appear in MIR. 

Note: I'm like 90% sure that this logic is correct, but this stuff is subtle and can be hard to keep straight.  However, the risk of this PR is fairly low -- if we miss types here, I believe the most common outcome is an ICE.

This fixes the original issue cited by #64477, but I'm leaving the issue open for now since there may be other cases we can detect and improve in a targeted way.

r? @Zoxc 