### PR TITLE
Differentiate AArch64 bare-metal targets between hf and non-hf.

### DIFF
--- a/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
+++ b/src/librustc_target/spec/aarch64_unknown_none_softfloat.rs
@@ -1,4 +1,4 @@
-// Generic AArch64 target for bare-metal code - Floating point enabled
+// Generic AArch64 target for bare-metal code - Floating point disabled
 //
 // Can be used in conjunction with the `target-feature` and
 // `target-cpu` compiler flags to opt-in more hardware-specific
@@ -11,7 +11,7 @@ use super::{LldFlavor, LinkerFlavor, Target, TargetOptions, PanicStrategy};
 pub fn target() -> Result<Target, String> {
     let opts = TargetOptions {
         linker: Some("rust-lld".to_owned()),
-        features: "+strict-align,+neon,+fp-armv8".to_string(),
+        features: "+strict-align,-neon,-fp-armv8".to_string(),
         executables: true,
         relocation_model: "static".to_string(),
         disable_redzone: true,

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -489,6 +489,7 @@ supported_targets! {
     ("riscv64gc-unknown-none-elf", riscv64gc_unknown_none_elf),
 
     ("aarch64-unknown-none", aarch64_unknown_none),
+    ("aarch64-unknown-none-softfloat", aarch64_unknown_none_softfloat),
 
     ("x86_64-fortanix-unknown-sgx", x86_64_fortanix_unknown_sgx),
 


### PR DESCRIPTION
CC @parched, kindly request you to review.

~~Note: This change breaks code that uses the target `aarch64-unknown-none` for the sake of clearer naming as discussed in the links posted below. A search on github reveals that code using `aarch64-unknown-none` is almost exclusively forked from our embedded WG's OS tutorials repo at https://github.com/rust-embedded/rust-raspi3-OS-tutorials, for which the target was originally created.~~

~~I will adapt this repo to the new target name asap once this PR would go upstream. The minor annoyance for the forks to break temporarily should be acceptable for the sake of introducing a better differentiation now before it is too late.
Also, the break would only happen upon updating the toolchain, giving the user a good hint at what has happened.~~

---------- Patch commit message:
Following up on [1] and [2], this PR adds differntiation for aarch64 bare-metal
targets between versions with and without floating point enabled.

This streamlines the target naming with other existing ARM targets and provides
the user clear indication if he is getting float or non-float for his bare-metal
target.

[1] https://github.com/rust-lang/rust/pull/60135#issuecomment-485851356
[2] https://github.com/rust-embedded/wg/issues/230

Closes: rust-embedded/wg#230