### PR TITLE
Point at original span when emitting unreachable lint

### DIFF
--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -170,12 +170,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             prior_arm_ty = Some(arm_ty);
         }
 
-        // If all of the arms in the 'match' diverge,
-        // and we're dealing with an actual 'match' block
-        // (as opposed to a 'match' desugared from something else'),
+        // If all of the arms in the `match` diverge,
+        // and we're dealing with an actual `match` block
+        // (as opposed to a `match` desugared from something else'),
         // we can emit a better note. Rather than pointing
         // at a diverging expression in an arbitrary arm,
-        // we can point at the entire 'match' expression
+        // we can point at the entire `match` expression
         match (all_arms_diverge, match_src) {
             (Diverges::Always { .. }, hir::MatchSource::Normal) => {
                 all_arms_diverge = Diverges::Always {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -43,7 +43,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If there are no arms, that is a diverging match; a special case.
         if arms.is_empty() {
-            self.diverges.set(self.diverges.get() | Diverges::Always);
+            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
             return tcx.types.never;
         }
 
@@ -69,7 +69,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // warnings).
             match all_pats_diverge {
                 Diverges::Maybe => Diverges::Maybe,
-                Diverges::Always | Diverges::WarnedAlways => Diverges::WarnedAlways,
+                Diverges::Always(..) | Diverges::WarnedAlways => Diverges::WarnedAlways,
             }
         }).collect();
 

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -43,10 +43,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If there are no arms, that is a diverging match; a special case.
         if arms.is_empty() {
-            self.diverges.set(self.diverges.get() | Diverges::Always {
-                span: expr.span,
-                custom_note: None
-            });
+            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
             return tcx.types.never;
         }
 
@@ -198,7 +195,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// When the previously checked expression (the scrutinee) diverges,
     /// warn the user about the match arms being unreachable.
     fn warn_arms_when_scrutinee_diverges(&self, arms: &'tcx [hir::Arm], source: hir::MatchSource) {
-        if self.diverges.get().always() {
+        if self.diverges.get().is_always() {
             use hir::MatchSource::*;
             let msg = match source {
                 IfDesugar { .. } | IfLetDesugar { .. } => "block in `if` expression",

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -173,17 +173,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // we can emit a better note. Rather than pointing
         // at a diverging expression in an arbitrary arm,
         // we can point at the entire `match` expression
-        match (all_arms_diverge, match_src) {
-            (Diverges::Always { .. }, hir::MatchSource::Normal) => {
-                all_arms_diverge = Diverges::Always {
-                    span: expr.span,
-                    custom_note: Some(
-                        "any code following this `match` expression is unreachable, \
-                        as all arms diverge"
-                    )
-                };
-            },
-            _ => {}
+        if let (Diverges::Always { .. }, hir::MatchSource::Normal) = (all_arms_diverge, match_src) {
+            all_arms_diverge = Diverges::Always {
+                span: expr.span,
+                custom_note: Some(
+                    "any code following this `match` expression is unreachable, as all arms diverge"
+                )
+            };
         }
 
         // We won't diverge unless the discriminant or all arms diverge.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,10 +170,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always {
-                span: expr.span,
-                custom_note: None
-            });
+            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,7 +170,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
+            self.diverges.set(self.diverges.get() | Diverges::Always {
+                span: expr.span,
+                custom_note: None
+            });
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,7 +170,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always);
+            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -470,16 +470,6 @@ pub enum Diverges {
     WarnedAlways
 }
 
-impl Diverges {
-    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
-    fn always(span: Span) -> Diverges {
-        Diverges::Always {
-            span,
-            custom_note: None
-        }
-    }
-}
-
 // Convenience impls for combinig `Diverges`.
 
 impl ops::BitAnd for Diverges {
@@ -509,6 +499,14 @@ impl ops::BitOrAssign for Diverges {
 }
 
 impl Diverges {
+    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
+    fn always(span: Span) -> Diverges {
+        Diverges::Always {
+            span,
+            custom_note: None
+        }
+    }
+
     fn is_always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -471,7 +471,7 @@ pub enum Diverges {
 }
 
 impl Diverges {
-    /// Creates a `Diverges::Always` with the provided span and the default note message
+    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
     fn always(span: Span) -> Diverges {
         Diverges::Always {
             span,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -470,6 +470,16 @@ pub enum Diverges {
     WarnedAlways
 }
 
+impl Diverges {
+    /// Creates a `Diverges::Always` with the provided span and the default note message
+    fn always(span: Span) -> Diverges {
+        Diverges::Always {
+            span,
+            custom_note: None
+        }
+    }
+}
+
 // Convenience impls for combinig `Diverges`.
 
 impl ops::BitAnd for Diverges {
@@ -499,7 +509,7 @@ impl ops::BitOrAssign for Diverges {
 }
 
 impl Diverges {
-    fn always(self) -> bool {
+    fn is_always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just
         // fill them in with garbage here.
@@ -3852,7 +3862,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 //
                 // #41425 -- label the implicit `()` as being the
                 // "found type" here, rather than the "expected type".
-                if !self.diverges.get().always() {
+                if !self.diverges.get().is_always() {
                     // #50009 -- Do not point at the entire fn block span, point at the return type
                     // span, as it is the cause of the requirement, and
                     // `consider_hint_about_removing_semicolon` will point at the last expression

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2338,13 +2338,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!("warn_if_unreachable: id={:?} span={:?} kind={}", id, span, kind);
 
                 let msg = format!("unreachable {}", kind);
-                let mut err = self.tcx().struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE,
-                                                              id, span, &msg);
-                err.span_note(
-                    orig_span,
-                    custom_note.unwrap_or("any code following this expression is unreachable")
-                );
-                err.emit();
+                self.tcx().struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, &msg)
+                    .span_note(
+                        orig_span,
+                        custom_note.unwrap_or("any code following this expression is unreachable")
+                    )
+                    .emit();
             }
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -453,15 +453,15 @@ pub enum Diverges {
     Always {
         /// The `Span` points to the expression
         /// that caused us to diverge
-        /// (e.g. `return`, `break`, etc)
+        /// (e.g. `return`, `break`, etc).
         span: Span,
-        /// In some cases (e.g. a 'match' expression
+        /// In some cases (e.g. a `match` expression
         /// where all arms diverge), we may be
         /// able to provide a more informative
         /// message to the user.
-        /// If this is None, a default messsage
+        /// If this is `None`, a default messsage
         /// will be generated, which is suitable
-        /// for most cases
+        /// for most cases.
         custom_note: Option<&'static str>
     },
 
@@ -502,7 +502,7 @@ impl Diverges {
     fn always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just
-        // fill them in with garbage here
+        // fill them in with garbage here.
         self >= Diverges::Always {
             span: DUMMY_SP,
             custom_note: None

--- a/src/test/ui/dead-code-ret.stderr
+++ b/src/test/ui/dead-code-ret.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/dead-code-ret.rs:6:5
+   |
+LL |     return;
+   |     ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/if-ret.stderr
+++ b/src/test/ui/if-ret.stderr
@@ -5,4 +5,9 @@ LL | fn foo() { if (return) { } }
    |                        ^^^
    |
    = note: `#[warn(unreachable_code)]` on by default
+note: any code following this expression is unreachable
+  --> $DIR/if-ret.rs:6:15
+   |
+LL | fn foo() { if (return) { } }
+   |               ^^^^^^^^
 

--- a/src/test/ui/issues/issue-2150.stderr
+++ b/src/test/ui/issues/issue-2150.stderr
@@ -9,6 +9,12 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/issue-2150.rs:7:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7246.stderr
+++ b/src/test/ui/issues/issue-7246.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/issue-7246.rs:6:5
+   |
+LL |     return;
+   |     ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-attr-non-item-node.stderr
+++ b/src/test/ui/lint/lint-attr-non-item-node.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL |     #[deny(unreachable_code)]
    |            ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/lint-attr-non-item-node.rs:6:9
+   |
+LL |         break;
+   |         ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -10,6 +10,11 @@ note: lint level defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+note: any code following this expression is unreachable
+  --> $DIR/liveness-unused.rs:91:9
+   |
+LL |         continue;
+   |         ^^^^^^^^
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:8:7

--- a/src/test/ui/match/match-no-arms-unreachable-after.stderr
+++ b/src/test/ui/match/match-no-arms-unreachable-after.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/match-no-arms-unreachable-after.rs:7:5
+   |
+LL |     match v { }
+   |     ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/never-assign-dead-code.stderr
+++ b/src/test/ui/never-assign-dead-code.stderr
@@ -10,12 +10,24 @@ note: lint level defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+note: any code following this expression is unreachable
+  --> $DIR/never-assign-dead-code.rs:9:16
+   |
+LL |     let x: ! = panic!("aah");
+   |                ^^^^^^^^^^^^^
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 warning: unreachable call
   --> $DIR/never-assign-dead-code.rs:10:5
    |
 LL |     drop(x);
    |     ^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/never-assign-dead-code.rs:10:10
+   |
+LL |     drop(x);
+   |          ^
 
 warning: unused variable: `x`
   --> $DIR/never-assign-dead-code.rs:9:9

--- a/src/test/ui/reachable/expr_add.stderr
+++ b/src/test/ui/reachable/expr_add.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_add.rs:17:19
+   |
+LL |     let x = Foo + return;
+   |                   ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_again.rs:7:9
+   |
+LL |         continue;
+   |         ^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/reachable/expr_array.stderr
+++ b/src/test/ui/reachable/expr_array.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_array.rs:9:26
+   |
+LL |     let x: [usize; 2] = [return, 22];
+   |                          ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_array.rs:14:25
    |
 LL |     let x: [usize; 2] = [22, return];
    |                         ^^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_array.rs:14:30
+   |
+LL |     let x: [usize; 2] = [22, return];
+   |                              ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_assign.stderr
+++ b/src/test/ui/reachable/expr_assign.stderr
@@ -9,18 +9,35 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:10:9
+   |
+LL |     x = return;
+   |         ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_assign.rs:20:14
    |
 LL |         *p = return;
    |              ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:20:9
+   |
+LL |         *p = return;
+   |         ^^
 
 error: unreachable expression
   --> $DIR/expr_assign.rs:26:15
    |
 LL |     *{return; &mut i} = 22;
    |               ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:26:7
+   |
+LL |     *{return; &mut i} = 22;
+   |       ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_block.rs:9:9
+   |
+LL |         return;
+   |         ^^^^^^
 
 error: unreachable statement
   --> $DIR/expr_block.rs:25:9
@@ -16,6 +21,11 @@ error: unreachable statement
 LL |         println!("foo");
    |         ^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_block.rs:24:9
+   |
+LL |         return;
+   |         ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_box.stderr
+++ b/src/test/ui/reachable/expr_box.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_box.rs:6:17
+   |
+LL |     let x = box return;
+   |                 ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_call.rs:13:9
+   |
+LL |     foo(return, 22);
+   |         ^^^^^^
 
 error: unreachable call
   --> $DIR/expr_call.rs:18:5
    |
 LL |     bar(return);
    |     ^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_call.rs:18:9
+   |
+LL |     bar(return);
+   |         ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_cast.stderr
+++ b/src/test/ui/reachable/expr_cast.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_cast.rs:9:14
+   |
+LL |     let x = {return} as !;
+   |              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -12,6 +12,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_if.rs:7:9
+   |
+LL |     if {return} {
+   |         ^^^^^^
 
 error: unreachable statement
   --> $DIR/expr_if.rs:27:5
@@ -19,6 +24,11 @@ error: unreachable statement
 LL |     println!("But I am.");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_if.rs:21:9
+   |
+LL |         return;
+   |         ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:7:12
+   |
+LL |     loop { return; }
+   |            ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -17,6 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:20:12
+   |
+LL |     loop { return; }
+   |            ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -25,6 +35,11 @@ error: unreachable statement
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:31:5
+   |
+LL |     loop { 'middle: loop { loop { break 'middle; } } }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -9,11 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-note: any code following this expression is unreachable
-  --> $DIR/expr_match.rs:7:22
+note: any code following this `match` expression is unreachable, as all arms diverge
+  --> $DIR/expr_match.rs:7:5
    |
 LL |     match () { () => return }
-   |                      ^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -22,11 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: any code following this expression is unreachable
-  --> $DIR/expr_match.rs:18:31
+note: any code following this `match` expression is unreachable, as all arms diverge
+  --> $DIR/expr_match.rs:18:5
    |
 LL |     match () { () if false => return, () => return }
-   |                               ^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_match.rs:7:22
+   |
+LL |     match () { () => return }
+   |                      ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -17,6 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_match.rs:18:31
+   |
+LL |     match () { () if false => return, () => return }
+   |                               ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_method.rs:16:13
+   |
+LL |     Foo.foo(return, 22);
+   |             ^^^^^^
 
 error: unreachable call
   --> $DIR/expr_method.rs:21:9
    |
 LL |     Foo.bar(return);
    |         ^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_method.rs:21:13
+   |
+LL |     Foo.bar(return);
+   |             ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_repeat.stderr
+++ b/src/test/ui/reachable/expr_repeat.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_repeat.rs:9:26
+   |
+LL |     let x: [usize; 2] = [return; 2];
+   |                          ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_return.stderr
+++ b/src/test/ui/reachable/expr_return.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_return.rs:10:30
+   |
+LL |     let x = {return {return {return;}}};
+   |                              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_return_in_macro.rs
+++ b/src/test/ui/reachable/expr_return_in_macro.rs
@@ -1,0 +1,15 @@
+// Tests that we generate nice error messages
+// when an expression is unreachble due to control
+// flow inside of a macro expansion
+#![deny(unreachable_code)]
+
+macro_rules! early_return {
+    () => {
+        return ()
+    }
+}
+
+fn main() {
+    return early_return!();
+    //~^ ERROR unreachable expression
+}

--- a/src/test/ui/reachable/expr_return_in_macro.rs
+++ b/src/test/ui/reachable/expr_return_in_macro.rs
@@ -1,6 +1,6 @@
 // Tests that we generate nice error messages
 // when an expression is unreachble due to control
-// flow inside of a macro expansion
+// flow inside of a macro expansion.
 #![deny(unreachable_code)]
 
 macro_rules! early_return {

--- a/src/test/ui/reachable/expr_return_in_macro.stderr
+++ b/src/test/ui/reachable/expr_return_in_macro.stderr
@@ -1,0 +1,22 @@
+error: unreachable expression
+  --> $DIR/expr_return_in_macro.rs:13:5
+   |
+LL |     return early_return!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/expr_return_in_macro.rs:4:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_return_in_macro.rs:8:9
+   |
+LL |         return ()
+   |         ^^^^^^^^^
+...
+LL |     return early_return!();
+   |            --------------- in this macro invocation
+
+error: aborting due to previous error
+

--- a/src/test/ui/reachable/expr_struct.stderr
+++ b/src/test/ui/reachable/expr_struct.stderr
@@ -9,24 +9,47 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:14:35
+   |
+LL |     let x = Foo { a: 22, b: 33, ..return };
+   |                                   ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:19:33
    |
 LL |     let x = Foo { a: return, b: 33, ..return };
    |                                 ^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:19:22
+   |
+LL |     let x = Foo { a: return, b: 33, ..return };
+   |                      ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:24:39
    |
 LL |     let x = Foo { a: 22, b: return, ..return };
    |                                       ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:24:29
+   |
+LL |     let x = Foo { a: 22, b: return, ..return };
+   |                             ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:29:13
    |
 LL |     let x = Foo { a: 22, b: return };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:29:29
+   |
+LL |     let x = Foo { a: 22, b: return };
+   |                             ^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/reachable/expr_tup.stderr
+++ b/src/test/ui/reachable/expr_tup.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_tup.rs:9:30
+   |
+LL |     let x: (usize, usize) = (return, 2);
+   |                              ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_tup.rs:14:29
    |
 LL |     let x: (usize, usize) = (2, return);
    |                             ^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_tup.rs:14:33
+   |
+LL |     let x: (usize, usize) = (2, return);
+   |                                 ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_type.stderr
+++ b/src/test/ui/reachable/expr_type.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_type.rs:9:14
+   |
+LL |     let x = {return}: !;
+   |              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -15,6 +15,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_unary.rs:8:20
+   |
+LL |     let x: ! = ! { return; };
+   |                    ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_while.stderr
+++ b/src/test/ui/reachable/expr_while.stderr
@@ -13,6 +13,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_while.rs:7:12
+   |
+LL |     while {return} {
+   |            ^^^^^^
 
 error: unreachable block in `while` expression
   --> $DIR/expr_while.rs:22:20
@@ -23,6 +28,12 @@ LL | |
 LL | |         println!("I am dead.");
 LL | |     }
    | |_____^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_while.rs:22:12
+   |
+LL |     while {return} {
+   |            ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
@@ -5,4 +5,9 @@ LL |         if let _ = return true && false {};
    |                                         ^^
    |
    = note: `#[warn(unreachable_code)]` on by default
+note: any code following this expression is unreachable
+  --> $DIR/protect-precedences.rs:13:20
+   |
+LL |         if let _ = return true && false {};
+   |                    ^^^^^^^^^^^^^^^^^^^^
 

--- a/src/test/ui/unreachable/unreachable-code.stderr
+++ b/src/test/ui/unreachable/unreachable-code.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-code.rs:5:3
+   |
+LL |   loop{}
+   |   ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unreachable/unreachable-in-call.stderr
+++ b/src/test/ui/unreachable/unreachable-in-call.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-in-call.rs:13:10
+   |
+LL |     call(diverge(),
+   |          ^^^^^^^^^
 
 error: unreachable call
   --> $DIR/unreachable-in-call.rs:17:5
    |
 LL |     call(
    |     ^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-in-call.rs:19:9
+   |
+LL |         diverge());
+   |         ^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unreachable/unreachable-try-pattern.stderr
+++ b/src/test/ui/unreachable/unreachable-try-pattern.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![warn(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-try-pattern.rs:19:36
+   |
+LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
+   |                                    ^
 
 warning: unreachable pattern
   --> $DIR/unreachable-try-pattern.rs:19:24

--- a/src/test/ui/unreachable/unwarned-match-on-never.stderr
+++ b/src/test/ui/unreachable/unwarned-match-on-never.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:8:11
+   |
+LL |     match x {}
+   |           ^
 
 error: unreachable arm
   --> $DIR/unwarned-match-on-never.rs:15:15
    |
 LL |         () => ()
    |               ^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:14:11
+   |
+LL |     match (return) {
+   |           ^^^^^^^^
 
 error: unreachable expression
   --> $DIR/unwarned-match-on-never.rs:21:5
@@ -23,6 +34,12 @@ LL | /     match () {
 LL | |         () => (),
 LL | |     }
    | |_____^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:20:5
+   |
+LL |     return;
+   |     ^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Fix #39858, CC #46426, CC #57377, fix #60394, fix #64590.

When we emit an 'unreachable' lint, we now add a note pointing at the
expression that actually causes the code to be unreachable (e.g.
`return`, `break`, `panic`).

This is especially useful when macros are involved, since a diverging
expression might be hidden inside of a macro invocation.