### PR TITLE
Fix backticks in documentation

### DIFF
--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -1136,7 +1136,7 @@ fn resolve_local<'tcx>(
     // Rule A. `let (ref x, ref y) = (foo().x, 44)`. The rvalue `(22, 44)`
     // would have an extended lifetime, but not `foo()`.
     //
-    // Rule B. `let x = &foo().x`. The rvalue ``foo()` would have extended
+    // Rule B. `let x = &foo().x`. The rvalue `foo()` would have extended
     // lifetime.
     //
     // In some cases, multiple rules may apply (though not to the same

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -643,7 +643,7 @@ impl<'a, 'tcx> SpecializedDecoder<DefIndex> for CacheDecoder<'a, 'tcx> {
 
 // Both the `CrateNum` and the `DefIndex` of a `DefId` can change in between two
 // compilation sessions. We use the `DefPathHash`, which is stable across
-// sessions, to map the old DefId`` to the new one.
+// sessions, to map the old `DefId` to the new one.
 impl<'a, 'tcx> SpecializedDecoder<DefId> for CacheDecoder<'a, 'tcx> {
     #[inline]
     fn specialized_decode(&mut self) -> Result<DefId, Self::Error> {

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -3,7 +3,7 @@
 //! of source parsed during crate parsing (typically files, in-memory strings,
 //! or various bits of macro expansion) cover a continuous range of bytes in the
 //! `SourceMap` and are represented by `SourceFile`s. Byte positions are stored in
-//! `Span`` and used pervasively in the compiler. They are absolute positions
+//! `Span` and used pervasively in the compiler. They are absolute positions
 //! within the `SourceMap`, which upon request can be converted to line and column
 //! information, source code snippets, etc.
 
@@ -645,7 +645,7 @@ impl SourceMap {
     }
 
     /// Given a `Span`, tries to get a shorter span ending before the first occurrence of `char`
-    /// ``c`.
+    /// `c`.
     pub fn span_until_char(&self, sp: Span, c: char) -> Span {
         match self.span_to_snippet(sp) {
             Ok(snippet) => {

--- a/src/test/ui/borrowck/two-phase-surprise-no-conflict.rs
+++ b/src/test/ui/borrowck/two-phase-surprise-no-conflict.rs
@@ -31,7 +31,7 @@ impl <'a> SpanlessHash<'a> {
                 //
                 // Not okay without two-phase borrows: the implicit
                 // `&mut self` of the receiver is evaluated first, and
-                // that conflicts with the `self.cx`` access during
+                // that conflicts with the `self.cx` access during
                 // argument evaluation, as demonstrated in `fn demo`
                 // above.
                 //


### PR DESCRIPTION
Fix a few typos in comments/documentation where backticks were doubled-up on one side.