### PR TITLE
rustbuild: Turn down compression on exe installers

### DIFF
--- a/src/etc/installer/exe/rust.iss
+++ b/src/etc/installer/exe/rust.iss
@@ -25,9 +25,9 @@ SourceDir=.\
 OutputBaseFilename={#CFG_PACKAGE_NAME}-{#CFG_BUILD}
 DefaultDirName={sd}\Rust
 
-Compression=lzma2/ultra
-InternalCompressLevel=ultra
-SolidCompression=true
+Compression=lzma2/normal
+InternalCompressLevel=normal
+SolidCompression=no
 
 ChangesEnvironment=true
 ChangesAssociations=no


### PR DESCRIPTION
The Windows dist builders are the slowest builders right now, and the
distribution phase of them is enormously slow clocking in at around 20
minutes to build all the related installers. This commit starts to
optimize these by turning down the compression level in the `exe`
installers. These aren't super heavily used so there's no great need for
them to be so ultra-compressed, so let's dial back the compression
parameters to get closer to the rest of our xz archives. This brings the
installer in line with the gz tarball installer locally, and also brings
the compression settings on par with the rest of our xz installers.