### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -762,7 +762,7 @@ impl Step for Analysis {
             return distdir(builder).join(format!("{}-{}.tar.gz", name, target));
         }
 
-        builder.ensure(Std { compiler, target });
+        builder.ensure(compile::Std { compiler, target });
 
         let image = tmpdir(builder).join(format!("{}-{}-image", name, target));
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -476,11 +476,11 @@ impl Step for Std {
                  .arg("--index-page").arg(&builder.src.join("src/doc/index.md"));
 
             builder.run(&mut cargo);
-            builder.cp_r(&my_out, &out);
         };
         for krate in &["alloc", "core", "std", "proc_macro", "test"] {
             run_cargo_rustdoc_for(krate);
         }
+        builder.cp_r(&my_out, &out);
     }
 }
 

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -1136,7 +1136,7 @@ fn resolve_local<'tcx>(
     // Rule A. `let (ref x, ref y) = (foo().x, 44)`. The rvalue `(22, 44)`
     // would have an extended lifetime, but not `foo()`.
     //
-    // Rule B. `let x = &foo().x`. The rvalue ``foo()` would have extended
+    // Rule B. `let x = &foo().x`. The rvalue `foo()` would have extended
     // lifetime.
     //
     // In some cases, multiple rules may apply (though not to the same

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -127,6 +127,7 @@ impl IntegerExt for Integer {
 
 pub trait PrimitiveExt {
     fn to_ty<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx>;
+    fn to_int_ty<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx>;
 }
 
 impl PrimitiveExt for Primitive {
@@ -136,6 +137,16 @@ impl PrimitiveExt for Primitive {
             Float(FloatTy::F32) => tcx.types.f32,
             Float(FloatTy::F64) => tcx.types.f64,
             Pointer => tcx.mk_mut_ptr(tcx.mk_unit()),
+        }
+    }
+
+    /// Return an *integer* type matching this primitive.
+    /// Useful in particular when dealing with enum discriminants.
+    fn to_int_ty(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        match *self {
+            Int(i, signed) => i.to_ty(tcx, signed),
+            Pointer => tcx.types.usize,
+            Float(..) => bug!("floats do not have an int type"),
         }
     }
 }

--- a/src/librustc/ty/query/on_disk_cache.rs
+++ b/src/librustc/ty/query/on_disk_cache.rs
@@ -643,7 +643,7 @@ impl<'a, 'tcx> SpecializedDecoder<DefIndex> for CacheDecoder<'a, 'tcx> {
 
 // Both the `CrateNum` and the `DefIndex` of a `DefId` can change in between two
 // compilation sessions. We use the `DefPathHash`, which is stable across
-// sessions, to map the old DefId`` to the new one.
+// sessions, to map the old `DefId` to the new one.
 impl<'a, 'tcx> SpecializedDecoder<DefId> for CacheDecoder<'a, 'tcx> {
     #[inline]
     fn specialized_decode(&mut self) -> Result<DefId, Self::Error> {

--- a/src/librustc_mir/interpret/operand.rs
+++ b/src/librustc_mir/interpret/operand.rs
@@ -698,28 +698,28 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                         // We need to use machine arithmetic.
                         let niche_start_val = ImmTy::from_uint(niche_start, discr_layout);
                         let variants_start_val = ImmTy::from_uint(variants_start, discr_layout);
-                        let adjusted_discr = self.binary_op(
+                        let variant_index_relative_val = self.binary_op(
                             mir::BinOp::Sub,
                             discr_val,
                             niche_start_val,
                         )?;
-                        let adjusted_discr = self.binary_op(
+                        let variant_index_val = self.binary_op(
                             mir::BinOp::Add,
-                            adjusted_discr,
+                            variant_index_relative_val,
                             variants_start_val,
                         )?;
-                        let adjusted_discr = adjusted_discr
+                        let variant_index = variant_index_val
                             .to_scalar()?
                             .assert_bits(discr_val.layout.size);
                         // Check if this is in the range that indicates an actual discriminant.
-                        if variants_start <= adjusted_discr && adjusted_discr <= variants_end {
-                            let index = adjusted_discr as usize;
-                            assert_eq!(index as u128, adjusted_discr);
+                        if variants_start <= variant_index && variant_index <= variants_end {
+                            let index = variant_index as usize;
+                            assert_eq!(index as u128, variant_index);
                             assert!(index < rval.layout.ty
                                 .ty_adt_def()
                                 .expect("tagged layout for non adt")
                                 .variants.len());
-                            (adjusted_discr, VariantIdx::from_usize(index))
+                            (variant_index, VariantIdx::from_usize(index))
                         } else {
                             (dataful_variant.as_u32() as u128, dataful_variant)
                         }

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -1073,19 +1073,19 @@ where
                     let variants_start_val = ImmTy::from_uint(variants_start, discr_layout);
                     let niche_start_val = ImmTy::from_uint(niche_start, discr_layout);
                     let variant_index_val = ImmTy::from_uint(variant_index.as_u32(), discr_layout);
-                    let niche_val = self.binary_op(
+                    let variant_index_relative_val = self.binary_op(
                         mir::BinOp::Sub,
                         variant_index_val,
                         variants_start_val,
                     )?;
-                    let niche_val = self.binary_op(
+                    let discr_val = self.binary_op(
                         mir::BinOp::Add,
-                        niche_val,
+                        variant_index_relative_val,
                         niche_start_val,
                     )?;
                     // Write result.
                     let niche_dest = self.place_field(dest, discr_index as u64)?;
-                    self.write_immediate(*niche_val, niche_dest)?;
+                    self.write_immediate(*discr_val, niche_dest)?;
                 }
             }
         }

--- a/src/librustc_mir/interpret/place.rs
+++ b/src/librustc_mir/interpret/place.rs
@@ -1064,7 +1064,8 @@ where
                     let variant_index_relative = variant_index.as_u32()
                         .checked_sub(variants_start)
                         .expect("overflow computing relative variant idx");
-                    // We need to use machine arithmetic when taking into account `niche_start`.
+                    // We need to use machine arithmetic when taking into account `niche_start`:
+                    // discr_val = variant_index_relative + niche_start_val
                     let discr_layout = self.layout_of(discr_layout.value.to_int_ty(*self.tcx))?;
                     let niche_start_val = ImmTy::from_uint(niche_start, discr_layout);
                     let variant_index_relative_val =

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -170,12 +170,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             prior_arm_ty = Some(arm_ty);
         }
 
-        // If all of the arms in the 'match' diverge,
-        // and we're dealing with an actual 'match' block
-        // (as opposed to a 'match' desugared from something else'),
+        // If all of the arms in the `match` diverge,
+        // and we're dealing with an actual `match` block
+        // (as opposed to a `match` desugared from something else'),
         // we can emit a better note. Rather than pointing
         // at a diverging expression in an arbitrary arm,
-        // we can point at the entire 'match' expression
+        // we can point at the entire `match` expression
         match (all_arms_diverge, match_src) {
             (Diverges::Always { .. }, hir::MatchSource::Normal) => {
                 all_arms_diverge = Diverges::Always {

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -43,7 +43,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If there are no arms, that is a diverging match; a special case.
         if arms.is_empty() {
-            self.diverges.set(self.diverges.get() | Diverges::Always);
+            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
             return tcx.types.never;
         }
 
@@ -69,7 +69,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // warnings).
             match all_pats_diverge {
                 Diverges::Maybe => Diverges::Maybe,
-                Diverges::Always | Diverges::WarnedAlways => Diverges::WarnedAlways,
+                Diverges::Always(..) | Diverges::WarnedAlways => Diverges::WarnedAlways,
             }
         }).collect();
 

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -43,10 +43,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If there are no arms, that is a diverging match; a special case.
         if arms.is_empty() {
-            self.diverges.set(self.diverges.get() | Diverges::Always {
-                span: expr.span,
-                custom_note: None
-            });
+            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
             return tcx.types.never;
         }
 
@@ -198,7 +195,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// When the previously checked expression (the scrutinee) diverges,
     /// warn the user about the match arms being unreachable.
     fn warn_arms_when_scrutinee_diverges(&self, arms: &'tcx [hir::Arm], source: hir::MatchSource) {
-        if self.diverges.get().always() {
+        if self.diverges.get().is_always() {
             use hir::MatchSource::*;
             let msg = match source {
                 IfDesugar { .. } | IfLetDesugar { .. } => "block in `if` expression",

--- a/src/librustc_typeck/check/_match.rs
+++ b/src/librustc_typeck/check/_match.rs
@@ -173,17 +173,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // we can emit a better note. Rather than pointing
         // at a diverging expression in an arbitrary arm,
         // we can point at the entire `match` expression
-        match (all_arms_diverge, match_src) {
-            (Diverges::Always { .. }, hir::MatchSource::Normal) => {
-                all_arms_diverge = Diverges::Always {
-                    span: expr.span,
-                    custom_note: Some(
-                        "any code following this `match` expression is unreachable, \
-                        as all arms diverge"
-                    )
-                };
-            },
-            _ => {}
+        if let (Diverges::Always { .. }, hir::MatchSource::Normal) = (all_arms_diverge, match_src) {
+            all_arms_diverge = Diverges::Always {
+                span: expr.span,
+                custom_note: Some(
+                    "any code following this `match` expression is unreachable, as all arms diverge"
+                )
+            };
         }
 
         // We won't diverge unless the discriminant or all arms diverge.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,10 +170,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always {
-                span: expr.span,
-                custom_note: None
-            });
+            self.diverges.set(self.diverges.get() | Diverges::always(expr.span));
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,7 +170,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
+            self.diverges.set(self.diverges.get() | Diverges::Always {
+                span: expr.span,
+                custom_note: None
+            });
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -170,7 +170,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Any expression that produces a value of type `!` must have diverged
         if ty.is_never() {
-            self.diverges.set(self.diverges.get() | Diverges::Always);
+            self.diverges.set(self.diverges.get() | Diverges::Always(expr.span));
         }
 
         // Record the type, which applies it effects.

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -470,16 +470,6 @@ pub enum Diverges {
     WarnedAlways
 }
 
-impl Diverges {
-    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
-    fn always(span: Span) -> Diverges {
-        Diverges::Always {
-            span,
-            custom_note: None
-        }
-    }
-}
-
 // Convenience impls for combinig `Diverges`.
 
 impl ops::BitAnd for Diverges {
@@ -509,6 +499,14 @@ impl ops::BitOrAssign for Diverges {
 }
 
 impl Diverges {
+    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
+    fn always(span: Span) -> Diverges {
+        Diverges::Always {
+            span,
+            custom_note: None
+        }
+    }
+
     fn is_always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -471,7 +471,7 @@ pub enum Diverges {
 }
 
 impl Diverges {
-    /// Creates a `Diverges::Always` with the provided span and the default note message
+    /// Creates a `Diverges::Always` with the provided `span` and the default note message.
     fn always(span: Span) -> Diverges {
         Diverges::Always {
             span,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -470,6 +470,16 @@ pub enum Diverges {
     WarnedAlways
 }
 
+impl Diverges {
+    /// Creates a `Diverges::Always` with the provided span and the default note message
+    fn always(span: Span) -> Diverges {
+        Diverges::Always {
+            span,
+            custom_note: None
+        }
+    }
+}
+
 // Convenience impls for combinig `Diverges`.
 
 impl ops::BitAnd for Diverges {
@@ -499,7 +509,7 @@ impl ops::BitOrAssign for Diverges {
 }
 
 impl Diverges {
-    fn always(self) -> bool {
+    fn is_always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just
         // fill them in with garbage here.
@@ -3852,7 +3862,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 //
                 // #41425 -- label the implicit `()` as being the
                 // "found type" here, rather than the "expected type".
-                if !self.diverges.get().always() {
+                if !self.diverges.get().is_always() {
                     // #50009 -- Do not point at the entire fn block span, point at the return type
                     // span, as it is the cause of the requirement, and
                     // `consider_hint_about_removing_semicolon` will point at the last expression

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2338,13 +2338,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 debug!("warn_if_unreachable: id={:?} span={:?} kind={}", id, span, kind);
 
                 let msg = format!("unreachable {}", kind);
-                let mut err = self.tcx().struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE,
-                                                              id, span, &msg);
-                err.span_note(
-                    orig_span,
-                    custom_note.unwrap_or("any code following this expression is unreachable")
-                );
-                err.emit();
+                self.tcx().struct_span_lint_hir(lint::builtin::UNREACHABLE_CODE, id, span, &msg)
+                    .span_note(
+                        orig_span,
+                        custom_note.unwrap_or("any code following this expression is unreachable")
+                    )
+                    .emit();
             }
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -453,15 +453,15 @@ pub enum Diverges {
     Always {
         /// The `Span` points to the expression
         /// that caused us to diverge
-        /// (e.g. `return`, `break`, etc)
+        /// (e.g. `return`, `break`, etc).
         span: Span,
-        /// In some cases (e.g. a 'match' expression
+        /// In some cases (e.g. a `match` expression
         /// where all arms diverge), we may be
         /// able to provide a more informative
         /// message to the user.
-        /// If this is None, a default messsage
+        /// If this is `None`, a default messsage
         /// will be generated, which is suitable
-        /// for most cases
+        /// for most cases.
         custom_note: Option<&'static str>
     },
 
@@ -502,7 +502,7 @@ impl Diverges {
     fn always(self) -> bool {
         // Enum comparison ignores the
         // contents of fields, so we just
-        // fill them in with garbage here
+        // fill them in with garbage here.
         self >= Diverges::Always {
             span: DUMMY_SP,
             custom_note: None

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -935,7 +935,7 @@ impl Stdio {
     ///     .expect("Failed to spawn child process");
     ///
     /// {
-    ///     let mut stdin = child.stdin.as_mut().expect("Failed to open stdin");
+    ///     let stdin = child.stdin.as_mut().expect("Failed to open stdin");
     ///     stdin.write_all("Hello, world!".as_bytes()).expect("Failed to write to stdin");
     /// }
     ///

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -3,7 +3,7 @@
 //! of source parsed during crate parsing (typically files, in-memory strings,
 //! or various bits of macro expansion) cover a continuous range of bytes in the
 //! `SourceMap` and are represented by `SourceFile`s. Byte positions are stored in
-//! `Span`` and used pervasively in the compiler. They are absolute positions
+//! `Span` and used pervasively in the compiler. They are absolute positions
 //! within the `SourceMap`, which upon request can be converted to line and column
 //! information, source code snippets, etc.
 
@@ -645,7 +645,7 @@ impl SourceMap {
     }
 
     /// Given a `Span`, tries to get a shorter span ending before the first occurrence of `char`
-    /// ``c`.
+    /// `c`.
     pub fn span_until_char(&self, sp: Span, c: char) -> Span {
         match self.span_to_snippet(sp) {
             Ok(snippet) => {

--- a/src/test/ui/borrowck/two-phase-surprise-no-conflict.rs
+++ b/src/test/ui/borrowck/two-phase-surprise-no-conflict.rs
@@ -31,7 +31,7 @@ impl <'a> SpanlessHash<'a> {
                 //
                 // Not okay without two-phase borrows: the implicit
                 // `&mut self` of the receiver is evaluated first, and
-                // that conflicts with the `self.cx`` access during
+                // that conflicts with the `self.cx` access during
                 // argument evaluation, as demonstrated in `fn demo`
                 // above.
                 //

--- a/src/test/ui/consts/miri_unleashed/enum_discriminants.rs
+++ b/src/test/ui/consts/miri_unleashed/enum_discriminants.rs
@@ -1,0 +1,110 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+// run-pass
+
+//! Make sure that we read and write enum discriminants correctly for corner cases caused
+//! by layout optimizations.
+
+const OVERFLOW: usize = {
+    // Tests for https://github.com/rust-lang/rust/issues/62138.
+    #[repr(u8)]
+    #[allow(dead_code)]
+    enum WithWraparoundInvalidValues {
+        X = 1,
+        Y = 254,
+    }
+
+    #[allow(dead_code)]
+    enum Foo {
+        A,
+        B,
+        C(WithWraparoundInvalidValues),
+    }
+
+    let x = Foo::B;
+    match x {
+        Foo::B => 0,
+        _ => panic!(),
+    }
+};
+
+const MORE_OVERFLOW: usize = {
+    pub enum Infallible {}
+
+    // The check that the `bool` field of `V1` is encoding a "niche variant"
+    // (i.e. not `V1`, so `V3` or `V4`) used to be mathematically incorrect,
+    // causing valid `V1` values to be interpreted as other variants.
+    #[allow(dead_code)]
+    pub enum E1 {
+        V1 { f: bool },
+        V2 { f: Infallible },
+        V3,
+        V4,
+    }
+
+    // Computing the discriminant used to be done using the niche type (here `u8`,
+    // from the `bool` field of `V1`), overflowing for variants with large enough
+    // indices (`V3` and `V4`), causing them to be interpreted as other variants.
+    #[allow(dead_code)]
+    pub enum E2<X> {
+        V1 { f: bool },
+
+        /*_00*/ _01(X), _02(X), _03(X), _04(X), _05(X), _06(X), _07(X),
+        _08(X), _09(X), _0A(X), _0B(X), _0C(X), _0D(X), _0E(X), _0F(X),
+        _10(X), _11(X), _12(X), _13(X), _14(X), _15(X), _16(X), _17(X),
+        _18(X), _19(X), _1A(X), _1B(X), _1C(X), _1D(X), _1E(X), _1F(X),
+        _20(X), _21(X), _22(X), _23(X), _24(X), _25(X), _26(X), _27(X),
+        _28(X), _29(X), _2A(X), _2B(X), _2C(X), _2D(X), _2E(X), _2F(X),
+        _30(X), _31(X), _32(X), _33(X), _34(X), _35(X), _36(X), _37(X),
+        _38(X), _39(X), _3A(X), _3B(X), _3C(X), _3D(X), _3E(X), _3F(X),
+        _40(X), _41(X), _42(X), _43(X), _44(X), _45(X), _46(X), _47(X),
+        _48(X), _49(X), _4A(X), _4B(X), _4C(X), _4D(X), _4E(X), _4F(X),
+        _50(X), _51(X), _52(X), _53(X), _54(X), _55(X), _56(X), _57(X),
+        _58(X), _59(X), _5A(X), _5B(X), _5C(X), _5D(X), _5E(X), _5F(X),
+        _60(X), _61(X), _62(X), _63(X), _64(X), _65(X), _66(X), _67(X),
+        _68(X), _69(X), _6A(X), _6B(X), _6C(X), _6D(X), _6E(X), _6F(X),
+        _70(X), _71(X), _72(X), _73(X), _74(X), _75(X), _76(X), _77(X),
+        _78(X), _79(X), _7A(X), _7B(X), _7C(X), _7D(X), _7E(X), _7F(X),
+        _80(X), _81(X), _82(X), _83(X), _84(X), _85(X), _86(X), _87(X),
+        _88(X), _89(X), _8A(X), _8B(X), _8C(X), _8D(X), _8E(X), _8F(X),
+        _90(X), _91(X), _92(X), _93(X), _94(X), _95(X), _96(X), _97(X),
+        _98(X), _99(X), _9A(X), _9B(X), _9C(X), _9D(X), _9E(X), _9F(X),
+        _A0(X), _A1(X), _A2(X), _A3(X), _A4(X), _A5(X), _A6(X), _A7(X),
+        _A8(X), _A9(X), _AA(X), _AB(X), _AC(X), _AD(X), _AE(X), _AF(X),
+        _B0(X), _B1(X), _B2(X), _B3(X), _B4(X), _B5(X), _B6(X), _B7(X),
+        _B8(X), _B9(X), _BA(X), _BB(X), _BC(X), _BD(X), _BE(X), _BF(X),
+        _C0(X), _C1(X), _C2(X), _C3(X), _C4(X), _C5(X), _C6(X), _C7(X),
+        _C8(X), _C9(X), _CA(X), _CB(X), _CC(X), _CD(X), _CE(X), _CF(X),
+        _D0(X), _D1(X), _D2(X), _D3(X), _D4(X), _D5(X), _D6(X), _D7(X),
+        _D8(X), _D9(X), _DA(X), _DB(X), _DC(X), _DD(X), _DE(X), _DF(X),
+        _E0(X), _E1(X), _E2(X), _E3(X), _E4(X), _E5(X), _E6(X), _E7(X),
+        _E8(X), _E9(X), _EA(X), _EB(X), _EC(X), _ED(X), _EE(X), _EF(X),
+        _F0(X), _F1(X), _F2(X), _F3(X), _F4(X), _F5(X), _F6(X), _F7(X),
+        _F8(X), _F9(X), _FA(X), _FB(X), _FC(X), _FD(X), _FE(X), _FF(X),
+
+        V3,
+        V4,
+    }
+
+    if let E1::V2 { .. } = (E1::V1 { f: true }) {
+        unreachable!()
+    }
+    if let E1::V1 { .. } = (E1::V1 { f: true }) {
+    } else {
+        unreachable!()
+    }
+
+    if let E2::V1 { .. } = E2::V3::<Infallible> {
+        unreachable!()
+    }
+    if let E2::V3 { .. } = E2::V3::<Infallible> {
+    } else {
+        unreachable!()
+    }
+
+    0
+};
+
+fn main() {
+    assert_eq!(OVERFLOW, 0);
+    assert_eq!(MORE_OVERFLOW, 0);
+}

--- a/src/test/ui/consts/miri_unleashed/enum_discriminants.stderr
+++ b/src/test/ui/consts/miri_unleashed/enum_discriminants.stderr
@@ -1,0 +1,72 @@
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:23:13
+   |
+LL |     let x = Foo::B;
+   |             ^^^^^^
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:25:9
+   |
+LL |         Foo::B => 0,
+   |         ^^^^^^
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:88:28
+   |
+LL |     if let E1::V2 { .. } = (E1::V1 { f: true }) {
+   |                            ^^^^^^^^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:88:12
+   |
+LL |     if let E1::V2 { .. } = (E1::V1 { f: true }) {
+   |            ^^^^^^^^^^^^^
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:108:5
+   |
+LL |     assert_eq!(OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:108:5
+   |
+LL |     assert_eq!(OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:108:5
+   |
+LL |     assert_eq!(OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:109:5
+   |
+LL |     assert_eq!(MORE_OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:109:5
+   |
+LL |     assert_eq!(MORE_OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+warning: skipping const checks
+  --> $DIR/enum_discriminants.rs:109:5
+   |
+LL |     assert_eq!(MORE_OVERFLOW, 0);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+

--- a/src/test/ui/dead-code-ret.stderr
+++ b/src/test/ui/dead-code-ret.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/dead-code-ret.rs:6:5
+   |
+LL |     return;
+   |     ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/if-ret.stderr
+++ b/src/test/ui/if-ret.stderr
@@ -5,4 +5,9 @@ LL | fn foo() { if (return) { } }
    |                        ^^^
    |
    = note: `#[warn(unreachable_code)]` on by default
+note: any code following this expression is unreachable
+  --> $DIR/if-ret.rs:6:15
+   |
+LL | fn foo() { if (return) { } }
+   |               ^^^^^^^^
 

--- a/src/test/ui/issues/issue-2150.stderr
+++ b/src/test/ui/issues/issue-2150.stderr
@@ -9,6 +9,12 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/issue-2150.rs:7:5
+   |
+LL |     panic!();
+   |     ^^^^^^^^^
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7246.stderr
+++ b/src/test/ui/issues/issue-7246.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/issue-7246.rs:6:5
+   |
+LL |     return;
+   |     ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/lint-attr-non-item-node.stderr
+++ b/src/test/ui/lint/lint-attr-non-item-node.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL |     #[deny(unreachable_code)]
    |            ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/lint-attr-non-item-node.rs:6:9
+   |
+LL |         break;
+   |         ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/liveness/liveness-unused.stderr
+++ b/src/test/ui/liveness/liveness-unused.stderr
@@ -10,6 +10,11 @@ note: lint level defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+note: any code following this expression is unreachable
+  --> $DIR/liveness-unused.rs:91:9
+   |
+LL |         continue;
+   |         ^^^^^^^^
 
 error: unused variable: `x`
   --> $DIR/liveness-unused.rs:8:7

--- a/src/test/ui/match/match-no-arms-unreachable-after.stderr
+++ b/src/test/ui/match/match-no-arms-unreachable-after.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/match-no-arms-unreachable-after.rs:7:5
+   |
+LL |     match v { }
+   |     ^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/never-assign-dead-code.stderr
+++ b/src/test/ui/never-assign-dead-code.stderr
@@ -10,12 +10,24 @@ note: lint level defined here
 LL | #![warn(unused)]
    |         ^^^^^^
    = note: `#[warn(unreachable_code)]` implied by `#[warn(unused)]`
+note: any code following this expression is unreachable
+  --> $DIR/never-assign-dead-code.rs:9:16
+   |
+LL |     let x: ! = panic!("aah");
+   |                ^^^^^^^^^^^^^
+   = note: this warning originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 warning: unreachable call
   --> $DIR/never-assign-dead-code.rs:10:5
    |
 LL |     drop(x);
    |     ^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/never-assign-dead-code.rs:10:10
+   |
+LL |     drop(x);
+   |          ^
 
 warning: unused variable: `x`
   --> $DIR/never-assign-dead-code.rs:9:9

--- a/src/test/ui/reachable/expr_add.stderr
+++ b/src/test/ui/reachable/expr_add.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_add.rs:17:19
+   |
+LL |     let x = Foo + return;
+   |                   ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_again.stderr
+++ b/src/test/ui/reachable/expr_again.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_again.rs:7:9
+   |
+LL |         continue;
+   |         ^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/reachable/expr_array.stderr
+++ b/src/test/ui/reachable/expr_array.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_array.rs:9:26
+   |
+LL |     let x: [usize; 2] = [return, 22];
+   |                          ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_array.rs:14:25
    |
 LL |     let x: [usize; 2] = [22, return];
    |                         ^^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_array.rs:14:30
+   |
+LL |     let x: [usize; 2] = [22, return];
+   |                              ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_assign.stderr
+++ b/src/test/ui/reachable/expr_assign.stderr
@@ -9,18 +9,35 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:10:9
+   |
+LL |     x = return;
+   |         ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_assign.rs:20:14
    |
 LL |         *p = return;
    |              ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:20:9
+   |
+LL |         *p = return;
+   |         ^^
 
 error: unreachable expression
   --> $DIR/expr_assign.rs:26:15
    |
 LL |     *{return; &mut i} = 22;
    |               ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_assign.rs:26:7
+   |
+LL |     *{return; &mut i} = 22;
+   |       ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/reachable/expr_block.stderr
+++ b/src/test/ui/reachable/expr_block.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_block.rs:9:9
+   |
+LL |         return;
+   |         ^^^^^^
 
 error: unreachable statement
   --> $DIR/expr_block.rs:25:9
@@ -16,6 +21,11 @@ error: unreachable statement
 LL |         println!("foo");
    |         ^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_block.rs:24:9
+   |
+LL |         return;
+   |         ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_box.stderr
+++ b/src/test/ui/reachable/expr_box.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_box.rs:6:17
+   |
+LL |     let x = box return;
+   |                 ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_call.stderr
+++ b/src/test/ui/reachable/expr_call.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_call.rs:13:9
+   |
+LL |     foo(return, 22);
+   |         ^^^^^^
 
 error: unreachable call
   --> $DIR/expr_call.rs:18:5
    |
 LL |     bar(return);
    |     ^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_call.rs:18:9
+   |
+LL |     bar(return);
+   |         ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_cast.stderr
+++ b/src/test/ui/reachable/expr_cast.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_cast.rs:9:14
+   |
+LL |     let x = {return} as !;
+   |              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_if.stderr
+++ b/src/test/ui/reachable/expr_if.stderr
@@ -12,6 +12,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_if.rs:7:9
+   |
+LL |     if {return} {
+   |         ^^^^^^
 
 error: unreachable statement
   --> $DIR/expr_if.rs:27:5
@@ -19,6 +24,11 @@ error: unreachable statement
 LL |     println!("But I am.");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_if.rs:21:9
+   |
+LL |         return;
+   |         ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_loop.stderr
+++ b/src/test/ui/reachable/expr_loop.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:7:12
+   |
+LL |     loop { return; }
+   |            ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -17,6 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:20:12
+   |
+LL |     loop { return; }
+   |            ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -25,6 +35,11 @@ error: unreachable statement
 LL |     println!("I am dead.");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_loop.rs:31:5
+   |
+LL |     loop { 'middle: loop { loop { break 'middle; } } }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -9,11 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
-note: any code following this expression is unreachable
-  --> $DIR/expr_match.rs:7:22
+note: any code following this `match` expression is unreachable, as all arms diverge
+  --> $DIR/expr_match.rs:7:5
    |
 LL |     match () { () => return }
-   |                      ^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -22,11 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: any code following this expression is unreachable
-  --> $DIR/expr_match.rs:18:31
+note: any code following this `match` expression is unreachable, as all arms diverge
+  --> $DIR/expr_match.rs:18:5
    |
 LL |     match () { () if false => return, () => return }
-   |                               ^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_match.stderr
+++ b/src/test/ui/reachable/expr_match.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_match.rs:7:22
+   |
+LL |     match () { () => return }
+   |                      ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: unreachable statement
@@ -17,6 +22,11 @@ error: unreachable statement
 LL |     println!("I am dead");
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
+note: any code following this expression is unreachable
+  --> $DIR/expr_match.rs:18:31
+   |
+LL |     match () { () if false => return, () => return }
+   |                               ^^^^^^
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/reachable/expr_method.stderr
+++ b/src/test/ui/reachable/expr_method.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_method.rs:16:13
+   |
+LL |     Foo.foo(return, 22);
+   |             ^^^^^^
 
 error: unreachable call
   --> $DIR/expr_method.rs:21:9
    |
 LL |     Foo.bar(return);
    |         ^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_method.rs:21:13
+   |
+LL |     Foo.bar(return);
+   |             ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_repeat.stderr
+++ b/src/test/ui/reachable/expr_repeat.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_repeat.rs:9:26
+   |
+LL |     let x: [usize; 2] = [return; 2];
+   |                          ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_return.stderr
+++ b/src/test/ui/reachable/expr_return.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_return.rs:10:30
+   |
+LL |     let x = {return {return {return;}}};
+   |                              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_return_in_macro.rs
+++ b/src/test/ui/reachable/expr_return_in_macro.rs
@@ -1,0 +1,15 @@
+// Tests that we generate nice error messages
+// when an expression is unreachble due to control
+// flow inside of a macro expansion
+#![deny(unreachable_code)]
+
+macro_rules! early_return {
+    () => {
+        return ()
+    }
+}
+
+fn main() {
+    return early_return!();
+    //~^ ERROR unreachable expression
+}

--- a/src/test/ui/reachable/expr_return_in_macro.rs
+++ b/src/test/ui/reachable/expr_return_in_macro.rs
@@ -1,6 +1,6 @@
 // Tests that we generate nice error messages
 // when an expression is unreachble due to control
-// flow inside of a macro expansion
+// flow inside of a macro expansion.
 #![deny(unreachable_code)]
 
 macro_rules! early_return {

--- a/src/test/ui/reachable/expr_return_in_macro.stderr
+++ b/src/test/ui/reachable/expr_return_in_macro.stderr
@@ -1,0 +1,22 @@
+error: unreachable expression
+  --> $DIR/expr_return_in_macro.rs:13:5
+   |
+LL |     return early_return!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/expr_return_in_macro.rs:4:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_return_in_macro.rs:8:9
+   |
+LL |         return ()
+   |         ^^^^^^^^^
+...
+LL |     return early_return!();
+   |            --------------- in this macro invocation
+
+error: aborting due to previous error
+

--- a/src/test/ui/reachable/expr_struct.stderr
+++ b/src/test/ui/reachable/expr_struct.stderr
@@ -9,24 +9,47 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:14:35
+   |
+LL |     let x = Foo { a: 22, b: 33, ..return };
+   |                                   ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:19:33
    |
 LL |     let x = Foo { a: return, b: 33, ..return };
    |                                 ^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:19:22
+   |
+LL |     let x = Foo { a: return, b: 33, ..return };
+   |                      ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:24:39
    |
 LL |     let x = Foo { a: 22, b: return, ..return };
    |                                       ^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:24:29
+   |
+LL |     let x = Foo { a: 22, b: return, ..return };
+   |                             ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_struct.rs:29:13
    |
 LL |     let x = Foo { a: 22, b: return };
    |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_struct.rs:29:29
+   |
+LL |     let x = Foo { a: 22, b: return };
+   |                             ^^^^^^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/reachable/expr_tup.stderr
+++ b/src/test/ui/reachable/expr_tup.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_tup.rs:9:30
+   |
+LL |     let x: (usize, usize) = (return, 2);
+   |                              ^^^^^^
 
 error: unreachable expression
   --> $DIR/expr_tup.rs:14:29
    |
 LL |     let x: (usize, usize) = (2, return);
    |                             ^^^^^^^^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_tup.rs:14:33
+   |
+LL |     let x: (usize, usize) = (2, return);
+   |                                 ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_type.stderr
+++ b/src/test/ui/reachable/expr_type.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_type.rs:9:14
+   |
+LL |     let x = {return}: !;
+   |              ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/reachable/expr_unary.stderr
+++ b/src/test/ui/reachable/expr_unary.stderr
@@ -15,6 +15,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_unary.rs:8:20
+   |
+LL |     let x: ! = ! { return; };
+   |                    ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reachable/expr_while.stderr
+++ b/src/test/ui/reachable/expr_while.stderr
@@ -13,6 +13,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/expr_while.rs:7:12
+   |
+LL |     while {return} {
+   |            ^^^^^^
 
 error: unreachable block in `while` expression
   --> $DIR/expr_while.rs:22:20
@@ -23,6 +28,12 @@ LL | |
 LL | |         println!("I am dead.");
 LL | |     }
    | |_____^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/expr_while.rs:22:12
+   |
+LL |     while {return} {
+   |            ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/protect-precedences.stderr
@@ -5,4 +5,9 @@ LL |         if let _ = return true && false {};
    |                                         ^^
    |
    = note: `#[warn(unreachable_code)]` on by default
+note: any code following this expression is unreachable
+  --> $DIR/protect-precedences.rs:13:20
+   |
+LL |         if let _ = return true && false {};
+   |                    ^^^^^^^^^^^^^^^^^^^^
 

--- a/src/test/ui/unreachable/unreachable-code.stderr
+++ b/src/test/ui/unreachable/unreachable-code.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-code.rs:5:3
+   |
+LL |   loop{}
+   |   ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/unreachable/unreachable-in-call.stderr
+++ b/src/test/ui/unreachable/unreachable-in-call.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-in-call.rs:13:10
+   |
+LL |     call(diverge(),
+   |          ^^^^^^^^^
 
 error: unreachable call
   --> $DIR/unreachable-in-call.rs:17:5
    |
 LL |     call(
    |     ^^^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-in-call.rs:19:9
+   |
+LL |         diverge());
+   |         ^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unreachable/unreachable-try-pattern.stderr
+++ b/src/test/ui/unreachable/unreachable-try-pattern.stderr
@@ -9,6 +9,11 @@ note: lint level defined here
    |
 LL | #![warn(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unreachable-try-pattern.rs:19:36
+   |
+LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
+   |                                    ^
 
 warning: unreachable pattern
   --> $DIR/unreachable-try-pattern.rs:19:24

--- a/src/test/ui/unreachable/unwarned-match-on-never.stderr
+++ b/src/test/ui/unreachable/unwarned-match-on-never.stderr
@@ -9,12 +9,23 @@ note: lint level defined here
    |
 LL | #![deny(unreachable_code)]
    |         ^^^^^^^^^^^^^^^^
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:8:11
+   |
+LL |     match x {}
+   |           ^
 
 error: unreachable arm
   --> $DIR/unwarned-match-on-never.rs:15:15
    |
 LL |         () => ()
    |               ^^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:14:11
+   |
+LL |     match (return) {
+   |           ^^^^^^^^
 
 error: unreachable expression
   --> $DIR/unwarned-match-on-never.rs:21:5
@@ -23,6 +34,12 @@ LL | /     match () {
 LL | |         () => (),
 LL | |     }
    | |_____^
+   |
+note: any code following this expression is unreachable
+  --> $DIR/unwarned-match-on-never.rs:20:5
+   |
+LL |     return;
+   |     ^^^^^^
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #63448 (fix Miri discriminant handling)
 - #64592 (Point at original span when emitting unreachable lint)
 - #64601 (Fix backticks in documentation)
 - #64606 (Remove unnecessary `mut` in doc example)
 - #64611 (rustbuild: Don't package libstd twice)
 - #64613 (rustbuild: Copy crate doc files fewer times)

Failed merges:


r? @ghost