### PR TITLE
rustbuild: Turn down compression on msi installers

### DIFF
--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -152,7 +152,7 @@
         </Upgrade>
 
         <!-- Specifies a single cab file to be embedded in the installer's .msi. -->
-        <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+        <MediaTemplate EmbedCab="yes" CompressionLevel="mszip" />
 
         <!-- Send a WM_SETTINGCHANGE message to tell processes like explorer to update their
              environments so any new command prompts get the updated %PATH% -->


### PR DESCRIPTION
This is the same as #64615 except applied to our MSI installers. The
same fix is applied effectively bringing these installers in line with
the gz tarball installers, which are about 3x faster to produce locally
and likely much faster to produce on CI.