### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -68,6 +68,13 @@ Misc
 - [`rustc` will now warn about some incorrect uses of
   `mem::{uninitialized, zeroed}` that are known to cause undefined behaviour.][63346]
 
+Compatibility Notes
+-------------------
+- Unfortunately the [`x86_64-unknown-uefi` platform can not be built][62785]
+  with rustc 1.39.0.
+- The [`armv7-unknown-linux-gnueabihf` platform is also known to have
+  issues][62896] for certain crates such as libc.
+
 [60260]: https://github.com/rust-lang/rust/pull/60260/
 [61457]: https://github.com/rust-lang/rust/pull/61457/
 [61491]: https://github.com/rust-lang/rust/pull/61491/
@@ -79,7 +86,9 @@ Misc
 [62735]: https://github.com/rust-lang/rust/pull/62735/
 [62766]: https://github.com/rust-lang/rust/pull/62766/
 [62784]: https://github.com/rust-lang/rust/pull/62784/
+[62785]: https://github.com/rust-lang/rust/issues/62785/
 [62814]: https://github.com/rust-lang/rust/pull/62814/
+[62896]: https://github.com/rust-lang/rust/issues/62896/
 [63000]: https://github.com/rust-lang/rust/pull/63000/
 [63056]: https://github.com/rust-lang/rust/pull/63056/
 [63107]: https://github.com/rust-lang/rust/pull/63107/

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -18,7 +18,7 @@ use build_helper::{output, t};
 
 use crate::{Compiler, Mode, LLVM_TOOLS};
 use crate::channel;
-use crate::util::{is_dylib, exe};
+use crate::util::{is_dylib, exe, timeit};
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::compile;
 use crate::tool::{self, Tool};
@@ -91,13 +91,14 @@ impl Step for Docs {
 
         let name = pkgname(builder, "rust-docs");
 
-        builder.info(&format!("Dist docs ({})", host));
         if !builder.config.docs {
-            builder.info("\tskipping - docs disabled");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, host));
         }
 
         builder.default_doc(None);
+
+        builder.info(&format!("Dist docs ({})", host));
+        let _time = timeit(builder);
 
         let image = tmpdir(builder).join(format!("{}-{}-image", name, host));
         let _ = fs::remove_dir_all(&image);
@@ -151,9 +152,7 @@ impl Step for RustcDocs {
 
         let name = pkgname(builder, "rustc-docs");
 
-        builder.info(&format!("Dist compiler docs ({})", host));
         if !builder.config.compiler_docs {
-            builder.info("\tskipping - compiler docs disabled");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, host));
         }
 
@@ -179,6 +178,9 @@ impl Step for RustcDocs {
            .arg("--component-name=rustc-docs")
            .arg("--legacy-manifest-dirs=rustlib,cargo")
            .arg("--bulk-dirs=share/doc/rust/html");
+
+        builder.info(&format!("Dist compiler docs ({})", host));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         builder.remove_dir(&image);
 
@@ -350,6 +352,7 @@ impl Step for Mingw {
         }
 
         builder.info(&format!("Dist mingw ({})", host));
+        let _time = timeit(builder);
         let name = pkgname(builder, "rust-mingw");
         let image = tmpdir(builder).join(format!("{}-{}-image", name, host));
         let _ = fs::remove_dir_all(&image);
@@ -403,7 +406,6 @@ impl Step for Rustc {
         let compiler = self.compiler;
         let host = self.compiler.host;
 
-        builder.info(&format!("Dist rustc stage{} ({})", compiler.stage, host));
         let name = pkgname(builder, "rustc");
         let image = tmpdir(builder).join(format!("{}-{}-image", name, host));
         let _ = fs::remove_dir_all(&image);
@@ -460,6 +462,9 @@ impl Step for Rustc {
            .arg(format!("--package-name={}-{}", name, host))
            .arg("--component-name=rustc")
            .arg("--legacy-manifest-dirs=rustlib,cargo");
+
+        builder.info(&format!("Dist rustc stage{} ({})", compiler.stage, host));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         builder.remove_dir(&image);
         builder.remove_dir(&overlay);
@@ -662,8 +667,6 @@ impl Step for Std {
         let target = self.target;
 
         let name = pkgname(builder, "rust-std");
-        builder.info(&format!("Dist std stage{} ({} -> {})",
-            compiler.stage, &compiler.host, target));
 
         // The only true set of target libraries came from the build triple, so
         // let's reduce redundant work by only producing archives from that host.
@@ -714,6 +717,10 @@ impl Step for Std {
            .arg(format!("--package-name={}-{}", name, target))
            .arg(format!("--component-name=rust-std-{}", target))
            .arg("--legacy-manifest-dirs=rustlib,cargo");
+
+        builder.info(&format!("Dist std stage{} ({} -> {})",
+            compiler.stage, &compiler.host, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         builder.remove_dir(&image);
         distdir(builder).join(format!("{}-{}.tar.gz", name, target))
@@ -754,11 +761,9 @@ impl Step for Analysis {
         let compiler = self.compiler;
         let target = self.target;
         assert!(builder.config.extended);
-        builder.info("Dist analysis");
         let name = pkgname(builder, "rust-analysis");
 
         if &compiler.host != builder.config.build {
-            builder.info("\tskipping, not a build host");
             return distdir(builder).join(format!("{}-{}.tar.gz", name, target));
         }
 
@@ -786,6 +791,9 @@ impl Step for Analysis {
            .arg(format!("--package-name={}-{}", name, target))
            .arg(format!("--component-name=rust-analysis-{}", target))
            .arg("--legacy-manifest-dirs=rustlib,cargo");
+
+        builder.info("Dist analysis");
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         builder.remove_dir(&image);
         distdir(builder).join(format!("{}-{}.tar.gz", name, target))
@@ -874,8 +882,6 @@ impl Step for Src {
 
     /// Creates the `rust-src` installer component
     fn run(self, builder: &Builder<'_>) -> PathBuf {
-        builder.info("Dist src");
-
         let name = pkgname(builder, "rust-src");
         let image = tmpdir(builder).join(format!("{}-image", name));
         let _ = fs::remove_dir_all(&image);
@@ -930,6 +936,9 @@ impl Step for Src {
            .arg(format!("--package-name={}", name))
            .arg("--component-name=rust-src")
            .arg("--legacy-manifest-dirs=rustlib,cargo");
+
+        builder.info("Dist src");
+        let _time = timeit(builder);
         builder.run(&mut cmd);
 
         builder.remove_dir(&image);
@@ -957,8 +966,6 @@ impl Step for PlainSourceTarball {
 
     /// Creates the plain source tarball
     fn run(self, builder: &Builder<'_>) -> PathBuf {
-        builder.info("Create plain source tarball");
-
         // Make sure that the root folder of tarball has the correct name
         let plain_name = format!("{}-src", pkgname(builder, "rustc"));
         let plain_dst_src = tmpdir(builder).join(&plain_name);
@@ -1020,6 +1027,9 @@ impl Step for PlainSourceTarball {
            .arg("--output").arg(&tarball)
            .arg("--work-dir=.")
            .current_dir(tmpdir(builder));
+
+        builder.info("Create plain source tarball");
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         distdir(builder).join(&format!("{}.tar.gz", plain_name))
     }
@@ -1073,7 +1083,6 @@ impl Step for Cargo {
         let compiler = self.compiler;
         let target = self.target;
 
-        builder.info(&format!("Dist cargo stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/cargo");
         let etc = src.join("src/etc");
         let release_num = builder.release_num("cargo");
@@ -1126,6 +1135,9 @@ impl Step for Cargo {
            .arg(format!("--package-name={}-{}", name, target))
            .arg("--component-name=cargo")
            .arg("--legacy-manifest-dirs=rustlib,cargo");
+
+        builder.info(&format!("Dist cargo stage{} ({})", compiler.stage, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         distdir(builder).join(format!("{}-{}.tar.gz", name, target))
     }
@@ -1161,7 +1173,6 @@ impl Step for Rls {
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist RLS stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/rls");
         let release_num = builder.release_num("rls");
         let name = pkgname(builder, "rls");
@@ -1210,6 +1221,8 @@ impl Step for Rls {
            .arg("--legacy-manifest-dirs=rustlib,cargo")
            .arg("--component-name=rls-preview");
 
+        builder.info(&format!("Dist RLS stage{} ({})", compiler.stage, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target)))
     }
@@ -1245,7 +1258,6 @@ impl Step for Clippy {
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist clippy stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/clippy");
         let release_num = builder.release_num("clippy");
         let name = pkgname(builder, "clippy");
@@ -1299,6 +1311,8 @@ impl Step for Clippy {
            .arg("--legacy-manifest-dirs=rustlib,cargo")
            .arg("--component-name=clippy-preview");
 
+        builder.info(&format!("Dist clippy stage{} ({})", compiler.stage, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target)))
     }
@@ -1334,7 +1348,6 @@ impl Step for Miri {
         let target = self.target;
         assert!(builder.config.extended);
 
-        builder.info(&format!("Dist miri stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/miri");
         let release_num = builder.release_num("miri");
         let name = pkgname(builder, "miri");
@@ -1389,6 +1402,8 @@ impl Step for Miri {
            .arg("--legacy-manifest-dirs=rustlib,cargo")
            .arg("--component-name=miri-preview");
 
+        builder.info(&format!("Dist miri stage{} ({})", compiler.stage, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target)))
     }
@@ -1423,7 +1438,6 @@ impl Step for Rustfmt {
         let compiler = self.compiler;
         let target = self.target;
 
-        builder.info(&format!("Dist Rustfmt stage{} ({})", compiler.stage, target));
         let src = builder.src.join("src/tools/rustfmt");
         let release_num = builder.release_num("rustfmt");
         let name = pkgname(builder, "rustfmt");
@@ -1476,6 +1490,8 @@ impl Step for Rustfmt {
            .arg("--legacy-manifest-dirs=rustlib,cargo")
            .arg("--component-name=rustfmt-preview");
 
+        builder.info(&format!("Dist Rustfmt stage{} ({})", compiler.stage, target));
+        let _time = timeit(builder);
         builder.run(&mut cmd);
         Some(distdir(builder).join(format!("{}-{}.tar.gz", name, target)))
     }
@@ -1576,6 +1592,7 @@ impl Step for Extended {
             input_tarballs.push(tarball);
         }
 
+        builder.info("building combined installer");
         let mut cmd = rust_installer(builder);
         cmd.arg("combine")
             .arg("--product-name=Rust")
@@ -1587,7 +1604,9 @@ impl Step for Extended {
             .arg("--legacy-manifest-dirs=rustlib,cargo")
             .arg("--input-tarballs").arg(input_tarballs)
             .arg("--non-installed-overlay").arg(&overlay);
+        let time = timeit(&builder);
         builder.run(&mut cmd);
+        drop(time);
 
         let mut license = String::new();
         license += &builder.read(&builder.src.join("COPYRIGHT"));
@@ -1643,6 +1662,7 @@ impl Step for Extended {
         };
 
         if target.contains("apple-darwin") {
+            builder.info("building pkg installer");
             let pkg = tmp.join("pkg");
             let _ = fs::remove_dir_all(&pkg);
 
@@ -1692,6 +1712,7 @@ impl Step for Extended {
                                                     pkgname(builder, "rust"),
                                                     target)))
                 .arg("--package-path").arg(&pkg);
+            let _time = timeit(builder);
             builder.run(&mut cmd);
         }
 
@@ -1742,14 +1763,18 @@ impl Step for Extended {
             builder.create(&exe.join("LICENSE.txt"), &license);
 
             // Generate exe installer
+            builder.info("building `exe` installer with `iscc`");
             let mut cmd = Command::new("iscc");
             cmd.arg("rust.iss")
+                .arg("/Q")
                 .current_dir(&exe);
             if target.contains("windows-gnu") {
                 cmd.arg("/dMINGW");
             }
             add_env(builder, &mut cmd, target);
+            let time = timeit(builder);
             builder.run(&mut cmd);
+            drop(time);
             builder.install(&exe.join(format!("{}-{}.exe", pkgname(builder, "rust"), target)),
                     &distdir(builder),
                     0o755);
@@ -1914,6 +1939,7 @@ impl Step for Extended {
             builder.install(&etc.join("gfx/banner.bmp"), &exe, 0o644);
             builder.install(&etc.join("gfx/dialogbg.bmp"), &exe, 0o644);
 
+            builder.info(&format!("building `msi` installer with {:?}", light));
             let filename = format!("{}-{}.msi", pkgname(builder, "rust"), target);
             let mut cmd = Command::new(&light);
             cmd.arg("-nologo")
@@ -1946,6 +1972,7 @@ impl Step for Extended {
             // ICE57 wrongly complains about the shortcuts
             cmd.arg("-sice:ICE57");
 
+            let _time = timeit(builder);
             builder.run(&mut cmd);
 
             if !builder.config.dry_run {
@@ -2114,6 +2141,7 @@ impl Step for LlvmTools {
         }
 
         builder.info(&format!("Dist LlvmTools ({})", target));
+        let _time = timeit(builder);
         let src = builder.src.join("src/llvm-project/llvm");
         let name = pkgname(builder, "llvm-tools");
 

--- a/src/etc/installer/exe/rust.iss
+++ b/src/etc/installer/exe/rust.iss
@@ -25,9 +25,9 @@ SourceDir=.\
 OutputBaseFilename={#CFG_PACKAGE_NAME}-{#CFG_BUILD}
 DefaultDirName={sd}\Rust
 
-Compression=lzma2/ultra
-InternalCompressLevel=ultra
-SolidCompression=true
+Compression=lzma2/normal
+InternalCompressLevel=normal
+SolidCompression=no
 
 ChangesEnvironment=true
 ChangesAssociations=no

--- a/src/etc/installer/msi/rust.wxs
+++ b/src/etc/installer/msi/rust.wxs
@@ -152,7 +152,7 @@
         </Upgrade>
 
         <!-- Specifies a single cab file to be embedded in the installer's .msi. -->
-        <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+        <MediaTemplate EmbedCab="yes" CompressionLevel="mszip" />
 
         <!-- Send a WM_SETTINGCHANGE message to tell processes like explorer to update their
              environments so any new command prompts get the updated %PATH% -->

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -7,7 +7,7 @@
 use crate::lint::{LintPass, LateLintPass, LintArray};
 use crate::middle::stability;
 use crate::session::Session;
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use syntax::ast;
 use syntax::source_map::Span;
 use syntax::symbol::Symbol;
@@ -524,7 +524,7 @@ pub(crate) fn add_elided_lifetime_in_path_suggestion(
     };
     db.span_suggestion(
         replace_span,
-        &format!("indicate the anonymous lifetime{}", if n >= 2 { "s" } else { "" }),
+        &format!("indicate the anonymous lifetime{}", pluralise!(n)),
         suggestion,
         Applicability::MachineApplicable
     );

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -17,7 +17,7 @@ use crate::ty::{self, DefIdTree, GenericParamDefKind, TyCtxt};
 use crate::rustc::lint;
 use crate::session::Session;
 use crate::util::nodemap::{DefIdMap, FxHashMap, FxHashSet, HirIdMap, HirIdSet};
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use rustc_macros::HashStable;
 use std::borrow::Cow;
 use std::cell::Cell;
@@ -3047,7 +3047,7 @@ pub fn report_missing_lifetime_specifiers(
         span,
         E0106,
         "missing lifetime specifier{}",
-        if count > 1 { "s" } else { "" }
+        pluralise!(count)
     )
 }
 

--- a/src/librustc/traits/chalk_fulfill.rs
+++ b/src/librustc/traits/chalk_fulfill.rs
@@ -81,6 +81,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                 .map(|obligation| FulfillmentError {
                     obligation: obligation.goal.clone(),
                     code: FulfillmentErrorCode::CodeAmbiguity,
+                    points_at_arg_span: false,
                 })
                 .collect();
             Err(errors)
@@ -129,6 +130,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                                     code: FulfillmentErrorCode::CodeSelectionError(
                                         SelectionError::Unimplemented
                                     ),
+                                    points_at_arg_span: false,
                                 }),
                             }
                         } else {
@@ -142,6 +144,7 @@ impl TraitEngine<'tcx> for FulfillmentContext<'tcx> {
                         code: FulfillmentErrorCode::CodeSelectionError(
                             SelectionError::Unimplemented
                         ),
+                        points_at_arg_span: false,
                     })
                 }
             }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -1014,6 +1014,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         _ => "_".to_string(),
                                     }).collect::<Vec<_>>().join(", "),
                             );
+                            // When the obligation error has been ensured to have been caused by
+                            // an argument, the `obligation.cause.span` points at the expression
+                            // of the argument, so we can provide a suggestion. This is signaled
+                            // by `points_at_arg`. Otherwise, we give a more general note.
                             if points_at_arg {
                                 err.span_suggestion(
                                     obligation.cause.span,

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -119,11 +119,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
 
     // returns if `cond` not occurring implies that `error` does not occur - i.e., that
     // `error` occurring implies that `cond` occurs.
-    fn error_implies(&self,
-                     cond: &ty::Predicate<'tcx>,
-                     error: &ty::Predicate<'tcx>)
-                     -> bool
-    {
+    fn error_implies(
+        &self,
+        cond: &ty::Predicate<'tcx>,
+        error: &ty::Predicate<'tcx>,
+    ) -> bool {
         if cond == error {
             return true
         }
@@ -155,13 +155,21 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         false
     }
 
-    fn report_fulfillment_error(&self, error: &FulfillmentError<'tcx>,
-                                body_id: Option<hir::BodyId>,
-                                fallback_has_occurred: bool) {
+    fn report_fulfillment_error(
+        &self,
+        error: &FulfillmentError<'tcx>,
+        body_id: Option<hir::BodyId>,
+        fallback_has_occurred: bool,
+    ) {
         debug!("report_fulfillment_errors({:?})", error);
         match error.code {
-            FulfillmentErrorCode::CodeSelectionError(ref e) => {
-                self.report_selection_error(&error.obligation, e, fallback_has_occurred);
+            FulfillmentErrorCode::CodeSelectionError(ref selection_error) => {
+                self.report_selection_error(
+                    &error.obligation,
+                    selection_error,
+                    fallback_has_occurred,
+                    error.points_at_arg_span,
+                );
             }
             FulfillmentErrorCode::CodeProjectionError(ref e) => {
                 self.report_projection_error(&error.obligation, e);
@@ -170,19 +178,21 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 self.maybe_report_ambiguity(&error.obligation, body_id);
             }
             FulfillmentErrorCode::CodeSubtypeError(ref expected_found, ref err) => {
-                self.report_mismatched_types(&error.obligation.cause,
-                                             expected_found.expected,
-                                             expected_found.found,
-                                             err.clone())
-                    .emit();
+                self.report_mismatched_types(
+                    &error.obligation.cause,
+                    expected_found.expected,
+                    expected_found.found,
+                    err.clone(),
+                ).emit();
             }
         }
     }
 
-    fn report_projection_error(&self,
-                               obligation: &PredicateObligation<'tcx>,
-                               error: &MismatchedProjectionTypes<'tcx>)
-    {
+    fn report_projection_error(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        error: &MismatchedProjectionTypes<'tcx>,
+    ) {
         let predicate =
             self.resolve_vars_if_possible(&obligation.predicate);
 
@@ -603,6 +613,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         error: &SelectionError<'tcx>,
         fallback_has_occurred: bool,
+        points_at_arg: bool,
     ) {
         let span = obligation.cause.span;
 
@@ -690,7 +701,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         }
 
                         self.suggest_borrow_on_unsized_slice(&obligation.cause.code, &mut err);
-                        self.suggest_fn_call(&obligation, &mut err, &trait_ref);
+                        self.suggest_fn_call(&obligation, &mut err, &trait_ref, points_at_arg);
                         self.suggest_remove_reference(&obligation, &mut err, &trait_ref);
                         self.suggest_semicolon_removal(&obligation, &mut err, span, &trait_ref);
 
@@ -963,6 +974,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         obligation: &PredicateObligation<'tcx>,
         err: &mut DiagnosticBuilder<'tcx>,
         trait_ref: &ty::Binder<ty::TraitRef<'tcx>>,
+        points_at_arg: bool,
     ) {
         let self_ty = trait_ref.self_ty();
         match self_ty.sty {
@@ -991,15 +1003,27 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             ..
                         })) = self.tcx.hir().get_if_local(def_id) {
                             let body = self.tcx.hir().body(*body_id);
-                            err.help(&format!(
-                                "use parentheses to call the function: `{}({})`",
+                            let msg = "use parentheses to call the function";
+                            let snippet = format!(
+                                "{}({})",
                                 ident,
                                 body.params.iter()
                                     .map(|arg| match &arg.pat.node {
                                         hir::PatKind::Binding(_, _, ident, None)
                                         if ident.name != kw::SelfLower => ident.to_string(),
                                         _ => "_".to_string(),
-                                    }).collect::<Vec<_>>().join(", ")));
+                                    }).collect::<Vec<_>>().join(", "),
+                            );
+                            if points_at_arg {
+                                err.span_suggestion(
+                                    obligation.cause.span,
+                                    msg,
+                                    snippet,
+                                    Applicability::HasPlaceholders,
+                                );
+                            } else {
+                                err.help(&format!("{}: `{}`", msg, snippet));
+                            }
                         }
                     }
                     _ => {}

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -33,7 +33,7 @@ use crate::ty::subst::Subst;
 use crate::ty::SubtypePredicate;
 use crate::util::nodemap::{FxHashMap, FxHashSet};
 
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use std::fmt;
 use syntax::ast;
 use syntax::symbol::{sym, kw};
@@ -1186,7 +1186,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 _ => format!("{} {}argument{}",
                              arg_length,
                              if distinct && arg_length > 1 { "distinct " } else { "" },
-                             if arg_length == 1 { "" } else { "s" }),
+                             pluralise!(arg_length))
             }
         };
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -484,7 +484,8 @@ EnumTypeFoldableImpl! {
 
 pub struct FulfillmentError<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
-    pub code: FulfillmentErrorCode<'tcx>
+    pub code: FulfillmentErrorCode<'tcx>,
+    pub points_at_arg_span: bool,
 }
 
 #[derive(Clone)]
@@ -1183,7 +1184,7 @@ impl<'tcx> FulfillmentError<'tcx> {
            code: FulfillmentErrorCode<'tcx>)
            -> FulfillmentError<'tcx>
     {
-        FulfillmentError { obligation: obligation, code: code }
+        FulfillmentError { obligation: obligation, code: code, points_at_arg_span: false }
     }
 }
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -485,6 +485,9 @@ EnumTypeFoldableImpl! {
 pub struct FulfillmentError<'tcx> {
     pub obligation: PredicateObligation<'tcx>,
     pub code: FulfillmentErrorCode<'tcx>,
+    /// Diagnostics only: we opportunistically change the `code.span` when we encounter an
+    /// obligation error caused by a call argument. When this is the case, we also signal that in
+    /// this field to ensure accuracy of suggestions.
     pub points_at_arg_span: bool,
 }
 

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -196,7 +196,7 @@ impl<'tcx> ty::TyS<'tcx> {
                 let n = tcx.lift_to_global(&n).unwrap();
                 match n.try_eval_usize(tcx, ty::ParamEnv::empty()) {
                     Some(n) => {
-                        format!("array of {} element{}", n, if n != 1 { "s" } else { "" }).into()
+                        format!("array of {} element{}", n, pluralise!(n)).into()
                     }
                     None => "array".into(),
                 }

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -9,7 +9,7 @@ use lint::{LintPass, EarlyLintPass, LateLintPass};
 
 use syntax::ast;
 use syntax::attr;
-use syntax::errors::Applicability;
+use syntax::errors::{Applicability, pluralise};
 use syntax::feature_gate::{AttributeType, BuiltinAttribute, BUILTIN_ATTRIBUTE_MAP};
 use syntax::print::pprust;
 use syntax::symbol::{kw, sym};
@@ -48,7 +48,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
         }
 
         let ty = cx.tables.expr_ty(&expr);
-        let type_permits_lack_of_use = check_must_use_ty(cx, ty, &expr, s.span, "", "", false);
+        let type_permits_lack_of_use = check_must_use_ty(cx, ty, &expr, s.span, "", "", 1);
 
         let mut fn_warned = false;
         let mut op_warned = false;
@@ -135,7 +135,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
             span: Span,
             descr_pre: &str,
             descr_post: &str,
-            plural: bool,
+            plural_len: usize,
         ) -> bool {
             if ty.is_unit() || cx.tcx.is_ty_uninhabited_from(
                 cx.tcx.hir().get_module_parent(expr.hir_id), ty)
@@ -143,13 +143,13 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
                 return true;
             }
 
-            let plural_suffix = if plural { "s" } else { "" };
+            let plural_suffix = pluralise!(plural_len);
 
             match ty.sty {
                 ty::Adt(..) if ty.is_box() => {
                     let boxed_ty = ty.boxed_ty();
                     let descr_pre = &format!("{}boxed ", descr_pre);
-                    check_must_use_ty(cx, boxed_ty, expr, span, descr_pre, descr_post, plural)
+                    check_must_use_ty(cx, boxed_ty, expr, span, descr_pre, descr_post, plural_len)
                 }
                 ty::Adt(def, _) => {
                     check_must_use_def(cx, def.did, span, descr_pre, descr_post)
@@ -202,7 +202,15 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
                     for (i, ty) in tys.iter().map(|k| k.expect_ty()).enumerate() {
                         let descr_post = &format!(" in tuple element {}", i);
                         let span = *spans.get(i).unwrap_or(&span);
-                        if check_must_use_ty(cx, ty, expr, span, descr_pre, descr_post, plural) {
+                        if check_must_use_ty(
+                            cx,
+                            ty,
+                            expr,
+                            span,
+                            descr_pre,
+                            descr_post,
+                            plural_len
+                        ) {
                             has_emitted = true;
                         }
                     }
@@ -216,7 +224,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedResults {
                             descr_pre,
                             plural_suffix,
                         );
-                        check_must_use_ty(cx, ty, expr, span, descr_pre, descr_post, true)
+                        check_must_use_ty(cx, ty, expr, span, descr_pre, descr_post, n as usize + 1)
                     }
                     // Otherwise, we don't lint, to avoid false positives.
                     _ => false,

--- a/src/librustc_mir/borrow_check/nll/type_check/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/mod.rs
@@ -1999,6 +1999,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                             ),
                             &traits::SelectionError::Unimplemented,
                             false,
+                            false,
                         );
                     }
                 }

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -26,6 +26,8 @@
 use crate::Resolver;
 use crate::resolve_imports::ImportDirectiveSubclass;
 
+use errors::pluralise;
+
 use rustc::util::nodemap::NodeMap;
 use rustc::{lint, ty};
 use rustc_data_structures::fx::FxHashSet;
@@ -295,7 +297,7 @@ impl Resolver<'_> {
                 }).collect::<Vec<String>>();
             span_snippets.sort();
             let msg = format!("unused import{}{}",
-                            if len > 1 { "s" } else { "" },
+                            pluralise!(len),
                             if !span_snippets.is_empty() {
                                 format!(": {}", span_snippets.join(", "))
                             } else {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -11,7 +11,7 @@ use crate::{Resolver, ResolutionError, Segment, ModuleKind};
 use crate::{names_to_string, module_to_string};
 use crate::diagnostics::Suggestion;
 
-use errors::Applicability;
+use errors::{Applicability, pluralise};
 
 use rustc_data_structures::ptr_key::PtrKey;
 use rustc::ty;
@@ -728,7 +728,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
 
             let msg = format!(
                 "unresolved import{} {}",
-                if paths.len() > 1 { "s" } else { "" },
+                pluralise!(paths.len()),
                 paths.join(", "),
             );
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -1346,7 +1346,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 span,
                 E0191,
                 "the value of the associated type{} {} must be specified",
-                if associated_types.len() == 1 { "" } else { "s" },
+                pluralise!(associated_types.len()),
                 names,
             );
             let (suggest, potential_assoc_types_spans) =

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -617,7 +617,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
                 // Object safety violations or miscellaneous.
                 Err(err) => {
-                    self.report_selection_error(&obligation, &err, false);
+                    self.report_selection_error(&obligation, &err, false, false);
                     // Treat this like an obligation and follow through
                     // with the unsizing - the lack of a coercion should
                     // be silent, as it causes a type mismatch later.

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -17,7 +17,7 @@ use crate::util::common::ErrorReported;
 use crate::util::nodemap::FxHashMap;
 use crate::astconv::AstConv as _;
 
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use syntax::ast;
 use syntax::symbol::{Symbol, kw, sym};
 use syntax::source_map::Span;
@@ -1178,7 +1178,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             struct_span_err!(tcx.sess, span, E0063,
                              "missing field{} {}{} in initializer of `{}`",
-                             if remaining_fields.len() == 1 { "" } else { "s" },
+                             pluralise!(remaining_fields.len()),
                              remaining_fields_names,
                              truncated_fields_error,
                              adt_ty)

--- a/src/librustc_typeck/check/method/suggest.rs
+++ b/src/librustc_typeck/check/method/suggest.rs
@@ -5,7 +5,7 @@ use crate::check::FnCtxt;
 use crate::middle::lang_items::FnOnceTraitLangItem;
 use crate::namespace::Namespace;
 use crate::util::nodemap::FxHashSet;
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use rustc::hir::{self, ExprKind, Node, QPath};
 use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::{CRATE_DEF_INDEX, LOCAL_CRATE, DefId};
@@ -560,7 +560,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let help = format!("{an}other candidate{s} {were} found in the following \
                                         trait{s}, perhaps add a `use` for {one_of_them}:",
                                     an = if candidates.len() == 1 {"an" } else { "" },
-                                    s = if candidates.len() == 1 { "" } else { "s" },
+                                    s = pluralise!(candidates.len()),
                                     were = if candidates.len() == 1 { "was" } else { "were" },
                                     one_of_them = if candidates.len() == 1 {
                                         "it"

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -88,7 +88,7 @@ pub mod intrinsic;
 mod op;
 
 use crate::astconv::{AstConv, PathSeg};
-use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId, pluralise};
 use rustc::hir::{self, ExprKind, GenericArg, ItemKind, Node, PatKind, QPath};
 use rustc::hir::def::{CtorOf, Res, DefKind};
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
@@ -4843,5 +4843,5 @@ fn fatally_break_rust(sess: &Session) {
 }
 
 fn potentially_plural_count(count: usize, word: &str) -> String {
-    format!("{} {}{}", count, word, if count == 1 { "" } else { "s" })
+    format!("{} {}{}", count, word, pluralise!(count))
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2847,10 +2847,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn select_obligations_where_possible(
         &self,
         fallback_has_occurred: bool,
-        f: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
+        mutate_fullfillment_errors: impl Fn(&mut Vec<traits::FulfillmentError<'tcx>>),
     ) {
         if let Err(mut errors) = self.fulfillment_cx.borrow_mut().select_where_possible(self) {
-            f(&mut errors);
+            mutate_fullfillment_errors(&mut errors);
             self.report_fulfillment_errors(&errors, self.inh.body_id, fallback_has_occurred);
         }
     }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3384,15 +3384,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // the `?` operator.
             for error in errors {
                 if let ty::Predicate::Trait(predicate) = error.obligation.predicate {
-                    let mut referenced_in = vec![];
-                    for (i, ty) in final_arg_types {
-                        let ty = self.resolve_vars_if_possible(ty);
-                        for ty in ty.walk() {
-                            if ty == predicate.skip_binder().self_ty() {
-                                referenced_in.push(*i);
-                            }
-                        }
-                    }
                     let mut referenced_in = final_arg_types.iter()
                         .flat_map(|(i, ty)| {
                             let ty = self.resolve_vars_if_possible(ty);

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -3396,6 +3396,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     if referenced_in.len() == 1 {
                         error.obligation.cause.span = args[referenced_in[0]].span;
+                        error.points_at_arg_span = true;
                     }
                 }
             }

--- a/src/librustc_typeck/check/op.rs
+++ b/src/librustc_typeck/check/op.rs
@@ -724,7 +724,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match method {
             Some(ok) => {
                 let method = self.register_infer_ok_obligations(ok);
-                self.select_obligations_where_possible(false);
+                self.select_obligations_where_possible(false, |_| {});
 
                 Ok(method)
             }

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -1,6 +1,6 @@
 use crate::check::FnCtxt;
 use crate::util::nodemap::FxHashMap;
-use errors::{Applicability, DiagnosticBuilder};
+use errors::{Applicability, DiagnosticBuilder, pluralise};
 use rustc::hir::{self, PatKind, Pat, HirId};
 use rustc::hir::def::{Res, DefKind, CtorKind};
 use rustc::hir::pat_util::EnumerateAndAdjustIterator;
@@ -684,8 +684,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn e0023(&self, pat_span: Span, res: Res, subpats: &'tcx [P<Pat>], fields: &[ty::FieldDef]) {
-        let subpats_ending = if subpats.len() == 1 { "" } else { "s" };
-        let fields_ending = if fields.len() == 1 { "" } else { "s" };
+        let subpats_ending = pluralise!(subpats.len());
+        let fields_ending = pluralise!(fields.len());
         let res_span = self.tcx.def_span(res.def_id());
         struct_span_err!(
             self.tcx.sess,
@@ -1103,10 +1103,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             E0527,
             "pattern requires {} element{} but array has {}",
             min_len,
-            if min_len != 1 { "s" } else { "" },
+            pluralise!(min_len),
             size,
         )
-        .span_label(span, format!("expected {} element{}", size, if size != 1 { "s" } else { "" }))
+        .span_label(span, format!("expected {} element{}", size, pluralise!(size)))
         .emit();
     }
 
@@ -1117,14 +1117,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             E0528,
             "pattern requires at least {} element{} but array has {}",
             min_len,
-            if min_len != 1 { "s" } else { "" },
+            pluralise!(min_len),
             size,
         ).span_label(
             span,
             format!(
                 "pattern cannot match array of {} element{}",
                 size,
-                if size != 1 { "s" } else { "" },
+                pluralise!(size),
             ),
         ).emit();
     }

--- a/src/libsyntax/ext/tt/transcribe.rs
+++ b/src/libsyntax/ext/tt/transcribe.rs
@@ -8,6 +8,7 @@ use crate::tokenstream::{DelimSpan, TokenStream, TokenTree, TreeAndJoint};
 
 use smallvec::{smallvec, SmallVec};
 
+use errors::pluralise;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
 use syntax_pos::hygiene::{ExpnId, Transparency};
@@ -348,10 +349,10 @@ impl LockstepIterSize {
                         "meta-variable `{}` repeats {} time{}, but `{}` repeats {} time{}",
                         l_id,
                         l_len,
-                        if l_len != 1 { "s" } else { "" },
+                        pluralise!(l_len),
                         r_id,
                         r_len,
-                        if r_len != 1 { "s" } else { "" },
+                        pluralise!(r_len),
                     );
                     LockstepIterSize::Contradiction(msg)
                 }

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -11,7 +11,7 @@ use crate::ptr::P;
 use crate::symbol::{kw, sym};
 use crate::ThinVec;
 use crate::util::parser::AssocOp;
-use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId, pluralise};
 use rustc_data_structures::fx::FxHashSet;
 use syntax_pos::{Span, DUMMY_SP, MultiSpan, SpanSnippetError};
 use log::{debug, trace};
@@ -532,15 +532,15 @@ impl<'a> Parser<'a> {
             self.eat_to_tokens(&[&end]);
             let span = lo.until(self.token.span);
 
-            let plural = number_of_gt > 1 || number_of_shr >= 1;
+            let total_num_of_gt = number_of_gt + number_of_shr * 2;
             self.diagnostic()
                 .struct_span_err(
                     span,
-                    &format!("unmatched angle bracket{}", if plural { "s" } else { "" }),
+                    &format!("unmatched angle bracket{}", pluralise!(total_num_of_gt)),
                 )
                 .span_suggestion(
                     span,
-                    &format!("remove extra angle bracket{}", if plural { "s" } else { "" }),
+                    &format!("remove extra angle bracket{}", pluralise!(total_num_of_gt)),
                     String::new(),
                     Applicability::MachineApplicable,
                 )

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -66,6 +66,10 @@ pub(super) enum LhsExpr {
 }
 
 impl From<Option<ThinVec<Attribute>>> for LhsExpr {
+    /// Converts `Some(attrs)` into `LhsExpr::AttributesParsed(attrs)`
+    /// and `None` into `LhsExpr::NotYetParsed`.
+    ///
+    /// This conversion does not allocate.
     fn from(o: Option<ThinVec<Attribute>>) -> Self {
         if let Some(attrs) = o {
             LhsExpr::AttributesParsed(attrs)
@@ -76,6 +80,9 @@ impl From<Option<ThinVec<Attribute>>> for LhsExpr {
 }
 
 impl From<P<Expr>> for LhsExpr {
+    /// Converts the `expr: P<Expr>` into `LhsExpr::AlreadyParsed(expr)`.
+    ///
+    /// This conversion does not allocate.
     fn from(expr: P<Expr>) -> Self {
         LhsExpr::AlreadyParsed(expr)
     }

--- a/src/libsyntax/parse/parser/path.rs
+++ b/src/libsyntax/parse/parser/path.rs
@@ -9,7 +9,7 @@ use crate::symbol::kw;
 
 use std::mem;
 use log::debug;
-use errors::{Applicability};
+use errors::{Applicability, pluralise};
 
 /// Specifies how to parse a path.
 #[derive(Copy, Clone, PartialEq)]
@@ -347,20 +347,19 @@ impl<'a> Parser<'a> {
                 let span = lo.with_hi(
                     lo.lo() + BytePos(snapshot.unmatched_angle_bracket_count)
                 );
-                let plural = snapshot.unmatched_angle_bracket_count > 1;
                 self.diagnostic()
                     .struct_span_err(
                         span,
                         &format!(
                             "unmatched angle bracket{}",
-                            if plural { "s" } else { "" }
+                            pluralise!(snapshot.unmatched_angle_bracket_count)
                         ),
                     )
                     .span_suggestion(
                         span,
                         &format!(
                             "remove extra angle bracket{}",
-                            if plural { "s" } else { "" }
+                            pluralise!(snapshot.unmatched_angle_bracket_count)
                         ),
                         String::new(),
                         Applicability::MachineApplicable,

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -11,7 +11,7 @@ use crate::symbol::{kw};
 
 use rustc_target::spec::abi::Abi;
 
-use errors::{Applicability};
+use errors::{Applicability, pluralise};
 
 /// Returns `true` if `IDENT t` can start a type -- `IDENT::a::b`, `IDENT<u8, u8>`,
 /// `IDENT<<u8 as Trait>::AssocTy>`.
@@ -397,7 +397,7 @@ impl<'a> Parser<'a> {
         }
 
         if !negative_bounds.is_empty() || was_negative {
-            let plural = negative_bounds.len() > 1;
+            let negative_bounds_len = negative_bounds.len();
             let last_span = negative_bounds.last().map(|sp| *sp);
             let mut err = self.struct_span_err(
                 negative_bounds,
@@ -420,7 +420,7 @@ impl<'a> Parser<'a> {
                 }
                 err.span_suggestion_hidden(
                     bound_list,
-                    &format!("remove the trait bound{}", if plural { "s" } else { "" }),
+                    &format!("remove the trait bound{}", pluralise!(negative_bounds_len)),
                     new_bound_list,
                     Applicability::MachineApplicable,
                 );

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1651,9 +1651,18 @@ impl<'a> State<'a> {
                 }
             }
             ast::StmtKind::Semi(ref expr) => {
-                self.space_if_not_bol();
-                self.print_expr_outer_attr_style(expr, false);
-                self.s.word(";");
+                match expr.node {
+                    // Filter out empty `Tup` exprs created for the `redundant_semicolon`
+                    // lint, as they shouldn't be visible and interact poorly
+                    // with proc macros.
+                    ast::ExprKind::Tup(ref exprs) if exprs.is_empty()
+                      && expr.attrs.is_empty() => (),
+                    _ => {
+                        self.space_if_not_bol();
+                        self.print_expr_outer_attr_style(expr, false);
+                        self.s.word(";");
+                    }
+                }
             }
             ast::StmtKind::Mac(ref mac) => {
                 let (ref mac, style, ref attrs) = **mac;

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -5,6 +5,7 @@ use fmt_macros as parse;
 
 use errors::DiagnosticBuilder;
 use errors::Applicability;
+use errors::pluralise;
 
 use syntax::ast;
 use syntax::ext::base::{self, *};
@@ -299,7 +300,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 &format!(
                     "{} positional argument{} in format string, but {}",
                     count,
-                    if count != 1 { "s" } else { "" },
+                    pluralise!(count),
                     self.describe_num_args(),
                 ),
             );

--- a/src/test/ui/associated-types/associated-types-bound-failure.stderr
+++ b/src/test/ui/associated-types/associated-types-bound-failure.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `<G as GetToInt>::R: ToInt` is not satisfied
-  --> $DIR/associated-types-bound-failure.rs:17:5
+  --> $DIR/associated-types-bound-failure.rs:17:19
    |
 LL |     fn to_int(&self) -> isize;
    |     -------------------------- required by `ToInt::to_int`
 ...
 LL |     ToInt::to_int(&g.get())
-   |     ^^^^^^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
+   |                   ^^^^^^^^ the trait `ToInt` is not implemented for `<G as GetToInt>::R`
    |
    = help: consider adding a `where <G as GetToInt>::R: ToInt` bound
 

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.rs
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.rs
@@ -14,7 +14,8 @@ async fn foo2() -> Result<(), ()> {
 }
 async fn foo3() -> Result<(), ()> {
     let _ = await bar()?; //~ ERROR incorrect use of `await`
-    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    //~^ ERROR the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
+    //~| ERROR the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
     Ok(())
 }
 async fn foo21() -> Result<(), ()> {

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.rs
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.rs
@@ -14,8 +14,7 @@ async fn foo2() -> Result<(), ()> {
 }
 async fn foo3() -> Result<(), ()> {
     let _ = await bar()?; //~ ERROR incorrect use of `await`
-    //~^ ERROR the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
-    //~| ERROR the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
+    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
     Ok(())
 }
 async fn foo21() -> Result<(), ()> {

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -17,103 +17,103 @@ LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:22:13
+  --> $DIR/incorrect-syntax-suggestions.rs:21:13
    |
 LL |     let _ = await { bar() };
    |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:26:13
+  --> $DIR/incorrect-syntax-suggestions.rs:25:13
    |
 LL |     let _ = await(bar());
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `(bar()).await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:30:13
+  --> $DIR/incorrect-syntax-suggestions.rs:29:13
    |
 LL |     let _ = await { bar() }?;
    |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:34:14
+  --> $DIR/incorrect-syntax-suggestions.rs:33:14
    |
 LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:38:24
+  --> $DIR/incorrect-syntax-suggestions.rs:37:24
    |
 LL |     let _ = bar().await();
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:42:24
+  --> $DIR/incorrect-syntax-suggestions.rs:41:24
    |
 LL |     let _ = bar().await()?;
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:54:13
+  --> $DIR/incorrect-syntax-suggestions.rs:53:13
    |
 LL |     let _ = await bar();
    |             ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:59:13
+  --> $DIR/incorrect-syntax-suggestions.rs:58:13
    |
 LL |     let _ = await? bar();
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await?`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:64:13
+  --> $DIR/incorrect-syntax-suggestions.rs:63:13
    |
 LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:69:14
+  --> $DIR/incorrect-syntax-suggestions.rs:68:14
    |
 LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:74:24
+  --> $DIR/incorrect-syntax-suggestions.rs:73:24
    |
 LL |     let _ = bar().await();
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:79:24
+  --> $DIR/incorrect-syntax-suggestions.rs:78:24
    |
 LL |     let _ = bar().await()?;
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:107:13
+  --> $DIR/incorrect-syntax-suggestions.rs:106:13
    |
 LL |     let _ = await!(bar());
    |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:111:13
+  --> $DIR/incorrect-syntax-suggestions.rs:110:13
    |
 LL |     let _ = await!(bar())?;
    |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:116:17
+  --> $DIR/incorrect-syntax-suggestions.rs:115:17
    |
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:124:17
+  --> $DIR/incorrect-syntax-suggestions.rs:123:17
    |
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: expected expression, found `=>`
-  --> $DIR/incorrect-syntax-suggestions.rs:132:25
+  --> $DIR/incorrect-syntax-suggestions.rs:131:25
    |
 LL |     match await { await => () }
    |                   ----- ^^ expected expression
@@ -121,13 +121,13 @@ LL |     match await { await => () }
    |                   while parsing this incorrect await expression
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:132:11
+  --> $DIR/incorrect-syntax-suggestions.rs:131:11
    |
 LL |     match await { await => () }
    |           ^^^^^^^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ await => () }.await`
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
-  --> $DIR/incorrect-syntax-suggestions.rs:135:1
+  --> $DIR/incorrect-syntax-suggestions.rs:134:1
    |
 LL |     match await { await => () }
    |     -----                      - expected one of `.`, `?`, `{`, or an operator here
@@ -138,7 +138,7 @@ LL | }
    | ^ unexpected token
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:54:13
+  --> $DIR/incorrect-syntax-suggestions.rs:53:13
    |
 LL | fn foo9() -> Result<(), ()> {
    |    ---- this is not `async`
@@ -146,7 +146,7 @@ LL |     let _ = await bar();
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:59:13
+  --> $DIR/incorrect-syntax-suggestions.rs:58:13
    |
 LL | fn foo10() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -154,7 +154,7 @@ LL |     let _ = await? bar();
    |             ^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:64:13
+  --> $DIR/incorrect-syntax-suggestions.rs:63:13
    |
 LL | fn foo11() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -162,7 +162,7 @@ LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:69:14
+  --> $DIR/incorrect-syntax-suggestions.rs:68:14
    |
 LL | fn foo12() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -170,7 +170,7 @@ LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:74:13
+  --> $DIR/incorrect-syntax-suggestions.rs:73:13
    |
 LL | fn foo13() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -178,7 +178,7 @@ LL |     let _ = bar().await();
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:79:13
+  --> $DIR/incorrect-syntax-suggestions.rs:78:13
    |
 LL | fn foo14() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -186,7 +186,7 @@ LL |     let _ = bar().await()?;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:84:13
+  --> $DIR/incorrect-syntax-suggestions.rs:83:13
    |
 LL | fn foo15() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -194,7 +194,7 @@ LL |     let _ = bar().await;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:88:13
+  --> $DIR/incorrect-syntax-suggestions.rs:87:13
    |
 LL | fn foo16() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -202,7 +202,7 @@ LL |     let _ = bar().await?;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:93:17
+  --> $DIR/incorrect-syntax-suggestions.rs:92:17
    |
 LL |     fn foo() -> Result<(), ()> {
    |        --- this is not `async`
@@ -210,7 +210,7 @@ LL |         let _ = bar().await?;
    |                 ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:100:17
+  --> $DIR/incorrect-syntax-suggestions.rs:99:17
    |
 LL |     let foo = || {
    |               -- this is not `async`
@@ -218,7 +218,7 @@ LL |         let _ = bar().await?;
    |                 ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:116:17
+  --> $DIR/incorrect-syntax-suggestions.rs:115:17
    |
 LL |     fn foo() -> Result<(), ()> {
    |        --- this is not `async`
@@ -226,27 +226,22 @@ LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:124:17
+  --> $DIR/incorrect-syntax-suggestions.rs:123:17
    |
 LL |     let foo = || {
    |               -- this is not `async`
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
-error[E0277]: the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/incorrect-syntax-suggestions.rs:16:19
    |
 LL |     let _ = await bar()?;
-   |                   ^^^^^ the trait `std::ops::Try` is not implemented for `impl std::future::Future`
+   |                   ^^^^^^ the `?` operator cannot be applied to type `impl std::future::Future`
    |
+   = help: the trait `std::ops::Try` is not implemented for `impl std::future::Future`
    = note: required by `std::ops::Try::into_result`
 
-error[E0277]: the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
-  --> $DIR/incorrect-syntax-suggestions.rs:16:19
-   |
-LL |     let _ = await bar()?;
-   |                   ^^^^^^ the trait `std::ops::Try` is not implemented for `impl std::future::Future`
-
-error: aborting due to 36 previous errors
+error: aborting due to 35 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -17,103 +17,103 @@ LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:21:13
+  --> $DIR/incorrect-syntax-suggestions.rs:22:13
    |
 LL |     let _ = await { bar() };
    |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:25:13
+  --> $DIR/incorrect-syntax-suggestions.rs:26:13
    |
 LL |     let _ = await(bar());
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `(bar()).await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:29:13
+  --> $DIR/incorrect-syntax-suggestions.rs:30:13
    |
 LL |     let _ = await { bar() }?;
    |             ^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ bar() }.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:33:14
+  --> $DIR/incorrect-syntax-suggestions.rs:34:14
    |
 LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:37:24
+  --> $DIR/incorrect-syntax-suggestions.rs:38:24
    |
 LL |     let _ = bar().await();
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:41:24
+  --> $DIR/incorrect-syntax-suggestions.rs:42:24
    |
 LL |     let _ = bar().await()?;
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:53:13
+  --> $DIR/incorrect-syntax-suggestions.rs:54:13
    |
 LL |     let _ = await bar();
    |             ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:58:13
+  --> $DIR/incorrect-syntax-suggestions.rs:59:13
    |
 LL |     let _ = await? bar();
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await?`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:63:13
+  --> $DIR/incorrect-syntax-suggestions.rs:64:13
    |
 LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ help: `await` is a postfix operation: `bar()?.await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:68:14
+  --> $DIR/incorrect-syntax-suggestions.rs:69:14
    |
 LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:73:24
+  --> $DIR/incorrect-syntax-suggestions.rs:74:24
    |
 LL |     let _ = bar().await();
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:78:24
+  --> $DIR/incorrect-syntax-suggestions.rs:79:24
    |
 LL |     let _ = bar().await()?;
    |                        ^^ help: `await` is not a method call, remove the parentheses
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:106:13
+  --> $DIR/incorrect-syntax-suggestions.rs:107:13
    |
 LL |     let _ = await!(bar());
    |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:110:13
+  --> $DIR/incorrect-syntax-suggestions.rs:111:13
    |
 LL |     let _ = await!(bar())?;
    |             ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:115:17
+  --> $DIR/incorrect-syntax-suggestions.rs:116:17
    |
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:123:17
+  --> $DIR/incorrect-syntax-suggestions.rs:124:17
    |
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ help: `await` is a postfix operation: `bar().await`
 
 error: expected expression, found `=>`
-  --> $DIR/incorrect-syntax-suggestions.rs:131:25
+  --> $DIR/incorrect-syntax-suggestions.rs:132:25
    |
 LL |     match await { await => () }
    |                   ----- ^^ expected expression
@@ -121,13 +121,13 @@ LL |     match await { await => () }
    |                   while parsing this incorrect await expression
 
 error: incorrect use of `await`
-  --> $DIR/incorrect-syntax-suggestions.rs:131:11
+  --> $DIR/incorrect-syntax-suggestions.rs:132:11
    |
 LL |     match await { await => () }
    |           ^^^^^^^^^^^^^^^^^^^^^ help: `await` is a postfix operation: `{ await => () }.await`
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
-  --> $DIR/incorrect-syntax-suggestions.rs:134:1
+  --> $DIR/incorrect-syntax-suggestions.rs:135:1
    |
 LL |     match await { await => () }
    |     -----                      - expected one of `.`, `?`, `{`, or an operator here
@@ -138,7 +138,7 @@ LL | }
    | ^ unexpected token
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:53:13
+  --> $DIR/incorrect-syntax-suggestions.rs:54:13
    |
 LL | fn foo9() -> Result<(), ()> {
    |    ---- this is not `async`
@@ -146,7 +146,7 @@ LL |     let _ = await bar();
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:58:13
+  --> $DIR/incorrect-syntax-suggestions.rs:59:13
    |
 LL | fn foo10() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -154,7 +154,7 @@ LL |     let _ = await? bar();
    |             ^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:63:13
+  --> $DIR/incorrect-syntax-suggestions.rs:64:13
    |
 LL | fn foo11() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -162,7 +162,7 @@ LL |     let _ = await bar()?;
    |             ^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:68:14
+  --> $DIR/incorrect-syntax-suggestions.rs:69:14
    |
 LL | fn foo12() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -170,7 +170,7 @@ LL |     let _ = (await bar())?;
    |              ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:73:13
+  --> $DIR/incorrect-syntax-suggestions.rs:74:13
    |
 LL | fn foo13() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -178,7 +178,7 @@ LL |     let _ = bar().await();
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:78:13
+  --> $DIR/incorrect-syntax-suggestions.rs:79:13
    |
 LL | fn foo14() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -186,7 +186,7 @@ LL |     let _ = bar().await()?;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:83:13
+  --> $DIR/incorrect-syntax-suggestions.rs:84:13
    |
 LL | fn foo15() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -194,7 +194,7 @@ LL |     let _ = bar().await;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:87:13
+  --> $DIR/incorrect-syntax-suggestions.rs:88:13
    |
 LL | fn foo16() -> Result<(), ()> {
    |    ----- this is not `async`
@@ -202,7 +202,7 @@ LL |     let _ = bar().await?;
    |             ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:92:17
+  --> $DIR/incorrect-syntax-suggestions.rs:93:17
    |
 LL |     fn foo() -> Result<(), ()> {
    |        --- this is not `async`
@@ -210,7 +210,7 @@ LL |         let _ = bar().await?;
    |                 ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:99:17
+  --> $DIR/incorrect-syntax-suggestions.rs:100:17
    |
 LL |     let foo = || {
    |               -- this is not `async`
@@ -218,7 +218,7 @@ LL |         let _ = bar().await?;
    |                 ^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:115:17
+  --> $DIR/incorrect-syntax-suggestions.rs:116:17
    |
 LL |     fn foo() -> Result<(), ()> {
    |        --- this is not `async`
@@ -226,22 +226,27 @@ LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
 error[E0728]: `await` is only allowed inside `async` functions and blocks
-  --> $DIR/incorrect-syntax-suggestions.rs:123:17
+  --> $DIR/incorrect-syntax-suggestions.rs:124:17
    |
 LL |     let foo = || {
    |               -- this is not `async`
 LL |         let _ = await!(bar())?;
    |                 ^^^^^^^^^^^^^ only allowed inside `async` functions and blocks
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+error[E0277]: the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
   --> $DIR/incorrect-syntax-suggestions.rs:16:19
    |
 LL |     let _ = await bar()?;
-   |                   ^^^^^^ the `?` operator cannot be applied to type `impl std::future::Future`
+   |                   ^^^^^ the trait `std::ops::Try` is not implemented for `impl std::future::Future`
    |
-   = help: the trait `std::ops::Try` is not implemented for `impl std::future::Future`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to 35 previous errors
+error[E0277]: the trait bound `impl std::future::Future: std::ops::Try` is not satisfied
+  --> $DIR/incorrect-syntax-suggestions.rs:16:19
+   |
+LL |     let _ = await bar()?;
+   |                   ^^^^^^ the trait `std::ops::Try` is not implemented for `impl std::future::Future`
+
+error: aborting due to 36 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/closure-expected.stderr
+++ b/src/test/ui/closure-expected.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `std::ops::FnOnce<()>` closure, found `{integer}`
-  --> $DIR/closure-expected.rs:3:15
+  --> $DIR/closure-expected.rs:3:23
    |
 LL |     let y = x.or_else(4);
-   |               ^^^^^^^ expected an `FnOnce<()>` closure, found `{integer}`
+   |                       ^ expected an `FnOnce<()>` closure, found `{integer}`
    |
    = help: the trait `std::ops::FnOnce<()>` is not implemented for `{integer}`
    = note: wrap the `{integer}` in a closure with no arguments: `|| { /* code */ }

--- a/src/test/ui/closures/closure-bounds-subtype.stderr
+++ b/src/test/ui/closures/closure-bounds-subtype.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `F` cannot be shared between threads safely
-  --> $DIR/closure-bounds-subtype.rs:13:5
+  --> $DIR/closure-bounds-subtype.rs:13:22
    |
 LL | fn take_const_owned<F>(_: F) where F: FnOnce() + Sync + Send {
    | ------------------------------------------------------------ required by `take_const_owned`
 ...
 LL |     take_const_owned(f);
-   |     ^^^^^^^^^^^^^^^^ `F` cannot be shared between threads safely
+   |                      ^ `F` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `F`
    = help: consider adding a `where F: std::marker::Sync` bound

--- a/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
+++ b/src/test/ui/const-generics/array-impls/core-traits-no-impls-length-33.stderr
@@ -8,10 +8,10 @@ LL |     println!("{:?}", [0_usize; 33]);
    = note: required by `std::fmt::Debug::fmt`
 
 error[E0277]: arrays only have std trait implementations for lengths 0..=32
-  --> $DIR/core-traits-no-impls-length-33.rs:9:9
+  --> $DIR/core-traits-no-impls-length-33.rs:9:16
    |
 LL |     set.insert([0_usize; 33]);
-   |         ^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[usize; 33]`
+   |                ^^^^^^^^^^^^^ the trait `std::array::LengthAtMost32` is not implemented for `[usize; 33]`
    |
    = note: required because of the requirements on the impl of `std::cmp::Eq` for `[usize; 33]`
 

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,33 +1,33 @@
 error[E0277]: the trait bound `C: std::marker::Copy` is not satisfied
-  --> $DIR/deriving-copyclone.rs:31:5
+  --> $DIR/deriving-copyclone.rs:31:13
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    | ------------------------- required by `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: C });
-   |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `C`
+   |             ^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `C`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `B<C>`
 
 error[E0277]: the trait bound `C: std::clone::Clone` is not satisfied
-  --> $DIR/deriving-copyclone.rs:32:5
+  --> $DIR/deriving-copyclone.rs:32:14
    |
 LL | fn is_clone<T: Clone>(_: T) {}
    | --------------------------- required by `is_clone`
 ...
 LL |     is_clone(B { a: 1, b: C });
-   |     ^^^^^^^^ the trait `std::clone::Clone` is not implemented for `C`
+   |              ^^^^^^^^^^^^^^^^ the trait `std::clone::Clone` is not implemented for `C`
    |
    = note: required because of the requirements on the impl of `std::clone::Clone` for `B<C>`
 
 error[E0277]: the trait bound `D: std::marker::Copy` is not satisfied
-  --> $DIR/deriving-copyclone.rs:35:5
+  --> $DIR/deriving-copyclone.rs:35:13
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    | ------------------------- required by `is_copy`
 ...
 LL |     is_copy(B { a: 1, b: D });
-   |     ^^^^^^^ the trait `std::marker::Copy` is not implemented for `D`
+   |             ^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `D`
    |
    = note: required because of the requirements on the impl of `std::marker::Copy` for `B<D>`
 

--- a/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
+++ b/src/test/ui/did_you_mean/issue-39802-show-5-trait-impls.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `i8: Foo<i32>` is not satisfied
-  --> $DIR/issue-39802-show-5-trait-impls.rs:24:5
+  --> $DIR/issue-39802-show-5-trait-impls.rs:24:21
    |
 LL |     fn bar(&self){}
    |     ------------- required by `Foo::bar`
 ...
 LL |     Foo::<i32>::bar(&1i8);
-   |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `i8`
+   |                     ^^^^ the trait `Foo<i32>` is not implemented for `i8`
    |
    = help: the following implementations were found:
              <i8 as Foo<bool>>
@@ -15,13 +15,13 @@ LL |     Foo::<i32>::bar(&1i8);
              <i8 as Foo<u8>>
 
 error[E0277]: the trait bound `u8: Foo<i32>` is not satisfied
-  --> $DIR/issue-39802-show-5-trait-impls.rs:25:5
+  --> $DIR/issue-39802-show-5-trait-impls.rs:25:21
    |
 LL |     fn bar(&self){}
    |     ------------- required by `Foo::bar`
 ...
 LL |     Foo::<i32>::bar(&1u8);
-   |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `u8`
+   |                     ^^^^ the trait `Foo<i32>` is not implemented for `u8`
    |
    = help: the following implementations were found:
              <u8 as Foo<bool>>
@@ -30,13 +30,13 @@ LL |     Foo::<i32>::bar(&1u8);
              <u8 as Foo<u64>>
 
 error[E0277]: the trait bound `bool: Foo<i32>` is not satisfied
-  --> $DIR/issue-39802-show-5-trait-impls.rs:26:5
+  --> $DIR/issue-39802-show-5-trait-impls.rs:26:21
    |
 LL |     fn bar(&self){}
    |     ------------- required by `Foo::bar`
 ...
 LL |     Foo::<i32>::bar(&true);
-   |     ^^^^^^^^^^^^^^^ the trait `Foo<i32>` is not implemented for `bool`
+   |                     ^^^^^ the trait `Foo<i32>` is not implemented for `bool`
    |
    = help: the following implementations were found:
              <bool as Foo<bool>>

--- a/src/test/ui/error-codes/E0277.stderr
+++ b/src/test/ui/error-codes/E0277.stderr
@@ -11,13 +11,13 @@ LL | fn f(p: Path) { }
    = help: unsized locals are gated as an unstable feature
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/E0277.rs:17:5
+  --> $DIR/E0277.rs:17:15
    |
 LL | fn some_func<T: Foo>(foo: T) {
    | ---------------------------- required by `some_func`
 ...
 LL |     some_func(5i32);
-   |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^ the trait `Foo` is not implemented for `i32`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-should-say-copy-not-pod.stderr
+++ b/src/test/ui/error-should-say-copy-not-pod.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/error-should-say-copy-not-pod.rs:6:5
+  --> $DIR/error-should-say-copy-not-pod.rs:6:17
    |
 LL | fn check_bound<T:Copy>(_: T) {}
    | ---------------------------- required by `check_bound`
 ...
 LL |     check_bound("nocopy".to_string());
-   |     ^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+   |                 ^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
 
 error: aborting due to previous error
 

--- a/src/test/ui/extern/extern-wrong-value-type.stderr
+++ b/src/test/ui/extern/extern-wrong-value-type.stderr
@@ -1,11 +1,11 @@
 error[E0277]: expected a `std::ops::Fn<()>` closure, found `extern "C" fn() {f}`
-  --> $DIR/extern-wrong-value-type.rs:9:5
+  --> $DIR/extern-wrong-value-type.rs:9:11
    |
 LL | fn is_fn<F>(_: F) where F: Fn() {}
    | ------------------------------- required by `is_fn`
 ...
 LL |     is_fn(f);
-   |     ^^^^^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
+   |           ^ expected an `Fn<()>` closure, found `extern "C" fn() {f}`
    |
    = help: the trait `std::ops::Fn<()>` is not implemented for `extern "C" fn() {f}`
    = note: wrap the `extern "C" fn() {f}` in a closure with no arguments: `|| { /* code */ }

--- a/src/test/ui/fn/fn-trait-formatting.stderr
+++ b/src/test/ui/fn/fn-trait-formatting.stderr
@@ -26,13 +26,13 @@ LL |     let _: () = (box || -> isize { unimplemented!() }) as Box<dyn FnMut() -
               found type `std::boxed::Box<dyn std::ops::FnMut() -> isize>`
 
 error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `{integer}`
-  --> $DIR/fn-trait-formatting.rs:19:5
+  --> $DIR/fn-trait-formatting.rs:19:14
    |
 LL | fn needs_fn<F>(x: F) where F: Fn(isize) -> isize {}
    | ------------------------------------------------ required by `needs_fn`
 ...
 LL |     needs_fn(1);
-   |     ^^^^^^^^ expected an `Fn<(isize,)>` closure, found `{integer}`
+   |              ^ expected an `Fn<(isize,)>` closure, found `{integer}`
    |
    = help: the trait `std::ops::Fn<(isize,)>` is not implemented for `{integer}`
 

--- a/src/test/ui/for/for-c-in-str.rs
+++ b/src/test/ui/for/for-c-in-str.rs
@@ -6,6 +6,9 @@ fn main() {
     //~| NOTE `&str` is not an iterator
     //~| HELP the trait `std::iter::Iterator` is not implemented for `&str`
     //~| NOTE required by `std::iter::IntoIterator::into_iter`
+    //~| NOTE in this expansion of desugaring of `for` loop
+    //~| NOTE in this expansion of desugaring of `for` loop
+    //~| NOTE in this expansion of desugaring of `for` loop
         println!();
     }
 }

--- a/src/test/ui/generator/static-not-unpin.stderr
+++ b/src/test/ui/generator/static-not-unpin.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]: std::marker::Unpin` is not satisfied
-  --> $DIR/static-not-unpin.rs:14:5
+  --> $DIR/static-not-unpin.rs:14:18
    |
 LL | fn assert_unpin<T: Unpin>(_: T) {
    | ------------------------------- required by `assert_unpin`
 ...
 LL |     assert_unpin(generator);
-   |     ^^^^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`
+   |                  ^^^^^^^^^ the trait `std::marker::Unpin` is not implemented for `[static generator@$DIR/static-not-unpin.rs:11:25: 13:6 _]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
-  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:5
+  --> $DIR/hrtb-higher-ranker-supertraits-transitive.rs:47:26
    |
 LL | / fn want_bar_for_any_ccx<B>(b: &B)
 LL | |     where B : for<'ccx> Bar<'ccx>
@@ -8,7 +8,7 @@ LL | | }
    | |_- required by `want_bar_for_any_ccx`
 ...
 LL |       want_bar_for_any_ccx(b);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |                            ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
    |
    = help: consider adding a `where for<'ccx> B: Bar<'ccx>` bound
 

--- a/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
+++ b/src/test/ui/hrtb/hrtb-higher-ranker-supertraits.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `for<'tcx> F: Foo<'tcx>` is not satisfied
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:18:5
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:18:26
    |
 LL |       want_foo_for_any_tcx(f);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
+   |                            ^ the trait `for<'tcx> Foo<'tcx>` is not implemented for `F`
 ...
 LL | / fn want_foo_for_any_tcx<F>(f: &F)
 LL | |     where F : for<'tcx> Foo<'tcx>
@@ -15,10 +15,10 @@ LL | | }
    = help: consider adding a `where for<'tcx> F: Foo<'tcx>` bound
 
 error[E0277]: the trait bound `for<'ccx> B: Bar<'ccx>` is not satisfied
-  --> $DIR/hrtb-higher-ranker-supertraits.rs:35:5
+  --> $DIR/hrtb-higher-ranker-supertraits.rs:35:26
    |
 LL |       want_bar_for_any_ccx(b);
-   |       ^^^^^^^^^^^^^^^^^^^^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
+   |                            ^ the trait `for<'ccx> Bar<'ccx>` is not implemented for `B`
 ...
 LL | / fn want_bar_for_any_ccx<B>(b: &B)
 LL | |     where B : for<'ccx> Bar<'ccx>

--- a/src/test/ui/issues/issue-17651.rs
+++ b/src/test/ui/issues/issue-17651.rs
@@ -4,4 +4,5 @@
 fn main() {
     (|| Box::new(*(&[0][..])))();
     //~^ ERROR the size for values of type
+    //~| ERROR the size for values of type
 }

--- a/src/test/ui/issues/issue-17651.stderr
+++ b/src/test/ui/issues/issue-17651.stderr
@@ -1,4 +1,14 @@
 error[E0277]: the size for values of type `[{integer}]` cannot be known at compilation time
+  --> $DIR/issue-17651.rs:5:18
+   |
+LL |     (|| Box::new(*(&[0][..])))();
+   |                  ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `std::marker::Sized` is not implemented for `[{integer}]`
+   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
+   = note: required by `std::boxed::Box::<T>::new`
+
+error[E0277]: the size for values of type `[{integer}]` cannot be known at compilation time
   --> $DIR/issue-17651.rs:5:9
    |
 LL |     (|| Box::new(*(&[0][..])))();
@@ -6,8 +16,9 @@ LL |     (|| Box::new(*(&[0][..])))();
    |
    = help: the trait `std::marker::Sized` is not implemented for `[{integer}]`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
-   = note: required by `std::boxed::Box::<T>::new`
+   = note: all function arguments must have a statically known size
+   = help: unsized locals are gated as an unstable feature
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-23966.stderr
+++ b/src/test/ui/issues/issue-23966.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `std::ops::FnMut<(_, char)>` closure, found `()`
-  --> $DIR/issue-23966.rs:2:16
+  --> $DIR/issue-23966.rs:2:32
    |
 LL |     "".chars().fold(|_, _| (), ());
-   |                ^^^^ expected an `FnMut<(_, char)>` closure, found `()`
+   |                                ^^ expected an `FnMut<(_, char)>` closure, found `()`
    |
    = help: the trait `std::ops::FnMut<(_, char)>` is not implemented for `()`
 

--- a/src/test/ui/issues/issue-25076.stderr
+++ b/src/test/ui/issues/issue-25076.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `(): InOut<_>` is not satisfied
-  --> $DIR/issue-25076.rs:10:5
+  --> $DIR/issue-25076.rs:10:20
    |
 LL | fn do_fold<B, F: InOut<B, Out=B>>(init: B, f: F) {}
    | ------------------------------------------------ required by `do_fold`
 ...
 LL |     do_fold(bot(), ());
-   |     ^^^^^^^ the trait `InOut<_>` is not implemented for `()`
+   |                    ^^ the trait `InOut<_>` is not implemented for `()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-28098.rs
+++ b/src/test/ui/issues/issue-28098.rs
@@ -1,6 +1,7 @@
 fn main() {
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
+    //~| ERROR `()` is not an iterator
 
     for _ in false {}
     //~^ ERROR `bool` is not an iterator
@@ -16,6 +17,7 @@ pub fn other() {
 
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator
+    //~| ERROR `()` is not an iterator
 
     let _ = Iterator::next(&mut ());
     //~^ ERROR `()` is not an iterator

--- a/src/test/ui/issues/issue-28098.stderr
+++ b/src/test/ui/issues/issue-28098.stderr
@@ -1,14 +1,58 @@
 error[E0277]: `()` is not an iterator
+  --> $DIR/issue-28098.rs:2:28
+   |
+LL |     let _ = Iterator::next(&mut ());
+   |                            ^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `()`
+   = note: required by `std::iter::Iterator::next`
+
+error[E0277]: `bool` is not an iterator
+  --> $DIR/issue-28098.rs:6:14
+   |
+LL |     for _ in false {}
+   |              ^^^^^ `bool` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `bool`
+   = note: required by `std::iter::IntoIterator::into_iter`
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/issue-28098.rs:9:28
+   |
+LL |     let _ = Iterator::next(&mut ());
+   |                            ^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `()`
+   = note: required by `std::iter::Iterator::next`
+
+error[E0277]: `()` is not an iterator
   --> $DIR/issue-28098.rs:2:13
    |
 LL |     let _ = Iterator::next(&mut ());
    |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/issue-28098.rs:18:28
+   |
+LL |     let _ = Iterator::next(&mut ());
+   |                            ^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `()`
+   = note: required by `std::iter::Iterator::next`
+
+error[E0277]: `()` is not an iterator
+  --> $DIR/issue-28098.rs:22:28
+   |
+LL |     let _ = Iterator::next(&mut ());
+   |                            ^^^^^^^ `()` is not an iterator
+   |
+   = help: the trait `std::iter::Iterator` is not implemented for `()`
    = note: required by `std::iter::Iterator::next`
 
 error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:5:14
+  --> $DIR/issue-28098.rs:25:14
    |
 LL |     for _ in false {}
    |              ^^^^^ `bool` is not an iterator
@@ -17,41 +61,13 @@ LL |     for _ in false {}
    = note: required by `std::iter::IntoIterator::into_iter`
 
 error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:8:13
+  --> $DIR/issue-28098.rs:18:13
    |
 LL |     let _ = Iterator::next(&mut ());
    |             ^^^^^^^^^^^^^^ `()` is not an iterator
    |
    = help: the trait `std::iter::Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
 
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:17:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `std::iter::Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
-
-error[E0277]: `()` is not an iterator
-  --> $DIR/issue-28098.rs:20:13
-   |
-LL |     let _ = Iterator::next(&mut ());
-   |             ^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `std::iter::Iterator` is not implemented for `()`
-   = note: required by `std::iter::Iterator::next`
-
-error[E0277]: `bool` is not an iterator
-  --> $DIR/issue-28098.rs:23:14
-   |
-LL |     for _ in false {}
-   |              ^^^^^ `bool` is not an iterator
-   |
-   = help: the trait `std::iter::Iterator` is not implemented for `bool`
-   = note: required by `std::iter::IntoIterator::into_iter`
-
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-47706-trait.stderr
+++ b/src/test/ui/issues/issue-47706-trait.stderr
@@ -1,10 +1,10 @@
 error[E0593]: function is expected to take a single 0-tuple as argument, but it takes 2 distinct arguments
-  --> $DIR/issue-47706-trait.rs:3:20
+  --> $DIR/issue-47706-trait.rs:3:24
    |
 LL |     fn f(&self, _: ()) {
    |     ------------------ takes 2 distinct arguments
 LL |         None::<()>.map(Self::f);
-   |                    ^^^ expected function that takes a single 0-tuple as argument
+   |                        ^^^^^^^ expected function that takes a single 0-tuple as argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47706.stderr
+++ b/src/test/ui/issues/issue-47706.stderr
@@ -1,14 +1,14 @@
 error[E0593]: function is expected to take 1 argument, but it takes 2 arguments
-  --> $DIR/issue-47706.rs:11:18
+  --> $DIR/issue-47706.rs:11:22
    |
 LL |     pub fn new(foo: Option<i32>, _: ()) -> Foo {
    |     ------------------------------------------ takes 2 arguments
 ...
 LL |         self.foo.map(Foo::new)
-   |                  ^^^ expected function that takes 1 argument
+   |                      ^^^^^^^^ expected function that takes 1 argument
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
-  --> $DIR/issue-47706.rs:27:5
+  --> $DIR/issue-47706.rs:27:9
    |
 LL |       Bar(i32),
    |       -------- takes 1 argument
@@ -21,7 +21,7 @@ LL | | }
    | |_- required by `foo`
 ...
 LL |       foo(Qux::Bar);
-   |       ^^^ expected function that takes 0 arguments
+   |           ^^^^^^^^ expected function that takes 0 arguments
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-60283.stderr
+++ b/src/test/ui/issues/issue-60283.stderr
@@ -1,5 +1,5 @@
 error[E0631]: type mismatch in function arguments
-  --> $DIR/issue-60283.rs:14:5
+  --> $DIR/issue-60283.rs:14:13
    |
 LL | / pub fn foo<T, F>(_: T, _: F)
 LL | | where T: for<'a> Trait<'a>,
@@ -7,10 +7,10 @@ LL | |       F: for<'a> FnMut(<T as Trait<'a>>::Item) {}
    | |_________________________________________________- required by `foo`
 ...
 LL |       foo((), drop)
-   |       ^^^
-   |       |
-   |       expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
-   |       found signature of `fn(_) -> _`
+   |               ^^^^
+   |               |
+   |               expected signature of `for<'a> fn(<() as Trait<'a>>::Item) -> _`
+   |               found signature of `fn(_) -> _`
 
 error[E0271]: type mismatch resolving `for<'a> <fn(_) {std::mem::drop::<_>} as std::ops::FnOnce<(<() as Trait<'a>>::Item,)>>::Output == ()`
   --> $DIR/issue-60283.rs:14:5

--- a/src/test/ui/kindck/kindck-impl-type-params-2.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params-2.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is not satisfied
-  --> $DIR/kindck-impl-type-params-2.rs:13:5
+  --> $DIR/kindck-impl-type-params-2.rs:13:16
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
    | ----------------------------- required by `take_param`
 ...
 LL |     take_param(&x);
-   |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
+   |                ^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
    |
    = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<{integer}>`
 

--- a/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
+++ b/src/test/ui/kindck/kindck-inherited-copy-bound.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `std::boxed::Box<{integer}>: std::marker::Copy` is not satisfied
-  --> $DIR/kindck-inherited-copy-bound.rs:18:5
+  --> $DIR/kindck-inherited-copy-bound.rs:18:16
    |
 LL | fn take_param<T:Foo>(foo: &T) { }
    | ----------------------------- required by `take_param`
 ...
 LL |     take_param(&x);
-   |     ^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
+   |                ^^ the trait `std::marker::Copy` is not implemented for `std::boxed::Box<{integer}>`
    |
    = note: required because of the requirements on the impl of `Foo` for `std::boxed::Box<{integer}>`
 

--- a/src/test/ui/lint/redundant-semicolon/auxiliary/redundant-semi-proc-macro-def.rs
+++ b/src/test/ui/lint/redundant-semicolon/auxiliary/redundant-semi-proc-macro-def.rs
@@ -1,0 +1,11 @@
+// no-prefer-dynamic
+#![crate_type="proc-macro"]
+#![crate_name="redundant_semi_proc_macro"]
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn should_preserve_spans(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    eprintln!("{:?}", item);
+    item
+}

--- a/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.rs
+++ b/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.rs
@@ -1,0 +1,19 @@
+// aux-build:redundant-semi-proc-macro-def.rs
+
+#![deny(redundant_semicolon)]
+extern crate redundant_semi_proc_macro;
+use redundant_semi_proc_macro::should_preserve_spans;
+
+#[should_preserve_spans]
+fn span_preservation()  {
+    let tst = 123;; //~ ERROR unnecessary trailing semicolon
+    match tst {
+        // Redundant semicolons are parsed as empty tuple exprs
+        // for the lint, so ensure the lint doesn't affect
+        // empty tuple exprs explicitly in source.
+        123 => (),
+        _ => ()
+    };;; //~ ERROR unnecessary trailing semicolons
+}
+
+fn main() {}

--- a/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
+++ b/src/test/ui/lint/redundant-semicolon/redundant-semi-proc-macro.stderr
@@ -1,0 +1,21 @@
+TokenStream [Ident { ident: "fn", span: #0 bytes(197..199) }, Ident { ident: "span_preservation", span: #0 bytes(200..217) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(217..219) }, Group { delimiter: Brace, stream: TokenStream [Ident { ident: "let", span: #0 bytes(227..230) }, Ident { ident: "tst", span: #0 bytes(231..234) }, Punct { ch: '=', spacing: Alone, span: #0 bytes(235..236) }, Literal { lit: Lit { kind: Integer, symbol: 123, suffix: None }, span: Span { lo: BytePos(237), hi: BytePos(240), ctxt: #0 } }, Punct { ch: ';', spacing: Joint, span: #0 bytes(240..241) }, Punct { ch: ';', spacing: Alone, span: #0 bytes(241..242) }, Ident { ident: "match", span: #0 bytes(288..293) }, Ident { ident: "tst", span: #0 bytes(294..297) }, Group { delimiter: Brace, stream: TokenStream [Literal { lit: Lit { kind: Integer, symbol: 123, suffix: None }, span: Span { lo: BytePos(482), hi: BytePos(485), ctxt: #0 } }, Punct { ch: '=', spacing: Joint, span: #0 bytes(486..488) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(486..488) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(489..491) }, Punct { ch: ',', spacing: Alone, span: #0 bytes(491..492) }, Ident { ident: "_", span: #0 bytes(501..502) }, Punct { ch: '=', spacing: Joint, span: #0 bytes(503..505) }, Punct { ch: '>', spacing: Alone, span: #0 bytes(503..505) }, Group { delimiter: Parenthesis, stream: TokenStream [], span: #0 bytes(506..508) }], span: #0 bytes(298..514) }, Punct { ch: ';', spacing: Joint, span: #0 bytes(514..515) }, Punct { ch: ';', spacing: Joint, span: #0 bytes(515..516) }, Punct { ch: ';', spacing: Alone, span: #0 bytes(516..517) }], span: #0 bytes(221..561) }]
+error: unnecessary trailing semicolon
+  --> $DIR/redundant-semi-proc-macro.rs:9:19
+   |
+LL |     let tst = 123;;
+   |                   ^ help: remove this semicolon
+   |
+note: lint level defined here
+  --> $DIR/redundant-semi-proc-macro.rs:3:9
+   |
+LL | #![deny(redundant_semicolon)]
+   |         ^^^^^^^^^^^^^^^^^^^
+
+error: unnecessary trailing semicolons
+  --> $DIR/redundant-semi-proc-macro.rs:16:7
+   |
+LL |     };;;
+   |       ^^ help: remove these semicolons
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/mismatched_types/E0631.stderr
+++ b/src/test/ui/mismatched_types/E0631.stderr
@@ -21,7 +21,7 @@ LL |     bar(|_: isize| {});
    |     expected signature of `fn(usize) -> _`
 
 error[E0631]: type mismatch in function arguments
-  --> $DIR/E0631.rs:9:5
+  --> $DIR/E0631.rs:9:9
    |
 LL | fn foo<F: Fn(usize)>(_: F) {}
    | -------------------------- required by `foo`
@@ -30,10 +30,10 @@ LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     foo(f);
-   |     ^^^ expected signature of `fn(usize) -> _`
+   |         ^ expected signature of `fn(usize) -> _`
 
 error[E0631]: type mismatch in function arguments
-  --> $DIR/E0631.rs:10:5
+  --> $DIR/E0631.rs:10:9
    |
 LL | fn bar<F: Fn<usize>>(_: F) {}
    | -------------------------- required by `bar`
@@ -42,7 +42,7 @@ LL |     fn f(_: u64) {}
    |     ------------ found signature of `fn(u64) -> _`
 ...
 LL |     bar(f);
-   |     ^^^ expected signature of `fn(usize) -> _`
+   |         ^ expected signature of `fn(usize) -> _`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -105,42 +105,42 @@ LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x, y| i);
    |                                                     expected closure that takes a single 2-tuple as argument
 
 error[E0593]: function is expected to take a single 2-tuple as argument, but it takes 0 arguments
-  --> $DIR/closure-arg-count.rs:24:53
+  --> $DIR/closure-arg-count.rs:24:57
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(foo);
-   |                                                     ^^^ expected function that takes a single 2-tuple as argument
+   |                                                         ^^^ expected function that takes a single 2-tuple as argument
 ...
 LL | fn foo() {}
    | -------- takes 0 arguments
 
 error[E0593]: closure is expected to take a single 2-tuple as argument, but it takes 3 distinct arguments
-  --> $DIR/closure-arg-count.rs:27:53
+  --> $DIR/closure-arg-count.rs:27:57
    |
 LL |     let bar = |i, x, y| i;
    |               --------- takes 3 distinct arguments
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(bar);
-   |                                                     ^^^ expected closure that takes a single 2-tuple as argument
+   |                                                         ^^^ expected closure that takes a single 2-tuple as argument
 
 error[E0593]: function is expected to take a single 2-tuple as argument, but it takes 2 distinct arguments
-  --> $DIR/closure-arg-count.rs:29:53
+  --> $DIR/closure-arg-count.rs:29:57
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(qux);
-   |                                                     ^^^ expected function that takes a single 2-tuple as argument
+   |                                                         ^^^ expected function that takes a single 2-tuple as argument
 ...
 LL | fn qux(x: usize, y: usize) {}
    | -------------------------- takes 2 distinct arguments
 
 error[E0593]: function is expected to take 1 argument, but it takes 2 arguments
-  --> $DIR/closure-arg-count.rs:32:41
+  --> $DIR/closure-arg-count.rs:32:45
    |
 LL |     let _it = vec![1, 2, 3].into_iter().map(usize::checked_add);
-   |                                         ^^^ expected function that takes 1 argument
+   |                                             ^^^^^^^^^^^^^^^^^^ expected function that takes 1 argument
 
 error[E0593]: function is expected to take 0 arguments, but it takes 1 argument
-  --> $DIR/closure-arg-count.rs:35:5
+  --> $DIR/closure-arg-count.rs:35:10
    |
 LL |     call(Foo);
-   |     ^^^^ expected function that takes 0 arguments
+   |          ^^^ expected function that takes 0 arguments
 ...
 LL | fn call<F, R>(_: F) where F: FnOnce() -> R {}
    | ------------------------------------------ required by `call`

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.stderr
@@ -23,16 +23,16 @@ LL |     a.iter().map(|_: (u16, u16)| 45);
    |              expected signature of `fn(&(u32, u32)) -> _`
 
 error[E0631]: type mismatch in function arguments
-  --> $DIR/closure-arg-type-mismatch.rs:10:5
+  --> $DIR/closure-arg-type-mismatch.rs:10:9
    |
 LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
    | ------------------------------ required by `baz`
 LL | fn _test<'a>(f: fn(*mut &'a u32)) {
 LL |     baz(f);
-   |     ^^^
-   |     |
-   |     expected signature of `for<'r> fn(*mut &'r u32) -> _`
-   |     found signature of `fn(*mut &'a u32) -> _`
+   |         ^
+   |         |
+   |         expected signature of `for<'r> fn(*mut &'r u32) -> _`
+   |         found signature of `fn(*mut &'a u32) -> _`
 
 error[E0271]: type mismatch resolving `for<'r> <fn(*mut &'a u32) as std::ops::FnOnce<(*mut &'r u32,)>>::Output == ()`
   --> $DIR/closure-arg-type-mismatch.rs:10:5

--- a/src/test/ui/mismatched_types/fn-variance-1.stderr
+++ b/src/test/ui/mismatched_types/fn-variance-1.stderr
@@ -1,5 +1,5 @@
 error[E0631]: type mismatch in function arguments
-  --> $DIR/fn-variance-1.rs:11:5
+  --> $DIR/fn-variance-1.rs:11:15
    |
 LL | fn takes_mut(x: &mut isize) { }
    | --------------------------- found signature of `for<'r> fn(&'r mut isize) -> _`
@@ -8,10 +8,10 @@ LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
    | --------------------------------------------- required by `apply`
 ...
 LL |     apply(&3, takes_mut);
-   |     ^^^^^ expected signature of `fn(&{integer}) -> _`
+   |               ^^^^^^^^^ expected signature of `fn(&{integer}) -> _`
 
 error[E0631]: type mismatch in function arguments
-  --> $DIR/fn-variance-1.rs:15:5
+  --> $DIR/fn-variance-1.rs:15:19
    |
 LL | fn takes_imm(x: &isize) { }
    | ----------------------- found signature of `for<'r> fn(&'r isize) -> _`
@@ -20,7 +20,7 @@ LL | fn apply<T, F>(t: T, f: F) where F: FnOnce(T) {
    | --------------------------------------------- required by `apply`
 ...
 LL |     apply(&mut 3, takes_imm);
-   |     ^^^^^ expected signature of `fn(&mut {integer}) -> _`
+   |                   ^^^^^^^^^ expected signature of `fn(&mut {integer}) -> _`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
+++ b/src/test/ui/mismatched_types/unboxed-closures-vtable-mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0631]: type mismatch in closure arguments
-  --> $DIR/unboxed-closures-vtable-mismatch.rs:15:13
+  --> $DIR/unboxed-closures-vtable-mismatch.rs:15:24
    |
 LL | fn call_it<F:FnMut(isize,isize)->isize>(y: isize, mut f: F) -> isize {
    | -------------------------------------------------------------------- required by `call_it`
@@ -8,7 +8,7 @@ LL |     let f = to_fn_mut(|x: usize, y: isize| -> isize { (x as isize) + y });
    |                       ----------------------------- found signature of `fn(usize, isize) -> _`
 LL |
 LL |     let z = call_it(3, f);
-   |             ^^^^^^^ expected signature of `fn(isize, isize) -> _`
+   |                        ^ expected signature of `fn(isize, isize) -> _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/mutexguard-sync.stderr
+++ b/src/test/ui/mutexguard-sync.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
-  --> $DIR/mutexguard-sync.rs:11:5
+  --> $DIR/mutexguard-sync.rs:11:15
    |
 LL | fn test_sync<T: Sync>(_t: T) {}
    | ---------------------------- required by `test_sync`
 ...
 LL |     test_sync(guard);
-   |     ^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
+   |               ^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::marker::Sync` for `std::sync::MutexGuard<'_, std::cell::Cell<i32>>`

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -67,400 +67,400 @@ LL | use namespace_mix::xm8::V;
    |
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:33:5
+  --> $DIR/namespace-mix.rs:33:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m1::S{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `c::S: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:35:5
+  --> $DIR/namespace-mix.rs:35:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m2::S{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::S`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::S`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:36:5
+  --> $DIR/namespace-mix.rs:36:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m2::S);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:39:5
+  --> $DIR/namespace-mix.rs:39:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm1::S{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::S: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:41:5
+  --> $DIR/namespace-mix.rs:41:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm2::S{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::S`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:42:5
+  --> $DIR/namespace-mix.rs:42:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm2::S);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:55:5
+  --> $DIR/namespace-mix.rs:55:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m3::TS{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `fn() -> c::TS {c::TS}: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:56:5
+  --> $DIR/namespace-mix.rs:56:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m3::TS);
-   |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::TS {c::TS}`
 
 error[E0277]: the trait bound `c::TS: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:57:5
+  --> $DIR/namespace-mix.rs:57:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m4::TS{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::TS`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::TS`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:58:5
+  --> $DIR/namespace-mix.rs:58:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m4::TS);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:61:5
+  --> $DIR/namespace-mix.rs:61:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm3::TS{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:62:5
+  --> $DIR/namespace-mix.rs:62:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm3::TS);
-   |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::TS {namespace_mix::c::TS}`
 
 error[E0277]: the trait bound `namespace_mix::c::TS: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:63:5
+  --> $DIR/namespace-mix.rs:63:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm4::TS{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::TS`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:64:5
+  --> $DIR/namespace-mix.rs:64:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm4::TS);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:77:5
+  --> $DIR/namespace-mix.rs:77:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m5::US{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:78:5
+  --> $DIR/namespace-mix.rs:78:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m5::US);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::US`
 
 error[E0277]: the trait bound `c::US: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:79:5
+  --> $DIR/namespace-mix.rs:79:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m6::US{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::US`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::US`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:80:5
+  --> $DIR/namespace-mix.rs:80:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m6::US);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:83:5
+  --> $DIR/namespace-mix.rs:83:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm5::US{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:84:5
+  --> $DIR/namespace-mix.rs:84:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm5::US);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
 
 error[E0277]: the trait bound `namespace_mix::c::US: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:85:5
+  --> $DIR/namespace-mix.rs:85:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm6::US{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::US`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:86:5
+  --> $DIR/namespace-mix.rs:86:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm6::US);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:99:5
+  --> $DIR/namespace-mix.rs:99:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m7::V{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:101:5
+  --> $DIR/namespace-mix.rs:101:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m8::V{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `c::E`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:102:5
+  --> $DIR/namespace-mix.rs:102:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m8::V);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:105:5
+  --> $DIR/namespace-mix.rs:105:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm7::V{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:107:5
+  --> $DIR/namespace-mix.rs:107:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm8::V{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:108:5
+  --> $DIR/namespace-mix.rs:108:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm8::V);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:121:5
+  --> $DIR/namespace-mix.rs:121:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m9::TV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `fn() -> c::E {c::E::TV}: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:122:5
+  --> $DIR/namespace-mix.rs:122:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(m9::TV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `fn() -> c::E {c::E::TV}`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:123:5
+  --> $DIR/namespace-mix.rs:123:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mA::TV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:124:5
+  --> $DIR/namespace-mix.rs:124:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mA::TV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:127:5
+  --> $DIR/namespace-mix.rs:127:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm9::TV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:128:5
+  --> $DIR/namespace-mix.rs:128:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xm9::TV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `fn() -> namespace_mix::c::E {namespace_mix::xm7::TV}`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:129:5
+  --> $DIR/namespace-mix.rs:129:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmA::TV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:130:5
+  --> $DIR/namespace-mix.rs:130:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmA::TV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:143:5
+  --> $DIR/namespace-mix.rs:143:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mB::UV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:144:5
+  --> $DIR/namespace-mix.rs:144:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mB::UV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::E`
 
 error[E0277]: the trait bound `c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:145:5
+  --> $DIR/namespace-mix.rs:145:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mC::UV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::E`
+   |           ^^^^^^^^ the trait `Impossible` is not implemented for `c::E`
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:146:5
+  --> $DIR/namespace-mix.rs:146:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(mC::UV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `c::Item`
+   |           ^^^^^^ the trait `Impossible` is not implemented for `c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:149:5
+  --> $DIR/namespace-mix.rs:149:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmB::UV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:150:5
+  --> $DIR/namespace-mix.rs:150:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmB::UV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
 
 error[E0277]: the trait bound `namespace_mix::c::E: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:151:5
+  --> $DIR/namespace-mix.rs:151:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmC::UV{});
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
+   |           ^^^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::E`
 
 error[E0277]: the trait bound `namespace_mix::c::Item: Impossible` is not satisfied
-  --> $DIR/namespace-mix.rs:152:5
+  --> $DIR/namespace-mix.rs:152:11
    |
 LL | fn check<T: Impossible>(_: T) {}
    | ----------------------------- required by `check`
 ...
 LL |     check(xmC::UV);
-   |     ^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
+   |           ^^^^^^^ the trait `Impossible` is not implemented for `namespace_mix::c::Item`
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/no_send-rc.stderr
+++ b/src/test/ui/no_send-rc.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `std::rc::Rc<{integer}>` cannot be sent between threads safely
-  --> $DIR/no_send-rc.rs:7:5
+  --> $DIR/no_send-rc.rs:7:9
    |
 LL | fn bar<T: Send>(_: T) {}
    | --------------------- required by `bar`
 ...
 LL |     bar(x);
-   |     ^^^ `std::rc::Rc<{integer}>` cannot be sent between threads safely
+   |         ^ `std::rc::Rc<{integer}>` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `std::rc::Rc<{integer}>`
 

--- a/src/test/ui/no_send-struct.stderr
+++ b/src/test/ui/no_send-struct.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `Foo` cannot be sent between threads safely
-  --> $DIR/no_send-struct.rs:15:5
+  --> $DIR/no_send-struct.rs:15:9
    |
 LL | fn bar<T: Send>(_: T) {}
    | --------------------- required by `bar`
 ...
 LL |     bar(x);
-   |     ^^^ `Foo` cannot be sent between threads safely
+   |         ^ `Foo` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `Foo`
 

--- a/src/test/ui/no_share-struct.stderr
+++ b/src/test/ui/no_share-struct.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `Foo` cannot be shared between threads safely
-  --> $DIR/no_share-struct.rs:12:5
+  --> $DIR/no_share-struct.rs:12:9
    |
 LL | fn bar<T: Sync>(_: T) {}
    | --------------------- required by `bar`
 ...
 LL |     bar(x);
-   |     ^^^ `Foo` cannot be shared between threads safely
+   |         ^ `Foo` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `Foo`
 

--- a/src/test/ui/object-does-not-impl-trait.stderr
+++ b/src/test/ui/object-does-not-impl-trait.stderr
@@ -1,10 +1,10 @@
 error[E0277]: the trait bound `std::boxed::Box<dyn Foo>: Foo` is not satisfied
-  --> $DIR/object-does-not-impl-trait.rs:6:35
+  --> $DIR/object-does-not-impl-trait.rs:6:44
    |
 LL | fn take_foo<F:Foo>(f: F) {}
    | ------------------------ required by `take_foo`
 LL | fn take_object(f: Box<dyn Foo>) { take_foo(f); }
-   |                                   ^^^^^^^^ the trait `Foo` is not implemented for `std::boxed::Box<dyn Foo>`
+   |                                            ^ the trait `Foo` is not implemented for `std::boxed::Box<dyn Foo>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/multiple-impls.stderr
+++ b/src/test/ui/on-unimplemented/multiple-impls.stderr
@@ -1,57 +1,57 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/multiple-impls.rs:33:5
+  --> $DIR/multiple-impls.rs:33:18
    |
 LL |     fn index(&self, index: Idx) -> &Self::Output;
    |     --------------------------------------------- required by `Index::index`
 ...
 LL |     Index::index(&[] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^ trait message
+   |                  ^^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
+
+error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
+  --> $DIR/multiple-impls.rs:36:18
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
+LL |     Index::index(&[] as &[i32], Foo(2u32));
+   |                  ^^^^^^^^^^^^^ on impl for Foo
+   |
+   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
+
+error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
+  --> $DIR/multiple-impls.rs:39:18
+   |
+LL |     fn index(&self, index: Idx) -> &Self::Output;
+   |     --------------------------------------------- required by `Index::index`
+...
+LL |     Index::index(&[] as &[i32], Bar(2u32));
+   |                  ^^^^^^^^^^^^^ on impl for Bar
+   |
+   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/multiple-impls.rs:33:5
    |
 LL |     Index::index(&[] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trait message
+   |     ^^^^^^^^^^^^ trait message
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
 
 error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:36:5
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::index(&[] as &[i32], Foo(2u32));
    |     ^^^^^^^^^^^^ on impl for Foo
    |
    = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
 
-error[E0277]: the trait bound `[i32]: Index<Foo<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:36:5
-   |
-LL |     Index::index(&[] as &[i32], Foo(2u32));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Foo
-   |
-   = help: the trait `Index<Foo<u32>>` is not implemented for `[i32]`
-
 error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
   --> $DIR/multiple-impls.rs:39:5
    |
-LL |     fn index(&self, index: Idx) -> &Self::Output;
-   |     --------------------------------------------- required by `Index::index`
-...
 LL |     Index::index(&[] as &[i32], Bar(2u32));
    |     ^^^^^^^^^^^^ on impl for Bar
-   |
-   = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
-
-error[E0277]: the trait bound `[i32]: Index<Bar<u32>>` is not satisfied
-  --> $DIR/multiple-impls.rs:39:5
-   |
-LL |     Index::index(&[] as &[i32], Bar(2u32));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ on impl for Bar
    |
    = help: the trait `Index<Bar<u32>>` is not implemented for `[i32]`
 

--- a/src/test/ui/on-unimplemented/on-impl.stderr
+++ b/src/test/ui/on-unimplemented/on-impl.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
-  --> $DIR/on-impl.rs:22:5
+  --> $DIR/on-impl.rs:22:25
    |
 LL |     fn index(&self, index: Idx) -> &Self::Output;
    |     --------------------------------------------- required by `Index::index`
 ...
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
+   |                         ^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
 
@@ -13,7 +13,7 @@ error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
   --> $DIR/on-impl.rs:22:5
    |
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
+   |     ^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
 

--- a/src/test/ui/phantom-oibit.stderr
+++ b/src/test/ui/phantom-oibit.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `T` cannot be shared between threads safely
-  --> $DIR/phantom-oibit.rs:21:5
+  --> $DIR/phantom-oibit.rs:21:12
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    | ----------------------- required by `is_zen`
 ...
 LL |     is_zen(x)
-   |     ^^^^^^ `T` cannot be shared between threads safely
+   |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Sync` bound
@@ -14,13 +14,13 @@ LL |     is_zen(x)
    = note: required because it appears within the type `Guard<'_, T>`
 
 error[E0277]: `T` cannot be shared between threads safely
-  --> $DIR/phantom-oibit.rs:26:5
+  --> $DIR/phantom-oibit.rs:26:12
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    | ----------------------- required by `is_zen`
 ...
 LL |     is_zen(x)
-   |     ^^^^^^ `T` cannot be shared between threads safely
+   |            ^ `T` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `T`
    = help: consider adding a `where T: std::marker::Sync` bound

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -40,14 +40,12 @@ fn nested_within_if_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         if let 0 = 0? {}
-        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
-        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
         Ok(())
     }
     if (let 0 = 0)? {} //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
+    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    //~| ERROR the `?` operator can only be used in a function that returns `Result`
 
     if true || let 0 = 0 {} //~ ERROR `let` expressions are not supported here
     if (true || let 0 = 0) {} //~ ERROR `let` expressions are not supported here
@@ -106,14 +104,12 @@ fn nested_within_while_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         while let 0 = 0? {}
-        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
-        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
         Ok(())
     }
     while (let 0 = 0)? {} //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
+    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    //~| ERROR the `?` operator can only be used in a function that returns `Result`
 
     while true || let 0 = 0 {} //~ ERROR `let` expressions are not supported here
     while (true || let 0 = 0) {} //~ ERROR `let` expressions are not supported here
@@ -181,14 +177,12 @@ fn outside_if_and_while_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         let 0 = 0?;
-        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
-        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
         Ok(())
     }
     (let 0 = 0)?; //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
-    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
+    //~^ ERROR the `?` operator can only be used in a function that returns `Result`
+    //~| ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
 
     true || let 0 = 0; //~ ERROR `let` expressions are not supported here
     (true || let 0 = 0); //~ ERROR `let` expressions are not supported here

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -40,12 +40,14 @@ fn nested_within_if_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         if let 0 = 0? {}
-        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
         Ok(())
     }
     if (let 0 = 0)? {} //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-    //~| ERROR the `?` operator can only be used in a function that returns `Result`
+    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
 
     if true || let 0 = 0 {} //~ ERROR `let` expressions are not supported here
     if (true || let 0 = 0) {} //~ ERROR `let` expressions are not supported here
@@ -104,12 +106,14 @@ fn nested_within_while_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         while let 0 = 0? {}
-        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
         Ok(())
     }
     while (let 0 = 0)? {} //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
-    //~| ERROR the `?` operator can only be used in a function that returns `Result`
+    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
 
     while true || let 0 = 0 {} //~ ERROR `let` expressions are not supported here
     while (true || let 0 = 0) {} //~ ERROR `let` expressions are not supported here
@@ -177,12 +181,14 @@ fn outside_if_and_while_expr() {
 
     fn _check_try_binds_tighter() -> Result<(), ()> {
         let 0 = 0?;
-        //~^ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+        //~^ ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
+        //~| ERROR the trait bound `{integer}: std::ops::Try` is not satisfied
         Ok(())
     }
     (let 0 = 0)?; //~ ERROR `let` expressions are not supported here
-    //~^ ERROR the `?` operator can only be used in a function that returns `Result`
-    //~| ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
+    //~^ ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the trait bound `bool: std::ops::Try` is not satisfied
+    //~| ERROR the `?` operator can only be used in a function that returns `Result` or `Option`
 
     true || let 0 = 0; //~ ERROR `let` expressions are not supported here
     (true || let 0 = 0); //~ ERROR `let` expressions are not supported here

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1,5 +1,5 @@
 error: expected one of `,` or `>`, found `&&`
-  --> $DIR/disallowed-positions.rs:248:14
+  --> $DIR/disallowed-positions.rs:242:14
    |
 LL |         true && let 1 = 1
    |              ^^ expected one of `,` or `>` here
@@ -41,7 +41,7 @@ LL |     if -let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:47:9
+  --> $DIR/disallowed-positions.rs:46:9
    |
 LL |     if (let 0 = 0)? {}
    |         ^^^^^^^^^
@@ -50,7 +50,7 @@ LL |     if (let 0 = 0)? {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:52:16
+  --> $DIR/disallowed-positions.rs:50:16
    |
 LL |     if true || let 0 = 0 {}
    |                ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     if true || let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:53:17
+  --> $DIR/disallowed-positions.rs:51:17
    |
 LL |     if (true || let 0 = 0) {}
    |                 ^^^^^^^^^
@@ -68,7 +68,7 @@ LL |     if (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:54:25
+  --> $DIR/disallowed-positions.rs:52:25
    |
 LL |     if true && (true || let 0 = 0) {}
    |                         ^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     if true && (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:55:25
+  --> $DIR/disallowed-positions.rs:53:25
    |
 LL |     if true || (true && let 0 = 0) {}
    |                         ^^^^^^^^^
@@ -86,7 +86,7 @@ LL |     if true || (true && let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:58:12
+  --> $DIR/disallowed-positions.rs:56:12
    |
 LL |     if x = let 0 = 0 {}
    |            ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     if x = let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:61:15
+  --> $DIR/disallowed-positions.rs:59:15
    |
 LL |     if true..(let 0 = 0) {}
    |               ^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     if true..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:63:11
+  --> $DIR/disallowed-positions.rs:61:11
    |
 LL |     if ..(let 0 = 0) {}
    |           ^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     if ..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:65:9
+  --> $DIR/disallowed-positions.rs:63:9
    |
 LL |     if (let 0 = 0).. {}
    |         ^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     if (let 0 = 0).. {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:69:8
+  --> $DIR/disallowed-positions.rs:67:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:73:8
+  --> $DIR/disallowed-positions.rs:71:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +140,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:80:8
+  --> $DIR/disallowed-positions.rs:78:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:88:8
+  --> $DIR/disallowed-positions.rs:86:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:94:19
+  --> $DIR/disallowed-positions.rs:92:19
    |
 LL |     if let true = let true = true {}
    |                   ^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     if let true = let true = true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:98:12
+  --> $DIR/disallowed-positions.rs:96:12
    |
 LL |     while &let 0 = 0 {}
    |            ^^^^^^^^^
@@ -176,7 +176,7 @@ LL |     while &let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:101:12
+  --> $DIR/disallowed-positions.rs:99:12
    |
 LL |     while !let 0 = 0 {}
    |            ^^^^^^^^^
@@ -185,7 +185,7 @@ LL |     while !let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:102:12
+  --> $DIR/disallowed-positions.rs:100:12
    |
 LL |     while *let 0 = 0 {}
    |            ^^^^^^^^^
@@ -194,7 +194,7 @@ LL |     while *let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:104:12
+  --> $DIR/disallowed-positions.rs:102:12
    |
 LL |     while -let 0 = 0 {}
    |            ^^^^^^^^^
@@ -203,7 +203,7 @@ LL |     while -let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:113:12
+  --> $DIR/disallowed-positions.rs:110:12
    |
 LL |     while (let 0 = 0)? {}
    |            ^^^^^^^^^
@@ -212,7 +212,7 @@ LL |     while (let 0 = 0)? {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:118:19
+  --> $DIR/disallowed-positions.rs:114:19
    |
 LL |     while true || let 0 = 0 {}
    |                   ^^^^^^^^^
@@ -221,7 +221,7 @@ LL |     while true || let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:119:20
+  --> $DIR/disallowed-positions.rs:115:20
    |
 LL |     while (true || let 0 = 0) {}
    |                    ^^^^^^^^^
@@ -230,7 +230,7 @@ LL |     while (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:120:28
+  --> $DIR/disallowed-positions.rs:116:28
    |
 LL |     while true && (true || let 0 = 0) {}
    |                            ^^^^^^^^^
@@ -239,7 +239,7 @@ LL |     while true && (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:121:28
+  --> $DIR/disallowed-positions.rs:117:28
    |
 LL |     while true || (true && let 0 = 0) {}
    |                            ^^^^^^^^^
@@ -248,7 +248,7 @@ LL |     while true || (true && let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:124:15
+  --> $DIR/disallowed-positions.rs:120:15
    |
 LL |     while x = let 0 = 0 {}
    |               ^^^^^^^^^
@@ -257,7 +257,7 @@ LL |     while x = let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:127:18
+  --> $DIR/disallowed-positions.rs:123:18
    |
 LL |     while true..(let 0 = 0) {}
    |                  ^^^^^^^^^
@@ -266,7 +266,7 @@ LL |     while true..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:129:14
+  --> $DIR/disallowed-positions.rs:125:14
    |
 LL |     while ..(let 0 = 0) {}
    |              ^^^^^^^^^
@@ -275,7 +275,7 @@ LL |     while ..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:131:12
+  --> $DIR/disallowed-positions.rs:127:12
    |
 LL |     while (let 0 = 0).. {}
    |            ^^^^^^^^^
@@ -284,7 +284,7 @@ LL |     while (let 0 = 0).. {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:135:11
+  --> $DIR/disallowed-positions.rs:131:11
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -293,7 +293,7 @@ LL |     while let Range { start: _, end: _ } = true..true && false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:139:11
+  --> $DIR/disallowed-positions.rs:135:11
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +302,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:146:11
+  --> $DIR/disallowed-positions.rs:142:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:154:11
+  --> $DIR/disallowed-positions.rs:150:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:160:22
+  --> $DIR/disallowed-positions.rs:156:22
    |
 LL |     while let true = let true = true {}
    |                      ^^^^^^^^^^^^^^^
@@ -329,7 +329,7 @@ LL |     while let true = let true = true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:174:6
+  --> $DIR/disallowed-positions.rs:170:6
    |
 LL |     &let 0 = 0;
    |      ^^^^^^^^^
@@ -338,7 +338,7 @@ LL |     &let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:176:6
+  --> $DIR/disallowed-positions.rs:172:6
    |
 LL |     !let 0 = 0;
    |      ^^^^^^^^^
@@ -347,7 +347,7 @@ LL |     !let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:177:6
+  --> $DIR/disallowed-positions.rs:173:6
    |
 LL |     *let 0 = 0;
    |      ^^^^^^^^^
@@ -356,7 +356,7 @@ LL |     *let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:179:6
+  --> $DIR/disallowed-positions.rs:175:6
    |
 LL |     -let 0 = 0;
    |      ^^^^^^^^^
@@ -365,7 +365,7 @@ LL |     -let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:188:6
+  --> $DIR/disallowed-positions.rs:183:6
    |
 LL |     (let 0 = 0)?;
    |      ^^^^^^^^^
@@ -374,7 +374,7 @@ LL |     (let 0 = 0)?;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:193:13
+  --> $DIR/disallowed-positions.rs:187:13
    |
 LL |     true || let 0 = 0;
    |             ^^^^^^^^^
@@ -383,7 +383,7 @@ LL |     true || let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:194:14
+  --> $DIR/disallowed-positions.rs:188:14
    |
 LL |     (true || let 0 = 0);
    |              ^^^^^^^^^
@@ -392,7 +392,7 @@ LL |     (true || let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:195:22
+  --> $DIR/disallowed-positions.rs:189:22
    |
 LL |     true && (true || let 0 = 0);
    |                      ^^^^^^^^^
@@ -401,7 +401,7 @@ LL |     true && (true || let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:198:9
+  --> $DIR/disallowed-positions.rs:192:9
    |
 LL |     x = let 0 = 0;
    |         ^^^^^^^^^
@@ -410,7 +410,7 @@ LL |     x = let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:200:12
+  --> $DIR/disallowed-positions.rs:194:12
    |
 LL |     true..(let 0 = 0);
    |            ^^^^^^^^^
@@ -419,7 +419,7 @@ LL |     true..(let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:201:8
+  --> $DIR/disallowed-positions.rs:195:8
    |
 LL |     ..(let 0 = 0);
    |        ^^^^^^^^^
@@ -428,7 +428,7 @@ LL |     ..(let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:202:6
+  --> $DIR/disallowed-positions.rs:196:6
    |
 LL |     (let 0 = 0)..;
    |      ^^^^^^^^^
@@ -437,7 +437,7 @@ LL |     (let 0 = 0)..;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:204:6
+  --> $DIR/disallowed-positions.rs:198:6
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +446,7 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:208:6
+  --> $DIR/disallowed-positions.rs:202:6
    |
 LL |     (let true = let true = true);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     (let true = let true = true);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:208:17
+  --> $DIR/disallowed-positions.rs:202:17
    |
 LL |     (let true = let true = true);
    |                 ^^^^^^^^^^^^^^^
@@ -464,10 +464,19 @@ LL |     (let true = let true = true);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:213:6
+  --> $DIR/disallowed-positions.rs:207:6
    |
 LL |     &let 0 = 0
    |      ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if`- and `while`-expressions
+   = note: as well as when nested within `&&` and parenthesis in those conditions
+
+error: `let` expressions are not supported here
+  --> $DIR/disallowed-positions.rs:218:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
    = note: as well as when nested within `&&` and parenthesis in those conditions
@@ -483,15 +492,6 @@ LL |         true && let 1 = 1
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:230:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:236:17
    |
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
@@ -536,16 +536,17 @@ LL |     if -let 0 = 0 {}
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:47:8
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/disallowed-positions.rs:46:8
    |
 LL |     if (let 0 = 0)? {}
-   |        ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+   |        ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
+   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:47:8
+  --> $DIR/disallowed-positions.rs:46:8
    |
 LL |     if (let 0 = 0)? {}
    |        ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -554,7 +555,7 @@ LL |     if (let 0 = 0)? {}
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:58:8
+  --> $DIR/disallowed-positions.rs:56:8
    |
 LL |     if x = let 0 = 0 {}
    |        ^^^^^^^^^^^^^
@@ -566,7 +567,7 @@ LL |     if x = let 0 = 0 {}
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:61:8
+  --> $DIR/disallowed-positions.rs:59:8
    |
 LL |     if true..(let 0 = 0) {}
    |        ^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -575,7 +576,7 @@ LL |     if true..(let 0 = 0) {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:63:8
+  --> $DIR/disallowed-positions.rs:61:8
    |
 LL |     if ..(let 0 = 0) {}
    |        ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeTo`
@@ -584,7 +585,7 @@ LL |     if ..(let 0 = 0) {}
               found type `std::ops::RangeTo<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:65:8
+  --> $DIR/disallowed-positions.rs:63:8
    |
 LL |     if (let 0 = 0).. {}
    |        ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeFrom`
@@ -593,7 +594,7 @@ LL |     if (let 0 = 0).. {}
               found type `std::ops::RangeFrom<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:69:12
+  --> $DIR/disallowed-positions.rs:67:12
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -604,7 +605,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:69:8
+  --> $DIR/disallowed-positions.rs:67:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -613,7 +614,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:73:12
+  --> $DIR/disallowed-positions.rs:71:12
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -624,7 +625,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:73:8
+  --> $DIR/disallowed-positions.rs:71:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -633,7 +634,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:80:12
+  --> $DIR/disallowed-positions.rs:78:12
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
@@ -642,16 +643,16 @@ LL |     if let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:80:41
+  --> $DIR/disallowed-positions.rs:78:41
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |                                         ^^^^^^^ expected bool, found closure
    |
    = note: expected type `bool`
-              found type `[closure@$DIR/disallowed-positions.rs:80:41: 80:48]`
+              found type `[closure@$DIR/disallowed-positions.rs:78:41: 78:48]`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:80:8
+  --> $DIR/disallowed-positions.rs:78:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -660,7 +661,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:88:12
+  --> $DIR/disallowed-positions.rs:86:12
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
@@ -671,7 +672,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:88:44
+  --> $DIR/disallowed-positions.rs:86:44
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |                                            ^^^^^^^ expected bool, found &&bool
@@ -680,7 +681,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
               found type `&&bool`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:88:8
+  --> $DIR/disallowed-positions.rs:86:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -688,41 +689,17 @@ LL |     if let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
               found type `std::ops::Range<bool>`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:47:8
-   |
-LL |     if (let 0 = 0)? {}
-   |        ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
-
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/disallowed-positions.rs:42:20
    |
 LL |         if let 0 = 0? {}
-   |                    ^ the trait `std::ops::Try` is not implemented for `{integer}`
+   |                    ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+   = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::into_result`
 
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:42:20
-   |
-LL |         if let 0 = 0? {}
-   |                    ^^ the trait `std::ops::Try` is not implemented for `{integer}`
-   |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
-
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:98:11
+  --> $DIR/disallowed-positions.rs:96:11
    |
 LL |     while &let 0 = 0 {}
    |           ^^^^^^^^^^ expected bool, found &bool
@@ -731,29 +708,30 @@ LL |     while &let 0 = 0 {}
               found type `&bool`
 
 error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:102:11
+  --> $DIR/disallowed-positions.rs:100:11
    |
 LL |     while *let 0 = 0 {}
    |           ^^^^^^^^^^
 
 error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:104:11
+  --> $DIR/disallowed-positions.rs:102:11
    |
 LL |     while -let 0 = 0 {}
    |           ^^^^^^^^^^ cannot apply unary operator `-`
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:113:11
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/disallowed-positions.rs:110:11
    |
 LL |     while (let 0 = 0)? {}
-   |           ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+   |           ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
+   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:113:11
+  --> $DIR/disallowed-positions.rs:110:11
    |
 LL |     while (let 0 = 0)? {}
    |           ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -762,7 +740,7 @@ LL |     while (let 0 = 0)? {}
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:124:11
+  --> $DIR/disallowed-positions.rs:120:11
    |
 LL |     while x = let 0 = 0 {}
    |           ^^^^^^^^^^^^^
@@ -774,7 +752,7 @@ LL |     while x = let 0 = 0 {}
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:127:11
+  --> $DIR/disallowed-positions.rs:123:11
    |
 LL |     while true..(let 0 = 0) {}
    |           ^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -783,7 +761,7 @@ LL |     while true..(let 0 = 0) {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:129:11
+  --> $DIR/disallowed-positions.rs:125:11
    |
 LL |     while ..(let 0 = 0) {}
    |           ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeTo`
@@ -792,7 +770,7 @@ LL |     while ..(let 0 = 0) {}
               found type `std::ops::RangeTo<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:131:11
+  --> $DIR/disallowed-positions.rs:127:11
    |
 LL |     while (let 0 = 0).. {}
    |           ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeFrom`
@@ -801,9 +779,29 @@ LL |     while (let 0 = 0).. {}
               found type `std::ops::RangeFrom<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:135:15
+  --> $DIR/disallowed-positions.rs:131:15
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |               |
+   |               expected bool, found struct `std::ops::Range`
+   |
+   = note: expected type `bool`
+              found type `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions.rs:131:11
+   |
+LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
+   |
+   = note: expected type `bool`
+              found type `std::ops::Range<bool>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions.rs:135:15
+   |
+LL |     while let Range { start: _, end: _ } = true..true || false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
    |               |
    |               expected bool, found struct `std::ops::Range`
@@ -814,26 +812,6 @@ LL |     while let Range { start: _, end: _ } = true..true && false {}
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:135:11
    |
-LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
-   |
-   = note: expected type `bool`
-              found type `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:139:15
-   |
-LL |     while let Range { start: _, end: _ } = true..true || false {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
-   |               |
-   |               expected bool, found struct `std::ops::Range`
-   |
-   = note: expected type `bool`
-              found type `std::ops::Range<_>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:139:11
-   |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
    |
@@ -841,7 +819,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:146:15
+  --> $DIR/disallowed-positions.rs:142:15
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
@@ -850,16 +828,16 @@ LL |     while let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:146:44
+  --> $DIR/disallowed-positions.rs:142:44
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |                                            ^^^^^^^ expected bool, found closure
    |
    = note: expected type `bool`
-              found type `[closure@$DIR/disallowed-positions.rs:146:44: 146:51]`
+              found type `[closure@$DIR/disallowed-positions.rs:142:44: 142:51]`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:146:11
+  --> $DIR/disallowed-positions.rs:142:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -868,7 +846,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:154:15
+  --> $DIR/disallowed-positions.rs:150:15
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
@@ -879,7 +857,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:154:47
+  --> $DIR/disallowed-positions.rs:150:47
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |                                               ^^^^^^^ expected bool, found &&bool
@@ -888,7 +866,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
               found type `&&bool`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:154:11
+  --> $DIR/disallowed-positions.rs:150:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -896,63 +874,40 @@ LL |     while let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
               found type `std::ops::Range<bool>`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:113:11
-   |
-LL |     while (let 0 = 0)? {}
-   |           ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
-
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:108:23
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/disallowed-positions.rs:106:23
    |
 LL |         while let 0 = 0? {}
-   |                       ^ the trait `std::ops::Try` is not implemented for `{integer}`
+   |                       ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+   = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::into_result`
 
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:108:23
-   |
-LL |         while let 0 = 0? {}
-   |                       ^^ the trait `std::ops::Try` is not implemented for `{integer}`
-   |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
-
 error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:177:5
+  --> $DIR/disallowed-positions.rs:173:5
    |
 LL |     *let 0 = 0;
    |     ^^^^^^^^^^
 
 error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:179:5
+  --> $DIR/disallowed-positions.rs:175:5
    |
 LL |     -let 0 = 0;
    |     ^^^^^^^^^^ cannot apply unary operator `-`
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:188:5
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/disallowed-positions.rs:183:5
    |
 LL |     (let 0 = 0)?;
-   |     ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
    |
+   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:188:5
+  --> $DIR/disallowed-positions.rs:183:5
    |
 LL |     (let 0 = 0)?;
    |     ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -961,7 +916,7 @@ LL |     (let 0 = 0)?;
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:204:10
+  --> $DIR/disallowed-positions.rs:198:10
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -972,7 +927,7 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:213:5
+  --> $DIR/disallowed-positions.rs:207:5
    |
 LL | fn outside_if_and_while_expr() {
    |                                - help: try adding a return type: `-> &bool`
@@ -983,38 +938,26 @@ LL |     &let 0 = 0
    = note: expected type `()`
               found type `&bool`
 
-error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:188:5
-   |
-LL |     (let 0 = 0)?;
-   |     ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
-
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:183:17
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/disallowed-positions.rs:179:17
    |
 LL |         let 0 = 0?;
-   |                 ^ the trait `std::ops::Try` is not implemented for `{integer}`
+   |                 ^^ the `?` operator cannot be applied to type `{integer}`
    |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+   = help: the trait `std::ops::Try` is not implemented for `{integer}`
    = note: required by `std::ops::Try::into_result`
 
-error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
-  --> $DIR/disallowed-positions.rs:183:17
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/disallowed-positions.rs:218:25
    |
-LL |         let 0 = 0?;
-   |                 ^^ the trait `std::ops::Try` is not implemented for `{integer}`
+LL |         true && let 1 = 1
+   |                         ^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/disallowed-positions.rs:218:21
    |
-   = help: the following implementations were found:
-             <std::iter::LoopState<C, B> as std::ops::Try>
-             <std::option::Option<T> as std::ops::Try>
-             <std::result::Result<T, E> as std::ops::Try>
-             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
-             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+LL |         true && let 1 = 1
+   |                     ^
 
 error[E0019]: constant contains unimplemented expression type
   --> $DIR/disallowed-positions.rs:224:25
@@ -1040,19 +983,7 @@ error[E0019]: constant contains unimplemented expression type
 LL |         true && let 1 = 1
    |                     ^
 
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/disallowed-positions.rs:236:25
-   |
-LL |         true && let 1 = 1
-   |                         ^
-
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/disallowed-positions.rs:236:21
-   |
-LL |         true && let 1 = 1
-   |                     ^
-
-error: aborting due to 115 previous errors
+error: aborting due to 109 previous errors
 
 Some errors have detailed explanations: E0019, E0277, E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1,5 +1,5 @@
 error: expected one of `,` or `>`, found `&&`
-  --> $DIR/disallowed-positions.rs:242:14
+  --> $DIR/disallowed-positions.rs:248:14
    |
 LL |         true && let 1 = 1
    |              ^^ expected one of `,` or `>` here
@@ -41,7 +41,7 @@ LL |     if -let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:46:9
+  --> $DIR/disallowed-positions.rs:47:9
    |
 LL |     if (let 0 = 0)? {}
    |         ^^^^^^^^^
@@ -50,7 +50,7 @@ LL |     if (let 0 = 0)? {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:50:16
+  --> $DIR/disallowed-positions.rs:52:16
    |
 LL |     if true || let 0 = 0 {}
    |                ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     if true || let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:51:17
+  --> $DIR/disallowed-positions.rs:53:17
    |
 LL |     if (true || let 0 = 0) {}
    |                 ^^^^^^^^^
@@ -68,7 +68,7 @@ LL |     if (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:52:25
+  --> $DIR/disallowed-positions.rs:54:25
    |
 LL |     if true && (true || let 0 = 0) {}
    |                         ^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     if true && (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:53:25
+  --> $DIR/disallowed-positions.rs:55:25
    |
 LL |     if true || (true && let 0 = 0) {}
    |                         ^^^^^^^^^
@@ -86,7 +86,7 @@ LL |     if true || (true && let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:56:12
+  --> $DIR/disallowed-positions.rs:58:12
    |
 LL |     if x = let 0 = 0 {}
    |            ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     if x = let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:59:15
+  --> $DIR/disallowed-positions.rs:61:15
    |
 LL |     if true..(let 0 = 0) {}
    |               ^^^^^^^^^
@@ -104,7 +104,7 @@ LL |     if true..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:61:11
+  --> $DIR/disallowed-positions.rs:63:11
    |
 LL |     if ..(let 0 = 0) {}
    |           ^^^^^^^^^
@@ -113,7 +113,7 @@ LL |     if ..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:63:9
+  --> $DIR/disallowed-positions.rs:65:9
    |
 LL |     if (let 0 = 0).. {}
    |         ^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     if (let 0 = 0).. {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:67:8
+  --> $DIR/disallowed-positions.rs:69:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:71:8
+  --> $DIR/disallowed-positions.rs:73:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +140,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:78:8
+  --> $DIR/disallowed-positions.rs:80:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -149,7 +149,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:86:8
+  --> $DIR/disallowed-positions.rs:88:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -158,7 +158,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:92:19
+  --> $DIR/disallowed-positions.rs:94:19
    |
 LL |     if let true = let true = true {}
    |                   ^^^^^^^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     if let true = let true = true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:96:12
+  --> $DIR/disallowed-positions.rs:98:12
    |
 LL |     while &let 0 = 0 {}
    |            ^^^^^^^^^
@@ -176,7 +176,7 @@ LL |     while &let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:99:12
+  --> $DIR/disallowed-positions.rs:101:12
    |
 LL |     while !let 0 = 0 {}
    |            ^^^^^^^^^
@@ -185,7 +185,7 @@ LL |     while !let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:100:12
+  --> $DIR/disallowed-positions.rs:102:12
    |
 LL |     while *let 0 = 0 {}
    |            ^^^^^^^^^
@@ -194,7 +194,7 @@ LL |     while *let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:102:12
+  --> $DIR/disallowed-positions.rs:104:12
    |
 LL |     while -let 0 = 0 {}
    |            ^^^^^^^^^
@@ -203,7 +203,7 @@ LL |     while -let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:110:12
+  --> $DIR/disallowed-positions.rs:113:12
    |
 LL |     while (let 0 = 0)? {}
    |            ^^^^^^^^^
@@ -212,7 +212,7 @@ LL |     while (let 0 = 0)? {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:114:19
+  --> $DIR/disallowed-positions.rs:118:19
    |
 LL |     while true || let 0 = 0 {}
    |                   ^^^^^^^^^
@@ -221,7 +221,7 @@ LL |     while true || let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:115:20
+  --> $DIR/disallowed-positions.rs:119:20
    |
 LL |     while (true || let 0 = 0) {}
    |                    ^^^^^^^^^
@@ -230,7 +230,7 @@ LL |     while (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:116:28
+  --> $DIR/disallowed-positions.rs:120:28
    |
 LL |     while true && (true || let 0 = 0) {}
    |                            ^^^^^^^^^
@@ -239,7 +239,7 @@ LL |     while true && (true || let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:117:28
+  --> $DIR/disallowed-positions.rs:121:28
    |
 LL |     while true || (true && let 0 = 0) {}
    |                            ^^^^^^^^^
@@ -248,7 +248,7 @@ LL |     while true || (true && let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:120:15
+  --> $DIR/disallowed-positions.rs:124:15
    |
 LL |     while x = let 0 = 0 {}
    |               ^^^^^^^^^
@@ -257,7 +257,7 @@ LL |     while x = let 0 = 0 {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:123:18
+  --> $DIR/disallowed-positions.rs:127:18
    |
 LL |     while true..(let 0 = 0) {}
    |                  ^^^^^^^^^
@@ -266,7 +266,7 @@ LL |     while true..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:125:14
+  --> $DIR/disallowed-positions.rs:129:14
    |
 LL |     while ..(let 0 = 0) {}
    |              ^^^^^^^^^
@@ -275,7 +275,7 @@ LL |     while ..(let 0 = 0) {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:127:12
+  --> $DIR/disallowed-positions.rs:131:12
    |
 LL |     while (let 0 = 0).. {}
    |            ^^^^^^^^^
@@ -284,7 +284,7 @@ LL |     while (let 0 = 0).. {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:131:11
+  --> $DIR/disallowed-positions.rs:135:11
    |
 LL |     while let Range { start: _, end: _ } = true..true && false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -293,7 +293,7 @@ LL |     while let Range { start: _, end: _ } = true..true && false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:135:11
+  --> $DIR/disallowed-positions.rs:139:11
    |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +302,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:142:11
+  --> $DIR/disallowed-positions.rs:146:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,7 +311,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:150:11
+  --> $DIR/disallowed-positions.rs:154:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -320,7 +320,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:156:22
+  --> $DIR/disallowed-positions.rs:160:22
    |
 LL |     while let true = let true = true {}
    |                      ^^^^^^^^^^^^^^^
@@ -329,7 +329,7 @@ LL |     while let true = let true = true {}
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:170:6
+  --> $DIR/disallowed-positions.rs:174:6
    |
 LL |     &let 0 = 0;
    |      ^^^^^^^^^
@@ -338,7 +338,7 @@ LL |     &let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:172:6
+  --> $DIR/disallowed-positions.rs:176:6
    |
 LL |     !let 0 = 0;
    |      ^^^^^^^^^
@@ -347,7 +347,7 @@ LL |     !let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:173:6
+  --> $DIR/disallowed-positions.rs:177:6
    |
 LL |     *let 0 = 0;
    |      ^^^^^^^^^
@@ -356,7 +356,7 @@ LL |     *let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:175:6
+  --> $DIR/disallowed-positions.rs:179:6
    |
 LL |     -let 0 = 0;
    |      ^^^^^^^^^
@@ -365,7 +365,7 @@ LL |     -let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:183:6
+  --> $DIR/disallowed-positions.rs:188:6
    |
 LL |     (let 0 = 0)?;
    |      ^^^^^^^^^
@@ -374,7 +374,7 @@ LL |     (let 0 = 0)?;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:187:13
+  --> $DIR/disallowed-positions.rs:193:13
    |
 LL |     true || let 0 = 0;
    |             ^^^^^^^^^
@@ -383,7 +383,7 @@ LL |     true || let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:188:14
+  --> $DIR/disallowed-positions.rs:194:14
    |
 LL |     (true || let 0 = 0);
    |              ^^^^^^^^^
@@ -392,7 +392,7 @@ LL |     (true || let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:189:22
+  --> $DIR/disallowed-positions.rs:195:22
    |
 LL |     true && (true || let 0 = 0);
    |                      ^^^^^^^^^
@@ -401,7 +401,7 @@ LL |     true && (true || let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:192:9
+  --> $DIR/disallowed-positions.rs:198:9
    |
 LL |     x = let 0 = 0;
    |         ^^^^^^^^^
@@ -410,7 +410,7 @@ LL |     x = let 0 = 0;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:194:12
+  --> $DIR/disallowed-positions.rs:200:12
    |
 LL |     true..(let 0 = 0);
    |            ^^^^^^^^^
@@ -419,7 +419,7 @@ LL |     true..(let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:195:8
+  --> $DIR/disallowed-positions.rs:201:8
    |
 LL |     ..(let 0 = 0);
    |        ^^^^^^^^^
@@ -428,7 +428,7 @@ LL |     ..(let 0 = 0);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:196:6
+  --> $DIR/disallowed-positions.rs:202:6
    |
 LL |     (let 0 = 0)..;
    |      ^^^^^^^^^
@@ -437,7 +437,7 @@ LL |     (let 0 = 0)..;
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:198:6
+  --> $DIR/disallowed-positions.rs:204:6
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -446,7 +446,7 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:202:6
+  --> $DIR/disallowed-positions.rs:208:6
    |
 LL |     (let true = let true = true);
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -455,7 +455,7 @@ LL |     (let true = let true = true);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:202:17
+  --> $DIR/disallowed-positions.rs:208:17
    |
 LL |     (let true = let true = true);
    |                 ^^^^^^^^^^^^^^^
@@ -464,19 +464,10 @@ LL |     (let true = let true = true);
    = note: as well as when nested within `&&` and parenthesis in those conditions
 
 error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:207:6
+  --> $DIR/disallowed-positions.rs:213:6
    |
 LL |     &let 0 = 0
    |      ^^^^^^^^^
-   |
-   = note: only supported directly in conditions of `if`- and `while`-expressions
-   = note: as well as when nested within `&&` and parenthesis in those conditions
-
-error: `let` expressions are not supported here
-  --> $DIR/disallowed-positions.rs:218:17
-   |
-LL |         true && let 1 = 1
-   |                 ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if`- and `while`-expressions
    = note: as well as when nested within `&&` and parenthesis in those conditions
@@ -492,6 +483,15 @@ LL |         true && let 1 = 1
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:230:17
+   |
+LL |         true && let 1 = 1
+   |                 ^^^^^^^^^
+   |
+   = note: only supported directly in conditions of `if`- and `while`-expressions
+   = note: as well as when nested within `&&` and parenthesis in those conditions
+
+error: `let` expressions are not supported here
+  --> $DIR/disallowed-positions.rs:236:17
    |
 LL |         true && let 1 = 1
    |                 ^^^^^^^^^
@@ -536,17 +536,16 @@ LL |     if -let 0 = 0 {}
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/disallowed-positions.rs:46:8
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:47:8
    |
 LL |     if (let 0 = 0)? {}
-   |        ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
+   |        ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
    |
-   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:46:8
+  --> $DIR/disallowed-positions.rs:47:8
    |
 LL |     if (let 0 = 0)? {}
    |        ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -555,7 +554,7 @@ LL |     if (let 0 = 0)? {}
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:56:8
+  --> $DIR/disallowed-positions.rs:58:8
    |
 LL |     if x = let 0 = 0 {}
    |        ^^^^^^^^^^^^^
@@ -567,7 +566,7 @@ LL |     if x = let 0 = 0 {}
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:59:8
+  --> $DIR/disallowed-positions.rs:61:8
    |
 LL |     if true..(let 0 = 0) {}
    |        ^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -576,7 +575,7 @@ LL |     if true..(let 0 = 0) {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:61:8
+  --> $DIR/disallowed-positions.rs:63:8
    |
 LL |     if ..(let 0 = 0) {}
    |        ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeTo`
@@ -585,7 +584,7 @@ LL |     if ..(let 0 = 0) {}
               found type `std::ops::RangeTo<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:63:8
+  --> $DIR/disallowed-positions.rs:65:8
    |
 LL |     if (let 0 = 0).. {}
    |        ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeFrom`
@@ -594,7 +593,7 @@ LL |     if (let 0 = 0).. {}
               found type `std::ops::RangeFrom<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:67:12
+  --> $DIR/disallowed-positions.rs:69:12
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -605,7 +604,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:67:8
+  --> $DIR/disallowed-positions.rs:69:8
    |
 LL |     if let Range { start: _, end: _ } = true..true && false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -614,7 +613,7 @@ LL |     if let Range { start: _, end: _ } = true..true && false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:71:12
+  --> $DIR/disallowed-positions.rs:73:12
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -625,7 +624,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:71:8
+  --> $DIR/disallowed-positions.rs:73:8
    |
 LL |     if let Range { start: _, end: _ } = true..true || false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -634,7 +633,7 @@ LL |     if let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:78:12
+  --> $DIR/disallowed-positions.rs:80:12
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
@@ -643,16 +642,16 @@ LL |     if let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:78:41
+  --> $DIR/disallowed-positions.rs:80:41
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |                                         ^^^^^^^ expected bool, found closure
    |
    = note: expected type `bool`
-              found type `[closure@$DIR/disallowed-positions.rs:78:41: 78:48]`
+              found type `[closure@$DIR/disallowed-positions.rs:80:41: 80:48]`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:78:8
+  --> $DIR/disallowed-positions.rs:80:8
    |
 LL |     if let Range { start: F, end } = F..|| true {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -661,7 +660,7 @@ LL |     if let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:86:12
+  --> $DIR/disallowed-positions.rs:88:12
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
@@ -672,7 +671,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:86:44
+  --> $DIR/disallowed-positions.rs:88:44
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |                                            ^^^^^^^ expected bool, found &&bool
@@ -681,7 +680,7 @@ LL |     if let Range { start: true, end } = t..&&false {}
               found type `&&bool`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:86:8
+  --> $DIR/disallowed-positions.rs:88:8
    |
 LL |     if let Range { start: true, end } = t..&&false {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -689,17 +688,41 @@ LL |     if let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
               found type `std::ops::Range<bool>`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:47:8
+   |
+LL |     if (let 0 = 0)? {}
+   |        ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
   --> $DIR/disallowed-positions.rs:42:20
    |
 LL |         if let 0 = 0? {}
-   |                    ^^ the `?` operator cannot be applied to type `{integer}`
+   |                    ^ the trait `std::ops::Try` is not implemented for `{integer}`
    |
-   = help: the trait `std::ops::Try` is not implemented for `{integer}`
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
    = note: required by `std::ops::Try::into_result`
 
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:42:20
+   |
+LL |         if let 0 = 0? {}
+   |                    ^^ the trait `std::ops::Try` is not implemented for `{integer}`
+   |
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:96:11
+  --> $DIR/disallowed-positions.rs:98:11
    |
 LL |     while &let 0 = 0 {}
    |           ^^^^^^^^^^ expected bool, found &bool
@@ -708,30 +731,29 @@ LL |     while &let 0 = 0 {}
               found type `&bool`
 
 error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:100:11
+  --> $DIR/disallowed-positions.rs:102:11
    |
 LL |     while *let 0 = 0 {}
    |           ^^^^^^^^^^
 
 error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:102:11
+  --> $DIR/disallowed-positions.rs:104:11
    |
 LL |     while -let 0 = 0 {}
    |           ^^^^^^^^^^ cannot apply unary operator `-`
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/disallowed-positions.rs:110:11
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:113:11
    |
 LL |     while (let 0 = 0)? {}
-   |           ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
+   |           ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
    |
-   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:110:11
+  --> $DIR/disallowed-positions.rs:113:11
    |
 LL |     while (let 0 = 0)? {}
    |           ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -740,7 +762,7 @@ LL |     while (let 0 = 0)? {}
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:120:11
+  --> $DIR/disallowed-positions.rs:124:11
    |
 LL |     while x = let 0 = 0 {}
    |           ^^^^^^^^^^^^^
@@ -752,7 +774,7 @@ LL |     while x = let 0 = 0 {}
               found type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:123:11
+  --> $DIR/disallowed-positions.rs:127:11
    |
 LL |     while true..(let 0 = 0) {}
    |           ^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -761,7 +783,7 @@ LL |     while true..(let 0 = 0) {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:125:11
+  --> $DIR/disallowed-positions.rs:129:11
    |
 LL |     while ..(let 0 = 0) {}
    |           ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeTo`
@@ -770,7 +792,7 @@ LL |     while ..(let 0 = 0) {}
               found type `std::ops::RangeTo<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:127:11
+  --> $DIR/disallowed-positions.rs:131:11
    |
 LL |     while (let 0 = 0).. {}
    |           ^^^^^^^^^^^^^ expected bool, found struct `std::ops::RangeFrom`
@@ -779,29 +801,9 @@ LL |     while (let 0 = 0).. {}
               found type `std::ops::RangeFrom<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:131:15
-   |
-LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
-   |               |
-   |               expected bool, found struct `std::ops::Range`
-   |
-   = note: expected type `bool`
-              found type `std::ops::Range<_>`
-
-error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:131:11
-   |
-LL |     while let Range { start: _, end: _ } = true..true && false {}
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
-   |
-   = note: expected type `bool`
-              found type `std::ops::Range<bool>`
-
-error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:135:15
    |
-LL |     while let Range { start: _, end: _ } = true..true || false {}
+LL |     while let Range { start: _, end: _ } = true..true && false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
    |               |
    |               expected bool, found struct `std::ops::Range`
@@ -812,6 +814,26 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:135:11
    |
+LL |     while let Range { start: _, end: _ } = true..true && false {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
+   |
+   = note: expected type `bool`
+              found type `std::ops::Range<bool>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions.rs:139:15
+   |
+LL |     while let Range { start: _, end: _ } = true..true || false {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
+   |               |
+   |               expected bool, found struct `std::ops::Range`
+   |
+   = note: expected type `bool`
+              found type `std::ops::Range<_>`
+
+error[E0308]: mismatched types
+  --> $DIR/disallowed-positions.rs:139:11
+   |
 LL |     while let Range { start: _, end: _ } = true..true || false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
    |
@@ -819,7 +841,7 @@ LL |     while let Range { start: _, end: _ } = true..true || false {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:142:15
+  --> $DIR/disallowed-positions.rs:146:15
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
@@ -828,16 +850,16 @@ LL |     while let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:142:44
+  --> $DIR/disallowed-positions.rs:146:44
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |                                            ^^^^^^^ expected bool, found closure
    |
    = note: expected type `bool`
-              found type `[closure@$DIR/disallowed-positions.rs:142:44: 142:51]`
+              found type `[closure@$DIR/disallowed-positions.rs:146:44: 146:51]`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:142:11
+  --> $DIR/disallowed-positions.rs:146:11
    |
 LL |     while let Range { start: F, end } = F..|| true {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -846,7 +868,7 @@ LL |     while let Range { start: F, end } = F..|| true {}
               found type `std::ops::Range<bool>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:150:15
+  --> $DIR/disallowed-positions.rs:154:15
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^   - this match expression has type `bool`
@@ -857,7 +879,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:150:47
+  --> $DIR/disallowed-positions.rs:154:47
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |                                               ^^^^^^^ expected bool, found &&bool
@@ -866,7 +888,7 @@ LL |     while let Range { start: true, end } = t..&&false {}
               found type `&&bool`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:150:11
+  --> $DIR/disallowed-positions.rs:154:11
    |
 LL |     while let Range { start: true, end } = t..&&false {}
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected bool, found struct `std::ops::Range`
@@ -874,40 +896,63 @@ LL |     while let Range { start: true, end } = t..&&false {}
    = note: expected type `bool`
               found type `std::ops::Range<bool>`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/disallowed-positions.rs:106:23
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:113:11
+   |
+LL |     while (let 0 = 0)? {}
+   |           ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:108:23
    |
 LL |         while let 0 = 0? {}
-   |                       ^^ the `?` operator cannot be applied to type `{integer}`
+   |                       ^ the trait `std::ops::Try` is not implemented for `{integer}`
    |
-   = help: the trait `std::ops::Try` is not implemented for `{integer}`
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
    = note: required by `std::ops::Try::into_result`
 
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:108:23
+   |
+LL |         while let 0 = 0? {}
+   |                       ^^ the trait `std::ops::Try` is not implemented for `{integer}`
+   |
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
+
 error[E0614]: type `bool` cannot be dereferenced
-  --> $DIR/disallowed-positions.rs:173:5
+  --> $DIR/disallowed-positions.rs:177:5
    |
 LL |     *let 0 = 0;
    |     ^^^^^^^^^^
 
 error[E0600]: cannot apply unary operator `-` to type `bool`
-  --> $DIR/disallowed-positions.rs:175:5
+  --> $DIR/disallowed-positions.rs:179:5
    |
 LL |     -let 0 = 0;
    |     ^^^^^^^^^^ cannot apply unary operator `-`
    |
    = note: an implementation of `std::ops::Neg` might be missing for `bool`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/disallowed-positions.rs:183:5
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:188:5
    |
 LL |     (let 0 = 0)?;
-   |     ^^^^^^^^^^^^ the `?` operator cannot be applied to type `bool`
+   |     ^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
    |
-   = help: the trait `std::ops::Try` is not implemented for `bool`
    = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/disallowed-positions.rs:183:5
+  --> $DIR/disallowed-positions.rs:188:5
    |
 LL |     (let 0 = 0)?;
    |     ^^^^^^^^^^^^ cannot use the `?` operator in a function that returns `()`
@@ -916,7 +961,7 @@ LL |     (let 0 = 0)?;
    = note: required by `std::ops::Try::from_error`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:198:10
+  --> $DIR/disallowed-positions.rs:204:10
    |
 LL |     (let Range { start: _, end: _ } = true..true || false);
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^   ---- this match expression has type `bool`
@@ -927,7 +972,7 @@ LL |     (let Range { start: _, end: _ } = true..true || false);
               found type `std::ops::Range<_>`
 
 error[E0308]: mismatched types
-  --> $DIR/disallowed-positions.rs:207:5
+  --> $DIR/disallowed-positions.rs:213:5
    |
 LL | fn outside_if_and_while_expr() {
    |                                - help: try adding a return type: `-> &bool`
@@ -938,26 +983,38 @@ LL |     &let 0 = 0
    = note: expected type `()`
               found type `&bool`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/disallowed-positions.rs:179:17
+error[E0277]: the trait bound `bool: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:188:5
+   |
+LL |     (let 0 = 0)?;
+   |     ^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `bool`
+
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:183:17
    |
 LL |         let 0 = 0?;
-   |                 ^^ the `?` operator cannot be applied to type `{integer}`
+   |                 ^ the trait `std::ops::Try` is not implemented for `{integer}`
    |
-   = help: the trait `std::ops::Try` is not implemented for `{integer}`
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
    = note: required by `std::ops::Try::into_result`
 
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/disallowed-positions.rs:218:25
+error[E0277]: the trait bound `{integer}: std::ops::Try` is not satisfied
+  --> $DIR/disallowed-positions.rs:183:17
    |
-LL |         true && let 1 = 1
-   |                         ^
-
-error[E0019]: constant contains unimplemented expression type
-  --> $DIR/disallowed-positions.rs:218:21
+LL |         let 0 = 0?;
+   |                 ^^ the trait `std::ops::Try` is not implemented for `{integer}`
    |
-LL |         true && let 1 = 1
-   |                     ^
+   = help: the following implementations were found:
+             <std::iter::LoopState<C, B> as std::ops::Try>
+             <std::option::Option<T> as std::ops::Try>
+             <std::result::Result<T, E> as std::ops::Try>
+             <std::task::Poll<std::option::Option<std::result::Result<T, E>>> as std::ops::Try>
+             <std::task::Poll<std::result::Result<T, E>> as std::ops::Try>
 
 error[E0019]: constant contains unimplemented expression type
   --> $DIR/disallowed-positions.rs:224:25
@@ -983,7 +1040,19 @@ error[E0019]: constant contains unimplemented expression type
 LL |         true && let 1 = 1
    |                     ^
 
-error: aborting due to 109 previous errors
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/disallowed-positions.rs:236:25
+   |
+LL |         true && let 1 = 1
+   |                         ^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/disallowed-positions.rs:236:21
+   |
+LL |         true && let 1 = 1
+   |                     ^
+
+error: aborting due to 115 previous errors
 
 Some errors have detailed explanations: E0019, E0277, E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/str/str-idx.stderr
+++ b/src/test/ui/str/str-idx.stderr
@@ -10,20 +10,20 @@ LL |     let _: u8 = s[4];
    = note: required because of the requirements on the impl of `std::ops::Index<{integer}>` for `str`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
-  --> $DIR/str-idx.rs:4:15
+  --> $DIR/str-idx.rs:4:19
    |
 LL |     let _ = s.get(4);
-   |               ^^^ string indices are ranges of `usize`
+   |                   ^ string indices are ranges of `usize`
    |
    = help: the trait `std::slice::SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
-  --> $DIR/str-idx.rs:5:15
+  --> $DIR/str-idx.rs:5:29
    |
 LL |     let _ = s.get_unchecked(4);
-   |               ^^^^^^^^^^^^^ string indices are ranges of `usize`
+   |                             ^ string indices are ranges of `usize`
    |
    = help: the trait `std::slice::SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`

--- a/src/test/ui/str/str-mut-idx.stderr
+++ b/src/test/ui/str/str-mut-idx.stderr
@@ -30,20 +30,20 @@ LL |     s[1usize] = bot();
    = note: required because of the requirements on the impl of `std::ops::Index<usize>` for `str`
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
-  --> $DIR/str-mut-idx.rs:9:7
+  --> $DIR/str-mut-idx.rs:9:15
    |
 LL |     s.get_mut(1);
-   |       ^^^^^^^ string indices are ranges of `usize`
+   |               ^ string indices are ranges of `usize`
    |
    = help: the trait `std::slice::SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            see chapter in The Book <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
 
 error[E0277]: the type `str` cannot be indexed by `{integer}`
-  --> $DIR/str-mut-idx.rs:11:7
+  --> $DIR/str-mut-idx.rs:11:25
    |
 LL |     s.get_unchecked_mut(1);
-   |       ^^^^^^^^^^^^^^^^^ string indices are ranges of `usize`
+   |                         ^ string indices are ranges of `usize`
    |
    = help: the trait `std::slice::SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `fn() -> impl std::future::Future {foo}: std::future::Future` is not satisfied
-  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:5
+  --> $DIR/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:9:9
    |
 LL | fn bar(f: impl Future<Output=()>) {}
    | --------------------------------- required by `bar`
 ...
 LL |     bar(foo);
-   |     ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
+   |         ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
    |
    = help: use parentheses to call the function: `foo()`
 

--- a/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/async-fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,9 +5,10 @@ LL | fn bar(f: impl Future<Output=()>) {}
    | --------------------------------- required by `bar`
 ...
 LL |     bar(foo);
-   |         ^^^ the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
-   |
-   = help: use parentheses to call the function: `foo()`
+   |         ^^^
+   |         |
+   |         the trait `std::future::Future` is not implemented for `fn() -> impl std::future::Future {foo}`
+   |         help: use parentheses to call the function: `foo()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `fn() -> impl T {foo}: T` is not satisfied
-  --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:5
+  --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:17:9
    |
 LL | fn bar(f: impl T<O=()>) {}
    | ----------------------- required by `bar`
 ...
 LL |     bar(foo);
-   |     ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
    |
    = help: use parentheses to call the function: `foo()`
 

--- a/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/src/test/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -5,9 +5,10 @@ LL | fn bar(f: impl T<O=()>) {}
    | ----------------------- required by `bar`
 ...
 LL |     bar(foo);
-   |         ^^^ the trait `T` is not implemented for `fn() -> impl T {foo}`
-   |
-   = help: use parentheses to call the function: `foo()`
+   |         ^^^
+   |         |
+   |         the trait `T` is not implemented for `fn() -> impl T {foo}`
+   |         help: use parentheses to call the function: `foo()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-62843.stderr
+++ b/src/test/ui/suggestions/issue-62843.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `std::ops::FnMut<(char,)>` closure, found `std::string::String`
-  --> $DIR/issue-62843.rs:4:27
+  --> $DIR/issue-62843.rs:4:32
    |
 LL |     println!("{:?}", line.find(pattern));
-   |                           ^^^^ expected an `FnMut<(char,)>` closure, found `std::string::String`
+   |                                ^^^^^^^ expected an `FnMut<(char,)>` closure, found `std::string::String`
    |
    = help: the trait `std::ops::FnMut<(char,)>` is not implemented for `std::string::String`
    = note: borrowing the `std::string::String` might fix the problem

--- a/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
+++ b/src/test/ui/traits/traits-inductive-overflow-supertrait-oibit.stderr
@@ -5,13 +5,13 @@ LL | auto trait Magic: Copy {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `NoClone: std::marker::Copy` is not satisfied
-  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:18
+  --> $DIR/traits-inductive-overflow-supertrait-oibit.rs:15:23
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
    | --------------------------------- required by `copy`
 ...
 LL |     let (a, b) = copy(NoClone);
-   |                  ^^^^ the trait `std::marker::Copy` is not implemented for `NoClone`
+   |                       ^^^^^^^ the trait `std::marker::Copy` is not implemented for `NoClone`
    |
    = note: required because of the requirements on the impl of `Magic` for `NoClone`
 

--- a/src/test/ui/traits/traits-negative-impls.stderr
+++ b/src/test/ui/traits/traits-negative-impls.stderr
@@ -1,11 +1,11 @@
 error[E0277]: `dummy::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:23:5
+  --> $DIR/traits-negative-impls.rs:23:11
    |
 LL | struct Outer<T: Send>(T);
    | ------------------------- required by `Outer`
 ...
 LL |     Outer(TestType);
-   |     ^^^^^ `dummy::TestType` cannot be sent between threads safely
+   |           ^^^^^^^^ `dummy::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy::TestType`
 
@@ -21,49 +21,49 @@ LL |     Outer(TestType);
    = help: the trait `std::marker::Send` is not implemented for `dummy::TestType`
 
 error[E0277]: `dummy1b::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:32:5
+  --> $DIR/traits-negative-impls.rs:32:13
    |
 LL | fn is_send<T: Send>(_: T) {}
    | ------------------------- required by `is_send`
 ...
 LL |     is_send(TestType);
-   |     ^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
+   |             ^^^^^^^^ `dummy1b::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy1b::TestType`
 
 error[E0277]: `dummy1c::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:40:5
+  --> $DIR/traits-negative-impls.rs:40:13
    |
 LL | fn is_send<T: Send>(_: T) {}
    | ------------------------- required by `is_send`
 ...
 LL |     is_send((8, TestType));
-   |     ^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
+   |             ^^^^^^^^^^^^^ `dummy1c::TestType` cannot be sent between threads safely
    |
    = help: within `({integer}, dummy1c::TestType)`, the trait `std::marker::Send` is not implemented for `dummy1c::TestType`
    = note: required because it appears within the type `({integer}, dummy1c::TestType)`
 
 error[E0277]: `dummy2::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:48:5
+  --> $DIR/traits-negative-impls.rs:48:13
    |
 LL | fn is_send<T: Send>(_: T) {}
    | ------------------------- required by `is_send`
 ...
 LL |     is_send(Box::new(TestType));
-   |     ^^^^^^^ `dummy2::TestType` cannot be sent between threads safely
+   |             ^^^^^^^^^^^^^^^^^^ `dummy2::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `dummy2::TestType`
    = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<dummy2::TestType>`
    = note: required because it appears within the type `std::boxed::Box<dummy2::TestType>`
 
 error[E0277]: `dummy3::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:56:5
+  --> $DIR/traits-negative-impls.rs:56:13
    |
 LL | fn is_send<T: Send>(_: T) {}
    | ------------------------- required by `is_send`
 ...
 LL |     is_send(Box::new(Outer2(TestType)));
-   |     ^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ `dummy3::TestType` cannot be sent between threads safely
    |
    = help: within `Outer2<dummy3::TestType>`, the trait `std::marker::Send` is not implemented for `dummy3::TestType`
    = note: required because it appears within the type `Outer2<dummy3::TestType>`
@@ -71,13 +71,13 @@ LL |     is_send(Box::new(Outer2(TestType)));
    = note: required because it appears within the type `std::boxed::Box<Outer2<dummy3::TestType>>`
 
 error[E0277]: `main::TestType` cannot be sent between threads safely
-  --> $DIR/traits-negative-impls.rs:66:5
+  --> $DIR/traits-negative-impls.rs:66:13
    |
 LL | fn is_sync<T: Sync>(_: T) {}
    | ------------------------- required by `is_sync`
 ...
 LL |     is_sync(Outer2(TestType));
-   |     ^^^^^^^ `main::TestType` cannot be sent between threads safely
+   |             ^^^^^^^^^^^^^^^^ `main::TestType` cannot be sent between threads safely
    |
    = help: the trait `std::marker::Send` is not implemented for `main::TestType`
    = note: required because of the requirements on the impl of `std::marker::Sync` for `Outer2<main::TestType>`

--- a/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-leak.stderr
@@ -19,19 +19,19 @@ LL |     3i32.test();
            candidate #1: `Foo`
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/trivial-bounds-leak.rs:25:5
+  --> $DIR/trivial-bounds-leak.rs:25:15
    |
 LL |     fn test(&self);
    |     --------------- required by `Foo::test`
 ...
 LL |     Foo::test(&4i32);
-   |     ^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |               ^^^^^ the trait `Foo` is not implemented for `i32`
 
 error[E0277]: the trait bound `i32: Foo` is not satisfied
-  --> $DIR/trivial-bounds-leak.rs:26:5
+  --> $DIR/trivial-bounds-leak.rs:26:22
    |
 LL |     generic_function(5i32);
-   |     ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `i32`
+   |                      ^^^^ the trait `Foo` is not implemented for `i32`
 ...
 LL | fn generic_function<T: Foo>(t: T) {}
    | --------------------------------- required by `generic_function`

--- a/src/test/ui/try-operator-on-main.rs
+++ b/src/test/ui/try-operator-on-main.rs
@@ -10,7 +10,6 @@ fn main() {
 
     // a non-`Try` type on a non-`Try` fn
     ()?; //~ ERROR the `?` operator can only
-    //~^ ERROR the trait bound `(): std::ops::Try` is not satisfied
 
     // an unrelated use of `Try`
     try_trait_generic::<()>(); //~ ERROR the trait bound
@@ -20,8 +19,7 @@ fn main() {
 
 fn try_trait_generic<T: Try>() -> T {
     // and a non-`Try` object on a `Try` fn.
-    ()?; //~ ERROR the trait bound `(): std::ops::Try` is not satisfied
-    //~^ ERROR the trait bound `(): std::ops::Try` is not satisfied
+    ()?; //~ ERROR the `?` operator can only be applied to values that implement `std::ops::Try`
 
     loop {}
 }

--- a/src/test/ui/try-operator-on-main.rs
+++ b/src/test/ui/try-operator-on-main.rs
@@ -10,6 +10,7 @@ fn main() {
 
     // a non-`Try` type on a non-`Try` fn
     ()?; //~ ERROR the `?` operator can only
+    //~^ ERROR the trait bound `(): std::ops::Try` is not satisfied
 
     // an unrelated use of `Try`
     try_trait_generic::<()>(); //~ ERROR the trait bound
@@ -19,7 +20,8 @@ fn main() {
 
 fn try_trait_generic<T: Try>() -> T {
     // and a non-`Try` object on a `Try` fn.
-    ()?; //~ ERROR the `?` operator can only
+    ()?; //~ ERROR the trait bound `(): std::ops::Try` is not satisfied
+    //~^ ERROR the trait bound `(): std::ops::Try` is not satisfied
 
     loop {}
 }

--- a/src/test/ui/try-operator-on-main.stderr
+++ b/src/test/ui/try-operator-on-main.stderr
@@ -7,17 +7,25 @@ LL |     std::fs::File::open("foo")?;
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::from_error`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
   --> $DIR/try-operator-on-main.rs:12:5
    |
 LL |     ()?;
-   |     ^^^ the `?` operator cannot be applied to type `()`
+   |     ^^ the trait `std::ops::Try` is not implemented for `()`
    |
-   = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::into_result`
 
+error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
+  --> $DIR/try-operator-on-main.rs:12:5
+   |
+LL |     ()?;
+   |     ^^^ cannot use the `?` operator in a function that returns `()`
+   |
+   = help: the trait `std::ops::Try` is not implemented for `()`
+   = note: required by `std::ops::Try::from_error`
+
 error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
-  --> $DIR/try-operator-on-main.rs:15:5
+  --> $DIR/try-operator-on-main.rs:16:5
    |
 LL |     try_trait_generic::<()>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `()`
@@ -25,15 +33,20 @@ LL |     try_trait_generic::<()>();
 LL | fn try_trait_generic<T: Try>() -> T {
    | ----------------------------------- required by `try_trait_generic`
 
-error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
-  --> $DIR/try-operator-on-main.rs:22:5
+error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
+  --> $DIR/try-operator-on-main.rs:23:5
    |
 LL |     ()?;
-   |     ^^^ the `?` operator cannot be applied to type `()`
+   |     ^^ the trait `std::ops::Try` is not implemented for `()`
    |
-   = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::into_result`
 
-error: aborting due to 4 previous errors
+error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
+  --> $DIR/try-operator-on-main.rs:23:5
+   |
+LL |     ()?;
+   |     ^^^ the trait `std::ops::Try` is not implemented for `()`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/try-operator-on-main.stderr
+++ b/src/test/ui/try-operator-on-main.stderr
@@ -7,25 +7,17 @@ LL |     std::fs::File::open("foo")?;
    = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::from_error`
 
-error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
   --> $DIR/try-operator-on-main.rs:12:5
    |
 LL |     ()?;
-   |     ^^ the trait `std::ops::Try` is not implemented for `()`
-   |
-   = note: required by `std::ops::Try::into_result`
-
-error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `std::ops::Try`)
-  --> $DIR/try-operator-on-main.rs:12:5
-   |
-LL |     ()?;
-   |     ^^^ cannot use the `?` operator in a function that returns `()`
+   |     ^^^ the `?` operator cannot be applied to type `()`
    |
    = help: the trait `std::ops::Try` is not implemented for `()`
-   = note: required by `std::ops::Try::from_error`
+   = note: required by `std::ops::Try::into_result`
 
 error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
-  --> $DIR/try-operator-on-main.rs:16:5
+  --> $DIR/try-operator-on-main.rs:15:5
    |
 LL |     try_trait_generic::<()>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::ops::Try` is not implemented for `()`
@@ -33,20 +25,15 @@ LL |     try_trait_generic::<()>();
 LL | fn try_trait_generic<T: Try>() -> T {
    | ----------------------------------- required by `try_trait_generic`
 
-error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
-  --> $DIR/try-operator-on-main.rs:23:5
+error[E0277]: the `?` operator can only be applied to values that implement `std::ops::Try`
+  --> $DIR/try-operator-on-main.rs:22:5
    |
 LL |     ()?;
-   |     ^^ the trait `std::ops::Try` is not implemented for `()`
+   |     ^^^ the `?` operator cannot be applied to type `()`
    |
+   = help: the trait `std::ops::Try` is not implemented for `()`
    = note: required by `std::ops::Try::into_result`
 
-error[E0277]: the trait bound `(): std::ops::Try` is not satisfied
-  --> $DIR/try-operator-on-main.rs:23:5
-   |
-LL |     ()?;
-   |     ^^^ the trait `std::ops::Try` is not implemented for `()`
-
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -20,30 +20,30 @@ LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
    = help: the trait `std::iter::FromIterator<i32>` is not implemented for `i32`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:11:1
+  --> $DIR/type-check-defaults.rs:11:17
    |
 LL | struct Bounds<T:Copy=String>(T);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | ----------------^^^^------------
+   | |               |
+   | |               the trait `std::marker::Copy` is not implemented for `std::string::String`
    | required by `Bounds`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:14:1
+  --> $DIR/type-check-defaults.rs:14:42
    |
 LL | struct WhereClause<T=String>(T) where T: Copy;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   | |
-   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | -----------------------------------------^^^^-
+   | |                                        |
+   | |                                        the trait `std::marker::Copy` is not implemented for `std::string::String`
    | required by `WhereClause`
 
 error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
-  --> $DIR/type-check-defaults.rs:17:1
+  --> $DIR/type-check-defaults.rs:17:20
    |
 LL | trait TraitBound<T:Copy=String> {}
-   | -------------------------------^^^
-   | |
-   | the trait `std::marker::Copy` is not implemented for `std::string::String`
+   | -------------------^^^^--------
+   | |                  |
+   | |                  the trait `std::marker::Copy` is not implemented for `std::string::String`
    | required by `TraitBound`
 
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
@@ -57,12 +57,12 @@ LL | trait Base<T = String>: Super<T> { }
    = help: consider adding a `where T: std::marker::Copy` bound
 
 error[E0277]: cannot add `u8` to `i32`
-  --> $DIR/type-check-defaults.rs:24:1
+  --> $DIR/type-check-defaults.rs:24:66
    |
 LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
-   | ------------------------------------------------------------------------^^^
-   | |
-   | no implementation for `i32 + u8`
+   | -----------------------------------------------------------------^^^^^^^
+   | |                                                                |
+   | |                                                                no implementation for `i32 + u8`
    | required by `ProjectionPred`
    |
    = help: the trait `std::ops::Add<u8>` is not implemented for `i32`

--- a/src/test/ui/typeck/typeck-unsafe-always-share.stderr
+++ b/src/test/ui/typeck/typeck-unsafe-always-share.stderr
@@ -1,22 +1,22 @@
 error[E0277]: `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
-  --> $DIR/typeck-unsafe-always-share.rs:19:5
+  --> $DIR/typeck-unsafe-always-share.rs:19:10
    |
 LL | fn test<T: Sync>(s: T) {}
    | ---------------------- required by `test`
 ...
 LL |     test(us);
-   |     ^^^^ `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
+   |          ^^ `std::cell::UnsafeCell<MySync<{integer}>>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<MySync<{integer}>>`
 
 error[E0277]: `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
-  --> $DIR/typeck-unsafe-always-share.rs:23:5
+  --> $DIR/typeck-unsafe-always-share.rs:23:10
    |
 LL | fn test<T: Sync>(s: T) {}
    | ---------------------- required by `test`
 ...
 LL |     test(uns);
-   |     ^^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
+   |          ^^^ `std::cell::UnsafeCell<NoSync>` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::UnsafeCell<NoSync>`
 
@@ -33,13 +33,13 @@ LL |     test(ms);
    = note: required because it appears within the type `MySync<NoSync>`
 
 error[E0277]: `NoSync` cannot be shared between threads safely
-  --> $DIR/typeck-unsafe-always-share.rs:30:5
+  --> $DIR/typeck-unsafe-always-share.rs:30:10
    |
 LL | fn test<T: Sync>(s: T) {}
    | ---------------------- required by `test`
 ...
 LL |     test(NoSync);
-   |     ^^^^ `NoSync` cannot be shared between threads safely
+   |          ^^^^^^ `NoSync` cannot be shared between threads safely
    |
    = help: the trait `std::marker::Sync` is not implemented for `NoSync`
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,11 +1,11 @@
 error[E0277]: expected a `std::ops::Fn<(isize,)>` closure, found `S`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:13
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
    |
 LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
    | -------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&S, 22);
-   |             ^^^^^^^ expected an `Fn<(isize,)>` closure, found `S`
+   |                     ^^ expected an `Fn<(isize,)>` closure, found `S`
    |
    = help: the trait `std::ops::Fn<(isize,)>` is not implemented for `S`
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-unsafe-extern-fn.stderr
@@ -1,55 +1,55 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:13
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:13
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:24:13
+  --> $DIR/unboxed-closures-unsafe-extern-fn.rs:24:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
    | ----------------------------------------------------------------- required by `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
-   |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
+   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> unsafe fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> unsafe fn(&'r isize) -> isize {square}`
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-abi.stderr
@@ -1,55 +1,55 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-abi.rs:12:13
+  --> $DIR/unboxed-closures-wrong-abi.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-abi.rs:12:13
+  --> $DIR/unboxed-closures-wrong-abi.rs:12:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-abi.rs:18:13
+  --> $DIR/unboxed-closures-wrong-abi.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-abi.rs:18:13
+  --> $DIR/unboxed-closures-wrong-abi.rs:18:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-abi.rs:24:13
+  --> $DIR/unboxed-closures-wrong-abi.rs:24:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
    | ----------------------------------------------------------------- required by `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
-   |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
+   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `for<'r> extern "C" fn(&'r isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `for<'r> extern "C" fn(&'r isize) -> isize {square}`
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-wrong-arg-type-extern-fn.stderr
@@ -1,55 +1,55 @@
 error[E0277]: expected a `std::ops::Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `Fn<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::Fn<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:13
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:13:21
    |
 LL | fn call_it<F:Fn(&isize)->isize>(_: &F, _: isize) -> isize { 0 }
    | --------------------------------------------------------- required by `call_it`
 ...
 LL |     let x = call_it(&square, 22);
-   |             ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |                     ^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnMut<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `for<'r> std::ops::FnMut<(&'r isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:13
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:19:25
    |
 LL | fn call_it_mut<F:FnMut(&isize)->isize>(_: &mut F, _: isize) -> isize { 0 }
    | -------------------------------------------------------------------- required by `call_it_mut`
 ...
 LL |     let y = call_it_mut(&mut square, 22);
-   |             ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |                         ^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 
 error[E0277]: expected a `std::ops::FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
-  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:25:13
+  --> $DIR/unboxed-closures-wrong-arg-type-extern-fn.rs:25:26
    |
 LL | fn call_it_once<F:FnOnce(&isize)->isize>(_: F, _: isize) -> isize { 0 }
    | ----------------------------------------------------------------- required by `call_it_once`
 ...
 LL |     let z = call_it_once(square, 22);
-   |             ^^^^^^^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
+   |                          ^^^^^^ expected an `FnOnce<(&isize,)>` closure, found `unsafe fn(isize) -> isize {square}`
    |
    = help: the trait `std::ops::FnOnce<(&isize,)>` is not implemented for `unsafe fn(isize) -> isize {square}`
 

--- a/src/test/ui/unsized3.stderr
+++ b/src/test/ui/unsized3.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:7:5
+  --> $DIR/unsized3.rs:7:13
    |
 LL |     f2::<X>(x);
-   |     ^^^^^^^ doesn't have a size known at compile-time
+   |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f2<X>(x: &X) {
    | --------------- required by `f2`
@@ -12,10 +12,10 @@ LL | fn f2<X>(x: &X) {
    = help: consider adding a `where X: std::marker::Sized` bound
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:18:5
+  --> $DIR/unsized3.rs:18:13
    |
 LL |     f4::<X>(x);
-   |     ^^^^^^^ doesn't have a size known at compile-time
+   |             ^ doesn't have a size known at compile-time
 ...
 LL | fn f4<X: T>(x: &X) {
    | ------------------ required by `f4`
@@ -25,13 +25,13 @@ LL | fn f4<X: T>(x: &X) {
    = help: consider adding a `where X: std::marker::Sized` bound
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:33:5
+  --> $DIR/unsized3.rs:33:8
    |
 LL | fn f5<Y>(x: &Y) {}
    | --------------- required by `f5`
 ...
 LL |     f5(x1);
-   |     ^^ doesn't have a size known at compile-time
+   |        ^^ doesn't have a size known at compile-time
    |
    = help: within `S<X>`, the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -39,10 +39,10 @@ LL |     f5(x1);
    = note: required because it appears within the type `S<X>`
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:40:5
+  --> $DIR/unsized3.rs:40:8
    |
 LL |     f5(&(*x1, 34));
-   |     ^^ doesn't have a size known at compile-time
+   |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `S<X>`, the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
@@ -64,13 +64,13 @@ LL |     f5(&(32, *x1));
    = note: tuples must have a statically known size to be initialized
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized3.rs:45:5
+  --> $DIR/unsized3.rs:45:8
    |
 LL | fn f5<Y>(x: &Y) {}
    | --------------- required by `f5`
 ...
 LL |     f5(&(32, *x1));
-   |     ^^ doesn't have a size known at compile-time
+   |        ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: within `({integer}, S<X>)`, the trait `std::marker::Sized` is not implemented for `X`
    = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>

--- a/src/test/ui/vtable-res-trait-param.stderr
+++ b/src/test/ui/vtable-res-trait-param.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `{integer}: TraitA` is not satisfied
-  --> $DIR/vtable-res-trait-param.rs:17:7
+  --> $DIR/vtable-res-trait-param.rs:17:18
    |
 LL |     b.gimme_an_a(y)
-   |       ^^^^^^^^^^ the trait `TraitA` is not implemented for `{integer}`
+   |                  ^ the trait `TraitA` is not implemented for `{integer}`
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:9
+  --> $DIR/where-clause-constraints-are-local-for-inherent-impl.rs:13:22
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    | ------------------------------ required by `require_copy`
 ...
 LL |         require_copy(self.x);
-   |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 

--- a/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/src/test/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `T: std::marker::Copy` is not satisfied
-  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:9
+  --> $DIR/where-clause-constraints-are-local-for-trait-impl.rs:18:22
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    | ------------------------------ required by `require_copy`
 ...
 LL |         require_copy(self.x);
-   |         ^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
+   |                      ^^^^^^ the trait `std::marker::Copy` is not implemented for `T`
    |
    = help: consider adding a `where T: std::marker::Copy` bound
 

--- a/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `Bar: std::cmp::Eq` is not satisfied
-  --> $DIR/where-clauses-method-unsatisfied.rs:18:7
+  --> $DIR/where-clauses-method-unsatisfied.rs:18:14
    |
 LL |     x.equals(&x);
-   |       ^^^^^^ the trait `std::cmp::Eq` is not implemented for `Bar`
+   |              ^^ the trait `std::cmp::Eq` is not implemented for `Bar`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #64136 (Document From trait for LhsExpr in parser)
 - #64342 (factor out pluralisation remains after #64280)
 - #64387 (Fix redundant semicolon lint interaction with proc macro attributes)
 - #64498 (When possible point at argument causing item obligation failure)
 - #64615 (rustbuild: Turn down compression on exe installers)
 - #64617 (rustbuild: Turn down compression on msi installers)
 - #64618 (rustbuild: Improve output of `dist` step)
 - #64621 (Add Compatibility Notes to RELEASES.md for 1.38.0)

Failed merges:


r? @ghost