### PR TITLE
Exempt extern "Rust" from improper_ctypes

### DIFF
--- a/src/liballoc/alloc.rs
+++ b/src/liballoc/alloc.rs
@@ -240,7 +240,7 @@ pub(crate) unsafe fn box_free<T: ?Sized>(ptr: Unique<T>) {
 #[stable(feature = "global_alloc", since = "1.28.0")]
 #[rustc_allocator_nounwind]
 pub fn handle_alloc_error(layout: Layout) -> ! {
-    #[allow(improper_ctypes)]
+    #[cfg_attr(bootstrap, allow(improper_ctypes))]
     extern "Rust" {
         #[lang = "oom"]
         fn oom_impl(layout: Layout) -> !;

--- a/src/libcore/panicking.rs
+++ b/src/libcore/panicking.rs
@@ -71,7 +71,7 @@ pub fn panic_fmt(fmt: fmt::Arguments<'_>, file_line_col: &(&'static str, u32, u3
     }
 
     // NOTE This function never crosses the FFI boundary; it's a Rust-to-Rust call
-    #[allow(improper_ctypes)] // PanicInfo contains a trait object which is not FFI safe
+    #[cfg_attr(boostrap_stdarch_ignore_this, allow(improper_ctypes))]
     extern "Rust" {
         #[lang = "panic_impl"]
         fn panic_impl(pi: &PanicInfo<'_>) -> !;

--- a/src/librustc_lint/types.rs
+++ b/src/librustc_lint/types.rs
@@ -975,7 +975,9 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for ImproperCTypes {
     fn check_foreign_item(&mut self, cx: &LateContext<'_, '_>, it: &hir::ForeignItem) {
         let mut vis = ImproperCTypesVisitor { cx };
         let abi = cx.tcx.hir().get_foreign_abi(it.hir_id);
-        if abi != Abi::RustIntrinsic && abi != Abi::PlatformIntrinsic {
+        if let Abi::Rust | Abi::RustCall | Abi::RustIntrinsic | Abi::PlatformIntrinsic = abi {
+            // Don't worry about types in internal ABIs.
+        } else {
             match it.node {
                 hir::ForeignItemKind::Fn(ref decl, _, _) => {
                     vis.check_foreign_fn(it.hir_id, decl);

--- a/src/test/ui/issues/issue-64593.rs
+++ b/src/test/ui/issues/issue-64593.rs
@@ -1,0 +1,12 @@
+// check-pass
+#![deny(improper_ctypes)]
+
+pub struct Error(std::num::NonZeroU32);
+
+extern "Rust" {
+    fn foo(dest: &mut [u8]) -> Result<(), Error>;
+}
+
+fn main() {
+    let _ = unsafe { foo(&mut []) };
+}


### PR DESCRIPTION
It should be fine for Rust ABIs to involve any Rust type.

Fixes #64593.