### PR TITLE
Fix the span used to suggest avoiding for-loop moves

### DIFF
--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -180,7 +180,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                     );
                 }
                 if Some(DesugaringKind::ForLoop) == move_span.desugaring_kind() {
-                    if let Ok(snippet) = self.infcx.tcx.sess.source_map().span_to_snippet(span) {
+                    let sess = self.infcx.tcx.sess;
+                    if let Ok(snippet) = sess.source_map().span_to_snippet(move_span) {
                         err.span_suggestion(
                             move_span,
                             "consider borrowing to avoid moving into the for loop",

--- a/src/test/ui/issues/issue-64559.rs
+++ b/src/test/ui/issues/issue-64559.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let orig = vec![true];
+    for _val in orig {}
+    let _closure = || orig;
+    //~^ ERROR use of moved value: `orig`
+}

--- a/src/test/ui/issues/issue-64559.stderr
+++ b/src/test/ui/issues/issue-64559.stderr
@@ -1,0 +1,18 @@
+error[E0382]: use of moved value: `orig`
+  --> $DIR/issue-64559.rs:4:20
+   |
+LL |     let orig = vec![true];
+   |         ---- move occurs because `orig` has type `std::vec::Vec<bool>`, which does not implement the `Copy` trait
+LL |     for _val in orig {}
+   |                 ----
+   |                 |
+   |                 value moved here
+   |                 help: consider borrowing to avoid moving into the for loop: `&orig`
+LL |     let _closure = || orig;
+   |                    ^^ ---- use occurs due to use in closure
+   |                    |
+   |                    value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
It was using the snippet from the "use" span, which often renders the
same, but with closures that snippet is on the start of the closure
where the value is captured. We should be using the snippet from the
span where it was moved into the `for` loop, which is `move_span`.

Fixes #64559.