### PR TITLE
REPL, part 1: Added interpreter mode to compiler interface, interpreter parsing functionality

### DIFF
--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -23,9 +23,9 @@ macro_rules! arena_types {
             [] generics: rustc::ty::Generics,
             [] trait_def: rustc::ty::TraitDef,
             [] adt_def: rustc::ty::AdtDef,
-            [] steal_mir: rustc::ty::steal::Steal<rustc::mir::Body<$tcx>>,
+            [] steal_mir: rustc_data_structures::steal::Steal<rustc::mir::Body<$tcx>>,
             [] mir: rustc::mir::Body<$tcx>,
-            [] steal_promoted: rustc::ty::steal::Steal<
+            [] steal_promoted: rustc_data_structures::steal::Steal<
                 rustc_index::vec::IndexVec<
                     rustc::mir::Promoted,
                     rustc::mir::Body<$tcx>

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -2077,6 +2077,7 @@ impl<'a> LoweringContext<'a> {
             span: l.span,
             attrs: l.attrs.clone(),
             source: hir::LocalSource::Normal,
+            interp_tag: l.interp_tag.clone(),
         }, ids)
     }
 
@@ -3046,6 +3047,7 @@ impl<'a> LoweringContext<'a> {
             source,
             span,
             ty: None,
+            interp_tag: None,
         };
         self.stmt(span, hir::StmtKind::Local(P(local)))
     }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1273,6 +1273,8 @@ pub struct Local {
     /// Can be `ForLoopDesugar` if the `let` statement is part of a `for` loop
     /// desugaring. Otherwise will be `Normal`.
     pub source: LocalSource,
+    /// See comment on `syntax::ast::Local`.
+    pub interp_tag: Option<ast::LocalInterpTag>,
 }
 
 /// Represents a single arm of a `match` expression, e.g.

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -392,3 +392,14 @@ impl<'hir> HashStable<StableHashingContext<'hir>> for attr::OptimizeAttr {
         mem::discriminant(self).hash_stable(hcx, hasher);
     }
 }
+
+impl_stable_hash_for!(enum ast::LocalInterpState {
+    Uninitialized,
+    Set,
+    Moved,
+});
+
+impl_stable_hash_for!(struct ast::LocalInterpTag {
+    id,
+    state,
+});

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -1,14 +1,15 @@
 //! This module contains `HashStable` implementations for various data types
-//! from rustc::ty in no particular order.
+//! from `rustc::ty` in no particular order.
 
 use crate::ich::{Fingerprint, StableHashingContext, NodeIdHashingMode};
+use crate::middle::region;
+use crate::mir;
+use crate::ty;
+
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 use std::cell::RefCell;
 use std::mem;
-use crate::middle::region;
-use crate::ty;
-use crate::mir;
 
 impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for &'tcx ty::List<T>
 where
@@ -194,15 +195,6 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::FloatVid {
         // `FloatVid` values are confined to an inference context and hence
         // should not be hashed.
         bug!("ty::TyKind::hash_stable() - can't hash a FloatVid {:?}.", *self)
-    }
-}
-
-impl<'a, T> HashStable<StableHashingContext<'a>> for ty::steal::Steal<T>
-where
-    T: HashStable<StableHashingContext<'a>>,
-{
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.borrow().hash_stable(hcx, hasher);
     }
 }
 

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -1120,8 +1120,7 @@ rustc_queries! {
         }
 
         // Get an estimate of the size of an InstanceDef based on its MIR for CGU partitioning.
-        query instance_def_size_estimate(def: ty::InstanceDef<'tcx>)
-            -> usize {
+        query instance_def_size_estimate(def: ty::InstanceDef<'tcx>) -> usize {
             no_force
             desc { |tcx| "estimating size for `{}`", tcx.def_path_str(def.def_id()) }
         }
@@ -1129,6 +1128,11 @@ rustc_queries! {
         query features_query(_: CrateNum) -> &'tcx feature_gate::Features {
             eval_always
             desc { "looking up enabled feature gates" }
+        }
+
+        query interp_user_fn(_: CrateNum) -> DefId {
+            eval_always
+            desc { "locating interpreter user fn in HIR" }
         }
     }
 }

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -391,6 +391,7 @@ top_level_options!(
         // can influence whether overflow checks are done or not.
         debug_assertions: bool [TRACKED],
         debuginfo: DebugInfo [TRACKED],
+        interp_mode: bool [TRACKED],
         lint_opts: Vec<(String, lint::Level)> [TRACKED],
         lint_cap: Option<lint::Level> [TRACKED],
         describe_lints: bool [UNTRACKED],
@@ -599,6 +600,7 @@ impl Default for Options {
             crate_types: Vec::new(),
             optimize: OptLevel::No,
             debuginfo: DebugInfo::None,
+            interp_mode: false,
             lint_opts: Vec::new(),
             lint_cap: None,
             describe_lints: false,
@@ -2467,6 +2469,7 @@ pub fn build_session_options_and_crate_config(
             crate_types,
             optimize: opt_level,
             debuginfo,
+            interp_mode: false,
             lint_opts,
             lint_cap,
             describe_lints,

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -105,7 +105,6 @@ pub mod outlives;
 pub mod print;
 pub mod query;
 pub mod relate;
-pub mod steal;
 pub mod subst;
 pub mod trait_def;
 pub mod walk;

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -34,7 +34,7 @@ use crate::traits::query::outlives_bounds::OutlivesBound;
 use crate::traits::specialization_graph;
 use crate::traits::Clauses;
 use crate::ty::{self, CrateInherentImpls, ParamEnvAnd, Ty, TyCtxt, AdtSizedConstraint};
-use crate::ty::steal::Steal;
+use rustc_data_structures::steal::Steal;
 use crate::ty::util::NeedsDrop;
 use crate::ty::subst::SubstsRef;
 use crate::util::nodemap::{DefIdSet, DefIdMap, ItemLocalSet};

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -94,6 +94,7 @@ pub use ena::unify;
 pub mod vec_linked_list;
 pub mod work_queue;
 pub mod fingerprint;
+pub mod steal;
 
 pub struct OnDrop<F: Fn()>(pub F);
 

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -19,3 +19,4 @@ mod proc_macro_decls;
 mod profile;
 
 pub use interface::{run_compiler, Config};
+pub use passes::BoxedGlobalCtxt;

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -1,10 +1,11 @@
 use crate::{build, shim};
+
 use rustc_index::vec::IndexVec;
+use rustc_data_structures::steal::Steal;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE};
 use rustc::mir::{Body, MirPhase, Promoted};
 use rustc::ty::{TyCtxt, InstanceDef};
 use rustc::ty::query::Providers;
-use rustc::ty::steal::Steal;
 use rustc::hir;
 use rustc::hir::intravisit::{self, Visitor, NestedVisitorMap};
 use rustc::util::nodemap::DefIdSet;

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -905,7 +905,27 @@ pub enum MacStmtStyle {
     NoBraces,
 }
 
-/// Local represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`.
+/// The interpreter state of a `Local`.
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Debug)]
+pub enum LocalInterpState {
+    /// The local was not uninitialized in any previous evaluation session.
+    Uninitialized,
+    /// The local was set to a value in a previous evaluation session.
+    Set,
+    /// The local was moved during a previous evaluation session.
+    Moved,
+}
+
+/// Extra information about a `Local` for the interpreter.
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
+pub struct LocalInterpTag {
+    /// The ID of this local, for use by the interpreter.
+    pub id: usize,
+    /// The state of the local.
+    pub state: LocalInterpState,
+}
+
+/// Represents a `let` statement, e.g., `let <pat>:<ty> = <expr>;`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct Local {
     pub id: NodeId,
@@ -915,6 +935,8 @@ pub struct Local {
     pub init: Option<P<Expr>>,
     pub span: Span,
     pub attrs: ThinVec<Attribute>,
+    /// In interpreter mode, extra information about the local.
+    pub interp_tag: Option<LocalInterpTag>,
 }
 
 /// An arm of a 'match'.

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -190,6 +190,7 @@ impl<'a> ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span: sp,
             attrs: ThinVec::new(),
+            interp_tag: None,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,
@@ -207,6 +208,7 @@ impl<'a> ExtCtxt<'a> {
             id: ast::DUMMY_NODE_ID,
             span,
             attrs: ThinVec::new(),
+            interp_tag: None,
         });
         ast::Stmt {
             id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -337,7 +337,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     gated!(allow_internal_unsafe, Normal, template!(Word), EXPLAIN_ALLOW_INTERNAL_UNSAFE),
 
     // ==========================================================================
-    // Internal attributes: Type system related:
+    // Internal attributes: Type system:
     // ==========================================================================
 
     gated!(fundamental, Whitelisted, template!(Word), experimental!(fundamental)),
@@ -352,7 +352,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // ==========================================================================
-    // Internal attributes: Runtime related:
+    // Internal attributes: Runtime:
     // ==========================================================================
 
     rustc_attr!(rustc_allocator, Whitelisted, template!(Word), IMPL_DETAIL),
@@ -389,7 +389,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // ==========================================================================
-    // Internal attributes, Linkage:
+    // Internal attributes: Linkage:
     // ==========================================================================
 
     gated!(
@@ -399,7 +399,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_std_internal_symbol, Whitelisted, template!(Word), INTERAL_UNSTABLE),
 
     // ==========================================================================
-    // Internal attributes, Macro related:
+    // Internal attributes: Macros:
     // ==========================================================================
 
     rustc_attr!(rustc_builtin_macro, Whitelisted, template!(Word), IMPL_DETAIL),
@@ -411,7 +411,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // ==========================================================================
-    // Internal attributes, Diagnostics related:
+    // Internal attributes: Diagnostics:
     // ==========================================================================
 
     gated!(
@@ -427,7 +427,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_conversion_suggestion, Whitelisted, template!(Word), INTERAL_UNSTABLE),
 
     // ==========================================================================
-    // Internal attributes, Const related:
+    // Internal attributes: Const:
     // ==========================================================================
 
     rustc_attr!(rustc_promotable, Whitelisted, template!(Word), IMPL_DETAIL),
@@ -435,7 +435,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(rustc_args_required_const, Whitelisted, template!(List: "N"), INTERAL_UNSTABLE),
 
     // ==========================================================================
-    // Internal attributes, Layout related:
+    // Internal attributes: Layout related:
     // ==========================================================================
 
     rustc_attr!(
@@ -455,7 +455,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // ==========================================================================
-    // Internal attributes, Misc:
+    // Internal attributes: Miscellaneous:
     // ==========================================================================
     gated!(
         lang, Normal, template!(NameValueStr: "name"), lang_items,
@@ -489,7 +489,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     gated!(
         rustc_paren_sugar, Normal, template!(Word), unboxed_closures,
-        "unboxed_closures are still evolving",
+        "the `unboxed_closures` feature is still evolving",
     ),
     rustc_attr!(
         rustc_inherit_overflow_checks, Whitelisted, template!(Word),
@@ -505,9 +505,14 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_test_marker, Normal, template!(Word),
         "the `#[rustc_test_marker]` attribute is used internally to track tests",
     ),
+    rustc_attr!(
+        // Used by interpreters:
+        rustc_interp_user_fn, Normal, template!(Word),
+        "`#[rustc_interp_user_fn]` is for use by interpreters only"
+    ),
 
     // ==========================================================================
-    // Internal attributes, Testing:
+    // Internal attributes: Testing:
     // ==========================================================================
 
     rustc_attr!(TEST, rustc_outlives, Normal, template!(Word)),
@@ -545,7 +550,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     rustc_attr!(TEST, rustc_dump_program_clauses, Whitelisted, template!(Word)),
     rustc_attr!(TEST, rustc_dump_env_program_clauses, Whitelisted, template!(Word)),
     rustc_attr!(TEST, rustc_object_lifetime_default, Whitelisted, template!(Word)),
-    rustc_attr!(TEST, rustc_dummy, Normal, template!(Word /* doesn't matter*/)),
+    rustc_attr!(TEST, rustc_dummy, Normal, template!(Word /* doesn't matter */)),
     gated!(
         omit_gdb_pretty_printer_section, Whitelisted, template!(Word),
         "the `#[omit_gdb_pretty_printer_section]` attribute is just used for the Rust test suite",

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -540,7 +540,7 @@ pub fn noop_visit_parenthesized_parameter_data<T: MutVisitor>(args: &mut Parenth
 }
 
 pub fn noop_visit_local<T: MutVisitor>(local: &mut P<Local>, vis: &mut T) {
-    let Local { id, pat, ty, init, span, attrs } = local.deref_mut();
+    let Local { id, pat, ty, init, span, attrs, interp_tag: _ } = local.deref_mut();
     vis.visit_id(id);
     vis.visit_pat(pat);
     visit_opt(ty, |ty| vis.visit_ty(ty));

--- a/src/libsyntax/parse/diagnostics.rs
+++ b/src/libsyntax/parse/diagnostics.rs
@@ -1087,7 +1087,9 @@ impl<'a> Parser<'a> {
     /// statement. This is something of a best-effort heuristic.
     ///
     /// We terminate when we find an unmatched `}` (without consuming it).
-    crate fn recover_stmt(&mut self) {
+    //
+    // NOTE: needs to be `pub` for interpreter.
+    pub fn recover_stmt(&mut self) {
         self.recover_stmt_(SemiColonMode::Ignore, BlockMode::Ignore)
     }
 

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -170,25 +170,40 @@ pub enum DirectoryOwnership {
 // uses a HOF to parse anything, and <source> includes file and
 // `source_str`.
 
-pub fn parse_crate_from_file<'a>(input: &Path, sess: &'a ParseSess) -> PResult<'a, ast::Crate> {
-    let mut parser = new_parser_from_file(sess, input);
-    parser.parse_crate_mod()
+pub fn parse_crate_from_file<'a>(
+    input: &Path,
+    sess: &'a ParseSess,
+) -> PResult<'a, ast::Crate> {
+    new_parser_from_file(sess, input)
+        .parse_crate_mod()
 }
 
-pub fn parse_crate_attrs_from_file<'a>(input: &Path, sess: &'a ParseSess)
-                                       -> PResult<'a, Vec<ast::Attribute>> {
-    let mut parser = new_parser_from_file(sess, input);
-    parser.parse_inner_attributes()
+pub fn parse_crate_attrs_from_file<'a>(
+    input: &Path,
+    sess: &'a ParseSess,
+) -> PResult<'a, Vec<ast::Attribute>> {
+    new_parser_from_file(sess, input)
+        .parse_inner_attributes()
 }
 
-pub fn parse_crate_from_source_str(name: FileName, source: String, sess: &ParseSess)
-                                       -> PResult<'_, ast::Crate> {
-    new_parser_from_source_str(sess, name, source).parse_crate_mod()
+pub fn parse_crate_from_source_str<'a>(
+    name: FileName,
+    source: String,
+    sess: &'a ParseSess,
+    interp_user_fn: Option<parser::InterpUserFn>,
+) -> PResult<'a, ast::Crate> {
+    new_parser_from_source_str(sess, name, source)
+        .set_interp_user_fn(interp_user_fn)
+        .parse_crate_mod()
 }
 
-pub fn parse_crate_attrs_from_source_str(name: FileName, source: String, sess: &ParseSess)
-                                             -> PResult<'_, Vec<ast::Attribute>> {
-    new_parser_from_source_str(sess, name, source).parse_inner_attributes()
+pub fn parse_crate_attrs_from_source_str<'a>(
+    name: FileName,
+    source: String,
+    sess: &'a ParseSess,
+) -> PResult<'a, Vec<ast::Attribute>> {
+    new_parser_from_source_str(sess, name, source)
+        .parse_inner_attributes()
 }
 
 pub fn parse_stream_from_source_str(

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -107,6 +107,15 @@ enum PrevTokenKind {
 
 // NOTE: `Ident`s are handled by `common.rs`.
 
+/// In interpreter mode, information about the user fn (where the user-input code goes).
+#[derive(Clone)]
+pub struct InterpUserFn {
+    /// The placeholder name. The parser looks for this as a single ident within a block.
+    pub placeholder: Symbol,
+    /// The body to insert in place of the placeholder ident.
+    pub body: Option<P<ast::Block>>,
+}
+
 #[derive(Clone)]
 pub struct Parser<'a> {
     pub sess: &'a ParseSess,
@@ -151,6 +160,8 @@ pub struct Parser<'a> {
     crate last_type_ascription: Option<(Span, bool /* likely path typo */)>,
     /// If present, this `Parser` is not parsing Rust code but rather a macro call.
     crate subparser_name: Option<&'static str>,
+    /// In interpreter mode, the user fn to use.
+    pub interp_user_fn: Option<InterpUserFn>,
 }
 
 impl<'a> Drop for Parser<'a> {
@@ -368,6 +379,7 @@ impl<'a> Parser<'a> {
             last_unexpected_token_span: None,
             last_type_ascription: None,
             subparser_name,
+            interp_user_fn: None,
         };
 
         parser.token = parser.next_tok();
@@ -385,6 +397,11 @@ impl<'a> Parser<'a> {
 
         parser.process_potential_macro_variable();
         parser
+    }
+
+    pub fn set_interp_user_fn(&mut self, interp_user_fn: Option<InterpUserFn>) -> &mut Self {
+        self.interp_user_fn = interp_user_fn;
+        self
     }
 
     fn next_tok(&mut self) -> Token {

--- a/src/libsyntax/parse/parser/stmt.rs
+++ b/src/libsyntax/parse/parser/stmt.rs
@@ -275,6 +275,7 @@ impl<'a> Parser<'a> {
             id: DUMMY_NODE_ID,
             span: lo.to(hi),
             attrs,
+            interp_tag: None,
         }))
     }
 
@@ -422,7 +423,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a statement, including the trailing semicolon.
-    crate fn parse_full_stmt(&mut self, macro_legacy_warnings: bool) -> PResult<'a, Option<Stmt>> {
+    //
+    // NOTE: needs to be `pub` for interpreter.
+    pub fn parse_full_stmt(&mut self, macro_legacy_warnings: bool) -> PResult<'a, Option<Stmt>> {
         // Skip looking for a trailing semicolon when we have an interpolated statement.
         maybe_whole!(self, NtStmt, |x| Some(x));
 

--- a/src/libsyntax_ext/deriving/debug.rs
+++ b/src/libsyntax_ext/deriving/debug.rs
@@ -128,6 +128,7 @@ fn stmt_let_undescore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast
         id: ast::DUMMY_NODE_ID,
         span: sp,
         attrs: ThinVec::new(),
+        interp_tag: None,
     });
     ast::Stmt {
         id: ast::DUMMY_NODE_ID,

--- a/src/libsyntax_pos/span_encoding.rs
+++ b/src/libsyntax_pos/span_encoding.rs
@@ -68,7 +68,7 @@ const LEN_TAG: u16 = 0b1000_0000_0000_0000;
 const MAX_LEN: u32 = 0b0111_1111_1111_1111;
 const MAX_CTXT: u32 = 0b1111_1111_1111_1111;
 
-/// Dummy span, both position and length are zero, syntax context is zero as well.
+/// Dummy span: both position and length are zero; syntax context is zero (empty) as well.
 pub const DUMMY_SP: Span = Span { base_or_index: 0, len_or_tag: 0, ctxt_or_zero: 0 };
 
 impl Span {

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -101,7 +101,7 @@ symbols! {
     }
 
     // Symbols that can be referred to with syntax_pos::sym::*. The symbol is
-    // the stringified identifier unless otherwise specified (e.g.
+    // the stringified identifier unless otherwise specified (e.g.,
     // `proc_dash_macro` represents "proc-macro").
     //
     // As well as the symbols listed, there are symbols for the the strings
@@ -581,6 +581,7 @@ symbols! {
         rustc_expected_cgu_reuse,
         rustc_if_this_changed,
         rustc_inherit_overflow_checks,
+        rustc_interp_user_fn,
         rustc_layout,
         rustc_layout_scalar_valid_range_end,
         rustc_layout_scalar_valid_range_start,

--- a/src/test/ui/interp-user-fn.rs
+++ b/src/test/ui/interp-user-fn.rs
@@ -1,0 +1,7 @@
+#![feature(stmt_expr_attributes)]
+
+fn main() {
+    let user_body = #[rustc_interp_user_fn] || {};
+    //~^ ERROR `#[rustc_interp_user_fn]` is for use by interpreters only [E0658]
+    user_body();
+}

--- a/src/test/ui/interp-user-fn.stderr
+++ b/src/test/ui/interp-user-fn.stderr
@@ -1,0 +1,12 @@
+error[E0658]: `#[rustc_interp_user_fn]` is for use by interpreters only
+  --> $DIR/interp-user-fn.rs:4:21
+   |
+LL |     let user_body = #[rustc_interp_user_fn] || {};
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(rustc_attrs)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Summary:
* Adds "interpreter mode" to compiler interface. This will be used later in several places, including diagnostics.
* Adds "interpreter tag" to `ast::Local`s to track info like whether they came from a previous eval session or have been moved.
* Added interface for injecting a pre-parsed "user body" into the parsing pipeline. cf. `TyCtxt::get_interp_user_fn`, `expr.rs`
* Moved `Steal` data structure to `rustc_data_structures` crate since a) it was already used outside of `rustc::ty` crate, b) it's now used even a little more outside there.
* Made a few more things `pub` (as little as possible), so the interpreter can use them.

If you want the big picture of where this is going in terms of compiler changes (probably 2/3 more PRs needed), take a look at my [personal branch](https://github.com/alexreg/rust/tree/rush). I will also be publishing the REPL repo itself soon.

Also, sorry for the lack of commits; I basically just carved this out of an even bigger squashed commit after much, much hacking! (It might be a tad heavy on cosmetic stuff too, for the same reason. If it's okay, then great, otherwise I can try to revert certain areas that people really don't want.)

Maybe @Centril / @Zoxc for review? Not wholly sure.

CC @nikomatsakis @mw @eddyb