### PR TITLE
Avoid ICE on return outside of fn with literal array

### DIFF
--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -192,20 +192,23 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
             // All valid indexing looks like this; might encounter non-valid indexes at this point.
             let base_ty = tables.expr_ty_adjusted_opt(&base).map(|t| &t.kind);
             if base_ty.is_none() {
+                // When encountering `return [0][0]` outside of a `fn` body we can encounter a base
+                // that isn't in the type table. We assume more relevant errors have already been
+                // emitted, so we delay an ICE if none have. (#64638)
                 self.tcx().sess.delay_span_bug(e.span, &format!("bad base: `{:?}`", base));
-                return;
             }
             if let Some(ty::Ref(_, base_ty, _)) = base_ty {
-                let index_ty = match tables.expr_ty_adjusted_opt(&index) {
-                    Some(t) => t,
-                    None => {
-                        self.tcx().sess.delay_span_bug(
-                            e.span,
-                            &format!("bad index {:?} for base: `{:?}`", index, base),
-                        );
-                        self.fcx.tcx.types.err
-                    }
-                };
+                let index_ty = tables.expr_ty_adjusted_opt(&index).unwrap_or_else(|| {
+                    // When encountering `return [0][0]` outside of a `fn` body we would attempt
+                    // to access an unexistend index. We assume that more relevant errors will
+                    // already have been emitted, so we only gate on this with an ICE if no
+                    // error has been emitted. (#64638)
+                    self.tcx().sess.delay_span_bug(
+                        e.span,
+                        &format!("bad index {:?} for base: `{:?}`", index, base),
+                    );
+                    self.fcx.tcx.types.err
+                });
                 let index_ty = self.fcx.resolve_vars_if_possible(&index_ty);
 
                 if base_ty.builtin_index().is_some() && index_ty == self.fcx.tcx.types.usize {

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -189,9 +189,23 @@ impl<'cx, 'tcx> WritebackCx<'cx, 'tcx> {
         if let hir::ExprKind::Index(ref base, ref index) = e.kind {
             let mut tables = self.fcx.tables.borrow_mut();
 
-            // All valid indexing looks like this; might encounter non-valid indexes at this point
-            if let ty::Ref(_, base_ty, _) = tables.expr_ty_adjusted(&base).kind {
-                let index_ty = tables.expr_ty_adjusted(&index);
+            // All valid indexing looks like this; might encounter non-valid indexes at this point.
+            let base_ty = tables.expr_ty_adjusted_opt(&base).map(|t| &t.kind);
+            if base_ty.is_none() {
+                self.tcx().sess.delay_span_bug(e.span, &format!("bad base: `{:?}`", base));
+                return;
+            }
+            if let Some(ty::Ref(_, base_ty, _)) = base_ty {
+                let index_ty = match tables.expr_ty_adjusted_opt(&index) {
+                    Some(t) => t,
+                    None => {
+                        self.tcx().sess.delay_span_bug(
+                            e.span,
+                            &format!("bad index {:?} for base: `{:?}`", index, base),
+                        );
+                        self.fcx.tcx.types.err
+                    }
+                };
                 let index_ty = self.fcx.resolve_vars_if_possible(&index_ty);
 
                 if base_ty.builtin_index().is_some() && index_ty == self.fcx.tcx.types.usize {

--- a/src/test/ui/issues/issue-64620.rs
+++ b/src/test/ui/issues/issue-64620.rs
@@ -1,0 +1,5 @@
+enum Bug {
+    V1 = return [0][0] //~ERROR return statement outside of function body
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-64620.stderr
+++ b/src/test/ui/issues/issue-64620.stderr
@@ -1,0 +1,9 @@
+error[E0572]: return statement outside of function body
+  --> $DIR/issue-64620.rs:2:10
+   |
+LL |     V1 = return [0][0]
+   |          ^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0572`.


### PR DESCRIPTION
Do not ICE when encountering `enum E { A = return [0][0] }`.

Fix #64638.