### PR TITLE
libtest: Add --report-time flag to print test execution time

### DIFF
--- a/src/libtest/formatters/mod.rs
+++ b/src/libtest/formatters/mod.rs
@@ -16,6 +16,7 @@ pub(crate) trait OutputFormatter {
         &mut self,
         desc: &TestDesc,
         result: &TestResult,
+        exec_time: Option<&TestExecTime>,
         stdout: &[u8],
         state: &ConsoleTestState,
     ) -> io::Result<()>;

--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -174,6 +174,7 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
         &mut self,
         desc: &TestDesc,
         result: &TestResult,
+        _: Option<&TestExecTime>,
         _: &[u8],
         _: &ConsoleTestState,
     ) -> io::Result<()> {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -566,6 +566,13 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
         ));
     }
 
+    let report_time = matches.opt_present("report-time");
+    if !allow_unstable && report_time {
+        return Some(Err(
+            "The \"report-time\" flag is only accepted on the nightly compiler".into(),
+        ));
+    }
+
     let run_ignored = match (include_ignored, matches.opt_present("ignored")) {
         (true, true) => {
             return Some(Err(
@@ -579,7 +586,6 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     let quiet = matches.opt_present("quiet");
     let exact = matches.opt_present("exact");
     let list = matches.opt_present("list");
-    let report_time = matches.opt_present("report-time");
 
     let logfile = matches.opt_str("logfile");
     let logfile = logfile.map(|s| PathBuf::from(&s));

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -378,6 +378,7 @@ pub struct TestOpts {
     pub format: OutputFormat,
     pub test_threads: Option<usize>,
     pub skip: Vec<String>,
+    pub report_time: bool,
     pub options: Options,
 }
 
@@ -460,6 +461,11 @@ fn optgroups() -> getopts::Options {
             "Enable nightly-only flags:
             unstable-options = Allow use of experimental features",
             "unstable-options",
+        )
+        .optflag(
+            "",
+            "report-time",
+            "Show execution time of each test. Not available for --format=terse"
         );
     return opts;
 }
@@ -573,6 +579,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
     let quiet = matches.opt_present("quiet");
     let exact = matches.opt_present("exact");
     let list = matches.opt_present("list");
+    let report_time = matches.opt_present("report-time");
 
     let logfile = matches.opt_str("logfile");
     let logfile = logfile.map(|s| PathBuf::from(&s));
@@ -653,6 +660,7 @@ pub fn parse_opts(args: &[String]) -> Option<OptRes> {
         format,
         test_threads,
         skip: matches.opt_strs("skip"),
+        report_time,
         options: Options::new().display_output(matches.opt_present("show-output")),
     };
 
@@ -676,6 +684,16 @@ pub enum TestResult {
 }
 
 unsafe impl Send for TestResult {}
+
+/// The meassured execution time of a unit test.
+#[derive(Clone, PartialEq)]
+pub struct TestExecTime(Duration);
+
+impl fmt::Display for TestExecTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.3}s", self.0.as_secs_f64())
+    }
+}
 
 enum OutputLocation<T> {
     Pretty(Box<term::StdoutTerminal>),
@@ -736,17 +754,30 @@ impl ConsoleTestState {
         })
     }
 
-    pub fn write_log<S: AsRef<str>>(&mut self, msg: S) -> io::Result<()> {
-        let msg = msg.as_ref();
+    pub fn write_log<F, S>(
+        &mut self,
+        msg: F,
+    ) -> io::Result<()>
+    where
+        S: AsRef<str>,
+        F: FnOnce() -> S,
+    {
         match self.log_out {
             None => Ok(()),
-            Some(ref mut o) => o.write_all(msg.as_bytes()),
+            Some(ref mut o) => {
+                let msg = msg();
+                let msg = msg.as_ref();
+                o.write_all(msg.as_bytes())
+            },
         }
     }
 
-    pub fn write_log_result(&mut self, test: &TestDesc, result: &TestResult) -> io::Result<()> {
-        self.write_log(format!(
-            "{} {}\n",
+    pub fn write_log_result(&mut self,test: &TestDesc,
+        result: &TestResult,
+        exec_time: Option<&TestExecTime>,
+    ) -> io::Result<()> {
+        self.write_log(|| format!(
+            "{} {}",
             match *result {
                 TrOk => "ok".to_owned(),
                 TrFailed => "failed".to_owned(),
@@ -755,8 +786,12 @@ impl ConsoleTestState {
                 TrAllowedFail => "failed (allowed)".to_owned(),
                 TrBench(ref bs) => fmt_bench_samples(bs),
             },
-            test.name
-        ))
+            test.name,
+        ))?;
+        if let Some(exec_time) = exec_time {
+            self.write_log(|| format!(" {}", exec_time))?;
+        }
+        self.write_log(|| "\n")
     }
 
     fn current_test_count(&self) -> usize {
@@ -843,7 +878,7 @@ pub fn list_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Res
         };
 
         writeln!(output, "{}: {}", name, fntype)?;
-        st.write_log(format!("{} {}\n", fntype, name))?;
+        st.write_log(|| format!("{} {}\n", fntype, name))?;
     }
 
     fn plural(count: u32, s: &str) -> String {
@@ -884,9 +919,9 @@ pub fn run_tests_console(opts: &TestOpts, tests: Vec<TestDescAndFn>) -> io::Resu
             TeFilteredOut(filtered_out) => Ok(st.filtered_out = filtered_out),
             TeWait(ref test) => out.write_test_start(test),
             TeTimeout(ref test) => out.write_timeout(test),
-            TeResult(test, result, stdout) => {
-                st.write_log_result(&test, &result)?;
-                out.write_result(&test, &result, &*stdout, &st)?;
+            TeResult(test, result, exec_time, stdout) => {
+                st.write_log_result(&test, &result, exec_time.as_ref())?;
+                out.write_result(&test, &result, exec_time.as_ref(), &*stdout, &st)?;
                 match result {
                     TrOk => {
                         st.passed += 1;
@@ -1004,12 +1039,12 @@ fn stdout_isatty() -> bool {
 pub enum TestEvent {
     TeFiltered(Vec<TestDesc>),
     TeWait(TestDesc),
-    TeResult(TestDesc, TestResult, Vec<u8>),
+    TeResult(TestDesc, TestResult, Option<TestExecTime>, Vec<u8>),
     TeTimeout(TestDesc),
     TeFilteredOut(usize),
 }
 
-pub type MonitorMsg = (TestDesc, TestResult, Vec<u8>);
+pub type MonitorMsg = (TestDesc, TestResult, Option<TestExecTime>, Vec<u8>);
 
 struct Sink(Arc<Mutex<Vec<u8>>>);
 impl Write for Sink {
@@ -1105,8 +1140,8 @@ where
             let test = remaining.pop().unwrap();
             callback(TeWait(test.desc.clone()))?;
             run_test(opts, !opts.run_tests, test, tx.clone(), Concurrent::No);
-            let (test, result, stdout) = rx.recv().unwrap();
-            callback(TeResult(test, result, stdout))?;
+            let (test, result, exec_time, stdout) = rx.recv().unwrap();
+            callback(TeResult(test, result, exec_time, stdout))?;
         }
     } else {
         while pending > 0 || !remaining.is_empty() {
@@ -1135,10 +1170,10 @@ where
                 }
             }
 
-            let (desc, result, stdout) = res.unwrap();
+            let (desc, result, exec_time, stdout) = res.unwrap();
             running_tests.remove(&desc);
 
-            callback(TeResult(desc, result, stdout))?;
+            callback(TeResult(desc, result, exec_time, stdout))?;
             pending -= 1;
         }
     }
@@ -1148,8 +1183,8 @@ where
         for b in filtered_benchs {
             callback(TeWait(b.desc.clone()))?;
             run_test(opts, false, b, tx.clone(), Concurrent::No);
-            let (test, result, stdout) = rx.recv().unwrap();
-            callback(TeResult(test, result, stdout))?;
+            let (test, result, exec_time, stdout) = rx.recv().unwrap();
+            callback(TeResult(test, result, exec_time, stdout))?;
         }
     }
     Ok(())
@@ -1384,7 +1419,7 @@ pub fn run_test(
         && desc.should_panic != ShouldPanic::No;
 
     if force_ignore || desc.ignore || ignore_because_panic_abort {
-        monitor_ch.send((desc, TrIgnored, Vec::new())).unwrap();
+        monitor_ch.send((desc, TrIgnored, None, Vec::new())).unwrap();
         return;
     }
 
@@ -1392,6 +1427,7 @@ pub fn run_test(
         desc: TestDesc,
         monitor_ch: Sender<MonitorMsg>,
         nocapture: bool,
+        report_time: bool,
         testfn: Box<dyn FnOnce() + Send>,
         concurrency: Concurrent,
     ) {
@@ -1410,7 +1446,16 @@ pub fn run_test(
                 None
             };
 
+            let start = if report_time {
+                Some(Instant::now())
+            } else {
+                None
+            };
             let result = catch_unwind(AssertUnwindSafe(testfn));
+            let exec_time = start.map(|start| {
+                let duration = start.elapsed();
+                TestExecTime(duration)
+            });
 
             if let Some((printio, panicio)) = oldio {
                 io::set_print(printio);
@@ -1420,7 +1465,7 @@ pub fn run_test(
             let test_result = calc_result(&desc, result);
             let stdout = data.lock().unwrap().to_vec();
             monitor_ch
-                .send((desc.clone(), test_result, stdout))
+                .send((desc.clone(), test_result, exec_time, stdout))
                 .unwrap();
         };
 
@@ -1449,12 +1494,20 @@ pub fn run_test(
         }
         DynTestFn(f) => {
             let cb = move || __rust_begin_short_backtrace(f);
-            run_test_inner(desc, monitor_ch, opts.nocapture, Box::new(cb), concurrency)
+            run_test_inner(
+                desc,
+                monitor_ch,
+                opts.nocapture,
+                opts.report_time,
+                Box::new(cb),
+                concurrency,
+            )
         }
         StaticTestFn(f) => run_test_inner(
             desc,
             monitor_ch,
             opts.nocapture,
+            opts.report_time,
             Box::new(move || __rust_begin_short_backtrace(f)),
             concurrency,
         ),
@@ -1702,7 +1755,7 @@ pub mod bench {
         };
 
         let stdout = data.lock().unwrap().to_vec();
-        monitor_ch.send((desc, test_result, stdout)).unwrap();
+        monitor_ch.send((desc, test_result, None, stdout)).unwrap();
     }
 
     pub fn run_once<F>(f: F)


### PR DESCRIPTION
Implements the flag `--report-time` to print the execution time of each executed (successful or failed) test.

Closes #46610

# Example

`cargo test -- --report-time` produces the following output to stdout:
```
running 6 tests
test tests::ignore ... ignored
test tests::noop ... ok 0.000s
test tests::should_panic ... ok 0.000s
test tests::panic_after_10millis ... FAILED 0.010s
test tests::sleep_100millis ... ok 0.100s
test tests::sleep_10secs ... ok 10.001s

failures:

---- tests::panic_after_10millis stdout ----
thread 'tests::panic_after_10millis' panicked at 'foo', src\lib.rs:31:9


failures:
    tests::panic_after_10millis

test result: FAILED. 4 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out
```
`cargo test -- --report-time -Z unstable-options --format=json` produces the following output to stdout:
```
{ "type": "suite", "event": "started", "test_count": 6 }
{ "type": "test", "event": "started", "name": "tests::ignore" }
{ "type": "test", "event": "started", "name": "tests::noop" }
{ "type": "test", "event": "started", "name": "tests::panic_after_10millis" }
{ "type": "test", "event": "started", "name": "tests::should_panic" }
{ "type": "test", "name": "tests::ignore", "event": "ignored" }
{ "type": "test", "event": "started", "name": "tests::sleep_100millis" }
{ "type": "test", "name": "tests::noop", "event": "ok", "exec_time": "0.000s" }
{ "type": "test", "event": "started", "name": "tests::sleep_10secs" }
{ "type": "test", "name": "tests::should_panic", "event": "ok", "exec_time": "0.000s" }
{ "type": "test", "name": "tests::panic_after_10millis", "event": "failed", "exec_time": "0.010s", "stdout": "thread 'tests::panic_after_10millis' panicked at 'foo', src\\lib.rs:31:9\n" }
{ "type": "test", "name": "tests::sleep_100millis", "event": "ok", "exec_time": "0.101s" }
{ "type": "test", "name": "tests::sleep_10secs", "event": "ok", "exec_time": "10.000s" }
{ "type": "suite", "event": "failed", "passed": 4, "failed": 1, "allowed_fail": 0, "ignored": 1, "measured": 0, "filtered_out": 0 }
```
`cargo test -- --report-time --logfile foo.log` produces the following logfile:
```
ignored tests::ignore
ok tests::noop 0.000s
ok tests::should_panic 0.000s
failed tests::panic_after_10millis 0.010s
ok tests::sleep_100millis 0.100s
ok tests::sleep_10secs 10.001s
```

