### PR TITLE
fully remove AstBuilder

### DIFF
--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -9,9 +9,6 @@ use crate::ThinVec;
 use rustc_target::spec::abi::Abi;
 use syntax_pos::{Pos, Span};
 
-// Left so that Cargo tests don't break, this can be removed once those no longer use it
-pub trait AstBuilder {}
-
 impl<'a> ExtCtxt<'a> {
     pub fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
         self.path_all(span, false, strs, vec![], vec![])


### PR DESCRIPTION
The mentioned Cargo test is fixed in https://github.com/rust-lang/cargo/pull/7210

I think this can be removed now?