### PR TITLE
Cleanup syntax::ext::build

### DIFF
--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -1,12 +1,11 @@
-use crate::ast::{self, Ident, Generics, Expr, BlockCheckMode, UnOp, PatKind};
+use crate::ast::{self, Ident, Expr, BlockCheckMode, UnOp, PatKind};
 use crate::attr;
-use crate::source_map::{dummy_spanned, respan, Spanned};
+use crate::source_map::{respan, Spanned};
 use crate::ext::base::ExtCtxt;
 use crate::ptr::P;
 use crate::symbol::{kw, sym, Symbol};
 use crate::ThinVec;
 
-use rustc_target::spec::abi::Abi;
 use syntax_pos::{Pos, Span};
 
 // Left so that Cargo tests don't break, this can be removed once those no longer use it
@@ -49,42 +48,6 @@ impl<'a> ExtCtxt<'a> {
             args,
         });
         ast::Path { span, segments }
-    }
-
-    /// Constructs a qualified path.
-    ///
-    /// Constructs a path like `<self_type as trait_path>::ident`.
-    pub fn qpath(&self,
-             self_type: P<ast::Ty>,
-             trait_path: ast::Path,
-             ident: ast::Ident)
-             -> (ast::QSelf, ast::Path) {
-        self.qpath_all(self_type, trait_path, ident, vec![], vec![])
-    }
-
-    /// Constructs a qualified path.
-    ///
-    /// Constructs a path like `<self_type as trait_path>::ident<'a, T, A = Bar>`.
-    pub fn qpath_all(&self,
-                 self_type: P<ast::Ty>,
-                 trait_path: ast::Path,
-                 ident: ast::Ident,
-                 args: Vec<ast::GenericArg>,
-                 constraints: Vec<ast::AssocTyConstraint>)
-                 -> (ast::QSelf, ast::Path) {
-        let mut path = trait_path;
-        let args = if !args.is_empty() || !constraints.is_empty() {
-            ast::AngleBracketedArgs { args, constraints, span: ident.span }.into()
-        } else {
-            None
-        };
-        path.segments.push(ast::PathSegment { ident, id: ast::DUMMY_NODE_ID, args });
-
-        (ast::QSelf {
-            ty: self_type,
-            path_span: path.span,
-            position: path.segments.len() - 1
-        }, path)
     }
 
     pub fn ty_mt(&self, ty: P<ast::Ty>, mutbl: ast::Mutability) -> ast::MutTy {
@@ -219,14 +182,6 @@ impl<'a> ExtCtxt<'a> {
         }
     }
 
-    pub fn stmt_semi(&self, expr: P<ast::Expr>) -> ast::Stmt {
-        ast::Stmt {
-            id: ast::DUMMY_NODE_ID,
-            span: expr.span,
-            node: ast::StmtKind::Semi(expr),
-        }
-    }
-
     pub fn stmt_let(&self, sp: Span, mutbl: bool, ident: ast::Ident,
                 ex: P<ast::Expr>) -> ast::Stmt {
         let pat = if mutbl {
@@ -238,34 +193,6 @@ impl<'a> ExtCtxt<'a> {
         let local = P(ast::Local {
             pat,
             ty: None,
-            init: Some(ex),
-            id: ast::DUMMY_NODE_ID,
-            span: sp,
-            attrs: ThinVec::new(),
-        });
-        ast::Stmt {
-            id: ast::DUMMY_NODE_ID,
-            node: ast::StmtKind::Local(local),
-            span: sp,
-        }
-    }
-
-    pub fn stmt_let_typed(&self,
-                      sp: Span,
-                      mutbl: bool,
-                      ident: ast::Ident,
-                      typ: P<ast::Ty>,
-                      ex: P<ast::Expr>)
-                      -> ast::Stmt {
-        let pat = if mutbl {
-            let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Mutable);
-            self.pat_ident_binding_mode(sp, ident, binding_mode)
-        } else {
-            self.pat_ident(sp, ident)
-        };
-        let local = P(ast::Local {
-            pat,
-            ty: Some(typ),
             init: Some(ex),
             id: ast::DUMMY_NODE_ID,
             span: sp,
@@ -332,11 +259,6 @@ impl<'a> ExtCtxt<'a> {
         self.expr(path.span, ast::ExprKind::Path(None, path))
     }
 
-    /// Constructs a `QPath` expression.
-    pub fn expr_qpath(&self, span: Span, qself: ast::QSelf, path: ast::Path) -> P<ast::Expr> {
-        self.expr(span, ast::ExprKind::Path(Some(qself), path))
-    }
-
     pub fn expr_ident(&self, span: Span, id: ast::Ident) -> P<ast::Expr> {
         self.expr_path(self.path_ident(span, id))
     }
@@ -350,26 +272,11 @@ impl<'a> ExtCtxt<'a> {
     }
 
     pub fn expr_deref(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
-        self.expr_unary(sp, UnOp::Deref, e)
-    }
-    pub fn expr_unary(&self, sp: Span, op: ast::UnOp, e: P<ast::Expr>) -> P<ast::Expr> {
-        self.expr(sp, ast::ExprKind::Unary(op, e))
+        self.expr(sp, ast::ExprKind::Unary(UnOp::Deref, e))
     }
 
-    pub fn expr_field_access(
-        &self, sp: Span, expr: P<ast::Expr>, ident: ast::Ident,
-    ) -> P<ast::Expr> {
-        self.expr(sp, ast::ExprKind::Field(expr, ident.with_span_pos(sp)))
-    }
-    pub fn expr_tup_field_access(&self, sp: Span, expr: P<ast::Expr>, idx: usize) -> P<ast::Expr> {
-        let ident = Ident::new(sym::integer(idx), sp);
-        self.expr(sp, ast::ExprKind::Field(expr, ident))
-    }
     pub fn expr_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Immutable, e))
-    }
-    pub fn expr_mut_addr_of(&self, sp: Span, e: P<ast::Expr>) -> P<ast::Expr> {
-        self.expr(sp, ast::ExprKind::AddrOf(ast::Mutability::Mutable, e))
     }
 
     pub fn expr_call(
@@ -426,27 +333,9 @@ impl<'a> ExtCtxt<'a> {
         self.expr_lit(span, ast::LitKind::Int(i as u128,
                                               ast::LitIntType::Unsigned(ast::UintTy::Usize)))
     }
-    pub fn expr_isize(&self, sp: Span, i: isize) -> P<ast::Expr> {
-        if i < 0 {
-            let i = (-i) as u128;
-            let lit_ty = ast::LitIntType::Signed(ast::IntTy::Isize);
-            let lit = self.expr_lit(sp, ast::LitKind::Int(i, lit_ty));
-            self.expr_unary(sp, ast::UnOp::Neg, lit)
-        } else {
-            self.expr_lit(sp, ast::LitKind::Int(i as u128,
-                                                ast::LitIntType::Signed(ast::IntTy::Isize)))
-        }
-    }
     pub fn expr_u32(&self, sp: Span, u: u32) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Int(u as u128,
                                             ast::LitIntType::Unsigned(ast::UintTy::U32)))
-    }
-    pub fn expr_u16(&self, sp: Span, u: u16) -> P<ast::Expr> {
-        self.expr_lit(sp, ast::LitKind::Int(u as u128,
-                                            ast::LitIntType::Unsigned(ast::UintTy::U16)))
-    }
-    pub fn expr_u8(&self, sp: Span, u: u8) -> P<ast::Expr> {
-        self.expr_lit(sp, ast::LitKind::Int(u as u128, ast::LitIntType::Unsigned(ast::UintTy::U8)))
     }
     pub fn expr_bool(&self, sp: Span, value: bool) -> P<ast::Expr> {
         self.expr_lit(sp, ast::LitKind::Bool(value))
@@ -454,10 +343,6 @@ impl<'a> ExtCtxt<'a> {
 
     pub fn expr_vec(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Array(exprs))
-    }
-    pub fn expr_vec_ng(&self, sp: Span) -> P<ast::Expr> {
-        self.expr_call_global(sp, self.std_path(&[sym::vec, sym::Vec, sym::new]),
-                              Vec::new())
     }
     pub fn expr_vec_slice(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr_addr_of(sp, self.expr_vec(sp, exprs))
@@ -473,16 +358,6 @@ impl<'a> ExtCtxt<'a> {
     pub fn expr_some(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let some = self.std_path(&[sym::option, sym::Option, sym::Some]);
         self.expr_call_global(sp, some, vec![expr])
-    }
-
-    pub fn expr_none(&self, sp: Span) -> P<ast::Expr> {
-        let none = self.std_path(&[sym::option, sym::Option, sym::None]);
-        let none = self.path_global(sp, none);
-        self.expr_path(none)
-    }
-
-    pub fn expr_break(&self, sp: Span) -> P<ast::Expr> {
-        self.expr(sp, ast::ExprKind::Break(None, None))
     }
 
     pub fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
@@ -511,11 +386,6 @@ impl<'a> ExtCtxt<'a> {
     pub fn expr_ok(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
         let ok = self.std_path(&[sym::result, sym::Result, sym::Ok]);
         self.expr_call_global(sp, ok, vec![expr])
-    }
-
-    pub fn expr_err(&self, sp: Span, expr: P<ast::Expr>) -> P<ast::Expr> {
-        let err = self.std_path(&[sym::result, sym::Result, sym::Err]);
-        self.expr_call_global(sp, err, vec![expr])
     }
 
     pub fn expr_try(&self, sp: Span, head: P<ast::Expr>) -> P<ast::Expr> {
@@ -634,10 +504,6 @@ impl<'a> ExtCtxt<'a> {
         self.expr(span, ast::ExprKind::If(cond, self.block_expr(then), els))
     }
 
-    pub fn expr_loop(&self, span: Span, block: P<ast::Block>) -> P<ast::Expr> {
-        self.expr(span, ast::ExprKind::Loop(block, None))
-    }
-
     pub fn lambda_fn_decl(&self,
                       span: Span,
                       fn_decl: P<ast::FnDecl>,
@@ -681,16 +547,6 @@ impl<'a> ExtCtxt<'a> {
         self.lambda(span, vec![ident], body)
     }
 
-    pub fn lambda_stmts(&self,
-                    span: Span,
-                    ids: Vec<ast::Ident>,
-                    stmts: Vec<ast::Stmt>)
-                    -> P<ast::Expr> {
-        self.lambda(span, ids, self.expr_block(self.block(span, stmts)))
-    }
-    pub fn lambda_stmts_0(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Expr> {
-        self.lambda0(span, self.expr_block(self.block(span, stmts)))
-    }
     pub fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>,
                       ident: ast::Ident) -> P<ast::Expr> {
         self.lambda1(span, self.expr_block(self.block(span, stmts)), ident)
@@ -732,43 +588,6 @@ impl<'a> ExtCtxt<'a> {
         })
     }
 
-    pub fn item_fn_poly(&self,
-                    span: Span,
-                    name: Ident,
-                    inputs: Vec<ast::Param> ,
-                    output: P<ast::Ty>,
-                    generics: Generics,
-                    body: P<ast::Block>) -> P<ast::Item> {
-        self.item(span,
-                  name,
-                  Vec::new(),
-                  ast::ItemKind::Fn(self.fn_decl(inputs, ast::FunctionRetTy::Ty(output)),
-                              ast::FnHeader {
-                                  unsafety: ast::Unsafety::Normal,
-                                  asyncness: dummy_spanned(ast::IsAsync::NotAsync),
-                                  constness: dummy_spanned(ast::Constness::NotConst),
-                                  abi: Abi::Rust,
-                              },
-                              generics,
-                              body))
-    }
-
-    pub fn item_fn(&self,
-               span: Span,
-               name: Ident,
-               inputs: Vec<ast::Param> ,
-               output: P<ast::Ty>,
-               body: P<ast::Block>
-              ) -> P<ast::Item> {
-        self.item_fn_poly(
-            span,
-            name,
-            inputs,
-            output,
-            Generics::default(),
-            body)
-    }
-
     pub fn variant(&self, span: Span, ident: Ident, tys: Vec<P<ast::Ty>> ) -> ast::Variant {
         let fields: Vec<_> = tys.into_iter().map(|ty| {
             ast::StructField {
@@ -799,52 +618,6 @@ impl<'a> ExtCtxt<'a> {
         }
     }
 
-    pub fn item_enum_poly(&self, span: Span, name: Ident,
-                      enum_definition: ast::EnumDef,
-                      generics: Generics) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::Enum(enum_definition, generics))
-    }
-
-    pub fn item_enum(&self, span: Span, name: Ident,
-                 enum_definition: ast::EnumDef) -> P<ast::Item> {
-        self.item_enum_poly(span, name, enum_definition,
-                            Generics::default())
-    }
-
-    pub fn item_struct(&self, span: Span, name: Ident,
-                   struct_def: ast::VariantData) -> P<ast::Item> {
-        self.item_struct_poly(
-            span,
-            name,
-            struct_def,
-            Generics::default()
-        )
-    }
-
-    pub fn item_struct_poly(&self, span: Span, name: Ident,
-        struct_def: ast::VariantData, generics: Generics) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::Struct(struct_def, generics))
-    }
-
-    pub fn item_mod(&self, span: Span, inner_span: Span, name: Ident,
-                attrs: Vec<ast::Attribute>,
-                items: Vec<P<ast::Item>>) -> P<ast::Item> {
-        self.item(
-            span,
-            name,
-            attrs,
-            ast::ItemKind::Mod(ast::Mod {
-                inner: inner_span,
-                items,
-                inline: true
-            })
-        )
-    }
-
-    pub fn item_extern_crate(&self, span: Span, name: Ident) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::ExternCrate(None))
-    }
-
     pub fn item_static(&self,
                    span: Span,
                    name: Ident,
@@ -862,15 +635,6 @@ impl<'a> ExtCtxt<'a> {
                   expr: P<ast::Expr>)
                   -> P<ast::Item> {
         self.item(span, name, Vec::new(), ast::ItemKind::Const(ty, expr))
-    }
-
-    pub fn item_ty_poly(&self, span: Span, name: Ident, ty: P<ast::Ty>,
-                    generics: Generics) -> P<ast::Item> {
-        self.item(span, name, Vec::new(), ast::ItemKind::TyAlias(ty, generics))
-    }
-
-    pub fn item_ty(&self, span: Span, name: Ident, ty: P<ast::Ty>) -> P<ast::Item> {
-        self.item_ty_poly(span, name, ty, Generics::default())
     }
 
     pub fn attribute(&self, mi: ast::MetaItem) -> ast::Attribute {
@@ -893,57 +657,5 @@ impl<'a> ExtCtxt<'a> {
     pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
                        -> ast::MetaItem {
         attr::mk_name_value_item(Ident::new(name, span), lit_kind, span)
-    }
-
-    pub fn item_use(&self, sp: Span,
-                vis: ast::Visibility, vp: P<ast::UseTree>) -> P<ast::Item> {
-        P(ast::Item {
-            id: ast::DUMMY_NODE_ID,
-            ident: Ident::invalid(),
-            attrs: vec![],
-            node: ast::ItemKind::Use(vp),
-            vis,
-            span: sp,
-            tokens: None,
-        })
-    }
-
-    pub fn item_use_simple(&self, sp: Span, vis: ast::Visibility, path: ast::Path) -> P<ast::Item> {
-        self.item_use_simple_(sp, vis, None, path)
-    }
-
-    pub fn item_use_simple_(&self, sp: Span, vis: ast::Visibility,
-                        rename: Option<ast::Ident>, path: ast::Path) -> P<ast::Item> {
-        self.item_use(sp, vis, P(ast::UseTree {
-            span: sp,
-            prefix: path,
-            kind: ast::UseTreeKind::Simple(rename, ast::DUMMY_NODE_ID, ast::DUMMY_NODE_ID),
-        }))
-    }
-
-    pub fn item_use_list(&self, sp: Span, vis: ast::Visibility,
-                     path: Vec<ast::Ident>, imports: &[ast::Ident]) -> P<ast::Item> {
-        let imports = imports.iter().map(|id| {
-            (ast::UseTree {
-                span: sp,
-                prefix: self.path(sp, vec![*id]),
-                kind: ast::UseTreeKind::Simple(None, ast::DUMMY_NODE_ID, ast::DUMMY_NODE_ID),
-            }, ast::DUMMY_NODE_ID)
-        }).collect();
-
-        self.item_use(sp, vis, P(ast::UseTree {
-            span: sp,
-            prefix: self.path(sp, path),
-            kind: ast::UseTreeKind::Nested(imports),
-        }))
-    }
-
-    pub fn item_use_glob(&self, sp: Span,
-                     vis: ast::Visibility, path: Vec<ast::Ident>) -> P<ast::Item> {
-        self.item_use(sp, vis, P(ast::UseTree {
-            span: sp,
-            prefix: self.path(sp, path),
-            kind: ast::UseTreeKind::Glob,
-        }))
     }
 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -640,18 +640,4 @@ impl<'a> ExtCtxt<'a> {
     pub fn meta_word(&self, sp: Span, w: ast::Name) -> ast::MetaItem {
         attr::mk_word_item(Ident::new(w, sp))
     }
-
-    pub fn meta_list_item_word(&self, sp: Span, w: ast::Name) -> ast::NestedMetaItem {
-        attr::mk_nested_word_item(Ident::new(w, sp))
-    }
-
-    pub fn meta_list(&self, sp: Span, name: ast::Name, mis: Vec<ast::NestedMetaItem>)
-                 -> ast::MetaItem {
-        attr::mk_list_item(Ident::new(name, sp), mis)
-    }
-
-    pub fn meta_name_value(&self, span: Span, name: ast::Name, lit_kind: ast::LitKind)
-                       -> ast::MetaItem {
-        attr::mk_name_value_item(Ident::new(name, span), lit_kind, span)
-    }
 }

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -111,10 +111,6 @@ impl<'a> ExtCtxt<'a> {
                 ast::TyKind::Ptr(self.ty_mt(ty, mutbl)))
     }
 
-    pub fn ty_infer(&self, span: Span) -> P<ast::Ty> {
-        self.ty(span, ast::TyKind::Infer)
-    }
-
     pub fn typaram(&self,
                span: Span,
                ident: ast::Ident,
@@ -524,7 +520,7 @@ impl<'a> ExtCtxt<'a> {
               body: P<ast::Expr>)
               -> P<ast::Expr> {
         let fn_decl = self.fn_decl(
-            ids.iter().map(|id| self.param(span, *id, self.ty_infer(span))).collect(),
+            ids.iter().map(|id| self.param(span, *id, self.ty(span, ast::TyKind::Infer))).collect(),
             ast::FunctionRetTy::Default(span));
 
         // FIXME -- We are using `span` as the span of the `|...|`

--- a/src/libsyntax/ext/build.rs
+++ b/src/libsyntax/ext/build.rs
@@ -14,20 +14,19 @@ pub trait AstBuilder {}
 
 impl<'a> ExtCtxt<'a> {
     pub fn path(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
-        self.path_all(span, false, strs, vec![], vec![])
+        self.path_all(span, false, strs, vec![])
     }
     pub fn path_ident(&self, span: Span, id: ast::Ident) -> ast::Path {
         self.path(span, vec![id])
     }
     pub fn path_global(&self, span: Span, strs: Vec<ast::Ident> ) -> ast::Path {
-        self.path_all(span, true, strs, vec![], vec![])
+        self.path_all(span, true, strs, vec![])
     }
     pub fn path_all(&self,
                 span: Span,
                 global: bool,
                 mut idents: Vec<ast::Ident> ,
-                args: Vec<ast::GenericArg>,
-                constraints: Vec<ast::AssocTyConstraint> )
+                args: Vec<ast::GenericArg>)
                 -> ast::Path {
         assert!(!idents.is_empty());
         let add_root = global && !idents[0].is_path_segment_keyword();
@@ -39,8 +38,8 @@ impl<'a> ExtCtxt<'a> {
         segments.extend(idents.into_iter().map(|ident| {
             ast::PathSegment::from_ident(ident.with_span_pos(span))
         }));
-        let args = if !args.is_empty() || !constraints.is_empty() {
-            ast::AngleBracketedArgs { args, constraints, span }.into()
+        let args = if !args.is_empty() {
+            ast::AngleBracketedArgs { args, constraints: Vec::new(), span }.into()
         } else {
             None
         };

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -115,7 +115,7 @@ fn cs_clone_shallow(name: &str,
         let span = cx.with_def_site_ctxt(span);
         let assert_path = cx.path_all(span, true,
                                         cx.std_path(&[sym::clone, Symbol::intern(helper_name)]),
-                                        vec![GenericArg::Type(ty)], vec![]);
+                                        vec![GenericArg::Type(ty)]);
         stmts.push(cx.stmt_let_type_only(span, cx.ty_path(assert_path)));
     }
     fn process_variant(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>, variant: &VariantData) {

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -56,7 +56,7 @@ fn cs_total_eq_assert(cx: &mut ExtCtxt<'_>,
         let span = cx.with_def_site_ctxt(span);
         let assert_path = cx.path_all(span, true,
                                         cx.std_path(&[sym::cmp, Symbol::intern(helper_name)]),
-                                        vec![GenericArg::Type(ty)], vec![]);
+                                        vec![GenericArg::Type(ty)]);
         stmts.push(cx.stmt_let_type_only(span, cx.ty_path(assert_path)));
     }
     fn process_variant(cx: &mut ExtCtxt<'_>,

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -2,7 +2,7 @@ use crate::deriving::path_std;
 use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
-use syntax::ast::{self, Expr, MetaItem, GenericArg};
+use syntax::ast::{self, Ident, Expr, MetaItem, GenericArg};
 use syntax::ext::base::{Annotatable, ExtCtxt, SpecialDerives};
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
@@ -16,8 +16,8 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,
     cx.resolver.add_derives(cx.current_expansion.id.expn_data().parent, SpecialDerives::EQ);
 
     let inline = cx.meta_word(span, sym::inline);
-    let hidden = cx.meta_list_item_word(span, sym::hidden);
-    let doc = cx.meta_list(span, sym::doc, vec![hidden]);
+    let hidden = syntax::attr::mk_nested_word_item(Ident::new(sym::hidden, span));
+    let doc = syntax::attr::mk_list_item(Ident::new(sym::doc, span), vec![hidden]);
     let attrs = vec![cx.attribute(inline), cx.attribute(doc)];
     let trait_def = TraitDef {
         span,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -672,8 +672,11 @@ impl<'a> TraitDef<'a> {
         attr::mark_used(&attr);
         let opt_trait_ref = Some(trait_ref);
         let unused_qual = {
-            let word = cx.meta_list_item_word(self.span, Symbol::intern("unused_qualifications"));
-            cx.attribute(cx.meta_list(self.span, sym::allow, vec![word]))
+            let word = syntax::attr::mk_nested_word_item(
+                Ident::new(Symbol::intern("unused_qualifications"), self.span));
+            let list = syntax::attr::mk_list_item(
+                Ident::new(sym::allow, self.span), vec![word]);
+            cx.attribute(list)
         };
 
         let mut a = vec![attr, unused_qual];

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -664,7 +664,7 @@ impl<'a> TraitDef<'a> {
         }).collect();
 
         // Create the type of `self`.
-        let path = cx.path_all(self.span, false, vec![type_ident], self_params, vec![]);
+        let path = cx.path_all(self.span, false, vec![type_ident], self_params);
         let self_type = cx.ty_path(path);
 
         let attr = cx.attribute(cx.meta_word(self.span, sym::automatically_derived));

--- a/src/libsyntax_ext/deriving/generic/ty.rs
+++ b/src/libsyntax_ext/deriving/generic/ty.rs
@@ -82,12 +82,12 @@ impl<'a> Path<'a> {
                        .collect();
 
         match self.kind {
-            PathKind::Global => cx.path_all(span, true, idents, params, Vec::new()),
-            PathKind::Local => cx.path_all(span, false, idents, params, Vec::new()),
+            PathKind::Global => cx.path_all(span, true, idents, params),
+            PathKind::Local => cx.path_all(span, false, idents, params),
             PathKind::Std => {
                 let def_site = cx.with_def_site_ctxt(DUMMY_SP);
                 idents.insert(0, Ident::new(kw::DollarCrate, def_site));
-                cx.path_all(span, false, idents, params, Vec::new())
+                cx.path_all(span, false, idents, params)
             }
         }
 
@@ -183,7 +183,7 @@ impl<'a> Ty<'a> {
                     }
                 }).collect();
 
-                cx.path_all(span, false, vec![self_ty], params, vec![])
+                cx.path_all(span, false, vec![self_ty], params)
             }
             Literal(ref p) => p.to_path(cx, span, self_ty, generics),
             Ptr(..) => cx.span_bug(span, "pointer in a path in generic `derive`"),

--- a/src/libsyntax_ext/env.rs
+++ b/src/libsyntax_ext/env.rs
@@ -32,7 +32,7 @@ pub fn expand_option_env<'cx>(cx: &'cx mut ExtCtxt<'_>,
                                                                  Ident::new(sym::str, sp)),
                                                      Some(lt),
                                                      ast::Mutability::Immutable))],
-                                     vec![]))
+                                     ))
         }
         Ok(s) => {
             cx.expr_call_global(sp,

--- a/src/libsyntax_ext/test.rs
+++ b/src/libsyntax_ext/test.rs
@@ -145,8 +145,8 @@ pub fn expand_test_or_bench(
     let mut test_const = cx.item(sp, ast::Ident::new(item.ident.name, sp),
         vec![
             // #[cfg(test)]
-            cx.attribute(cx.meta_list(attr_sp, sym::cfg, vec![
-                cx.meta_list_item_word(attr_sp, sym::test)
+            cx.attribute(attr::mk_list_item(ast::Ident::new(sym::cfg, attr_sp), vec![
+                attr::mk_nested_word_item(ast::Ident::new(sym::test, attr_sp))
             ])),
             // #[rustc_test_marker]
             cx.attribute(cx.meta_word(attr_sp, sym::rustc_test_marker)),


### PR DESCRIPTION
I suspect most of this code could be inlined but I only removed the bits where the inlining didn't really hurt readability (i.e., method call -> function call) or the completely unused code.
