### PR TITLE
Propagate `types.err` in locals further to avoid spurious knock-down errors

### DIFF
--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -163,7 +163,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
 
         // Just ignore error types.
         if a.references_error() || b.references_error() {
-            return success(vec![], b, vec![]);
+            return success(vec![], self.fcx.tcx.types.err, vec![]);
         }
 
         if a.is_never() {
@@ -821,7 +821,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let (adjustments, _) = self.register_infer_ok_obligations(ok);
         self.apply_adjustments(expr, adjustments);
-        Ok(target)
+        if expr_ty.references_error() {
+            Ok(self.tcx.types.err)
+        } else {
+            Ok(target)
+        }
     }
 
     /// Same as `try_coerce()`, but without side-effects.

--- a/src/librustc_typeck/check/coercion.rs
+++ b/src/librustc_typeck/check/coercion.rs
@@ -821,11 +821,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let (adjustments, _) = self.register_infer_ok_obligations(ok);
         self.apply_adjustments(expr, adjustments);
-        if expr_ty.references_error() {
-            Ok(self.tcx.types.err)
+        Ok(if expr_ty.references_error() {
+            self.tcx.types.err
         } else {
-            Ok(target)
-        }
+            target
+        })
     }
 
     /// Same as `try_coerce()`, but without side-effects.

--- a/src/test/ui/issues/issue-33575.rs
+++ b/src/test/ui/issues/issue-33575.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let baz = ().foo(); //~ ERROR no method named `foo` found for type `()` in the current scope
+    <i32 as std::str::FromStr>::from_str(&baz); // No complains about `str` being unsized
+}

--- a/src/test/ui/issues/issue-33575.rs
+++ b/src/test/ui/issues/issue-33575.rs
@@ -1,4 +1,4 @@
 fn main() {
     let baz = ().foo(); //~ ERROR no method named `foo` found for type `()` in the current scope
-    <i32 as std::str::FromStr>::from_str(&baz); // No complains about `str` being unsized
+    <i32 as std::str::FromStr>::from_str(&baz); // No complaints about `str` being unsized
 }

--- a/src/test/ui/issues/issue-33575.stderr
+++ b/src/test/ui/issues/issue-33575.stderr
@@ -1,0 +1,9 @@
+error[E0599]: no method named `foo` found for type `()` in the current scope
+  --> $DIR/issue-33575.rs:2:18
+   |
+LL |     let baz = ().foo();
+   |                  ^^^ method not found in `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Fix #33575, fix #44504.