### PR TITLE
Deprecate `#![plugin]` & `#[plugin_registrar]`

### DIFF
--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -278,13 +278,21 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // Plugins:
-    ungated!(plugin_registrar, Normal, template!(Word)),
+    (
+        sym::plugin_registrar, Normal, template!(Word),
+        Gated(
+            Stability::Deprecated("https://github.com/rust-lang/rust/issues/29597", None),
+            sym::plugin_registrar,
+            "compiler plugins are deprecated",
+            cfg_fn!(plugin_registrar)
+        )
+    ),
     (
         sym::plugin, CrateLevel, template!(List: "name|name(args)"),
         Gated(
             Stability::Deprecated("https://github.com/rust-lang/rust/issues/29597", None),
             sym::plugin,
-            "compiler plugins are deprecated and will be removed in 1.44.0",
+            "compiler plugins are deprecated",
             cfg_fn!(plugin)
         )
     ),

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -279,9 +279,14 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     // Plugins:
     ungated!(plugin_registrar, Normal, template!(Word)),
-    gated!(
-        plugin, CrateLevel, template!(List: "name|name(args)"),
-        "compiler plugins are experimental and possibly buggy",
+    (
+        sym::plugin, CrateLevel, template!(List: "name|name(args)"),
+        Gated(
+            Stability::Deprecated("https://github.com/rust-lang/rust/issues/29597", None),
+            sym::plugin,
+            "compiler plugins are deprecated and will be removed in 1.44.0",
+            cfg_fn!(plugin)
+        )
     ),
 
     // Testing:

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -311,10 +311,6 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 if attr::contains_name(&i.attrs[..], sym::plugin_registrar) {
                     gate_feature_post!(&self, plugin_registrar, i.span,
                                        "compiler plugins are experimental and possibly buggy");
-                    self.parse_sess.span_diagnostic.span_warn(
-                        i.span,
-                        "`#[plugin_registrar]` is deprecated and will be removed in 1.44.0",
-                    );
                 }
                 if attr::contains_name(&i.attrs[..], sym::start) {
                     gate_feature_post!(&self, start, i.span,

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -311,6 +311,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 if attr::contains_name(&i.attrs[..], sym::plugin_registrar) {
                     gate_feature_post!(&self, plugin_registrar, i.span,
                                        "compiler plugins are experimental and possibly buggy");
+                    self.parse_sess.span_diagnostic.span_warn(
+                        i.span,
+                        "`#[plugin_registrar]` is deprecated and will be removed in 1.44.0",
+                    );
                 }
                 if attr::contains_name(&i.attrs[..], sym::start) {
                     gate_feature_post!(&self, start, i.span,

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -41,7 +41,7 @@ impl MetadataLoader for NoLlvmMetadataLoader {
 struct TheBackend;
 
 impl CodegenBackend for TheBackend {
-    fn metadata_loader(&self) -> Box<MetadataLoader + Sync> {
+    fn metadata_loader(&self) -> Box<dyn MetadataLoader + Sync> {
         Box::new(NoLlvmMetadataLoader)
     }
 
@@ -64,7 +64,7 @@ impl CodegenBackend for TheBackend {
         tcx: TyCtxt<'tcx>,
         _metadata: EncodedMetadata,
         _need_metadata_module: bool,
-    ) -> Box<Any> {
+    ) -> Box<dyn Any> {
         use rustc::hir::def_id::LOCAL_CRATE;
 
         Box::new(tcx.crate_name(LOCAL_CRATE) as Symbol)
@@ -72,7 +72,7 @@ impl CodegenBackend for TheBackend {
 
     fn join_codegen_and_link(
         &self,
-        ongoing_codegen: Box<Any>,
+        ongoing_codegen: Box<dyn Any>,
         sess: &Session,
         _dep_graph: &DepGraph,
         outputs: &OutputFilenames,
@@ -97,6 +97,6 @@ impl CodegenBackend for TheBackend {
 
 /// This is the entrypoint for a hot plugged rustc_codegen_llvm
 #[no_mangle]
-pub fn __rustc_codegen_backend() -> Box<CodegenBackend> {
+pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
     Box::new(TheBackend)
 }

--- a/src/test/ui-fulldeps/gated-plugin.rs
+++ b/src/test/ui-fulldeps/gated-plugin.rs
@@ -1,6 +1,8 @@
+// ignore-tidy-linelength
 // aux-build:attr-plugin-test.rs
 
 #![plugin(attr_plugin_test)]
-//~^ ERROR compiler plugins are experimental and possibly buggy
+//~^ ERROR compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui-fulldeps/gated-plugin.rs
+++ b/src/test/ui-fulldeps/gated-plugin.rs
@@ -1,8 +1,7 @@
-// ignore-tidy-linelength
 // aux-build:attr-plugin-test.rs
 
 #![plugin(attr_plugin_test)]
-//~^ ERROR compiler plugins are deprecated and will be removed in 1.44.0
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~^ ERROR compiler plugins are deprecated
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -1,11 +1,19 @@
-error[E0658]: compiler plugins are experimental and possibly buggy
-  --> $DIR/gated-plugin.rs:3:1
+error[E0658]: compiler plugins are deprecated and will be removed in 1.44.0
+  --> $DIR/gated-plugin.rs:4:1
    |
 LL | #![plugin(attr_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin)]` to the crate attributes to enable
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/gated-plugin.rs:4:1
+   |
+LL | #![plugin(attr_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui-fulldeps/gated-plugin.stderr
+++ b/src/test/ui-fulldeps/gated-plugin.stderr
@@ -1,5 +1,5 @@
-error[E0658]: compiler plugins are deprecated and will be removed in 1.44.0
-  --> $DIR/gated-plugin.rs:4:1
+error[E0658]: compiler plugins are deprecated
+  --> $DIR/gated-plugin.rs:3:1
    |
 LL | #![plugin(attr_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,8 +7,8 @@ LL | #![plugin(attr_plugin_test)]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/gated-plugin.rs:4:1
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/gated-plugin.rs:3:1
    |
 LL | #![plugin(attr_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute

--- a/src/test/ui-fulldeps/issue-15778-fail.rs
+++ b/src/test/ui-fulldeps/issue-15778-fail.rs
@@ -4,5 +4,6 @@
 
 #![feature(plugin)] //~ ERROR crate is not marked with #![crate_okay]
 #![plugin(lint_for_crate)]
+//~^ WARN use of deprecated attribute `plugin`
 
 pub fn main() { }

--- a/src/test/ui-fulldeps/issue-15778-fail.stderr
+++ b/src/test/ui-fulldeps/issue-15778-fail.stderr
@@ -1,8 +1,17 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-15778-fail.rs:6:1
+   |
+LL | #![plugin(lint_for_crate)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: crate is not marked with #![crate_okay]
   --> $DIR/issue-15778-fail.rs:5:1
    |
 LL | / #![feature(plugin)]
 LL | | #![plugin(lint_for_crate)]
+LL | |
 LL | |
 LL | | pub fn main() { }
    | |_________________^

--- a/src/test/ui-fulldeps/issue-15778-pass.stderr
+++ b/src/test/ui-fulldeps/issue-15778-pass.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-15778-pass.rs:8:1
+   |
+LL | #![plugin(lint_for_crate_rpass)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/issue-40001.stderr
+++ b/src/test/ui-fulldeps/issue-40001.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-40001.rs:6:1
+   |
+LL | #![plugin(issue_40001_plugin)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.rs
@@ -3,7 +3,9 @@
 // compile-flags: -D lint-me
 
 #![feature(plugin)]
+
 #![plugin(lint_group_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 
 fn lintme() { } //~ ERROR item is named 'lintme'
 

--- a/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin-deny-cmdline.stderr
@@ -1,5 +1,13 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:7:1
+   |
+LL | #![plugin(lint_group_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
-  --> $DIR/lint-group-plugin-deny-cmdline.rs:8:1
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:10:1
    |
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
@@ -7,7 +15,7 @@ LL | fn lintme() { }
    = note: `-D test-lint` implied by `-D lint-me`
 
 error: item is named 'pleaselintme'
-  --> $DIR/lint-group-plugin-deny-cmdline.rs:10:1
+  --> $DIR/lint-group-plugin-deny-cmdline.rs:12:1
    |
 LL | fn pleaselintme() { }
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/lint-group-plugin.stderr
+++ b/src/test/ui-fulldeps/lint-group-plugin.stderr
@@ -1,3 +1,11 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-group-plugin.rs:6:1
+   |
+LL | #![plugin(lint_group_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 warning: item is named 'lintme'
   --> $DIR/lint-group-plugin.rs:9:1
    |

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
@@ -1,3 +1,11 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-plugin-cmdline-allow.rs:8:1
+   |
+LL | #![plugin(lint_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 warning: function is never used: `lintme`
   --> $DIR/lint-plugin-cmdline-allow.rs:10:1
    |

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.rs
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.rs
@@ -3,6 +3,7 @@
 
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 #![deny(test_lint)]
 
 fn lintme() { } //~ ERROR item is named 'lintme'

--- a/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-attr.stderr
@@ -1,11 +1,19 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-plugin-deny-attr.rs:5:1
+   |
+LL | #![plugin(lint_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
-  --> $DIR/lint-plugin-deny-attr.rs:8:1
+  --> $DIR/lint-plugin-deny-attr.rs:9:1
    |
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint-plugin-deny-attr.rs:6:9
+  --> $DIR/lint-plugin-deny-attr.rs:7:9
    |
 LL | #![deny(test_lint)]
    |         ^^^^^^^^^

--- a/src/test/ui-fulldeps/lint-plugin-deny-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-plugin-deny-cmdline.rs
@@ -4,6 +4,7 @@
 
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 
 fn lintme() { } //~ ERROR item is named 'lintme'
 

--- a/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-deny-cmdline.stderr
@@ -1,5 +1,13 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-plugin-deny-cmdline.rs:6:1
+   |
+LL | #![plugin(lint_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
-  --> $DIR/lint-plugin-deny-cmdline.rs:8:1
+  --> $DIR/lint-plugin-deny-cmdline.rs:9:1
    |
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/lint-plugin-forbid-attrs.rs
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-attrs.rs
@@ -3,6 +3,7 @@
 
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 #![forbid(test_lint)]
 
 fn lintme() { } //~ ERROR item is named 'lintme'

--- a/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-attrs.stderr
@@ -1,5 +1,5 @@
 error[E0453]: allow(test_lint) overruled by outer forbid(test_lint)
-  --> $DIR/lint-plugin-forbid-attrs.rs:10:9
+  --> $DIR/lint-plugin-forbid-attrs.rs:11:9
    |
 LL | #![forbid(test_lint)]
    |           --------- `forbid` level set here
@@ -7,14 +7,22 @@ LL | #![forbid(test_lint)]
 LL | #[allow(test_lint)]
    |         ^^^^^^^^^ overruled by previous forbid
 
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-plugin-forbid-attrs.rs:5:1
+   |
+LL | #![plugin(lint_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
-  --> $DIR/lint-plugin-forbid-attrs.rs:8:1
+  --> $DIR/lint-plugin-forbid-attrs.rs:9:1
    |
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint-plugin-forbid-attrs.rs:6:11
+  --> $DIR/lint-plugin-forbid-attrs.rs:7:11
    |
 LL | #![forbid(test_lint)]
    |           ^^^^^^^^^

--- a/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.rs
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.rs
@@ -4,7 +4,7 @@
 
 #![feature(plugin)]
 #![plugin(lint_plugin_test)]
-
+//~^ WARN use of deprecated attribute `plugin`
 fn lintme() { } //~ ERROR item is named 'lintme'
 
 #[allow(test_lint)] //~ ERROR allow(test_lint) overruled by outer forbid(test_lint)

--- a/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-forbid-cmdline.stderr
@@ -6,6 +6,14 @@ LL | #[allow(test_lint)]
    |
    = note: `forbid` lint level was set on command line
 
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-plugin-forbid-cmdline.rs:6:1
+   |
+LL | #![plugin(lint_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
   --> $DIR/lint-plugin-forbid-cmdline.rs:8:1
    |

--- a/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
@@ -2,6 +2,14 @@ warning: lint name `test_lint` is deprecated and does not have an effect anymore
    |
    = note: requested on the command line with `-A test_lint`
 
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-tool-cmdline-allow.rs:8:1
+   |
+LL | #![plugin(lint_tool_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 warning: item is named 'lintme'
   --> $DIR/lint-tool-cmdline-allow.rs:10:1
    |

--- a/src/test/ui-fulldeps/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/lint-tool-test.rs
@@ -4,6 +4,7 @@
 
 #![feature(plugin)]
 #![plugin(lint_tool_test)]
+//~^ WARN use of deprecated attribute `plugin`
 #![allow(dead_code)]
 #![cfg_attr(foo, warn(test_lint))]
 //~^ WARNING lint name `test_lint` is deprecated and may not have an effect in the future

--- a/src/test/ui-fulldeps/lint-tool-test.stderr
+++ b/src/test/ui-fulldeps/lint-tool-test.stderr
@@ -1,5 +1,5 @@
 warning: lint name `test_lint` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint-tool-test.rs:8:23
+  --> $DIR/lint-tool-test.rs:9:23
    |
 LL | #![cfg_attr(foo, warn(test_lint))]
    |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
@@ -7,19 +7,19 @@ LL | #![cfg_attr(foo, warn(test_lint))]
    = note: `#[warn(renamed_and_removed_lints)]` on by default
 
 warning: lint name `clippy_group` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint-tool-test.rs:11:9
+  --> $DIR/lint-tool-test.rs:12:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^ help: change it to: `clippy::group`
 
 warning: lint name `test_group` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint-tool-test.rs:25:9
+  --> $DIR/lint-tool-test.rs:26:9
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
 
 warning: unknown lint: `this_lint_does_not_exist`
-  --> $DIR/lint-tool-test.rs:27:8
+  --> $DIR/lint-tool-test.rs:28:8
    |
 LL | #[deny(this_lint_does_not_exist)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -27,32 +27,40 @@ LL | #[deny(this_lint_does_not_exist)]
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: lint name `test_lint` is deprecated and may not have an effect in the future. Also `cfg_attr(cargo-clippy)` won't be necessary anymore
-  --> $DIR/lint-tool-test.rs:8:23
+  --> $DIR/lint-tool-test.rs:9:23
    |
 LL | #![cfg_attr(foo, warn(test_lint))]
    |                       ^^^^^^^^^ help: change it to: `clippy::test_lint`
 
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lint-tool-test.rs:6:1
+   |
+LL | #![plugin(lint_tool_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: item is named 'lintme'
-  --> $DIR/lint-tool-test.rs:14:1
+  --> $DIR/lint-tool-test.rs:15:1
    |
 LL | fn lintme() { }
    | ^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint-tool-test.rs:11:9
+  --> $DIR/lint-tool-test.rs:12:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^
    = note: `#[deny(clippy::test_lint)]` implied by `#[deny(clippy::group)]`
 
 error: item is named 'lintmetoo'
-  --> $DIR/lint-tool-test.rs:22:5
+  --> $DIR/lint-tool-test.rs:23:5
    |
 LL |     fn lintmetoo() { }
    |     ^^^^^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/lint-tool-test.rs:11:9
+  --> $DIR/lint-tool-test.rs:12:9
    |
 LL | #![deny(clippy_group)]
    |         ^^^^^^^^^^^^

--- a/src/test/ui-fulldeps/llvm-pass-plugin.stderr
+++ b/src/test/ui-fulldeps/llvm-pass-plugin.stderr
@@ -1,16 +1,8 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/lint-plugin.rs:5:1
+  --> $DIR/llvm-pass-plugin.rs:6:1
    |
-LL | #![plugin(lint_plugin_test)]
+LL | #![plugin(llvm_pass_plugin)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
    = note: `#[warn(deprecated)]` on by default
-
-warning: item is named 'lintme'
-  --> $DIR/lint-plugin.rs:8:1
-   |
-LL | fn lintme() { }
-   | ^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(test_lint)]` on by default
 

--- a/src/test/ui-fulldeps/lto-syntax-extension.stderr
+++ b/src/test/ui-fulldeps/lto-syntax-extension.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/lto-syntax-extension.rs:9:1
+   |
+LL | #![plugin(lto_syntax_extension_plugin)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/macro-crate-rlib.rs
+++ b/src/test/ui-fulldeps/macro-crate-rlib.rs
@@ -5,6 +5,6 @@
 #![feature(plugin)]
 #![plugin(rlib_crate_test)]
 //~^ ERROR: plugin `rlib_crate_test` only found in rlib format, but must be available in dylib format
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui-fulldeps/macro-crate-rlib.rs
+++ b/src/test/ui-fulldeps/macro-crate-rlib.rs
@@ -5,5 +5,6 @@
 #![feature(plugin)]
 #![plugin(rlib_crate_test)]
 //~^ ERROR: plugin `rlib_crate_test` only found in rlib format, but must be available in dylib format
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui-fulldeps/macro-crate-rlib.stderr
+++ b/src/test/ui-fulldeps/macro-crate-rlib.stderr
@@ -4,5 +4,13 @@ error[E0457]: plugin `rlib_crate_test` only found in rlib format, but must be av
 LL | #![plugin(rlib_crate_test)]
    |           ^^^^^^^^^^^^^^^
 
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/macro-crate-rlib.rs:6:1
+   |
+LL | #![plugin(rlib_crate_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: aborting due to previous error
 

--- a/src/test/ui-fulldeps/macro-crate-rlib.stderr
+++ b/src/test/ui-fulldeps/macro-crate-rlib.stderr
@@ -4,7 +4,7 @@ error[E0457]: plugin `rlib_crate_test` only found in rlib format, but must be av
 LL | #![plugin(rlib_crate_test)]
    |           ^^^^^^^^^^^^^^^
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
   --> $DIR/macro-crate-rlib.rs:6:1
    |
 LL | #![plugin(rlib_crate_test)]

--- a/src/test/ui-fulldeps/outlive-expansion-phase.stderr
+++ b/src/test/ui-fulldeps/outlive-expansion-phase.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/outlive-expansion-phase.rs:6:1
+   |
+LL | #![plugin(outlive_expansion_phase)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/plugin-args-1.stderr
+++ b/src/test/ui-fulldeps/plugin-args-1.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/plugin-args-1.rs:6:1
+   |
+LL | #![plugin(plugin_args)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/plugin-args-2.stderr
+++ b/src/test/ui-fulldeps/plugin-args-2.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/plugin-args-2.rs:6:1
+   |
+LL | #![plugin(plugin_args())]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/plugin-args-3.stderr
+++ b/src/test/ui-fulldeps/plugin-args-3.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/plugin-args-3.rs:6:1
+   |
+LL | #![plugin(plugin_args(hello(there), how(are="you")))]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui-fulldeps/plugin-attr-register-deny.rs
+++ b/src/test/ui-fulldeps/plugin-attr-register-deny.rs
@@ -3,6 +3,7 @@
 
 #![feature(plugin)]
 #![plugin(attr_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 #![deny(unused_attributes)]
 
 #[baz]

--- a/src/test/ui-fulldeps/plugin-attr-register-deny.stderr
+++ b/src/test/ui-fulldeps/plugin-attr-register-deny.stderr
@@ -1,23 +1,31 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/plugin-attr-register-deny.rs:5:1
+   |
+LL | #![plugin(attr_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: unused attribute
-  --> $DIR/plugin-attr-register-deny.rs:14:5
+  --> $DIR/plugin-attr-register-deny.rs:15:5
    |
 LL |     #[bar]
    |     ^^^^^^
    |
 note: lint level defined here
-  --> $DIR/plugin-attr-register-deny.rs:6:9
+  --> $DIR/plugin-attr-register-deny.rs:7:9
    |
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/plugin-attr-register-deny.rs:14:5
+  --> $DIR/plugin-attr-register-deny.rs:15:5
    |
 LL |     #[bar]
    |     ^^^^^^
 
 error: unused attribute
-  --> $DIR/plugin-attr-register-deny.rs:11:1
+  --> $DIR/plugin-attr-register-deny.rs:12:1
    |
 LL | #[foo]
    | ^^^^^^

--- a/src/test/ui-fulldeps/plugin-reexport.rs
+++ b/src/test/ui-fulldeps/plugin-reexport.rs
@@ -4,6 +4,7 @@
 
 #![feature(plugin)]
 #![plugin(attr_plugin_test)]
+//~^ WARN use of deprecated attribute `plugin`
 
 pub use mac as reexport; //~ ERROR `mac` is private, and cannot be re-exported
 

--- a/src/test/ui-fulldeps/plugin-reexport.stderr
+++ b/src/test/ui-fulldeps/plugin-reexport.stderr
@@ -1,14 +1,22 @@
 error[E0364]: `mac` is private, and cannot be re-exported
-  --> $DIR/plugin-reexport.rs:8:9
+  --> $DIR/plugin-reexport.rs:9:9
    |
 LL | pub use mac as reexport;
    |         ^^^^^^^^^^^^^^^
    |
 note: consider marking `mac` as `pub` in the imported module
-  --> $DIR/plugin-reexport.rs:8:9
+  --> $DIR/plugin-reexport.rs:9:9
    |
 LL | pub use mac as reexport;
    |         ^^^^^^^^^^^^^^^
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/plugin-reexport.rs:6:1
+   |
+LL | #![plugin(attr_plugin_test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui-fulldeps/roman-numerals-macro.stderr
+++ b/src/test/ui-fulldeps/roman-numerals-macro.stderr
@@ -1,0 +1,8 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/roman-numerals-macro.rs:6:1
+   |
+LL | #![plugin(roman_numerals)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
@@ -32,8 +32,12 @@
 
 // check-pass
 
-#![feature(test)]
+#![feature(test, plugin_registrar)]
 #![warn(unused_attributes, unknown_lints)]
+
+// Exception, a gated and deprecated attribute.
+
+#![plugin_registrar] //~ WARN unused attribute
 
 // UNGATED WHITE-LISTED BUILT-IN ATTRIBUTES
 
@@ -43,7 +47,6 @@
 #![deny(x5100)] //~ WARN unknown lint: `x5100`
 #![macro_use] // (allowed if no argument; see issue-43160-gating-of-macro_use.rs)
 #![macro_export] //~ WARN unused attribute
-#![plugin_registrar] //~ WARN unused attribute
 // skipping testing of cfg
 // skipping testing of cfg_attr
 #![main] //~ WARN unused attribute

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:40:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:44:9
    |
 LL | #![warn(x5400)]
    |         ^^^^^
@@ -11,197 +11,233 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |                            ^^^^^^^^^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:41:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:10
    |
 LL | #![allow(x5300)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:42:11
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:46:11
    |
 LL | #![forbid(x5200)]
    |           ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:43:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:47:9
    |
 LL | #![deny(x5100)]
    |         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:101:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:104:8
    |
 LL | #[warn(x5400)]
    |        ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:104:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:107:25
    |
 LL |     mod inner { #![warn(x5400)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:107:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:110:12
    |
 LL |     #[warn(x5400)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:110:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:12
    |
 LL |     #[warn(x5400)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:12
    |
 LL |     #[warn(x5400)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:119:12
    |
 LL |     #[warn(x5400)] impl S { }
    |            ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:120:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:123:9
    |
 LL | #[allow(x5300)]
    |         ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:123:26
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:126:26
    |
 LL |     mod inner { #![allow(x5300)] }
    |                          ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:126:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:129:13
    |
 LL |     #[allow(x5300)] fn f() { }
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:129:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:13
    |
 LL |     #[allow(x5300)] struct S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:13
    |
 LL |     #[allow(x5300)] type T = S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:138:13
    |
 LL |     #[allow(x5300)] impl S { }
    |             ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:139:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:142:10
    |
 LL | #[forbid(x5200)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:142:27
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:145:27
    |
 LL |     mod inner { #![forbid(x5200)] }
    |                           ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:145:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:148:14
    |
 LL |     #[forbid(x5200)] fn f() { }
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:148:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:14
    |
 LL |     #[forbid(x5200)] struct S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:14
    |
 LL |     #[forbid(x5200)] type T = S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:157:14
    |
 LL |     #[forbid(x5200)] impl S { }
    |              ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:158:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:161:8
    |
 LL | #[deny(x5100)]
    |        ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:161:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:164:25
    |
 LL |     mod inner { #![deny(x5100)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:164:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:167:12
    |
 LL |     #[deny(x5100)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:167:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:12
    |
 LL |     #[deny(x5100)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:12
    |
 LL |     #[deny(x5100)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:176:12
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: macro_escape is a deprecated synonym for macro_use
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:457:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:460:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
 
 warning: macro_escape is a deprecated synonym for macro_use
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:460:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:463:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
    |
    = help: consider an outer attribute, `#[macro_use]` mod ...
 
-warning: use of deprecated attribute `crate_id`: no longer used.
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:87:1
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
    |
-LL | #![crate_id = "10"]
-   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+LL |     mod inner { #![plugin_registrar] }
+   |                 ^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
    |
    = note: `#[warn(deprecated)]` on by default
 
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:5
+   |
+LL |     #[plugin_registrar] struct S;
+   |     ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+   |
+LL |     #[plugin_registrar] type T = S;
+   |     ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:230:5
+   |
+LL |     #[plugin_registrar] impl S { }
+   |     ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
+   |
+LL | #[plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:40:1
+   |
+LL | #![plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
+warning: use of deprecated attribute `crate_id`: no longer used.
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:90:1
+   |
+LL | #![crate_id = "10"]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+
 warning: use of deprecated attribute `no_start`: no longer used.
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:92:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:95:1
    |
 LL | #![no_start]
    | ^^^^^^^^^^^^ help: remove this attribute
 
 warning: the feature `rust1` has been stable since 1.0.0 and no longer requires an attribute to enable
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:90:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:93:12
    |
 LL | #![feature(rust1)]
    |            ^^^^^
@@ -209,7 +245,7 @@ LL | #![feature(rust1)]
    = note: `#[warn(stable_features)]` on by default
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:181:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:184:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
@@ -221,925 +257,919 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:184:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:187:5
    |
 LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:187:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:190:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:190:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:200:17
    |
 LL |     mod inner { #![macro_export] }
    |                 ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:200:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
    |
 LL |     #[macro_export] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:206:5
    |
 LL |     #[macro_export] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:206:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
    |
 LL |     #[macro_export] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:212:5
    |
 LL |     #[macro_export] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:194:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:1
    |
 LL | #[macro_export]
    | ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
    |
 LL |     mod inner { #![plugin_registrar] }
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:5
    |
 LL |     #[plugin_registrar] struct S;
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
    |
 LL |     #[plugin_registrar] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:230:5
    |
 LL |     #[plugin_registrar] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:213:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
    |
 LL | #[plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:234:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:237:17
    |
 LL |     mod inner { #![main] }
    |                 ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:239:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:242:5
    |
 LL |     #[main] struct S;
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:242:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:245:5
    |
 LL |     #[main] type T = S;
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:245:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:248:5
    |
 LL |     #[main] impl S { }
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:231:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:234:1
    |
 LL | #[main]
    | ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:252:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:255:17
    |
 LL |     mod inner { #![start] }
    |                 ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:257:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:260:5
    |
 LL |     #[start] struct S;
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:260:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:263:5
    |
 LL |     #[start] type T = S;
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:263:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:266:5
    |
 LL |     #[start] impl S { }
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:249:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:252:1
    |
 LL | #[start]
    | ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:316:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:319:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:319:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:322:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:322:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:325:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:325:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:328:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:335:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:335:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:338:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:338:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:344:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:344:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:347:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:329:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:364:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:17
    |
 LL |     mod inner { #![no_link] }
    |                 ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:370:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:370:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:376:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:376:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:361:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:364:1
    |
 LL | #[no_link]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:383:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:386:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:386:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:5
    |
 LL |     #[should_panic] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:380:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:383:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:405:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:405:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
    |
 LL |     #[ignore] fn f() { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:411:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:411:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:417:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:399:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:421:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:424:17
    |
 LL |     mod inner { #![no_implicit_prelude] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:424:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:430:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:430:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:433:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:433:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:436:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:418:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:421:1
    |
 LL | #[no_implicit_prelude]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:440:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:443:17
    |
 LL |     mod inner { #![reexport_test_harness_main="2900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:443:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:446:5
    |
 LL |     #[reexport_test_harness_main = "2900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:446:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:5
    |
 LL |     #[reexport_test_harness_main = "2900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:452:5
    |
 LL |     #[reexport_test_harness_main = "2900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:452:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:455:5
    |
 LL |     #[reexport_test_harness_main = "2900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:437:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:440:1
    |
 LL | #[reexport_test_harness_main = "2900"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:463:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:480:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:480:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:484:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:484:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:488:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:492:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:492:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:499:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:496:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:499:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:476:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:635:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:638:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:635:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:638:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:639:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:639:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:643:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:643:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:647:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:647:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:651:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:651:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:631:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:631:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:664:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:667:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:664:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:667:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:668:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:668:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:672:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:672:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:676:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:679:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:676:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:679:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:656:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:659:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:656:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:659:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:689:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:689:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:693:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:693:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:697:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:697:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:704:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:701:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:704:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:681:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:684:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:681:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:684:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:711:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:714:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:711:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:714:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:715:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:715:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:719:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:719:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:723:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:723:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:727:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:730:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:727:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:730:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:707:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:707:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:749:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:752:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:749:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:752:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:753:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:753:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:757:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:757:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:761:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:765:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:765:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:745:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:748:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:745:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:748:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:778:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:782:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:786:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:790:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:790:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:1
-   |
-LL | #![macro_export]
-   | ^^^^^^^^^^^^^^^^
-
-warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:46:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:40:1
    |
 LL | #![plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -1147,53 +1177,59 @@ LL | #![plugin_registrar]
 warning: unused attribute
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:49:1
    |
+LL | #![macro_export]
+   | ^^^^^^^^^^^^^^^^
+
+warning: unused attribute
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:52:1
+   |
 LL | #![main]
    | ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:50:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:53:1
    |
 LL | #![start]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:53:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:56:1
    |
 LL | #![repr()]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:55:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:58:1
    |
 LL | #![path = "3800"]
    | ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:56:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:59:1
    |
 LL | #![automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:58:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:61:1
    |
 LL | #![no_link]
    | ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:60:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
    |
 LL | #![should_panic]
    | ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:61:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:64:1
    |
 LL | #![ignore]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:67:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:70:1
    |
 LL | #![proc_macro_derive()]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-plugin.rs
+++ b/src/test/ui/feature-gates/feature-gate-plugin.rs
@@ -1,6 +1,7 @@
 // Test that `#![plugin(...)]` attribute is gated by `plugin` feature gate
 
 #![plugin(foo)]
-//~^ ERROR compiler plugins are experimental and possibly buggy
+//~^ ERROR compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-plugin.rs
+++ b/src/test/ui/feature-gates/feature-gate-plugin.rs
@@ -1,7 +1,7 @@
 // Test that `#![plugin(...)]` attribute is gated by `plugin` feature gate
 
 #![plugin(foo)]
-//~^ ERROR compiler plugins are deprecated and will be removed in 1.44.0
+//~^ ERROR compiler plugins are deprecated
 //~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-plugin.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin.stderr
@@ -1,4 +1,4 @@
-error[E0658]: compiler plugins are deprecated and will be removed in 1.44.0
+error[E0658]: compiler plugins are deprecated
   --> $DIR/feature-gate-plugin.rs:3:1
    |
 LL | #![plugin(foo)]
@@ -7,7 +7,7 @@ LL | #![plugin(foo)]
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin)]` to the crate attributes to enable
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
   --> $DIR/feature-gate-plugin.rs:3:1
    |
 LL | #![plugin(foo)]

--- a/src/test/ui/feature-gates/feature-gate-plugin.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin.stderr
@@ -1,4 +1,4 @@
-error[E0658]: compiler plugins are experimental and possibly buggy
+error[E0658]: compiler plugins are deprecated and will be removed in 1.44.0
   --> $DIR/feature-gate-plugin.rs:3:1
    |
 LL | #![plugin(foo)]
@@ -6,6 +6,14 @@ LL | #![plugin(foo)]
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin)]` to the crate attributes to enable
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/feature-gate-plugin.rs:3:1
+   |
+LL | #![plugin(foo)]
+   | ^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.rs
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.rs
@@ -3,8 +3,9 @@
 
 // the registration function isn't typechecked yet
 #[plugin_registrar]
+//~^ ERROR compiler plugins are deprecated
+//~| WARN use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated
 pub fn registrar() {}
-//~^ ERROR compiler plugins are experimental
-//~| WARN `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
+//~^ ERROR compiler plugins are experimental and possibly buggy
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.rs
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.rs
@@ -5,4 +5,6 @@
 #[plugin_registrar]
 pub fn registrar() {}
 //~^ ERROR compiler plugins are experimental
+//~| WARN `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
+
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
@@ -7,6 +7,12 @@ LL | pub fn registrar() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
+warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
+  --> $DIR/feature-gate-plugin_registrar.rs:6:1
+   |
+LL | pub fn registrar() {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
+++ b/src/test/ui/feature-gates/feature-gate-plugin_registrar.stderr
@@ -1,5 +1,5 @@
 error[E0658]: compiler plugins are experimental and possibly buggy
-  --> $DIR/feature-gate-plugin_registrar.rs:6:1
+  --> $DIR/feature-gate-plugin_registrar.rs:8:1
    |
 LL | pub fn registrar() {}
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -7,12 +7,23 @@ LL | pub fn registrar() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/29597
    = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
-warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
-  --> $DIR/feature-gate-plugin_registrar.rs:6:1
+error[E0658]: compiler plugins are deprecated
+  --> $DIR/feature-gate-plugin_registrar.rs:5:1
    |
-LL | pub fn registrar() {}
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL | #[plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29597
+   = help: add `#![feature(plugin_registrar)]` to the crate attributes to enable
 
-error: aborting due to previous error
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/feature-gate-plugin_registrar.rs:5:1
+   |
+LL | #[plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/invalid/invalid-plugin-attr.rs
+++ b/src/test/ui/invalid/invalid-plugin-attr.rs
@@ -1,10 +1,8 @@
-// ignore-tidy-linelength
-
 #![deny(unused_attributes)]
 #![feature(plugin)]
 
 #[plugin(bla)]  //~ ERROR unused attribute
                 //~^ ERROR should be an inner attribute
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/invalid/invalid-plugin-attr.rs
+++ b/src/test/ui/invalid/invalid-plugin-attr.rs
@@ -1,7 +1,10 @@
+// ignore-tidy-linelength
+
 #![deny(unused_attributes)]
 #![feature(plugin)]
 
 #[plugin(bla)]  //~ ERROR unused attribute
                 //~^ ERROR should be an inner attribute
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui/invalid/invalid-plugin-attr.stderr
+++ b/src/test/ui/invalid/invalid-plugin-attr.stderr
@@ -1,17 +1,25 @@
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/invalid-plugin-attr.rs:6:1
+   |
+LL | #[plugin(bla)]
+   | ^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: unused attribute
-  --> $DIR/invalid-plugin-attr.rs:4:1
+  --> $DIR/invalid-plugin-attr.rs:6:1
    |
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/invalid-plugin-attr.rs:1:9
+  --> $DIR/invalid-plugin-attr.rs:3:9
    |
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/invalid-plugin-attr.rs:4:1
+  --> $DIR/invalid-plugin-attr.rs:6:1
    |
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^

--- a/src/test/ui/invalid/invalid-plugin-attr.stderr
+++ b/src/test/ui/invalid/invalid-plugin-attr.stderr
@@ -1,5 +1,5 @@
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/invalid-plugin-attr.rs:6:1
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/invalid-plugin-attr.rs:4:1
    |
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^ help: remove this attribute
@@ -7,19 +7,19 @@ LL | #[plugin(bla)]
    = note: `#[warn(deprecated)]` on by default
 
 error: unused attribute
-  --> $DIR/invalid-plugin-attr.rs:6:1
+  --> $DIR/invalid-plugin-attr.rs:4:1
    |
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^
    |
 note: lint level defined here
-  --> $DIR/invalid-plugin-attr.rs:3:9
+  --> $DIR/invalid-plugin-attr.rs:1:9
    |
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
 error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/invalid-plugin-attr.rs:6:1
+  --> $DIR/invalid-plugin-attr.rs:4:1
    |
 LL | #[plugin(bla)]
    | ^^^^^^^^^^^^^^

--- a/src/test/ui/malformed/malformed-plugin-1.rs
+++ b/src/test/ui/malformed/malformed-plugin-1.rs
@@ -1,4 +1,7 @@
+// ignore-tidy-linelength
+
 #![feature(plugin)]
 #![plugin] //~ ERROR malformed `plugin` attribute
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-1.rs
+++ b/src/test/ui/malformed/malformed-plugin-1.rs
@@ -1,7 +1,5 @@
-// ignore-tidy-linelength
-
 #![feature(plugin)]
 #![plugin] //~ ERROR malformed `plugin` attribute
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-1.stderr
+++ b/src/test/ui/malformed/malformed-plugin-1.stderr
@@ -1,8 +1,16 @@
 error: malformed `plugin` attribute input
-  --> $DIR/malformed-plugin-1.rs:2:1
+  --> $DIR/malformed-plugin-1.rs:4:1
    |
 LL | #![plugin]
    | ^^^^^^^^^^ help: must be of the form: `#[plugin(name|name(args))]`
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-1.rs:4:1
+   |
+LL | #![plugin]
+   | ^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/malformed/malformed-plugin-1.stderr
+++ b/src/test/ui/malformed/malformed-plugin-1.stderr
@@ -1,11 +1,11 @@
 error: malformed `plugin` attribute input
-  --> $DIR/malformed-plugin-1.rs:4:1
+  --> $DIR/malformed-plugin-1.rs:2:1
    |
 LL | #![plugin]
    | ^^^^^^^^^^ help: must be of the form: `#[plugin(name|name(args))]`
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/malformed-plugin-1.rs:4:1
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-1.rs:2:1
    |
 LL | #![plugin]
    | ^^^^^^^^^^ help: remove this attribute

--- a/src/test/ui/malformed/malformed-plugin-2.rs
+++ b/src/test/ui/malformed/malformed-plugin-2.rs
@@ -1,4 +1,7 @@
+// ignore-tidy-linelength
+
 #![feature(plugin)]
 #![plugin="bleh"] //~ ERROR malformed `plugin` attribute
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-2.rs
+++ b/src/test/ui/malformed/malformed-plugin-2.rs
@@ -1,7 +1,5 @@
-// ignore-tidy-linelength
-
 #![feature(plugin)]
 #![plugin="bleh"] //~ ERROR malformed `plugin` attribute
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-2.stderr
+++ b/src/test/ui/malformed/malformed-plugin-2.stderr
@@ -1,11 +1,11 @@
 error: malformed `plugin` attribute input
-  --> $DIR/malformed-plugin-2.rs:4:1
+  --> $DIR/malformed-plugin-2.rs:2:1
    |
 LL | #![plugin="bleh"]
    | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[plugin(name|name(args))]`
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/malformed-plugin-2.rs:4:1
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-2.rs:2:1
    |
 LL | #![plugin="bleh"]
    | ^^^^^^^^^^^^^^^^^ help: remove this attribute

--- a/src/test/ui/malformed/malformed-plugin-2.stderr
+++ b/src/test/ui/malformed/malformed-plugin-2.stderr
@@ -1,8 +1,16 @@
 error: malformed `plugin` attribute input
-  --> $DIR/malformed-plugin-2.rs:2:1
+  --> $DIR/malformed-plugin-2.rs:4:1
    |
 LL | #![plugin="bleh"]
    | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[plugin(name|name(args))]`
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-2.rs:4:1
+   |
+LL | #![plugin="bleh"]
+   | ^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/malformed/malformed-plugin-3.rs
+++ b/src/test/ui/malformed/malformed-plugin-3.rs
@@ -1,7 +1,5 @@
-// ignore-tidy-linelength
-
 #![feature(plugin)]
 #![plugin(foo="bleh")] //~ ERROR malformed `plugin` attribute
-//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-3.rs
+++ b/src/test/ui/malformed/malformed-plugin-3.rs
@@ -1,4 +1,7 @@
+// ignore-tidy-linelength
+
 #![feature(plugin)]
 #![plugin(foo="bleh")] //~ ERROR malformed `plugin` attribute
+//~| WARN use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0
 
 fn main() {}

--- a/src/test/ui/malformed/malformed-plugin-3.stderr
+++ b/src/test/ui/malformed/malformed-plugin-3.stderr
@@ -1,11 +1,11 @@
 error[E0498]: malformed `plugin` attribute
-  --> $DIR/malformed-plugin-3.rs:4:1
+  --> $DIR/malformed-plugin-3.rs:2:1
    |
 LL | #![plugin(foo="bleh")]
    | ^^^^^^^^^^^^^^^^^^^^^^ malformed attribute
 
-warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
-  --> $DIR/malformed-plugin-3.rs:4:1
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-3.rs:2:1
    |
 LL | #![plugin(foo="bleh")]
    | ^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute

--- a/src/test/ui/malformed/malformed-plugin-3.stderr
+++ b/src/test/ui/malformed/malformed-plugin-3.stderr
@@ -1,8 +1,16 @@
 error[E0498]: malformed `plugin` attribute
-  --> $DIR/malformed-plugin-3.rs:2:1
+  --> $DIR/malformed-plugin-3.rs:4:1
    |
 LL | #![plugin(foo="bleh")]
    | ^^^^^^^^^^^^^^^^^^^^^^ malformed attribute
+
+warning: use of deprecated attribute `plugin`: compiler plugins are deprecated and will be removed in 1.44.0. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/malformed-plugin-3.rs:4:1
+   |
+LL | #![plugin(foo="bleh")]
+   | ^^^^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
 error: aborting due to previous error
 

--- a/src/test/ui/multiple-plugin-registrars.stderr
+++ b/src/test/ui/multiple-plugin-registrars.stderr
@@ -1,14 +1,16 @@
-warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
-  --> $DIR/multiple-plugin-registrars.rs:7:1
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/multiple-plugin-registrars.rs:6:1
    |
-LL | pub fn one() {}
-   | ^^^^^^^^^^^^^^^
+LL | #[plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
+   |
+   = note: `#[warn(deprecated)]` on by default
 
-warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
-  --> $DIR/multiple-plugin-registrars.rs:10:1
+warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/issues/29597
+  --> $DIR/multiple-plugin-registrars.rs:9:1
    |
-LL | pub fn two() {}
-   | ^^^^^^^^^^^^^^^
+LL | #[plugin_registrar]
+   | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
 
 error: multiple plugin registration functions found
    |

--- a/src/test/ui/multiple-plugin-registrars.stderr
+++ b/src/test/ui/multiple-plugin-registrars.stderr
@@ -1,3 +1,15 @@
+warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
+  --> $DIR/multiple-plugin-registrars.rs:7:1
+   |
+LL | pub fn one() {}
+   | ^^^^^^^^^^^^^^^
+
+warning: `#[plugin_registrar]` is deprecated and will be removed in 1.44.0
+  --> $DIR/multiple-plugin-registrars.rs:10:1
+   |
+LL | pub fn two() {}
+   | ^^^^^^^^^^^^^^^
+
 error: multiple plugin registration functions found
    |
 note: one is here


### PR DESCRIPTION
This PR deprecates `#![plugin]` and `#[plugin_registrar]`.

~A removal deadline is set: 1.44.0. This will be in 9 months from now and should give everyone who is still relying on the feature ample time to rid themselves of this dependency.~

cc https://github.com/rust-lang/rust/issues/29597

r? @Mark-Simulacrum 