### PR TITLE
[rustdoc] add sub settings

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1230,18 +1230,87 @@ impl AllTypes {
     }
 }
 
+#[derive(Debug)]
+enum Setting {
+    Section {
+        description: &'static str,
+        sub_settings: Vec<Setting>,
+    },
+    Entry {
+        js_data_name: &'static str,
+        description: &'static str,
+        default_value: bool,
+    }
+}
+
+impl Setting {
+    fn display(&self) -> String {
+        match *self {
+            Setting::Section { ref description, ref sub_settings } => {
+                format!(
+                    "<div class='setting-line'>\
+                        <div class='title'>{}</div>\
+                        <div class='sub-setting'>{}</div>
+                    </div>",
+                    description,
+                    sub_settings.iter().map(|s| s.display()).collect::<String>()
+                )
+            }
+            Setting::Entry { ref js_data_name, ref description, ref default_value } => {
+                format!(
+                    "<div class='setting-line'>\
+                        <label class='toggle'>\
+                        <input type='checkbox' id='{}' {}>\
+                        <span class='slider'></span>\
+                        </label>\
+                        <div>{}</div>\
+                    </div>",
+                    js_data_name,
+                    if *default_value { " checked" } else { "" },
+                    description,
+                )
+            }
+        }
+    }
+}
+
+impl From<(&'static str, &'static str, bool)> for Setting {
+    fn from(values: (&'static str, &'static str, bool)) -> Setting {
+        Setting::Entry {
+            js_data_name: values.0,
+            description: values.1,
+            default_value: values.2,
+        }
+    }
+}
+
+impl<T: Into<Setting>> From<(&'static str, Vec<T>)> for Setting {
+    fn from(values: (&'static str, Vec<T>)) -> Setting {
+        Setting::Section {
+            description: values.0,
+            sub_settings: values.1.into_iter().map(|v| v.into()).collect::<Vec<_>>(),
+        }
+    }
+}
+
 fn settings(root_path: &str, suffix: &str) -> String {
     // (id, explanation, default value)
-    let settings = [
-        ("item-declarations", "Auto-hide item declarations.", true),
-        ("item-attributes", "Auto-hide item attributes.", true),
-        ("trait-implementations", "Auto-hide trait implementations documentation",
-            true),
-        ("method-docs", "Auto-hide item methods' documentation", false),
+    let settings: &[Setting] = &[
+        ("Auto-hide item declarations", vec![
+            ("auto-hide-struct", "Auto-hide structs declaration", true),
+            ("auto-hide-enum", "Auto-hide enums declaration", false),
+            ("auto-hide-union", "Auto-hide unions declaration", true),
+            ("auto-hide-trait", "Auto-hide traits declaration", true),
+            ("auto-hide-macro", "Auto-hide macros declaration", false),
+        ]).into(),
+        ("auto-hide-attributes", "Auto-hide item attributes.", true).into(),
+        ("auto-hide-method-docs", "Auto-hide item methods' documentation", false).into(),
+        ("auto-hide-trait-implementations", "Auto-hide trait implementations documentation",
+            true).into(),
         ("go-to-only-result", "Directly go to item in search if there is only one result",
-            false),
-        ("line-numbers", "Show line numbers on code examples", false),
-        ("disable-shortcuts", "Disable keyboard shortcuts", false),
+            false).into(),
+        ("line-numbers", "Show line numbers on code examples", false).into(),
+        ("disable-shortcuts", "Disable keyboard shortcuts", false).into(),
     ];
     format!(
 "<h1 class='fqn'>\
@@ -1249,17 +1318,7 @@ fn settings(root_path: &str, suffix: &str) -> String {
 </h1>\
 <div class='settings'>{}</div>\
 <script src='{}settings{}.js'></script>",
-            settings.iter()
-                        .map(|(id, text, enabled)| {
-                            format!("<div class='setting-line'>\
-                                            <label class='toggle'>\
-                                            <input type='checkbox' id='{}' {}>\
-                                            <span class='slider'></span>\
-                                            </label>\
-                                            <div>{}</div>\
-                                        </div>", id, if *enabled { " checked" } else { "" }, text)
-                        })
-                        .collect::<String>(),
+            settings.iter().map(|s| s.display()).collect::<String>(),
             root_path,
             suffix)
 }

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -1250,7 +1250,7 @@ impl Setting {
                 format!(
                     "<div class='setting-line'>\
                         <div class='title'>{}</div>\
-                        <div class='sub-setting'>{}</div>
+                        <div class='sub-settings'>{}</div>
                     </div>",
                     description,
                     sub_settings.iter().map(|s| s.display()).collect::<String>()

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -2102,7 +2102,7 @@ function getSearchElement() {
     function autoCollapse(pageId, collapse) {
         if (collapse) {
             toggleAllDocs(pageId, true);
-        } else if (getCurrentValue("rustdoc-trait-implementations") !== "false") {
+        } else if (getCurrentValue("rustdoc-auto-hide-trait-implementations") !== "false") {
             var impl_list = document.getElementById("implementations-list");
 
             if (impl_list !== null) {
@@ -2140,7 +2140,7 @@ function getSearchElement() {
     }
 
     var toggle = createSimpleToggle(false);
-    var hideMethodDocs = getCurrentValue("rustdoc-method-docs") === "true";
+    var hideMethodDocs = getCurrentValue("rustdoc-auto-hide-method-docs") === "true";
     var pageId = getPageId();
 
     var func = function(e) {
@@ -2270,7 +2270,31 @@ function getSearchElement() {
         return wrapper;
     }
 
-    var showItemDeclarations = getCurrentValue("rustdoc-item-declarations") === "false";
+    var currentType = document.getElementsByClassName("type-decl")[0];
+    var className = null;
+    if (currentType) {
+        currentType = currentType.getElementsByClassName("rust")[0];
+        if (currentType) {
+            currentType.classList.forEach(function(item) {
+                if (item !== "main") {
+                    className = item;
+                    return true;
+                }
+            });
+        }
+    }
+    var showItemDeclarations = getCurrentValue("rustdoc-auto-hide-" + className);
+    if (showItemDeclarations === null) {
+        if (className === "enum" || className === "macro") {
+            showItemDeclarations = "false";
+        } else if (className === "struct" || className === "union" || className === "trait") {
+            showItemDeclarations = "true";
+        } else {
+            // In case we found an unknown type, we just use the "parent" value.
+            showItemDeclarations = getCurrentValue("rustdoc-auto-hide-declarations");
+        }
+    }
+    showItemDeclarations = showItemDeclarations === "false";
     function buildToggleWrapper(e) {
         if (hasClass(e, "autohide")) {
             var wrap = e.previousElementSibling;
@@ -2353,7 +2377,7 @@ function getSearchElement() {
 
     // To avoid checking on "rustdoc-item-attributes" value on every loop...
     var itemAttributesFunc = function() {};
-    if (getCurrentValue("rustdoc-item-attributes") !== "false") {
+    if (getCurrentValue("rustdoc-auto-hide-attributes") !== "false") {
         itemAttributesFunc = function(x) {
             collapseDocs(x.previousSibling.childNodes[0], "toggle");
         };

--- a/src/librustdoc/html/static/settings.css
+++ b/src/librustdoc/html/static/settings.css
@@ -68,7 +68,7 @@ input:checked + .slider:before {
 	transform: translateX(19px);
 }
 
-.setting-line > .sub-setting {
+.setting-line > .sub-settings {
 	padding-left: 42px;
 	width: 100%;
 	display: block;

--- a/src/librustdoc/html/static/settings.css
+++ b/src/librustdoc/html/static/settings.css
@@ -1,5 +1,6 @@
 .setting-line {
 	padding: 5px;
+	position: relative;
 }
 
 .setting-line > div {
@@ -8,6 +9,13 @@
 	vertical-align: top;
 	font-size: 17px;
 	padding-top: 2px;
+}
+
+.setting-line > .title {
+	font-size: 19px;
+	width: 100%;
+	max-width: none;
+	border-bottom: 1px solid;
 }
 
 .toggle {
@@ -58,4 +66,10 @@ input:checked + .slider:before {
 	-webkit-transform: translateX(19px);
 	-ms-transform: translateX(19px);
 	transform: translateX(19px);
+}
+
+.setting-line > .sub-setting {
+	padding-left: 42px;
+	width: 100%;
+	display: block;
 }

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -425,3 +425,6 @@ div.files > a:hover, div.name:hover {
 div.files > .selected {
 	background-color: #333;
 }
+.setting-line > .title {
+	border-bottom-color: #ddd;
+}

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -419,3 +419,6 @@ div.files > a:hover, div.name:hover {
 div.files > .selected {
 	background-color: #fff;
 }
+.setting-line > .title {
+	border-bottom-color: #D5D5D5;
+}


### PR DESCRIPTION
This PR is to give a finer control over what types are automatically expanded or not as well as the possibility to add sub-settings in the settings page.

![Screenshot from 2019-09-23 00-46-14](https://user-images.githubusercontent.com/3050060/65395521-15aff300-dd9c-11e9-9437-429ca347d455.png)

r? @Mark-Simulacrum 