### PR TITLE
Recover on `const X = 42;` and infer type + Error Stash API

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -321,6 +321,7 @@ impl Session {
     }
     pub fn compile_status(&self) -> Result<(), ErrorReported> {
         if self.has_errors() {
+            self.diagnostic().emit_stashed_diagnostics();
             Err(ErrorReported)
         } else {
             Ok(())

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -296,7 +296,6 @@ pub fn run_compiler(
                     );
                     Ok(())
                 })?;
-                return sess.compile_status();
             } else {
                 let mut krate = compiler.parse()?.take();
                 pretty::visit_crate(sess, &mut krate, ppm);
@@ -307,8 +306,8 @@ pub fn run_compiler(
                     ppm,
                     compiler.output_file().as_ref().map(|p| &**p),
                 );
-                return sess.compile_status();
             }
+            return sess.compile_status();
         }
 
         if callbacks.after_parsing(compiler) == Compilation::Stop {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -832,7 +832,7 @@ fn check_method_receiver<'fcx, 'tcx>(
 }
 
 fn e0307(fcx: &FnCtxt<'fcx, 'tcx>, span: Span, receiver_ty: Ty<'_>) {
-    fcx.tcx.sess.diagnostic().mut_span_err(
+    fcx.tcx.sess.diagnostic().struct_span_err(
         span,
         &format!("invalid `self` parameter type: {:?}", receiver_ty)
     ).note("type of `self` must be `Self` or a type that dereferences to it")

--- a/src/libsyntax/ext/base.rs
+++ b/src/libsyntax/ext/base.rs
@@ -1041,10 +1041,6 @@ impl<'a> ExtCtxt<'a> {
     pub fn span_err_with_code<S: Into<MultiSpan>>(&self, sp: S, msg: &str, code: DiagnosticId) {
         self.parse_sess.span_diagnostic.span_err_with_code(sp, msg, code);
     }
-    pub fn mut_span_err<S: Into<MultiSpan>>(&self, sp: S, msg: &str)
-                        -> DiagnosticBuilder<'a> {
-        self.parse_sess.span_diagnostic.mut_span_err(sp, msg)
-    }
     pub fn span_warn<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.parse_sess.span_diagnostic.span_warn(sp, msg);
     }

--- a/src/libsyntax/ext/expand.rs
+++ b/src/libsyntax/ext/expand.rs
@@ -384,7 +384,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                         let attr = attr::find_by_name(item.attrs(), sym::derive)
                             .expect("`derive` attribute should exist");
                         let span = attr.span;
-                        let mut err = self.cx.mut_span_err(span,
+                        let mut err = self.cx.struct_span_err(span,
                             "`derive` may only be applied to structs, enums and unions");
                         if let ast::AttrStyle::Inner = attr.style {
                             let trait_list = derives.iter()

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -295,7 +295,7 @@ impl<'a, 'b> Context<'a, 'b> {
             .filter(|fmt| fmt.precision_span.is_some())
             .count();
         if self.names.is_empty() && !numbered_position_args && count != self.args.len() {
-            e = self.ecx.mut_span_err(
+            e = self.ecx.struct_span_err(
                 sp,
                 &format!(
                     "{} positional argument{} in format string, but {}",
@@ -336,7 +336,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 sp = MultiSpan::from_span(self.fmtsp);
             }
 
-            e = self.ecx.mut_span_err(sp,
+            e = self.ecx.struct_span_err(sp,
                 &format!("invalid reference to positional {} ({})",
                          arg_list,
                          self.describe_num_args()));

--- a/src/test/ui/suggestions/const-no-type.rs
+++ b/src/test/ui/suggestions/const-no-type.rs
@@ -1,0 +1,46 @@
+// In the cases below, the type is missing from the `const` and `static` items.
+//
+// Here, we test that we:
+//
+// a) Perform parser recovery.
+//
+// b) Emit a diagnostic with the actual inferred type to RHS of `=` as the suggestion.
+
+fn main() {}
+
+// These will not reach typeck:
+
+#[cfg(FALSE)]
+const C2 = 42;
+//~^ ERROR missing type for `const` item
+//~| HELP provide a type for the item
+//~| SUGGESTION C2: <type>
+
+#[cfg(FALSE)]
+static S2 = "abc";
+//~^ ERROR missing type for `static` item
+//~| HELP provide a type for the item
+//~| SUGGESTION S2: <type>
+
+#[cfg(FALSE)]
+static mut SM2 = "abc";
+//~^ ERROR missing type for `static mut` item
+//~| HELP provide a type for the item
+//~| SUGGESTION SM2: <type>
+
+// These will, so the diagnostics should be stolen by typeck:
+
+const C = 42;
+//~^ ERROR missing type for `const` item
+//~| HELP provide a type for the item
+//~| SUGGESTION C: i32
+
+static S = Vec::<String>::new();
+//~^ ERROR missing type for `static` item
+//~| HELP provide a type for the item
+//~| SUGGESTION S: std::vec::Vec<std::string::String>
+
+static mut SM = "abc";
+//~^ ERROR missing type for `static mut` item
+//~| HELP provide a type for the item
+//~| SUGGESTION &'static str

--- a/src/test/ui/suggestions/const-no-type.stderr
+++ b/src/test/ui/suggestions/const-no-type.stderr
@@ -1,0 +1,38 @@
+error: missing type for `const` item
+  --> $DIR/const-no-type.rs:33:7
+   |
+LL | const C = 42;
+   |       ^ help: provide a type for the item: `C: i32`
+
+error: missing type for `static` item
+  --> $DIR/const-no-type.rs:38:8
+   |
+LL | static S = Vec::<String>::new();
+   |        ^ help: provide a type for the item: `S: std::vec::Vec<std::string::String>`
+
+error: missing type for `static mut` item
+  --> $DIR/const-no-type.rs:43:12
+   |
+LL | static mut SM = "abc";
+   |            ^^ help: provide a type for the item: `SM: &'static str`
+
+error: missing type for `const` item
+  --> $DIR/const-no-type.rs:14:7
+   |
+LL | const C2 = 42;
+   |       ^^ help: provide a type for the item: `C2: <type>`
+
+error: missing type for `static` item
+  --> $DIR/const-no-type.rs:20:8
+   |
+LL | static S2 = "abc";
+   |        ^^ help: provide a type for the item: `S2: <type>`
+
+error: missing type for `static mut` item
+  --> $DIR/const-no-type.rs:26:12
+   |
+LL | static mut SM2 = "abc";
+   |            ^^^ help: provide a type for the item: `SM2: <type>`
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Here we:

1. Introduce a notion of the "error stash".

   This is a map in the `Handler` to which you can `err.stash(...)` away your diagnostics and then steal them in a later "phase" of the compiler (e.g. stash in parser, steal in typeck) to enrich them with more information that isn't available in the previous "phase".

    I believe I've covered all the bases to make sure these diagnostics are actually emitted eventually even under `#[cfg(FALSE)]` but please check my logic.

2. Recover when parsing `[const | static mut?] $ident = $expr;` which has a missing type.

    Use the "error stash" to stash away the error and later steal the error in typeck where we emit the error as `MachineApplicable` with the actual inferred type. This builds on https://github.com/rust-lang/rust/pull/62804.

cc https://github.com/rust-lang/rfcs/pull/2545

r? @estebank 