### PR TITLE
Suggest enclosing const expression in block

### DIFF
--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1494,14 +1494,15 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
         );
     }
 
-    fn smart_resolve_path_fragment(&mut self,
-                                   id: NodeId,
-                                   qself: Option<&QSelf>,
-                                   path: &[Segment],
-                                   span: Span,
-                                   source: PathSource<'_>,
-                                   crate_lint: CrateLint)
-                                   -> PartialRes {
+    fn smart_resolve_path_fragment(
+        &mut self,
+        id: NodeId,
+        qself: Option<&QSelf>,
+        path: &[Segment],
+        span: Span,
+        source: PathSource<'_>,
+        crate_lint: CrateLint,
+    ) -> PartialRes {
         let ns = source.namespace();
         let is_expected = &|res| source.is_expected(res);
 
@@ -1620,9 +1621,10 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
                 match self.resolve_qpath(id, qself, path, ns, span, crate_lint) {
                     // If defer_to_typeck, then resolution > no resolution,
                     // otherwise full resolution > partial resolution > no resolution.
-                    Some(partial_res) if partial_res.unresolved_segments() == 0 ||
-                                         defer_to_typeck =>
-                        return Some(partial_res),
+                    Some(partial_res)
+                    if partial_res.unresolved_segments() == 0 || defer_to_typeck => {
+                        return Some(partial_res)
+                    }
                     partial_res => if fin_res.is_none() { fin_res = partial_res },
                 }
             }

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1253,6 +1253,23 @@ pub enum ExprKind {
     Err,
 }
 
+impl ExprKind {
+    /// Whether this expression can appear in a contst argument without being surrounded by braces.
+    ///
+    /// Only used in error recovery.
+    pub(crate) fn is_valid_const_on_its_own(&self) -> bool {
+        match self {
+            ExprKind::Tup(_) |
+            ExprKind::Lit(_) |
+            ExprKind::Type(..) |
+            ExprKind::Path(..) |
+            ExprKind::Unary(..) |
+            ExprKind::Err => true,
+            _ => false,
+        }
+    }
+}
+
 /// The explicit `Self` type in a "qualified path". The actual
 /// path, including the trait and the associated item, is stored
 /// separately. `position` represents the index of the associated

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1253,32 +1253,6 @@ pub enum ExprKind {
     Err,
 }
 
-impl ExprKind {
-    /// Whether this expression can appear applied to a `const` parameter without being surrounded
-    /// by braces.
-    ///
-    /// Only used in error recovery.
-    crate fn is_valid_const_on_its_own(&self) -> bool {
-        fn is_const_lit(kind: &ExprKind) -> bool {
-            // These are the only literals that can be negated as a bare `const` argument.
-            match kind {
-                ExprKind::Lit(Lit { node: LitKind::Int(..), ..}) |
-                ExprKind::Lit(Lit { node: LitKind::Float(..), ..}) |
-                ExprKind::Lit(Lit { node: LitKind::FloatUnsuffixed(..), ..}) => true,
-                _ => false,
-            }
-        }
-
-        match self {
-            ExprKind::Lit(_) | // `foo::<42>()`
-            ExprKind::Err => true,
-            // `foo::<-42>()`
-            ExprKind::Unary(UnOp::Neg, expr) if is_const_lit(&expr.node) => true,
-            _ => false,
-        }
-    }
-}
-
 /// The explicit `Self` type in a "qualified path". The actual
 /// path, including the trait and the associated item, is stored
 /// separately. `position` represents the index of the associated

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -38,8 +38,9 @@ use std::path::PathBuf;
 
 bitflags::bitflags! {
     struct Restrictions: u8 {
-        const STMT_EXPR         = 1 << 0;
-        const NO_STRUCT_LITERAL = 1 << 1;
+        const STMT_EXPR           = 1 << 0;
+        const NO_STRUCT_LITERAL   = 1 << 1;
+        const CONST_EXPR_RECOVERY = 1 << 2;
     }
 }
 

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -40,7 +40,7 @@ bitflags::bitflags! {
     struct Restrictions: u8 {
         const STMT_EXPR           = 1 << 0;
         const NO_STRUCT_LITERAL   = 1 << 1;
-        const CONST_EXPR_RECOVERY = 1 << 2;
+        const CLOSING_ANGLE_BRACKET = 1 << 2;
     }
 }
 

--- a/src/libsyntax/parse/parser/expr.rs
+++ b/src/libsyntax/parse/parser/expr.rs
@@ -355,7 +355,9 @@ impl<'a> Parser<'a> {
         (self.restrictions.contains(Restrictions::STMT_EXPR) &&
             !classify::expr_requires_semi_to_be_stmt(e)) ||
             (self.restrictions.contains(Restrictions::CONST_EXPR_RECOVERY) &&
-             (self.token == token::Lt || self.token == token::Gt || self.token == token::Comma))
+             // `<` is necessary here to avoid cases like `foo::< 1 < 3 >()` where we'll fallback
+             // to a regular parse error without recovery or suggestions.
+             [token::Lt, token::Gt, token::Comma].contains(&self.token.kind))
     }
 
     fn is_at_start_of_range_notation_rhs(&self) -> bool {

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -48,8 +48,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    pub(super) fn parse_ty_common(&mut self, allow_plus: bool, allow_qpath_recovery: bool,
-                       allow_c_variadic: bool) -> PResult<'a, P<Ty>> {
+    pub(super) fn parse_ty_common(
+        &mut self,
+        allow_plus: bool,
+        allow_qpath_recovery: bool,
+        allow_c_variadic: bool,
+    ) -> PResult<'a, P<Ty>> {
         maybe_recover_from_interpolated_ty_qpath!(self, allow_qpath_recovery);
         maybe_whole!(self, NtTy, |x| x);
 

--- a/src/test/ui/const-generics/const-expression-parameter.rs
+++ b/src/test/ui/const-generics/const-expression-parameter.rs
@@ -1,39 +1,40 @@
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
-fn i32_identity<const X: i32>() -> i32 {
-    5
-}
+fn foo<const X: i32>() -> i32 { 5 }
 
-fn foo_a() {
-    i32_identity::<-1>(); // ok
-}
+fn baz<const X: i32, const Y: i32>() { }
 
-fn foo_b() {
-    i32_identity::<1 + 2>(); //~ ERROR complex const arguments must be surrounded by braces
-}
+fn bar<const X: bool>() {}
 
-fn foo_c() {
-    i32_identity::< -1 >(); // ok
-}
+fn bat<const X: (i32, i32, i32)>() {}
 
-fn foo_d() {
-    i32_identity::<1 + 2, 3 + 4>();
+fn main() {
+    foo::<-1>(); // ok
+    foo::<1 + 2>(); //~ ERROR complex const arguments must be surrounded by braces
+    foo::< -1 >(); // ok
+    foo::<1 + 2, 3 + 4>();
     //~^ ERROR complex const arguments must be surrounded by braces
     //~| ERROR complex const arguments must be surrounded by braces
     //~| ERROR wrong number of const arguments: expected 1, found 2
-}
+    foo::<5>(); // ok
 
-fn baz<const X: i32, const Y: i32>() -> i32 {
-    42
-}
-
-fn foo_e() {
+    baz::<-1, -2>(); // ok
     baz::<1 + 2, 3 + 4>();
     //~^ ERROR complex const arguments must be surrounded by braces
     //~| ERROR complex const arguments must be surrounded by braces
+    baz::< -1 , 2 >(); // ok
+    baz::< -1 , "2" >(); //~ ERROR mismatched types
+
+    bat::<(1, 2, 3)>(); //~ ERROR complex const arguments must be surrounded by braces
+    bat::<(1, 2)>();
+    //~^ ERROR complex const arguments must be surrounded by braces
+    //~| ERROR mismatched types
+
+    bar::<false>(); // ok
+    bar::<!false>(); //~ ERROR complex const arguments must be surrounded by braces
 }
 
-fn main() {
-    i32_identity::<5>(); // ok
+fn parse_err_1() {
+    bar::< 3 < 4 >(); //~ ERROR expected one of `,` or `>`, found `<`
 }

--- a/src/test/ui/const-generics/const-expression-parameter.rs
+++ b/src/test/ui/const-generics/const-expression-parameter.rs
@@ -10,11 +10,28 @@ fn foo_a() {
 }
 
 fn foo_b() {
-    i32_identity::<1 + 2>(); //~ ERROR expected one of `,` or `>`, found `+`
+    i32_identity::<1 + 2>(); //~ ERROR complex const arguments must be surrounded by braces
 }
 
 fn foo_c() {
     i32_identity::< -1 >(); // ok
+}
+
+fn foo_d() {
+    i32_identity::<1 + 2, 3 + 4>();
+    //~^ ERROR complex const arguments must be surrounded by braces
+    //~| ERROR complex const arguments must be surrounded by braces
+    //~| ERROR wrong number of const arguments: expected 1, found 2
+}
+
+fn baz<const X: i32, const Y: i32>() -> i32 {
+    42
+}
+
+fn foo_e() {
+    baz::<1 + 2, 3 + 4>();
+    //~^ ERROR complex const arguments must be surrounded by braces
+    //~| ERROR complex const arguments must be surrounded by braces
 }
 
 fn main() {

--- a/src/test/ui/const-generics/const-expression-parameter.rs
+++ b/src/test/ui/const-generics/const-expression-parameter.rs
@@ -1,6 +1,15 @@
 #![feature(const_generics)]
 //~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
 
+const fn const_i32() -> i32 {
+    42
+}
+
+const fn const_bool() -> bool {
+    true
+}
+const X: i32 = 1;
+
 fn foo<const X: i32>() -> i32 { 5 }
 
 fn baz<const X: i32, const Y: i32>() { }
@@ -11,30 +20,51 @@ fn bat<const X: (i32, i32, i32)>() {}
 
 fn main() {
     foo::<-1>(); // ok
-    foo::<1 + 2>(); //~ ERROR complex const arguments must be surrounded by braces
+    foo::<1 + 2>(); // ok
     foo::< -1 >(); // ok
-    foo::<1 + 2, 3 + 4>();
-    //~^ ERROR complex const arguments must be surrounded by braces
-    //~| ERROR complex const arguments must be surrounded by braces
-    //~| ERROR wrong number of const arguments: expected 1, found 2
+    foo::<1 + 2, 3 + 4>(); //~ ERROR wrong number of const arguments: expected 1, found 2
     foo::<5>(); // ok
+    foo::< const_i32() >(); //~ ERROR expected type, found function `const_i32`
+    //~^ ERROR wrong number of const arguments: expected 1, found 0
+    //~| ERROR wrong number of type arguments: expected 0, found 1
+    foo::< X >(); //~ ERROR expected type, found constant `X`
+    //~^ ERROR wrong number of const arguments: expected 1, found 0
+    //~| ERROR wrong number of type arguments: expected 0, found 1
+    foo::<{ X }>(); // ok
+    foo::< 42 + X >(); // ok
+    foo::<{ const_i32() }>(); // ok
 
     baz::<-1, -2>(); // ok
-    baz::<1 + 2, 3 + 4>();
-    //~^ ERROR complex const arguments must be surrounded by braces
-    //~| ERROR complex const arguments must be surrounded by braces
+    baz::<1 + 2, 3 + 4>(); // ok
     baz::< -1 , 2 >(); // ok
     baz::< -1 , "2" >(); //~ ERROR mismatched types
 
-    bat::<(1, 2, 3)>(); //~ ERROR complex const arguments must be surrounded by braces
+    bat::<(1, 2, 3)>(); //~ ERROR tuples in const arguments must be surrounded by braces
     bat::<(1, 2)>();
-    //~^ ERROR complex const arguments must be surrounded by braces
+    //~^ ERROR tuples in const arguments must be surrounded by braces
     //~| ERROR mismatched types
 
     bar::<false>(); // ok
     bar::<!false>(); //~ ERROR complex const arguments must be surrounded by braces
+    bar::<{ const_bool() }>(); // ok
+    bar::< const_bool() >(); //~ ERROR expected type, found function `const_bool`
+    //~^ ERROR wrong number of const arguments: expected 1, found 0
+    //~| ERROR wrong number of type arguments: expected 0, found 1
+    bar::<{ !const_bool() }>(); // ok
+    bar::< !const_bool() >(); //~ ERROR complex const arguments must be surrounded by braces
+
+    foo::<foo::<42>()>(); //~ ERROR expected one of `!`, `+`, `,`, `::`, or `>`, found `(`
 }
 
 fn parse_err_1() {
-    bar::< 3 < 4 >(); //~ ERROR expected one of `,` or `>`, found `<`
+    bar::< 3 < 4 >(); //~ ERROR expected one of `,`, `.`, `>`, or `?`, found `<`
+}
+
+fn parse_err_2() {
+    foo::< const_i32() + 42 >();
+    //~^ ERROR expected one of `!`, `(`, `,`, `>`, `?`, `for`, lifetime, or path, found `42`
+}
+fn parse_err_3() {
+    foo::< X + 42 >();
+    //~^ ERROR expected one of `!`, `(`, `,`, `>`, `?`, `for`, lifetime, or path, found `42`
 }

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -1,35 +1,35 @@
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:13:20
+  --> $DIR/const-expression-parameter.rs:14:11
    |
-LL |     i32_identity::<1 + 2>();
-   |                    ^^^^^
+LL |     foo::<1 + 2>();
+   |           ^^^^^
 help: surround this const argument in braces
    |
-LL |     i32_identity::<{ 1 + 2 }>();
-   |                    ^       ^
+LL |     foo::<{ 1 + 2 }>();
+   |           ^       ^
 
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:21:20
+  --> $DIR/const-expression-parameter.rs:16:11
    |
-LL |     i32_identity::<1 + 2, 3 + 4>();
-   |                    ^^^^^
+LL |     foo::<1 + 2, 3 + 4>();
+   |           ^^^^^
 help: surround this const argument in braces
    |
-LL |     i32_identity::<{ 1 + 2 }, 3 + 4>();
-   |                    ^       ^
+LL |     foo::<{ 1 + 2 }, 3 + 4>();
+   |           ^       ^
 
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:21:27
+  --> $DIR/const-expression-parameter.rs:16:18
    |
-LL |     i32_identity::<1 + 2, 3 + 4>();
-   |                           ^^^^^
+LL |     foo::<1 + 2, 3 + 4>();
+   |                  ^^^^^
 help: surround this const argument in braces
    |
-LL |     i32_identity::<1 + 2, { 3 + 4 }>();
-   |                           ^       ^
+LL |     foo::<1 + 2, { 3 + 4 }>();
+   |                  ^       ^
 
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:32:11
+  --> $DIR/const-expression-parameter.rs:23:11
    |
 LL |     baz::<1 + 2, 3 + 4>();
    |           ^^^^^
@@ -39,7 +39,7 @@ LL |     baz::<{ 1 + 2 }, 3 + 4>();
    |           ^       ^
 
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:32:18
+  --> $DIR/const-expression-parameter.rs:23:18
    |
 LL |     baz::<1 + 2, 3 + 4>();
    |                  ^^^^^
@@ -47,6 +47,42 @@ help: surround this const argument in braces
    |
 LL |     baz::<1 + 2, { 3 + 4 }>();
    |                  ^       ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:29:11
+   |
+LL |     bat::<(1, 2, 3)>();
+   |           ^^^^^^^^^
+help: surround this const argument in braces
+   |
+LL |     bat::<{ (1, 2, 3) }>();
+   |           ^           ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:30:11
+   |
+LL |     bat::<(1, 2)>();
+   |           ^^^^^^
+help: surround this const argument in braces
+   |
+LL |     bat::<{ (1, 2) }>();
+   |           ^        ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:35:11
+   |
+LL |     bar::<!false>();
+   |           ^^^^^^
+help: surround this const argument in braces
+   |
+LL |     bar::<{ !false }>();
+   |           ^        ^
+
+error: expected one of `,` or `>`, found `<`
+  --> $DIR/const-expression-parameter.rs:39:14
+   |
+LL |     bar::< 3 < 4 >();
+   |              ^ expected one of `,` or `>` here
 
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
   --> $DIR/const-expression-parameter.rs:1:12
@@ -57,11 +93,30 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0107]: wrong number of const arguments: expected 1, found 2
-  --> $DIR/const-expression-parameter.rs:21:27
+  --> $DIR/const-expression-parameter.rs:16:18
    |
-LL |     i32_identity::<1 + 2, 3 + 4>();
-   |                           ^^^^^ unexpected const argument
+LL |     foo::<1 + 2, 3 + 4>();
+   |                  ^^^^^ unexpected const argument
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/const-expression-parameter.rs:27:17
+   |
+LL |     baz::< -1 , "2" >();
+   |                 ^^^ expected i32, found reference
+   |
+   = note: expected type `i32`
+              found type `&'static str`
 
-For more information about this error, try `rustc --explain E0107`.
+error[E0308]: mismatched types
+  --> $DIR/const-expression-parameter.rs:30:11
+   |
+LL |     bat::<(1, 2)>();
+   |           ^^^^^^ expected a tuple with 3 elements, found one with 2 elements
+   |
+   = note: expected type `(i32, i32, i32)`
+              found type `(i32, i32)`
+
+error: aborting due to 12 previous errors
+
+Some errors have detailed explanations: E0107, E0308.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -1,8 +1,52 @@
-error: expected one of `,` or `>`, found `+`
-  --> $DIR/const-expression-parameter.rs:13:22
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:13:20
    |
 LL |     i32_identity::<1 + 2>();
-   |                      ^ expected one of `,` or `>` here
+   |                    ^^^^^
+help: surround this const argument in braces
+   |
+LL |     i32_identity::<{ 1 + 2 }>();
+   |                    ^       ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:21:20
+   |
+LL |     i32_identity::<1 + 2, 3 + 4>();
+   |                    ^^^^^
+help: surround this const argument in braces
+   |
+LL |     i32_identity::<{ 1 + 2 }, 3 + 4>();
+   |                    ^       ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:21:27
+   |
+LL |     i32_identity::<1 + 2, 3 + 4>();
+   |                           ^^^^^
+help: surround this const argument in braces
+   |
+LL |     i32_identity::<1 + 2, { 3 + 4 }>();
+   |                           ^       ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:32:11
+   |
+LL |     baz::<1 + 2, 3 + 4>();
+   |           ^^^^^
+help: surround this const argument in braces
+   |
+LL |     baz::<{ 1 + 2 }, 3 + 4>();
+   |           ^       ^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:32:18
+   |
+LL |     baz::<1 + 2, 3 + 4>();
+   |                  ^^^^^
+help: surround this const argument in braces
+   |
+LL |     baz::<1 + 2, { 3 + 4 }>();
+   |                  ^       ^
 
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
   --> $DIR/const-expression-parameter.rs:1:12
@@ -12,5 +56,12 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error: aborting due to previous error
+error[E0107]: wrong number of const arguments: expected 1, found 2
+  --> $DIR/const-expression-parameter.rs:21:27
+   |
+LL |     i32_identity::<1 + 2, 3 + 4>();
+   |                           ^^^^^ unexpected const argument
 
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/const-generics/const-expression-parameter.stderr
+++ b/src/test/ui/const-generics/const-expression-parameter.stderr
@@ -1,55 +1,5 @@
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:14:11
-   |
-LL |     foo::<1 + 2>();
-   |           ^^^^^
-help: surround this const argument in braces
-   |
-LL |     foo::<{ 1 + 2 }>();
-   |           ^       ^
-
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:16:11
-   |
-LL |     foo::<1 + 2, 3 + 4>();
-   |           ^^^^^
-help: surround this const argument in braces
-   |
-LL |     foo::<{ 1 + 2 }, 3 + 4>();
-   |           ^       ^
-
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:16:18
-   |
-LL |     foo::<1 + 2, 3 + 4>();
-   |                  ^^^^^
-help: surround this const argument in braces
-   |
-LL |     foo::<1 + 2, { 3 + 4 }>();
-   |                  ^       ^
-
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:23:11
-   |
-LL |     baz::<1 + 2, 3 + 4>();
-   |           ^^^^^
-help: surround this const argument in braces
-   |
-LL |     baz::<{ 1 + 2 }, 3 + 4>();
-   |           ^       ^
-
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:23:18
-   |
-LL |     baz::<1 + 2, 3 + 4>();
-   |                  ^^^^^
-help: surround this const argument in braces
-   |
-LL |     baz::<1 + 2, { 3 + 4 }>();
-   |                  ^       ^
-
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:29:11
+error: tuples in const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:42:11
    |
 LL |     bat::<(1, 2, 3)>();
    |           ^^^^^^^^^
@@ -58,8 +8,8 @@ help: surround this const argument in braces
 LL |     bat::<{ (1, 2, 3) }>();
    |           ^           ^
 
-error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:30:11
+error: tuples in const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:43:11
    |
 LL |     bat::<(1, 2)>();
    |           ^^^^^^
@@ -69,7 +19,7 @@ LL |     bat::<{ (1, 2) }>();
    |           ^        ^
 
 error: complex const arguments must be surrounded by braces
-  --> $DIR/const-expression-parameter.rs:35:11
+  --> $DIR/const-expression-parameter.rs:48:11
    |
 LL |     bar::<!false>();
    |           ^^^^^^
@@ -78,11 +28,57 @@ help: surround this const argument in braces
 LL |     bar::<{ !false }>();
    |           ^        ^
 
-error: expected one of `,` or `>`, found `<`
-  --> $DIR/const-expression-parameter.rs:39:14
+error: complex const arguments must be surrounded by braces
+  --> $DIR/const-expression-parameter.rs:54:12
+   |
+LL |     bar::< !const_bool() >();
+   |            ^^^^^^^^^^^^^
+help: surround this const argument in braces
+   |
+LL |     bar::< { !const_bool() } >();
+   |            ^               ^
+
+error: expected one of `!`, `+`, `,`, `::`, or `>`, found `(`
+  --> $DIR/const-expression-parameter.rs:56:20
+   |
+LL |     foo::<foo::<42>()>();
+   |                    ^ expected one of `!`, `+`, `,`, `::`, or `>` here
+
+error: expected one of `,`, `.`, `>`, or `?`, found `<`
+  --> $DIR/const-expression-parameter.rs:60:14
    |
 LL |     bar::< 3 < 4 >();
-   |              ^ expected one of `,` or `>` here
+   |              ^ expected one of `,`, `.`, `>`, or `?` here
+
+error: expected one of `!`, `(`, `,`, `>`, `?`, `for`, lifetime, or path, found `42`
+  --> $DIR/const-expression-parameter.rs:64:26
+   |
+LL |     foo::< const_i32() + 42 >();
+   |                          ^^ expected one of 8 possible tokens here
+
+error: expected one of `!`, `(`, `,`, `>`, `?`, `for`, lifetime, or path, found `42`
+  --> $DIR/const-expression-parameter.rs:68:16
+   |
+LL |     foo::< X + 42 >();
+   |                ^^ expected one of 8 possible tokens here
+
+error[E0573]: expected type, found function `const_i32`
+  --> $DIR/const-expression-parameter.rs:27:12
+   |
+LL |     foo::< const_i32() >();
+   |            ^^^^^^^^^^^ not a type
+
+error[E0573]: expected type, found constant `X`
+  --> $DIR/const-expression-parameter.rs:30:12
+   |
+LL |     foo::< X >();
+   |            ^ not a type
+
+error[E0573]: expected type, found function `const_bool`
+  --> $DIR/const-expression-parameter.rs:50:12
+   |
+LL |     bar::< const_bool() >();
+   |            ^^^^^^^^^^^^ not a type
 
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
   --> $DIR/const-expression-parameter.rs:1:12
@@ -93,13 +89,37 @@ LL | #![feature(const_generics)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0107]: wrong number of const arguments: expected 1, found 2
-  --> $DIR/const-expression-parameter.rs:16:18
+  --> $DIR/const-expression-parameter.rs:25:18
    |
 LL |     foo::<1 + 2, 3 + 4>();
    |                  ^^^^^ unexpected const argument
 
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/const-expression-parameter.rs:27:5
+   |
+LL |     foo::< const_i32() >();
+   |     ^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/const-expression-parameter.rs:27:12
+   |
+LL |     foo::< const_i32() >();
+   |            ^^^^^^^^^^^ unexpected type argument
+
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/const-expression-parameter.rs:30:5
+   |
+LL |     foo::< X >();
+   |     ^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/const-expression-parameter.rs:30:12
+   |
+LL |     foo::< X >();
+   |            ^ unexpected type argument
+
 error[E0308]: mismatched types
-  --> $DIR/const-expression-parameter.rs:27:17
+  --> $DIR/const-expression-parameter.rs:40:17
    |
 LL |     baz::< -1 , "2" >();
    |                 ^^^ expected i32, found reference
@@ -108,7 +128,7 @@ LL |     baz::< -1 , "2" >();
               found type `&'static str`
 
 error[E0308]: mismatched types
-  --> $DIR/const-expression-parameter.rs:30:11
+  --> $DIR/const-expression-parameter.rs:43:11
    |
 LL |     bat::<(1, 2)>();
    |           ^^^^^^ expected a tuple with 3 elements, found one with 2 elements
@@ -116,7 +136,19 @@ LL |     bat::<(1, 2)>();
    = note: expected type `(i32, i32, i32)`
               found type `(i32, i32)`
 
-error: aborting due to 12 previous errors
+error[E0107]: wrong number of const arguments: expected 1, found 0
+  --> $DIR/const-expression-parameter.rs:50:5
+   |
+LL |     bar::< const_bool() >();
+   |     ^^^^^^^^^^^^^^^^^^^^^ expected 1 const argument
+
+error[E0107]: wrong number of type arguments: expected 0, found 1
+  --> $DIR/const-expression-parameter.rs:50:12
+   |
+LL |     bar::< const_bool() >();
+   |            ^^^^^^^^^^^^ unexpected type argument
+
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0107, E0308.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -239,6 +239,7 @@ fn inside_const_generic_arguments() {
     // admit non-IDENT expressions in const generic arguments.
 
     if A::<
-        true && let 1 = 1 //~ ERROR expected one of `,` or `>`, found `&&`
-    >::O == 5 {}
+        true && let 1 = 1 //~ ERROR complex const arguments must be surrounded by braces
+    >::O == 5 {}  //~ ERROR chained comparison operators require parentheses
+    //~^ ERROR expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
 }

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -239,7 +239,6 @@ fn inside_const_generic_arguments() {
     // admit non-IDENT expressions in const generic arguments.
 
     if A::<
-        true && let 1 = 1 //~ ERROR complex const arguments must be surrounded by braces
-    >::O == 5 {}  //~ ERROR chained comparison operators require parentheses
-    //~^ ERROR expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
+        true && let 1 = 1 //~ ERROR expected one of `,` or `>`, found `&&`
+    >::O == 5 {} //~ ERROR chained comparison operators require parentheses
 }

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.rs
@@ -239,6 +239,7 @@ fn inside_const_generic_arguments() {
     // admit non-IDENT expressions in const generic arguments.
 
     if A::<
-        true && let 1 = 1 //~ ERROR expected one of `,` or `>`, found `&&`
+        true && let 1 = 1
     >::O == 5 {} //~ ERROR chained comparison operators require parentheses
+    //~^ ERROR expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
 }

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -4,23 +4,11 @@ error: chained comparison operators require parentheses
 LL |     >::O == 5 {}
    |     ^^^^^^^^^
 
-error: complex const arguments must be surrounded by braces
-  --> $DIR/disallowed-positions.rs:242:9
+error: expected one of `,` or `>`, found `&&`
+  --> $DIR/disallowed-positions.rs:242:14
    |
-LL | /         true && let 1 = 1
-LL | |     >::O == 5 {}
-   | |_____________^
-help: surround this const argument in braces
-   |
-LL |         { true && let 1 = 1
-LL |     >::O == 5 } {}
-   |
-
-error: expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
-  --> $DIR/disallowed-positions.rs:243:15
-   |
-LL |     >::O == 5 {}
-   |               ^ expected one of `,`, `.`, `>`, `?`, or an operator here
+LL |         true && let 1 = 1
+   |              ^^ expected one of `,` or `>` here
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:32:9
@@ -1001,7 +989,7 @@ error[E0019]: constant contains unimplemented expression type
 LL |         true && let 1 = 1
    |                     ^
 
-error: aborting due to 111 previous errors
+error: aborting due to 110 previous errors
 
 Some errors have detailed explanations: E0019, E0277, E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1,8 +1,26 @@
-error: expected one of `,` or `>`, found `&&`
-  --> $DIR/disallowed-positions.rs:242:14
+error: chained comparison operators require parentheses
+  --> $DIR/disallowed-positions.rs:243:5
    |
-LL |         true && let 1 = 1
-   |              ^^ expected one of `,` or `>` here
+LL |     >::O == 5 {}
+   |     ^^^^^^^^^
+
+error: complex const arguments must be surrounded by braces
+  --> $DIR/disallowed-positions.rs:242:9
+   |
+LL | /         true && let 1 = 1
+LL | |     >::O == 5 {}
+   | |_____________^
+help: surround this const argument in braces
+   |
+LL |         { true && let 1 = 1
+LL |     >::O == 5 } {}
+   |
+
+error: expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
+  --> $DIR/disallowed-positions.rs:243:15
+   |
+LL |     >::O == 5 {}
+   |               ^ expected one of `,`, `.`, `>`, `?`, or an operator here
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:32:9
@@ -983,7 +1001,7 @@ error[E0019]: constant contains unimplemented expression type
 LL |         true && let 1 = 1
    |                     ^
 
-error: aborting due to 109 previous errors
+error: aborting due to 111 previous errors
 
 Some errors have detailed explanations: E0019, E0277, E0308, E0600, E0614.
 For more information about an error, try `rustc --explain E0019`.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -4,11 +4,11 @@ error: chained comparison operators require parentheses
 LL |     >::O == 5 {}
    |     ^^^^^^^^^
 
-error: expected one of `,` or `>`, found `&&`
-  --> $DIR/disallowed-positions.rs:242:14
+error: expected one of `,`, `.`, `>`, `?`, or an operator, found `{`
+  --> $DIR/disallowed-positions.rs:243:15
    |
-LL |         true && let 1 = 1
-   |              ^^ expected one of `,` or `>` here
+LL |     >::O == 5 {}
+   |               ^ expected one of `,`, `.`, `>`, `?`, or an operator here
 
 error: `let` expressions are not supported here
   --> $DIR/disallowed-positions.rs:32:9


### PR DESCRIPTION
When encountering `foo::<X + 1>()`, suggest `foo::<{ X + 1 }>()`. When encountering `foo::<1 + 1>()` or `foo::<1 + X>()`, parse correctly.

Fix #61175.