### PR TITLE
Docs: slice elements are equidistant

### DIFF
--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -566,7 +566,9 @@ mod prim_array { }
 #[doc(alias = "[")]
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
-/// A dynamically-sized view into a contiguous sequence, `[T]`.
+/// A dynamically-sized view into a contiguous sequence, `[T]`. Contiguous here
+/// means that elements are laid out so that every element is the same distance
+/// from its neighbors.
 ///
 /// *[See also the `std::slice` module](slice/index.html).*
 ///


### PR DESCRIPTION
Recently, someone asked why `[char]` and `str` are not interchangeable, and I explained that in a slice, the elements must be laid out equidistantly, whereas the chars in a `str` are stored compactly regardless their size. However I couldn't find this documented anywhere, so here's a small addition of this fact.