### PR TITLE
Add --measure-time flag to libtest

### DIFF
--- a/src/libtest/formatters/json.rs
+++ b/src/libtest/formatters/json.rs
@@ -72,13 +72,13 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
         stdout: &[u8],
         state: &ConsoleTestState,
     ) -> io::Result<()> {
-        let stdout = if (state.options.display_output || *result != TrOk) && stdout.len() > 0 {
+        let stdout = if (state.options.display_output || !result.is_ok()) && stdout.len() > 0 {
             Some(String::from_utf8_lossy(stdout))
         } else {
             None
         };
         match *result {
-            TrOk => self.write_event("test", desc.name.as_slice(), "ok", stdout, None),
+            TrOk(_) => self.write_event("test", desc.name.as_slice(), "ok", stdout, None),
 
             TrFailed => self.write_event("test", desc.name.as_slice(), "failed", stdout, None),
 

--- a/src/libtest/formatters/terse.rs
+++ b/src/libtest/formatters/terse.rs
@@ -178,7 +178,7 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
         _: &ConsoleTestState,
     ) -> io::Result<()> {
         match *result {
-            TrOk => self.write_ok(),
+            TrOk(_) => self.write_ok(),
             TrFailed | TrFailedMsg(_) => self.write_failed(),
             TrIgnored => self.write_ignored(),
             TrAllowedFail => self.write_allowed_fail(),


### PR DESCRIPTION
## Overview

This PR introduces a new option flag for `rust` `test` command: `measure-time`. With this flag applied, `rustc` will measure the execution time of each test and print it out (into file log or if `pretty` formatter is chosen).

`--measure-time` is intended for a single-threaded run, so using with `--test-threads` set to any value other than `1` will result in an error.

Time is measured only when flag is applied, thus there is no overhead for common runs.

In the output, time is written in red if test duration time >= `RUST_TEST_TIME_CRITICAL` (defaults to 1000 milliseconds), in yellow if test duration time >= `RUST_TEST_TIME_WARN` (defaults to 500 milliseconds), otherwise default formatting is applied.

![rustc_timed_tests](https://user-images.githubusercontent.com/12111581/65449072-e1434200-de42-11e9-8296-d1c7a54f5e55.gif)

## Rationale

Usually, big Rust projects have a lot of tests. And tests are not always written carefully. As a result, if some poorly written test gets merged into a big project, it will be difficult to find that test, because there is no tool for that. `libtest` checks for timed out tests, but the constant `TEST_WARN_TIMEOUT_S` is not configurable, and it's not really an instrument to detect not optimized tests.

This PR allows developers to inspect their codebase to detect long-running tests and optimize/rewrite/remove them.

## Backward compatibility

This PR is fully backward compatible, it does not introduce any breaking changes.

r? @Centril
