### PR TITLE
Fixed issue from #64447

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1049,7 +1049,7 @@ impl EmitterWriter {
 
         for sub in children {
             let sub_result = self.get_multispan_max_line_num(&sub.span);
-            max = if sub_result > max { sub_result } else { max };
+            max = std::cmp::max(sub_result, max);
         }
         max
     }

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1043,14 +1043,13 @@ impl EmitterWriter {
     }
 
     fn get_max_line_num(&mut self, span: &MultiSpan, children: &[SubDiagnostic]) -> usize {
-        let mut max = 0;
 
         let primary = self.get_multispan_max_line_num(span);
-        max = if primary > max { primary } else { max };
+        let mut max = primary;
 
         for sub in children {
             let sub_result = self.get_multispan_max_line_num(&sub.span);
-            max = if sub_result > max { primary } else { max };
+            max = if sub_result > max { sub_result } else { max };
         }
         max
     }


### PR DESCRIPTION
Did two tiny fixes. One is a micro optimization since we know that max is going to be assigned a `usize`, we do not have to worry about a possible negative number. 
The other issue that was fixed is that the max from the children isn't updated correctly. Now it will use `sub_result` instead of `primary` and will properly get the needed value.