### PR TITLE
Make all alt builders produce parallel-enabled compilers

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -55,6 +55,9 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"
   elif [ "$DEPLOY_ALT" != "" ]; then
+    if [ "$NO_PARALLEL_COMPILER" = "" ]; then
+      RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.parallel-compiler"
+    fi
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-assertions"
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.verify-llvm-ir"
   fi

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -813,6 +813,7 @@ macro_rules! options {
         pub const parse_list: Option<&str> = Some("a space-separated list of strings");
         pub const parse_opt_list: Option<&str> = Some("a space-separated list of strings");
         pub const parse_opt_comma_list: Option<&str> = Some("a comma-separated list of strings");
+        pub const parse_threads: Option<&str> = Some("a number");
         pub const parse_uint: Option<&str> = Some("a number");
         pub const parse_passes: Option<&str> =
             Some("a space-separated list of passes, or `all`");
@@ -953,6 +954,14 @@ macro_rules! options {
                     true
                 },
                 None => false,
+            }
+        }
+
+        fn parse_threads(slot: &mut usize, v: Option<&str>) -> bool {
+            match v.and_then(|s| s.parse().ok()) {
+                Some(0) => { *slot = ::num_cpus::get(); true },
+                Some(i) => { *slot = i; true },
+                None => false
             }
         }
 
@@ -1259,7 +1268,11 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
         "prints the LLVM optimization passes being run"),
     ast_json: bool = (false, parse_bool, [UNTRACKED],
         "print the AST as JSON and halt"),
-    threads: Option<usize> = (None, parse_opt_uint, [UNTRACKED],
+    // We default to 1 here since we want to behave like
+    // a sequential compiler for now. This'll likely be adjusted
+    // in the future. Note that -Zthreads=0 is the way to get
+    // the num_cpus behavior.
+    threads: usize = (1, parse_threads, [UNTRACKED],
         "use a thread pool with N threads"),
     ast_json_noexpand: bool = (false, parse_bool, [UNTRACKED],
         "print the pre-expansion AST as JSON and halt"),
@@ -2160,14 +2173,14 @@ pub fn build_session_options_and_crate_config(
         }
     }
 
-    if debugging_opts.threads == Some(0) {
+    if debugging_opts.threads == 0 {
         early_error(
             error_format,
             "value for threads must be a positive non-zero integer",
         );
     }
 
-    if debugging_opts.threads.unwrap_or(1) > 1 && debugging_opts.fuel.is_some() {
+    if debugging_opts.threads > 1 && debugging_opts.fuel.is_some() {
         early_error(
             error_format,
             "optimization fuel is incompatible with multiple threads",

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -899,14 +899,8 @@ impl Session {
 
     /// Returns the number of query threads that should be used for this
     /// compilation
-    pub fn threads_from_count(query_threads: Option<usize>) -> usize {
-        query_threads.unwrap_or(::num_cpus::get())
-    }
-
-    /// Returns the number of query threads that should be used for this
-    /// compilation
     pub fn threads(&self) -> usize {
-        Self::threads_from_count(self.opts.debugging_opts.threads)
+        self.opts.debugging_opts.threads
     }
 
     /// Returns the number of codegen units that should be used for this

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -147,5 +147,8 @@ where
     F: FnOnce() -> R + Send,
     R: Send,
 {
-    util::spawn_thread_pool(edition, None, &None, f)
+    // the 1 here is duplicating code in config.opts.debugging_opts.threads
+    // which also defaults to 1; it ultimately doesn't matter as the default
+    // isn't threaded, and just ignores this parameter
+    util::spawn_thread_pool(edition, 1, &None, f)
 }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -173,7 +173,7 @@ pub fn scoped_thread<F: FnOnce() -> R + Send, R: Send>(cfg: thread::Builder, f: 
 #[cfg(not(parallel_compiler))]
 pub fn spawn_thread_pool<F: FnOnce() -> R + Send, R: Send>(
     edition: Edition,
-    _threads: Option<usize>,
+    _threads: usize,
     stderr: &Option<Arc<Mutex<Vec<u8>>>>,
     f: F,
 ) -> R {
@@ -198,7 +198,7 @@ pub fn spawn_thread_pool<F: FnOnce() -> R + Send, R: Send>(
 #[cfg(parallel_compiler)]
 pub fn spawn_thread_pool<F: FnOnce() -> R + Send, R: Send>(
     edition: Edition,
-    threads: Option<usize>,
+    threads: usize,
     stderr: &Option<Arc<Mutex<Vec<u8>>>>,
     f: F,
 ) -> R {
@@ -209,7 +209,7 @@ pub fn spawn_thread_pool<F: FnOnce() -> R + Send, R: Send>(
     let mut config = ThreadPoolBuilder::new()
         .acquire_thread_handler(jobserver::acquire_thread)
         .release_thread_handler(jobserver::release_thread)
-        .num_threads(Session::threads_from_count(threads))
+        .num_threads(threads)
         .deadlock_handler(|| unsafe { ty::query::handle_deadlock() });
 
     if let Some(size) = get_stack_size() {


### PR DESCRIPTION
We're not quite ready to ship parallel compilers by default, but the alt
builders are not used too much (in theory), so we believe that shipping
a possibly-broken compiler there is not too problematic.

r? @nikomatsakis 
