### PR TITLE
Stabilize `Option::flatten`

### DIFF
--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -3,7 +3,6 @@
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
 #![feature(new_uninit)]
-#![feature(option_flattening)]
 #![feature(pattern)]
 #![feature(trusted_len)]
 #![feature(try_reserve)]

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1568,7 +1568,6 @@ impl<T> Option<Option<T>> {
     /// # Examples
     /// Basic usage:
     /// ```
-    /// #![feature(option_flattening)]
     /// let x: Option<Option<u32>> = Some(Some(6));
     /// assert_eq!(Some(6), x.flatten());
     ///
@@ -1580,13 +1579,12 @@ impl<T> Option<Option<T>> {
     /// ```
     /// Flattening once only removes one level of nesting:
     /// ```
-    /// #![feature(option_flattening)]
     /// let x: Option<Option<Option<u32>>> = Some(Some(Some(6)));
     /// assert_eq!(Some(Some(6)), x.flatten());
     /// assert_eq!(Some(6), x.flatten().flatten());
     /// ```
     #[inline]
-    #[unstable(feature = "option_flattening", issue = "60258")]
+    #[stable(feature = "option_flattening", since = "1.40.0")]
     pub fn flatten(self) -> Option<T> {
         self.and_then(convert::identity)
     }


### PR DESCRIPTION
- PR: https://github.com/rust-lang/rust/pull/60256
- Tracking issue: https://github.com/rust-lang/rust/issues/60258

@elahn 

> I was trying to `flat_map()` and found `map().flatten()` does the trick. This has been on nightly for 4 months, can we stabilise it?

@ethanboxx 

> @Centril Helped me get this merged. What is the stabilization process?

@Centril 

> @ethanboxx I'd just file a PR to stabilize it and we'll ask T-libs to FCP.

So here I am.

I am was unsure what number to put in `since = "-"` so I copied what someone had done in a recent PR.



