### PR TITLE
Don't emit explain with json short messages.

### DIFF
--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -112,6 +112,13 @@ impl Emitter for JsonEmitter {
             panic!("failed to print notification: {:?}", e);
         }
     }
+
+    fn should_show_explain(&self) -> bool {
+        match self.json_rendered {
+            HumanReadableErrorType::Short(_) => false,
+            _ => true,
+        }
+    }
 }
 
 // The following data types are provided just for serialisation.

--- a/src/test/ui/json-short.stderr
+++ b/src/test/ui/json-short.stderr
@@ -15,5 +15,3 @@ started: https://doc.rust-lang.org/book/
 "}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error
 "}
-{"message":"For more information about this error, try `rustc --explain E0601`.","code":null,"level":"failure-note","spans":[],"children":[],"rendered":"For more information about this error, try `rustc --explain E0601`.
-"}


### PR DESCRIPTION
This fixes an issue where `--error-format=json --json=diagnostic-short` would emit the "For more information about this error" message, which doesn't match the behavior of `--error-format=short` which explicitly excludes it.
