### PR TITLE
Fix GAT lifetime bounds

### DIFF
--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -790,12 +790,12 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             }
             Type(ref bounds, ref ty) => {
                 let generics = &trait_item.generics;
-                let mut index = self.next_early_index();
+                let index = self.next_early_index();
                 debug!("visit_ty: index = {}", index);
                 let mut non_lifetime_count = 0;
                 let lifetimes = generics.params.iter().filter_map(|param| match param.kind {
                     GenericParamKind::Lifetime { .. } => {
-                        Some(Region::early(&self.tcx.hir(), &mut index, param))
+                        Some(Region::late(&self.tcx.hir(), param))
                     }
                     GenericParamKind::Type { .. } |
                     GenericParamKind::Const { .. } => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2450,11 +2450,11 @@ impl<'tcx> Bounds<'tcx> {
 
         sized_predicate.into_iter().chain(
             self.region_bounds.iter().map(|&(region_bound, span)| {
-                // Account for the binder being introduced below; no need to shift `param_ty`
-                // because, at present at least, it can only refer to early-bound regions.
                 let region_bound = ty::fold::shift_region(tcx, region_bound, 1);
+                // Because of GAT bounds, param_ty may have late-bound regions.
+                let param_ty = ty::fold::shift_vars(tcx, &param_ty, 1);
                 let outlives = ty::OutlivesPredicate(param_ty, region_bound);
-                (ty::Binder::dummy(outlives).to_predicate(), span)
+                (ty::Binder::bind(outlives).to_predicate(), span)
             }).chain(
                 self.trait_bounds.iter().map(|&(bound_trait_ref, span)| {
                     (bound_trait_ref.to_predicate(), span)

--- a/src/test/ui/rfc1598-generic-associated-types/lifetime_bound.rs
+++ b/src/test/ui/rfc1598-generic-associated-types/lifetime_bound.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+// rust-lang/rust#62521: Do not ICE when a generic lifetime is used
+// in the type's bound.
+
+#![feature(generic_associated_types)]
+//~^ WARNING the feature `generic_associated_types` is incomplete
+
+trait Foo {
+  type PublicKey<'a>: From<&'a [u8]>;
+}
+
+trait Bar {
+    type Item<'a>: 'a;
+}
+
+fn main() {}

--- a/src/test/ui/rfc1598-generic-associated-types/lifetime_bound.stderr
+++ b/src/test/ui/rfc1598-generic-associated-types/lifetime_bound.stderr
@@ -1,0 +1,8 @@
+warning: the feature `generic_associated_types` is incomplete and may cause the compiler to crash
+  --> $DIR/lifetime_bound.rs:6:12
+   |
+LL | #![feature(generic_associated_types)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
This makes GAT lifetimes in traits (not impls) late-bound regions, which matches the RFC, stating that bounds placed on the GAT should be interpreted as HRTBs.

This fixes most of #62521, but the last code block in that issue fails because GAT impls are unimplemented (pun not intended).