### PR TITLE
Remove tx_to_llvm_workers from TyCtxt

### DIFF
--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -103,7 +103,11 @@ pub fn iter_globals(llmod: &'ll llvm::Module) -> ValueIter<'ll> {
     }
 }
 
-pub fn compile_codegen_unit(tcx: TyCtxt<'tcx>, cgu_name: InternedString) {
+pub fn compile_codegen_unit(
+    tcx: TyCtxt<'tcx>,
+    cgu_name: InternedString,
+    tx_to_llvm_workers: &std::sync::mpsc::Sender<Box<dyn std::any::Any + Send>>,
+) {
     let start_time = Instant::now();
 
     let dep_node = tcx.codegen_unit(cgu_name).codegen_dep_node(tcx);
@@ -121,7 +125,7 @@ pub fn compile_codegen_unit(tcx: TyCtxt<'tcx>, cgu_name: InternedString) {
     let cost = time_to_codegen.as_secs() * 1_000_000_000 +
                time_to_codegen.subsec_nanos() as u64;
 
-    submit_codegened_module_to_llvm(&LlvmCodegenBackend(()), tcx, module, cost);
+    submit_codegened_module_to_llvm(&LlvmCodegenBackend(()), tx_to_llvm_workers, module, cost);
 
     fn module_codegen(
         tcx: TyCtxt<'_>,

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -8,6 +8,7 @@ use rustc::session::{Session, config};
 use rustc::ty::TyCtxt;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use std::sync::Arc;
+use std::sync::mpsc;
 use syntax::ext::allocator::AllocatorKind;
 use syntax_pos::symbol::InternedString;
 
@@ -44,7 +45,12 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
         mods: &mut Self::Module,
         kind: AllocatorKind,
     );
-    fn compile_codegen_unit(&self, tcx: TyCtxt<'_>, cgu_name: InternedString);
+    fn compile_codegen_unit(
+        &self,
+        tcx: TyCtxt<'_>,
+        cgu_name: InternedString,
+        tx_to_llvm_workers: &mpsc::Sender<Box<dyn std::any::Any + Send>>,
+    );
     // If find_features is true this won't access `sess.crate_types` by assuming
     // that `is_pie_binary` is false. When we discover LLVM target features
     // `sess.crate_types` is uninitialized so we cannot access it.

--- a/src/librustc_codegen_utils/codegen_backend.rs
+++ b/src/librustc_codegen_utils/codegen_backend.rs
@@ -7,7 +7,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 use std::any::Any;
-use std::sync::mpsc;
 
 use syntax::symbol::Symbol;
 use rustc::session::Session;
@@ -36,7 +35,6 @@ pub trait CodegenBackend {
         tcx: TyCtxt<'tcx>,
         metadata: EncodedMetadata,
         need_metadata_module: bool,
-        rx: mpsc::Receiver<Box<dyn Any + Send>>,
     ) -> Box<dyn Any>;
 
     /// This is called on the returned `Box<dyn Any>` from `codegen_backend`

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -54,7 +54,6 @@ use std::fs;
 use std::io::{self, Write};
 use std::iter;
 use std::path::PathBuf;
-use std::sync::mpsc;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -816,7 +815,6 @@ pub fn create_global_ctxt(
     defs: hir::map::Definitions,
     resolutions: Resolutions,
     outputs: OutputFilenames,
-    tx: mpsc::Sender<Box<dyn Any + Send>>,
     crate_name: &str,
 ) -> BoxedGlobalCtxt {
     let sess = compiler.session().clone();
@@ -858,7 +856,6 @@ pub fn create_global_ctxt(
             hir_map,
             query_result_on_disk_cache,
             &crate_name,
-            tx,
             &outputs
         );
 
@@ -1068,7 +1065,6 @@ fn encode_and_write_metadata(
 pub fn start_codegen<'tcx>(
     codegen_backend: &dyn CodegenBackend,
     tcx: TyCtxt<'tcx>,
-    rx: mpsc::Receiver<Box<dyn Any + Send>>,
     outputs: &OutputFilenames,
 ) -> Box<dyn Any> {
     if log_enabled!(::log::Level::Info) {
@@ -1082,7 +1078,7 @@ pub fn start_codegen<'tcx>(
 
     tcx.sess.profiler(|p| p.start_activity("codegen crate"));
     let codegen = time(tcx.sess, "codegen", move || {
-        codegen_backend.codegen_crate(tcx, metadata, need_metadata_module, rx)
+        codegen_backend.codegen_crate(tcx, metadata, need_metadata_module)
     });
     tcx.sess.profiler(|p| p.end_activity("codegen crate"));
 

--- a/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
+++ b/src/test/run-make-fulldeps/hotplug_codegen_backend/the_backend.rs
@@ -64,7 +64,6 @@ impl CodegenBackend for TheBackend {
         tcx: TyCtxt<'tcx>,
         _metadata: EncodedMetadata,
         _need_metadata_module: bool,
-        _rx: mpsc::Receiver<Box<Any + Send>>
     ) -> Box<Any> {
         use rustc::hir::def_id::LOCAL_CRATE;
 


### PR DESCRIPTION
This can be kept within the codegen backend crates entirely -- there's no reason for us to create it outside and attempt to hold it in the (global) context.

Changes here aren't really too easily reviewable I suspect -- not sure if they can be cleaned up by splitting into more commits though, it's just hard to reason about `Box<Any>` in general. If there are thoughts though I'd be happy to hear them.

The primary goal of this PR is to get rid of the field on `rustc_interface::Queries`.