### PR TITLE
Fix issue #64732

### DIFF
--- a/src/libsyntax/parse/unescape_error_reporting.rs
+++ b/src/libsyntax/parse/unescape_error_reporting.rs
@@ -47,6 +47,12 @@ pub(crate) fn emit_unescape_error(
                 .emit();
         }
         EscapeError::MoreThanOneChar => {
+            let msg = if mode.is_bytes() {
+                "if you meant to write a byte string literal, use double quotes"
+            } else {
+                "if you meant to write a `str` literal, use double quotes"
+            };
+
             handler
                 .struct_span_err(
                     span_with_quotes,
@@ -54,7 +60,7 @@ pub(crate) fn emit_unescape_error(
                 )
                 .span_suggestion(
                     span_with_quotes,
-                    "if you meant to write a `str` literal, use double quotes",
+                    msg,
                     format!("\"{}\"", lit),
                     Applicability::MachineApplicable,
                 ).emit()

--- a/src/test/ui/issues/issue-64732.rs
+++ b/src/test/ui/issues/issue-64732.rs
@@ -1,0 +1,9 @@
+#![allow(unused)]
+fn main() {
+    let _foo = b'hello\0';
+    //~^ ERROR character literal may only contain one codepoint
+    //~| HELP if you meant to write a byte string literal, use double quotes
+    let _bar = 'hello';
+    //~^ ERROR character literal may only contain one codepoint
+    //~| HELP if you meant to write a `str` literal, use double quotes
+}

--- a/src/test/ui/issues/issue-64732.stderr
+++ b/src/test/ui/issues/issue-64732.stderr
@@ -1,0 +1,22 @@
+error: character literal may only contain one codepoint
+  --> $DIR/issue-64732.rs:3:17
+   |
+LL |     let _foo = b'hello\0';
+   |                 ^^^^^^^^^
+help: if you meant to write a byte string literal, use double quotes
+   |
+LL |     let _foo = b"hello\0";
+   |                 ^^^^^^^^^
+
+error: character literal may only contain one codepoint
+  --> $DIR/issue-64732.rs:6:16
+   |
+LL |     let _bar = 'hello';
+   |                ^^^^^^^
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _bar = "hello";
+   |                ^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Based on issue #64732, when creating a byte literal with single quotes,
the suggestion message would indicate that you meant to write a `str` literal,
but we actually meant to write a byte string literal.

So I changed the unescape_error_reporting.rs to decide whether to print out
"if you meant to write a `str` literal, use double quotes",
or "if you meant to write a byte string literal, use double quotes".

Fixes #64732.