### PR TITLE
Use https for curl when building for linux

### DIFF
--- a/src/ci/docker/dist-x86_64-linux/build-curl.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-curl.sh
@@ -3,9 +3,11 @@
 set -ex
 source shared.sh
 
-VERSION=7.51.0
+VERSION=7.66.0
 
-curl http://cool.haxx.se/download/curl-$VERSION.tar.bz2 | tar xjf -
+curl https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/curl-$VERSION.tar.xz \
+  | xz --decompress \
+  | tar xf -
 
 mkdir curl-build
 cd curl-build


### PR DESCRIPTION
I noticed that the dist-x86_64-linux builder uses http to fetch curl and doesn't do any signature verification. It should probably use https.

r? @alexcrichton @Mark-Simulacrum 