### PR TITLE
Fix ExitStatus on Fuchsia

### DIFF
--- a/src/libstd/sys/unix/process/mod.rs
+++ b/src/libstd/sys/unix/process/mod.rs
@@ -1,5 +1,5 @@
-pub use self::process_common::{Command, ExitStatus, ExitCode, Stdio, StdioPipes};
-pub use self::process_inner::Process;
+pub use self::process_common::{Command, ExitCode, Stdio, StdioPipes};
+pub use self::process_inner::{ExitStatus, Process};
 pub use crate::ffi::OsString as EnvKey;
 
 mod process_common;

--- a/src/libstd/sys/unix/process/process_common.rs
+++ b/src/libstd/sys/unix/process/process_common.rs
@@ -393,57 +393,6 @@ impl fmt::Debug for Command {
     }
 }
 
-/// Unix exit statuses
-#[derive(PartialEq, Eq, Clone, Copy, Debug)]
-pub struct ExitStatus(c_int);
-
-impl ExitStatus {
-    pub fn new(status: c_int) -> ExitStatus {
-        ExitStatus(status)
-    }
-
-    fn exited(&self) -> bool {
-        unsafe { libc::WIFEXITED(self.0) }
-    }
-
-    pub fn success(&self) -> bool {
-        self.code() == Some(0)
-    }
-
-    pub fn code(&self) -> Option<i32> {
-        if self.exited() {
-            Some(unsafe { libc::WEXITSTATUS(self.0) })
-        } else {
-            None
-        }
-    }
-
-    pub fn signal(&self) -> Option<i32> {
-        if !self.exited() {
-            Some(unsafe { libc::WTERMSIG(self.0) })
-        } else {
-            None
-        }
-    }
-}
-
-impl From<c_int> for ExitStatus {
-    fn from(a: c_int) -> ExitStatus {
-        ExitStatus(a)
-    }
-}
-
-impl fmt::Display for ExitStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(code) = self.code() {
-            write!(f, "exit code: {}", code)
-        } else {
-            let signal = self.signal().unwrap();
-            write!(f, "signal: {}", signal)
-        }
-    }
-}
-
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct ExitCode(u8);
 

--- a/src/libstd/sys/unix/process/zircon.rs
+++ b/src/libstd/sys/unix/process/zircon.rs
@@ -65,29 +65,14 @@ impl Drop for Handle {
     }
 }
 
-// Common ZX_INFO header
-#[derive(Default)]
-#[repr(C)]
-pub struct zx_info_header_t {
-    pub topic: u32,              // identifies the info struct
-    pub avail_topic_size: u16,   // “native” size of the struct
-    pub topic_size: u16,         // size of the returned struct (<=topic_size)
-    pub avail_count: u32,        // number of records the kernel has
-    pub count: u32,              // number of records returned (limited by buffer size)
-}
-
-#[derive(Default)]
-#[repr(C)]
-pub struct zx_record_process_t {
-    pub return_code: c_int,
-}
-
 // Returned for topic ZX_INFO_PROCESS
 #[derive(Default)]
 #[repr(C)]
 pub struct zx_info_process_t {
-    pub hdr: zx_info_header_t,
-    pub rec: zx_record_process_t,
+    pub return_code: i64,
+    pub started: bool,
+    pub exited: bool,
+    pub debugger_attached: bool,
 }
 
 extern {


### PR DESCRIPTION
Fuchsia exit codes don't follow the convention of libc::WEXITSTATUS et
al, and they are 64 bits instead of 32 bits. This gives Fuchsia its own
representation of ExitStatus.

Additionally, the zircon syscall structs were out of date, causing us to
see bogus exit codes.

r? @cramertj @alexcrichton 