### PR TITLE
Avoid `chain()` in `find_constraint_paths_between_regions()`.

### DIFF
--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -25,6 +25,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(mem_take)]
 #![feature(associated_type_bounds)]
 #![feature(range_is_empty)]
+#![feature(stmt_expr_attributes)]
 
 #![recursion_limit="256"]
 


### PR DESCRIPTION
This iterator can be hot, and chained iterators are slow. The second
half of the chain is almost always empty, so this commit specializes the
code to avoid the chained iteration.

This change reduces instruction counts for the `wg-grammar` benchmark by
up to 1.5%.