### PR TITLE
No StableHasherResult everywhere

### DIFF
--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -17,7 +17,7 @@ use syntax_pos::Span;
 use std::iter::repeat;
 
 use crate::ich::StableHashingContext;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 
 /// A visitor that walks over the HIR and collects `Node`s into a HIR map.
 pub(super) struct NodeCollector<'a, 'hir> {
@@ -602,9 +602,7 @@ impl<'hir, T> HashStable<StableHashingContext<'hir>> for HirItemLike<T>
 where
     T: HashStable<StableHashingContext<'hir>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'hir>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'hir>, hasher: &mut StableHasher) {
         hcx.while_hashing_hir_bodies(self.hash_bodies, |hcx| {
             self.item_like.hash_stable(hcx, hasher);
         });

--- a/src/librustc/hir/ptr.rs
+++ b/src/librustc/hir/ptr.rs
@@ -9,8 +9,7 @@ use std::{slice, vec};
 
 use rustc_serialize::{Encodable, Decodable, Encoder, Decoder};
 
-use rustc_data_structures::stable_hasher::{StableHasher, StableHasherResult,
-                                           HashStable};
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 /// An owned smart pointer.
 #[derive(Hash, PartialEq, Eq)]
 pub struct P<T: ?Sized> {
@@ -133,9 +132,7 @@ impl<T: Decodable> Decodable for P<[T]> {
 impl<CTX, T> HashStable<CTX> for P<T>
     where T: ?Sized + HashStable<CTX>
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -20,7 +20,7 @@ use syntax_pos::{Span, DUMMY_SP};
 use syntax_pos::hygiene;
 
 use rustc_data_structures::stable_hasher::{
-    HashStable, StableHasher, StableHasherResult, ToStableHashKey,
+    HashStable, StableHasher, ToStableHashKey,
 };
 use rustc_data_structures::fx::{FxHashSet, FxHashMap};
 use smallvec::SmallVec;
@@ -219,9 +219,7 @@ impl<'a> StableHashingContextProvider<'a> for StableHashingContext<'a> {
 impl<'a> crate::dep_graph::DepGraphSafe for StableHashingContext<'a> {}
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::BodyId {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         if hcx.hash_bodies() {
             hcx.body_resolver.body(*self).hash_stable(hcx, hasher);
         }
@@ -230,9 +228,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::BodyId {
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::HirId {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         match hcx.node_id_hashing_mode {
             NodeIdHashingMode::Ignore => {
                 // Don't do anything.
@@ -263,9 +259,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::HirId {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::NodeId {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         match hcx.node_id_hashing_mode {
             NodeIdHashingMode::Ignore => {
                 // Don't do anything.
@@ -298,9 +292,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for Span {
     /// codepoint offsets. For the purpose of the hash that's sufficient.
     /// Also, hashing filenames is expensive so we avoid doing it twice when the
     /// span starts and ends in the same file, which is almost always the case.
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         const TAG_VALID_SPAN: u8 = 0;
         const TAG_INVALID_SPAN: u8 = 1;
         const TAG_EXPANSION: u8 = 0;
@@ -379,24 +371,18 @@ impl<'a> HashStable<StableHashingContext<'a>> for Span {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for DelimSpan {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.open.hash_stable(hcx, hasher);
         self.close.hash_stable(hcx, hasher);
     }
 }
 
-pub fn hash_stable_trait_impls<'a, W>(
+pub fn hash_stable_trait_impls<'a>(
     hcx: &mut StableHashingContext<'a>,
-    hasher: &mut StableHasher<W>,
+    hasher: &mut StableHasher,
     blanket_impls: &[DefId],
     non_blanket_impls: &FxHashMap<fast_reject::SimplifiedType, Vec<DefId>>,
-) where
-    W: StableHasherResult,
-{
+) {
     {
         let mut blanket_impls: SmallVec<[_; 8]> = blanket_impls
             .iter()

--- a/src/librustc/ich/impls_hir.rs
+++ b/src/librustc/ich/impls_hir.rs
@@ -6,9 +6,7 @@ use crate::hir::map::DefPathHash;
 use crate::hir::def_id::{DefId, LocalDefId, CrateNum, CRATE_DEF_INDEX};
 use crate::ich::{StableHashingContext, NodeIdHashingMode, Fingerprint};
 
-use rustc_data_structures::stable_hasher::{
-    HashStable, ToStableHashKey, StableHasher, StableHasherResult,
-};
+use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 use smallvec::SmallVec;
 use std::mem;
 use syntax::ast;
@@ -16,9 +14,7 @@ use syntax::attr;
 
 impl<'a> HashStable<StableHashingContext<'a>> for DefId {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.def_path_hash(*self).hash_stable(hcx, hasher);
     }
 }
@@ -34,9 +30,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for DefId {
 
 impl<'a> HashStable<StableHashingContext<'a>> for LocalDefId {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.def_path_hash(self.to_def_id()).hash_stable(hcx, hasher);
     }
 }
@@ -52,9 +46,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for LocalDefId {
 
 impl<'a> HashStable<StableHashingContext<'a>> for CrateNum {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.def_path_hash(DefId {
             krate: *self,
             index: CRATE_DEF_INDEX
@@ -92,9 +84,7 @@ for hir::ItemLocalId {
 // in "DefPath Mode".
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::ItemId {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::ItemId {
             id
         } = *self;
@@ -106,9 +96,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::ItemId {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitItemId {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::TraitItemId {
             hir_id
         } = * self;
@@ -120,9 +108,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitItemId {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::ImplItemId {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::ImplItemId {
             hir_id
         } = * self;
@@ -138,9 +124,7 @@ impl_stable_hash_for!(struct ast::Label {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Ty {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.while_hashing_hir_bodies(true, |hcx| {
             let hir::Ty {
                 hir_id: _,
@@ -166,9 +150,7 @@ impl_stable_hash_for!(struct hir::Stmt {
 impl_stable_hash_for_spanned!(ast::Name);
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Expr {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.while_hashing_hir_bodies(true, |hcx| {
             let hir::Expr {
                 hir_id: _,
@@ -192,9 +174,7 @@ impl_stable_hash_for!(struct ast::Ident {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitItem {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::TraitItem {
             hir_id: _,
             ident,
@@ -216,9 +196,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitItem {
 
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::ImplItem {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::ImplItem {
             hir_id: _,
             ident,
@@ -248,9 +226,7 @@ impl_stable_hash_for!(enum ast::CrateSugar {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::VisibilityKind {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             hir::VisibilityKind::Public |
@@ -273,9 +249,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::VisibilityKind {
 impl_stable_hash_for_spanned!(hir::VisibilityKind);
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Mod {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::Mod {
             inner: ref inner_span,
             ref item_ids,
@@ -305,9 +279,7 @@ impl_stable_hash_for_spanned!(hir::Variant);
 
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Item {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::Item {
             ident,
             ref attrs,
@@ -328,9 +300,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for hir::Item {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::Body {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let hir::Body {
             params,
             value,
@@ -359,9 +329,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::BodyId {
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::def_id::DefIndex {
 
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.local_def_path_hash(*self).hash_stable(hcx, hasher);
     }
 }
@@ -376,17 +344,13 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::def_id::DefIndex {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for crate::middle::lang_items::LangItem {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for hir::TraitCandidate {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             let hir::TraitCandidate {
                 def_id,
@@ -418,17 +382,13 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for hir::TraitCandidate {
 }
 
 impl<'hir> HashStable<StableHashingContext<'hir>> for attr::InlineAttr {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'hir>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'hir>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
     }
 }
 
 impl<'hir> HashStable<StableHashingContext<'hir>> for attr::OptimizeAttr {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'hir>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'hir>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
     }
 }

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -16,14 +16,11 @@ use syntax_pos::SourceFile;
 use crate::hir::def_id::{DefId, CrateNum, CRATE_DEF_INDEX};
 
 use smallvec::SmallVec;
-use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey,
-                                           StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 
 impl<'a> HashStable<StableHashingContext<'a>> for InternedString {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.with(|s| s.hash_stable(hcx, hasher))
     }
 }
@@ -41,9 +38,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for InternedString {
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::Name {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.as_str().hash_stable(hcx, hasher);
     }
 }
@@ -110,9 +105,7 @@ impl_stable_hash_for!(enum ::syntax::edition::Edition {
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for ::syntax::attr::StabilityLevel {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             ::syntax::attr::StabilityLevel::Unstable { ref reason, ref issue, ref is_soft } => {
@@ -172,9 +165,7 @@ impl_stable_hash_for!(enum ::syntax::ast::StrStyle { Cooked, Raw(pounds) });
 impl_stable_hash_for!(enum ::syntax::ast::AttrStyle { Outer, Inner });
 
 impl<'a> HashStable<StableHashingContext<'a>> for [ast::Attribute] {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         if self.len() == 0 {
             self.len().hash_stable(hcx, hasher);
             return
@@ -197,9 +188,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for [ast::Attribute] {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::Path {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.segments.len().hash_stable(hcx, hasher);
         for segment in &self.segments {
             segment.ident.name.hash_stable(hcx, hasher);
@@ -208,9 +197,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ast::Path {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::Attribute {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         // Make sure that these have been filtered out.
         debug_assert!(!self.ident().map_or(false, |ident| hcx.is_ignored_attr(ident.name)));
         debug_assert!(!self.is_sugared_doc);
@@ -235,9 +222,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ast::Attribute {
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for tokenstream::TokenTree {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             tokenstream::TokenTree::Token(ref token) => {
@@ -256,9 +241,7 @@ for tokenstream::TokenTree {
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for tokenstream::TokenStream {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         for sub_tt in self.trees() {
             sub_tt.hash_stable(hcx, hasher);
         }
@@ -285,9 +268,7 @@ impl_stable_hash_for!(struct token::Lit {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for token::TokenKind {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             token::Eq |
@@ -426,9 +407,7 @@ impl_stable_hash_for!(enum ::syntax_pos::FileName {
 });
 
 impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let SourceFile {
             name: _, // We hash the smaller name_hash instead of this
             name_hash,
@@ -502,11 +481,7 @@ fn stable_non_narrow_char(swc: ::syntax_pos::NonNarrowChar,
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for feature_gate::Features {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'tcx>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         // Unfortunately we cannot exhaustively list fields here, since the
         // struct is macro generated.
         self.declared_lang_features.hash_stable(hcx, hasher);

--- a/src/librustc/ich/impls_ty.rs
+++ b/src/librustc/ich/impls_ty.rs
@@ -3,8 +3,7 @@
 
 use crate::ich::{Fingerprint, StableHashingContext, NodeIdHashingMode};
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey,
-                                           StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 use std::cell::RefCell;
 use std::mem;
 use crate::middle::region;
@@ -15,9 +14,7 @@ impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for &'tcx ty::List<T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         thread_local! {
             static CACHE: RefCell<FxHashMap<(usize, usize), Fingerprint>> =
                 RefCell::new(Default::default());
@@ -57,18 +54,14 @@ where
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::subst::GenericArg<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.unpack().hash_stable(hcx, hasher);
     }
 }
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for ty::RegionKind {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             ty::ReErased |
@@ -112,31 +105,21 @@ for ty::RegionKind {
 
 impl<'a> HashStable<StableHashingContext<'a>> for ty::RegionVid {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.index().hash_stable(hcx, hasher);
     }
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::ConstVid<'tcx> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.index.hash_stable(hcx, hasher);
     }
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for ty::BoundVar {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'tcx>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         self.index().hash_stable(hcx, hasher);
     }
 }
@@ -145,20 +128,14 @@ impl<'a, T> HashStable<StableHashingContext<'a>> for ty::Binder<T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.skip_binder().hash_stable(hcx, hasher);
     }
 }
 
 // AllocIds get resolved to whatever they point to (to be stable)
 impl<'a> HashStable<StableHashingContext<'a>> for mir::interpret::AllocId {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         ty::tls::with_opt(|tcx| {
             trace!("hashing {:?}", *self);
             let tcx = tcx.expect("can't hash AllocIds during hir lowering");
@@ -174,11 +151,7 @@ for mir::interpret::Relocations<Tag>
 where
     Tag: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.len().hash_stable(hcx, hasher);
         for reloc in self.iter() {
             reloc.hash_stable(hcx, hasher);
@@ -201,9 +174,7 @@ impl<'a> ToStableHashKey<StableHashingContext<'a>> for region::Scope {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ty::TyVid {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _hcx: &mut StableHashingContext<'a>,
-                                          _hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _hcx: &mut StableHashingContext<'a>, _hasher: &mut StableHasher) {
         // `TyVid` values are confined to an inference context and hence
         // should not be hashed.
         bug!("ty::TyKind::hash_stable() - can't hash a TyVid {:?}.", *self)
@@ -211,9 +182,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::TyVid {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ty::IntVid {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _hcx: &mut StableHashingContext<'a>,
-                                          _hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _hcx: &mut StableHashingContext<'a>, _hasher: &mut StableHasher) {
         // `IntVid` values are confined to an inference context and hence
         // should not be hashed.
         bug!("ty::TyKind::hash_stable() - can't hash an IntVid {:?}.", *self)
@@ -221,9 +190,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ty::IntVid {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ty::FloatVid {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _hcx: &mut StableHashingContext<'a>,
-                                          _hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _hcx: &mut StableHashingContext<'a>, _hasher: &mut StableHasher) {
         // `FloatVid` values are confined to an inference context and hence
         // should not be hashed.
         bug!("ty::TyKind::hash_stable() - can't hash a FloatVid {:?}.", *self)
@@ -234,18 +201,14 @@ impl<'a, T> HashStable<StableHashingContext<'a>> for ty::steal::Steal<T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.borrow().hash_stable(hcx, hasher);
     }
 }
 
 impl<'a> HashStable<StableHashingContext<'a>>
 for crate::middle::privacy::AccessLevels {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             let crate::middle::privacy::AccessLevels {
                 ref map

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -8,8 +8,7 @@ use crate::lint::{self, Lint, LintId, Level, LintSource};
 use crate::session::Session;
 use crate::util::nodemap::FxHashMap;
 use errors::{Applicability, DiagnosticBuilder};
-use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey,
-                                           StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 use syntax::ast;
 use syntax::attr;
 use syntax::feature_gate;
@@ -526,9 +525,7 @@ impl LintLevelMap {
 
 impl<'a> HashStable<StableHashingContext<'a>> for LintLevelMap {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let LintLevelMap {
             ref sets,
             ref id_to_set,
@@ -567,9 +564,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for LintLevelMap {
 
 impl<HCX> HashStable<HCX> for LintId {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         self.lint_name_raw().hash_stable(hcx, hasher);
     }
 }

--- a/src/librustc/macros.rs
+++ b/src/librustc/macros.rs
@@ -97,9 +97,9 @@ macro_rules! impl_stable_hash_for {
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
             #[inline]
-            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
-                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
-                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
+            fn hash_stable(&self,
+                           __ctx: &mut $crate::ich::StableHashingContext<'a>,
+                           __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
                 use $enum_path::*;
                 ::std::mem::discriminant(self).hash_stable(__ctx, __hasher);
 
@@ -128,9 +128,9 @@ macro_rules! impl_stable_hash_for {
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
             #[inline]
-            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
-                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
-                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
+            fn hash_stable(&self,
+                           __ctx: &mut $crate::ich::StableHashingContext<'a>,
+                           __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
                 let $struct_name {
                     $(ref $field),*
                 } = *self;
@@ -153,9 +153,9 @@ macro_rules! impl_stable_hash_for {
             where $($T: ::rustc_data_structures::stable_hasher::HashStable<$crate::ich::StableHashingContext<'a>>),*
         {
             #[inline]
-            fn hash_stable<W: ::rustc_data_structures::stable_hasher::StableHasherResult>(&self,
-                                                  __ctx: &mut $crate::ich::StableHashingContext<'a>,
-                                                  __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<W>) {
+            fn hash_stable(&self,
+                           __ctx: &mut $crate::ich::StableHashingContext<'a>,
+                           __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
                 let $struct_name (
                     $(ref $field),*
                 ) = *self;
@@ -173,9 +173,9 @@ macro_rules! impl_stable_hash_for_spanned {
         impl HashStable<StableHashingContext<'a>> for ::syntax::source_map::Spanned<$T>
         {
             #[inline]
-            fn hash_stable<W: StableHasherResult>(&self,
-                                                  hcx: &mut StableHashingContext<'a>,
-                                                  hasher: &mut StableHasher<W>) {
+            fn hash_stable(&self,
+                           hcx: &mut StableHashingContext<'a>,
+                           hasher: &mut StableHasher) {
                 self.node.hash_stable(hcx, hasher);
                 self.span.hash_stable(hcx, hasher);
             }

--- a/src/librustc/middle/exported_symbols.rs
+++ b/src/librustc/middle/exported_symbols.rs
@@ -1,7 +1,6 @@
 use crate::hir::def_id::{DefId, LOCAL_CRATE};
 use crate::ich::StableHashingContext;
-use rustc_data_structures::stable_hasher::{StableHasher, HashStable,
-                                           StableHasherResult};
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 use std::cmp;
 use std::mem;
 use crate::ty::{self, TyCtxt};
@@ -94,9 +93,7 @@ pub fn metadata_symbol_name(tcx: TyCtxt<'_>) -> String {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ExportedSymbol<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             ExportedSymbol::NonGeneric(def_id) => {

--- a/src/librustc/middle/region.rs
+++ b/src/librustc/middle/region.rs
@@ -17,7 +17,7 @@ use crate::ty::{self, DefIdTree, TyCtxt};
 use crate::ty::query::Providers;
 
 use rustc_data_structures::indexed_vec::Idx;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_macros::HashStable;
 use syntax::source_map;
 use syntax_pos::{Span, DUMMY_SP};
@@ -1491,9 +1491,7 @@ pub fn provide(providers: &mut Providers<'_>) {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ScopeTree {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ScopeTree {
             root_body,
             root_parent,

--- a/src/librustc/mir/cache.rs
+++ b/src/librustc/mir/cache.rs
@@ -1,6 +1,6 @@
 use rustc_data_structures::indexed_vec::IndexVec;
 use rustc_data_structures::sync::{RwLock, MappedReadGuard, ReadGuard};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
 use crate::ich::StableHashingContext;
 use crate::mir::{Body, BasicBlock};
@@ -24,9 +24,7 @@ impl rustc_serialize::Decodable for Cache {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for Cache {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _: &mut StableHashingContext<'a>,
-                                          _: &mut StableHasher<W>) {
+    fn hash_stable(&self, _: &mut StableHashingContext<'a>, _: &mut StableHasher) {
         // Do nothing.
     }
 }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -682,14 +682,10 @@ impl_stable_hash_for!(enum self::MirPhase {
 
 mod binding_form_impl {
     use crate::ich::StableHashingContext;
-    use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+    use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 
     impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for super::BindingForm<'tcx> {
-        fn hash_stable<W: StableHasherResult>(
-            &self,
-            hcx: &mut StableHashingContext<'a>,
-            hasher: &mut StableHasher<W>,
-        ) {
+        fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
             use super::BindingForm::*;
             ::std::mem::discriminant(self).hash_stable(hcx, hasher);
 

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -8,8 +8,7 @@ use crate::util::nodemap::FxHashMap;
 use crate::ty::print::obsolete::DefPathBasedNames;
 use crate::dep_graph::{WorkProductId, DepNode, WorkProduct, DepConstructor};
 use rustc_data_structures::base_n;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasherResult,
-                                           StableHasher};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use crate::ich::{Fingerprint, StableHashingContext, NodeIdHashingMode};
 use crate::session::config::OptLevel;
 use std::fmt;
@@ -223,9 +222,7 @@ impl<'tcx> MonoItem<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for MonoItem<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                           hcx: &mut StableHashingContext<'a>,
-                                           hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         ::std::mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
@@ -419,9 +416,7 @@ impl<'tcx> CodegenUnit<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for CodegenUnit<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                           hcx: &mut StableHashingContext<'a>,
-                                           hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let CodegenUnit {
             ref items,
             name,

--- a/src/librustc/traits/query/outlives_bounds.rs
+++ b/src/librustc/traits/query/outlives_bounds.rs
@@ -7,8 +7,7 @@ use crate::traits::query::NoSolution;
 use crate::ty::{self, Ty, TyCtxt};
 
 use crate::ich::StableHashingContext;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
-                                           StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use std::mem;
 
 /// Outlives bounds are relationships between generic parameters,
@@ -43,9 +42,7 @@ EnumTypeFoldableImpl! {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for OutlivesBound<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             OutlivesBound::RegionSubRegion(ref a, ref b) => {

--- a/src/librustc/traits/specialize/specialization_graph.rs
+++ b/src/librustc/traits/specialize/specialization_graph.rs
@@ -2,8 +2,7 @@ use super::OverlapError;
 
 use crate::hir::def_id::DefId;
 use crate::ich::{self, StableHashingContext};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
-                                           StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use crate::traits;
 use crate::ty::{self, TyCtxt, TypeFoldable};
 use crate::ty::fast_reject::{self, SimplifiedType};
@@ -512,9 +511,7 @@ pub fn ancestors(
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for Children {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let Children {
             ref nonblanket_impls,
             ref blanket_impls,

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -50,7 +50,7 @@ use errors::DiagnosticBuilder;
 use arena::SyncDroplessArena;
 use smallvec::SmallVec;
 use rustc_data_structures::stable_hasher::{
-    HashStable, StableHasher, StableHasherResult, StableVec, hash_stable_hashmap,
+    HashStable, StableHasher, StableVec, hash_stable_hashmap,
 };
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
 use rustc_data_structures::sharded::ShardedHashMap;
@@ -705,9 +705,7 @@ impl<'tcx> TypeckTables<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ty::TypeckTables {
             local_id_root,
             ref type_dependent_defs,

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -1,7 +1,6 @@
 use crate::hir::def_id::DefId;
 use crate::ich::StableHashingContext;
-use rustc_data_structures::stable_hasher::{StableHasher, StableHasherResult,
-                                           HashStable};
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
@@ -158,9 +157,7 @@ impl<'a, D> HashStable<StableHashingContext<'a>> for SimplifiedTypeGen<D>
 where
     D: Copy + Debug + Ord + Eq + Hash + HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             BoolSimplifiedType |

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -19,8 +19,7 @@ use crate::ty::GeneratorSubsts;
 use crate::ty::subst::Subst;
 use rustc_data_structures::bit_set::BitSet;
 use rustc_data_structures::indexed_vec::{IndexVec, Idx};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
-                                           StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 
 pub use rustc_target::abi::*;
 use rustc_target::spec::{HasTargetSpec, abi::Abi as SpecAbi};
@@ -2323,9 +2322,7 @@ where
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for Variants {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         use crate::ty::layout::Variants::*;
         mem::discriminant(self).hash_stable(hcx, hasher);
 
@@ -2349,9 +2346,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for Variants {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for DiscriminantKind {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         use crate::ty::layout::DiscriminantKind::*;
         mem::discriminant(self).hash_stable(hcx, hasher);
 
@@ -2372,9 +2367,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for DiscriminantKind {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for FieldPlacement {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         use crate::ty::layout::FieldPlacement::*;
         mem::discriminant(self).hash_stable(hcx, hasher);
 
@@ -2395,19 +2388,13 @@ impl<'a> HashStable<StableHashingContext<'a>> for FieldPlacement {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for VariantIdx {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.as_u32().hash_stable(hcx, hasher)
     }
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for Abi {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         use crate::ty::layout::Abi::*;
         mem::discriminant(self).hash_stable(hcx, hasher);
 
@@ -2432,9 +2419,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for Abi {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for Scalar {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let Scalar { value, ref valid_range } = *self;
         value.hash_stable(hcx, hasher);
         valid_range.start().hash_stable(hcx, hasher);
@@ -2476,29 +2461,19 @@ impl_stable_hash_for!(struct crate::ty::layout::AbiAndPrefAlign {
 });
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for Align {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'tcx>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         self.bytes().hash_stable(hcx, hasher);
     }
 }
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for Size {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'tcx>,
-        hasher: &mut StableHasher<W>,
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         self.bytes().hash_stable(hcx, hasher);
     }
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for LayoutError<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         use crate::ty::layout::LayoutError::*;
         mem::discriminant(self).hash_stable(hcx, hasher);
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -52,8 +52,7 @@ use syntax_pos::Span;
 use smallvec;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::indexed_vec::{Idx, IndexVec};
-use rustc_data_structures::stable_hasher::{StableHasher, StableHasherResult,
-                                           HashStable};
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 
 use crate::hir;
 
@@ -577,9 +576,7 @@ impl<'tcx> TyS<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ty::TyS<'tcx> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ty::TyS {
             ref kind,
 
@@ -1633,11 +1630,7 @@ impl<'a, T> HashStable<StableHashingContext<'a>> for Placeholder<T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(
-        &self,
-        hcx: &mut StableHashingContext<'a>,
-        hasher: &mut StableHasher<W>
-    ) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         self.universe.hash_stable(hcx, hasher);
         self.name.hash_stable(hcx, hasher);
     }
@@ -1774,9 +1767,7 @@ impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for ParamEnvAnd<'tcx, T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let ParamEnvAnd {
             ref param_env,
             ref value
@@ -2010,9 +2001,7 @@ impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx AdtDef {}
 
 
 impl<'a> HashStable<StableHashingContext<'a>> for AdtDef {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         thread_local! {
             static CACHE: RefCell<FxHashMap<usize, Fingerprint>> = Default::default();
         }

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -334,13 +334,13 @@ fn pick_query<'a, 'tcx, T, F: Fn(&T) -> (Span, Lrc<QueryJob<'tcx>>)>(
     let mut hcx = tcx.create_stable_hashing_context();
     queries.iter().min_by_key(|v| {
         let (span, query) = f(v);
-        let mut stable_hasher = StableHasher::<u64>::new();
+        let mut stable_hasher = StableHasher::new();
         query.info.query.hash_stable(&mut hcx, &mut stable_hasher);
         // Prefer entry points which have valid spans for nicer error messages
         // We add an integer to the tuple ensuring that entry points
         // with valid spans are picked first
         let span_cmp = if span == DUMMY_SP { 1 } else { 0 };
-        (span_cmp, stable_hasher.finish())
+        (span_cmp, stable_hasher.finish::<u64>())
     }).unwrap()
 }
 

--- a/src/librustc/ty/query/plumbing.rs
+++ b/src/librustc/ty/query/plumbing.rs
@@ -716,7 +716,6 @@ macro_rules! define_queries_inner {
         use rustc_data_structures::sharded::Sharded;
         use crate::{
             rustc_data_structures::stable_hasher::HashStable,
-            rustc_data_structures::stable_hasher::StableHasherResult,
             rustc_data_structures::stable_hasher::StableHasher,
             ich::StableHashingContext
         };
@@ -925,9 +924,7 @@ macro_rules! define_queries_inner {
         }
 
         impl<'a, $tcx> HashStable<StableHashingContext<'a>> for Query<$tcx> {
-            fn hash_stable<W: StableHasherResult>(&self,
-                                                hcx: &mut StableHashingContext<'a>,
-                                                hasher: &mut StableHasher<W>) {
+            fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
                 mem::discriminant(self).hash_stable(hcx, hasher);
                 match *self {
                     $(Query::$name(key) => key.hash_stable(hcx, hasher),)*

--- a/src/librustc/ty/trait_def.rs
+++ b/src/librustc/ty/trait_def.rs
@@ -8,8 +8,7 @@ use crate::ty::fold::TypeFoldable;
 use crate::ty::{Ty, TyCtxt};
 
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher,
-                                           StableHasherResult};
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_macros::HashStable;
 
 /// A trait's definition with type information.
@@ -194,9 +193,7 @@ pub(super) fn trait_impls_of_provider(
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for TraitImpls {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut StableHashingContext<'a>,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         let TraitImpls {
             ref blanket_impls,
             ref non_blanket_impls,

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -187,7 +187,7 @@ impl TypeMap<'ll, 'tcx> {
 
         // The hasher we are using to generate the UniqueTypeId. We want
         // something that provides more than the 64 bits of the DefaultHasher.
-        let mut hasher = StableHasher::<Fingerprint>::new();
+        let mut hasher = StableHasher::new();
         let mut hcx = cx.tcx.create_stable_hashing_context();
         let type_ = cx.tcx.erase_regions(&type_);
         hcx.while_hashing_spans(false, |hcx| {
@@ -195,7 +195,7 @@ impl TypeMap<'ll, 'tcx> {
                 type_.hash_stable(hcx, &mut hasher);
             });
         });
-        let unique_type_id = hasher.finish().to_hex();
+        let unique_type_id = hasher.finish::<Fingerprint>().to_hex();
 
         let key = self.unique_id_interner.intern(&unique_type_id);
         self.type_to_unique_id.insert(type_, UniqueTypeId(key));

--- a/src/librustc_codegen_ssa/common.rs
+++ b/src/librustc_codegen_ssa/common.rs
@@ -109,14 +109,11 @@ pub enum TypeKind {
 //            for now we content ourselves with providing a no-op HashStable
 //            implementation for CGUs.
 mod temp_stable_hash_impls {
-    use rustc_data_structures::stable_hasher::{StableHasherResult, StableHasher,
-                                               HashStable};
+    use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
     use crate::ModuleCodegen;
 
     impl<HCX, M> HashStable<HCX> for ModuleCodegen<M> {
-        fn hash_stable<W: StableHasherResult>(&self,
-                                              _: &mut HCX,
-                                              _: &mut StableHasher<W>) {
+        fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
             // do nothing
         }
     }

--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -89,7 +89,7 @@ fn get_symbol_hash<'tcx>(
         def_id, substs
     );
 
-    let mut hasher = StableHasher::<u64>::new();
+    let mut hasher = StableHasher::new();
     let mut hcx = tcx.create_stable_hashing_context();
 
     record_time(&tcx.sess.perf_stats.symbol_hash_time, || {
@@ -132,7 +132,7 @@ fn get_symbol_hash<'tcx>(
     });
 
     // 64 bits should be enough to avoid collisions.
-    hasher.finish()
+    hasher.finish::<u64>()
 }
 
 // Follow C++ namespace-mangling style, see

--- a/src/librustc_data_structures/fingerprint.rs
+++ b/src/librustc_data_structures/fingerprint.rs
@@ -76,7 +76,7 @@ impl ::std::fmt::Display for Fingerprint {
 
 impl stable_hasher::StableHasherResult for Fingerprint {
     #[inline]
-    fn finish(hasher: stable_hasher::StableHasher<Self>) -> Self {
+    fn finish(hasher: stable_hasher::StableHasher) -> Self {
         let (_0, _1) = hasher.finalize();
         Fingerprint(_0, _1)
     }

--- a/src/librustc_data_structures/stable_hasher.rs
+++ b/src/librustc_data_structures/stable_hasher.rs
@@ -1,5 +1,4 @@
 use std::hash::{Hash, Hasher, BuildHasher};
-use std::marker::PhantomData;
 use std::mem;
 use smallvec::SmallVec;
 use crate::sip128::SipHasher128;
@@ -24,7 +23,7 @@ impl ::std::fmt::Debug for StableHasher {
 }
 
 pub trait StableHasherResult: Sized {
-    fn finish(hasher: StableHasher<Self>) -> Self;
+    fn finish(hasher: StableHasher) -> Self;
 }
 
 impl StableHasher {
@@ -40,14 +39,14 @@ impl StableHasher {
 }
 
 impl StableHasherResult for u128 {
-    fn finish(hasher: StableHasher<Self>) -> Self {
+    fn finish(hasher: StableHasher) -> Self {
         let (_0, _1) = hasher.finalize();
         u128::from(_0) | (u128::from(_1) << 64)
     }
 }
 
 impl StableHasherResult for u64 {
-    fn finish(hasher: StableHasher<Self>) -> Self {
+    fn finish(hasher: StableHasher) -> Self {
         hasher.finalize().0
     }
 }
@@ -181,10 +180,10 @@ macro_rules! impl_stable_hash_via_hash {
     ($t:ty) => (
         impl<CTX> $crate::stable_hasher::HashStable<CTX> for $t {
             #[inline]
-            fn hash_stable<W: $crate::stable_hasher::StableHasherResult>(
+            fn hash_stable(
                 &self,
                 _: &mut CTX,
-                hasher: &mut $crate::stable_hasher::StableHasher<W>
+                hasher: &mut $crate::stable_hasher::StableHasher
             ) {
                 ::std::hash::Hash::hash(self, hasher);
             }
@@ -211,17 +210,13 @@ impl_stable_hash_via_hash!(char);
 impl_stable_hash_via_hash!(());
 
 impl<CTX> HashStable<CTX> for ::std::num::NonZeroU32 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.get().hash_stable(ctx, hasher)
     }
 }
 
 impl<CTX> HashStable<CTX> for f32 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let val: u32 = unsafe {
             ::std::mem::transmute(*self)
         };
@@ -230,9 +225,7 @@ impl<CTX> HashStable<CTX> for f32 {
 }
 
 impl<CTX> HashStable<CTX> for f64 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let val: u64 = unsafe {
             ::std::mem::transmute(*self)
         };
@@ -241,26 +234,20 @@ impl<CTX> HashStable<CTX> for f64 {
 }
 
 impl<CTX> HashStable<CTX> for ::std::cmp::Ordering {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (*self as i8).hash_stable(ctx, hasher);
     }
 }
 
 impl<T1: HashStable<CTX>, CTX> HashStable<CTX> for (T1,) {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let (ref _0,) = *self;
         _0.hash_stable(ctx, hasher);
     }
 }
 
 impl<T1: HashStable<CTX>, T2: HashStable<CTX>, CTX> HashStable<CTX> for (T1, T2) {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let (ref _0, ref _1) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -272,9 +259,7 @@ impl<T1, T2, T3, CTX> HashStable<CTX> for (T1, T2, T3)
            T2: HashStable<CTX>,
            T3: HashStable<CTX>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -288,9 +273,7 @@ impl<T1, T2, T3, T4, CTX> HashStable<CTX> for (T1, T2, T3, T4)
            T3: HashStable<CTX>,
            T4: HashStable<CTX>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         let (ref _0, ref _1, ref _2, ref _3) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -300,9 +283,7 @@ impl<T1, T2, T3, T4, CTX> HashStable<CTX> for (T1, T2, T3, T4)
 }
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
-    default fn hash_stable<W: StableHasherResult>(&self,
-                                                  ctx: &mut CTX,
-                                                  hasher: &mut StableHasher<W>) {
+    default fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.len().hash_stable(ctx, hasher);
         for item in self {
             item.hash_stable(ctx, hasher);
@@ -312,9 +293,7 @@ impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for Vec<T> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (&self[..]).hash_stable(ctx, hasher);
     }
 }
@@ -325,9 +304,7 @@ impl<K, V, R, CTX> HashStable<CTX> for indexmap::IndexMap<K, V, R>
           R: BuildHasher,
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.len().hash_stable(ctx, hasher);
         for kv in self {
             kv.hash_stable(ctx, hasher);
@@ -340,9 +317,7 @@ impl<K, R, CTX> HashStable<CTX> for indexmap::IndexSet<K, R>
           R: BuildHasher,
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.len().hash_stable(ctx, hasher);
         for key in self {
             key.hash_stable(ctx, hasher);
@@ -352,45 +327,35 @@ impl<K, R, CTX> HashStable<CTX> for indexmap::IndexSet<K, R>
 
 impl<A, CTX> HashStable<CTX> for SmallVec<[A; 1]> where A: HashStable<CTX> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (&self[..]).hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for Box<T> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::rc::Rc<T> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::sync::Arc<T> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for str {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
         self.len().hash(hasher);
         self.as_bytes().hash(hasher);
     }
@@ -399,9 +364,7 @@ impl<CTX> HashStable<CTX> for str {
 
 impl<CTX> HashStable<CTX> for String {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         (&self[..]).hash_stable(hcx, hasher);
     }
 }
@@ -416,9 +379,7 @@ impl<HCX> ToStableHashKey<HCX> for String {
 
 impl<CTX> HashStable<CTX> for bool {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (if *self { 1u8 } else { 0u8 }).hash_stable(ctx, hasher);
     }
 }
@@ -428,9 +389,7 @@ impl<T, CTX> HashStable<CTX> for Option<T>
     where T: HashStable<CTX>
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         if let Some(ref value) = *self {
             1u8.hash_stable(ctx, hasher);
             value.hash_stable(ctx, hasher);
@@ -445,9 +404,7 @@ impl<T1, T2, CTX> HashStable<CTX> for Result<T1, T2>
           T2: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(ctx, hasher);
         match *self {
             Ok(ref x) => x.hash_stable(ctx, hasher),
@@ -460,18 +417,14 @@ impl<'a, T, CTX> HashStable<CTX> for &'a T
     where T: HashStable<CTX> + ?Sized
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T, CTX> HashStable<CTX> for ::std::mem::Discriminant<T> {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          _: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -479,9 +432,7 @@ impl<T, CTX> HashStable<CTX> for ::std::mem::Discriminant<T> {
 impl<I: indexed_vec::Idx, T, CTX> HashStable<CTX> for indexed_vec::IndexVec<I, T>
     where T: HashStable<CTX>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.len().hash_stable(ctx, hasher);
         for v in &self.raw {
             v.hash_stable(ctx, hasher);
@@ -492,9 +443,7 @@ impl<I: indexed_vec::Idx, T, CTX> HashStable<CTX> for indexed_vec::IndexVec<I, T
 
 impl<I: indexed_vec::Idx, CTX> HashStable<CTX> for bit_set::BitSet<I>
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.words().hash_stable(ctx, hasher);
     }
 }
@@ -502,9 +451,7 @@ impl<I: indexed_vec::Idx, CTX> HashStable<CTX> for bit_set::BitSet<I>
 impl<R: indexed_vec::Idx, C: indexed_vec::Idx, CTX> HashStable<CTX>
 for bit_set::BitMatrix<R, C>
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          ctx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.words().hash_stable(ctx, hasher);
     }
 }
@@ -518,9 +465,7 @@ impl<K, V, R, HCX> HashStable<HCX> for ::std::collections::HashMap<K, V, R>
           R: BuildHasher,
 {
     #[inline]
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         hash_stable_hashmap(hcx, hasher, self, ToStableHashKey::to_stable_hash_key);
     }
 }
@@ -529,9 +474,7 @@ impl<K, R, HCX> HashStable<HCX> for ::std::collections::HashSet<K, R>
     where K: ToStableHashKey<HCX> + Eq + Hash,
           R: BuildHasher,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         let mut keys: Vec<_> = self.iter()
                                    .map(|k| k.to_stable_hash_key(hcx))
                                    .collect();
@@ -544,9 +487,7 @@ impl<K, V, HCX> HashStable<HCX> for ::std::collections::BTreeMap<K, V>
     where K: ToStableHashKey<HCX>,
           V: HashStable<HCX>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         let mut entries: Vec<_> = self.iter()
                                       .map(|(k, v)| (k.to_stable_hash_key(hcx), v))
                                       .collect();
@@ -558,9 +499,7 @@ impl<K, V, HCX> HashStable<HCX> for ::std::collections::BTreeMap<K, V>
 impl<K, HCX> HashStable<HCX> for ::std::collections::BTreeSet<K>
     where K: ToStableHashKey<HCX>,
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         let mut keys: Vec<_> = self.iter()
                                    .map(|k| k.to_stable_hash_key(hcx))
                                    .collect();
@@ -569,9 +508,9 @@ impl<K, HCX> HashStable<HCX> for ::std::collections::BTreeSet<K>
     }
 }
 
-pub fn hash_stable_hashmap<HCX, K, V, R, SK, F, W>(
+pub fn hash_stable_hashmap<HCX, K, V, R, SK, F>(
     hcx: &mut HCX,
-    hasher: &mut StableHasher<W>,
+    hasher: &mut StableHasher,
     map: &::std::collections::HashMap<K, V, R>,
     to_stable_hash_key: F)
     where K: Eq + Hash,
@@ -579,7 +518,6 @@ pub fn hash_stable_hashmap<HCX, K, V, R, SK, F, W>(
           R: BuildHasher,
           SK: HashStable<HCX> + Ord + Clone,
           F: Fn(&K, &HCX) -> SK,
-          W: StableHasherResult,
 {
     let mut entries: Vec<_> = map.iter()
                                   .map(|(k, v)| (to_stable_hash_key(k, hcx), v))
@@ -610,9 +548,7 @@ impl<T> ::std::ops::Deref for StableVec<T> {
 impl<T, HCX> HashStable<HCX> for StableVec<T>
     where T: HashStable<HCX> + ToStableHashKey<HCX>
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut HCX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
         let StableVec(ref v) = *self;
 
         let mut sorted: Vec<_> = v.iter()

--- a/src/librustc_data_structures/svh.rs
+++ b/src/librustc_data_structures/svh.rs
@@ -61,11 +61,7 @@ impl Decodable for Svh {
 
 impl<T> stable_hasher::HashStable<T> for Svh {
     #[inline]
-    fn hash_stable<W: stable_hasher::StableHasherResult>(
-        &self,
-        ctx: &mut T,
-        hasher: &mut stable_hasher::StableHasher<W>
-    ) {
+    fn hash_stable(&self, ctx: &mut T, hasher: &mut stable_hasher::StableHasher) {
         let Svh {
             hash
         } = *self;

--- a/src/librustc_data_structures/thin_vec.rs
+++ b/src/librustc_data_structures/thin_vec.rs
@@ -1,4 +1,4 @@
-use crate::stable_hasher::{StableHasher, StableHasherResult, HashStable};
+use crate::stable_hasher::{StableHasher, HashStable};
 
 /// A vector type optimized for cases where this size is usually 0 (cf. `SmallVector`).
 /// The `Option<Box<..>>` wrapping allows us to represent a zero sized vector with `None`,
@@ -60,9 +60,7 @@ impl<T> Extend<T> for ThinVec<T> {
 }
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for ThinVec<T> {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher)
     }
 }

--- a/src/librustc_data_structures/transitive_relation.rs
+++ b/src/librustc_data_structures/transitive_relation.rs
@@ -1,6 +1,6 @@
 use crate::bit_set::BitMatrix;
 use crate::fx::FxHashMap;
-use crate::stable_hasher::{HashStable, StableHasher, StableHasherResult};
+use crate::stable_hasher::{HashStable, StableHasher};
 use crate::sync::Lock;
 use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
 use std::fmt::Debug;
@@ -442,9 +442,7 @@ impl<T> Decodable for TransitiveRelation<T>
 impl<CTX, T> HashStable<CTX> for TransitiveRelation<T>
     where T: HashStable<CTX> + Eq + Debug + Clone + Hash
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         // We are assuming here that the relation graph has been built in a
         // deterministic way and we can just hash it the way it is.
         let TransitiveRelation {
@@ -462,9 +460,7 @@ impl<CTX, T> HashStable<CTX> for TransitiveRelation<T>
 }
 
 impl<CTX> HashStable<CTX> for Edge {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         let Edge {
             ref source,
             ref target,
@@ -476,9 +472,7 @@ impl<CTX> HashStable<CTX> for Edge {
 }
 
 impl<CTX> HashStable<CTX> for Index {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         let Index(idx) = *self;
         idx.hash_stable(hcx, hasher);
     }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -502,7 +502,7 @@ pub(crate) fn compute_crate_disambiguator(session: &Session) -> CrateDisambiguat
     // into various other hashes quite a bit (symbol hashes, incr. comp. hashes,
     // debuginfo type IDs, etc), so we don't want it to be too wide. 128 bits
     // should still be safe enough to avoid collisions in practice.
-    let mut hasher = StableHasher::<Fingerprint>::new();
+    let mut hasher = StableHasher::new();
 
     let mut metadata = session.opts.cg.metadata.clone();
     // We don't want the crate_disambiguator to dependent on the order
@@ -528,7 +528,7 @@ pub(crate) fn compute_crate_disambiguator(session: &Session) -> CrateDisambiguat
         .contains(&config::CrateType::Executable);
     hasher.write(if is_exe { b"exe" } else { b"lib" });
 
-    CrateDisambiguator::from(hasher.finish())
+    CrateDisambiguator::from(hasher.finish::<Fingerprint>())
 }
 
 pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<config::CrateType> {

--- a/src/librustc_macros/src/hash_stable.rs
+++ b/src/librustc_macros/src/hash_stable.rs
@@ -76,10 +76,10 @@ pub fn hash_stable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::To
 
     s.bound_impl(quote!(::rustc_data_structures::stable_hasher::HashStable
                         <::rustc::ich::StableHashingContext<'__ctx>>), quote!{
-        fn hash_stable<__W: ::rustc_data_structures::stable_hasher::StableHasherResult>(
+        fn hash_stable(
             &self,
             __hcx: &mut ::rustc::ich::StableHashingContext<'__ctx>,
-            __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<__W>) {
+            __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
             #discriminant
             match *self { #body }
         }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -368,9 +368,9 @@ impl<'tcx> EncodeContext<'tcx> {
                         let mut adapted = (**source_file).clone();
                         adapted.name = Path::new(&working_dir).join(name).into();
                         adapted.name_hash = {
-                            let mut hasher: StableHasher<u128> = StableHasher::new();
+                            let mut hasher: StableHasher = StableHasher::new();
                             adapted.name.hash(&mut hasher);
-                            hasher.finish()
+                            hasher.finish::<u128>()
                         };
                         Lrc::new(adapted)
                     },

--- a/src/librustc_mir/interpret/snapshot.rs
+++ b/src/librustc_mir/interpret/snapshot.rs
@@ -52,9 +52,9 @@ impl<'mir, 'tcx> InfiniteLoopDetector<'mir, 'tcx> {
     ) -> InterpResult<'tcx, ()> {
         // Compute stack's hash before copying anything
         let mut hcx = tcx.get_stable_hashing_context();
-        let mut hasher = StableHasher::<u64>::new();
+        let mut hasher = StableHasher::new();
         stack.hash_stable(&mut hcx, &mut hasher);
-        let hash = hasher.finish();
+        let hash = hasher.finish::<u64>();
 
         // Check if we know that hash already
         if self.hashes.is_empty() {
@@ -428,9 +428,9 @@ impl<'mir, 'tcx> Hash for InterpSnapshot<'mir, 'tcx> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Implement in terms of hash stable, so that k1 == k2 -> hash(k1) == hash(k2)
         let mut hcx = self.memory.tcx.get_stable_hashing_context();
-        let mut hasher = StableHasher::<u64>::new();
+        let mut hasher = StableHasher::new();
         self.hash_stable(&mut hcx, &mut hasher);
-        hasher.finish().hash(state)
+        hasher.finish::<u64>().hash(state)
     }
 }
 

--- a/src/libsyntax/ptr.rs
+++ b/src/libsyntax/ptr.rs
@@ -33,8 +33,7 @@ use std::{slice, vec};
 
 use rustc_serialize::{Encodable, Decodable, Encoder, Decoder};
 
-use rustc_data_structures::stable_hasher::{StableHasher, StableHasherResult,
-                                           HashStable};
+use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 /// An owned smart pointer.
 #[derive(Hash, PartialEq, Eq)]
 pub struct P<T: ?Sized> {
@@ -218,9 +217,7 @@ impl<T: Decodable> Decodable for P<[T]> {
 impl<CTX, T> HashStable<CTX> for P<T>
     where T: ?Sized + HashStable<CTX>
 {
-    fn hash_stable<W: StableHasherResult>(&self,
-                                          hcx: &mut CTX,
-                                          hasher: &mut StableHasher<W>) {
+    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
         (**self).hash_stable(hcx, hasher);
     }
 }

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -1067,14 +1067,14 @@ impl SourceFile {
         normalize_newlines(&mut src);
 
         let src_hash = {
-            let mut hasher: StableHasher<u128> = StableHasher::new();
+            let mut hasher: StableHasher = StableHasher::new();
             hasher.write(src.as_bytes());
-            hasher.finish()
+            hasher.finish::<u128>()
         };
         let name_hash = {
-            let mut hasher: StableHasher<u128> = StableHasher::new();
+            let mut hasher: StableHasher = StableHasher::new();
             name.hash(&mut hasher);
-            hasher.finish()
+            hasher.finish::<u128>()
         };
         let end_pos = start_pos.to_usize() + src.len();
         if end_pos > u32::max_value() as usize {
@@ -1120,10 +1120,10 @@ impl SourceFile {
             // Check that no-one else have provided the source while we were getting it
             if *external_src == ExternalSource::AbsentOk {
                 if let Some(src) = src {
-                    let mut hasher: StableHasher<u128> = StableHasher::new();
+                    let mut hasher: StableHasher = StableHasher::new();
                     hasher.write(src.as_bytes());
 
-                    if hasher.finish() == self.src_hash {
+                    if hasher.finish::<u128>() == self.src_hash {
                         *external_src = ExternalSource::Present(src);
                         return true;
                     }


### PR DESCRIPTION
This removes the generic parameter on `StableHasher`, instead moving it to the call to `finish`. This has the side-effect of making all `HashStable` impls nicer, since we no longer need the verbose `<W: StableHasherResult>` that previously existed -- often forcing line wrapping.

This is done for two reasons:
 * we should avoid false "generic" dependency on the result of StableHasher
     * we don't need to codegen two/three copies of all the HashStable impls when they're transitively used to produce a fingerprint, u64, or u128. I haven't measured, but this might actually make our artifacts somewhat smaller too.
 * Easier to understand/read/write code -- the result of the stable hasher is irrelevant when writing a hash impl.