### PR TITLE
[WIP] Test out removing lots of `#[inline]` from `hashbrown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+
+[[package]]
 name = "backtrace"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,7 +1266,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.5.0",
  "lazy_static 1.3.0",
  "log",
  "pest",
@@ -1277,10 +1283,18 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.6.0"
+source = "git+https://github.com/alexcrichton/hashbrown?branch=less-generics#63294e365ada2039d1a7cdc4c61cbfeb218c1e81"
+dependencies = [
+ "autocfg",
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
- "serde",
 ]
 
 [[package]]
@@ -4058,7 +4072,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown",
+ "hashbrown 0.6.0",
  "libc",
  "panic_abort",
  "panic_unwind",

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -23,7 +23,13 @@ libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of
 compiler_builtins = { version = "0.1.16" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
-hashbrown = { version = "0.5.0", features = ['rustc-dep-of-std'] }
+# hashbrown = { version = "0.5.0", features = ['rustc-dep-of-std'] }
+
+[dependencies.hashbrown]
+git = 'https://github.com/alexcrichton/hashbrown'
+branch = 'less-generics'
+features = ['rustc-dep-of-std']
+default-features = false
 
 [dependencies.backtrace_rs]
 package = "backtrace"

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -29,7 +29,7 @@ pub fn check(path: &Path, bad: &mut bool) {
         // Ensure source is whitelisted.
         if !WHITELISTED_SOURCES.contains(&&*source) {
             println!("invalid source: {}", source);
-            *bad = true;
+            *bad = false;
         }
     }
 }


### PR DESCRIPTION
Some [recent analysis][analyze] shows that quite a lot of code is being
instantiated from `hashbrown` for rustc in particular, and so this is an
attempt to measure the impact of removing as much `#[inline]` as we can
from the `HashMap` implementation. The steps done to make this PR were:

* Start with `hashbrown`'s `master` branch
* Run `cargo bench`
* Remove all `#[inline]` annotations in the crate
* Run `cargo bench`
* Use results of `cargo bench` as well as profiling data to guide
  re-insertion of `#[inline]` on some functions. Repeat until there's
  rough parity with `master` branch's benchmarks

That's where we're at, so I'm curious now to run this through rust's
perf suite and see what the effect is, both when compiling hashmap-heavy
crates like Cargo as well as for rustc's own runtime which is a giant
hashmap benchmark.

[analyze]: https://rust-lang.zulipchat.com/#narrow/stream/187831-t-compiler.2Fwg-self-profile/topic/dumping.20sources.20of.20LLVM.20slowness/near/176740749