### PR TITLE
Add mailmap entry for Dustin Bensing by request

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -69,6 +69,7 @@ David Manescu <david.manescu@gmail.com> <dman2626@uni.sydney.edu.au>
 David Ross <daboross@daboross.net>
 Derek Chiang <derekchiang93@gmail.com> Derek Chiang (Enchi Jiang) <derekchiang93@gmail.com>
 Diggory Hardy <diggory.hardy@gmail.com> Diggory Hardy <github@dhardy.name>
+Dustin Bensing <dustin.bensing@googlemail.com>
 Dylan Braithwaite <dylanbraithwaite1@gmail.com> <mail@dylanb.me>
 Dzmitry Malyshau <kvarkus@gmail.com>
 E. Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>


### PR DESCRIPTION
This should deduplicate entries from @pythoneer between the stdarch submodule and this repo itself on thanks.rust-lang.org.