### PR TITLE
Change to non-line buffered output if output is not a TTY

### DIFF
--- a/src/libstd/sys/cloudabi/stdio.rs
+++ b/src/libstd/sys/cloudabi/stdio.rs
@@ -21,6 +21,9 @@ impl Stdout {
     pub fn new() -> io::Result<Stdout> {
         Ok(Stdout(()))
     }
+    pub fn should_be_line_buffered(&self) -> bool {
+        true
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/libstd/sys/sgx/stdio.rs
+++ b/src/libstd/sys/sgx/stdio.rs
@@ -30,6 +30,10 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn should_be_line_buffered(&self) -> bool {
+        // FIXME: Implement me.
+        true
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/libstd/sys/unix/stdio.rs
+++ b/src/libstd/sys/unix/stdio.rs
@@ -22,6 +22,11 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn should_be_line_buffered(&self) -> bool {
+        unsafe {
+            libc::isatty(libc::STDOUT_FILENO) != 0
+        }
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/libstd/sys/vxworks/stdio.rs
+++ b/src/libstd/sys/vxworks/stdio.rs
@@ -20,6 +20,10 @@ impl io::Read for Stdin {
 
 impl Stdout {
     pub fn new() -> io::Result<Stdout> { Ok(Stdout(())) }
+    pub fn should_be_line_buffered(&self) -> bool {
+        // FIXME: Implement me.
+        true
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/libstd/sys/wasi/stdio.rs
+++ b/src/libstd/sys/wasi/stdio.rs
@@ -40,6 +40,12 @@ impl Stdout {
     pub fn flush(&self) -> io::Result<()> {
         Ok(())
     }
+
+    pub fn should_be_line_buffered(&self) -> bool {
+        // FIXME: Currently there seems to be no way to query whether stdout is
+        // a tty, `isatty` is not exposed by WASI.
+        true
+    }
 }
 
 impl Stderr {

--- a/src/libstd/sys/wasm/stdio.rs
+++ b/src/libstd/sys/wasm/stdio.rs
@@ -30,6 +30,10 @@ impl io::Write for Stdout {
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
+
+    fn should_be_line_buffered(&self) -> bool {
+        true
+    }
 }
 
 impl Stderr {

--- a/src/libstd/sys/windows/stdio.rs
+++ b/src/libstd/sys/windows/stdio.rs
@@ -246,6 +246,11 @@ impl Stdout {
     pub fn new() -> io::Result<Stdout> {
         Ok(Stdout)
     }
+    pub fn should_be_line_buffered(&self) -> bool {
+        // FIXME: Fill in. I don't know how to check whether output is
+        // redirected on Windows.
+        true
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/libstd/sys/windows/stdio_uwp.rs
+++ b/src/libstd/sys/windows/stdio_uwp.rs
@@ -48,6 +48,11 @@ impl Stdout {
     pub fn new() -> io::Result<Stdout> {
         Ok(Stdout)
     }
+    pub fn should_be_line_buffered(&self) -> bool {
+        // FIXME: Fill in. I don't know how to check whether output is
+        // redirected on Windows.
+        true
+    }
 }
 
 impl io::Write for Stdout {

--- a/src/test/ui/command-pre-exec.rs
+++ b/src/test/ui/command-pre-exec.rs
@@ -10,7 +10,7 @@
 extern crate libc;
 
 use std::env;
-use std::io::Error;
+use std::io::{self, Error, Write};
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -35,6 +35,7 @@ fn main() {
             .arg("test1")
             .pre_exec(|| {
                 println!("hello");
+                io::stdout().flush().unwrap();
                 Ok(())
             })
             .output()

--- a/src/test/ui/issues/issue-30490.rs
+++ b/src/test/ui/issues/issue-30490.rs
@@ -57,6 +57,7 @@ fn main() {
 
     stdout().write_all("parent stdout\n".as_bytes()).expect("failed to write to stdout");
     stderr().write_all("parent stderr\n".as_bytes()).expect("failed to write to stderr");
+    stdout().flush().expect("failed to flush stdout");
 
     let child = {
         Command::new(name)


### PR DESCRIPTION
This matches glibc behavior.

This is determined using the `isatty` function on Unixes, and not
attempted at all for other operating systems.

Fixes #60673.