### PR TITLE
Build rustc for the host as well as target in tools

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -187,6 +187,10 @@ fn dist_only_cross_host() {
             },
             compile::Rustc {
                 compiler: Compiler { host: a, stage: 1 },
+                target: a,
+            },
+            compile::Rustc {
+                compiler: Compiler { host: a, stage: 1 },
                 target: b,
             },
         ]

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -54,6 +54,10 @@ impl Step for ToolBuild {
 
         match self.mode {
             Mode::ToolRustc => {
+                // e.g. clippy wants to depend on compiler internals from
+                // the host, too -- this seems to be because we run rustc w/o the target flag, which
+                // is probably because clippy is a "plugin" so is intended for the host.
+                builder.ensure(compile::Rustc { compiler, target: compiler.host });
                 builder.ensure(compile::Rustc { compiler, target })
             }
             Mode::ToolStd => {


### PR DESCRIPTION
I believe this should fix clippy etc for cross compiled platforms (clippy is currently broken for other reasons it seems, though, so not sure how to test. I don't get the 'crate not found' errors, anyway).

cc #62558

r? @alexcrichton 