### PR TITLE
Upgrade async/await to "used" keywords.

### DIFF
--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -83,11 +83,11 @@ symbols! {
         Yield:              "yield",
 
         // Edition-specific keywords that are used in stable Rust.
+        Async:              "async", // >= 2018 Edition only
+        Await:              "await", // >= 2018 Edition only
         Dyn:                "dyn", // >= 2018 Edition only
 
         // Edition-specific keywords that are used in unstable Rust or reserved for future use.
-        Async:              "async", // >= 2018 Edition only
-        Await:              "await", // >= 2018 Edition only
         Try:                "try", // >= 2018 Edition only
 
         // Special lifetime names
@@ -1088,11 +1088,11 @@ pub mod sym {
 
 impl Symbol {
     fn is_used_keyword_2018(self) -> bool {
-        self == kw::Dyn
+        self >= kw::Async && self <= kw::Dyn
     }
 
     fn is_unused_keyword_2018(self) -> bool {
-        self >= kw::Async && self <= kw::Try
+        self == kw::Try
     }
 
     /// Used for sanity checking rustdoc keyword sections.

--- a/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.rs
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.rs
@@ -3,21 +3,21 @@
 #![allow(non_camel_case_types)]
 
 mod outer_mod {
-    pub mod await { //~ ERROR expected identifier, found reserved keyword `await`
-        pub struct await; //~ ERROR expected identifier, found reserved keyword `await`
+    pub mod await { //~ ERROR expected identifier, found keyword `await`
+        pub struct await; //~ ERROR expected identifier, found keyword `await`
     }
 }
-use self::outer_mod::await::await; //~ ERROR expected identifier, found reserved keyword `await`
-//~^ ERROR expected identifier, found reserved keyword `await`
+use self::outer_mod::await::await; //~ ERROR expected identifier, found keyword `await`
+//~^ ERROR expected identifier, found keyword `await`
 
 struct Foo { await: () }
-//~^ ERROR expected identifier, found reserved keyword `await`
+//~^ ERROR expected identifier, found keyword `await`
 
 impl Foo { fn await() {} }
-//~^ ERROR expected identifier, found reserved keyword `await`
+//~^ ERROR expected identifier, found keyword `await`
 
 macro_rules! await {
-//~^ ERROR expected identifier, found reserved keyword `await`
+//~^ ERROR expected identifier, found keyword `await`
     () => {}
 }
 

--- a/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
@@ -1,68 +1,68 @@
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:6:13
    |
 LL |     pub mod await {
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     pub mod r#await {
    |             ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:7:20
    |
 LL |         pub struct await;
-   |                    ^^^^^ expected identifier, found reserved keyword
+   |                    ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |         pub struct r#await;
    |                    ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:10:22
    |
 LL | use self::outer_mod::await::await;
-   |                      ^^^^^ expected identifier, found reserved keyword
+   |                      ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::r#await::await;
    |                      ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:10:29
    |
 LL | use self::outer_mod::await::await;
-   |                             ^^^^^ expected identifier, found reserved keyword
+   |                             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::await::r#await;
    |                             ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:13:14
    |
 LL | struct Foo { await: () }
-   |              ^^^^^ expected identifier, found reserved keyword
+   |              ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | struct Foo { r#await: () }
    |              ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:16:15
    |
 LL | impl Foo { fn await() {} }
-   |               ^^^^^ expected identifier, found reserved keyword
+   |               ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | impl Foo { fn r#await() {} }
    |               ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:19:14
    |
 LL | macro_rules! await {
-   |              ^^^^^ expected identifier, found reserved keyword
+   |              ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | macro_rules! r#await {

--- a/src/test/ui/async-await/await-keyword/2018-edition-error.rs
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error.rs
@@ -7,9 +7,9 @@ mod outer_mod {
     }
 }
 use self::outer_mod::await::await; //~ ERROR expected identifier
-    //~^ ERROR expected identifier, found reserved keyword `await`
+    //~^ ERROR expected identifier, found keyword `await`
 
-macro_rules! await { () => {}; } //~ ERROR expected identifier, found reserved keyword `await`
+macro_rules! await { () => {}; } //~ ERROR expected identifier, found keyword `await`
 
 fn main() {
     await!(); //~ ERROR expected expression, found `)`

--- a/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
@@ -1,48 +1,48 @@
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:5:13
    |
 LL |     pub mod await {
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     pub mod r#await {
    |             ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:6:20
    |
 LL |         pub struct await;
-   |                    ^^^^^ expected identifier, found reserved keyword
+   |                    ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |         pub struct r#await;
    |                    ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:9:22
    |
 LL | use self::outer_mod::await::await;
-   |                      ^^^^^ expected identifier, found reserved keyword
+   |                      ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::r#await::await;
    |                      ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:9:29
    |
 LL | use self::outer_mod::await::await;
-   |                             ^^^^^ expected identifier, found reserved keyword
+   |                             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::await::r#await;
    |                             ^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:12:14
    |
 LL | macro_rules! await { () => {}; }
-   |              ^^^^^ expected identifier, found reserved keyword
+   |              ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | macro_rules! r#await { () => {}; }

--- a/src/test/ui/async-await/no-const-async.rs
+++ b/src/test/ui/async-await/no-const-async.rs
@@ -3,5 +3,5 @@
 // compile-flags: --crate-type lib
 
 pub const async fn x() {}
-//~^ ERROR expected identifier, found reserved keyword `async`
+//~^ ERROR expected identifier, found keyword `async`
 //~^^ expected `:`, found keyword `fn`

--- a/src/test/ui/async-await/no-const-async.stderr
+++ b/src/test/ui/async-await/no-const-async.stderr
@@ -1,8 +1,8 @@
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/no-const-async.rs:5:11
    |
 LL | pub const async fn x() {}
-   |           ^^^^^ expected identifier, found reserved keyword
+   |           ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | pub const r#async fn x() {}

--- a/src/test/ui/editions/edition-keywords-2015-2018-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2015-2018-expansion.rs
@@ -5,7 +5,7 @@
 extern crate edition_kw_macro_2018;
 
 mod one_async {
-    produces_async! {} //~ ERROR expected identifier, found reserved keyword
+    produces_async! {} //~ ERROR expected identifier, found keyword
 }
 mod two_async {
     produces_async_raw! {} // OK

--- a/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
@@ -1,8 +1,8 @@
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2015-2018-expansion.rs:8:5
    |
 LL |     produces_async! {}
-   |     ^^^^^^^^^^^^^^^^^^ expected identifier, found reserved keyword
+   |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -5,7 +5,7 @@
 extern crate edition_kw_macro_2015;
 
 pub fn check_async() {
-    let mut async = 1; //~ ERROR expected identifier, found reserved keyword `async`
+    let mut async = 1; //~ ERROR expected identifier, found keyword `async`
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
@@ -15,6 +15,6 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {}
     if passes_ident!(r#async) == 1 {} // OK
-    module::async(); //~ ERROR expected identifier, found reserved keyword `async`
+    module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
 }

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -1,18 +1,18 @@
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:8:13
    |
 LL |     let mut async = 1;
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut r#async = 1;
    |             ^^^^^^^
 
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:18:13
    |
 LL |     module::async();
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     module::r#async();

--- a/src/test/ui/editions/edition-keywords-2018-2018-expansion.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2018-expansion.rs
@@ -5,7 +5,7 @@
 extern crate edition_kw_macro_2018;
 
 mod one_async {
-    produces_async! {} //~ ERROR expected identifier, found reserved keyword `async`
+    produces_async! {} //~ ERROR expected identifier, found keyword `async`
 }
 mod two_async {
     produces_async_raw! {} // OK

--- a/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
@@ -1,8 +1,8 @@
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2018-expansion.rs:8:5
    |
 LL |     produces_async! {}
-   |     ^^^^^^^^^^^^^^^^^^ expected identifier, found reserved keyword
+   |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 help: you can escape reserved keywords to use them as identifiers

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -5,7 +5,7 @@
 extern crate edition_kw_macro_2018;
 
 pub fn check_async() {
-    let mut async = 1; //~ ERROR expected identifier, found reserved keyword `async`
+    let mut async = 1; //~ ERROR expected identifier, found keyword `async`
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
@@ -15,6 +15,6 @@ pub fn check_async() {
 
     if passes_ident!(async) == 1 {}
     if passes_ident!(r#async) == 1 {} // OK
-    module::async(); //~ ERROR expected identifier, found reserved keyword `async`
+    module::async(); //~ ERROR expected identifier, found keyword `async`
     module::r#async(); // OK
 }

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -1,18 +1,18 @@
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:8:13
    |
 LL |     let mut async = 1;
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut r#async = 1;
    |             ^^^^^^^
 
-error: expected identifier, found reserved keyword `async`
+error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:18:13
    |
 LL |     module::async();
-   |             ^^^^^ expected identifier, found reserved keyword
+   |             ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     module::r#async();

--- a/src/test/ui/parser/mut-patterns.rs
+++ b/src/test/ui/parser/mut-patterns.rs
@@ -28,7 +28,7 @@ pub fn main() {
     //~| ERROR `mut` must be attached to each individual binding
     //~| ERROR expected identifier, found reserved keyword `yield`
     //~| ERROR expected identifier, found reserved keyword `become`
-    //~| ERROR expected identifier, found reserved keyword `await`
+    //~| ERROR expected identifier, found keyword `await`
 
     struct W<T, U>(T, U);
     struct B { f: Box<u8> }

--- a/src/test/ui/parser/mut-patterns.stderr
+++ b/src/test/ui/parser/mut-patterns.stderr
@@ -62,11 +62,11 @@ help: you can escape reserved keywords to use them as identifiers
 LL |     let mut mut yield(r#become, await) = r#yield(0, 0);
    |                       ^^^^^^^^
 
-error: expected identifier, found reserved keyword `await`
+error: expected identifier, found keyword `await`
   --> $DIR/mut-patterns.rs:26:31
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
-   |                               ^^^^^ expected identifier, found reserved keyword
+   |                               ^^^^^ expected identifier, found keyword
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut mut yield(become, r#await) = r#yield(0, 0);


### PR DESCRIPTION
AFAIK, this only affects error messages, removing the word "reserved".

Closes #64853