### PR TITLE
Slice docs: fix typo

### DIFF
--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -567,7 +567,7 @@ mod prim_array { }
 #[doc(alias = "]")]
 #[doc(alias = "[]")]
 /// A dynamically-sized view into a contiguous sequence, `[T]`. Contiguous here
-/// means that elements are layed out so that every element is the same
+/// means that elements are laid out so that every element is the same
 /// distance from its neighbors.
 ///
 /// *[See also the `std::slice` module](slice/index.html).*


### PR DESCRIPTION
With #64703, I introduced a typo. Here is the fix. Sorry for the inconvenience.