### PR TITLE
Add pkg-config to dependency list if building for Linux on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or reading the [rustc guide][rustcguidebuild].
    * `curl`
    * `git`
    * `ssl` which comes in `libssl-dev` or `openssl-devel`
-   * `pkg-config` if you are on compiling on Linux and targeting linux 
+   * `pkg-config` if you are on compiling on Linux and targeting Linux
 
 2. Clone the [source] with `git`:
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ or reading the [rustc guide][rustcguidebuild].
    * `curl`
    * `git`
    * `ssl` which comes in `libssl-dev` or `openssl-devel`
+   * `pkg-config` if you are on compiling on Linux and targeting linux 
 
 2. Clone the [source] with `git`:
 


### PR DESCRIPTION
I got this message when building from source on Ubuntu: 

```
It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.
```

I feel like it would be a better experience to show this in the dependencies instead of having to run into this issue.