### PR TITLE
syntax: recover trailing `|` in or-patterns

### DIFF
--- a/src/test/ui/or-patterns/issue-64879-trailing-before-guard.rs
+++ b/src/test/ui/or-patterns/issue-64879-trailing-before-guard.rs
@@ -1,0 +1,15 @@
+// In this regression test we check that a trailing `|` in an or-pattern just
+// before the `if` token of a `match` guard will receive parser recovery with
+// an appropriate error message.
+
+enum E { A, B }
+
+fn main() {
+    match E::A {
+        E::A |
+        E::B | //~ ERROR a trailing `|` is not allowed in an or-pattern
+        if true => {
+            let recovery_witness: bool = 0; //~ ERROR mismatched types
+        }
+    }
+}

--- a/src/test/ui/or-patterns/issue-64879-trailing-before-guard.stderr
+++ b/src/test/ui/or-patterns/issue-64879-trailing-before-guard.stderr
@@ -1,0 +1,20 @@
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/issue-64879-trailing-before-guard.rs:10:14
+   |
+LL |         E::A |
+   |         ---- while parsing this or-pattern starting here
+LL |         E::B |
+   |              ^ help: remove the `|`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-64879-trailing-before-guard.rs:12:42
+   |
+LL |             let recovery_witness: bool = 0;
+   |                                          ^ expected bool, found integer
+   |
+   = note: expected type `bool`
+              found type `{integer}`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/or-patterns/multiple-pattern-typo.stderr
+++ b/src/test/ui/or-patterns/multiple-pattern-typo.stderr
@@ -2,37 +2,49 @@ error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:8:15
    |
 LL |         1 | 2 || 3 => (),
-   |               ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         |
+   |         while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:13:16
    |
 LL |         (1 | 2 || 3) => (),
-   |                ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          |
+   |          while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:18:16
    |
 LL |         (1 | 2 || 3,) => (),
-   |                ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          |
+   |          while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:25:18
    |
 LL |         TS(1 | 2 || 3) => (),
-   |                  ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |            -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |            |
+   |            while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:32:23
    |
 LL |         NS { f: 1 | 2 || 3 } => (),
-   |                       ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |                 -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |                 |
+   |                 while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:37:16
    |
 LL |         [1 | 2 || 3] => (),
-   |                ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          -     ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |          |
+   |          while parsing this or-pattern starting here
 
 error: unexpected token `||` after pattern
   --> $DIR/multiple-pattern-typo.rs:42:9

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail.stderr
@@ -51,24 +51,32 @@ error: a leading `|` is only allowed in a top-level pattern
    |
 LL |     let ( || A | B) = E::A;
    |           ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/or-patterns-syntactic-fail.rs:48:11
    |
 LL |     let [ || A | B ] = [E::A];
    |           ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/or-patterns-syntactic-fail.rs:49:13
    |
 LL |     let TS( || A | B );
    |             ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/or-patterns-syntactic-fail.rs:50:17
    |
 LL |     let NS { f: || A | B };
    |                 ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: no rules expected the token `|`
   --> $DIR/or-patterns-syntactic-fail.rs:14:15

--- a/src/test/ui/or-patterns/remove-leading-vert.fixed
+++ b/src/test/ui/or-patterns/remove-leading-vert.fixed
@@ -1,4 +1,4 @@
-// Test the suggestion to remove a leading `|`.
+// Test the suggestion to remove a leading, or trailing `|`.
 
 // run-rustfix
 
@@ -8,7 +8,7 @@
 fn main() {}
 
 #[cfg(FALSE)]
-fn leading_vert() {
+fn leading() {
     fn fun1(  A: E) {} //~ ERROR a leading `|` is not allowed in a parameter pattern
     fn fun2(  A: E) {} //~ ERROR a leading `|` is not allowed in a parameter pattern
     let (  A): E; //~ ERROR a leading `|` is only allowed in a top-level pattern
@@ -20,4 +20,27 @@ fn leading_vert() {
     let TS(  A ): TS; //~ ERROR a leading `|` is only allowed in a top-level pattern
     let NS { f:  A }: NS; //~ ERROR a leading `|` is only allowed in a top-level pattern
     let NS { f:  A }: NS; //~ ERROR a leading `|` is only allowed in a top-level pattern
+}
+
+#[cfg(FALSE)]
+fn trailing() {
+    let ( A  ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let (a ,): (E,); //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A | B  ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let [ A | B  ]: [E; 1]; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let S { f: B  }; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A | B  ): E; //~ ERROR unexpected token `||` after pattern
+    //~^ ERROR a trailing `|` is not allowed in an or-pattern
+    match A {
+        A  => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A  => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A | B  => {} //~ ERROR unexpected token `||` after pattern
+        //~^ ERROR a trailing `|` is not allowed in an or-pattern
+        | A | B  => {}
+        //~^ ERROR a trailing `|` is not allowed in an or-pattern
+    }
+
+    let a  : u8 = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a  = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a  ; //~ ERROR a trailing `|` is not allowed in an or-pattern
 }

--- a/src/test/ui/or-patterns/remove-leading-vert.rs
+++ b/src/test/ui/or-patterns/remove-leading-vert.rs
@@ -1,4 +1,4 @@
-// Test the suggestion to remove a leading `|`.
+// Test the suggestion to remove a leading, or trailing `|`.
 
 // run-rustfix
 
@@ -8,7 +8,7 @@
 fn main() {}
 
 #[cfg(FALSE)]
-fn leading_vert() {
+fn leading() {
     fn fun1( | A: E) {} //~ ERROR a leading `|` is not allowed in a parameter pattern
     fn fun2( || A: E) {} //~ ERROR a leading `|` is not allowed in a parameter pattern
     let ( | A): E; //~ ERROR a leading `|` is only allowed in a top-level pattern
@@ -20,4 +20,27 @@ fn leading_vert() {
     let TS( || A ): TS; //~ ERROR a leading `|` is only allowed in a top-level pattern
     let NS { f: | A }: NS; //~ ERROR a leading `|` is only allowed in a top-level pattern
     let NS { f: || A }: NS; //~ ERROR a leading `|` is only allowed in a top-level pattern
+}
+
+#[cfg(FALSE)]
+fn trailing() {
+    let ( A | ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let (a |,): (E,); //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A | B | ): E; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let [ A | B | ]: [E; 1]; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let S { f: B | }; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let ( A || B | ): E; //~ ERROR unexpected token `||` after pattern
+    //~^ ERROR a trailing `|` is not allowed in an or-pattern
+    match A {
+        A | => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A || => {} //~ ERROR a trailing `|` is not allowed in an or-pattern
+        A || B | => {} //~ ERROR unexpected token `||` after pattern
+        //~^ ERROR a trailing `|` is not allowed in an or-pattern
+        | A | B | => {}
+        //~^ ERROR a trailing `|` is not allowed in an or-pattern
+    }
+
+    let a | : u8 = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a | = 0; //~ ERROR a trailing `|` is not allowed in an or-pattern
+    let a | ; //~ ERROR a trailing `|` is not allowed in an or-pattern
 }

--- a/src/test/ui/or-patterns/remove-leading-vert.stderr
+++ b/src/test/ui/or-patterns/remove-leading-vert.stderr
@@ -9,6 +9,8 @@ error: a leading `|` is not allowed in a parameter pattern
    |
 LL |     fn fun2( || A: E) {}
    |              ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/remove-leading-vert.rs:14:11
@@ -21,6 +23,8 @@ error: a leading `|` is only allowed in a top-level pattern
    |
 LL |     let ( || A): (E);
    |           ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/remove-leading-vert.rs:16:11
@@ -39,6 +43,8 @@ error: a leading `|` is only allowed in a top-level pattern
    |
 LL |     let [ || A ]: [E; 1];
    |           ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/remove-leading-vert.rs:19:13
@@ -51,6 +57,8 @@ error: a leading `|` is only allowed in a top-level pattern
    |
 LL |     let TS( || A ): TS;
    |             ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
 error: a leading `|` is only allowed in a top-level pattern
   --> $DIR/remove-leading-vert.rs:21:17
@@ -63,6 +71,130 @@ error: a leading `|` is only allowed in a top-level pattern
    |
 LL |     let NS { f: || A }: NS;
    |                 ^^ help: remove the `||`
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
 
-error: aborting due to 11 previous errors
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:27:13
+   |
+LL |     let ( A | ): E;
+   |           - ^ help: remove the `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:28:12
+   |
+LL |     let (a |,): (E,);
+   |          - ^ help: remove the `|`
+   |          |
+   |          while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:29:17
+   |
+LL |     let ( A | B | ): E;
+   |           -     ^ help: remove the `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:30:17
+   |
+LL |     let [ A | B | ]: [E; 1];
+   |           -     ^ help: remove the `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:31:18
+   |
+LL |     let S { f: B | };
+   |                - ^ help: remove the `|`
+   |                |
+   |                while parsing this or-pattern starting here
+
+error: unexpected token `||` after pattern
+  --> $DIR/remove-leading-vert.rs:32:13
+   |
+LL |     let ( A || B | ): E;
+   |           - ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:32:18
+   |
+LL |     let ( A || B | ): E;
+   |           -      ^ help: remove the `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:35:11
+   |
+LL |         A | => {}
+   |         - ^ help: remove the `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:36:11
+   |
+LL |         A || => {}
+   |         - ^^ help: remove the `||`
+   |         |
+   |         while parsing this or-pattern starting here
+   |
+   = note: alternatives in or-patterns are separated with `|`, not `||`
+
+error: unexpected token `||` after pattern
+  --> $DIR/remove-leading-vert.rs:37:11
+   |
+LL |         A || B | => {}
+   |         - ^^ help: use a single `|` to separate multiple alternative patterns: `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:37:16
+   |
+LL |         A || B | => {}
+   |         -      ^ help: remove the `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:39:17
+   |
+LL |         | A | B | => {}
+   |           -     ^ help: remove the `|`
+   |           |
+   |           while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:43:11
+   |
+LL |     let a | : u8 = 0;
+   |         - ^ help: remove the `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:44:11
+   |
+LL |     let a | = 0;
+   |         - ^ help: remove the `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: a trailing `|` is not allowed in an or-pattern
+  --> $DIR/remove-leading-vert.rs:45:11
+   |
+LL |     let a | ;
+   |         - ^ help: remove the `|`
+   |         |
+   |         while parsing this or-pattern starting here
+
+error: aborting due to 26 previous errors
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/64879.

For example (this also shows that we are sensitive to the typo `||`):

```
error: a trailing `|` is not allowed in an or-pattern
  --> $DIR/remove-leading-vert.rs:33:11
   |
LL |         A || => {}
   |         - ^^ help: remove the `||`
   |         |
   |         while parsing this or-pattern starting here
   |
   = note: alternatives in or-patterns are separated with `|`, not `||`
```

r? @estebank 