### PR TITLE
fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or reading the [rustc guide][rustcguidebuild].
    * `curl`
    * `git`
    * `ssl` which comes in `libssl-dev` or `openssl-devel`
-   * `pkg-config` if you are on compiling on Linux and targeting Linux
+   * `pkg-config` if you are compiling on Linux and targeting Linux
 
 2. Clone the [source] with `git`:
 


### PR DESCRIPTION
Accidentally had a typo in https://github.com/rust-lang/rust/pull/64884, sorry!