### PR TITLE
rustdoc: Fix default logo filename

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -574,7 +574,7 @@ fn write_shared(
 
     let write = |p, c| { cx.shared.fs.write(p, c) };
     if (*cx.shared).layout.logo.is_empty() {
-        write(cx.path("rust-log.png"), static_files::RUST_LOGO)?;
+        write(cx.path("rust-logo.png"), static_files::RUST_LOGO)?;
     }
     if (*cx.shared).layout.favicon.is_empty() {
         write(cx.path("favicon.ico"), static_files::RUST_FAVICON)?;


### PR DESCRIPTION
This was a typo made in #64443. It's the reason the logo is missing on the [nightly docs](https://doc.rust-lang.org/nightly/std/).

r? @Mark-Simulacrum