### PR TITLE
rustdoc: fix rust-logo.png being included with the wrong name

### DIFF
--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -574,7 +574,7 @@ fn write_shared(
 
     let write = |p, c| { cx.shared.fs.write(p, c) };
     if (*cx.shared).layout.logo.is_empty() {
-        write(cx.path("rust-log.png"), static_files::RUST_LOGO)?;
+        write(cx.path("rust-logo.png"), static_files::RUST_LOGO)?;
     }
     if (*cx.shared).layout.favicon.is_empty() {
         write(cx.path("favicon.ico"), static_files::RUST_FAVICON)?;


### PR DESCRIPTION
During a refactoring in #64443 a typo was introduced in rustdoc's html renderer, and `rust-logo.png` was saved as `rust-log.png`. This fixes the regression by restoring the proper file name.

r? @Mark-Simulacrum