### PR TITLE
Silence unreachable code lint from await desugaring

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2364,7 +2364,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // which diverges, that we are about to lint on. This gives suboptimal diagnostics.
             // Instead, stop here so that the `if`- or `while`-expression's block is linted instead.
             if !span.is_desugaring(DesugaringKind::CondTemporary) &&
-                !span.is_desugaring(DesugaringKind::Async)
+                !span.is_desugaring(DesugaringKind::Async) &&
+                !orig_span.is_desugaring(DesugaringKind::Await)
             {
                 self.diverges.set(Diverges::WarnedAlways);
 

--- a/src/test/ui/async-await/unreachable-lint-1.rs
+++ b/src/test/ui/async-await/unreachable-lint-1.rs
@@ -1,0 +1,12 @@
+// edition:2018
+#![deny(unreachable_code)]
+
+async fn foo() {
+    return; bar().await;
+    //~^ ERROR unreachable statement
+}
+
+async fn bar() {
+}
+
+fn main() { }

--- a/src/test/ui/async-await/unreachable-lint-1.stderr
+++ b/src/test/ui/async-await/unreachable-lint-1.stderr
@@ -1,0 +1,16 @@
+error: unreachable statement
+  --> $DIR/unreachable-lint-1.rs:5:13
+   |
+LL |     return; bar().await;
+   |     ------  ^^^^^^^^^^^^ unreachable statement
+   |     |
+   |     any code following this expression is unreachable
+   |
+note: lint level defined here
+  --> $DIR/unreachable-lint-1.rs:2:9
+   |
+LL | #![deny(unreachable_code)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/async-await/unreachable-lint.rs
+++ b/src/test/ui/async-await/unreachable-lint.rs
@@ -1,0 +1,13 @@
+// check-pass
+// edition:2018
+#![deny(unreachable_code)]
+
+async fn foo() {
+    endless().await;
+}
+
+async fn endless() -> ! {
+    loop {}
+}
+
+fn main() { }


### PR DESCRIPTION
Fixes #61798.

This PR silences the unreachable code lint when it originates from within an await desugaring.