### PR TITLE
Reword E0392 slightly

### DIFF
--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1001,7 +1001,7 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
     // Help is available only in presence of lang items.
     let msg = if let Some(def_id) = suggested_marker_id {
         format!(
-            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            "consider removing `{}`, refering to it in a field, or using a marker such as `{}`",
             param_name,
             tcx.def_path_str(def_id),
         )

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -999,11 +999,16 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
 
     let suggested_marker_id = tcx.lang_items().phantom_data();
     // Help is available only in presence of lang items.
-    if let Some(def_id) = suggested_marker_id {
-        err.help(&format!("consider removing `{}` or using a marker such as `{}`",
-                          param_name,
-                          tcx.def_path_str(def_id)));
-    }
+    let msg = if let Some(def_id) = suggested_marker_id {
+        format!(
+            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            param_name,
+            tcx.def_path_str(def_id),
+        )
+    } else {
+        format!( "consider removing `{}` or refering to it in a field", param_name)
+    };
+    err.help(&msg);
     err.emit();
 }
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Make it clearer that a type or lifetime argument not being used can be
fixed by referencing it in a struct's fields, not just using `PhathomData`.

CC #53589.