### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/libarena/lib.rs
+++ b/src/libarena/lib.rs
@@ -500,7 +500,7 @@ impl DroplessArena {
                 // though it was supposed to give us `len`
                 return slice::from_raw_parts_mut(mem, i);
             }
-            ptr::write(mem.offset(i as isize), value.unwrap());
+            ptr::write(mem.add(i), value.unwrap());
             i += 1;
         }
     }

--- a/src/librustc_apfloat/ieee.rs
+++ b/src/librustc_apfloat/ieee.rs
@@ -1199,8 +1199,8 @@ impl<S: Semantics> Float for IeeeFloat<S> {
         }
 
         // Handle a leading minus sign.
-        let minus = s.starts_with("-");
-        if minus || s.starts_with("+") {
+        let minus = s.starts_with('-');
+        if minus || s.starts_with('+') {
             s = &s[1..];
             if s.is_empty() {
                 return Err(ParseError("String has no digits"));

--- a/src/librustc_data_structures/graph/implementation/mod.rs
+++ b/src/librustc_data_structures/graph/implementation/mod.rs
@@ -303,11 +303,11 @@ pub struct AdjacentEdges<'g, N, E> {
 
 impl<'g, N: Debug, E: Debug> AdjacentEdges<'g, N, E> {
     fn targets(self) -> impl Iterator<Item = NodeIndex> + 'g {
-        self.into_iter().map(|(_, edge)| edge.target)
+        self.map(|(_, edge)| edge.target)
     }
 
     fn sources(self) -> impl Iterator<Item = NodeIndex> + 'g {
-        self.into_iter().map(|(_, edge)| edge.source)
+        self.map(|(_, edge)| edge.source)
     }
 }
 

--- a/src/librustc_index/bit_set.rs
+++ b/src/librustc_index/bit_set.rs
@@ -621,7 +621,7 @@ impl<'a, T: Idx> Iterator for HybridIter<'a, T> {
 
     fn next(&mut self) -> Option<T> {
         match self {
-            HybridIter::Sparse(sparse) => sparse.next().map(|e| *e),
+            HybridIter::Sparse(sparse) => sparse.next().copied(),
             HybridIter::Dense(dense) => dense.next(),
         }
     }

--- a/src/libserialize/json.rs
+++ b/src/libserialize/json.rs
@@ -1053,12 +1053,12 @@ impl Json {
     /// a value associated with the provided key is found. If no value is found
     /// or the Json value is not an Object, returns `None`.
     pub fn search(&self, key: &str) -> Option<&Json> {
-        match self {
-            &Json::Object(ref map) => {
+        match *self {
+            Json::Object(ref map) => {
                 match map.get(key) {
                     Some(json_value) => Some(json_value),
                     None => {
-                        for (_, v) in map {
+                        for v in map.values() {
                             match v.search(key) {
                                 x if x.is_some() => return x,
                                 _ => ()
@@ -1487,12 +1487,12 @@ impl<T: Iterator<Item=char>> Parser<T> {
     }
 
     fn parse_number(&mut self) -> JsonEvent {
-        let mut neg = false;
-
-        if self.ch_is('-') {
+        let neg = if self.ch_is('-') {
             self.bump();
-            neg = true;
-        }
+            true
+        } else {
+            false
+        };
 
         let res = match self.parse_u64() {
             Ok(res) => res,
@@ -2162,10 +2162,9 @@ impl crate::Decoder for Decoder {
         let s = self.read_str()?;
         {
             let mut it = s.chars();
-            match (it.next(), it.next()) {
+            if let (Some(c), None) = (it.next(), it.next()) {
                 // exactly one character
-                (Some(c), None) => return Ok(c),
-                _ => ()
+                return Ok(c);
             }
         }
         Err(ExpectedError("single character string".to_owned(), s.to_string()))


### PR DESCRIPTION
* Use `match` instead of `if` chain
* Remove redundant `into_iter()`
* Use `copied()` instead of `map()`

etc.