### PR TITLE
Improve sidebar styling to make its integration easier

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -183,7 +183,7 @@ nav.sub {
 	position: fixed;
 	left: 0;
 	top: 0;
-	height: 100vh;
+	bottom: 0;
 	overflow: auto;
 }
 
@@ -573,7 +573,7 @@ h4 > code, h3 > code, .invisible > code {
 	margin-top: 0;
 }
 
-nav {
+nav:not(.sidebar) {
 	border-bottom: 1px solid;
 	padding-bottom: 10px;
 	margin-bottom: 10px;

--- a/src/librustdoc/html/static/themes/dark.css
+++ b/src/librustdoc/html/static/themes/dark.css
@@ -129,7 +129,7 @@ pre {
 pre.rust .comment { color: #8d8d8b; }
 pre.rust .doccomment { color: #8ca375; }
 
-nav {
+nav:not(.sidebar) {
 	border-bottom-color: #4e4e4e;
 }
 nav.main .current {

--- a/src/librustdoc/html/static/themes/light.css
+++ b/src/librustdoc/html/static/themes/light.css
@@ -129,7 +129,7 @@ pre {
 pre.rust .comment { color: #8E908C; }
 pre.rust .doccomment { color: #4D4D4C; }
 
-nav {
+nav:not(.sidebar) {
 	border-bottom-color: #e0e0e0;
 }
 nav.main .current {


### PR DESCRIPTION
Part of https://github.com/rust-lang/docs.rs/issues/417

Setting the height was an error: forcing the element bottom to be at the bottom allows to change to top of the sidebar.

r? @Mark-Simulacrum 