### PR TITLE
syntax: improve parameter without type suggestions

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1212,6 +1212,7 @@ impl<'a> Parser<'a> {
                     &mut err,
                     pat,
                     is_name_required,
+                    is_self_allowed,
                     is_trait_item,
                 ) {
                     err.emit();

--- a/src/test/ui/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params-denied-2018.stderr
@@ -5,6 +5,10 @@ LL |     fn foo(i32);
    |               ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn foo(self: i32);
+   |            ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn foo(i32: TypeName);
@@ -21,6 +25,10 @@ LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar_with_default_impl(self: String, String) {}
+   |                              ^^^^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String: TypeName, String) {}

--- a/src/test/ui/parser/pat-lt-bracket-2.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-2.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn a(B<) {}
    |       ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn a(_: B<) {}
+   |      ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
@@ -5,6 +5,10 @@ LL | trait Trait2015 { fn foo(#[allow(C)] i32); }
    |                                         ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | trait Trait2015 { fn foo(#[allow(C)] self: i32); }
+   |                                      ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] i32: TypeName); }

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn foo(Option<i32>, String) {}
    |              ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn foo(_: Option<i32>, String) {}
+   |        ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/issue-34264.rs:1:27

--- a/src/test/ui/suggestions/issue-64252-self-type.rs
+++ b/src/test/ui/suggestions/issue-64252-self-type.rs
@@ -1,0 +1,14 @@
+// This test checks that a suggestion to add a `self: ` parameter name is provided
+// to functions where this is applicable.
+
+pub fn foo(Box<Self>) { }
+//~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+
+struct Bar;
+
+impl Bar {
+    fn bar(Box<Self>) { }
+    //~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+}
+
+fn main() { }

--- a/src/test/ui/suggestions/issue-64252-self-type.stderr
+++ b/src/test/ui/suggestions/issue-64252-self-type.stderr
@@ -1,0 +1,30 @@
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:4:15
+   |
+LL | pub fn foo(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | pub fn foo(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:10:15
+   |
+LL |     fn bar(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar(self: Box<Self>) { }
+   |            ^^^^^^^^^
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn bar(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #64252.

This PR improves the suggestions provided when function parameters
do not have types:

- A new suggestion is added for arbitrary self types, which suggests
adding `self: ` before the type.

- Existing suggestions are now provided when a `<` is found where a `:`
was expected (previously only `,` and `)` or trait items), this gives
suggestions in the case where the unnamed parameter type is generic
in a free function.

- The suggestion that a type name be provided (e.g. `fn foo(HashMap<u32>)`
-> `fn foo(HashMap: TypeName<u32>)`) will no longer occur when a `<` was
found instead of `:`.

- The ident will not be used for recovery when a `<` was found instead
of `:`.

r? @Centril 
cc @estebank @yoshuawuyts