### PR TITLE
Enabling -Zdoctest-xcompile for crate tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1788,6 +1788,7 @@ impl Step for Crate {
 
         cargo.arg("-p").arg(krate);
 
+        cargo.arg("-Zdoctest-xcompile");
         // The tests are going to run with the *target* libraries, so we need to
         // ensure that those libraries show up in the LD_LIBRARY_PATH equivalent.
         //

--- a/src/libstd/env.rs
+++ b/src/libstd/env.rs
@@ -36,7 +36,7 @@ use crate::sys::os as os_imp;
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore-sgx
 /// use std::env;
 ///
 /// fn main() -> std::io::Result<()> {

--- a/src/libstd/net/addr.rs
+++ b/src/libstd/net/addr.rs
@@ -772,7 +772,7 @@ impl hash::Hash for SocketAddrV6 {
 /// Attempting to create a [`SocketAddr`] iterator from an improperly formatted
 /// socket address `&str` (missing the port):
 ///
-/// ```
+/// ```ignore-sgx
 /// use std::io;
 /// use std::net::ToSocketAddrs;
 ///

--- a/src/libstd/primitive_docs.rs
+++ b/src/libstd/primitive_docs.rs
@@ -420,7 +420,7 @@ mod prim_unit { }
 ///
 /// ## 3. Get it from C.
 ///
-/// ```
+/// ```ignore-sgx
 /// # #![feature(rustc_private)]
 /// extern crate libc;
 ///

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -379,7 +379,7 @@ impl fmt::Debug for ChildStderr {
 /// program to be executed. Additional builder methods allow the configuration
 /// to be changed (for example, by adding arguments) prior to spawning:
 ///
-/// ```
+/// ```ignore-sgx
 /// use std::process::Command;
 ///
 /// let output = if cfg!(target_os = "windows") {

--- a/src/libstd/sync/condvar.rs
+++ b/src/libstd/sync/condvar.rs
@@ -27,7 +27,7 @@ impl WaitTimeoutResult {
     /// The main thread will wait with a timeout on the condvar and then leave
     /// once the boolean has been updated and notified.
     ///
-    /// ```
+    /// ```ignore-sgx
     /// use std::sync::{Arc, Condvar, Mutex};
     /// use std::thread;
     /// use std::time::Duration;
@@ -293,7 +293,7 @@ impl Condvar {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-sgx
     /// use std::sync::{Arc, Mutex, Condvar};
     /// use std::thread;
     ///
@@ -365,7 +365,7 @@ impl Condvar {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-sgx
     /// use std::sync::{Arc, Mutex, Condvar};
     /// use std::thread;
     /// use std::time::Duration;
@@ -438,7 +438,7 @@ impl Condvar {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-sgx
     /// #![feature(wait_timeout_until)]
     ///
     /// use std::sync::{Arc, Mutex, Condvar};

--- a/src/libstd/sync/mpsc/mod.rs
+++ b/src/libstd/sync/mpsc/mod.rs
@@ -297,7 +297,7 @@ mod cache_aligned;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore-sgx
 /// use std::sync::mpsc::channel;
 /// use std::thread;
 /// use std::time::Duration;
@@ -377,7 +377,7 @@ pub struct Iter<'a, T: 'a> {
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```ignore-sgx
 /// use std::sync::mpsc::channel;
 /// use std::thread;
 /// use std::time::Duration;

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -835,7 +835,7 @@ const NOTIFIED: usize = 2;
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore-sgx
 /// use std::thread;
 /// use std::sync::{Arc, atomic::{Ordering, AtomicBool}};
 /// use std::time::Duration;
@@ -1138,7 +1138,7 @@ impl Thread {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-sgx
     /// use std::thread;
     /// use std::time::Duration;
     ///


### PR DESCRIPTION
This PR would unconditionally enable the `-Zdoctest-xcompile` on crate test invocations. In particular this enables it for testing the standard library crate.

On the other hand this is changing behavior, since some CI probably relies on doc tests not being run when the target is not the host target. This could be assuaged by instead adding a flag to bootstrap. 

Feedback is welcome.