### PR TITLE
Fix typo while setting `compile-flags` in test

### DIFF
--- a/src/test/ui/issues/issue-23477.rs
+++ b/src/test/ui/issues/issue-23477.rs
@@ -1,5 +1,5 @@
 // build-pass (FIXME(62277): could be check-pass?)
-// compiler-flags: -g
+// compile-flags: -g
 
 pub struct Dst {
     pub a: (),

--- a/src/test/ui/issues/issue-23477.rs
+++ b/src/test/ui/issues/issue-23477.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 // compile-flags: -g
 
 pub struct Dst {


### PR DESCRIPTION
This test is meant to check for an ICE when generating debug info, but didn't actually pass `-g` due to the typo.

I also removed the `FIXME`, since this needs to actually be built (not just checked) to trigger the ICE.