### PR TITLE
Stop failing on toolstate changes

### DIFF
--- a/src/ci/azure-pipelines/pr.yml
+++ b/src/ci/azure-pipelines/pr.yml
@@ -32,4 +32,5 @@ jobs:
       parameters:
         only_on_updated_submodules: 'yes'
   variables:
+    FORCE_FAIL_TOOLSTATE: true
     IMAGE: x86_64-gnu-tools

--- a/src/ci/docker/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/x86_64-gnu-tools/checktools.sh
@@ -61,6 +61,11 @@ verify_submodule_changed() {
             if [ $SIX_WEEK_CYCLE -ge 35 ]; then
                 exit 3
             fi
+            # we want the PR builder to error out even though the auto branch
+            # builder will not
+            if [ -n "$FORCE_FAIL_TOOLSTATE" ]; then
+                exit 3
+            fi
         fi
     fi
 }


### PR DESCRIPTION
r? @kennytm 

@Centril, @Manishearth, and I were discussing this on Discord today (there's probably some issues to cc, but I can't find them at a cursory search).

Previously, toolstate would always error the build if the tool regressed (or didn't improve to test-pass). This isn't great for rollups, in particular, as it means we basically can't viably rollup tool updates.

In most cases, when trying to land a submodule (tool) change, you mostly want to just bump the sub-commit, and don't care too much if that actually fully fixes the tool (according to @Manishearth).

This amends that logic to also fail the PR builder "as if" we were on beta, since a PR author changing a submodule likely does want some indication of failure rather than silent acceptance. Ideally, there'd be some way to provide a "warning" but I don't believe that's possible with current set of checks.