### PR TITLE
Emit `_fltused` on `uefi` targets as a short-term workaround

### DIFF
--- a/src/libcore/num/float.rs
+++ b/src/libcore/num/float.rs
@@ -1,0 +1,6 @@
+// HACK(https://github.com/rust-lang/rust/issues/62785): uefi targets need special LLVM support
+// unless we emit the _fltused
+#[cfg(target_os = "uefi")]
+#[no_mangle]
+#[used]
+static _fltused: i32 = 0;

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -213,6 +213,7 @@ pub mod dec2flt;
 pub mod bignum;
 pub mod diy_float;
 
+mod float;
 mod wrapping;
 
 macro_rules! usize_isize_to_xe_bytes_doc {

--- a/src/test/ui/uefi-float.rs
+++ b/src/test/ui/uefi-float.rs
@@ -1,0 +1,25 @@
+// build-pass
+// https://github.com/rust-lang/rust/issues/62785
+
+#![no_std]
+#![no_main]
+use core::fmt::{Write,Error};
+
+struct Dummy;
+
+impl Write for Dummy {
+    fn write_str(&mut self, _s: &str) -> Result<(), Error>{
+        Ok(())
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn efi_main() -> i32 {
+    write!(Dummy,"Hello, world!").unwrap();
+    0
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop{}
+}

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -44,6 +44,9 @@ const EXCEPTION_PATHS: &[&str] = &[
     // target_os to tell targets with different LLVM-versions appart
     // (e.g. `wasm32-unknown-emscripten` vs `wasm32-unknown-unknown`):
     "src/libcore/hint.rs",
+    // HACK(https://github.com/rust-lang/rust/issues/62785): uefi targets need special LLVM support
+    // unless we emit the _fltused
+    "src/libcore/num/float.rs",
     "src/libstd/sys/", // Platform-specific code for std lives here.
                        // This has the trailing slash so that sys_common is not excepted.
     "src/libstd/os", // Platform-specific public interfaces


### PR DESCRIPTION
fixes #62785

I'm not sure how to test this locally. I keep running into problems with `compiler-rt` when cross compiling via `x.py`