### PR TITLE
[const-prop] Correctly handle locals that can't be propagated

### DIFF
--- a/src/test/ui/consts/const-eval/issue-64970.rs
+++ b/src/test/ui/consts/const-eval/issue-64970.rs
@@ -1,0 +1,15 @@
+// run-pass
+
+fn main() {
+    foo(10);
+}
+
+fn foo(mut n: i32) {
+    if false {
+        n = 0i32;
+    }
+
+    if n > 0i32 {
+        1i32 / n;
+    }
+}

--- a/src/test/ui/consts/const-eval/issue-64970.stderr
+++ b/src/test/ui/consts/const-eval/issue-64970.stderr
@@ -1,0 +1,8 @@
+warning: unused arithmetic operation that must be used
+  --> $DIR/issue-64970.rs:13:9
+   |
+LL |         1i32 / n;
+   |         ^^^^^^^^
+   |
+   = note: `#[warn(unused_must_use)]` on by default
+


### PR DESCRIPTION
`const_prop()` now handles writing the Rvalue into the Place in the
stack frame for us. So if we're not supposed to propagate that value,
we need to clear it.

r? @oli-obk 

Fixes #64970