### PR TITLE
BacktraceStatus: add Eq impl

### DIFF
--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -113,7 +113,7 @@ pub struct Backtrace {
 /// The current status of a backtrace, indicating whether it was captured or
 /// whether it is empty for some other reason.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BacktraceStatus {
     /// Capturing a backtrace is not supported, likely because it's not
     /// implemented for the current platform.


### PR DESCRIPTION
See discussion on #53487.

---
Is adding `Copy` too ambitious? It's a "status", so I don't forsee any non-POD data that might go in there, but it would restrict future variants more than `Eq` does.

Cc: @withoutboats @abonander 