### PR TITLE
Fix rustdoc display with js disabled

### DIFF
--- a/src/librustdoc/html/static/noscript.css
+++ b/src/librustdoc/html/static/noscript.css
@@ -5,3 +5,11 @@
 .loading-content {
 	display: none;
 }
+
+#main > h2 + div, #main > h3 + div {
+	display: block;
+}
+
+#main > h2 + h3 {
+	display: flex;
+}


### PR DESCRIPTION
Fixes #64988.

Currently, all sections are collapsed when the page is loading, and then is displayed once done. However, if js is disabled, they never get expanded. Therefore, they need to be shown by default.

r? @Mark-Simulacrum 