### PR TITLE
Remove rustdoc warning

### DIFF
--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -1109,7 +1109,7 @@ pub enum RunStrategy {
     InProcess,
 
     /// Spawns a subprocess to run the test, and sends the result back over the
-    /// supplied channel. Requires argv[0] to exist and point to the binary
+    /// supplied channel. Requires `argv[0]` to exist and point to the binary
     /// that's currently running.
     SpawnPrimary,
 }


### PR DESCRIPTION
Removes this warning:

```bash
    Finished release [optimized] target(s) in 2.62s
 Documenting core v0.0.0 (/home/imperio/rust/rust/src/libcore)
    Finished release [optimized] target(s) in 15.23s
 Documenting std v0.0.0 (/home/imperio/rust/rust/src/libstd)
    Finished release [optimized] target(s) in 17.30s
 Documenting proc_macro v0.0.0 (/home/imperio/rust/rust/src/libproc_macro)
    Finished release [optimized] target(s) in 2.36s
 Documenting test v0.0.0 (/home/imperio/rust/rust/src/libtest)
warning: `[0]` cannot be resolved, ignoring it...
    --> src/libtest/lib.rs:1112:41
     |
1112 |     /// supplied channel. Requires argv[0] to exist and point to the binary
     |                                         ^ cannot be resolved, ignoring
     |
     = note: `#[warn(intra_doc_link_resolution_failure)]` on by default
     = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

    Finished release [optimized] target(s) in 1.64s
Build completed successfully in 0:02:07
```