### PR TITLE
rustc book: nitpick SLP vectorization

### DIFF
--- a/src/doc/rustc/src/codegen-options/index.md
+++ b/src/doc/rustc/src/codegen-options/index.md
@@ -105,7 +105,7 @@ flag will turn that behavior off.
 
 ## no-vectorize-slp
 
-By default, `rustc` will attempt to vectorize loops using [superword-level
+By default, `rustc` will attempt to vectorize code using [superword-level
 parallelism](https://llvm.org/docs/Vectorizers.html#the-slp-vectorizer). This
 flag will turn that behavior off.
 


### PR DESCRIPTION
SLP vectorization (in general and as implemented in LLVM) is not limited to loops.