### PR TITLE
Compare `primary` with maximum of `children`s' line num instead of dropping it

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1026,7 +1026,8 @@ impl EmitterWriter {
         children.iter()
             .map(|sub| self.get_multispan_max_line_num(&sub.span))
             .max()
-            .unwrap_or(primary)
+            .unwrap_or(0)
+            .max(primary)
     }
 
     /// Adds a left margin to every line but the first, given a padding length and the label being


### PR DESCRIPTION
Fix #65001.