### PR TITLE
Do not ICE when dereferencing non-Copy raw pointer

### DIFF
--- a/src/test/ui/issues/issue-52262.rs
+++ b/src/test/ui/issues/issue-52262.rs
@@ -1,0 +1,25 @@
+// compile-flags:-Ztreat-err-as-bug=5
+#[derive(Debug)]
+enum MyError {
+    NotFound { key: Vec<u8> },
+    Err41,
+}
+
+impl std::error::Error for MyError {}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            MyError::NotFound { key } => write!(
+                f,
+                "unknown error with code {}.",
+                String::from_utf8(*key).unwrap()
+                //~^ ERROR cannot move out of `*key` which is behind a shared reference
+            ),
+            MyError::Err41 => write!(f, "Sit by a lake"),
+        }
+    }
+}
+fn main() {
+    println!("Hello, world!");
+}

--- a/src/test/ui/issues/issue-52262.stderr
+++ b/src/test/ui/issues/issue-52262.stderr
@@ -1,0 +1,9 @@
+error[E0507]: cannot move out of `*key` which is behind a shared reference
+  --> $DIR/issue-52262.rs:16:35
+   |
+LL |                 String::from_utf8(*key).unwrap()
+   |                                   ^^^^ move occurs because `*key` has type `std::vec::Vec<u8>`, which does not implement the `Copy` trait
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
CC #52262. Confirmed to remove the unnecessary ICE, but without a repro case.