### PR TITLE
Implement Default for MaybeUninit

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -230,6 +230,29 @@ impl<T: Copy> Clone for MaybeUninit<T> {
     }
 }
 
+#[unstable(feature = "maybe_uninit_default", issue = "0")]
+impl<T> Default for MaybeUninit<T> {
+    /// Equivalent to `MaybeUninit::uninit()`.
+    ///
+    /// Useful in conjunction with container types. For example to initialize an array:
+    ///
+    /// ```rust
+    /// # use std::mem::{self, MaybeUninit};
+    /// let mut uninit: [MaybeUninit<bool>; 10] = Default::default();
+    ///
+    /// for b in uninit {
+    ///     b.write(true);
+    /// }
+    ///
+    /// let init: [bool; 10] = unsafe { mem::transmute(uninit) };
+    /// assert_eq!(init, [true; 10]);
+    /// ```
+    #[inline(always)]
+    fn default() -> Self {
+        MaybeUninit::uninit()
+    }
+}
+
 impl<T> MaybeUninit<T> {
     /// Creates a new `MaybeUninit<T>` initialized with the given value.
     /// It is safe to call [`assume_init`] on the return value of this function.

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -230,7 +230,7 @@ impl<T: Copy> Clone for MaybeUninit<T> {
     }
 }
 
-#[unstable(feature = "maybe_uninit_default", issue = "0")]
+#[stable(feature = "maybe_uninit_default", since = "1.39.0")]
 impl<T> Default for MaybeUninit<T> {
     /// Equivalent to `MaybeUninit::uninit()`.
     ///

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -230,7 +230,7 @@ impl<T: Copy> Clone for MaybeUninit<T> {
     }
 }
 
-#[stable(feature = "maybe_uninit_default", since = "1.39.0")]
+#[stable(feature = "maybe_uninit_default", since = "1.40.0")]
 impl<T> Default for MaybeUninit<T> {
     /// Equivalent to `MaybeUninit::uninit()`.
     ///

--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -240,7 +240,7 @@ impl<T> Default for MaybeUninit<T> {
     /// # use std::mem::{self, MaybeUninit};
     /// let mut uninit: [MaybeUninit<bool>; 10] = Default::default();
     ///
-    /// for b in uninit {
+    /// for b in &uninit {
     ///     b.write(true);
     /// }
     ///


### PR DESCRIPTION
Note how if implemented this removes an unsafe in the array initialization example in the `MaybeUninit` main docs, as with `Default` you can just create the array directly. This also could serve as an alternate API concept to the current (unstable) `Foo::<T>::uninit()` stuff, at least for the sized types. Though even if `uninit()` is stabilized I think they still makes sense to implement.

I guess I'd need to open a tracking issue for this?