### PR TITLE
Implement Debug for MaybeUninit

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -1,3 +1,5 @@
+use crate::any::type_name;
+use crate::fmt;
 use crate::intrinsics;
 use crate::mem::ManuallyDrop;
 
@@ -227,6 +229,13 @@ impl<T: Copy> Clone for MaybeUninit<T> {
     fn clone(&self) -> Self {
         // Not calling `T::clone()`, we cannot know if we are initialized enough for that.
         *self
+    }
+}
+
+#[stable(feature = "maybe_uninit_debug", since = "1.41.0")]
+impl<T> fmt::Debug for MaybeUninit<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(type_name::<Self>())
     }
 }
 


### PR DESCRIPTION
Precedent: `UnsafeCell` implements `Debug` even though it can't actually display the value. I noticed this omission while writing the following:

```
#[derive(Debug)]
 pub struct SliceInitializer<'a, T> {
    marker: PhantomData<&'a mut T>, 
    uninit: &'a mut [MaybeUninit<T>],
    written: usize,
}
```

...which currently unergonomically fails to compile.

`UnsafeCell` does require `T: Debug`. Because of things like the above I think it'd be better to leave that requirement off. In fact, I'd also suggest removing that requirement for `UnsafeCell` too, which again I noticed in some low-level real world code.