### PR TITLE
Set RUST_BACKTRACE=0 in tests that include a backtrace in stderr

### DIFF
--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// rustc-env:RUST_BACKTRACE=0
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
 // normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-1.rs:15:1
+  --> $DIR/invalid-punct-ident-1.rs:16:1
    |
 LL | invalid_punct!();
    | ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// rustc-env:RUST_BACKTRACE=0
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
 // normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""

--- a/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-2.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-2.rs:15:1
+  --> $DIR/invalid-punct-ident-2.rs:16:1
    |
 LL | invalid_ident!();
    | ^^^^^^^^^^^^^^^^^

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.rs
@@ -1,4 +1,5 @@
 // aux-build:invalid-punct-ident.rs
+// rustc-env:RUST_BACKTRACE=0
 
 // FIXME https://github.com/rust-lang/rust/issues/59998
 // normalize-stderr-test "thread.*panicked.*proc_macro_server.rs.*\n" -> ""

--- a/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-3.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-3.rs:15:1
+  --> $DIR/invalid-punct-ident-3.rs:16:1
    |
 LL | invalid_raw_ident!();
    | ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/test-panic-abort.rs
+++ b/src/test/ui/test-panic-abort.rs
@@ -3,6 +3,7 @@
 // run-flags: --test-threads=1
 // run-fail
 // check-run-results
+// exec-env:RUST_BACKTRACE=0
 
 // ignore-wasm no panic or subprocess support
 // ignore-emscripten no panic or subprocess support

--- a/src/test/ui/test-panic-abort.run.stdout
+++ b/src/test/ui/test-panic-abort.run.stdout
@@ -17,7 +17,7 @@ testing123
 testing321
 thread 'main' panicked at 'assertion failed: `(left == right)`
   left: `2`,
- right: `5`', $DIR/test-panic-abort.rs:30:5
+ right: `5`', $DIR/test-panic-abort.rs:31:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 


### PR DESCRIPTION
This removes the implicit dependency on the environment variables set
when running `./x.py test`