### PR TITLE
metadata: Some crate loading cleanup

### DIFF
--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -148,9 +148,7 @@ pub enum ExternCrateSource {
         /// such ids
         DefId,
     ),
-    // Crate is loaded by `use`.
-    Use,
-    /// Crate is implicitly loaded by an absolute path.
+    /// Crate is implicitly loaded by a path resolving through extern prelude.
     Path,
 }
 

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -191,7 +191,6 @@ impl<'a> CrateLoader<'a> {
         &mut self,
         host_lib: Option<Library>,
         root: &Option<CratePaths>,
-        ident: Symbol,
         span: Span,
         lib: Library,
         dep_kind: DepKind,
@@ -204,8 +203,7 @@ impl<'a> CrateLoader<'a> {
             .map(|e| e.is_private_dep)
             .unwrap_or(false);
 
-        info!("register crate `extern crate {} as {}` (private_dep = {})",
-            crate_root.name, ident, private_dep);
+        info!("register crate `{}` (private_dep = {})", crate_root.name, private_dep);
 
         // Claim this crate number and cache it
         let cnum = self.cstore.alloc_new_crate_num();
@@ -213,7 +211,7 @@ impl<'a> CrateLoader<'a> {
         // Stash paths for top-most crate locally if necessary.
         let crate_paths = if root.is_none() {
             Some(CratePaths {
-                ident: ident.to_string(),
+                ident: crate_root.name.to_string(),
                 dylib: lib.dylib.clone().map(|p| p.0),
                 rlib:  lib.rlib.clone().map(|p| p.0),
                 rmeta: lib.rmeta.clone().map(|p| p.0),
@@ -391,7 +389,7 @@ impl<'a> CrateLoader<'a> {
                 Ok((cnum, data))
             }
             (LoadResult::Loaded(library), host_library) => {
-                Ok(self.register_crate(host_library, root, ident, span, library, dep_kind, name))
+                Ok(self.register_crate(host_library, root, span, library, dep_kind, name))
             }
             _ => panic!()
         }

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -207,7 +207,6 @@ impl<'a> CrateLoader<'a> {
         info!("register crate `extern crate {} as {}` (private_dep = {})",
             crate_root.name, ident, private_dep);
 
-
         // Claim this crate number and cache it
         let cnum = self.cstore.alloc_new_crate_num();
 
@@ -255,7 +254,6 @@ impl<'a> CrateLoader<'a> {
 
         let cmeta = cstore::CrateMetadata {
             name: crate_root.name,
-            imported_name: ident,
             extern_crate: Lock::new(None),
             def_path_table: Lrc::new(def_path_table),
             trait_impls,

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -112,7 +112,7 @@ impl<'a> CrateLoader<'a> {
                       -> Option<CrateNum> {
         let mut ret = None;
         self.cstore.iter_crate_data(|cnum, data| {
-            if data.name != name { return }
+            if data.root.name != name { return }
 
             match hash {
                 Some(hash) if *hash == data.root.hash => { ret = Some(cnum); return }
@@ -252,7 +252,6 @@ impl<'a> CrateLoader<'a> {
         });
 
         let cmeta = cstore::CrateMetadata {
-            name: crate_root.name,
             extern_crate: Lock::new(None),
             def_path_table: Lrc::new(def_path_table),
             trait_impls,
@@ -789,7 +788,7 @@ impl<'a> CrateLoader<'a> {
 
             let mut uses_std = false;
             self.cstore.iter_crate_data(|_, data| {
-                if data.name == sym::std {
+                if data.root.name == sym::std {
                     uses_std = true;
                 }
             });

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -271,7 +271,6 @@ impl<'a> CrateLoader<'a> {
             },
             private_dep,
             span,
-            host_lib,
             raw_proc_macros
         };
 

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -49,10 +49,6 @@ pub struct CrateMetadata {
     /// Original name of the crate.
     pub name: Symbol,
 
-    /// Name of the crate as imported. I.e., if imported with
-    /// `extern crate foo as bar;` this will be `bar`.
-    pub imported_name: Symbol,
-
     /// Information about the extern crate that caused this crate to
     /// be loaded. If this is `None`, then the crate was injected
     /// (e.g., by the allocator)

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -12,7 +12,6 @@ use rustc::util::nodemap::{FxHashMap, NodeMap};
 use rustc_data_structures::sync::{Lrc, RwLock, Lock};
 use syntax::ast;
 use syntax::ext::base::SyntaxExtension;
-use syntax::symbol::Symbol;
 use syntax_pos;
 
 pub use rustc::middle::cstore::{NativeLibrary, NativeLibraryKind, LinkagePreference};
@@ -45,9 +44,6 @@ pub struct ImportedSourceFile {
 }
 
 pub struct CrateMetadata {
-    /// Original name of the crate.
-    pub name: Symbol,
-
     /// Information about the extern crate that caused this crate to
     /// be loaded. If this is `None`, then the crate was injected
     /// (e.g., by the allocator)

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -28,7 +28,6 @@ pub use crate::cstore_impl::{provide, provide_extern};
 pub type CrateNumMap = IndexVec<CrateNum, CrateNum>;
 
 pub use rustc_data_structures::sync::MetadataRef;
-use crate::creader::Library;
 use syntax_pos::Span;
 use proc_macro::bridge::client::ProcMacro;
 
@@ -85,7 +84,6 @@ pub struct CrateMetadata {
     /// for purposes of the 'exported_private_dependencies' lint
     pub private_dep: bool,
 
-    pub host_lib: Option<Library>,
     pub span: Span,
 
     pub raw_proc_macros: Option<&'static [ProcMacro]>,

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -453,8 +453,7 @@ impl cstore::CStore {
         }
 
         let def = data.get_macro(id.index);
-        let macro_full_name = data.def_path(id.index)
-            .to_string_friendly(|_| data.imported_name);
+        let macro_full_name = data.def_path(id.index).to_string_friendly(|_| data.name);
         let source_name = FileName::Macros(macro_full_name);
 
         let source_file = sess.parse_sess.source_map().new_source_file(source_name, def.body);

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -220,7 +220,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         let r = *cdata.dep_kind.lock();
         r
     }
-    crate_name => { cdata.name }
+    crate_name => { cdata.root.name }
     item_children => {
         let mut result = SmallVec::<[_; 8]>::new();
         cdata.each_child_of_item(def_id.index, |child| result.push(child), tcx.sess);
@@ -453,7 +453,7 @@ impl cstore::CStore {
         }
 
         let def = data.get_macro(id.index);
-        let macro_full_name = data.def_path(id.index).to_string_friendly(|_| data.name);
+        let macro_full_name = data.def_path(id.index).to_string_friendly(|_| data.root.name);
         let source_name = FileName::Macros(macro_full_name);
 
         let source_file = sess.parse_sess.source_map().new_source_file(source_name, def.body);
@@ -503,7 +503,7 @@ impl CrateStore for cstore::CStore {
 
     fn crate_name_untracked(&self, cnum: CrateNum) -> Symbol
     {
-        self.get_crate_data(cnum).name
+        self.get_crate_data(cnum).root.name
     }
 
     fn crate_is_private_dep_untracked(&self, cnum: CrateNum) -> bool {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -473,7 +473,7 @@ impl<'a, 'tcx> CrateMetadata {
             None => {
                 bug!("entry: id not found: {:?} in crate {:?} with number {}",
                      item_id,
-                     self.name,
+                     self.root.name,
                      self.cnum)
             }
             Some(d) => d.decode(self),

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -543,18 +543,13 @@ impl<'a, 'tcx> CrateMetadata {
                 name, SyntaxExtensionKind::Bang(Box::new(BangProcMacro { client })), Vec::new()
             )
         };
-        let edition = if sess.opts.debugging_opts.dual_proc_macros {
-            self.host_lib.as_ref().unwrap().metadata.get_root().edition
-        } else {
-            self.root.edition
-        };
 
         SyntaxExtension::new(
             &sess.parse_sess,
             kind,
             self.get_span(id, sess),
             helper_attrs,
-            edition,
+            self.root.edition,
             Symbol::intern(name),
             &self.get_attributes(&self.entry(id), sess),
         )

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -261,7 +261,7 @@ pub struct Context<'a> {
     pub target: &'a Target,
     pub triple: TargetTriple,
     pub filesearch: FileSearch<'a>,
-    pub root: &'a Option<CratePaths>,
+    pub root: Option<&'a CratePaths>,
     pub rejected_via_hash: Vec<CrateMismatch>,
     pub rejected_via_triple: Vec<CrateMismatch>,
     pub rejected_via_kind: Vec<CrateMismatch>,
@@ -322,8 +322,8 @@ impl<'a> Context<'a> {
 
     pub fn report_errs(self) -> ! {
         let add = match self.root {
-            &None => String::new(),
-            &Some(ref r) => format!(" which `{}` depends on", r.ident),
+            None => String::new(),
+            Some(r) => format!(" which `{}` depends on", r.ident),
         };
         let mut msg = "the following crate versions were found:".to_string();
         let mut err = if !self.rejected_via_hash.is_empty() {
@@ -339,8 +339,8 @@ impl<'a> Context<'a> {
                 msg.push_str(&format!("\ncrate `{}`: {}", self.crate_name, path.display()));
             }
             match self.root {
-                &None => {}
-                &Some(ref r) => {
+                None => {}
+                Some(r) => {
                     for path in r.paths().iter() {
                         msg.push_str(&format!("\ncrate `{}`: {}", r.ident, path.display()));
                     }

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -254,7 +254,6 @@ pub struct CrateMismatch {
 pub struct Context<'a> {
     pub sess: &'a Session,
     pub span: Span,
-    pub ident: Symbol,
     pub crate_name: Symbol,
     pub hash: Option<&'a Svh>,
     pub extra_filename: Option<&'a str>,
@@ -332,12 +331,12 @@ impl<'a> Context<'a> {
                                            self.span,
                                            E0460,
                                            "found possibly newer version of crate `{}`{}",
-                                           self.ident,
+                                           self.crate_name,
                                            add);
             err.note("perhaps that crate needs to be recompiled?");
             let mismatches = self.rejected_via_hash.iter();
             for &CrateMismatch { ref path, .. } in mismatches {
-                msg.push_str(&format!("\ncrate `{}`: {}", self.ident, path.display()));
+                msg.push_str(&format!("\ncrate `{}`: {}", self.crate_name, path.display()));
             }
             match self.root {
                 &None => {}
@@ -355,13 +354,13 @@ impl<'a> Context<'a> {
                                            E0461,
                                            "couldn't find crate `{}` \
                                             with expected target triple {}{}",
-                                           self.ident,
+                                           self.crate_name,
                                            self.triple,
                                            add);
             let mismatches = self.rejected_via_triple.iter();
             for &CrateMismatch { ref path, ref got } in mismatches {
                 msg.push_str(&format!("\ncrate `{}`, target triple {}: {}",
-                                      self.ident,
+                                      self.crate_name,
                                       got,
                                       path.display()));
             }
@@ -372,12 +371,12 @@ impl<'a> Context<'a> {
                                            self.span,
                                            E0462,
                                            "found staticlib `{}` instead of rlib or dylib{}",
-                                           self.ident,
+                                           self.crate_name,
                                            add);
             err.help("please recompile that crate using --crate-type lib");
             let mismatches = self.rejected_via_kind.iter();
             for &CrateMismatch { ref path, .. } in mismatches {
-                msg.push_str(&format!("\ncrate `{}`: {}", self.ident, path.display()));
+                msg.push_str(&format!("\ncrate `{}`: {}", self.crate_name, path.display()));
             }
             err.note(&msg);
             err
@@ -387,14 +386,14 @@ impl<'a> Context<'a> {
                                            E0514,
                                            "found crate `{}` compiled by an incompatible version \
                                             of rustc{}",
-                                           self.ident,
+                                           self.crate_name,
                                            add);
             err.help(&format!("please recompile that crate using this compiler ({})",
                               rustc_version()));
             let mismatches = self.rejected_via_version.iter();
             for &CrateMismatch { ref path, ref got } in mismatches {
                 msg.push_str(&format!("\ncrate `{}` compiled by {}: {}",
-                                      self.ident,
+                                      self.crate_name,
                                       got,
                                       path.display()));
             }
@@ -405,10 +404,10 @@ impl<'a> Context<'a> {
                                            self.span,
                                            E0463,
                                            "can't find crate for `{}`{}",
-                                           self.ident,
+                                           self.crate_name,
                                            add);
 
-            if (self.ident == sym::std || self.ident == sym::core)
+            if (self.crate_name == sym::std || self.crate_name == sym::core)
                 && self.triple != TargetTriple::from_triple(config::host_triple()) {
                 err.note(&format!("the `{}` target may not be installed", self.triple));
             }

--- a/src/test/ui/use/use-meta-mismatch.rs
+++ b/src/test/ui/use/use-meta-mismatch.rs
@@ -1,4 +1,4 @@
-// error-pattern:can't find crate for `extra`
+// error-pattern:can't find crate for `fake_crate`
 
 extern crate fake_crate as extra;
 

--- a/src/test/ui/use/use-meta-mismatch.stderr
+++ b/src/test/ui/use/use-meta-mismatch.stderr
@@ -1,4 +1,4 @@
-error[E0463]: can't find crate for `extra`
+error[E0463]: can't find crate for `fake_crate`
   --> $DIR/use-meta-mismatch.rs:3:1
    |
 LL | extern crate fake_crate as extra;


### PR DESCRIPTION
So, my goal was to fix caching of loaded crates which is broken and causes ICEs like #56935 or #64450.
While investigating I found that the code is pretty messy and likes to confuse various things that look similar but are actually different.
This PR does some initial cleanup in that area, I hope to get to the caching itself a bit later.