### PR TITLE
Check type of place base (not projection) for `Freeze` in `IndirectlyMutableLocals`

### DIFF
--- a/src/librustc_mir/transform/rustc_peek.rs
+++ b/src/librustc_mir/transform/rustc_peek.rs
@@ -276,7 +276,7 @@ impl<'tcx> RustcPeekAt<'tcx> for IndirectlyMutableLocals<'_, 'tcx> {
         flow_state: &BitSet<Local>,
         call: PeekCall,
     ) {
-        warn!("peek_at: place={:?}", place);
+        trace!("peek_at: place={:?}", place);
         let local = match place {
             mir::Place { base: mir::PlaceBase::Local(l), projection: box [] } => *l,
             _ => {

--- a/src/test/ui/mir-dataflow/indirect-mutation-1.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-1.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics, rustc_attrs, const_raw_ptr_deref)]
+#![feature(core_intrinsics, rustc_attrs)]
 
 use std::cell::Cell;
 use std::intrinsics::rustc_peek;
@@ -6,7 +6,7 @@ use std::intrinsics::rustc_peek;
 #[rustc_mir(rustc_peek_indirectly_mutable, stop_after_dataflow)]
 pub fn mut_ref(flag: bool) -> i32 {
     let mut i = 0;
-    let cell = Cell::new(0);
+    let mut cell = Cell::new(0);
 
     if flag {
         let p = &mut i;

--- a/src/test/ui/mir-dataflow/indirect-mutation-1.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-1.rs
@@ -1,0 +1,33 @@
+#![feature(core_intrinsics, rustc_attrs, const_raw_ptr_deref)]
+
+use std::cell::Cell;
+use std::intrinsics::rustc_peek;
+
+#[rustc_mir(rustc_peek_indirectly_mutable, stop_after_dataflow)]
+pub fn mut_ref(flag: bool) -> i32 {
+    let mut i = 0;
+    let cell = Cell::new(0);
+
+    if flag {
+        let p = &mut i;
+        unsafe { rustc_peek(i) };
+        *p = 1;
+
+        let p = &cell;
+        unsafe { rustc_peek(cell) };
+        p.set(2);
+    } else {
+        unsafe { rustc_peek(i) };    //~ ERROR rustc_peek: bit not set
+        unsafe { rustc_peek(cell) }; //~ ERROR rustc_peek: bit not set
+
+        let p = &mut cell;
+        unsafe { rustc_peek(cell) };
+        *p = Cell::new(3);
+    }
+
+    unsafe { rustc_peek(i) };
+    unsafe { rustc_peek(cell) };
+    i + cell.get()
+}
+
+fn main() {}

--- a/src/test/ui/mir-dataflow/indirect-mutation-1.stderr
+++ b/src/test/ui/mir-dataflow/indirect-mutation-1.stderr
@@ -1,0 +1,16 @@
+error: rustc_peek: bit not set
+  --> $DIR/indirect-mutation-1.rs:20:18
+   |
+LL |         unsafe { rustc_peek(i) };
+   |                  ^^^^^^^^^^^^^
+
+error: rustc_peek: bit not set
+  --> $DIR/indirect-mutation-1.rs:21:18
+   |
+LL |         unsafe { rustc_peek(cell) };
+   |                  ^^^^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/mir-dataflow/indirect-mutation-2.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-2.rs
@@ -1,0 +1,30 @@
+#![feature(core_intrinsics, rustc_attrs, const_raw_ptr_deref)]
+
+use std::cell::Cell;
+use std::intrinsics::rustc_peek;
+
+struct Arr {
+    inner: [Cell<i32>; 0],
+    _peek: (),
+}
+
+// Zero-sized arrays are never mutable.
+#[rustc_mir(rustc_peek_indirectly_mutable, stop_after_dataflow)]
+pub fn zst(flag: bool) {
+    {
+        let arr: [i32; 0] = [];
+        let s: &mut [i32] = &mut arr;
+        unsafe { rustc_peek(arr) }; //~ ERROR rustc_peek: bit not set
+    }
+
+    {
+        let arr: [Cell<i32>; 0] = [];
+        let s: &[Cell<i32>] = &arr;
+        unsafe { rustc_peek(arr) }; //~ ERROR rustc_peek: bit not set
+
+        let ss = &s;
+        unsafe { rustc_peek(arr) }; //~ ERROR rustc_peek: bit not set
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mir-dataflow/indirect-mutation-2.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-2.rs
@@ -1,4 +1,4 @@
-#![feature(core_intrinsics, rustc_attrs, const_raw_ptr_deref)]
+#![feature(core_intrinsics, rustc_attrs)]
 
 use std::cell::Cell;
 use std::intrinsics::rustc_peek;
@@ -12,7 +12,7 @@ struct Arr {
 #[rustc_mir(rustc_peek_indirectly_mutable, stop_after_dataflow)]
 pub fn zst(flag: bool) {
     {
-        let arr: [i32; 0] = [];
+        let mut arr: [i32; 0] = [];
         let s: &mut [i32] = &mut arr;
         unsafe { rustc_peek(arr) }; //~ ERROR rustc_peek: bit not set
     }

--- a/src/test/ui/mir-dataflow/indirect-mutation-2.stderr
+++ b/src/test/ui/mir-dataflow/indirect-mutation-2.stderr
@@ -1,0 +1,22 @@
+error: rustc_peek: bit not set
+  --> $DIR/indirect-mutation-2.rs:17:18
+   |
+LL |         unsafe { rustc_peek(arr) };
+   |                  ^^^^^^^^^^^^^^^
+
+error: rustc_peek: bit not set
+  --> $DIR/indirect-mutation-2.rs:23:18
+   |
+LL |         unsafe { rustc_peek(arr) };
+   |                  ^^^^^^^^^^^^^^^
+
+error: rustc_peek: bit not set
+  --> $DIR/indirect-mutation-2.rs:26:18
+   |
+LL |         unsafe { rustc_peek(arr) };
+   |                  ^^^^^^^^^^^^^^^
+
+error: stop_after_dataflow ended compilation
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/mir-dataflow/indirect-mutation-offset.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-offset.rs
@@ -12,7 +12,6 @@ struct PartialInteriorMut {
 }
 
 #[rustc_mir(rustc_peek_indirectly_mutable,stop_after_dataflow)]
-#[rustc_mir(borrowck_graphviz_postflow="indirect.dot")]
 const BOO: i32 = {
     let x = PartialInteriorMut {
         zst: [],

--- a/src/test/ui/mir-dataflow/indirect-mutation-offset.rs
+++ b/src/test/ui/mir-dataflow/indirect-mutation-offset.rs
@@ -19,7 +19,11 @@ const BOO: i32 = {
         cell: UnsafeCell::new(0),
     };
 
-    let p_zst: *const _ = &x.zst ; // Doesn't cause `x` to get marked as indirectly mutable.
+    unsafe { rustc_peek(x) }; //~ ERROR rustc_peek: bit not set
+
+    let p_zst: *const _ = &x.zst ;
+
+    unsafe { rustc_peek(x) };
 
     let rmut_cell = unsafe {
         // Take advantage of the fact that `zst` and `cell` are at the same location in memory.
@@ -30,9 +34,9 @@ const BOO: i32 = {
         &mut *pmut_cell
     };
 
-    *rmut_cell = 42;  // Mutates `x` indirectly even though `x` is not marked indirectly mutable!!!
+    *rmut_cell = 42;
     let val = *rmut_cell;
-    unsafe { rustc_peek(x) }; //~ ERROR rustc_peek: bit not set
+    unsafe { rustc_peek(x) };
 
     val
 };

--- a/src/test/ui/mir-dataflow/indirect-mutation-offset.stderr
+++ b/src/test/ui/mir-dataflow/indirect-mutation-offset.stderr
@@ -1,5 +1,5 @@
 error: rustc_peek: bit not set
-  --> $DIR/indirect-mutation-offset.rs:35:14
+  --> $DIR/indirect-mutation-offset.rs:21:14
    |
 LL |     unsafe { rustc_peek(x) };
    |              ^^^^^^^^^^^^^


### PR DESCRIPTION
Resolves #65006.

This fixes the test I wrote in #64980, which demonstrated a way for code to circumvent `IndirectlyMutableLocals`. Now, we are more conservative and check the type of the entire local for `!Freeze` (not just the target of the projection) when doing a shared borrow. This shouldn't affect the dataflow-based const validator since references that allow mutation are forbidden anyway in const contexts. I can't rule out an edge case around empty slices though.

I also added some simplistic tests for `IndirectlyMutableLocals` to demonstrate the purpose of the analysis.

r? @oli-obk 