### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1203,8 +1203,8 @@ impl<T: Clone> Clone for LinkedList<T> {
         if self.len() > other.len() {
             self.split_off(other.len());
         }
-        for elem in self.iter_mut() {
-            elem.clone_from(iter_other.next().unwrap());
+        for (elem, elem_other) in self.iter_mut().zip(&mut iter_other) {
+            elem.clone_from(elem_other);
         }
         if !iter_other.is_empty() {
             self.extend(iter_other.cloned());

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1197,6 +1197,19 @@ impl<T: Clone> Clone for LinkedList<T> {
     fn clone(&self) -> Self {
         self.iter().cloned().collect()
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        let mut iter_other = other.iter();
+        if self.len() > other.len() {
+            self.split_off(other.len());
+        }
+        for elem in self.iter_mut() {
+            elem.clone_from(iter_other.next().unwrap());
+        }
+        if !iter_other.is_empty() {
+            self.extend(iter_other.cloned());
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/liballoc/collections/linked_list/tests.rs
+++ b/src/liballoc/collections/linked_list/tests.rs
@@ -111,6 +111,49 @@ fn test_append() {
 }
 
 #[test]
+fn test_clone_from() {
+    // Short cloned from long
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![8, 7, 6, 2, 3, 4, 5];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+    // Long cloned from short
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![6, 7, 8];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+    // Two equal length lists
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![9, 8, 1, 2, 3];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+}
+
+#[test]
 fn test_insert_prev() {
     let mut m = list_from(&[0, 2, 4, 6, 8]);
     let len = m.len();

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -775,10 +775,12 @@ impl LoweringContext<'_> {
                     None
                 };
                 let async_body = this.make_async_expr(
-                    capture_clause, closure_id, async_ret_ty, body.span, hir::AsyncGeneratorKind::Closure,
-                    |this| {
-                        this.with_new_scopes(|this| this.lower_expr(body))
-                    }
+                    capture_clause,
+                    closure_id,
+                    async_ret_ty,
+                    body.span,
+                    hir::AsyncGeneratorKind::Closure,
+                    |this| this.with_new_scopes(|this| this.lower_expr(body)),
                 );
                 this.expr(fn_decl_span, async_body, ThinVec::new())
             });

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -89,9 +89,14 @@ impl LoweringContext<'_> {
                 hir::MatchSource::Normal,
             ),
             ExprKind::Async(capture_clause, closure_node_id, ref block) => {
-                self.make_async_expr(capture_clause, closure_node_id, None, block.span, |this| {
-                    this.with_new_scopes(|this| this.lower_block_expr(block))
-                })
+                self.make_async_expr(
+                    capture_clause,
+                    closure_node_id,
+                    None,
+                    block.span,
+                    hir::AsyncGeneratorKind::Block,
+                    |this| this.with_new_scopes(|this| this.lower_block_expr(block)),
+                )
             }
             ExprKind::Await(ref expr) => self.lower_expr_await(e.span, expr),
             ExprKind::Closure(
@@ -440,6 +445,7 @@ impl LoweringContext<'_> {
         closure_node_id: NodeId,
         ret_ty: Option<AstP<Ty>>,
         span: Span,
+        async_gen_kind: hir::AsyncGeneratorKind,
         body: impl FnOnce(&mut LoweringContext<'_>) -> hir::Expr,
     ) -> hir::ExprKind {
         let capture_clause = self.lower_capture_clause(capture_clause);
@@ -453,7 +459,7 @@ impl LoweringContext<'_> {
         };
         let decl = self.lower_fn_decl(&ast_decl, None, /* impl trait allowed */ false, None);
         let body_id = self.lower_fn_body(&ast_decl, |this| {
-            this.generator_kind = Some(hir::GeneratorKind::Async);
+            this.generator_kind = Some(hir::GeneratorKind::Async(async_gen_kind));
             body(this)
         });
 
@@ -505,7 +511,7 @@ impl LoweringContext<'_> {
     /// ```
     fn lower_expr_await(&mut self, await_span: Span, expr: &Expr) -> hir::ExprKind {
         match self.generator_kind {
-            Some(hir::GeneratorKind::Async) => {},
+            Some(hir::GeneratorKind::Async(_)) => {},
             Some(hir::GeneratorKind::Gen) |
             None => {
                 let mut err = struct_span_err!(
@@ -710,7 +716,7 @@ impl LoweringContext<'_> {
                     Movability::Static => hir::GeneratorMovability::Static,
                 })
             },
-            Some(hir::GeneratorKind::Async) => {
+            Some(hir::GeneratorKind::Async(_)) => {
                 bug!("non-`async` closure body turned `async` during lowering");
             },
             None => {
@@ -769,7 +775,7 @@ impl LoweringContext<'_> {
                     None
                 };
                 let async_body = this.make_async_expr(
-                    capture_clause, closure_id, async_ret_ty, body.span,
+                    capture_clause, closure_id, async_ret_ty, body.span, hir::AsyncGeneratorKind::Closure,
                     |this| {
                         this.with_new_scopes(|this| this.lower_expr(body))
                     }
@@ -988,7 +994,7 @@ impl LoweringContext<'_> {
     fn lower_expr_yield(&mut self, span: Span, opt_expr: Option<&Expr>) -> hir::ExprKind {
         match self.generator_kind {
             Some(hir::GeneratorKind::Gen) => {},
-            Some(hir::GeneratorKind::Async) => {
+            Some(hir::GeneratorKind::Async(_)) => {
                 span_err!(
                     self.sess,
                     span,

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -1222,7 +1222,11 @@ impl LoweringContext<'_> {
             }
 
             let async_expr = this.make_async_expr(
-                CaptureBy::Value, closure_id, None, body.span,
+                CaptureBy::Value,
+                closure_id,
+                None,
+                body.span,
+                hir::AsyncGeneratorKind::Fn,
                 |this| {
                     // Create a block from the user's function body:
                     let user_body = this.lower_block_expr(body);

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1404,7 +1404,7 @@ impl fmt::Display for AsyncGeneratorKind {
         f.write_str(match self {
             AsyncGeneratorKind::Block => "`async` block",
             AsyncGeneratorKind::Closure => "`async` closure body",
-            AsyncGeneratorKind::Fn => "`async` fn body",
+            AsyncGeneratorKind::Fn => "`async fn` body",
         })
     }
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1366,17 +1366,43 @@ impl Body {
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, HashStable,
          RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum GeneratorKind {
-    /// An `async` block or function.
-    Async,
+    /// An explicit `async` block or the body of an async function.
+    Async(AsyncGeneratorKind),
+
     /// A generator literal created via a `yield` inside a closure.
     Gen,
 }
 
 impl fmt::Display for GeneratorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GeneratorKind::Async(k) => fmt::Display::fmt(k, f),
+            GeneratorKind::Gen => f.write_str("generator"),
+        }
+    }
+}
+
+/// The type of source expression that caused this generator to be created.
+// Not `IsAsync` because we want to eventually add support for `AsyncGen`
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, HashStable,
+         RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
+pub enum AsyncGeneratorKind {
+    /// An explicit `async` block written by the user.
+    Block,
+
+    /// An explicit `async` block written by the user.
+    Closure,
+
+    /// The `async` block generated as the body of an async function.
+    Fn,
+}
+
+impl fmt::Display for AsyncGeneratorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
-            GeneratorKind::Async => "`async` object",
-            GeneratorKind::Gen => "generator",
+            AsyncGeneratorKind::Block => "`async` block",
+            AsyncGeneratorKind::Closure => "`async` closure body",
+            AsyncGeneratorKind::Fn => "`async` fn body",
         })
     }
 }
@@ -1758,6 +1784,7 @@ pub struct Destination {
 pub enum GeneratorMovability {
     /// May contain self-references, `!Unpin`.
     Static,
+
     /// Must not contain self-references, `Unpin`.
     Movable,
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1362,7 +1362,6 @@ impl Body {
 }
 
 /// The type of source expression that caused this generator to be created.
-// Not `IsAsync` because we want to eventually add support for `AsyncGen`
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, HashStable,
          RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum GeneratorKind {
@@ -1382,8 +1381,11 @@ impl fmt::Display for GeneratorKind {
     }
 }
 
-/// The type of source expression that caused this generator to be created.
-// Not `IsAsync` because we want to eventually add support for `AsyncGen`
+/// In the case of a generator created as part of an async construct,
+/// which kind of async construct caused it to be created?
+///
+/// This helps error messages but is also used to drive coercions in
+/// type-checking (see #60424).
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, HashStable,
          RustcEncodable, RustcDecodable, Hash, Debug, Copy)]
 pub enum AsyncGeneratorKind {

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -1307,6 +1307,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         }
     }
 
+    /// Resolve any type variables found in `value` -- but only one
+    /// level.  So, if the variable `?X` is bound to some type
+    /// `Foo<?Y>`, then this would return `Foo<?Y>` (but `?Y` may
+    /// itself be bound to a type).
+    ///
+    /// Useful when you only need to inspect the outermost level of
+    /// the type and don't care about nested types (or perhaps you
+    /// will be resolving them as well, e.g. in a loop).
     pub fn shallow_resolve<T>(&self, value: T) -> T
     where
         T: TypeFoldable<'tcx>,
@@ -1567,6 +1575,9 @@ impl<'a, 'tcx> ShallowResolver<'a, 'tcx> {
         ShallowResolver { infcx }
     }
 
+    /// If `typ` is a type variable of some kind, resolve it one level
+    /// (but do not resolve types found in the result). If `typ` is
+    /// not a type variable, just return it unmodified.
     pub fn shallow_resolve(&mut self, typ: Ty<'tcx>) -> Ty<'tcx> {
         match typ.kind {
             ty::Infer(ty::TyVar(v)) => {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1026,7 +1026,8 @@ impl EmitterWriter {
         children.iter()
             .map(|sub| self.get_multispan_max_line_num(&sub.span))
             .max()
-            .unwrap_or(primary)
+            .unwrap_or(0)
+            .max(primary)
     }
 
     /// Adds a left margin to every line but the first, given a padding length and the label being

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -663,7 +663,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // be inferring.
         let ret_ty = ret_coercion.borrow().expected_ty();
         let ret_ty = self.inh.infcx.shallow_resolve(ret_ty);
-        let ret_vid = match ret_ty.sty {
+        let ret_vid = match ret_ty.kind {
             ty::Infer(ty::TyVar(ret_vid)) => ret_vid,
             _ => {
                 span_bug!(

--- a/src/librustc_typeck/check/closure.rs
+++ b/src/librustc_typeck/check/closure.rs
@@ -595,6 +595,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> ty::PolyFnSig<'tcx> {
         let astconv: &dyn AstConv<'_> = self;
 
+        debug!(
+            "supplied_sig_of_closure(decl={:?}, body.generator_kind={:?})",
+            decl,
+            body.generator_kind,
+        );
+
         // First, convert the types that the user supplied (if any).
         let supplied_arguments = decl.inputs.iter().map(|a| astconv.ast_ty_to_ty(a));
         let supplied_return = match decl.output {

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -55,7 +55,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
             expr_and_pat_count: 0,
             source: match self.kind { // Guess based on the kind of the current generator.
                 hir::GeneratorKind::Gen => hir::YieldSource::Yield,
-                hir::GeneratorKind::Async => hir::YieldSource::Await,
+                hir::GeneratorKind::Async(_) => hir::YieldSource::Await,
             },
         }));
 

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -562,7 +562,19 @@ pub struct FnCtxt<'a, 'tcx> {
     // if type checking is run in parallel.
     err_count_on_creation: usize,
 
+    /// If `Some`, this stores coercion information for returned
+    /// expressions. If `None`, this is in a context where return is
+    /// inappropriate, such as a const expression.
+    ///
+    /// This is a `RefCell<DynamicCoerceMany>`, which means that we
+    /// can track all the return expressions and then use them to
+    /// compute a useful coercion from the set, similar to a match
+    /// expression or other branching context. You can use methods
+    /// like `expected_ty` to access the declared return type (if
+    /// any).
     ret_coercion: Option<RefCell<DynamicCoerceMany<'tcx>>>,
+
+    /// First span of a return site that we find. Used in error messages.
     ret_coercion_span: RefCell<Option<Span>>,
 
     yield_ty: Option<Ty<'tcx>>,

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4534,7 +4534,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let item_id = self.tcx().hir().get_parent_node(self.body_id);
         if let Some(body_id) = self.tcx().hir().maybe_body_owned_by(item_id) {
             let body = self.tcx().hir().body(body_id);
-            if let Some(hir::GeneratorKind::Async) = body.generator_kind {
+            if let Some(hir::GeneratorKind::Async(_)) = body.generator_kind {
                 let sp = expr.span;
                 // Check for `Future` implementations by constructing a predicate to
                 // prove: `<T as Future>::Output == U`

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1001,7 +1001,7 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
     // Help is available only in presence of lang items.
     let msg = if let Some(def_id) = suggested_marker_id {
         format!(
-            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            "consider removing `{}`, refering to it in a field, or using a marker such as `{}`",
             param_name,
             tcx.def_path_str(def_id),
         )

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -999,11 +999,16 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
 
     let suggested_marker_id = tcx.lang_items().phantom_data();
     // Help is available only in presence of lang items.
-    if let Some(def_id) = suggested_marker_id {
-        err.help(&format!("consider removing `{}` or using a marker such as `{}`",
-                          param_name,
-                          tcx.def_path_str(def_id)));
-    }
+    let msg = if let Some(def_id) = suggested_marker_id {
+        format!(
+            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            param_name,
+            tcx.def_path_str(def_id),
+        )
+    } else {
+        format!( "consider removing `{}` or refering to it in a field", param_name)
+    };
+    err.help(&msg);
     err.emit();
 }
 

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -113,7 +113,7 @@ pub struct Backtrace {
 /// The current status of a backtrace, indicating whether it was captured or
 /// whether it is empty for some other reason.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BacktraceStatus {
     /// Capturing a backtrace is not supported, likely because it's not
     /// implemented for the current platform.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1212,6 +1212,7 @@ impl<'a> Parser<'a> {
                     &mut err,
                     pat,
                     is_name_required,
+                    is_self_allowed,
                     is_trait_item,
                 ) {
                     err.emit();

--- a/src/test/ui/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params-denied-2018.stderr
@@ -5,6 +5,10 @@ LL |     fn foo(i32);
    |               ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn foo(self: i32);
+   |            ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn foo(i32: TypeName);
@@ -21,6 +25,10 @@ LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar_with_default_impl(self: String, String) {}
+   |                              ^^^^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String: TypeName, String) {}

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.rs
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.rs
@@ -20,7 +20,7 @@ fn return_targets_async_block_not_fn() -> u8 {
 }
 
 async fn return_targets_async_block_not_async_fn() -> u8 {
-    //~^ ERROR type mismatch resolving
+    //~^ ERROR mismatched types
     let block = async {
         return 0u8;
     };

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -39,6 +39,22 @@ LL |     let _: &dyn Future<Output = ()> = &block;
               found type `()`
    = note: required for the cast to the object type `dyn std::future::Future<Output = ()>`
 
+error[E0308]: mismatched types
+  --> $DIR/async-block-control-flow-static-semantics.rs:22:58
+   |
+LL |   async fn return_targets_async_block_not_async_fn() -> u8 {
+   |  __________________________________________________________^
+LL | |
+LL | |     let block = async {
+LL | |         return 0u8;
+...  |
+LL | |
+LL | | }
+   | |_^ expected u8, found ()
+   |
+   = note: expected type `u8`
+              found type `()`
+
 error[E0271]: type mismatch resolving `<impl std::future::Future as std::future::Future>::Output == ()`
   --> $DIR/async-block-control-flow-static-semantics.rs:27:39
    |
@@ -48,16 +64,6 @@ LL |     let _: &dyn Future<Output = ()> = &block;
    = note: expected type `u8`
               found type `()`
    = note: required for the cast to the object type `dyn std::future::Future<Output = ()>`
-
-error[E0271]: type mismatch resolving `<impl std::future::Future as std::future::Future>::Output == u8`
-  --> $DIR/async-block-control-flow-static-semantics.rs:22:55
-   |
-LL | async fn return_targets_async_block_not_async_fn() -> u8 {
-   |                                                       ^^ expected (), found u8
-   |
-   = note: expected type `()`
-              found type `u8`
-   = note: the return type of a function must have a statically known size
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:48:44

--- a/src/test/ui/async-await/async-error-span.rs
+++ b/src/test/ui/async-await/async-error-span.rs
@@ -9,7 +9,7 @@ fn get_future() -> impl Future<Output = ()> {
 }
 
 async fn foo() {
-    let a; //~ ERROR type inside `async` object must be known in this context
+    let a; //~ ERROR type inside `async` fn body must be known in this context
     get_future().await;
 }
 

--- a/src/test/ui/async-await/async-error-span.rs
+++ b/src/test/ui/async-await/async-error-span.rs
@@ -9,7 +9,7 @@ fn get_future() -> impl Future<Output = ()> {
 }
 
 async fn foo() {
-    let a; //~ ERROR type inside `async` fn body must be known in this context
+    let a; //~ ERROR type inside `async fn` body must be known in this context
     get_future().await;
 }
 

--- a/src/test/ui/async-await/async-error-span.stderr
+++ b/src/test/ui/async-await/async-error-span.stderr
@@ -1,10 +1,10 @@
-error[E0698]: type inside `async` object must be known in this context
+error[E0698]: type inside `async` fn body must be known in this context
   --> $DIR/async-error-span.rs:12:9
    |
 LL |     let a;
    |         ^ cannot infer type
    |
-note: the type is part of the `async` object because of this `await`
+note: the type is part of the `async` fn body because of this `await`
   --> $DIR/async-error-span.rs:13:5
    |
 LL |     get_future().await;

--- a/src/test/ui/async-await/async-error-span.stderr
+++ b/src/test/ui/async-await/async-error-span.stderr
@@ -1,10 +1,10 @@
-error[E0698]: type inside `async` fn body must be known in this context
+error[E0698]: type inside `async fn` body must be known in this context
   --> $DIR/async-error-span.rs:12:9
    |
 LL |     let a;
    |         ^ cannot infer type
    |
-note: the type is part of the `async` fn body because of this `await`
+note: the type is part of the `async fn` body because of this `await`
   --> $DIR/async-error-span.rs:13:5
    |
 LL |     get_future().await;

--- a/src/test/ui/async-await/issues/issue-63388-1.rs
+++ b/src/test/ui/async-await/issues/issue-63388-1.rs
@@ -9,9 +9,9 @@ trait Foo {}
 impl Xyz {
     async fn do_sth<'a>(
         &'a self, foo: &dyn Foo
-    ) -> &dyn Foo //~ ERROR lifetime mismatch
+    ) -> &dyn Foo
     {
-        foo
+        foo  //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/async-await/issues/issue-63388-1.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-1.stderr
@@ -1,12 +1,13 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/issue-63388-1.rs:12:10
+  --> $DIR/issue-63388-1.rs:14:9
    |
 LL |         &'a self, foo: &dyn Foo
    |         -------- this parameter and the return type are declared with different lifetimes...
 LL |     ) -> &dyn Foo
-   |          ^^^^^^^^
-   |          |
-   |          ...but data from `foo` is returned here
+   |          --------
+LL |     {
+LL |         foo
+   |         ^^^ ...but data from `foo` is returned here
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issues/issue-63388-2.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-2.stderr
@@ -11,8 +11,9 @@ error: cannot infer an appropriate lifetime
    |
 LL |         foo: &dyn Foo, bar: &'a dyn Foo
    |         ^^^ ...but this borrow...
-LL |     ) -> &dyn Foo
-   |          -------- this return type evaluates to the `'static` lifetime...
+...
+LL |         foo
+   |         --- this return type evaluates to the `'static` lifetime...
    |
 note: ...can't outlive the lifetime '_ as defined on the method body at 11:14
   --> $DIR/issue-63388-2.rs:11:14
@@ -21,8 +22,8 @@ LL |         foo: &dyn Foo, bar: &'a dyn Foo
    |              ^
 help: you can add a constraint to the return type to make it last less than `'static` and match the lifetime '_ as defined on the method body at 11:14
    |
-LL |     ) -> &dyn Foo + '_
-   |          ^^^^^^^^^^^^^
+LL |         foo + '_
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/async-await/return-ty-raw-ptr-coercion.rs
+++ b/src/test/ui/async-await/return-ty-raw-ptr-coercion.rs
@@ -1,0 +1,25 @@
+// Check that we apply unsizing coercions based on the return type.
+//
+// Also serves as a regression test for #60424.
+//
+// edition:2018
+// check-pass
+
+#![allow(warnings)]
+
+use std::fmt::Debug;
+
+const TMP: u32 = 22;
+
+// Coerce from `Box<"asdf">` to `Box<dyn Debug>`.
+fn raw_pointer_coercion() {
+    fn sync_example() -> *const u32 {
+        &TMP
+    }
+
+    async fn async_example() -> *const u32 {
+        &TMP
+    }
+}
+
+fn main() {}

--- a/src/test/ui/async-await/return-ty-raw-ptr-coercion.rs
+++ b/src/test/ui/async-await/return-ty-raw-ptr-coercion.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 
 const TMP: u32 = 22;
 
-// Coerce from `Box<"asdf">` to `Box<dyn Debug>`.
+// Coerce from `&u32` to `*const u32`
 fn raw_pointer_coercion() {
     fn sync_example() -> *const u32 {
         &TMP

--- a/src/test/ui/async-await/return-ty-unsize-coercion.rs
+++ b/src/test/ui/async-await/return-ty-unsize-coercion.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::Debug;
 
-// Coerce from `Box<"asdf">` to `Box<dyn Debug>`.
+// Unsizing coercion from `Box<&'static str>` to `Box<dyn Debug>`.
 fn unsize_trait_coercion() {
     fn sync_example() -> Box<dyn Debug> {
         Box::new("asdf")
@@ -20,7 +20,7 @@ fn unsize_trait_coercion() {
     }
 }
 
-// Coerce from `Box<[u32; N]>` to `Box<[32]>`.
+// Unsizing coercion from `Box<[u32; N]>` to `Box<[32]>`.
 fn unsize_slice_coercion() {
     fn sync_example() -> Box<[u32]> {
         Box::new([0])

--- a/src/test/ui/async-await/return-ty-unsize-coercion.rs
+++ b/src/test/ui/async-await/return-ty-unsize-coercion.rs
@@ -31,4 +31,15 @@ fn unsize_slice_coercion() {
     }
 }
 
+// Unsizing coercion from `&[&str; 1]` to `&[&str]`
+fn unsize_slice_str_coercion() {
+    fn func() -> &'static [&'static str] {
+        &["hi"]
+    }
+
+    async fn func() -> &'static [&'static str] {
+        &["hi"]
+    }
+}
+
 fn main() {}

--- a/src/test/ui/async-await/return-ty-unsize-coercion.rs
+++ b/src/test/ui/async-await/return-ty-unsize-coercion.rs
@@ -1,0 +1,34 @@
+// Check that we apply unsizing coercions based on the return type.
+//
+// Also serves as a regression test for #60424.
+//
+// edition:2018
+// check-pass
+
+#![allow(warnings)]
+
+use std::fmt::Debug;
+
+// Coerce from `Box<"asdf">` to `Box<dyn Debug>`.
+fn unsize_trait_coercion() {
+    fn sync_example() -> Box<dyn Debug> {
+        Box::new("asdf")
+    }
+
+    async fn async_example() -> Box<dyn Debug> {
+        Box::new("asdf")
+    }
+}
+
+// Coerce from `Box<[u32; N]>` to `Box<[32]>`.
+fn unsize_slice_coercion() {
+    fn sync_example() -> Box<[u32]> {
+        Box::new([0])
+    }
+
+    async fn async_example() -> Box<[u32]> {
+        Box::new([0])
+    }
+}
+
+fn main() {}

--- a/src/test/ui/async-await/return-ty-unsize-coercion.rs
+++ b/src/test/ui/async-await/return-ty-unsize-coercion.rs
@@ -33,11 +33,11 @@ fn unsize_slice_coercion() {
 
 // Unsizing coercion from `&[&str; 1]` to `&[&str]`
 fn unsize_slice_str_coercion() {
-    fn func() -> &'static [&'static str] {
+    fn sync_example() -> &'static [&'static str] {
         &["hi"]
     }
 
-    async fn func() -> &'static [&'static str] {
+    async fn async_example() -> &'static [&'static str] {
         &["hi"]
     }
 }

--- a/src/test/ui/async-await/unresolved_type_param.rs
+++ b/src/test/ui/async-await/unresolved_type_param.rs
@@ -7,9 +7,9 @@ async fn bar<T>() -> () {}
 
 async fn foo() {
     bar().await;
-    //~^ ERROR type inside `async` fn body must be known in this context
+    //~^ ERROR type inside `async fn` body must be known in this context
     //~| NOTE cannot infer type for `T`
-    //~| NOTE the type is part of the `async` fn body because of this `await`
+    //~| NOTE the type is part of the `async fn` body because of this `await`
     //~| NOTE in this expansion of desugaring of `await`
 }
 fn main() {}

--- a/src/test/ui/async-await/unresolved_type_param.rs
+++ b/src/test/ui/async-await/unresolved_type_param.rs
@@ -7,9 +7,9 @@ async fn bar<T>() -> () {}
 
 async fn foo() {
     bar().await;
-    //~^ ERROR type inside `async` object must be known in this context
+    //~^ ERROR type inside `async` fn body must be known in this context
     //~| NOTE cannot infer type for `T`
-    //~| NOTE the type is part of the `async` object because of this `await`
+    //~| NOTE the type is part of the `async` fn body because of this `await`
     //~| NOTE in this expansion of desugaring of `await`
 }
 fn main() {}

--- a/src/test/ui/async-await/unresolved_type_param.stderr
+++ b/src/test/ui/async-await/unresolved_type_param.stderr
@@ -1,10 +1,10 @@
-error[E0698]: type inside `async` object must be known in this context
+error[E0698]: type inside `async` fn body must be known in this context
   --> $DIR/unresolved_type_param.rs:9:5
    |
 LL |     bar().await;
    |     ^^^ cannot infer type for `T`
    |
-note: the type is part of the `async` object because of this `await`
+note: the type is part of the `async` fn body because of this `await`
   --> $DIR/unresolved_type_param.rs:9:5
    |
 LL |     bar().await;

--- a/src/test/ui/async-await/unresolved_type_param.stderr
+++ b/src/test/ui/async-await/unresolved_type_param.stderr
@@ -1,10 +1,10 @@
-error[E0698]: type inside `async` fn body must be known in this context
+error[E0698]: type inside `async fn` body must be known in this context
   --> $DIR/unresolved_type_param.rs:9:5
    |
 LL |     bar().await;
    |     ^^^ cannot infer type for `T`
    |
-note: the type is part of the `async` fn body because of this `await`
+note: the type is part of the `async fn` body because of this `await`
   --> $DIR/unresolved_type_param.rs:9:5
    |
 LL |     bar().await;

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/pat-lt-bracket-2.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-2.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn a(B<) {}
    |       ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn a(_: B<) {}
+   |      ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
@@ -5,6 +5,10 @@ LL | trait Trait2015 { fn foo(#[allow(C)] i32); }
    |                                         ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | trait Trait2015 { fn foo(#[allow(C)] self: i32); }
+   |                                      ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] i32: TypeName); }

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_mismatch-async.stderr
@@ -1,28 +1,25 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:45
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:8:52
    |
 LL |     async fn a(self: Pin<&Foo>, f: &Foo) -> &Foo { f }
-   |                          ----               ^^^^
-   |                          |                  |
-   |                          |                  ...but data from `f` is returned here
+   |                          ----               ----   ^ ...but data from `f` is returned here
+   |                          |
    |                          this parameter and the return type are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:55
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:11:82
    |
 LL |     async fn c(self: Pin<&Self>, f: &Foo, g: &Foo) -> (Pin<&Foo>, &Foo) { (self, f) }
-   |                          -----                        ^^^^^^^^^^^^^^^^^
-   |                          |                            |
-   |                          |                            ...but data from `f` is returned here
+   |                          -----                        -----------------          ^ ...but data from `f` is returned here
+   |                          |
    |                          this parameter and the return type are declared with different lifetimes...
 
 error[E0623]: lifetime mismatch
-  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:58
+  --> $DIR/arbitrary_self_types_pin_lifetime_mismatch-async.rs:17:64
    |
 LL |     async fn bar<'a>(self: Alias<&Self>, arg: &'a ()) -> &() { arg }
-   |                                  -----                   ^^^
-   |                                  |                       |
-   |                                  |                       ...but data from `arg` is returned here
+   |                                  -----                   ---   ^^^ ...but data from `arg` is returned here
+   |                                  |
    |                                  this parameter and the return type are declared with different lifetimes...
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/self/elision/lt-ref-self-async.rs
+++ b/src/test/ui/self/elision/lt-ref-self-async.rs
@@ -11,29 +11,29 @@ impl<'a> Struct<'a> {
     // Test using `&self` sugar:
 
     async fn ref_self(&self, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     // Test using `&Self` explicitly:
 
     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -1,56 +1,62 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:13:42
+  --> $DIR/lt-ref-self-async.rs:14:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
-   |                       -----              ^^^^
-   |                       |                  |
-   |                       |                  ...but data from `f` is returned here
+   |                       -----              ----
+   |                       |
    |                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:19:48
+  --> $DIR/lt-ref-self-async.rs:20:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
-   |                             -----              ^^^^
-   |                             |                  |
-   |                             |                  ...but data from `f` is returned here
+   |                             -----              ----
+   |                             |
    |                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:23:57
+  --> $DIR/lt-ref-self-async.rs:24:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
-   |                                     -----               ^^^^
-   |                                     |                   |
-   |                                     |                   ...but data from `f` is returned here
+   |                                     -----               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:27:57
+  --> $DIR/lt-ref-self-async.rs:28:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
-   |                                     -----               ^^^^
-   |                                     |                   |
-   |                                     |                   ...but data from `f` is returned here
+   |                                     -----               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:31:66
+  --> $DIR/lt-ref-self-async.rs:32:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
-   |                                             -----                ^^^^
-   |                                             |                    |
-   |                                             |                    ...but data from `f` is returned here
+   |                                             -----                ----
+   |                                             |
    |                                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:35:62
+  --> $DIR/lt-ref-self-async.rs:36:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
-   |                                         -----                ^^^^
-   |                                         |                    |
-   |                                         |                    ...but data from `f` is returned here
+   |                                         -----                ----
+   |                                         |
    |                                         this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-self-async.rs
+++ b/src/test/ui/self/elision/ref-mut-self-async.rs
@@ -10,30 +10,30 @@ struct Struct { }
 impl Struct {
     // Test using `&mut self` sugar:
 
-    async fn ref_self(&mut self, f: &u32) -> &u32 { //~ ERROR lifetime mismatch
-        f
+    async fn ref_self(&mut self, f: &u32) -> &u32 {
+        f //~ ERROR lifetime mismatch
     }
 
     // Test using `&mut Self` explicitly:
 
     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -1,56 +1,62 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:13:46
+  --> $DIR/ref-mut-self-async.rs:14:9
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
-   |                       ---------              ^^^^
-   |                       |                      |
-   |                       |                      ...but data from `f` is returned here
+   |                       ---------              ----
+   |                       |
    |                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:19:52
+  --> $DIR/ref-mut-self-async.rs:20:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
-   |                             ---------              ^^^^
-   |                             |                      |
-   |                             |                      ...but data from `f` is returned here
+   |                             ---------              ----
+   |                             |
    |                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:23:61
+  --> $DIR/ref-mut-self-async.rs:24:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
-   |                                     ---------               ^^^^
-   |                                     |                       |
-   |                                     |                       ...but data from `f` is returned here
+   |                                     ---------               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:27:61
+  --> $DIR/ref-mut-self-async.rs:28:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
-   |                                     ---------               ^^^^
-   |                                     |                       |
-   |                                     |                       ...but data from `f` is returned here
+   |                                     ---------               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:31:70
+  --> $DIR/ref-mut-self-async.rs:32:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
-   |                                             ---------                ^^^^
-   |                                             |                        |
-   |                                             |                        ...but data from `f` is returned here
+   |                                             ---------                ----
+   |                                             |
    |                                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:35:70
+  --> $DIR/ref-mut-self-async.rs:36:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
-   |                                             ---------                ^^^^
-   |                                             |                        |
-   |                                             |                        ...but data from `f` is returned here
+   |                                             ---------                ----
+   |                                             |
    |                                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/self/elision/ref-mut-struct-async.rs
+++ b/src/test/ui/self/elision/ref-mut-struct-async.rs
@@ -11,23 +11,23 @@ impl Struct {
     // Test using `&mut Struct` explicitly:
 
     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -1,47 +1,52 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:13:56
+  --> $DIR/ref-mut-struct-async.rs:14:9
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
-   |                               -----------              ^^^^
-   |                               |                        |
-   |                               |                        ...but data from `f` is returned here
+   |                               -----------              ----
+   |                               |
    |                               this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:17:65
+  --> $DIR/ref-mut-struct-async.rs:18:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
-   |                                       -----------               ^^^^
-   |                                       |                         |
-   |                                       |                         ...but data from `f` is returned here
+   |                                       -----------               ----
+   |                                       |
    |                                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:21:65
+  --> $DIR/ref-mut-struct-async.rs:22:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
-   |                                       -----------               ^^^^
-   |                                       |                         |
-   |                                       |                         ...but data from `f` is returned here
+   |                                       -----------               ----
+   |                                       |
    |                                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:25:74
+  --> $DIR/ref-mut-struct-async.rs:26:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
-   |                                               -----------                ^^^^
-   |                                               |                          |
-   |                                               |                          ...but data from `f` is returned here
+   |                                               -----------                ----
+   |                                               |
    |                                               this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:29:74
+  --> $DIR/ref-mut-struct-async.rs:30:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
-   |                                               -----------                ^^^^
-   |                                               |                          |
-   |                                               |                          ...but data from `f` is returned here
+   |                                               -----------                ----
+   |                                               |
    |                                               this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/elision/ref-self-async.rs
+++ b/src/test/ui/self/elision/ref-self-async.rs
@@ -19,34 +19,34 @@ impl<T, P> Deref for Wrap<T, P> {
 impl Struct {
     // Test using `&self` sugar:
 
-    async fn ref_self(&self, f: &u32) -> &u32 { //~ ERROR lifetime mismatch
-        f
+    async fn ref_self(&self, f: &u32) -> &u32 {
+        f //~ ERROR lifetime mismatch
     }
 
     // Test using `&Self` explicitly:
 
     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -1,65 +1,72 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:22:42
+  --> $DIR/ref-self-async.rs:23:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
-   |                       -----              ^^^^
-   |                       |                  |
-   |                       |                  ...but data from `f` is returned here
+   |                       -----              ----
+   |                       |
    |                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:28:48
+  --> $DIR/ref-self-async.rs:29:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
-   |                             -----              ^^^^
-   |                             |                  |
-   |                             |                  ...but data from `f` is returned here
+   |                             -----              ----
+   |                             |
    |                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:32:57
+  --> $DIR/ref-self-async.rs:33:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
-   |                                     -----               ^^^^
-   |                                     |                   |
-   |                                     |                   ...but data from `f` is returned here
+   |                                     -----               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:36:57
+  --> $DIR/ref-self-async.rs:37:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
-   |                                     -----               ^^^^
-   |                                     |                   |
-   |                                     |                   ...but data from `f` is returned here
+   |                                     -----               ----
+   |                                     |
    |                                     this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:40:66
+  --> $DIR/ref-self-async.rs:41:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
-   |                                             -----                ^^^^
-   |                                             |                    |
-   |                                             |                    ...but data from `f` is returned here
+   |                                             -----                ----
+   |                                             |
    |                                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:44:66
+  --> $DIR/ref-self-async.rs:45:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
-   |                                             -----                ^^^^
-   |                                             |                    |
-   |                                             |                    ...but data from `f` is returned here
+   |                                             -----                ----
+   |                                             |
    |                                             this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:48:69
+  --> $DIR/ref-self-async.rs:49:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
-   |                                            -----                    ^^^
-   |                                            |                        |
-   |                                            |                        ...but data from `f` is returned here
+   |                                            -----                    ---
+   |                                            |
    |                                            this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/self/elision/ref-struct-async.rs
+++ b/src/test/ui/self/elision/ref-struct-async.rs
@@ -11,23 +11,23 @@ impl Struct {
     // Test using `&Struct` explicitly:
 
     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 
     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
-        f //~^ ERROR lifetime mismatch
+        f //~ ERROR lifetime mismatch
     }
 }
 

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -1,47 +1,52 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:13:52
+  --> $DIR/ref-struct-async.rs:14:9
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
-   |                               -------              ^^^^
-   |                               |                    |
-   |                               |                    ...but data from `f` is returned here
+   |                               -------              ----
+   |                               |
    |                               this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:17:61
+  --> $DIR/ref-struct-async.rs:18:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
-   |                                       -------               ^^^^
-   |                                       |                     |
-   |                                       |                     ...but data from `f` is returned here
+   |                                       -------               ----
+   |                                       |
    |                                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:21:61
+  --> $DIR/ref-struct-async.rs:22:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
-   |                                       -------               ^^^^
-   |                                       |                     |
-   |                                       |                     ...but data from `f` is returned here
+   |                                       -------               ----
+   |                                       |
    |                                       this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:25:70
+  --> $DIR/ref-struct-async.rs:26:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
-   |                                               -------                ^^^^
-   |                                               |                      |
-   |                                               |                      ...but data from `f` is returned here
+   |                                               -------                ----
+   |                                               |
    |                                               this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:29:66
+  --> $DIR/ref-struct-async.rs:30:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
-   |                                           -------                ^^^^
-   |                                           |                      |
-   |                                           |                      ...but data from `f` is returned here
+   |                                           -------                ----
+   |                                           |
    |                                           this parameter and the return type are declared with different lifetimes...
+LL |         f
+   |         ^ ...but data from `f` is returned here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn foo(Option<i32>, String) {}
    |              ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn foo(_: Option<i32>, String) {}
+   |        ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/issue-34264.rs:1:27

--- a/src/test/ui/suggestions/issue-64252-self-type.rs
+++ b/src/test/ui/suggestions/issue-64252-self-type.rs
@@ -1,0 +1,14 @@
+// This test checks that a suggestion to add a `self: ` parameter name is provided
+// to functions where this is applicable.
+
+pub fn foo(Box<Self>) { }
+//~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+
+struct Bar;
+
+impl Bar {
+    fn bar(Box<Self>) { }
+    //~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+}
+
+fn main() { }

--- a/src/test/ui/suggestions/issue-64252-self-type.stderr
+++ b/src/test/ui/suggestions/issue-64252-self-type.stderr
@@ -1,0 +1,30 @@
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:4:15
+   |
+LL | pub fn foo(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | pub fn foo(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:10:15
+   |
+LL |     fn bar(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar(self: Box<Self>) { }
+   |            ^^^^^^^^^
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn bar(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -53,6 +53,9 @@ fn filter_dirs(path: &Path) -> bool {
         "src/tools/rls",
         "src/tools/rust-installer",
         "src/tools/rustfmt",
+
+        // Filter RLS output directories
+        "target/rls",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
Successful merges:

 - #64931 (Reword E0392 slightly)
 - #64959 (syntax: improve parameter without type suggestions)
 - #64975 (Implement Clone::clone_from for LinkedList)
 - #64993 (BacktraceStatus: add Eq impl)
 - #64998 (Filter out RLS output directories on tidy runs)
 - #64999 (extract expected return type for async fn generators)
 - #65010 (Compare `primary` with maximum of `children`s' line num instead of dropping it)

Failed merges:


r? @ghost