### PR TITLE
`#[track_caller]` feature gate (RFC 2091 1/N)

### DIFF
--- a/src/doc/unstable-book/src/language-features/track-caller.md
+++ b/src/doc/unstable-book/src/language-features/track-caller.md
@@ -1,0 +1,5 @@
+# `track_caller`
+
+The tracking issue for this feature is: [#47809](https://github.com/rust-lang/rust/issues/47809).
+
+------------------------

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1641,13 +1641,13 @@ attribute.
 "##,
 
 E0900: r##"
-TODO: change error number
-TODO: track_caller: invalid syntax
+FIXME(anp): change error number
+FIXME(anp): track_caller: invalid syntax
 "##,
 
 E0901: r##"
-TODO: change error number
-TODO: track_caller: no naked functions
+FIXME(anp): change error number
+FIXME(anp): track_caller: no naked functions
 "##,
 
 E0522: r##"

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -2145,5 +2145,5 @@ See [RFC 2091] for details on this and other limitations.
     E0726, // non-explicit (not `'_`) elided lifetime in unsupported position
     E0727, // `async` generators are not yet supported
     E0728, // `await` must be in an `async` function or block
-    E0735, // invalid track_caller application/syntax
+    E0739, // invalid track_caller application/syntax
 }

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -2078,6 +2078,16 @@ rejected in your own crates.
 E0736: r##"
 #[track_caller] and #[naked] cannot be applied to the same function.
 
+Erroneous code example:
+
+```compile_fail,E0736
+#![feature(track_caller)]
+
+#[naked]
+#[track_caller]
+fn foo() {}
+```
+
 This is primarily due to ABI incompatibilities between the two attributes.
 See [RFC 2091] for details on this and other limitations.
 

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1640,16 +1640,6 @@ each method; it is not possible to annotate the entire impl with an `#[inline]`
 attribute.
 "##,
 
-E0900: r##"
-FIXME(anp): change error number
-FIXME(anp): track_caller: invalid syntax
-"##,
-
-E0901: r##"
-FIXME(anp): change error number
-FIXME(anp): track_caller: no naked functions
-"##,
-
 E0522: r##"
 The lang attribute is intended for marking special items that are built-in to
 Rust itself. This includes special traits (like `Copy` and `Sized`) that affect
@@ -2085,6 +2075,15 @@ These attributes are meant to only be used by the standard library and are
 rejected in your own crates.
 "##,
 
+E0736: r##"
+#[track_caller] and #[naked] cannot be applied to the same function.
+
+This is primarily due to ABI incompatibilities between the two attributes.
+See [RFC 2091] for details on this and other limitations.
+
+[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
+"##,
+
 ;
 //  E0006, // merged with E0005
 //  E0101, // replaced with E0282
@@ -2146,4 +2145,5 @@ rejected in your own crates.
     E0726, // non-explicit (not `'_`) elided lifetime in unsupported position
     E0727, // `async` generators are not yet supported
     E0728, // `await` must be in an `async` function or block
+    E0735, // invalid track_caller application/syntax
 }

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -1640,6 +1640,16 @@ each method; it is not possible to annotate the entire impl with an `#[inline]`
 attribute.
 "##,
 
+E0900: r##"
+TODO: change error number
+TODO: track_caller: invalid syntax
+"##,
+
+E0901: r##"
+TODO: change error number
+TODO: track_caller: no naked functions
+"##,
+
 E0522: r##"
 The lang attribute is intended for marking special items that are built-in to
 Rust itself. This includes special traits (like `Copy` and `Sized`) that affect

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -143,7 +143,7 @@ impl CheckAttrVisitor<'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 attr.span,
-                E0900,
+                E0735,
                 "attribute should be applied to function"
             )
             .span_label(item.span, "not a function")
@@ -153,7 +153,7 @@ impl CheckAttrVisitor<'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 attr.span,
-                E0901,
+                E0736,
                 "cannot use `#[track_caller]` with `#[naked]`",
             )
             .emit();

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -143,7 +143,7 @@ impl CheckAttrVisitor<'tcx> {
             struct_span_err!(
                 self.tcx.sess,
                 attr.span,
-                E0735,
+                E0739,
                 "attribute should be applied to function"
             )
             .span_label(item.span, "not a function")

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2721,7 +2721,9 @@ bitflags! {
         const USED                      = 1 << 9;
         /// #[ffi_returns_twice], indicates that an extern function can return
         /// multiple times
-        const FFI_RETURNS_TWICE = 1 << 10;
+        const FFI_RETURNS_TWICE         = 1 << 10;
+        /// #[track_caller]: allow access to the caller location
+        const TRACK_CALLER              = 1 << 11;
     }
 }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -172,6 +172,18 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
         _ => None
     };
     check_associated_item(tcx, trait_item.hir_id, trait_item.span, method_sig);
+
+    // Prohibits applying `#[track_caller]` to trait methods
+    for attr in &trait_item.attrs {
+        if attr.check_name(sym::track_caller) {
+            struct_span_err!(
+                tcx.sess,
+                attr.span,
+                E0903,
+                "`#[track_caller]` is not supported for trait items yet."
+            ).emit();
+        }
+    }
 }
 
 pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -179,7 +179,7 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
             struct_span_err!(
                 tcx.sess,
                 attr.span,
-                E0903,
+                E0738,
                 "`#[track_caller]` is not supported for trait items yet."
             ).emit();
         }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -180,7 +180,7 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
                 tcx.sess,
                 attr.span,
                 E0738,
-                "`#[track_caller]` is not supported for trait items yet."
+                "`#[track_caller]` is not supported in trait declarations."
             ).emit();
         }
     }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -196,19 +196,18 @@ pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {
     };
 
     // Prohibits applying `#[track_caller]` to trait impls
-    if method_sig.is_some() { 
+    if method_sig.is_some() {
         let track_caller_attr = impl_item.attrs.iter()
             .find(|a| a.check_name(sym::track_caller));
         if let Some(tc_attr) = track_caller_attr {
             let parent_hir_id = tcx.hir().get_parent_item(hir_id);
             let containing_item = tcx.hir().expect_item(parent_hir_id);
-            let containing_impl_trait_ref = match &containing_item.kind {
-                hir::ItemKind::Impl(_, _, _, _, tr, _, _) => tr,
+            let containing_impl_is_for_trait = match &containing_item.kind {
+                hir::ItemKind::Impl(_, _, _, _, tr, _, _) => tr.is_some(),
                 _ => bug!("parent of an ImplItem must be an Impl"),
             };
 
-            // if the impl block this item is within is for a trait...
-            if containing_impl_trait_ref.is_some() {
+            if containing_impl_is_for_trait {
                 struct_span_err!(
                     tcx.sess,
                     tc_attr.span,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2594,6 +2594,16 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::USED;
         } else if attr.check_name(sym::thread_local) {
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::THREAD_LOCAL;
+        } else if attr.check_name(sym::track_caller) {
+            if tcx.fn_sig(id).abi() != abi::Abi::Rust {
+                struct_span_err!(
+                    tcx.sess,
+                    attr.span,
+                    E0902,
+                    "rust ABI is required to use `#[track_caller]`"
+                ).emit();
+            }
+            codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER;
         } else if attr.check_name(sym::export_name) {
             if let Some(s) = attr.value_str() {
                 if s.as_str().contains("\0") {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2599,7 +2599,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                 struct_span_err!(
                     tcx.sess,
                     attr.span,
-                    E0902,
+                    E0737,
                     "rust ABI is required to use `#[track_caller]`"
                 ).emit();
             }

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4907,6 +4907,17 @@ fn foo_recursive(n: usize) -> Pin<Box<dyn Future<Output = ()>>> {
 The `Box<...>` ensures that the result is of known size,
 and the pin is required to keep it in the same place in memory.
 "##,
+
+E0902: r##"
+TODO: change error number
+TODO: track_caller: require Rust ABI to use track_caller
+"##,
+
+E0903: r##"
+TODO: change error number
+TODO: track_caller: can't apply in traits
+"##,
+
 ;
 //  E0035, merged into E0087/E0089
 //  E0036, merged into E0087/E0089

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4909,13 +4909,13 @@ and the pin is required to keep it in the same place in memory.
 "##,
 
 E0902: r##"
-TODO: change error number
-TODO: track_caller: require Rust ABI to use track_caller
+FIXME(anp): change error number
+FIXME(anp): track_caller: require Rust ABI to use track_caller
 "##,
 
 E0903: r##"
-TODO: change error number
-TODO: track_caller: can't apply in traits
+FIXME(anp): change error number
+FIXME(anp): track_caller: can't apply in traits
 "##,
 
 ;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4908,14 +4908,18 @@ The `Box<...>` ensures that the result is of known size,
 and the pin is required to keep it in the same place in memory.
 "##,
 
-E0902: r##"
-FIXME(anp): change error number
-FIXME(anp): track_caller: require Rust ABI to use track_caller
+E0737: r##"
+#[track_caller] requires functions to have the "Rust" ABI for passing caller
+location. See [RFC 2091] for details on this and other restrictions.
+
+[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
-E0903: r##"
-FIXME(anp): change error number
-FIXME(anp): track_caller: can't apply in traits
+E0738: r##"
+#[track_caller] cannot be applied to trait methods. See [RFC 2091]
+for details on this and other restrictions.
+
+[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
 ;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4960,7 +4960,7 @@ trait Foo {
 Erroneous example with a trait method declaration:
 
 ```compile_fail,E0738
-#[!feature(track_caller)]
+#![feature(track_caller)]
 
 trait Foo {
     fn bar(&self) {}

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4926,12 +4926,11 @@ extern "C" fn foo() {}
 "##,
 
 E0738: r##"
-#[track_caller] cannot be applied to trait methods.
+#[track_caller] cannot be used in traits yet.  This is due to limitations in the
+compiler which are likely to be temporary. See [RFC 2091] for details on this
+and other restrictions.
 
-This is due to limitations in the compiler which are likely to be temporary.
-See [RFC 2091] for details on this and other restrictions.
-
-Erroneous code example:
+Erroneous example with a trait method implementation:
 
 ```compile_fail,E0738
 #![feature(track_caller)]
@@ -4940,13 +4939,39 @@ trait Foo {
     fn bar(&self);
 }
 
-struct Bar;
-
-impl Foo for Bar {
+impl Foo for u64 {
     #[track_caller]
     fn bar(&self) {}
 }
 ```
+
+Erroneous example with a blanket trait method implementation:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    #[track_caller]
+    fn bar(&self) {}
+    fn baz(&self);
+}
+```
+
+Erroneous example with a trait method declaration:
+
+```compile_fail,E0738
+#[!feature(track_caller)]
+
+trait Foo {
+    fn bar(&self) {}
+
+    #[track_caller]
+    fn baz(&self);
+}
+```
+
+Note that while the compiler may be able to support the attribute in traits in
+the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4909,15 +4909,44 @@ and the pin is required to keep it in the same place in memory.
 "##,
 
 E0737: r##"
-#[track_caller] requires functions to have the "Rust" ABI for passing caller
-location. See [RFC 2091] for details on this and other restrictions.
+#[track_caller] requires functions to have the "Rust" ABI for implicitly
+receiving caller location. See [RFC 2091] for details on this and other
+restrictions.
+
+Erroneous code example:
+
+```compile_fail,E0737
+#![feature(track_caller)]
+
+#[track_caller]
+extern "C" fn foo() {}
+```
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
 E0738: r##"
-#[track_caller] cannot be applied to trait methods. See [RFC 2091]
-for details on this and other restrictions.
+#[track_caller] cannot be applied to trait methods.
+
+This is due to limitations in the compiler which are likely to be temporary.
+See [RFC 2091] for details on this and other restrictions.
+
+Erroneous code example:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    fn bar(&self);
+}
+
+struct Bar;
+
+impl Foo for Bar {
+    #[track_caller]
+    fn bar(&self) {}
+}
+```
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -543,4 +543,5 @@ pub const INCOMPLETE_FEATURES: &[Symbol] = &[
     sym::or_patterns,
     sym::let_chains,
     sym::raw_dylib,
+    sym::track_caller,
 ];

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -525,6 +525,9 @@ declare_features! (
     // Allows the use of raw-dylibs (RFC 2627).
     (active, raw_dylib, "1.40.0", Some(58713), None),
 
+    /// Enable accurate caller location reporting during panic (RFC 2091).
+    (active, track_caller, "1.37.0", Some(47809), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -526,7 +526,7 @@ declare_features! (
     (active, raw_dylib, "1.40.0", Some(58713), None),
 
     /// Enable accurate caller location reporting during panic (RFC 2091).
-    (active, track_caller, "1.39.0", Some(47809), None),
+    (active, track_caller, "1.40.0", Some(47809), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -526,7 +526,7 @@ declare_features! (
     (active, raw_dylib, "1.40.0", Some(58713), None),
 
     /// Enable accurate caller location reporting during panic (RFC 2091).
-    (active, track_caller, "1.37.0", Some(47809), None),
+    (active, track_caller, "1.39.0", Some(47809), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -500,6 +500,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         )
     ),
     gated!(
+        track_caller, Whitelisted, template!(Word),
+        "the `#[track_caller]` attribute is an experimental feature",
+    ),
+    gated!(
         // Used in resolve:
         prelude_import, Whitelisted, template!(Word),
         "`#[prelude_import]` is for use by rustc only",

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -324,6 +324,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     gated!(ffi_returns_twice, Whitelisted, template!(Word), experimental!(ffi_returns_twice)),
+    gated!(track_caller, Whitelisted, template!(Word), experimental!(track_caller)),
 
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:
@@ -498,10 +499,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
             deprecated due to lack of demand",
             cfg_fn!(no_debug)
         )
-    ),
-    gated!(
-        track_caller, Whitelisted, template!(Word),
-        "the `#[track_caller]` attribute is an experimental feature",
     ),
     gated!(
         // Used in resolve:

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -674,6 +674,7 @@ symbols! {
         tool_attributes,
         tool_lints,
         trace_macros,
+        track_caller,
         trait_alias,
         transmute,
         transparent,

--- a/src/test/ui/feature-gates/feature-gate-track_caller.rs
+++ b/src/test/ui/feature-gates/feature-gate-track_caller.rs
@@ -1,0 +1,6 @@
+
+#[track_caller]
+fn f() {}
+//~^^ ERROR the `#[track_caller]` attribute is an experimental feature
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-track_caller.rs
+++ b/src/test/ui/feature-gates/feature-gate-track_caller.rs
@@ -1,4 +1,3 @@
-
 #[track_caller]
 fn f() {}
 //~^^ ERROR the `#[track_caller]` attribute is an experimental feature

--- a/src/test/ui/feature-gates/feature-gate-track_caller.stderr
+++ b/src/test/ui/feature-gates/feature-gate-track_caller.stderr
@@ -1,0 +1,12 @@
+error[E0658]: the `#[track_caller]` attribute is an experimental feature
+  --> $DIR/feature-gate-track_caller.rs:2:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/47809
+   = help: add `#![feature(track_caller)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-track_caller.stderr
+++ b/src/test/ui/feature-gates/feature-gate-track_caller.stderr
@@ -1,5 +1,5 @@
 error[E0658]: the `#[track_caller]` attribute is an experimental feature
-  --> $DIR/feature-gate-track_caller.rs:2:1
+  --> $DIR/feature-gate-track_caller.rs:1:1
    |
 LL | #[track_caller]
    | ^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2091-track-caller/error-odd-syntax.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-odd-syntax.rs
@@ -1,0 +1,7 @@
+#![feature(track_caller)]
+
+#[track_caller(1)]
+fn f() {}
+//~^^ ERROR malformed `track_caller` attribute input
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-odd-syntax.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-odd-syntax.rs
@@ -1,4 +1,4 @@
-#![feature(track_caller)]
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 #[track_caller(1)]
 fn f() {}

--- a/src/test/ui/rfc-2091-track-caller/error-odd-syntax.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-odd-syntax.stderr
@@ -1,0 +1,8 @@
+error: malformed `track_caller` attribute input
+  --> $DIR/error-odd-syntax.rs:3:1
+   |
+LL | #[track_caller(1)]
+   | ^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[track_caller]`
+
+error: aborting due to previous error
+

--- a/src/test/ui/rfc-2091-track-caller/error-odd-syntax.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-odd-syntax.stderr
@@ -4,5 +4,13 @@ error: malformed `track_caller` attribute input
 LL | #[track_caller(1)]
    | ^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[track_caller]`
 
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-odd-syntax.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
@@ -1,0 +1,7 @@
+#![feature(track_caller)]
+
+#[track_caller]
+extern "C" fn f() {}
+//~^^ ERROR rust ABI is required to use `#[track_caller]`
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
@@ -1,4 +1,4 @@
-#![feature(track_caller)]
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 #[track_caller]
 extern "C" fn f() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -1,3 +1,11 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-with-invalid-abi.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0737]: rust ABI is required to use `#[track_caller]`
   --> $DIR/error-with-invalid-abi.rs:3:1
    |

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -1,0 +1,9 @@
+error[E0902]: rust ABI is required to use `#[track_caller]`
+  --> $DIR/error-with-invalid-abi.rs:3:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0902`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -1,4 +1,4 @@
-error[E0902]: rust ABI is required to use `#[track_caller]`
+error[E0737]: rust ABI is required to use `#[track_caller]`
   --> $DIR/error-with-invalid-abi.rs:3:1
    |
 LL | #[track_caller]
@@ -6,4 +6,4 @@ LL | #[track_caller]
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0902`.
+For more information about this error, try `rustc --explain E0737`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
@@ -1,0 +1,8 @@
+#![feature(naked_functions, track_caller)]
+
+#[track_caller]
+#[naked]
+fn f() {}
+//~^^^ ERROR cannot use `#[track_caller]` with `#[naked]`
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.rs
@@ -1,4 +1,4 @@
-#![feature(naked_functions, track_caller)]
+#![feature(naked_functions, track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 #[track_caller]
 #[naked]

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
@@ -1,0 +1,9 @@
+error[E0901]: cannot use `#[track_caller]` with `#[naked]`
+  --> $DIR/error-with-naked.rs:3:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0901`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
@@ -1,3 +1,11 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-with-naked.rs:1:29
+   |
+LL | #![feature(naked_functions, track_caller)]
+   |                             ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0736]: cannot use `#[track_caller]` with `#[naked]`
   --> $DIR/error-with-naked.rs:3:1
    |

--- a/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-naked.stderr
@@ -1,4 +1,4 @@
-error[E0901]: cannot use `#[track_caller]` with `#[naked]`
+error[E0736]: cannot use `#[track_caller]` with `#[naked]`
   --> $DIR/error-with-naked.rs:3:1
    |
 LL | #[track_caller]
@@ -6,4 +6,4 @@ LL | #[track_caller]
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0901`.
+For more information about this error, try `rustc --explain E0736`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
@@ -3,7 +3,7 @@
 trait Trait {
     #[track_caller]
     fn unwrap(&self);
-    //~^^ ERROR: `#[track_caller]` is not supported in traits yet.
+    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 impl Trait for u64 {

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
@@ -1,0 +1,13 @@
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
+
+trait Trait {
+    #[track_caller]
+    fn unwrap(&self);
+    //~^^ ERROR: `#[track_caller]` is not supported in traits yet.
+}
+
+impl Trait for u64 {
+    fn unwrap(&self) {}
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
@@ -1,0 +1,17 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-with-trait-decl.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0738]: `#[track_caller]` is not supported in trait declarations.
+  --> $DIR/error-with-trait-decl.rs:4:5
+   |
+LL |     #[track_caller]
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0738`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
@@ -2,12 +2,8 @@
 
 trait Trait {
     #[track_caller]
-    fn unwrap(&self);
-    //~^^ ERROR: `#[track_caller]` is not supported for trait items yet.
-}
-
-impl Trait for u64 {
     fn unwrap(&self) {}
+    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in traits yet.
+error[E0738]: `#[track_caller]` is not supported in trait declarations.
   --> $DIR/error-with-trait-default-impl.rs:4:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
@@ -1,0 +1,17 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-with-trait-default-impl.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0738]: `#[track_caller]` is not supported in traits yet.
+  --> $DIR/error-with-trait-default-impl.rs:4:5
+   |
+LL |     #[track_caller]
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0738`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
@@ -1,0 +1,13 @@
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
+
+trait Trait {
+    fn unwrap(&self);
+}
+
+impl Trait for u64 {
+    #[track_caller]
+    fn unwrap(&self) {}
+    //~^^ ERROR: `#[track_caller]` is not supported in traits yet.
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -7,7 +7,7 @@ LL | #![feature(track_caller)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0738]: `#[track_caller]` is not supported in traits yet.
-  --> $DIR/error-with-trait-fn-impl.rs:4:5
+  --> $DIR/error-with-trait-fn-impl.rs:8:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -1,13 +1,13 @@
 warning: the feature `track_caller` is incomplete and may cause the compiler to crash
-  --> $DIR/error-with-trait-fns.rs:1:12
+  --> $DIR/error-with-trait-fn-impl.rs:1:12
    |
 LL | #![feature(track_caller)]
    |            ^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported for trait items yet.
-  --> $DIR/error-with-trait-fns.rs:4:5
+error[E0738]: `#[track_caller]` is not supported in traits yet.
+  --> $DIR/error-with-trait-fn-impl.rs:4:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.rs
@@ -1,4 +1,4 @@
-#![feature(track_caller)]
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.rs
@@ -1,0 +1,13 @@
+#![feature(track_caller)]
+
+trait Trait {
+    #[track_caller]
+    fn unwrap(&self);
+    //~^^ ERROR: `#[track_caller]` is not supported for trait items yet.
+}
+
+impl Trait for u64 {
+    fn unwrap(&self) {}
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
@@ -1,4 +1,4 @@
-error[E0903]: `#[track_caller]` is not supported for trait items yet.
+error[E0738]: `#[track_caller]` is not supported for trait items yet.
   --> $DIR/error-with-trait-fns.rs:4:5
    |
 LL |     #[track_caller]
@@ -6,4 +6,4 @@ LL |     #[track_caller]
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0903`.
+For more information about this error, try `rustc --explain E0738`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
@@ -1,0 +1,9 @@
+error[E0903]: `#[track_caller]` is not supported for trait items yet.
+  --> $DIR/error-with-trait-fns.rs:4:5
+   |
+LL |     #[track_caller]
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0903`.

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fns.stderr
@@ -1,3 +1,11 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/error-with-trait-fns.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0738]: `#[track_caller]` is not supported for trait items yet.
   --> $DIR/error-with-trait-fns.rs:4:5
    |

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.rs
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.rs
@@ -1,0 +1,7 @@
+#![feature(track_caller)]
+
+#[track_caller]
+struct S;
+//~^^ ERROR attribute should be applied to function
+
+fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.rs
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.rs
@@ -1,4 +1,4 @@
-#![feature(track_caller)]
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 #[track_caller]
 struct S;

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
@@ -1,0 +1,11 @@
+error[E0900]: attribute should be applied to function
+  --> $DIR/only-for-fns.rs:3:1
+   |
+LL | #[track_caller]
+   | ^^^^^^^^^^^^^^^
+LL | struct S;
+   | --------- not a function
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0900`.

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
@@ -1,3 +1,11 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/only-for-fns.rs:1:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
 error[E0735]: attribute should be applied to function
   --> $DIR/only-for-fns.rs:3:1
    |
@@ -8,4 +16,3 @@ LL | struct S;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0735`.

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
@@ -1,4 +1,4 @@
-error[E0900]: attribute should be applied to function
+error[E0735]: attribute should be applied to function
   --> $DIR/only-for-fns.rs:3:1
    |
 LL | #[track_caller]
@@ -8,4 +8,4 @@ LL | struct S;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0900`.
+For more information about this error, try `rustc --explain E0735`.

--- a/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
+++ b/src/test/ui/rfc-2091-track-caller/only-for-fns.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0735]: attribute should be applied to function
+error[E0739]: attribute should be applied to function
   --> $DIR/only-for-fns.rs:3:1
    |
 LL | #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/pass.rs
+++ b/src/test/ui/rfc-2091-track-caller/pass.rs
@@ -1,0 +1,9 @@
+// run-pass
+#![feature(track_caller)]
+
+#[track_caller]
+fn f() {}
+
+fn main() {
+    f();
+}

--- a/src/test/ui/rfc-2091-track-caller/pass.rs
+++ b/src/test/ui/rfc-2091-track-caller/pass.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(track_caller)]
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 #[track_caller]
 fn f() {}

--- a/src/test/ui/rfc-2091-track-caller/pass.stderr
+++ b/src/test/ui/rfc-2091-track-caller/pass.stderr
@@ -1,0 +1,8 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/pass.rs:2:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+


### PR DESCRIPTION
RFC text: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
Tracking issue: https://github.com/rust-lang/rust/issues/47809

I started with @ayosec's commit to add the feature gate with tests and rebased it onto current master. I fixed up some tidy lints and added a test.