### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1203,8 +1203,8 @@ impl<T: Clone> Clone for LinkedList<T> {
         if self.len() > other.len() {
             self.split_off(other.len());
         }
-        for elem in self.iter_mut() {
-            elem.clone_from(iter_other.next().unwrap());
+        for (elem, elem_other) in self.iter_mut().zip(&mut iter_other) {
+            elem.clone_from(elem_other);
         }
         if !iter_other.is_empty() {
             self.extend(iter_other.cloned());

--- a/src/liballoc/collections/linked_list.rs
+++ b/src/liballoc/collections/linked_list.rs
@@ -1197,6 +1197,19 @@ impl<T: Clone> Clone for LinkedList<T> {
     fn clone(&self) -> Self {
         self.iter().cloned().collect()
     }
+
+    fn clone_from(&mut self, other: &Self) {
+        let mut iter_other = other.iter();
+        if self.len() > other.len() {
+            self.split_off(other.len());
+        }
+        for elem in self.iter_mut() {
+            elem.clone_from(iter_other.next().unwrap());
+        }
+        if !iter_other.is_empty() {
+            self.extend(iter_other.cloned());
+        }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/liballoc/collections/linked_list/tests.rs
+++ b/src/liballoc/collections/linked_list/tests.rs
@@ -111,6 +111,49 @@ fn test_append() {
 }
 
 #[test]
+fn test_clone_from() {
+    // Short cloned from long
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![8, 7, 6, 2, 3, 4, 5];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+    // Long cloned from short
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![6, 7, 8];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+    // Two equal length lists
+    {
+        let v = vec![1, 2, 3, 4, 5];
+        let u = vec![9, 8, 1, 2, 3];
+        let mut m = list_from(&v);
+        let n = list_from(&u);
+        m.clone_from(&n);
+        check_links(&m);
+        assert_eq!(m, n);
+        for elt in u {
+            assert_eq!(m.pop_front(), Some(elt))
+        }
+    }
+}
+
+#[test]
 fn test_insert_prev() {
     let mut m = list_from(&[0, 2, 4, 6, 8]);
     let len = m.len();

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -418,7 +418,9 @@ pub enum NLLRegionVariableOrigin {
     /// from a `for<'a> T` binder). Meant to represent "any region".
     Placeholder(ty::PlaceholderRegion),
 
-    Existential,
+    Existential {
+        was_placeholder: bool
+    },
 }
 
 impl NLLRegionVariableOrigin {
@@ -426,7 +428,7 @@ impl NLLRegionVariableOrigin {
         match self {
             NLLRegionVariableOrigin::FreeRegion => true,
             NLLRegionVariableOrigin::Placeholder(..) => true,
-            NLLRegionVariableOrigin::Existential => false,
+            NLLRegionVariableOrigin::Existential{ .. } => false,
         }
     }
 

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -419,7 +419,17 @@ pub enum NLLRegionVariableOrigin {
     Placeholder(ty::PlaceholderRegion),
 
     Existential {
-        was_placeholder: bool
+        /// If this is true, then this variable was created to represent a lifetime
+        /// bound in a `for` binder. For example, it might have been created to
+        /// represent the lifetime `'a` in a type like `for<'a> fn(&'a u32)`.
+        /// Such variables are created when we are trying to figure out if there
+        /// is any valid instantiation of `'a` that could fit into some scenario.
+        ///
+        /// This is used to inform error reporting: in the case that we are trying to
+        /// determine whether there is any valid instantiation of a `'a` variable that meets
+        /// some constraint C, we want to blame the "source" of that `for` type,
+        /// rather than blaming the source of the constraint C.
+        from_forall: bool
     },
 }
 

--- a/src/librustc/infer/nll_relate/mod.rs
+++ b/src/librustc/infer/nll_relate/mod.rs
@@ -93,7 +93,7 @@ pub trait TypeRelatingDelegate<'tcx> {
     /// we will invoke this method to instantiate `'a` with an
     /// inference variable (though `'b` would be instantiated first,
     /// as a placeholder).
-    fn next_existential_region_var(&mut self) -> ty::Region<'tcx>;
+    fn next_existential_region_var(&mut self, was_placeholder: bool) -> ty::Region<'tcx>;
 
     /// Creates a new region variable representing a
     /// higher-ranked region that is instantiated universally.
@@ -193,7 +193,7 @@ where
                     let placeholder = ty::PlaceholderRegion { universe, name: br };
                     delegate.next_placeholder_region(placeholder)
                 } else {
-                    delegate.next_existential_region_var()
+                    delegate.next_existential_region_var(true)
                 }
             }
         };

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1026,7 +1026,8 @@ impl EmitterWriter {
         children.iter()
             .map(|sub| self.get_multispan_max_line_num(&sub.span))
             .max()
-            .unwrap_or(primary)
+            .unwrap_or(0)
+            .max(primary)
     }
 
     /// Adds a left margin to every line but the first, given a padding length and the label being

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/mod.rs
@@ -159,11 +159,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
         let should_reverse = match from_region_origin {
             NLLRegionVariableOrigin::FreeRegion
-                | NLLRegionVariableOrigin::Existential { was_placeholder: false  } => {
+                | NLLRegionVariableOrigin::Existential { from_forall: false  } => {
                     true
             }
             NLLRegionVariableOrigin::Placeholder(_)
-                | NLLRegionVariableOrigin::Existential { was_placeholder: true  } => {
+                | NLLRegionVariableOrigin::Existential { from_forall: true  } => {
                     false
             }
         };

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -406,7 +406,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     }
                 }
 
-                NLLRegionVariableOrigin::Existential => {
+                NLLRegionVariableOrigin::Existential { .. } => {
                     // For existential, regions, nothing to do.
                 }
             }
@@ -1348,7 +1348,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                     self.check_bound_universal_region(infcx, body, mir_def_id, fr, placeholder);
                 }
 
-                NLLRegionVariableOrigin::Existential => {
+                NLLRegionVariableOrigin::Existential { .. } => {
                     // nothing to check here
                 }
             }
@@ -1461,7 +1461,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 debug!("check_universal_region: fr_minus={:?}", fr_minus);
 
                 let blame_span_category =
-                    self.find_outlives_blame_span(body, longer_fr, shorter_fr);
+                    self.find_outlives_blame_span(body, longer_fr,
+                                                  NLLRegionVariableOrigin::FreeRegion,shorter_fr);
 
                 // Grow `shorter_fr` until we find some non-local regions. (We
                 // always will.)  We'll call them `shorter_fr+` -- they're ever
@@ -1494,6 +1495,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             infcx,
             mir_def_id,
             longer_fr,
+            NLLRegionVariableOrigin::FreeRegion,
             shorter_fr,
             region_naming,
         );
@@ -1547,7 +1549,9 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         };
 
         // Find the code to blame for the fact that `longer_fr` outlives `error_fr`.
-        let (_, span) = self.find_outlives_blame_span(body, longer_fr, error_region);
+        let (_, span) = self.find_outlives_blame_span(
+            body, longer_fr, NLLRegionVariableOrigin::Placeholder(placeholder), error_region
+        );
 
         // Obviously, this error message is far from satisfactory.
         // At present, though, it only appears in unit tests --
@@ -1608,7 +1612,7 @@ impl<'tcx> RegionDefinition<'tcx> {
 
         let origin = match rv_origin {
             RegionVariableOrigin::NLL(origin) => origin,
-            _ => NLLRegionVariableOrigin::Existential,
+            _ => NLLRegionVariableOrigin::Existential { was_placeholder: false },
         };
 
         Self { origin, universe, external_name: None }

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -1612,7 +1612,7 @@ impl<'tcx> RegionDefinition<'tcx> {
 
         let origin = match rv_origin {
             RegionVariableOrigin::NLL(origin) => origin,
-            _ => NLLRegionVariableOrigin::Existential { was_placeholder: false },
+            _ => NLLRegionVariableOrigin::Existential { from_forall: false },
         };
 
         Self { origin, universe, external_name: None }

--- a/src/librustc_mir/borrow_check/nll/renumber.rs
+++ b/src/librustc_mir/borrow_check/nll/renumber.rs
@@ -35,7 +35,7 @@ where
     infcx
         .tcx
         .fold_regions(value, &mut false, |_region, _depth| {
-            let origin = NLLRegionVariableOrigin::Existential;
+            let origin = NLLRegionVariableOrigin::Existential { was_placeholder: false };
             infcx.next_nll_region_var(origin)
         })
 }

--- a/src/librustc_mir/borrow_check/nll/renumber.rs
+++ b/src/librustc_mir/borrow_check/nll/renumber.rs
@@ -35,7 +35,7 @@ where
     infcx
         .tcx
         .fold_regions(value, &mut false, |_region, _depth| {
-            let origin = NLLRegionVariableOrigin::Existential { was_placeholder: false };
+            let origin = NLLRegionVariableOrigin::Existential { from_forall: false };
             infcx.next_nll_region_var(origin)
         })
 }

--- a/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
@@ -66,9 +66,9 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
         self.infcx.create_next_universe()
     }
 
-    fn next_existential_region_var(&mut self) -> ty::Region<'tcx> {
+    fn next_existential_region_var(&mut self, was_placeholder: bool) -> ty::Region<'tcx> {
         if let Some(_) = &mut self.borrowck_context {
-            let origin = NLLRegionVariableOrigin::Existential;
+            let origin = NLLRegionVariableOrigin::Existential { was_placeholder };
             self.infcx.next_nll_region_var(origin)
         } else {
             self.infcx.tcx.lifetimes.re_erased
@@ -88,7 +88,9 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
 
     fn generalize_existential(&mut self, universe: ty::UniverseIndex) -> ty::Region<'tcx> {
         self.infcx
-            .next_nll_region_var_in_universe(NLLRegionVariableOrigin::Existential, universe)
+            .next_nll_region_var_in_universe(NLLRegionVariableOrigin::Existential {
+                was_placeholder: false
+            }, universe)
     }
 
     fn push_outlives(&mut self, sup: ty::Region<'tcx>, sub: ty::Region<'tcx>) {

--- a/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
+++ b/src/librustc_mir/borrow_check/nll/type_check/relate_tys.rs
@@ -66,9 +66,9 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
         self.infcx.create_next_universe()
     }
 
-    fn next_existential_region_var(&mut self, was_placeholder: bool) -> ty::Region<'tcx> {
+    fn next_existential_region_var(&mut self, from_forall: bool) -> ty::Region<'tcx> {
         if let Some(_) = &mut self.borrowck_context {
-            let origin = NLLRegionVariableOrigin::Existential { was_placeholder };
+            let origin = NLLRegionVariableOrigin::Existential { from_forall };
             self.infcx.next_nll_region_var(origin)
         } else {
             self.infcx.tcx.lifetimes.re_erased
@@ -89,7 +89,7 @@ impl TypeRelatingDelegate<'tcx> for NllTypeRelatingDelegate<'_, '_, 'tcx> {
     fn generalize_existential(&mut self, universe: ty::UniverseIndex) -> ty::Region<'tcx> {
         self.infcx
             .next_nll_region_var_in_universe(NLLRegionVariableOrigin::Existential {
-                was_placeholder: false
+                from_forall: false
             }, universe)
     }
 

--- a/src/librustc_traits/chalk_context/unify.rs
+++ b/src/librustc_traits/chalk_context/unify.rs
@@ -65,7 +65,7 @@ impl TypeRelatingDelegate<'tcx> for &mut ChalkTypeRelatingDelegate<'_, 'tcx> {
         self.infcx.create_next_universe()
     }
 
-    fn next_existential_region_var(&mut self) -> ty::Region<'tcx> {
+    fn next_existential_region_var(&mut self, _was_placeholder: bool) -> ty::Region<'tcx> {
         self.infcx.next_region_var(RegionVariableOrigin::MiscVariable(DUMMY_SP))
     }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -1001,7 +1001,7 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
     // Help is available only in presence of lang items.
     let msg = if let Some(def_id) = suggested_marker_id {
         format!(
-            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            "consider removing `{}`, refering to it in a field, or using a marker such as `{}`",
             param_name,
             tcx.def_path_str(def_id),
         )

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -999,11 +999,16 @@ fn report_bivariance(tcx: TyCtxt<'_>, span: Span, param_name: ast::Name) {
 
     let suggested_marker_id = tcx.lang_items().phantom_data();
     // Help is available only in presence of lang items.
-    if let Some(def_id) = suggested_marker_id {
-        err.help(&format!("consider removing `{}` or using a marker such as `{}`",
-                          param_name,
-                          tcx.def_path_str(def_id)));
-    }
+    let msg = if let Some(def_id) = suggested_marker_id {
+        format!(
+            "consider removing `{}`, refering to it in a field or using a marker such as `{}`",
+            param_name,
+            tcx.def_path_str(def_id),
+        )
+    } else {
+        format!( "consider removing `{}` or refering to it in a field", param_name)
+    };
+    err.help(&msg);
     err.emit();
 }
 

--- a/src/libstd/backtrace.rs
+++ b/src/libstd/backtrace.rs
@@ -113,7 +113,7 @@ pub struct Backtrace {
 /// The current status of a backtrace, indicating whether it was captured or
 /// whether it is empty for some other reason.
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BacktraceStatus {
     /// Capturing a backtrace is not supported, likely because it's not
     /// implemented for the current platform.

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -1212,6 +1212,7 @@ impl<'a> Parser<'a> {
                     &mut err,
                     pat,
                     is_name_required,
+                    is_self_allowed,
                     is_trait_item,
                 ) {
                     err.emit();

--- a/src/test/ui/anon-params-denied-2018.stderr
+++ b/src/test/ui/anon-params-denied-2018.stderr
@@ -5,6 +5,10 @@ LL |     fn foo(i32);
    |               ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn foo(self: i32);
+   |            ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn foo(i32: TypeName);
@@ -21,6 +25,10 @@ LL |     fn bar_with_default_impl(String, String) {}
    |                                    ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar_with_default_impl(self: String, String) {}
+   |                              ^^^^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL |     fn bar_with_default_impl(String: TypeName, String) {}

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -18,7 +18,7 @@ error[E0392]: parameter `T` is never used
 LL | pub struct Dependent<T, const X: T>([(); X]);
    |                      ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0392.stderr
+++ b/src/test/ui/error-codes/E0392.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Foo<T> { Bar }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/hrtb/issue-30786.nll.stderr
+++ b/src/test/ui/hrtb/issue-30786.nll.stderr
@@ -1,14 +1,20 @@
 error: higher-ranked subtype error
-  --> $DIR/issue-30786.rs:113:18
+  --> $DIR/issue-30786.rs:108:15
+   |
+LL |     let map = source.map(|x: &_| x);
+   |               ^^^^^^^^^^^^^^^^^^^^^
+
+error: higher-ranked subtype error
+  --> $DIR/issue-30786.rs:114:18
    |
 LL |     let filter = map.filter(|x: &_| true);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: higher-ranked subtype error
-  --> $DIR/issue-30786.rs:115:17
+  --> $DIR/issue-30786.rs:116:17
    |
 LL |     let count = filter.count(); // Assert that we still have a valid stream.
    |                 ^^^^^^^^^^^^^^
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/hrtb/issue-30786.rs
+++ b/src/test/ui/hrtb/issue-30786.rs
@@ -106,7 +106,8 @@ impl<T> StreamExt for T where for<'a> &'a mut T: Stream { }
 fn main() {
     let source = Repeat(10);
     let map = source.map(|x: &_| x);
-    //[migrate]~^ ERROR implementation of `Stream` is not general enough
+    //[nll]~^ ERROR higher-ranked subtype error
+    //[migrate]~^^ ERROR implementation of `Stream` is not general enough
     //[migrate]~| NOTE  `Stream` would have to be implemented for the type `&'0 mut Map
     //[migrate]~| NOTE  but `Stream` is actually implemented for the type `&'1
     //[migrate]~| NOTE  implementation of `Stream` is not general enough

--- a/src/test/ui/hrtb/issue-30786.rs
+++ b/src/test/ui/hrtb/issue-30786.rs
@@ -114,4 +114,5 @@ fn main() {
     //[nll]~^ ERROR higher-ranked subtype error
     let count = filter.count(); // Assert that we still have a valid stream.
     //[nll]~^ ERROR higher-ranked subtype error
+
 }

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inner-static-type-parameter.stderr
+++ b/src/test/ui/inner-static-type-parameter.stderr
@@ -14,7 +14,7 @@ error[E0392]: parameter `T` is never used
 LL | enum Bar<T> { What }
    |          ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-20413.stderr
+++ b/src/test/ui/issues/issue-20413.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `T` is never used
 LL | struct NoData<T>;
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0275]: overflow evaluating the requirement `NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<NoData<T>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>: Foo`
   --> $DIR/issue-20413.rs:8:1

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36299.stderr
+++ b/src/test/ui/issues/issue-36299.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Foo<'a, A> {}
    |            ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/issue-36299.rs:1:16
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | struct Foo<'a, A> {}
    |                ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-36638.stderr
+++ b/src/test/ui/issues/issue-36638.stderr
@@ -16,7 +16,7 @@ error[E0392]: parameter `Self` is never used
 LL | struct Foo<Self>(Self);
    |            ^^^^ unused parameter
    |
-   = help: consider removing `Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/relate_tys/fn-subtype.rs
+++ b/src/test/ui/nll/relate_tys/fn-subtype.rs
@@ -1,0 +1,10 @@
+// Test that NLL produces correct spans for higher-ranked subtyping errors.
+//
+// compile-flags:-Zno-leak-check
+
+#![feature(nll)]
+
+fn main() {
+    let x: fn(&'static ()) = |_| {};
+    let y: for<'a> fn(&'a ()) = x; //~ ERROR higher-ranked subtype error
+}

--- a/src/test/ui/nll/relate_tys/fn-subtype.stderr
+++ b/src/test/ui/nll/relate_tys/fn-subtype.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked subtype error
+  --> $DIR/fn-subtype.rs:9:33
+   |
+LL |     let y: for<'a> fn(&'a ()) = x;
+   |                                 ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/nll/relate_tys/trait-hrtb.rs
+++ b/src/test/ui/nll/relate_tys/trait-hrtb.rs
@@ -1,0 +1,16 @@
+// Test that NLL generates proper error spans for trait HRTB errors
+//
+// compile-flags:-Zno-leak-check
+
+#![feature(nll)]
+
+trait Foo<'a> {}
+
+fn make_foo<'a>() -> Box<dyn Foo<'a>> {
+    panic!()
+}
+
+fn main() {
+    let x: Box<dyn Foo<'static>> = make_foo();
+    let y: Box<dyn for<'a> Foo<'a>> = x; //~ ERROR higher-ranked subtype error
+}

--- a/src/test/ui/nll/relate_tys/trait-hrtb.stderr
+++ b/src/test/ui/nll/relate_tys/trait-hrtb.stderr
@@ -1,0 +1,8 @@
+error: higher-ranked subtype error
+  --> $DIR/trait-hrtb.rs:15:39
+   |
+LL |     let y: Box<dyn for<'a> Foo<'a>> = x;
+   |                                       ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/pat-lt-bracket-2.stderr
+++ b/src/test/ui/parser/pat-lt-bracket-2.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn a(B<) {}
    |       ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn a(_: B<) {}
+   |      ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
+++ b/src/test/ui/regions/region-bounds-on-objects-and-type-parameters.stderr
@@ -27,7 +27,7 @@ error[E0392]: parameter `'c` is never used
 LL | struct Foo<'a,'b,'c> {
    |                  ^^ unused parameter
    |
-   = help: consider removing `'c`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'c`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
+++ b/src/test/ui/rfc-2565-param-attrs/param-attrs-2018.stderr
@@ -5,6 +5,10 @@ LL | trait Trait2015 { fn foo(#[allow(C)] i32); }
    |                                         ^ expected one of `:`, `@`, or `|` here
    |
    = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL | trait Trait2015 { fn foo(#[allow(C)] self: i32); }
+   |                                      ^^^^^^^^^
 help: if this was a parameter name, give it a type
    |
 LL | trait Trait2015 { fn foo(#[allow(C)] i32: TypeName); }

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -76,7 +76,7 @@ error[E0392]: parameter `'Self` is never used
 LL | struct Bar<'Self>;
    |            ^^^^^ unused parameter
    |
-   = help: consider removing `'Self` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'Self`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 12 previous errors
 

--- a/src/test/ui/span/issue-34264.stderr
+++ b/src/test/ui/span/issue-34264.stderr
@@ -3,6 +3,12 @@ error: expected one of `:`, `@`, or `|`, found `<`
    |
 LL | fn foo(Option<i32>, String) {}
    |              ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | fn foo(_: Option<i32>, String) {}
+   |        ^^^^^^^^^
 
 error: expected one of `:`, `@`, or `|`, found `)`
   --> $DIR/issue-34264.rs:1:27

--- a/src/test/ui/suggestions/issue-64252-self-type.rs
+++ b/src/test/ui/suggestions/issue-64252-self-type.rs
@@ -1,0 +1,14 @@
+// This test checks that a suggestion to add a `self: ` parameter name is provided
+// to functions where this is applicable.
+
+pub fn foo(Box<Self>) { }
+//~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+
+struct Bar;
+
+impl Bar {
+    fn bar(Box<Self>) { }
+    //~^ ERROR expected one of `:`, `@`, or `|`, found `<`
+}
+
+fn main() { }

--- a/src/test/ui/suggestions/issue-64252-self-type.stderr
+++ b/src/test/ui/suggestions/issue-64252-self-type.stderr
@@ -1,0 +1,30 @@
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:4:15
+   |
+LL | pub fn foo(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL | pub fn foo(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: expected one of `:`, `@`, or `|`, found `<`
+  --> $DIR/issue-64252-self-type.rs:10:15
+   |
+LL |     fn bar(Box<Self>) { }
+   |               ^ expected one of `:`, `@`, or `|` here
+   |
+   = note: anonymous parameters are removed in the 2018 edition (see RFC 1685)
+help: if this is a `self` type, give it a parameter name
+   |
+LL |     fn bar(self: Box<Self>) { }
+   |            ^^^^^^^^^
+help: if this is a type, explicitly ignore the parameter name
+   |
+LL |     fn bar(_: Box<Self>) { }
+   |            ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-direct.stderr
+++ b/src/test/ui/variance/variance-regions-unused-direct.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct Bivariant<'a>;
    |                  ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'d` is never used
   --> $DIR/variance-regions-unused-direct.rs:7:19
@@ -12,7 +12,7 @@ error[E0392]: parameter `'d` is never used
 LL | struct Struct<'a, 'd> {
    |                   ^^ unused parameter
    |
-   = help: consider removing `'d`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'d`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-regions-unused-indirect.stderr
+++ b/src/test/ui/variance/variance-regions-unused-indirect.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Foo<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-regions-unused-indirect.rs:7:10
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum Bar<'a> {
    |          ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-region-param.stderr
+++ b/src/test/ui/variance/variance-unused-region-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `'a` is never used
 LL | struct SomeStruct<'a> { x: u32 }
    |                   ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `'a` is never used
   --> $DIR/variance-unused-region-param.rs:4:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `'a` is never used
 LL | enum SomeEnum<'a> { Nothing }
    |               ^^ unused parameter
    |
-   = help: consider removing `'a` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `'a`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field, or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -4,7 +4,7 @@ error[E0392]: parameter `A` is never used
 LL | struct SomeStruct<A> { x: u32 }
    |                   ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `A` is never used
   --> $DIR/variance-unused-type-param.rs:9:15
@@ -12,7 +12,7 @@ error[E0392]: parameter `A` is never used
 LL | enum SomeEnum<A> { Nothing }
    |               ^ unused parameter
    |
-   = help: consider removing `A` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `A`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error[E0392]: parameter `T` is never used
   --> $DIR/variance-unused-type-param.rs:13:15
@@ -20,7 +20,7 @@ error[E0392]: parameter `T` is never used
 LL | enum ListCell<T> {
    |               ^ unused parameter
    |
-   = help: consider removing `T` or using a marker such as `std::marker::PhantomData`
+   = help: consider removing `T`, refering to it in a field or using a marker such as `std::marker::PhantomData`
 
 error: aborting due to 3 previous errors
 

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -53,6 +53,9 @@ fn filter_dirs(path: &Path) -> bool {
         "src/tools/rls",
         "src/tools/rust-installer",
         "src/tools/rustfmt",
+
+        // Filter RLS output directories
+        "target/rls",
     ];
     skip.iter().any(|p| path.ends_with(p))
 }


### PR DESCRIPTION
Successful merges:

 - #63678 (Improve HRTB error span when -Zno-leak-check is used)
 - #64931 (Reword E0392 slightly)
 - #64959 (syntax: improve parameter without type suggestions)
 - #64975 (Implement Clone::clone_from for LinkedList)
 - #64993 (BacktraceStatus: add Eq impl)
 - #64998 (Filter out RLS output directories on tidy runs)
 - #65010 (Compare `primary` with maximum of `children`s' line num instead of dropping it)

Failed merges:


r? @ghost