### PR TITLE
Added doc about behavior of extend on HashMap

### DIFF
--- a/src/libstd/collections/hash/map.rs
+++ b/src/libstd/collections/hash/map.rs
@@ -2362,6 +2362,8 @@ where
     }
 }
 
+/// Inserts all new key-values from the iterator and replaces values with existing
+/// keys with new values returned from the iterator.
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K, V, S> Extend<(K, V)> for HashMap<K, V, S>
 where


### PR DESCRIPTION
It was unclear what the implementation does when it encounters existing keys. This change makes it clear by documenting the trait impl.