### PR TITLE
WIP: stability annotations on generic parameters

### DIFF
--- a/src/librustc/middle/privacy.rs
+++ b/src/librustc/middle/privacy.rs
@@ -12,7 +12,7 @@ use std::hash::Hash;
 // Accessibility levels, sorted in ascending order
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, HashStable)]
 pub enum AccessLevel {
-    /// Superset of `AccessLevel::Reachable` used to mark impl Trait items.
+    /// Superset of `AccessLevel::Reachable` used to mark `impl Trait` items.
     ReachableFromImplTrait,
     /// Exported items + items participating in various kinds of public interfaces,
     /// but not directly nameable. For example, if function `fn f() -> T {...}` is

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -281,14 +281,21 @@ impl<'tcx> TyCtxt<'tcx> {
     /// If `id` is `Some(_)`, this function will also check if the item at `def_id` has been
     /// deprecated. If the item is indeed deprecated, we will emit a deprecation lint attached to
     /// `id`.
-    pub fn eval_stability(self, def_id: DefId, id: Option<HirId>, span: Span) -> EvalResult {
+    pub fn eval_stability(
+        self,
+        def_id: DefId,
+        id: Option<HirId>,
+        span: Span,
+        inherit_dep: bool,
+    ) -> EvalResult {
         // Deprecated attributes apply in-crate and cross-crate.
         if let Some(id) = id {
             if let Some(depr_entry) = self.lookup_deprecation_entry(def_id) {
                 let parent_def_id = self.hir().local_def_id(self.hir().get_parent_item(id));
-                let skip = self
-                    .lookup_deprecation_entry(parent_def_id)
-                    .map_or(false, |parent_depr| parent_depr.same_origin(&depr_entry));
+                let skip = !inherit_dep
+                    || self
+                        .lookup_deprecation_entry(parent_def_id)
+                        .map_or(false, |parent_depr| parent_depr.same_origin(&depr_entry));
 
                 if !skip {
                     let (message, lint) =
@@ -386,9 +393,26 @@ impl<'tcx> TyCtxt<'tcx> {
     /// Additionally, this function will also check if the item is deprecated. If so, and `id` is
     /// not `None`, a deprecated lint attached to `id` will be emitted.
     pub fn check_stability(self, def_id: DefId, id: Option<HirId>, span: Span) {
+        self.check_stability_internal(def_id, id, span, true)
+    }
+
+    /// Checks if an item is stable or error out.
+    ///
+    /// If the item defined by `def_id` is unstable and the corresponding `#![feature]` does not
+    /// exist, emits an error.
+    ///
+    /// Additionally when `inherit_dep` is `true`, this function will also check if the item is deprecated. If so, and `id` is
+    /// not `None`, a deprecated lint attached to `id` will be emitted.
+    pub fn check_stability_internal(
+        self,
+        def_id: DefId,
+        id: Option<HirId>,
+        span: Span,
+        inherit_dep: bool,
+    ) {
         let soft_handler =
             |lint, span, msg: &_| self.lint_hir(lint, id.unwrap_or(hir::CRATE_HIR_ID), span, msg);
-        match self.eval_stability(def_id, id, span) {
+        match self.eval_stability(def_id, id, span, inherit_dep) {
             EvalResult::Allow => {}
             EvalResult::Deny { feature, reason, issue, is_soft } => {
                 report_unstable(self.sess, feature, reason, issue, is_soft, span, soft_handler)

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1579,9 +1579,13 @@ impl EncodeContext<'tcx> {
                         EntryKind::TypeParam,
                         default.is_some(),
                     );
+                    if default.is_some() {
+                        self.encode_stability(def_id);
+                    }
                 }
                 GenericParamKind::Const { .. } => {
                     self.encode_info_for_generic_param(def_id, EntryKind::ConstParam, true);
+                    // FIXME(const_generics:defaults)
                 }
             }
         }

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -309,7 +309,6 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             | Node::Ctor(..)
             | Node::Field(_)
             | Node::Ty(_)
-            | Node::GenericParam(_)
             | Node::MacroDef(_) => {}
             _ => {
                 bug!(

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -309,6 +309,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             | Node::Ctor(..)
             | Node::Field(_)
             | Node::Ty(_)
+            | Node::GenericParam(_)
             | Node::MacroDef(_) => {}
             _ => {
                 bug!(

--- a/src/librustc_passes/reachable.rs
+++ b/src/librustc_passes/reachable.rs
@@ -303,7 +303,7 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             Node::Expr(&hir::Expr { kind: hir::ExprKind::Closure(.., body, _, _), .. }) => {
                 self.visit_nested_body(body);
             }
-            // Nothing to recurse on for these
+            // Nothing to recurse on for these.
             Node::ForeignItem(_)
             | Node::Variant(_)
             | Node::Ctor(..)

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -138,10 +138,13 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             } else {
                 debug!("annotate: not found, parent = {:?}", self.parent_stab);
                 if let Some(stab) = self.parent_stab {
-                    // Instability (but not stability) is inherited from the parent.
+                    // Instability (but not typically stability) is inherited from the parent.
                     // If something is unstable, everything inside it should also be
                     // considered unstable.
-                    if stab.level.is_unstable() {
+                    // `AnnotationKind::Optional` items also inherit stability, as they may be
+                    // considered stable-by-default items, requiring an instability attribute to
+                    // override this.
+                    if stab.level.is_unstable() || kind == AnnotationKind::Optional {
                         self.index.stab_map.insert(hir_id, stab);
                     }
                 }
@@ -173,7 +176,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // Propagate unstability.  This can happen even for non-staged-api crates in case
             // -Zforce-unstable-if-unmarked is set.
             if let Some(stab) = self.parent_stab {
-                if stab.level.is_unstable() {
+                if stab.level.is_unstable() || kind == AnnotationKind::Optional {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -138,13 +138,10 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             } else {
                 debug!("annotate: not found, parent = {:?}", self.parent_stab);
                 if let Some(stab) = self.parent_stab {
-                    // Instability (but not typically stability) is inherited from the parent.
-                    // If something is unstable, everything inside it should also be
-                    // considered unstable.
-                    // `AnnotationKind::Optional` items also inherit stability, as they may be
-                    // considered stable-by-default items, requiring an instability attribute to
-                    // override this.
-                    if stab.level.is_unstable() || kind == AnnotationKind::Optional {
+                    // Instability is inherited from the parent: if something is unstable,
+                    // everything inside it should also be considered unstable for the same
+                    // reason.
+                    if stab.level.is_unstable() {
                         self.index.stab_map.insert(hir_id, stab);
                     }
                 }
@@ -176,7 +173,7 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             // Propagate unstability.  This can happen even for non-staged-api crates in case
             // -Zforce-unstable-if-unmarked is set.
             if let Some(stab) = self.parent_stab {
-                if stab.level.is_unstable() || kind == AnnotationKind::Optional {
+                if stab.level.is_unstable() {
                     self.index.stab_map.insert(hir_id, stab);
                 }
             }

--- a/src/librustc_passes/stability.rs
+++ b/src/librustc_passes/stability.rs
@@ -26,6 +26,20 @@ use std::cmp::Ordering;
 use std::mem::replace;
 use std::num::NonZeroU32;
 
+/// *** Adding stability attributes to a new kind of node ***
+///
+/// 1.  In `<Annotator as Visitor>`, visit the node and call `self.annotate` to record the new
+///     stability attribute. This will also do some validity checking for the attributes.
+/// 2.  If stability attributes should be required, visit the node in
+///     `<MissingStabilityAnnotations as Visitor>` and call `self.check_missing_stability`.
+/// 3.  If using `check_missing_stability`, you'll also need to make sure the node is reachable. In
+///     `ReachableContext::propagate_node` in `src/librustc_passes/reachable.rs`, make sure the node
+///     is handled. Then, in `<EmbargoVisitor as Visitor>` in `src/librustc_privacy`, visit the node
+///     and call `self.reach`.
+/// 4.  Finally, we need to make sure that stability information is recorded in crate metadata. In
+///     `src/librustc_metadata/rmeta/encoder.rs`, make sure that `self.encode_stability(def_id)` is
+///     called in the relevant `encode_info_for_[your node]` method.
+
 #[derive(PartialEq)]
 enum AnnotationKind {
     // Annotation is required if not inherited from unstable parents.

--- a/src/librustc_privacy/lib.rs
+++ b/src/librustc_privacy/lib.rs
@@ -946,20 +946,6 @@ impl Visitor<'tcx> for EmbargoVisitor<'tcx> {
             module_id = self.tcx.hir().get_parent_node(module_id);
         }
     }
-
-    fn visit_generic_param(&mut self, p: &'tcx hir::GenericParam<'tcx>) {
-        // Generic parameters cannot be directly accessed by users, so restricting privacy is
-        // unimportant here.
-        // However, parameters must be (at least) `Reachable` in order for stability requirements to
-        // be enforced (see `check_missing_stability` in `src/librustc_passes/stability.rs`).
-        match &p.kind {
-            // FIXME(const_generics:defaults)
-            hir::GenericParamKind::Type { default, .. } if default.is_some() => {
-                self.update(p.hir_id, Some(AccessLevel::Reachable));
-            }
-            _ => {}
-        }
-    }
 }
 
 impl ReachEverythingInTheInterfaceVisitor<'_, 'tcx> {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -697,7 +697,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
                     self.ast_region_to_region(&lt, Some(param)).into()
                 }
-                (GenericParamDefKind::Type { .. }, GenericArg::Type(ty)) => {
+                (GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
+                    if *has_default {
+                        tcx.check_stability(param.def_id, Some(arg.id()), arg.span());
+                    }
+
                     self.ast_ty_to_ty(&ty).into()
                 }
                 (GenericParamDefKind::Const, GenericArg::Const(ct)) => {

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -2,6 +2,7 @@
 //! Conversion from AST representation of types to the `ty.rs` representation.
 //! The main routine here is `ast_ty_to_ty()`; each use is parameterized by an
 //! instance of `AstConv`.
+// ignore-tidy-filelength
 
 // ignore-tidy-filelength
 

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -699,7 +699,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 }
                 (GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
                     if *has_default {
-                        tcx.check_stability(param.def_id, Some(arg.id()), arg.span());
+                        tcx.check_stability_internal(
+                            param.def_id,
+                            Some(arg.id()),
+                            arg.span(),
+                            false,
+                        );
                     }
 
                     self.ast_ty_to_ty(&ty).into()

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -705,6 +705,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                             Some(arg.id()),
                             arg.span(),
                             false,
+                            |_, _| (),
                         );
                     }
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1252,7 +1252,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         if let Some(uc) = unstable_candidates {
             applicable_candidates.retain(|&(p, _)| {
                 if let stability::EvalResult::Deny { feature, .. } =
-                    self.tcx.eval_stability(p.item.def_id, None, self.span)
+                    self.tcx.eval_stability(p.item.def_id, None, self.span, false)
                 {
                     uc.push((p, feature));
                     return false;

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1155,7 +1155,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
                             param.span,
                             &format!(
                                 "defaults for type parameters are only allowed in \
-                                        `struct`, `enum`, `type`, or `trait` definitions."
+                                        `struct`, `enum`, `type`, or `trait` definitions"
                             ),
                         );
                     }

--- a/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
+++ b/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
@@ -1,4 +1,4 @@
-error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions.
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:3:8
    |
 LL | fn avg<T=i32>(_: T) {}
@@ -8,7 +8,7 @@ LL | fn avg<T=i32>(_: T) {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
 
-error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions.
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:8:6
    |
 LL | impl<T=i32> S<T> {}

--- a/src/test/ui/missing/missing-stability.rs
+++ b/src/test/ui/missing/missing-stability.rs
@@ -16,7 +16,7 @@ pub mod foo {
     pub fn unmarked() {}
 }
 
-#[stable(feature = "stable_test_feature", since="1.0.0")]
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
 pub mod bar {
     // #[stable] is not inherited
     pub fn unmarked() {}

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -4,7 +4,13 @@
 #![stable(feature = "stable_test_feature", since = "1.0.0")]
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
-pub trait Trait<#[unstable(feature = "ty", issue = "none")] T = ()> {
+pub trait Trait1<#[unstable(feature = "unstable_default", issue = "none")] T = ()> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait2<T = ()> {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     fn foo() -> T;
 }

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -1,0 +1,10 @@
+#![crate_type = "lib"]
+#![feature(staged_api)]
+
+#![stable(feature = "stable_test_feature", since = "1.0.0")]
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait<#[unstable(feature = "ty", issue = "none")] T = ()> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -14,3 +14,22 @@ pub trait Trait2<T = ()> {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     fn foo() -> T;
 }
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct1<#[unstable(feature = "unstable_default", issue = "none")] T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: T,
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub struct Struct2<T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    pub field: T,
+}
+
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT1: Struct1 = Struct1 { field: 1 };
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub const STRUCT2: Struct2 = Struct2 { field: 1 };

--- a/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
+++ b/src/test/ui/stability-attribute/auxiliary/unstable_generic_param.rs
@@ -10,7 +10,13 @@ pub trait Trait1<#[unstable(feature = "unstable_default", issue = "none")] T = (
 }
 
 #[stable(feature = "stable_test_feature", since = "1.0.0")]
-pub trait Trait2<T = ()> {
+pub trait Trait2<#[unstable(feature = "unstable_default", issue = "none")] T = usize> {
+    #[stable(feature = "stable_test_feature", since = "1.0.0")]
+    fn foo() -> T;
+}
+
+#[stable(feature = "stable_test_feature", since = "1.0.0")]
+pub trait Trait3<T = ()> {
     #[stable(feature = "stable_test_feature", since = "1.0.0")]
     fn foo() -> T;
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -16,7 +16,15 @@ impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_d
     fn foo() -> usize { 0 }
 }
 
-impl Trait2<usize> for S {
+impl Trait1<isize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait2<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait3<usize> for S {
     fn foo() -> usize { 0 } // ok
 }
 
@@ -25,9 +33,9 @@ fn main() {
 
     let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
     let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1<usize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
 
-    let _ = STRUCT1;
+    let _ = STRUCT1; // ok
     let _: Struct1 = STRUCT1; // ok
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
     let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -2,7 +2,7 @@
 
 extern crate unstable_generic_param;
 
-use unstable_generic_param::{Trait1, Trait2};
+use unstable_generic_param::*;
 
 struct R;
 
@@ -22,4 +22,30 @@ impl Trait2<usize> for S {
 
 fn main() {
     let _ = S;
+
+    let _ = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1 = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<usize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+
+    let _ = STRUCT1;
+    let _: Struct1 = STRUCT1; // ok
+    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field; // ok
+    let _: usize = STRUCT1.field; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1; //~ ERROR use of unstable library feature 'unstable_default'
+    let _ = STRUCT1.field + 1usize; //~ ERROR use of unstable library feature 'unstable_default'
+
+    let _ = Struct2 { field: 1 }; // ok
+    let _: Struct2 = Struct2 { field: 1 }; // ok
+    let _: Struct2<usize> = Struct2 { field: 1 }; // ok
+
+    let _ = STRUCT2;
+    let _: Struct2 = STRUCT2; // ok
+    let _: Struct2<usize> = STRUCT2; // ok
+    let _: Struct2<usize> = STRUCT2; // ok
+    let _ = STRUCT2.field; // ok
+    let _: usize = STRUCT2.field; // ok
+    let _ = STRUCT2.field + 1; // ok
+    let _ = STRUCT2.field + 1usize; // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -2,12 +2,22 @@
 
 extern crate unstable_generic_param;
 
-use unstable_generic_param::Trait;
+use unstable_generic_param::{Trait1, Trait2};
+
+struct R;
+
+impl Trait1 for S {
+    fn foo() -> () { () } // ok
+}
 
 struct S;
 
-impl Trait<usize> for S {
+impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
     fn foo() -> usize { 0 }
+}
+
+impl Trait2<usize> for S {
+    fn foo() -> usize { 0 } // ok
 }
 
 fn main() {

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -1,0 +1,15 @@
+// aux-build:unstable_generic_param.rs
+
+extern crate unstable_generic_param;
+
+use unstable_generic_param::Trait;
+
+struct S;
+
+impl Trait<usize> for S {
+    fn foo() -> usize { 0 }
+}
+
+fn main() {
+    let _ = S;
+}

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -6,6 +6,22 @@ LL | impl Trait1<usize> for S {
    |
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:19:13
+   |
+LL | impl Trait1<isize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:23:13
+   |
+LL | impl Trait2<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -1,0 +1,11 @@
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability.rs:15:13
+   |
+LL | impl Trait1<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -63,7 +63,7 @@ fn multiple3() { }
 #[rustc_const_unstable(feature = "c", issue = "none")]
 #[rustc_const_unstable(feature = "d", issue = "none")] //~ ERROR multiple stability levels
 pub const fn multiple4() { } //~ ERROR multiple rustc_deprecated attributes [E0540]
-//~^ ERROR Invalid stability or deprecation version found
+//~^ ERROR item has an invalid stability or deprecation version
 
 #[rustc_deprecated(since = "a", reason = "text")]
 fn deprecated_without_unstable_or_stable() { }

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -94,7 +94,7 @@ error[E0544]: multiple stability levels
 LL | #[rustc_const_unstable(feature = "d", issue = "none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Invalid stability or deprecation version found
+error: item has an invalid stability or deprecation version
   --> $DIR/stability-attribute-sanity.rs:65:1
    |
 LL | pub const fn multiple4() { }


### PR DESCRIPTION
This will be a fix to [wg-allocators #2](https://github.com/rust-lang/wg-allocators/issues/2).
I'm currently trying to figure out why `src/test/ui/stability-attribute/stability-attribute-generic.rs` does not produce the desired error.