### PR TITLE
make is_power_of_two a const function

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3749,8 +3749,8 @@ assert!(!10", stringify!($SelfT), ".is_power_of_two());", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline]
-            pub fn is_power_of_two(self) -> bool {
-                (self.wrapping_sub(1)) & self == 0 && !(self == 0)
+            pub const fn is_power_of_two(self) -> bool {
+                ((self.wrapping_sub(1)) & self == 0) & !(self == 0)
             }
         }
 

--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3750,7 +3750,7 @@ assert!(!10", stringify!($SelfT), ".is_power_of_two());", $EndFeature, "
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline]
             pub const fn is_power_of_two(self) -> bool {
-                ((self.wrapping_sub(1)) & self == 0) & !(self == 0)
+                self.count_ones() == 1
             }
         }
 

--- a/src/test/ui/consts/const-int-pow-rpass.rs
+++ b/src/test/ui/consts/const-int-pow-rpass.rs
@@ -1,0 +1,11 @@
+// run-pass
+
+const IS_POWER_OF_TWO_A: bool = 0u32.is_power_of_two();
+const IS_POWER_OF_TWO_B: bool = 32u32.is_power_of_two();
+const IS_POWER_OF_TWO_C: bool = 33u32.is_power_of_two();
+
+fn main() {
+    assert!(!IS_POWER_OF_TWO_A);
+    assert!(IS_POWER_OF_TWO_B);
+    assert!(!IS_POWER_OF_TWO_C);
+}


### PR DESCRIPTION
This makes `is_power_of_two` a const function by using `&` instead of short-circuiting `&&`; Rust supports bitwise `&` for `bool` and short-circuiting is not required in the existing expression.

I don't think this needs a const-hack label as I don't find the changed code less readable, if anything I prefer that it is clearer that short circuiting is not used.

@oli-obk