### PR TITLE
remove event that causes panics in measureme tools

### DIFF
--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -321,8 +321,6 @@ pub fn start_async_codegen<B: ExtraBackendMethods>(
     let (coordinator_send, coordinator_receive) = channel();
     let sess = tcx.sess;
 
-    sess.prof.generic_activity_start("codegen_and_optimize_crate");
-
     let crate_name = tcx.crate_name(LOCAL_CRATE);
     let crate_hash = tcx.crate_hash(LOCAL_CRATE);
     let no_builtins = attr::contains_name(&tcx.hir().krate().attrs, sym::no_builtins);
@@ -1773,8 +1771,6 @@ impl<B: ExtraBackendMethods> OngoingCodegen<B> {
         if sess.codegen_units() == 1 && sess.time_llvm_passes() {
             self.backend.print_pass_timings()
         }
-
-        sess.prof.generic_activity_end("codegen_and_optimize_crate");
 
         (CodegenResults {
             crate_name: self.crate_name,


### PR DESCRIPTION
the measureme tools summarize and crox do not alow a event to go out of scope of the parent event

codegen_and_optimize_crate ends after the codegen_crate event

r? @wesleywiser 
cc @michaelwoerister @Mark-Simulacrum 