### PR TITLE
Use a single map for the CurrentDepGraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,7 @@ dependencies = [
  "chalk-engine",
  "fmt_macros",
  "graphviz",
+ "indexmap",
  "jobserver",
  "log",
  "measureme",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -37,3 +37,4 @@ chalk-engine = { version = "0.9.0", default-features=false }
 rustc_fs_util = { path = "../librustc_fs_util" }
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }
 measureme = "0.3"
+indexmap = "1"


### PR DESCRIPTION
An IndexMap instead of a HashMap and IndexVec is used. Internally this is much the same, but wrapping the two into one data structure is less prone to accidents of updating just one and is cleaner. Big-O lookups are the same as previously for DepNode/DepNodeIndex, so performance wise this is not expected to have significant effect. IndexMap retains the same cache characteristics though at our size it probably has little to no effect. 

Changes here are pretty straightforward, though could be made even more so with an addition to librustc_index that exposes a wrapper around IndexMap which seamlessly presents `Idx` implementing indices rather than needing conversions to/from `usize` (which may even be costly, but this is unlikely).

cc @Zoxc as this'll both conflict but also help with #63756, at least from an audit perspective

r? @michaelwoerister @nikomatsakis 