### PR TITLE
Improve message when attempting to instantiate tuple structs with private fields

### DIFF
--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -33,6 +33,7 @@ use syntax::source_map;
 use syntax::edition::Edition;
 use syntax::parse::source_file_to_stream;
 use syntax::parse::parser::emit_unclosed_delims;
+use syntax::source_map::Spanned;
 use syntax::symbol::Symbol;
 use syntax_pos::{Span, FileName};
 use rustc_index::bit_set::BitSet;
@@ -420,8 +421,8 @@ impl cstore::CStore {
         self.get_crate_data(cnum).root.edition
     }
 
-    pub fn struct_field_names_untracked(&self, def: DefId) -> Vec<ast::Name> {
-        self.get_crate_data(def.krate).get_struct_field_names(def.index)
+    pub fn struct_field_names_untracked(&self, def: DefId, sess: &Session) -> Vec<Spanned<Symbol>> {
+        self.get_crate_data(def.krate).get_struct_field_names(def.index, sess)
     }
 
     pub fn ctor_kind_untracked(&self, def: DefId) -> def::CtorKind {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -29,7 +29,7 @@ use std::u32;
 use rustc_serialize::{Decodable, Decoder, SpecializedDecoder, opaque};
 use syntax::attr;
 use syntax::ast::{self, Ident};
-use syntax::source_map;
+use syntax::source_map::{self, respan, Spanned};
 use syntax::symbol::{Symbol, sym};
 use syntax::ext::base::{MacroKind, SyntaxExtensionKind, SyntaxExtension};
 use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, symbol::{InternedString}};
@@ -1021,11 +1021,11 @@ impl<'a, 'tcx> CrateMetadata {
         Lrc::from(self.get_attributes(&item, sess))
     }
 
-    pub fn get_struct_field_names(&self, id: DefIndex) -> Vec<ast::Name> {
+    pub fn get_struct_field_names(&self, id: DefIndex, sess: &Session) -> Vec<Spanned<ast::Name>> {
         self.entry(id)
             .children
             .decode(self)
-            .map(|index| self.item_name(index))
+            .map(|index| respan(self.get_span(index, sess), self.item_name(index)))
             .collect()
     }
 

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -497,7 +497,8 @@ impl<'a> LateResolutionVisitor<'a, '_> {
                         Res::Def(DefKind::Struct, did) | Res::Def(DefKind::Union, did)
                                 if resolution.unresolved_segments() == 0 => {
                             if let Some(field_names) = self.r.field_names.get(&did) {
-                                if field_names.iter().any(|&field_name| ident.name == field_name) {
+                                if field_names.iter()
+                                        .any(|&field_name| ident.name == field_name.node) {
                                     return Some(AssocSuggestion::Field);
                                 }
                             }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -47,6 +47,7 @@ use syntax::attr;
 use syntax::ast::{CRATE_NODE_ID, Crate};
 use syntax::ast::{ItemKind, Path};
 use syntax::{struct_span_err, unwrap_or};
+use syntax::source_map::Spanned;
 
 use syntax_pos::{Span, DUMMY_SP};
 use errors::{Applicability, DiagnosticBuilder};
@@ -840,7 +841,7 @@ pub struct Resolver<'a> {
 
     /// Names of fields of an item `DefId` accessible with dot syntax.
     /// Used for hints during error reporting.
-    field_names: FxHashMap<DefId, Vec<Name>>,
+    field_names: FxHashMap<DefId, Vec<Spanned<Name>>>,
 
     /// All imports known to succeed or fail.
     determined_imports: Vec<&'a ImportDirective<'a>>,

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -1,386 +1,482 @@
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:51:16
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a = a::A(());
    |                ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:52:16
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let b = a::B(2);
    |                ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:53:16
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let c = a::C(2, 3);
    |                ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:56:12
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::A(()) = a;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:57:12
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::A(_) = a;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:58:18
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match a { a::A(()) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:59:18
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match a { a::A(_) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:61:12
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::B(_) = b;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:62:12
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::B(_b) = b;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:63:18
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match b { a::B(_) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:64:18
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match b { a::B(_b) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:65:18
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:65:32
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:68:12
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::C(_, _) = c;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:69:12
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::C(_a, _) = c;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:70:12
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::C(_, _b) = c;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:71:12
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a::C(_a, _b) = c;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:72:18
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match c { a::C(_, _) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:73:18
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match c { a::C(_a, _) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:74:18
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match c { a::C(_, _b) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:75:18
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:83:17
    |
+LL |     pub struct A(());
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let a2 = a::A;
    |                 ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:84:17
    |
+LL |     pub struct B(isize);
+   |                  ----- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let b2 = a::B;
    |                 ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:85:17
    |
+LL |     pub struct C(pub isize, isize);
+   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let c2 = a::C;
    |                 ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:90:20
    |
 LL |     let a = other::A(());
    |                    ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:91:20
    |
 LL |     let b = other::B(2);
    |                    ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:92:20
    |
 LL |     let c = other::C(2, 3);
    |                    ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:95:16
    |
 LL |     let other::A(()) = a;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:96:16
    |
 LL |     let other::A(_) = a;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:97:22
    |
 LL |     match a { other::A(()) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:98:22
    |
 LL |     match a { other::A(_) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:100:16
    |
 LL |     let other::B(_) = b;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:101:16
    |
 LL |     let other::B(_b) = b;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:102:22
    |
 LL |     match b { other::B(_) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:103:22
    |
 LL |     match b { other::B(_b) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:104:22
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:104:40
    |
 LL |     match b { other::B(1) => {} other::B(_) => {} }
    |                                        ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:107:16
    |
 LL |     let other::C(_, _) = c;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:108:16
    |
 LL |     let other::C(_a, _) = c;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:109:16
    |
 LL |     let other::C(_, _b) = c;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:110:16
    |
 LL |     let other::C(_a, _b) = c;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:111:22
    |
 LL |     match c { other::C(_, _) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:112:22
    |
 LL |     match c { other::C(_a, _) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:113:22
    |
 LL |     match c { other::C(_, _b) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:114:22
    |
 LL |     match c { other::C(_a, _b) => {} }
    |                      ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `A` is private
   --> $DIR/privacy5.rs:122:21
    |
 LL |     let a2 = other::A;
    |                     ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct A(());
+   |              -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `B` is private
   --> $DIR/privacy5.rs:123:21
    |
 LL |     let b2 = other::B;
    |                     ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct B(isize);
+   |              ----- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `C` is private
   --> $DIR/privacy5.rs:124:21
    |
 LL |     let c2 = other::C;
    |                     ^
+   | 
+  ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct C(pub isize, isize);
+   |              ---------------- a tuple struct constructor is private if any of its fields is private
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -37,50 +37,60 @@ LL | use m::S;
 error[E0603]: tuple struct `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12
    |
+LL |         pub(in m) struct Z(pub(in m::n) u8);
+   |                            --------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |         n::Z;
    |            ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:29:8
    |
+LL |     pub struct S(u8);
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     m::S;
    |        ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:31:19
    |
+LL |     pub struct S(u8);
+   |                  -- a tuple struct constructor is private if any of its fields is private
+...
 LL |     let _: S = m::S(2);
    |                   ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `Z` is private
   --> $DIR/privacy-struct-ctor.rs:35:11
    |
+LL |         pub(in m) struct Z(pub(in m::n) u8);
+   |                            --------------- a tuple struct constructor is private if any of its fields is private
+...
 LL |     m::n::Z;
    |           ^
-   |
-   = note: a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `S` is private
   --> $DIR/privacy-struct-ctor.rs:41:16
    |
 LL |     xcrate::m::S;
    |                ^
+   | 
+  ::: $DIR/auxiliary/privacy-struct-ctor.rs:2:18
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL |     pub struct S(u8);
+   |                  -- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: tuple struct `Z` is private
   --> $DIR/privacy-struct-ctor.rs:45:19
    |
 LL |     xcrate::m::n::Z;
    |                   ^
+   | 
+  ::: $DIR/auxiliary/privacy-struct-ctor.rs:5:28
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL |         pub(in m) struct Z(pub(in m::n) u8);
+   |                            --------------- a tuple struct constructor is private if any of its fields is private
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -15,8 +15,11 @@ error[E0603]: tuple struct `TupleStruct` is private
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);
    |                                ^^^^^^^^^^^
+   | 
+  ::: $DIR/auxiliary/structs.rs:13:24
    |
-   = note: a tuple struct constructor is private if any of its fields is private
+LL | pub struct TupleStruct(pub u16, pub u16);
+   |                        ---------------- a tuple struct constructor is private if any of its fields is private
 
 error[E0603]: unit struct `UnitStruct` is private
   --> $DIR/struct.rs:32:32

--- a/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/variant.stderr
@@ -3,8 +3,6 @@ error[E0603]: tuple variant `Tuple` is private
    |
 LL |     let variant_tuple = NonExhaustiveVariants::Tuple(640);
    |                                                ^^^^^
-   |
-   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0603]: unit variant `Unit` is private
   --> $DIR/variant.rs:14:47
@@ -23,16 +21,12 @@ error[E0603]: tuple variant `Tuple` is private
    |
 LL |         NonExhaustiveVariants::Tuple(fe_tpl) => "",
    |                                ^^^^^
-   |
-   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0603]: tuple variant `Tuple` is private
   --> $DIR/variant.rs:26:35
    |
 LL |     if let NonExhaustiveVariants::Tuple(fe_tpl) = variant_struct {
    |                                   ^^^^^
-   |
-   = note: a tuple variant constructor is private if any of its fields is private
 
 error[E0639]: cannot create non-exhaustive variant using struct expression
   --> $DIR/variant.rs:8:26


### PR DESCRIPTION
Fixes #58017, fixes #39703.

```
error[E0603]: tuple struct `Error` is private
  --> main.rs:22:16
   |
2  |     pub struct Error(usize, pub usize, usize);
   |                      -----             ----- field is private
   |                      |
   |                      field is private
...
22 |     let x = a::Error(3, 1, 2);
   |                ^^^^^
   |
   = note: a tuple struct constructor is private if any of its fields is private
```