### PR TITLE
Suggest to add `move` keyword for generator capture

### DIFF
--- a/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/explain_borrow/mod.rs
@@ -17,6 +17,7 @@ use syntax_pos::Span;
 
 mod find_use;
 
+#[derive(Debug)]
 pub(in crate::borrow_check) enum BorrowExplanation {
     UsedLater(LaterUseKind, Span),
     UsedLaterInLoop(LaterUseKind, Span),
@@ -35,7 +36,7 @@ pub(in crate::borrow_check) enum BorrowExplanation {
     Unexplained,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub(in crate::borrow_check) enum LaterUseKind {
     TraitCapture,
     ClosureCapture,

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.fixed
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.fixed
@@ -3,7 +3,7 @@
 
 fn foo() -> Box<impl std::future::Future<Output = u32>> {
     let x = 0u32;
-    Box::new(async { x } )
+    Box::new(async move { x } )
     //~^ ERROR E0373
 }
 

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.rs
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.rs
@@ -1,0 +1,9 @@
+// edition:2018
+#![feature(async_closure,async_await)]
+fn foo() -> Box<impl std::future::Future<Output = u32>> {
+    let x = 0u32;
+    Box::new(async { x } )
+    //~^ ERROR E0373
+}
+
+fn main() {}

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
@@ -1,5 +1,5 @@
 error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
-  --> $DIR/async-borrowck-escaping-block-error.rs:5:20
+  --> $DIR/async-borrowck-escaping-block-error.rs:6:20
    |
 LL |     Box::new(async { x } )
    |                    ^^-^^
@@ -8,7 +8,7 @@ LL |     Box::new(async { x } )
    |                    may outlive borrowed value `x`
    |
 note: generator is returned here
-  --> $DIR/async-borrowck-escaping-block-error.rs:3:13
+  --> $DIR/async-borrowck-escaping-block-error.rs:4:13
    |
 LL | fn foo() -> Box<impl std::future::Future<Output = u32>> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
+++ b/src/test/ui/async-await/async-borrowck-escaping-block-error.stderr
@@ -1,0 +1,22 @@
+error[E0373]: closure may outlive the current function, but it borrows `x`, which is owned by the current function
+  --> $DIR/async-borrowck-escaping-block-error.rs:5:20
+   |
+LL |     Box::new(async { x } )
+   |                    ^^-^^
+   |                    | |
+   |                    | `x` is borrowed here
+   |                    may outlive borrowed value `x`
+   |
+note: generator is returned here
+  --> $DIR/async-borrowck-escaping-block-error.rs:3:13
+   |
+LL | fn foo() -> Box<impl std::future::Future<Output = u32>> {
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to force the closure to take ownership of `x` (and any other referenced variables), use the `move` keyword
+   |
+LL |     Box::new(async move { x } )
+   |                    ^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0373`.


### PR DESCRIPTION
 Closes #64382
r? @estebank 