### PR TITLE
use 'invalid argument' for vxWorks

### DIFF
--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -3112,8 +3112,10 @@ mod tests {
 
         #[cfg(windows)]
         let invalid_options = 87; // ERROR_INVALID_PARAMETER
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "vxworks")))]
         let invalid_options = "Invalid argument";
+        #[cfg(target_os = "vxworks")]
+        let invalid_options = "invalid argument";
 
         // Test various combinations of creation modes and access modes.
         //


### PR DESCRIPTION
vxWorks is using "invalid argument" instead of "Invalid argument" in reporting invalid options

r? @rkruppe 