### PR TITLE
Lockless LintStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,6 +3483,7 @@ dependencies = [
  "rustc_data_structures",
  "rustc_errors",
  "rustc_interface",
+ "rustc_lint",
  "rustc_metadata",
  "rustc_mir",
  "rustc_plugin",

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -22,7 +22,7 @@ declare_lint! {
     pub CONST_ERR,
     Deny,
     "constant evaluation detected erroneous expression",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 declare_lint! {
@@ -71,7 +71,7 @@ declare_lint! {
     pub UNREACHABLE_CODE,
     Warn,
     "detects unreachable code paths",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 declare_lint! {
@@ -211,7 +211,7 @@ declare_lint! {
     pub DEPRECATED,
     Warn,
     "detects use of deprecated items",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 declare_lint! {
@@ -381,7 +381,7 @@ declare_lint! {
     pub DEPRECATED_IN_FUTURE,
     Allow,
     "detects use of items that will be deprecated in a future version",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 declare_lint! {

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -4,11 +4,12 @@
 //! compiler code, rather than using their own custom pass. Those
 //! lints are all available in `rustc_lint::builtin`.
 
-use crate::lint::{LintPass, LateLintPass, LintArray};
+use crate::lint::{LintPass, LateLintPass, LintArray, FutureIncompatibleInfo};
 use crate::middle::stability;
 use crate::session::Session;
 use errors::{Applicability, DiagnosticBuilder, pluralise};
 use syntax::ast;
+use syntax::edition::Edition;
 use syntax::source_map::Span;
 use syntax::symbol::Symbol;
 
@@ -125,7 +126,11 @@ declare_lint! {
 declare_lint! {
     pub PRIVATE_IN_PUBLIC,
     Warn,
-    "detect private items in public interfaces not caught by the old implementation"
+    "detect private items in public interfaces not caught by the old implementation",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
+        edition: None,
+    };
 }
 
 declare_lint! {
@@ -137,13 +142,21 @@ declare_lint! {
 declare_lint! {
     pub PUB_USE_OF_PRIVATE_EXTERN_CRATE,
     Deny,
-    "detect public re-exports of private extern crates"
+    "detect public re-exports of private extern crates",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub INVALID_TYPE_PARAM_DEFAULT,
     Deny,
-    "type parameter default erroneously allowed in invalid location"
+    "type parameter default erroneously allowed in invalid location",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
+        edition: None,
+    };
 }
 
 declare_lint! {
@@ -155,56 +168,92 @@ declare_lint! {
 declare_lint! {
     pub SAFE_EXTERN_STATICS,
     Deny,
-    "safe access to extern statics was erroneously allowed"
+    "safe access to extern statics was erroneously allowed",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub SAFE_PACKED_BORROWS,
     Warn,
-    "safe borrows of fields of packed structs were was erroneously allowed"
+    "safe borrows of fields of packed structs were was erroneously allowed",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #46043 <https://github.com/rust-lang/rust/issues/46043>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub PATTERNS_IN_FNS_WITHOUT_BODY,
     Warn,
-    "patterns in functions without body were erroneously allowed"
+    "patterns in functions without body were erroneously allowed",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #35203 <https://github.com/rust-lang/rust/issues/35203>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub LEGACY_DIRECTORY_OWNERSHIP,
     Deny,
     "non-inline, non-`#[path]` modules (e.g., `mod foo;`) were erroneously allowed in some files \
-     not named `mod.rs`"
+     not named `mod.rs`",
+     @future_incompatible = FutureIncompatibleInfo {
+         reference: "issue #37872 <https://github.com/rust-lang/rust/issues/37872>",
+         edition: None,
+     };
 }
 
 declare_lint! {
     pub LEGACY_CONSTRUCTOR_VISIBILITY,
     Deny,
-    "detects use of struct constructors that would be invisible with new visibility rules"
+    "detects use of struct constructors that would be invisible with new visibility rules",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #39207 <https://github.com/rust-lang/rust/issues/39207>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub MISSING_FRAGMENT_SPECIFIER,
     Deny,
-    "detects missing fragment specifiers in unused `macro_rules!` patterns"
+    "detects missing fragment specifiers in unused `macro_rules!` patterns",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES,
     Deny,
-    "detects parenthesized generic parameters in type and module names"
+    "detects parenthesized generic parameters in type and module names",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub LATE_BOUND_LIFETIME_ARGUMENTS,
     Warn,
-    "detects generic lifetime arguments in path segments with late bound lifetime parameters"
+    "detects generic lifetime arguments in path segments with late bound lifetime parameters",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #42868 <https://github.com/rust-lang/rust/issues/42868>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub ORDER_DEPENDENT_TRAIT_OBJECTS,
     Deny,
-    "trait-object types were treated as different depending on marker-trait order"
+    "trait-object types were treated as different depending on marker-trait order",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #56484 <https://github.com/rust-lang/rust/issues/56484>",
+        edition: None,
+    };
 }
 
 declare_lint! {
@@ -247,7 +296,11 @@ declare_lint! {
 declare_lint! {
     pub TYVAR_BEHIND_RAW_POINTER,
     Warn,
-    "raw pointer to an inference variable"
+    "raw pointer to an inference variable",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #46906 <https://github.com/rust-lang/rust/issues/46906>",
+        edition: Some(Edition::Edition2018),
+    };
 }
 
 declare_lint! {
@@ -266,19 +319,33 @@ declare_lint! {
     pub ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
     Allow,
     "fully qualified paths that start with a module name \
-     instead of `crate`, `self`, or an extern crate name"
+     instead of `crate`, `self`, or an extern crate name",
+     @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #53130 <https://github.com/rust-lang/rust/issues/53130>",
+        edition: Some(Edition::Edition2018),
+     };
 }
 
 declare_lint! {
     pub ILLEGAL_FLOATING_POINT_LITERAL_PATTERN,
     Warn,
-    "floating-point literals cannot be used in patterns"
+    "floating-point literals cannot be used in patterns",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub UNSTABLE_NAME_COLLISIONS,
     Warn,
-    "detects name collision with an existing but unstable method"
+    "detects name collision with an existing but unstable method",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #48919 <https://github.com/rust-lang/rust/issues/48919>",
+        edition: None,
+        // Note: this item represents future incompatibility of all unstable functions in the
+        //       standard library, and thus should never be removed or changed to an error.
+    };
 }
 
 declare_lint! {
@@ -296,7 +363,11 @@ declare_lint! {
 declare_lint! {
     pub DUPLICATE_MACRO_EXPORTS,
     Deny,
-    "detects duplicate macro exports"
+    "detects duplicate macro exports",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #35896 <https://github.com/rust-lang/rust/issues/35896>",
+        edition: Some(Edition::Edition2018),
+    };
 }
 
 declare_lint! {
@@ -320,13 +391,21 @@ declare_lint! {
 declare_lint! {
     pub WHERE_CLAUSES_OBJECT_SAFETY,
     Warn,
-    "checks the object safety of where clauses"
+    "checks the object safety of where clauses",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #51443 <https://github.com/rust-lang/rust/issues/51443>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
     Warn,
-    "detects proc macro derives using inaccessible names from parent modules"
+    "detects proc macro derives using inaccessible names from parent modules",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #50504 <https://github.com/rust-lang/rust/issues/50504>",
+        edition: None,
+    };
 }
 
 declare_lint! {
@@ -340,7 +419,11 @@ declare_lint! {
     pub MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
     Deny,
     "macro-expanded `macro_export` macros from the current crate \
-     cannot be referred to by absolute paths"
+     cannot be referred to by absolute paths",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
+        edition: None,
+    };
 }
 
 declare_lint! {
@@ -353,7 +436,11 @@ declare_lint! {
     pub INDIRECT_STRUCTURAL_MATCH,
     // defaulting to allow until rust-lang/rust#62614 is fixed.
     Allow,
-    "pattern with const indirectly referencing non-`#[structural_match]` type"
+    "pattern with const indirectly referencing non-`#[structural_match]` type",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #62411 <https://github.com/rust-lang/rust/issues/62411>",
+        edition: None,
+    };
 }
 
 /// Some lints that are buffered from `libsyntax`. See `syntax::early_buffered_lints`.
@@ -361,7 +448,11 @@ pub mod parser {
     declare_lint! {
         pub ILL_FORMED_ATTRIBUTE_INPUT,
         Warn,
-        "ill-formed attribute inputs that were previously accepted and used in practice"
+        "ill-formed attribute inputs that were previously accepted and used in practice",
+        @future_incompatible = super::FutureIncompatibleInfo {
+            reference: "issue #57571 <https://github.com/rust-lang/rust/issues/57571>",
+            edition: None,
+        };
     }
 
     declare_lint! {
@@ -387,25 +478,41 @@ declare_lint! {
 declare_lint! {
     pub AMBIGUOUS_ASSOCIATED_ITEMS,
     Deny,
-    "ambiguous associated items"
+    "ambiguous associated items",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #57644 <https://github.com/rust-lang/rust/issues/57644>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub NESTED_IMPL_TRAIT,
     Warn,
-    "nested occurrence of `impl Trait` type"
+    "nested occurrence of `impl Trait` type",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #59014 <https://github.com/rust-lang/rust/issues/59014>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub MUTABLE_BORROW_RESERVATION_CONFLICT,
     Warn,
-    "reservation of a two-phased borrow conflicts with other shared borrows"
+    "reservation of a two-phased borrow conflicts with other shared borrows",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #59159 <https://github.com/rust-lang/rust/issues/59159>",
+        edition: None,
+    };
 }
 
 declare_lint! {
     pub SOFT_UNSTABLE,
     Deny,
-    "a feature gate that doesn't break dependent crates"
+    "a feature gate that doesn't break dependent crates",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #64266 <https://github.com/rust-lang/rust/issues/64266>",
+        edition: None,
+    };
 }
 
 declare_lint_pass! {

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -169,22 +169,18 @@ impl LintStore {
     }
 
     pub fn register_early_pass(&mut self, pass: EarlyLintPassObject) {
-        self.register_lints(&pass.get_lints());
         self.early_passes.as_mut().unwrap().push(pass);
     }
 
     pub fn register_pre_expansion_pass(&mut self, pass: EarlyLintPassObject) {
-        self.register_lints(&pass.get_lints());
         self.pre_expansion_passes.as_mut().unwrap().push(pass);
     }
 
     pub fn register_late_pass(&mut self, pass: LateLintPassObject) {
-        self.register_lints(&pass.get_lints());
         self.late_passes.lock().as_mut().unwrap().push(pass);
     }
 
     pub fn register_late_mod_pass(&mut self, pass: LateLintPassObject) {
-        self.register_lints(&pass.get_lints());
         self.late_module_passes.push(pass);
     }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -218,16 +218,7 @@ impl LintStore {
 
             let id = LintId::of(lint);
             if self.by_name.insert(lint.name_lower(), Id(id)).is_some() {
-                let msg = format!("duplicate specification of lint {}", lint.name_lower());
-                match (sess, from_plugin) {
-                    // We load builtin lints first, so a duplicate is a compiler bug.
-                    // Use early_error when handling -W help with no crate.
-                    (None, _) => early_error(config::ErrorOutputType::default(), &msg[..]),
-                    (Some(_), false) => bug!("{}", msg),
-
-                    // A duplicate name from a plugin is a user error.
-                    (Some(sess), true)  => sess.err(&msg[..]),
-                }
+                bug!("duplicate specification of lint {}", lint.name_lower())
             }
         }
     }
@@ -300,16 +291,7 @@ impl LintStore {
         }
 
         if !new {
-            let msg = format!("duplicate specification of lint group {}", name);
-            match (sess, from_plugin) {
-                // We load builtin lints first, so a duplicate is a compiler bug.
-                // Use early_error when handling -W help with no crate.
-                (None, _) => early_error(config::ErrorOutputType::default(), &msg[..]),
-                (Some(_), false) => bug!("{}", msg),
-
-                // A duplicate name from a plugin is a user error.
-                (Some(sess), true)  => sess.err(&msg[..]),
-            }
+            bug!("duplicate specification of lint group {}", name);
         }
     }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -168,42 +168,28 @@ impl LintStore {
             .collect()
     }
 
-    pub fn register_early_pass(&mut self,
-                               register_only: bool,
-                               pass: EarlyLintPassObject) {
-        self.push_lints(&pass.get_lints());
-        if !register_only {
-            self.early_passes.as_mut().unwrap().push(pass);
-        }
+    pub fn register_early_pass(&mut self, pass: EarlyLintPassObject) {
+        self.register_lints(&pass.get_lints());
+        self.early_passes.as_mut().unwrap().push(pass);
     }
 
-    pub fn register_pre_expansion_pass(
-        &mut self,
-        register_only: bool,
-        pass: EarlyLintPassObject,
-    ) {
-        self.push_lints(&pass.get_lints());
-        if !register_only {
-            self.pre_expansion_passes.as_mut().unwrap().push(pass);
-        }
+    pub fn register_pre_expansion_pass(&mut self, pass: EarlyLintPassObject) {
+        self.register_lints(&pass.get_lints());
+        self.pre_expansion_passes.as_mut().unwrap().push(pass);
     }
 
-    pub fn register_late_pass(&mut self, register_only: bool, pass: LateLintPassObject) {
-        self.push_lints(&pass.get_lints());
-        if !register_only {
-            self.late_passes.lock().as_mut().unwrap().push(pass);
-        }
+    pub fn register_late_pass(&mut self, pass: LateLintPassObject) {
+        self.register_lints(&pass.get_lints());
+        self.late_passes.lock().as_mut().unwrap().push(pass);
     }
 
-    pub fn register_late_mod_pass(&mut self, register_only: bool, pass: LateLintPassObject) {
-        self.push_lints(&pass.get_lints());
-        if !register_only {
-            self.late_module_passes.push(pass);
-        }
+    pub fn register_late_mod_pass(&mut self, pass: LateLintPassObject) {
+        self.register_lints(&pass.get_lints());
+        self.late_module_passes.push(pass);
     }
 
     // Helper method for register_early/late_pass
-    fn push_lints(&mut self, lints: &[&'static Lint]) {
+    pub fn register_lints(&mut self, lints: &[&'static Lint]) {
         for lint in lints {
             self.lints.push(lint);
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -172,7 +172,7 @@ impl LintStore {
                                from_plugin: bool,
                                register_only: bool,
                                pass: EarlyLintPassObject) {
-        self.push_pass(from_plugin, &pass);
+        self.push_lints(from_plugin, &pass.get_lints());
         if !register_only {
             self.early_passes.as_mut().unwrap().push(pass);
         }
@@ -184,7 +184,7 @@ impl LintStore {
         register_only: bool,
         pass: EarlyLintPassObject,
     ) {
-        self.push_pass(from_plugin, &pass);
+        self.push_lints(from_plugin, &pass.get_lints());
         if !register_only {
             self.pre_expansion_passes.as_mut().unwrap().push(pass);
         }
@@ -195,7 +195,7 @@ impl LintStore {
                               register_only: bool,
                               per_module: bool,
                               pass: LateLintPassObject) {
-        self.push_pass(from_plugin, &pass);
+        self.push_lints(from_plugin, &pass.get_lints());
         if !register_only {
             if per_module {
                 self.late_module_passes.push(pass);
@@ -206,10 +206,8 @@ impl LintStore {
     }
 
     // Helper method for register_early/late_pass
-    fn push_pass<P: LintPass + ?Sized + 'static>(&mut self,
-                                        from_plugin: bool,
-                                        pass: &Box<P>) {
-        for lint in pass.get_lints() {
+    fn push_lints(&mut self, from_plugin: bool, lints: &[&'static Lint]) {
+        for lint in lints {
             self.lints.push((lint, from_plugin));
 
             let id = LintId::of(lint);

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -22,7 +22,7 @@ use crate::hir::intravisit as hir_visit;
 use crate::hir::intravisit::Visitor;
 use crate::hir::map::{definitions::DisambiguatedDefPathData, DefPathData};
 use crate::lint::{EarlyLintPass, LateLintPass, EarlyLintPassObject, LateLintPassObject};
-use crate::lint::{LintArray, Level, Lint, LintId, LintPass, LintBuffer};
+use crate::lint::{Level, Lint, LintId, LintPass, LintBuffer};
 use crate::lint::builtin::BuiltinLintDiagnostics;
 use crate::lint::levels::{LintLevelSets, LintLevelsBuilder};
 use crate::middle::privacy::AccessLevels;
@@ -1307,10 +1307,6 @@ impl LintPass for LateLintPassObjects<'_> {
     fn name(&self) -> &'static str {
         panic!()
     }
-
-    fn get_lints(&self) -> LintArray {
-        panic!()
-    }
 }
 
 macro_rules! expand_late_lint_pass_impl_methods {
@@ -1475,10 +1471,6 @@ struct EarlyLintPassObjects<'a> {
 #[allow(rustc::lint_pass_impl_without_macro)]
 impl LintPass for EarlyLintPassObjects<'_> {
     fn name(&self) -> &'static str {
-        panic!()
-    }
-
-    fn get_lints(&self) -> LintArray {
         panic!()
     }
 }

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -155,23 +155,31 @@ impl LintStore {
             .collect()
     }
 
-    pub fn register_early_pass(&mut self,
-        pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync) {
+    pub fn register_early_pass(
+        &mut self,
+        pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync
+    ) {
         self.early_passes.push(Box::new(pass));
     }
 
-    pub fn register_pre_expansion_pass(&mut self,
-        pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync) {
+    pub fn register_pre_expansion_pass(
+        &mut self,
+        pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync,
+    ) {
         self.pre_expansion_passes.push(Box::new(pass));
     }
 
-    pub fn register_late_pass(&mut self,
-        pass: impl Fn() -> LateLintPassObject + 'static + sync::Send + sync::Sync) {
+    pub fn register_late_pass(
+        &mut self,
+        pass: impl Fn() -> LateLintPassObject + 'static + sync::Send + sync::Sync,
+    ) {
         self.late_passes.push(Box::new(pass));
     }
 
-    pub fn register_late_mod_pass(&mut self,
-        pass: impl Fn() -> LateLintPassObject + 'static + sync::Send + sync::Sync) {
+    pub fn register_late_mod_pass(
+        &mut self,
+        pass: impl Fn() -> LateLintPassObject + 'static + sync::Send + sync::Sync,
+    ) {
         self.late_module_passes.push(Box::new(pass));
     }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -203,10 +203,6 @@ impl LintStore {
         }
     }
 
-    pub fn future_incompatible(&self, id: LintId) -> Option<FutureIncompatibleInfo> {
-        id.lint.future_incompatible
-    }
-
     pub fn register_group_alias(
         &mut self,
         lint_name: &'static str,

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -168,20 +168,20 @@ impl LintStore {
             .collect()
     }
 
-    pub fn register_early_pass(&mut self, pass: EarlyLintPassObject) {
-        self.early_passes.as_mut().unwrap().push(pass);
+    pub fn register_early_pass(&mut self, pass: fn() -> EarlyLintPassObject) {
+        self.early_passes.as_mut().unwrap().push((pass)());
     }
 
-    pub fn register_pre_expansion_pass(&mut self, pass: EarlyLintPassObject) {
-        self.pre_expansion_passes.as_mut().unwrap().push(pass);
+    pub fn register_pre_expansion_pass(&mut self, pass: fn() -> EarlyLintPassObject) {
+        self.pre_expansion_passes.as_mut().unwrap().push((pass)());
     }
 
-    pub fn register_late_pass(&mut self, pass: LateLintPassObject) {
-        self.late_passes.lock().as_mut().unwrap().push(pass);
+    pub fn register_late_pass(&mut self, pass: fn() -> LateLintPassObject) {
+        self.late_passes.lock().as_mut().unwrap().push((pass)());
     }
 
-    pub fn register_late_mod_pass(&mut self, pass: LateLintPassObject) {
-        self.late_module_passes.push(pass);
+    pub fn register_late_mod_pass(&mut self, pass: fn() -> LateLintPassObject) {
+        self.late_module_passes.push((pass)());
     }
 
     // Helper method for register_early/late_pass

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -188,17 +188,17 @@ impl LintStore {
         }
     }
 
-    pub fn register_late_pass(&mut self,
-                              register_only: bool,
-                              per_module: bool,
-                              pass: LateLintPassObject) {
+    pub fn register_late_pass(&mut self, register_only: bool, pass: LateLintPassObject) {
         self.push_lints(&pass.get_lints());
         if !register_only {
-            if per_module {
-                self.late_module_passes.push(pass);
-            } else {
-                self.late_passes.lock().as_mut().unwrap().push(pass);
-            }
+            self.late_passes.lock().as_mut().unwrap().push(pass);
+        }
+    }
+
+    pub fn register_late_mod_pass(&mut self, register_only: bool, pass: LateLintPassObject) {
+        self.push_lints(&pass.get_lints());
+        if !register_only {
+            self.late_module_passes.push(pass);
         }
     }
 

--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use crate::hir::HirId;
 use crate::ich::StableHashingContext;
 use crate::lint::builtin;
-use crate::lint::context::CheckLintNameResult;
+use crate::lint::context::{LintStore, CheckLintNameResult};
 use crate::lint::{self, Lint, LintId, Level, LintSource};
 use crate::session::Session;
 use crate::util::nodemap::FxHashMap;
@@ -35,21 +35,20 @@ enum LintSet {
 }
 
 impl LintLevelSets {
-    pub fn new(sess: &Session) -> LintLevelSets {
+    pub fn new(sess: &Session, lint_store: &LintStore) -> LintLevelSets {
         let mut me = LintLevelSets {
             list: Vec::new(),
             lint_cap: Level::Forbid,
         };
-        me.process_command_line(sess);
+        me.process_command_line(sess, lint_store);
         return me
     }
 
-    pub fn builder(sess: &Session) -> LintLevelsBuilder<'_> {
-        LintLevelsBuilder::new(sess, LintLevelSets::new(sess))
+    pub fn builder<'a>(sess: &'a Session, store: &LintStore) -> LintLevelsBuilder<'a> {
+        LintLevelsBuilder::new(sess, LintLevelSets::new(sess, store))
     }
 
-    fn process_command_line(&mut self, sess: &Session) {
-        let store = sess.lint_store.borrow();
+    fn process_command_line(&mut self, sess: &Session, store: &LintStore) {
         let mut specs = FxHashMap::default();
         self.lint_cap = sess.opts.lint_cap.unwrap_or(Level::Forbid);
 
@@ -186,9 +185,8 @@ impl<'a> LintLevelsBuilder<'a> {
     ///   #[allow]
     ///
     /// Don't forget to call `pop`!
-    pub fn push(&mut self, attrs: &[ast::Attribute]) -> BuilderPush {
+    pub fn push(&mut self, attrs: &[ast::Attribute], store: &LintStore) -> BuilderPush {
         let mut specs = FxHashMap::default();
-        let store = self.sess.lint_store.borrow();
         let sess = self.sess;
         let bad_attr = |span| {
             struct_span_err!(sess, span, E0452, "malformed lint attribute input")

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -286,9 +286,6 @@ macro_rules! expand_lint_pass_methods {
 macro_rules! declare_late_lint_pass {
     ([], [$hir:tt], [$($methods:tt)*]) => (
         pub trait LateLintPass<'a, $hir>: LintPass {
-            fn fresh_late_pass(&self) -> LateLintPassObject {
-                panic!()
-            }
             expand_lint_pass_methods!(&LateContext<'a, $hir>, [$($methods)*]);
         }
     )

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -81,6 +81,17 @@ pub struct Lint {
 }
 
 impl Lint {
+    pub const fn default_fields_for_macro() -> Self {
+        Lint {
+            name: "",
+            default_level: Level::Forbid,
+            desc: "",
+            edition_lint_opts: None,
+            is_plugin: false,
+            report_in_external_macro: false,
+        }
+    }
+
     /// Returns the `rust::lint::Lint` for a `syntax::early_buffered_lints::BufferedEarlyLintId`.
     pub fn from_parser_lint_id(lint_id: BufferedEarlyLintId) -> &'static Self {
         match lint_id {
@@ -107,19 +118,19 @@ impl Lint {
 #[macro_export]
 macro_rules! declare_lint {
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr) => (
-        declare_lint!{$vis $NAME, $Level, $desc, false}
+        declare_lint!(
+            $vis $NAME, $Level, $desc,
+        );
     );
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, report_in_external_macro: $rep: expr) => (
-        declare_lint!{$vis $NAME, $Level, $desc, $rep}
-    );
-    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $external: expr) => (
+    ($vis: vis $NAME: ident, $Level: ident, $desc: expr, $($v:ident),*) => (
         $vis static $NAME: &$crate::lint::Lint = &$crate::lint::Lint {
             name: stringify!($NAME),
             default_level: $crate::lint::$Level,
             desc: $desc,
             edition_lint_opts: None,
-            report_in_external_macro: $external,
             is_plugin: false,
+            $($v: true,)*
+            ..$crate::lint::Lint::default_fields_for_macro()
         };
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr,

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -777,11 +777,11 @@ pub fn maybe_lint_level_root(tcx: TyCtxt<'_>, id: hir::HirId) -> bool {
 
 fn lint_levels(tcx: TyCtxt<'_>, cnum: CrateNum) -> &LintLevelMap {
     assert_eq!(cnum, LOCAL_CRATE);
-    let store = tcx.sess.lint_store.borrow();
+    let store = &tcx.lint_store;
     let mut builder = LintLevelMapBuilder {
         levels: LintLevelSets::builder(tcx.sess, &store),
         tcx: tcx,
-        store: &*store,
+        store: store,
     };
     let krate = tcx.hir().krate();
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -76,6 +76,8 @@ pub struct Lint {
 
     /// `true` if this lint is reported even inside expansions of external macros.
     pub report_in_external_macro: bool,
+
+    pub is_plugin: bool,
 }
 
 impl Lint {
@@ -117,6 +119,7 @@ macro_rules! declare_lint {
             desc: $desc,
             edition_lint_opts: None,
             report_in_external_macro: $external,
+            is_plugin: false,
         };
     );
     ($vis: vis $NAME: ident, $Level: ident, $desc: expr,
@@ -128,6 +131,7 @@ macro_rules! declare_lint {
             desc: $desc,
             edition_lint_opts: Some(($lint_edition, $crate::lint::Level::$edition_level)),
             report_in_external_macro: false,
+            is_plugin: false,
         };
     );
 }
@@ -156,6 +160,7 @@ macro_rules! declare_tool_lint {
             desc: $desc,
             edition_lint_opts: None,
             report_in_external_macro: $external,
+            is_plugin: true,
         };
     );
 }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -672,9 +672,8 @@ pub fn struct_lint_level<'a>(sess: &'a Session,
     };
 
     // Check for future incompatibility lints and issue a stronger warning.
-    let lints = sess.lint_store.borrow();
     let lint_id = LintId::of(lint);
-    let future_incompatible = lints.future_incompatible(lint_id);
+    let future_incompatible = lint.future_incompatible;
 
     // If this code originates in a foreign macro, aka something that this crate
     // did not itself author, then it's likely that there's nothing this crate

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1035,6 +1035,8 @@ pub struct GlobalCtxt<'tcx> {
 
     pub sess: &'tcx Session,
 
+    pub lint_store: Lrc<lint::LintStore>,
+
     pub dep_graph: DepGraph,
 
     pub prof: SelfProfilerRef,
@@ -1199,6 +1201,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// reference to the context, to allow formatting values that need it.
     pub fn create_global_ctxt(
         s: &'tcx Session,
+        lint_store: Lrc<lint::LintStore>,
         cstore: &'tcx CrateStoreDyn,
         local_providers: ty::query::Providers<'tcx>,
         extern_providers: ty::query::Providers<'tcx>,
@@ -1268,6 +1271,7 @@ impl<'tcx> TyCtxt<'tcx> {
 
         GlobalCtxt {
             sess: s,
+            lint_store,
             cstore,
             arena: WorkerLocal::new(|_| Arena::default()),
             interners,

--- a/src/librustc_driver/Cargo.toml
+++ b/src/librustc_driver/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 env_logger = { version = "0.7", default-features = false }
 rustc = { path = "../librustc" }
 rustc_target = { path = "../librustc_target" }
+rustc_lint = { path = "../librustc_lint" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_metadata = { path = "../librustc_metadata" }

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -106,6 +106,7 @@ pub fn abort_on_err<T>(result: Result<T, ErrorReported>, sess: &Session) -> T {
 pub trait Callbacks {
     /// Called before creating the compiler instance
     fn config(&mut self, _config: &mut interface::Config) {}
+    /// Called early during compilation to allow other drivers to easily register lints.
     fn extra_lints(&mut self, _ls: &mut lint::LintStore) {}
     /// Called after parsing. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -835,8 +835,7 @@ Available lint options:
 
 ");
 
-    fn sort_lints(sess: &Session, lints: Vec<(&'static Lint, bool)>) -> Vec<&'static Lint> {
-        let mut lints: Vec<_> = lints.into_iter().map(|(x, _)| x).collect();
+    fn sort_lints(sess: &Session, mut lints: Vec<&'static Lint>) -> Vec<&'static Lint> {
         // The sort doesn't case-fold but it's doubtful we care.
         lints.sort_by_cached_key(|x: &&Lint| (x.default_level(sess), x.name));
         lints
@@ -852,7 +851,7 @@ Available lint options:
     let (plugin, builtin): (Vec<_>, _) = lint_store.get_lints()
                                                    .iter()
                                                    .cloned()
-                                                   .partition(|&(_, p)| p);
+                                                   .partition(|&lint| lint.is_plugin);
     let plugin = sort_lints(sess, plugin);
     let builtin = sort_lints(sess, builtin);
 

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -106,6 +106,7 @@ pub fn abort_on_err<T>(result: Result<T, ErrorReported>, sess: &Session) -> T {
 pub trait Callbacks {
     /// Called before creating the compiler instance
     fn config(&mut self, _config: &mut interface::Config) {}
+    fn extra_lints(&mut self, _ls: &mut lint::LintStore) {}
     /// Called after parsing. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {
@@ -182,6 +183,7 @@ pub fn run_compiler(
             stderr: None,
             crate_name: None,
             lint_caps: Default::default(),
+            register_lints: None,
         };
         callbacks.config(&mut config);
         config
@@ -259,6 +261,7 @@ pub fn run_compiler(
         stderr: None,
         crate_name: None,
         lint_caps: Default::default(),
+        register_lints: None,
     };
 
     callbacks.config(&mut config);

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -34,6 +34,7 @@ pub struct Compiler {
     pub(crate) queries: Queries,
     pub(crate) cstore: Lrc<CStore>,
     pub(crate) crate_name: Option<String>,
+    pub(crate) register_lints: Option<Box<dyn Fn(&Session, &mut lint::LintStore) + Send + Sync>>,
 }
 
 impl Compiler {
@@ -80,6 +81,8 @@ pub struct Config {
 
     pub crate_name: Option<String>,
     pub lint_caps: FxHashMap<lint::LintId, lint::Level>,
+
+    pub register_lints: Option<Box<dyn Fn(&Session, &mut lint::LintStore) + Send + Sync>>,
 }
 
 pub fn run_compiler_in_existing_thread_pool<F, R>(config: Config, f: F) -> R
@@ -108,6 +111,7 @@ where
         output_file: config.output_file,
         queries: Default::default(),
         crate_name: config.crate_name,
+        register_lints: config.register_lints,
     };
 
     let _sess_abort_error = OnDrop(|| {

--- a/src/librustc_interface/interface.rs
+++ b/src/librustc_interface/interface.rs
@@ -82,6 +82,11 @@ pub struct Config {
     pub crate_name: Option<String>,
     pub lint_caps: FxHashMap<lint::LintId, lint::Level>,
 
+    /// This is a callback from the driver that is called when we're registering lints;
+    /// it is called during plugin registration when we have the LintStore in a non-shared state.
+    ///
+    /// Note that if you find a Some here you probably want to call that function in the new
+    /// function being registered.
     pub register_lints: Option<Box<dyn Fn(&Session, &mut lint::LintStore) + Send + Sync>>,
 }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -291,6 +291,7 @@ pub fn register_plugins<'a>(
         syntax_exts,
         early_lint_passes,
         late_lint_passes,
+        lints,
         lint_groups,
         llvm_passes,
         attributes,
@@ -298,12 +299,11 @@ pub fn register_plugins<'a>(
     } = registry;
 
     let mut ls = sess.lint_store.borrow_mut();
+    ls.register_lints(&lints);
     for pass in early_lint_passes {
-        ls.register_lints(&pass.get_lints());
         ls.register_early_pass(pass);
     }
     for pass in late_lint_passes {
-        ls.register_lints(&pass.get_lints());
         ls.register_late_pass(pass);
     }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -299,14 +299,14 @@ pub fn register_plugins<'a>(
 
     let mut ls = sess.lint_store.borrow_mut();
     for pass in early_lint_passes {
-        ls.register_early_pass(Some(sess), true, false, pass);
+        ls.register_early_pass(true, false, pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(Some(sess), true, false, false, pass);
+        ls.register_late_pass(true, false, false, pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {
-        ls.register_group(Some(sess), true, name, deprecated_name, to);
+        ls.register_group(true, name, deprecated_name, to);
     }
 
     *sess.plugin_llvm_passes.borrow_mut() = llvm_passes;

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -299,10 +299,10 @@ pub fn register_plugins<'a>(
 
     let mut ls = sess.lint_store.borrow_mut();
     for pass in early_lint_passes {
-        ls.register_early_pass(false, pass);
+        ls.register_early_pass(pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(false, pass);
+        ls.register_late_pass(pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -299,10 +299,10 @@ pub fn register_plugins<'a>(
 
     let mut ls = sess.lint_store.borrow_mut();
     for pass in early_lint_passes {
-        ls.register_early_pass(true, false, pass);
+        ls.register_early_pass(false, pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(true, false, false, pass);
+        ls.register_late_pass(false, false, pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -299,9 +299,11 @@ pub fn register_plugins<'a>(
 
     let mut ls = sess.lint_store.borrow_mut();
     for pass in early_lint_passes {
+        ls.register_lints(&pass.get_lints());
         ls.register_early_pass(pass);
     }
     for pass in late_lint_passes {
+        ls.register_lints(&pass.get_lints());
         ls.register_late_pass(pass);
     }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -329,6 +329,7 @@ fn configure_and_expand_inner<'a>(
     time(sess, "pre-AST-expansion lint checks", || {
         lint::check_ast_crate(
             sess,
+            &*sess.lint_store.borrow(),
             &krate,
             true,
             rustc_lint::BuiltinCombinedPreExpansionLintPass::new());
@@ -556,7 +557,13 @@ pub fn lower_to_hir(
     });
 
     time(sess, "early lint checks", || {
-        lint::check_ast_crate(sess, &krate, false, rustc_lint::BuiltinCombinedEarlyLintPass::new())
+        lint::check_ast_crate(
+            sess,
+            &*sess.lint_store.borrow(),
+            &krate,
+            false,
+            rustc_lint::BuiltinCombinedEarlyLintPass::new(),
+        )
     });
 
     // Discard hygiene data, which isn't required after lowering to HIR.

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -302,7 +302,7 @@ pub fn register_plugins<'a>(
         ls.register_early_pass(false, pass);
     }
     for pass in late_lint_passes {
-        ls.register_late_pass(false, false, pass);
+        ls.register_late_pass(false, pass);
     }
 
     for (name, (to, deprecated_name)) in lint_groups {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -227,6 +227,7 @@ pub struct PluginInfo {
 pub fn register_plugins<'a>(
     sess: &'a Session,
     cstore: &'a CStore,
+    register_lints: impl Fn(&Session, &mut lint::LintStore),
     mut krate: ast::Crate,
     crate_name: &str,
 ) -> Result<(ast::Crate, PluginInfo, Lrc<lint::LintStore>)> {
@@ -284,6 +285,8 @@ pub fn register_plugins<'a>(
         sess.opts.debugging_opts.no_interleave_lints,
         sess.unstable_options(),
     );
+
+    (register_lints)(&sess, &mut lint_store);
 
     let mut registry = Registry::new(sess, &mut lint_store, krate.span);
 

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -2,9 +2,11 @@ use crate::interface::{Compiler, Result};
 use crate::passes::{self, BoxedResolver, ExpansionResult, BoxedGlobalCtxt, PluginInfo};
 
 use rustc_incremental::DepGraphFuture;
+use rustc_data_structures::sync::Lrc;
 use rustc::session::config::{OutputFilenames, OutputType};
 use rustc::util::common::{time, ErrorReported};
 use rustc::hir;
+use rustc::lint::LintStore;
 use rustc::hir::def_id::LOCAL_CRATE;
 use rustc::ty::steal::Steal;
 use rustc::dep_graph::DepGraph;
@@ -74,8 +76,8 @@ pub(crate) struct Queries {
     dep_graph_future: Query<Option<DepGraphFuture>>,
     parse: Query<ast::Crate>,
     crate_name: Query<String>,
-    register_plugins: Query<(ast::Crate, PluginInfo)>,
-    expansion: Query<(ast::Crate, Steal<Rc<RefCell<BoxedResolver>>>)>,
+    register_plugins: Query<(ast::Crate, PluginInfo, Lrc<LintStore>)>,
+    expansion: Query<(ast::Crate, Steal<Rc<RefCell<BoxedResolver>>>, Lrc<LintStore>)>,
     dep_graph: Query<DepGraph>,
     lower_to_hir: Query<(Steal<hir::map::Forest>, ExpansionResult)>,
     prepare_outputs: Query<OutputFilenames>,
@@ -106,7 +108,7 @@ impl Compiler {
         })
     }
 
-    pub fn register_plugins(&self) -> Result<&Query<(ast::Crate, PluginInfo)>> {
+    pub fn register_plugins(&self) -> Result<&Query<(ast::Crate, PluginInfo, Lrc<LintStore>)>> {
         self.queries.register_plugins.compute(|| {
             let crate_name = self.crate_name()?.peek().clone();
             let krate = self.parse()?.take();
@@ -148,17 +150,20 @@ impl Compiler {
 
     pub fn expansion(
         &self
-    ) -> Result<&Query<(ast::Crate, Steal<Rc<RefCell<BoxedResolver>>>)>> {
+    ) -> Result<&Query<(ast::Crate, Steal<Rc<RefCell<BoxedResolver>>>, Lrc<LintStore>)>> {
         self.queries.expansion.compute(|| {
             let crate_name = self.crate_name()?.peek().clone();
-            let (krate, plugin_info) = self.register_plugins()?.take();
+            let (krate, plugin_info, lint_store) = self.register_plugins()?.take();
             passes::configure_and_expand(
                 self.sess.clone(),
+                lint_store.clone(),
                 self.cstore().clone(),
                 krate,
                 &crate_name,
                 plugin_info,
-            ).map(|(krate, resolver)| (krate, Steal::new(Rc::new(RefCell::new(resolver)))))
+            ).map(|(krate, resolver)| {
+                (krate, Steal::new(Rc::new(RefCell::new(resolver))), lint_store)
+            })
         })
     }
 
@@ -185,9 +190,11 @@ impl Compiler {
             let peeked = expansion_result.peek();
             let krate = &peeked.0;
             let resolver = peeked.1.steal();
+            let lint_store = &peeked.2;
             let hir = Steal::new(resolver.borrow_mut().access(|resolver| {
                 passes::lower_to_hir(
                     self.session(),
+                    lint_store,
                     self.cstore(),
                     resolver,
                     &*self.dep_graph()?.peek(),
@@ -212,11 +219,13 @@ impl Compiler {
         self.queries.global_ctxt.compute(|| {
             let crate_name = self.crate_name()?.peek().clone();
             let outputs = self.prepare_outputs()?.peek().clone();
+            let lint_store = self.expansion()?.peek().2.clone();
             let hir = self.lower_to_hir()?;
             let hir = hir.peek();
             let (ref hir_forest, ref expansion) = *hir;
             Ok(passes::create_global_ctxt(
                 self,
+                lint_store,
                 hir_forest.steal(),
                 expansion.defs.steal(),
                 expansion.resolutions.steal(),

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -108,9 +108,10 @@ pub fn create_session(
 
     let codegen_backend = get_codegen_backend(&sess);
 
-    rustc_lint::register_builtins(&mut sess.lint_store.borrow_mut(), Some(&sess));
+    rustc_lint::register_builtins(&mut sess.lint_store.get_mut(),
+        sess.opts.debugging_opts.no_interleave_lints);
     if sess.unstable_options() {
-        rustc_lint::register_internals(&mut sess.lint_store.borrow_mut(), Some(&sess));
+        rustc_lint::register_internals(&mut sess.lint_store.get_mut());
     }
 
     let mut cfg = config::build_configuration(&sess, config::to_crate_config(cfg));

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -13,7 +13,6 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_data_structures::fx::{FxHashSet, FxHashMap};
 use rustc_errors::registry::Registry;
-use rustc_lint;
 use rustc_metadata::dynamic_lib::DynamicLibrary;
 use rustc_mir;
 use rustc_passes;
@@ -107,12 +106,6 @@ pub fn create_session(
     );
 
     let codegen_backend = get_codegen_backend(&sess);
-
-    rustc_lint::register_builtins(&mut sess.lint_store.get_mut(),
-        sess.opts.debugging_opts.no_interleave_lints);
-    if sess.unstable_options() {
-        rustc_lint::register_internals(&mut sess.lint_store.get_mut());
-    }
 
     let mut cfg = config::build_configuration(&sess, config::to_crate_config(cfg));
     add_configuration(&mut cfg, &sess, &*codegen_backend);

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -27,6 +27,7 @@ use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::{DefId, LOCAL_CRATE};
 use rustc::ty::{self, Ty, TyCtxt, layout::VariantIdx};
 use rustc::{lint, util};
+use rustc::lint::FutureIncompatibleInfo;
 use hir::Node;
 use util::nodemap::HirIdSet;
 use lint::{LateContext, LintContext, LintArray};
@@ -601,7 +602,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for MissingDebugImplementations {
 declare_lint! {
     pub ANONYMOUS_PARAMETERS,
     Allow,
-    "detects anonymous parameters"
+    "detects anonymous parameters",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
+        edition: Some(Edition::Edition2018),
+    };
 }
 
 declare_lint_pass!(
@@ -1423,7 +1428,11 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnnameableTestItems {
 declare_lint! {
     pub KEYWORD_IDENTS,
     Allow,
-    "detects edition keywords being used as an identifier"
+    "detects edition keywords being used as an identifier",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #49716 <https://github.com/rust-lang/rust/issues/49716>",
+        edition: Some(Edition::Edition2018),
+    };
 }
 
 declare_lint_pass!(

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -280,7 +280,7 @@ declare_lint! {
     pub MISSING_DOCS,
     Allow,
     "detects missing documentation for public members",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 pub struct MissingDoc {
@@ -1374,7 +1374,7 @@ declare_lint! {
     UNNAMEABLE_TEST_ITEMS,
     Warn,
     "detects an item that cannot be named being marked as `#[test_case]`",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 pub struct UnnameableTestItems {

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -205,7 +205,7 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 
     macro_rules! register_pass {
         ($method:ident, $constructor:expr, [$($args:expr),*]) => (
-            store.$method(false, false, $($args,)* box $constructor);
+            store.$method(false, $($args,)* box $constructor);
         )
     }
 
@@ -224,16 +224,15 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
         late_lint_mod_passes!(register_passes, [register_late_pass, [true]]);
     } else {
         store.register_pre_expansion_pass(
-            false,
             true,
             box BuiltinCombinedPreExpansionLintPass::new()
         );
-        store.register_early_pass(false, true, box BuiltinCombinedEarlyLintPass::new());
+        store.register_early_pass(true, box BuiltinCombinedEarlyLintPass::new());
         store.register_late_pass(
-            false, true, true, box BuiltinCombinedModuleLateLintPass::new()
+            true, true, box BuiltinCombinedModuleLateLintPass::new()
         );
         store.register_late_pass(
-            false, true, false, box BuiltinCombinedLateLintPass::new()
+            true, false, box BuiltinCombinedLateLintPass::new()
         );
     }
 
@@ -492,9 +491,9 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 }
 
 pub fn register_internals(store: &mut lint::LintStore) {
-    store.register_early_pass(false, false, box DefaultHashTypes::new());
-    store.register_early_pass(false, false, box LintPassImpl);
-    store.register_late_pass(false, false, false, box TyTyKind);
+    store.register_early_pass(false, box DefaultHashTypes::new());
+    store.register_early_pass(false, box LintPassImpl);
+    store.register_late_pass(false, false, box TyTyKind);
     store.register_group(
         false,
         "rustc::internal",

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -204,9 +204,9 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
     }
 
     macro_rules! register_pass {
-        ($method:ident, $constructor:expr) => (
+        ($method:ident, $ty:ident, $constructor:expr) => (
             let obj = box $constructor;
-            store.register_lints(&obj.get_lints());
+            store.register_lints(&$ty::get_lints());
             store.$method(obj);
         )
     }
@@ -214,7 +214,7 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
     macro_rules! register_passes {
         ($method:ident, [$($passes:ident: $constructor:expr,)*]) => (
             $(
-                register_pass!($method, $constructor);
+                register_pass!($method, $passes, $constructor);
             )*
         )
     }
@@ -225,10 +225,10 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
         late_lint_passes!(register_passes, register_late_pass);
         late_lint_mod_passes!(register_passes, register_late_mod_pass);
     } else {
-        store.register_lints(&BuiltinCombinedPreExpansionLintPass::new().get_lints());
-        store.register_lints(&BuiltinCombinedEarlyLintPass::new().get_lints());
-        store.register_lints(&BuiltinCombinedModuleLateLintPass::new().get_lints());
-        store.register_lints(&BuiltinCombinedLateLintPass::new().get_lints());
+        store.register_lints(&BuiltinCombinedPreExpansionLintPass::get_lints());
+        store.register_lints(&BuiltinCombinedEarlyLintPass::get_lints());
+        store.register_lints(&BuiltinCombinedModuleLateLintPass::get_lints());
+        store.register_lints(&BuiltinCombinedLateLintPass::get_lints());
     }
 
     add_lint_group!("nonstandard_style",
@@ -486,11 +486,11 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 }
 
 pub fn register_internals(store: &mut lint::LintStore) {
-    store.register_lints(&DefaultHashTypes::new().get_lints());
+    store.register_lints(&DefaultHashTypes::get_lints());
     store.register_early_pass(box DefaultHashTypes::new());
-    store.register_lints(&LintPassImpl.get_lints());
+    store.register_lints(&LintPassImpl::get_lints());
     store.register_early_pass(box LintPassImpl);
-    store.register_lints(&TyTyKind.get_lints());
+    store.register_lints(&TyTyKind::get_lints());
     store.register_late_pass(box TyTyKind);
     store.register_group(
         false,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -204,29 +204,29 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
     }
 
     macro_rules! register_pass {
-        ($method:ident, $constructor:expr, [$($args:expr),*]) => (
-            store.$method(false, $($args,)* box $constructor);
+        ($method:ident, $constructor:expr) => (
+            store.$method(box $constructor);
         )
     }
 
     macro_rules! register_passes {
-        ([$method:ident, $args:tt], [$($passes:ident: $constructor:expr,)*]) => (
+        ($method:ident, [$($passes:ident: $constructor:expr,)*]) => (
             $(
-                register_pass!($method, $constructor, $args);
+                register_pass!($method, $constructor);
             )*
         )
     }
 
     if no_interleave_lints {
-        pre_expansion_lint_passes!(register_passes, [register_pre_expansion_pass, []]);
-        early_lint_passes!(register_passes, [register_early_pass, []]);
-        late_lint_passes!(register_passes, [register_late_pass, []]);
-        late_lint_mod_passes!(register_passes, [register_late_mod_pass, []]);
+        pre_expansion_lint_passes!(register_passes, register_pre_expansion_pass);
+        early_lint_passes!(register_passes, register_early_pass);
+        late_lint_passes!(register_passes, register_late_pass);
+        late_lint_mod_passes!(register_passes, register_late_mod_pass);
     } else {
-        store.register_pre_expansion_pass(true, box BuiltinCombinedPreExpansionLintPass::new());
-        store.register_early_pass(true, box BuiltinCombinedEarlyLintPass::new());
-        store.register_late_mod_pass(true, box BuiltinCombinedModuleLateLintPass::new());
-        store.register_late_pass(true, box BuiltinCombinedLateLintPass::new());
+        store.register_lints(&BuiltinCombinedPreExpansionLintPass::new().get_lints());
+        store.register_lints(&BuiltinCombinedEarlyLintPass::new().get_lints());
+        store.register_lints(&BuiltinCombinedModuleLateLintPass::new().get_lints());
+        store.register_lints(&BuiltinCombinedLateLintPass::new().get_lints());
     }
 
     add_lint_group!("nonstandard_style",
@@ -484,9 +484,9 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 }
 
 pub fn register_internals(store: &mut lint::LintStore) {
-    store.register_early_pass(false, box DefaultHashTypes::new());
-    store.register_early_pass(false, box LintPassImpl);
-    store.register_late_pass(false, box TyTyKind);
+    store.register_early_pass(box DefaultHashTypes::new());
+    store.register_early_pass(box LintPassImpl);
+    store.register_late_pass(box TyTyKind);
     store.register_group(
         false,
         "rustc::internal",

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -189,10 +189,21 @@ late_lint_passes!(declare_combined_late_pass, [pub BuiltinCombinedLateLintPass])
 
 late_lint_mod_passes!(declare_combined_late_pass, [BuiltinCombinedModuleLateLintPass]);
 
+pub fn new_lint_store(no_interleave_lints: bool, internal_lints: bool) -> lint::LintStore {
+    let mut lint_store = lint::LintStore::new();
+
+    register_builtins(&mut lint_store, no_interleave_lints);
+    if internal_lints {
+        register_internals(&mut lint_store);
+    }
+
+    lint_store
+}
+
 /// Tell the `LintStore` about all the built-in lints (the ones
 /// defined in this crate and the ones defined in
 /// `rustc::lint::builtin`).
-pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool) {
+fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool) {
     macro_rules! add_lint_group {
         ($name:expr, $($lint:ident),*) => (
             store.register_group(false, $name, None, vec![$(LintId::of($lint)),*]);
@@ -327,7 +338,7 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
         "converted into hard error, see https://github.com/rust-lang/rust/issues/46205");
 }
 
-pub fn register_internals(store: &mut lint::LintStore) {
+fn register_internals(store: &mut lint::LintStore) {
     store.register_lints(&DefaultHashTypes::get_lints());
     store.register_early_pass(|| box DefaultHashTypes::new());
     store.register_lints(&LintPassImpl::get_lints());

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -205,7 +205,9 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 
     macro_rules! register_pass {
         ($method:ident, $constructor:expr) => (
-            store.$method(box $constructor);
+            let obj = box $constructor;
+            store.register_lints(&obj.get_lints());
+            store.$method(obj);
         )
     }
 
@@ -484,8 +486,11 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 }
 
 pub fn register_internals(store: &mut lint::LintStore) {
+    store.register_lints(&DefaultHashTypes::new().get_lints());
     store.register_early_pass(box DefaultHashTypes::new());
+    store.register_lints(&LintPassImpl.get_lints());
     store.register_early_pass(box LintPassImpl);
+    store.register_lints(&TyTyKind.get_lints());
     store.register_late_pass(box TyTyKind);
     store.register_group(
         false,

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -220,20 +220,13 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
     if no_interleave_lints {
         pre_expansion_lint_passes!(register_passes, [register_pre_expansion_pass, []]);
         early_lint_passes!(register_passes, [register_early_pass, []]);
-        late_lint_passes!(register_passes, [register_late_pass, [false]]);
-        late_lint_mod_passes!(register_passes, [register_late_pass, [true]]);
+        late_lint_passes!(register_passes, [register_late_pass, []]);
+        late_lint_mod_passes!(register_passes, [register_late_mod_pass, []]);
     } else {
-        store.register_pre_expansion_pass(
-            true,
-            box BuiltinCombinedPreExpansionLintPass::new()
-        );
+        store.register_pre_expansion_pass(true, box BuiltinCombinedPreExpansionLintPass::new());
         store.register_early_pass(true, box BuiltinCombinedEarlyLintPass::new());
-        store.register_late_pass(
-            true, true, box BuiltinCombinedModuleLateLintPass::new()
-        );
-        store.register_late_pass(
-            true, false, box BuiltinCombinedLateLintPass::new()
-        );
+        store.register_late_mod_pass(true, box BuiltinCombinedModuleLateLintPass::new());
+        store.register_late_pass(true, box BuiltinCombinedLateLintPass::new());
     }
 
     add_lint_group!("nonstandard_style",
@@ -493,7 +486,7 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 pub fn register_internals(store: &mut lint::LintStore) {
     store.register_early_pass(false, box DefaultHashTypes::new());
     store.register_early_pass(false, box LintPassImpl);
-    store.register_late_pass(false, false, box TyTyKind);
+    store.register_late_pass(false, box TyTyKind);
     store.register_group(
         false,
         "rustc::internal",

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -33,13 +33,11 @@ use rustc::lint;
 use rustc::lint::{EarlyContext, LateContext, LateLintPass, EarlyLintPass, LintPass, LintArray};
 use rustc::lint::builtin::{
     BARE_TRAIT_OBJECTS,
-    ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
     ELIDED_LIFETIMES_IN_PATHS,
     EXPLICIT_OUTLIVES_REQUIREMENTS,
     INTRA_DOC_LINK_RESOLUTION_FAILURE,
     MISSING_DOC_CODE_EXAMPLES,
     PRIVATE_DOC_TESTS,
-    parser::ILL_FORMED_ATTRIBUTE_INPUT,
 };
 use rustc::hir;
 use rustc::hir::def_id::DefId;
@@ -47,11 +45,9 @@ use rustc::ty::query::Providers;
 use rustc::ty::TyCtxt;
 
 use syntax::ast;
-use syntax::edition::Edition;
 use syntax_pos::Span;
 
 use lint::LintId;
-use lint::FutureIncompatibleInfo;
 
 use redundant_semicolon::*;
 use nonstandard_style::*;
@@ -275,159 +271,6 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
                     INTRA_DOC_LINK_RESOLUTION_FAILURE,
                     MISSING_DOC_CODE_EXAMPLES,
                     PRIVATE_DOC_TESTS);
-
-    // Guidelines for creating a future incompatibility lint:
-    //
-    // - Create a lint defaulting to warn as normal, with ideally the same error
-    //   message you would normally give
-    // - Add a suitable reference, typically an RFC or tracking issue. Go ahead
-    //   and include the full URL, sort items in ascending order of issue numbers.
-    // - Later, change lint to error
-    // - Eventually, remove lint
-    store.register_future_incompatible(vec![
-        FutureIncompatibleInfo {
-            id: LintId::of(PRIVATE_IN_PUBLIC),
-            reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(PUB_USE_OF_PRIVATE_EXTERN_CRATE),
-            reference: "issue #34537 <https://github.com/rust-lang/rust/issues/34537>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(PATTERNS_IN_FNS_WITHOUT_BODY),
-            reference: "issue #35203 <https://github.com/rust-lang/rust/issues/35203>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(DUPLICATE_MACRO_EXPORTS),
-            reference: "issue #35896 <https://github.com/rust-lang/rust/issues/35896>",
-            edition: Some(Edition::Edition2018),
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(KEYWORD_IDENTS),
-            reference: "issue #49716 <https://github.com/rust-lang/rust/issues/49716>",
-            edition: Some(Edition::Edition2018),
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(SAFE_EXTERN_STATICS),
-            reference: "issue #36247 <https://github.com/rust-lang/rust/issues/36247>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(INVALID_TYPE_PARAM_DEFAULT),
-            reference: "issue #36887 <https://github.com/rust-lang/rust/issues/36887>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(LEGACY_DIRECTORY_OWNERSHIP),
-            reference: "issue #37872 <https://github.com/rust-lang/rust/issues/37872>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(LEGACY_CONSTRUCTOR_VISIBILITY),
-            reference: "issue #39207 <https://github.com/rust-lang/rust/issues/39207>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(MISSING_FRAGMENT_SPECIFIER),
-            reference: "issue #40107 <https://github.com/rust-lang/rust/issues/40107>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ILLEGAL_FLOATING_POINT_LITERAL_PATTERN),
-            reference: "issue #41620 <https://github.com/rust-lang/rust/issues/41620>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ANONYMOUS_PARAMETERS),
-            reference: "issue #41686 <https://github.com/rust-lang/rust/issues/41686>",
-            edition: Some(Edition::Edition2018),
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(PARENTHESIZED_PARAMS_IN_TYPES_AND_MODULES),
-            reference: "issue #42238 <https://github.com/rust-lang/rust/issues/42238>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(LATE_BOUND_LIFETIME_ARGUMENTS),
-            reference: "issue #42868 <https://github.com/rust-lang/rust/issues/42868>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(SAFE_PACKED_BORROWS),
-            reference: "issue #46043 <https://github.com/rust-lang/rust/issues/46043>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ORDER_DEPENDENT_TRAIT_OBJECTS),
-            reference: "issue #56484 <https://github.com/rust-lang/rust/issues/56484>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(TYVAR_BEHIND_RAW_POINTER),
-            reference: "issue #46906 <https://github.com/rust-lang/rust/issues/46906>",
-            edition: Some(Edition::Edition2018),
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(UNSTABLE_NAME_COLLISIONS),
-            reference: "issue #48919 <https://github.com/rust-lang/rust/issues/48919>",
-            edition: None,
-            // Note: this item represents future incompatibility of all unstable functions in the
-            //       standard library, and thus should never be removed or changed to an error.
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE),
-            reference: "issue #53130 <https://github.com/rust-lang/rust/issues/53130>",
-            edition: Some(Edition::Edition2018),
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(WHERE_CLAUSES_OBJECT_SAFETY),
-            reference: "issue #51443 <https://github.com/rust-lang/rust/issues/51443>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(PROC_MACRO_DERIVE_RESOLUTION_FALLBACK),
-            reference: "issue #50504 <https://github.com/rust-lang/rust/issues/50504>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS),
-            reference: "issue #52234 <https://github.com/rust-lang/rust/issues/52234>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(ILL_FORMED_ATTRIBUTE_INPUT),
-            reference: "issue #57571 <https://github.com/rust-lang/rust/issues/57571>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(AMBIGUOUS_ASSOCIATED_ITEMS),
-            reference: "issue #57644 <https://github.com/rust-lang/rust/issues/57644>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(NESTED_IMPL_TRAIT),
-            reference: "issue #59014 <https://github.com/rust-lang/rust/issues/59014>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(MUTABLE_BORROW_RESERVATION_CONFLICT),
-            reference: "issue #59159 <https://github.com/rust-lang/rust/issues/59159>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(INDIRECT_STRUCTURAL_MATCH),
-            reference: "issue #62411 <https://github.com/rust-lang/rust/issues/62411>",
-            edition: None,
-        },
-        FutureIncompatibleInfo {
-            id: LintId::of(SOFT_UNSTABLE),
-            reference: "issue #64266 <https://github.com/rust-lang/rust/issues/64266>",
-            edition: None,
-        },
-        ]);
 
     // Register renamed and removed lints.
     store.register_renamed("single_use_lifetime", "single_use_lifetimes");

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -205,9 +205,8 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 
     macro_rules! register_pass {
         ($method:ident, $ty:ident, $constructor:expr) => (
-            let obj = box $constructor;
             store.register_lints(&$ty::get_lints());
-            store.$method(obj);
+            store.$method(|| box $constructor);
         )
     }
 
@@ -487,11 +486,11 @@ pub fn register_builtins(store: &mut lint::LintStore, no_interleave_lints: bool)
 
 pub fn register_internals(store: &mut lint::LintStore) {
     store.register_lints(&DefaultHashTypes::get_lints());
-    store.register_early_pass(box DefaultHashTypes::new());
+    store.register_early_pass(|| box DefaultHashTypes::new());
     store.register_lints(&LintPassImpl::get_lints());
-    store.register_early_pass(box LintPassImpl);
+    store.register_early_pass(|| box LintPassImpl);
     store.register_lints(&TyTyKind::get_lints());
-    store.register_late_pass(box TyTyKind);
+    store.register_late_pass(|| box TyTyKind);
     store.register_group(
         false,
         "rustc::internal",

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -25,7 +25,7 @@ declare_lint! {
     pub UNUSED_MUST_USE,
     Warn,
     "unused result of a type flagged as `#[must_use]`",
-    report_in_external_macro: true
+    report_in_external_macro
 }
 
 declare_lint! {

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -36,10 +36,10 @@ pub struct Registry<'a> {
     pub syntax_exts: Vec<NamedSyntaxExtension>,
 
     #[doc(hidden)]
-    pub early_lint_passes: Vec<EarlyLintPassObject>,
+    pub early_lint_passes: Vec<fn() -> EarlyLintPassObject>,
 
     #[doc(hidden)]
-    pub late_lint_passes: Vec<LateLintPassObject>,
+    pub late_lint_passes: Vec<fn() -> LateLintPassObject>,
 
     #[doc(hidden)]
     pub lints: Vec<&'static Lint>,
@@ -109,12 +109,12 @@ impl<'a> Registry<'a> {
     }
 
     /// Register a compiler lint pass.
-    pub fn register_early_lint_pass(&mut self, lint_pass: EarlyLintPassObject) {
+    pub fn register_early_lint_pass(&mut self, lint_pass: fn() -> EarlyLintPassObject) {
         self.early_lint_passes.push(lint_pass);
     }
 
     /// Register a compiler lint pass.
-    pub fn register_late_lint_pass(&mut self, lint_pass: LateLintPassObject) {
+    pub fn register_late_lint_pass(&mut self, lint_pass: fn() -> LateLintPassObject) {
         self.late_lint_passes.push(lint_pass);
     }
     /// Register a lint group.

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -42,6 +42,9 @@ pub struct Registry<'a> {
     pub late_lint_passes: Vec<LateLintPassObject>,
 
     #[doc(hidden)]
+    pub lints: Vec<&'static Lint>,
+
+    #[doc(hidden)]
     pub lint_groups: FxHashMap<&'static str, (Vec<LintId>, Option<&'static str>)>,
 
     #[doc(hidden)]
@@ -59,6 +62,7 @@ impl<'a> Registry<'a> {
             args_hidden: None,
             krate_span,
             syntax_exts: vec![],
+            lints: vec![],
             early_lint_passes: vec![],
             late_lint_passes: vec![],
             lint_groups: FxHashMap::default(),
@@ -97,6 +101,11 @@ impl<'a> Registry<'a> {
         let kind = SyntaxExtensionKind::LegacyBang(Box::new(expander));
         let ext = SyntaxExtension::default(kind, self.sess.edition());
         self.register_syntax_extension(Symbol::intern(name), ext);
+    }
+
+    /// Register a compiler lint pass.
+    pub fn register_lints(&mut self, lints: &[&'static Lint]) {
+        self.lints.extend(lints);
     }
 
     /// Register a compiler lint pass.

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -25,6 +25,7 @@ pub struct Registry<'a> {
     /// from the plugin registrar.
     pub sess: &'a Session,
 
+    /// The `LintStore` allows plugins to register new lints.
     pub lint_store: &'a mut LintStore,
 
     #[doc(hidden)]

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -338,6 +338,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
         stderr: None,
         crate_name,
         lint_caps,
+        register_lints: None,
     };
 
     interface::run_compiler_in_existing_thread_pool(config, |compiler| {

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -5,7 +5,7 @@ use rustc::hir::HirId;
 use rustc::middle::cstore::CrateStore;
 use rustc::middle::privacy::AccessLevels;
 use rustc::ty::{Ty, TyCtxt};
-use rustc::lint::{self, LintPass};
+use rustc::lint;
 use rustc::session::config::ErrorOutputType;
 use rustc::session::DiagnosticOutput;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
@@ -273,10 +273,9 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     whitelisted_lints.extend(lint_opts.iter().map(|(lint, _)| lint).cloned());
 
     let lints = || {
-        lint::builtin::HardwiredLints
-            .get_lints()
+        lint::builtin::HardwiredLints::get_lints()
             .into_iter()
-            .chain(rustc_lint::SoftLints.get_lints().into_iter())
+            .chain(rustc_lint::SoftLints::get_lints().into_iter())
     };
 
     let lint_opts = lints().filter_map(|lint| {

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -77,6 +77,7 @@ pub fn run(options: Options) -> i32 {
         stderr: None,
         crate_name: options.crate_name.clone(),
         lint_caps: Default::default(),
+        register_lints: None,
     };
 
     let mut test_args = options.test_args.clone();

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -59,6 +59,7 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         stderr: None,
         crate_name: None,
         lint_caps: Default::default(),
+        register_lints: None,
     };
 
     interface::run_compiler(config, |compiler| {

--- a/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
+++ b/src/test/ui-fulldeps/auxiliary/issue-40001-plugin.rs
@@ -15,15 +15,14 @@ use syntax::symbol::Symbol;
 
 use rustc::hir;
 use rustc::hir::intravisit;
-use rustc::hir::map as hir_map;
 use hir::Node;
 use rustc::lint::{LateContext, LintPass, LintArray, LateLintPass, LintContext};
-use rustc::ty;
-use syntax::{ast, source_map};
+use syntax::source_map;
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box MissingWhitelistedAttrPass);
+    reg.lint_store.register_lints(&[&MISSING_WHITELISTED_ATTR]);
+    reg.lint_store.register_late_pass(|| box MissingWhitelistedAttrPass);
     reg.register_attribute(Symbol::intern("whitelisted_attr"), Whitelisted);
 }
 

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
@@ -32,5 +32,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass);
+    reg.register_lint(&[&CRATE_NOT_OKAY]);
+    reg.register_late_lint_pass(|| box Pass);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-for-crate.rs
@@ -7,7 +7,7 @@
 extern crate rustc_driver;
 extern crate syntax;
 
-use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LateLintPassObject, LintArray};
+use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LintArray};
 use rustc_driver::plugin::Registry;
 use rustc::hir;
 use syntax::attr;
@@ -32,6 +32,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_lint(&[&CRATE_NOT_OKAY]);
-    reg.register_late_lint_pass(|| box Pass);
+    reg.lint_store.register_lints(&[&CRATE_NOT_OKAY]);
+    reg.lint_store.register_late_pass(|| box Pass);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-group-plugin-test.rs
@@ -9,7 +9,7 @@ extern crate rustc;
 extern crate rustc_driver;
 
 use rustc::hir;
-use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LateLintPassObject, LintArray};
+use rustc::lint::{LateContext, LintContext, LintPass, LateLintPass, LintArray, LintId};
 use rustc_driver::plugin::Registry;
 
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
@@ -30,6 +30,8 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_late_lint_pass(box Pass);
-    reg.register_lint_group("lint_me", None, vec![TEST_LINT, PLEASE_LINT]);
+    reg.lint_store.register_lints(&[&TEST_LINT, &PLEASE_LINT]);
+    reg.lint_store.register_late_pass(|| box Pass);
+    reg.lint_store.register_group(true, "lint_me", None,
+        vec![LintId::of(&TEST_LINT), LintId::of(&PLEASE_LINT)]);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-plugin-test.rs
@@ -10,8 +10,7 @@ extern crate syntax;
 extern crate rustc;
 extern crate rustc_driver;
 
-use rustc::lint::{EarlyContext, LintContext, LintPass, EarlyLintPass,
-                  EarlyLintPassObject, LintArray};
+use rustc::lint::{EarlyContext, LintContext, LintPass, EarlyLintPass, LintArray};
 use rustc_driver::plugin::Registry;
 use syntax::ast;
 declare_lint!(TEST_LINT, Warn, "Warn about items named 'lintme'");
@@ -28,5 +27,6 @@ impl EarlyLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_early_lint_pass(box Pass as EarlyLintPassObject);
+    reg.lint_store.register_lints(&[&TEST_LINT]);
+    reg.lint_store.register_early_pass(|| box Pass);
 }

--- a/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
+++ b/src/test/ui-fulldeps/auxiliary/lint-tool-test.rs
@@ -8,7 +8,7 @@ extern crate syntax;
 extern crate rustc;
 extern crate rustc_driver;
 
-use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass};
+use rustc::lint::{EarlyContext, EarlyLintPass, LintArray, LintContext, LintPass, LintId};
 use rustc_driver::plugin::Registry;
 use syntax::ast;
 declare_tool_lint!(pub clippy::TEST_LINT, Warn, "Warn about stuff");
@@ -40,6 +40,8 @@ impl EarlyLintPass for Pass {
 
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
-    reg.register_early_lint_pass(box Pass);
-    reg.register_lint_group("clippy::group", Some("clippy_group"), vec![TEST_LINT, TEST_GROUP]);
+    reg.lint_store.register_lints(&[&TEST_RUSTC_TOOL_LINT, &TEST_LINT, &TEST_GROUP]);
+    reg.lint_store.register_early_pass(|| box Pass);
+    reg.lint_store.register_group(true, "clippy::group", Some("clippy_group"),
+        vec![LintId::of(&TEST_LINT), LintId::of(&TEST_GROUP)]);
 }

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.rs
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.rs
@@ -6,7 +6,7 @@
 extern crate rustc;
 
 use rustc::lint::{LintArray, LintPass};
-use rustc::{declare_lint, declare_lint_pass, impl_lint_pass, lint_array};
+use rustc::{declare_lint, declare_lint_pass, impl_lint_pass};
 
 declare_lint! {
     pub TEST_LINT,
@@ -17,10 +17,6 @@ declare_lint! {
 struct Foo;
 
 impl LintPass for Foo { //~ERROR implementing `LintPass` by hand
-    fn get_lints(&self) -> LintArray {
-        lint_array!(TEST_LINT)
-    }
-
     fn name(&self) -> &'static str {
         "Foo"
     }
@@ -31,10 +27,6 @@ macro_rules! custom_lint_pass_macro {
         struct Custom;
 
         impl LintPass for Custom { //~ERROR implementing `LintPass` by hand
-            fn get_lints(&self) -> LintArray {
-                lint_array!(TEST_LINT)
-            }
-
             fn name(&self) -> &'static str {
                 "Custom"
             }

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -23,3 +23,4 @@ LL | custom_lint_pass_macro!();
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
 
 error: aborting due to 2 previous errors
+

--- a/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
+++ b/src/test/ui-fulldeps/internal-lints/lint_pass_impl_without_macro.stderr
@@ -12,7 +12,7 @@ LL | #![deny(rustc::lint_pass_impl_without_macro)]
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
 
 error: implementing `LintPass` by hand
-  --> $DIR/lint_pass_impl_without_macro.rs:33:14
+  --> $DIR/lint_pass_impl_without_macro.rs:29:14
    |
 LL |         impl LintPass for Custom {
    |              ^^^^^^^^
@@ -23,4 +23,3 @@ LL | custom_lint_pass_macro!();
    = help: try using `declare_lint_pass!` or `impl_lint_pass!` instead
 
 error: aborting due to 2 previous errors
-


### PR DESCRIPTION
This removes mutability from the lint store after registration. Each commit stands alone, for the most part, though they don't make sense out of sequence.

The intent here is to move LintStore to a more parallel-friendly architecture, although also just a cleaner one from an implementation perspective. Specifically, this has the following changes:
 * We no longer implicitly register lints when registering lint passes
    * For the most part this means that registration calls now likely want to call something like:
       `lint_store.register_lints(&Pass::get_lints())` as well as `register_*_pass`.
    * In theory this is a simplification as it's much easier for folks to just register lints and then have passes that implement whichever lint however they want, rather than necessarily tying passes to lints.
 * Lint passes still have a list of associated lints, but a followup PR could plausibly change that
   * This list must be known for a given pass type, not instance, i.e., `fn get_lints()` is the signature instead of `fn get_lints(&self)` as before.
 * We do not store pass objects, instead storing constructor functions. This means we always get new passes when running lints (this happens approximately once though for a given compiler session, so no behavior change is expected).
 * Registration API is _much_ simpler: generally all functions are just taking `Fn() -> PassObject` rather than several different `bool`s.