### PR TITLE
Rename `bool::then_*` to `bool::to_option_*` and use where appropriate

### DIFF
--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -9,12 +9,12 @@ impl bool {
     /// ```
     /// #![feature(bool_to_option)]
     ///
-    /// assert_eq!(false.then(0), None);
-    /// assert_eq!(true.then(0), Some(0));
+    /// assert_eq!(false.to_option(0), None);
+    /// assert_eq!(true.to_option(0), Some(0));
     /// ```
     #[unstable(feature = "bool_to_option", issue = "64260")]
     #[inline]
-    pub fn then<T>(self, t: T) -> Option<T> {
+    pub fn to_option<T>(self, t: T) -> Option<T> {
         if self {
             Some(t)
         } else {
@@ -29,12 +29,12 @@ impl bool {
     /// ```
     /// #![feature(bool_to_option)]
     ///
-    /// assert_eq!(false.then_with(|| 0), None);
-    /// assert_eq!(true.then_with(|| 0), Some(0));
+    /// assert_eq!(false.to_option_with(|| 0), None);
+    /// assert_eq!(true.to_option_with(|| 0), Some(0));
     /// ```
     #[unstable(feature = "bool_to_option", issue = "64260")]
     #[inline]
-    pub fn then_with<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
+    pub fn to_option_with<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self {
             Some(f())
         } else {

--- a/src/libcore/bool.rs
+++ b/src/libcore/bool.rs
@@ -9,12 +9,12 @@ impl bool {
     /// ```
     /// #![feature(bool_to_option)]
     ///
-    /// assert_eq!(false.to_option(0), None);
-    /// assert_eq!(true.to_option(0), Some(0));
+    /// assert_eq!(false.then_some(0), None);
+    /// assert_eq!(true.then_some(0), Some(0));
     /// ```
     #[unstable(feature = "bool_to_option", issue = "64260")]
     #[inline]
-    pub fn to_option<T>(self, t: T) -> Option<T> {
+    pub fn then_some<T>(self, t: T) -> Option<T> {
         if self {
             Some(t)
         } else {
@@ -29,12 +29,12 @@ impl bool {
     /// ```
     /// #![feature(bool_to_option)]
     ///
-    /// assert_eq!(false.to_option_with(|| 0), None);
-    /// assert_eq!(true.to_option_with(|| 0), Some(0));
+    /// assert_eq!(false.then(|| 0), None);
+    /// assert_eq!(true.then(|| 0), Some(0));
     /// ```
     #[unstable(feature = "bool_to_option", issue = "64260")]
     #[inline]
-    pub fn to_option_with<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
+    pub fn then<T, F: FnOnce() -> T>(self, f: F) -> Option<T> {
         if self {
             Some(f())
         } else {

--- a/src/libcore/tests/bool.rs
+++ b/src/libcore/tests/bool.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_bool_to_option() {
-    assert_eq!(false.then(0), None);
-    assert_eq!(true.then(0), Some(0));
-    assert_eq!(false.then_with(|| 0), None);
-    assert_eq!(true.then_with(|| 0), Some(0));
+    assert_eq!(false.to_option(0), None);
+    assert_eq!(true.to_option(0), Some(0));
+    assert_eq!(false.to_option_with(|| 0), None);
+    assert_eq!(true.to_option_with(|| 0), Some(0));
 }

--- a/src/libcore/tests/bool.rs
+++ b/src/libcore/tests/bool.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_bool_to_option() {
-    assert_eq!(false.to_option(0), None);
-    assert_eq!(true.to_option(0), Some(0));
-    assert_eq!(false.to_option_with(|| 0), None);
-    assert_eq!(true.to_option_with(|| 0), Some(0));
+    assert_eq!(false.then_some(0), None);
+    assert_eq!(true.then_some(0), Some(0));
+    assert_eq!(false.then(|| 0), None);
+    assert_eq!(true.then(|| 0), Some(0));
 }

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -645,7 +645,7 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
-        found.to_option(cur)
+        found.then_some(cur)
     }
 }
 

--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -11,6 +11,7 @@
 #![feature(nll)]
 #![feature(rustc_private)]
 #![feature(unicode_internals)]
+#![feature(bool_to_option)]
 
 pub use Piece::*;
 pub use Position::*;
@@ -644,11 +645,7 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
-        if found {
-            Some(cur)
-        } else {
-            None
-        }
+        found.to_option(cur)
     }
 }
 

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -147,13 +147,7 @@ impl<'a> FnLikeNode<'a> {
             map::Node::Expr(e) => e.is_fn_like(),
             _ => false
         };
-        if fn_like {
-            Some(FnLikeNode {
-                node,
-            })
-        } else {
-            None
-        }
+        fn_like.to_option(FnLikeNode { node })
     }
 
     pub fn body(self) -> ast::BodyId {

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -147,7 +147,7 @@ impl<'a> FnLikeNode<'a> {
             map::Node::Expr(e) => e.is_fn_like(),
             _ => false
         };
-        fn_like.to_option(FnLikeNode { node })
+        fn_like.then_some(FnLikeNode { node })
     }
 
     pub fn body(self) -> ast::BodyId {

--- a/src/librustc/infer/outlives/verify.rs
+++ b/src/librustc/infer/outlives/verify.rs
@@ -211,11 +211,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 (r, p)
             );
             let p_ty = p.to_ty(tcx);
-            if compare_ty(p_ty) {
-                Some(ty::OutlivesPredicate(p_ty, r))
-            } else {
-                None
-            }
+            compare_ty(p_ty).to_option(ty::OutlivesPredicate(p_ty, r))
         });
 
         param_bounds

--- a/src/librustc/infer/outlives/verify.rs
+++ b/src/librustc/infer/outlives/verify.rs
@@ -211,7 +211,7 @@ impl<'cx, 'tcx> VerifyBoundCx<'cx, 'tcx> {
                 (r, p)
             );
             let p_ty = p.to_ty(tcx);
-            compare_ty(p_ty).to_option(ty::OutlivesPredicate(p_ty, r))
+            compare_ty(p_ty).then_some(ty::OutlivesPredicate(p_ty, r))
         });
 
         param_bounds

--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -29,6 +29,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(arbitrary_self_types)]
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(const_fn)]

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -242,11 +242,7 @@ impl<'tcx> Body<'tcx> {
     pub fn vars_iter<'a>(&'a self) -> impl Iterator<Item = Local> + 'a {
         (self.arg_count + 1..self.local_decls.len()).filter_map(move |index| {
             let local = Local::new(index);
-            if self.local_decls[local].is_user_variable() {
-                Some(local)
-            } else {
-                None
-            }
+            self.local_decls[local].is_user_variable().to_option(local)
         })
     }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -242,7 +242,7 @@ impl<'tcx> Body<'tcx> {
     pub fn vars_iter<'a>(&'a self) -> impl Iterator<Item = Local> + 'a {
         (self.arg_count + 1..self.local_decls.len()).filter_map(move |index| {
             let local = Local::new(index);
-            self.local_decls[local].is_user_variable().to_option(local)
+            self.local_decls[local].is_user_variable().then_some(local)
         })
     }
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -363,11 +363,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             return None
         };
 
-        if tcx.has_attr(impl_def_id, sym::rustc_on_unimplemented) {
-            Some(impl_def_id)
-        } else {
-            None
-        }
+        tcx.has_attr(impl_def_id, sym::rustc_on_unimplemented).to_option(impl_def_id)
     }
 
     fn describe_generator(&self, body_id: hir::BodyId) -> Option<&'static str> {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -363,7 +363,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             return None
         };
 
-        tcx.has_attr(impl_def_id, sym::rustc_on_unimplemented).to_option(impl_def_id)
+        tcx.has_attr(impl_def_id, sym::rustc_on_unimplemented).then_some(impl_def_id)
     }
 
     fn describe_generator(&self, body_id: hir::BodyId) -> Option<&'static str> {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2784,7 +2784,7 @@ impl<'tcx> TyCtxt<'tcx> {
             }
         };
 
-        is_associated_item.to_option_with(|| self.associated_item(def_id))
+        is_associated_item.then(|| self.associated_item(def_id))
     }
 
     fn associated_item_from_trait_item_ref(self,
@@ -3249,7 +3249,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ParamEnv<'_> {
     let unnormalized_env = ty::ParamEnv::new(
         tcx.intern_predicates(&predicates),
         traits::Reveal::UserFacing,
-        tcx.sess.opts.debugging_opts.chalk.to_option(def_id),
+        tcx.sess.opts.debugging_opts.chalk.then_some(def_id),
     );
 
     let body_id = tcx.hir().as_local_hir_id(def_id).map_or(hir::DUMMY_HIR_ID, |id| {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -2784,11 +2784,7 @@ impl<'tcx> TyCtxt<'tcx> {
             }
         };
 
-        if is_associated_item {
-            Some(self.associated_item(def_id))
-        } else {
-            None
-        }
+        is_associated_item.to_option_with(|| self.associated_item(def_id))
     }
 
     fn associated_item_from_trait_item_ref(self,
@@ -3253,7 +3249,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ParamEnv<'_> {
     let unnormalized_env = ty::ParamEnv::new(
         tcx.intern_predicates(&predicates),
         traits::Reveal::UserFacing,
-        if tcx.sess.opts.debugging_opts.chalk { Some(def_id) } else { None }
+        tcx.sess.opts.debugging_opts.chalk.to_option(def_id),
     );
 
     let body_id = tcx.hir().as_local_hir_id(def_id).map_or(hir::DUMMY_HIR_ID, |id| {

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -303,13 +303,8 @@ fn connected_to_root<'tcx>(
         return true;
     }
 
-    visit_waiters(query, |_, successor| {
-        if connected_to_root(successor, visited) {
-            Some(None)
-        } else {
-            None
-        }
-    }).is_some()
+    visit_waiters(query, |_, successor| connected_to_root(successor, visited).to_option(None))
+        .is_some()
 }
 
 // Deterministically pick an query from a list

--- a/src/librustc/ty/query/job.rs
+++ b/src/librustc/ty/query/job.rs
@@ -303,7 +303,7 @@ fn connected_to_root<'tcx>(
         return true;
     }
 
-    visit_waiters(query, |_, successor| connected_to_root(successor, visited).to_option(None))
+    visit_waiters(query, |_, successor| connected_to_root(successor, visited).then_some(None))
         .is_some()
 }
 

--- a/src/librustc_codegen_llvm/attributes.rs
+++ b/src/librustc_codegen_llvm/attributes.rs
@@ -375,11 +375,7 @@ pub fn provide_extern(providers: &mut Providers<'_>) {
         let native_libs = tcx.native_libraries(cnum);
 
         let def_id_to_native_lib = native_libs.iter().filter_map(|lib|
-            if let Some(id) = lib.foreign_module {
-                Some((id, lib))
-            } else {
-                None
-            }
+            lib.foreign_module.map(|id| (id, lib))
         ).collect::<FxHashMap<_, _>>();
 
         let mut ret = FxHashMap::default();

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -245,7 +245,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             let (mut lo, mut hi) = (0u64, 0u64);
             let success = llvm::LLVMRustConstInt128Get(v, sign_ext,
                                                         &mut hi, &mut lo);
-            success.to_option(hi_lo_to_u128(lo, hi))
+            success.then_some(hi_lo_to_u128(lo, hi))
         })
     }
 

--- a/src/librustc_codegen_llvm/common.rs
+++ b/src/librustc_codegen_llvm/common.rs
@@ -245,11 +245,7 @@ impl ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             let (mut lo, mut hi) = (0u64, 0u64);
             let success = llvm::LLVMRustConstInt128Get(v, sign_ext,
                                                         &mut hi, &mut lo);
-            if success {
-                Some(hi_lo_to_u128(lo, hi))
-            } else {
-                None
-            }
+            success.to_option(hi_lo_to_u128(lo, hi))
         })
     }
 

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -6,6 +6,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(const_cstr_unchecked)]

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -119,7 +119,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
     if path.is_absolute() != base.is_absolute() {
-        path.is_absolute().to_option(PathBuf::from(path))
+        path.is_absolute().to_option_with(|| PathBuf::from(path))
     } else {
         let mut ita = path.components();
         let mut itb = base.components();

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -119,11 +119,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
     if path.is_absolute() != base.is_absolute() {
-        if path.is_absolute() {
-            Some(PathBuf::from(path))
-        } else {
-            None
-        }
+        path.is_absolute().to_option(PathBuf::from(path))
     } else {
         let mut ita = path.components();
         let mut itb = base.components();

--- a/src/librustc_codegen_ssa/back/rpath.rs
+++ b/src/librustc_codegen_ssa/back/rpath.rs
@@ -119,7 +119,7 @@ fn path_relative_from(path: &Path, base: &Path) -> Option<PathBuf> {
     use std::path::Component;
 
     if path.is_absolute() != base.is_absolute() {
-        path.is_absolute().to_option_with(|| PathBuf::from(path))
+        path.is_absolute().then(|| PathBuf::from(path))
     } else {
         let mut ita = path.components();
         let mut itb = base.components();

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -85,11 +85,7 @@ fn reachable_non_generics_provider(
             match tcx.hir().get(hir_id) {
                 Node::ForeignItem(..) => {
                     let def_id = tcx.hir().local_def_id(hir_id);
-                    if tcx.is_statically_included_foreign_item(def_id) {
-                        Some(def_id)
-                    } else {
-                        None
-                    }
+                    tcx.is_statically_included_foreign_item(def_id).to_option(def_id)
                 }
 
                 // Only consider nodes that actually have exported symbols.

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -85,7 +85,7 @@ fn reachable_non_generics_provider(
             match tcx.hir().get(hir_id) {
                 Node::ForeignItem(..) => {
                     let def_id = tcx.hir().local_def_id(hir_id);
-                    tcx.is_statically_included_foreign_item(def_id).to_option(def_id)
+                    tcx.is_statically_included_foreign_item(def_id).then_some(def_id)
                 }
 
                 // Only consider nodes that actually have exported symbols.

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(core_intrinsics)]
@@ -68,22 +69,11 @@ impl<M> ModuleCodegen<M> {
                             emit_bc: bool,
                             emit_bc_compressed: bool,
                             outputs: &OutputFilenames) -> CompiledModule {
-        let object = if emit_obj {
-            Some(outputs.temp_path(OutputType::Object, Some(&self.name)))
-        } else {
-            None
-        };
-        let bytecode = if emit_bc {
-            Some(outputs.temp_path(OutputType::Bitcode, Some(&self.name)))
-        } else {
-            None
-        };
-        let bytecode_compressed = if emit_bc_compressed {
-            Some(outputs.temp_path(OutputType::Bitcode, Some(&self.name))
-                    .with_extension(RLIB_BYTECODE_EXTENSION))
-        } else {
-            None
-        };
+        let object = emit_obj.to_option(outputs.temp_path(OutputType::Object, Some(&self.name)));
+        let bytecode = emit_bc.to_option(outputs.temp_path(OutputType::Bitcode, Some(&self.name)));
+        let bytecode_compressed = emit_bc_compressed.to_option(
+            outputs.temp_path(OutputType::Bitcode, Some(&self.name))
+                    .with_extension(RLIB_BYTECODE_EXTENSION));
 
         CompiledModule {
             name: self.name.clone(),

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -69,11 +69,14 @@ impl<M> ModuleCodegen<M> {
                             emit_bc: bool,
                             emit_bc_compressed: bool,
                             outputs: &OutputFilenames) -> CompiledModule {
-        let object = emit_obj.to_option(outputs.temp_path(OutputType::Object, Some(&self.name)));
-        let bytecode = emit_bc.to_option(outputs.temp_path(OutputType::Bitcode, Some(&self.name)));
-        let bytecode_compressed = emit_bc_compressed.to_option(
+        let object = emit_obj
+            .to_option_with(|| outputs.temp_path(OutputType::Object, Some(&self.name)));
+        let bytecode = emit_bc
+            .to_option_with(|| outputs.temp_path(OutputType::Bitcode, Some(&self.name)));
+        let bytecode_compressed = emit_bc_compressed.to_option_with(|| {
             outputs.temp_path(OutputType::Bitcode, Some(&self.name))
-                    .with_extension(RLIB_BYTECODE_EXTENSION));
+                .with_extension(RLIB_BYTECODE_EXTENSION)
+        });
 
         CompiledModule {
             name: self.name.clone(),

--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -70,10 +70,10 @@ impl<M> ModuleCodegen<M> {
                             emit_bc_compressed: bool,
                             outputs: &OutputFilenames) -> CompiledModule {
         let object = emit_obj
-            .to_option_with(|| outputs.temp_path(OutputType::Object, Some(&self.name)));
+            .then(|| outputs.temp_path(OutputType::Object, Some(&self.name)));
         let bytecode = emit_bc
-            .to_option_with(|| outputs.temp_path(OutputType::Bitcode, Some(&self.name)));
-        let bytecode_compressed = emit_bc_compressed.to_option_with(|| {
+            .then(|| outputs.temp_path(OutputType::Bitcode, Some(&self.name)));
+        let bytecode_compressed = emit_bc_compressed.then(|| {
             outputs.temp_path(OutputType::Bitcode, Some(&self.name))
                 .with_extension(RLIB_BYTECODE_EXTENSION)
         });

--- a/src/librustc_interface/lib.rs
+++ b/src/librustc_interface/lib.rs
@@ -1,3 +1,4 @@
+#![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(set_stdio)]
 #![feature(nll)]

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -547,7 +547,7 @@ fn output_contains_path(output_paths: &[PathBuf], input_path: &PathBuf) -> bool 
 }
 
 fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
-    let check = |output_path: &PathBuf| output_path.is_dir().to_option_with(|| output_path.clone());
+    let check = |output_path: &PathBuf| output_path.is_dir().then(|| output_path.clone());
     check_output(output_paths, check)
 }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -547,7 +547,7 @@ fn output_contains_path(output_paths: &[PathBuf], input_path: &PathBuf) -> bool 
 }
 
 fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
-    let check = |output_path: &PathBuf| output_path.is_dir().to_option(output_path.clone());
+    let check = |output_path: &PathBuf| output_path.is_dir().to_option_with(|| output_path.clone());
     check_output(output_paths, check)
 }
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -547,13 +547,7 @@ fn output_contains_path(output_paths: &[PathBuf], input_path: &PathBuf) -> bool 
 }
 
 fn output_conflicts_with_dir(output_paths: &[PathBuf]) -> Option<PathBuf> {
-    let check = |output_path: &PathBuf| {
-        if output_path.is_dir() {
-            Some(output_path.clone())
-        } else {
-            None
-        }
-    };
+    let check = |output_path: &PathBuf| output_path.is_dir().to_option(output_path.clone());
     check_output(output_paths, check)
 }
 

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -117,11 +117,9 @@ impl<'tcx> Queries<'tcx> {
 
     pub fn dep_graph_future(&self) -> Result<&Query<Option<DepGraphFuture>>> {
         self.dep_graph_future.compute(|| {
-            Ok(if self.session().opts.build_dep_graph() {
-                Some(rustc_incremental::load_dep_graph(self.session()))
-            } else {
-                None
-            })
+            Ok(self.session().opts.build_dep_graph().to_option_with(|| {
+                rustc_incremental::load_dep_graph(self.session())
+            }))
         })
     }
 

--- a/src/librustc_interface/queries.rs
+++ b/src/librustc_interface/queries.rs
@@ -117,7 +117,7 @@ impl<'tcx> Queries<'tcx> {
 
     pub fn dep_graph_future(&self) -> Result<&Query<Option<DepGraphFuture>>> {
         self.dep_graph_future.compute(|| {
-            Ok(self.session().opts.build_dep_graph().to_option_with(|| {
+            Ok(self.session().opts.build_dep_graph().then(|| {
                 rustc_incremental::load_dep_graph(self.session())
             }))
         })

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -107,7 +107,7 @@ const STACK_SIZE: usize = 16 * 1024 * 1024;
 fn get_stack_size() -> Option<usize> {
     // FIXME: Hacks on hacks. If the env is trying to override the stack size
     // then *don't* set it explicitly.
-    env::var_os("RUST_MIN_STACK").is_none().to_option(STACK_SIZE)
+    env::var_os("RUST_MIN_STACK").is_none().then_some(STACK_SIZE)
 }
 
 struct Sink(Arc<Mutex<Vec<u8>>>);
@@ -281,7 +281,7 @@ fn get_rustc_path_inner(bin_path: &str) -> Option<PathBuf> {
             } else {
                 "rustc"
             });
-            candidate.exists().to_option(candidate)
+            candidate.exists().then_some(candidate)
         })
         .next()
 }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -107,11 +107,7 @@ const STACK_SIZE: usize = 16 * 1024 * 1024;
 fn get_stack_size() -> Option<usize> {
     // FIXME: Hacks on hacks. If the env is trying to override the stack size
     // then *don't* set it explicitly.
-    if env::var_os("RUST_MIN_STACK").is_none() {
-        Some(STACK_SIZE)
-    } else {
-        None
-    }
+    env::var_os("RUST_MIN_STACK").is_none().to_option(STACK_SIZE)
 }
 
 struct Sink(Arc<Mutex<Vec<u8>>>);
@@ -285,11 +281,7 @@ fn get_rustc_path_inner(bin_path: &str) -> Option<PathBuf> {
             } else {
                 "rustc"
             });
-            if candidate.exists() {
-                Some(candidate)
-            } else {
-                None
-            }
+            candidate.exists().to_option(candidate)
         })
         .next()
 }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1491,11 +1491,7 @@ impl ExplicitOutlivesRequirements {
             match pred {
                 ty::Predicate::TypeOutlives(outlives) => {
                     let outlives = outlives.skip_binder();
-                    if outlives.0.is_param(index) {
-                        Some(outlives.1)
-                    } else {
-                        None
-                    }
+                    outlives.0.is_param(index).to_option(outlives.1)
                 }
                 _ => None
             }
@@ -1554,11 +1550,7 @@ impl ExplicitOutlivesRequirements {
                             }),
                         _ => false,
                     };
-                    if is_inferred {
-                        Some((i, bound.span()))
-                    } else {
-                        None
-                    }
+                    is_inferred.to_option((i, bound.span()))
                 } else {
                     None
                 }

--- a/src/librustc_lint/builtin.rs
+++ b/src/librustc_lint/builtin.rs
@@ -1491,7 +1491,7 @@ impl ExplicitOutlivesRequirements {
             match pred {
                 ty::Predicate::TypeOutlives(outlives) => {
                     let outlives = outlives.skip_binder();
-                    outlives.0.is_param(index).to_option(outlives.1)
+                    outlives.0.is_param(index).then_some(outlives.1)
                 }
                 _ => None
             }
@@ -1550,7 +1550,7 @@ impl ExplicitOutlivesRequirements {
                             }),
                         _ => false,
                     };
-                    is_inferred.to_option((i, bound.span()))
+                    is_inferred.then_some((i, bound.span()))
                 } else {
                     None
                 }

--- a/src/librustc_lint/lib.rs
+++ b/src/librustc_lint/lib.rs
@@ -12,6 +12,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![cfg_attr(test, feature(test))]
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(nll)]

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -803,7 +803,7 @@ impl<'a> CrateLoader<'a> {
         // and see what's a global allocator, including if we ourselves are a
         // global allocator.
         let mut global_allocator = self.cstore.has_global_allocator
-            .to_option_with(|| Symbol::intern("this crate"));
+            .then(|| Symbol::intern("this crate"));
         self.cstore.iter_crate_data(|_, data| {
             if !data.has_global_allocator() {
                 return

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -802,11 +802,8 @@ impl<'a> CrateLoader<'a> {
         // First up we check for global allocators. Look at the crate graph here
         // and see what's a global allocator, including if we ourselves are a
         // global allocator.
-        let mut global_allocator = if self.cstore.has_global_allocator {
-            Some(Symbol::intern("this crate"))
-        } else {
-            None
-        };
+        let mut global_allocator = self.cstore.has_global_allocator
+            .to_option_with(|| Symbol::intern("this crate"));
         self.cstore.iter_crate_data(|_, data| {
             if !data.has_global_allocator() {
                 return

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(core_intrinsics)]
 #![feature(crate_visibility_modifier)]

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -173,11 +173,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     Option<Rc<Output<RegionVid, BorrowIndex, LocationIndex, Local, MovePathIndex>>>,
     Option<ClosureRegionRequirements<'tcx>>,
 ) {
-    let mut all_facts = if AllFacts::enabled(infcx.tcx) {
-        Some(AllFacts::default())
-    } else {
-        None
-    };
+    let mut all_facts = AllFacts::enabled(infcx.tcx).to_option(AllFacts::default());
 
     let universal_regions = Rc::new(universal_regions);
 

--- a/src/librustc_mir/borrow_check/nll/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/mod.rs
@@ -173,7 +173,7 @@ pub(in crate::borrow_check) fn compute_regions<'cx, 'tcx>(
     Option<Rc<Output<RegionVid, BorrowIndex, LocationIndex, Local, MovePathIndex>>>,
     Option<ClosureRegionRequirements<'tcx>>,
 ) {
-    let mut all_facts = AllFacts::enabled(infcx.tcx).to_option(AllFacts::default());
+    let mut all_facts = AllFacts::enabled(infcx.tcx).then_some(AllFacts::default());
 
     let universal_regions = Rc::new(universal_regions);
 

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -493,7 +493,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // functions below, which will trigger them to report errors
         // eagerly.
         let mut outlives_requirements =
-            if infcx.tcx.is_closure(mir_def_id) { Some(vec![]) } else { None };
+            infcx.tcx.is_closure(mir_def_id).to_option_with(|| vec![]);
 
         self.check_type_tests(
             infcx,
@@ -709,14 +709,11 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         let min = |r1: ty::RegionVid, r2: ty::RegionVid| -> Option<ty::RegionVid> {
             let r1_outlives_r2 = self.universal_region_relations.outlives(r1, r2);
             let r2_outlives_r1 = self.universal_region_relations.outlives(r2, r1);
-            if r1_outlives_r2 && r2_outlives_r1 {
-                Some(r1.min(r2))
-            } else if r1_outlives_r2 {
-                Some(r2)
-            } else if r2_outlives_r1 {
-                Some(r1)
-            } else {
-                None
+            match (r1_outlives_r2, r2_outlives_r1) {
+                (true, true) => Some(r1.min(r2)),
+                (true, false) => Some(r2),
+                (false, true) => Some(r1),
+                (false, false) => None,
             }
         };
         let mut min_choice = choice_regions[0];

--- a/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/mod.rs
@@ -493,7 +493,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         // functions below, which will trigger them to report errors
         // eagerly.
         let mut outlives_requirements =
-            infcx.tcx.is_closure(mir_def_id).to_option_with(|| vec![]);
+            infcx.tcx.is_closure(mir_def_id).then(|| vec![]);
 
         self.check_type_tests(
             infcx,

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -680,7 +680,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     }
                 })();
 
-                if no_overlap == Some(true) {
+                if let Some(true) = no_overlap {
                     // Testing range does not overlap with pattern range,
                     // so the pattern can be matched only if this test fails.
                     Some(1)
@@ -690,7 +690,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             (&TestKind::Range(range), &PatKind::Constant { value }) => {
-                if self.const_range_contains(range, value) == Some(false) {
+                if let Some(false) = self.const_range_contains(range, value) {
                     // `value` is not contained in the testing range,
                     // so `value` can be matched only if this test fails.
                     Some(1)

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -1154,13 +1154,7 @@ pub fn compare_const_vals<'tcx>(
 ) -> Option<Ordering> {
     trace!("compare_const_vals: {:?}, {:?}", a, b);
 
-    let from_bool = |v: bool| {
-        if v {
-            Some(Ordering::Equal)
-        } else {
-            None
-        }
-    };
+    let from_bool = |v: bool| v.to_option(Ordering::Equal);
 
     let fallback = || from_bool(a == b);
 

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -1154,7 +1154,7 @@ pub fn compare_const_vals<'tcx>(
 ) -> Option<Ordering> {
     trace!("compare_const_vals: {:?}, {:?}", a, b);
 
-    let from_bool = |v: bool| v.to_option(Ordering::Equal);
+    let from_bool = |v: bool| v.then_some(Ordering::Equal);
 
     let fallback = || from_bool(a == b);
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -324,7 +324,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         size: Size,
         align: Align,
     ) -> InterpResult<'tcx, Option<Pointer<M::PointerTag>>> {
-        let align = if M::CHECK_ALIGN { Some(align) } else { None };
+        let align = M::CHECK_ALIGN.to_option(align);
         self.check_ptr_access_align(sptr, size, align, CheckInAllocMsg::MemoryAccessTest)
     }
 

--- a/src/librustc_mir/interpret/memory.rs
+++ b/src/librustc_mir/interpret/memory.rs
@@ -324,7 +324,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> Memory<'mir, 'tcx, M> {
         size: Size,
         align: Align,
     ) -> InterpResult<'tcx, Option<Pointer<M::PointerTag>>> {
-        let align = M::CHECK_ALIGN.to_option(align);
+        let align = M::CHECK_ALIGN.then_some(align);
         self.check_ptr_access_align(sptr, size, align, CheckInAllocMsg::MemoryAccessTest)
     }
 

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -157,9 +157,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             BinaryOp(bin_op, ref left, ref right) => {
-                let layout = binop_left_homogeneous(bin_op).to_option(dest.layout);
+                let layout = binop_left_homogeneous(bin_op).then_some(dest.layout);
                 let left = self.read_immediate(self.eval_operand(left, layout)?)?;
-                let layout = binop_right_homogeneous(bin_op).to_option(left.layout);
+                let layout = binop_right_homogeneous(bin_op).then_some(left.layout);
                 let right = self.read_immediate(self.eval_operand(right, layout)?)?;
                 self.binop_ignore_overflow(
                     bin_op,
@@ -172,7 +172,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             CheckedBinaryOp(bin_op, ref left, ref right) => {
                 // Due to the extra boolean in the result, we can never reuse the `dest.layout`.
                 let left = self.read_immediate(self.eval_operand(left, None)?)?;
-                let layout = binop_right_homogeneous(bin_op).to_option(left.layout);
+                let layout = binop_right_homogeneous(bin_op).then_some(left.layout);
                 let right = self.read_immediate(self.eval_operand(right, layout)?)?;
                 self.binop_with_overflow(
                     bin_op,

--- a/src/librustc_mir/interpret/step.rs
+++ b/src/librustc_mir/interpret/step.rs
@@ -157,9 +157,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
 
             BinaryOp(bin_op, ref left, ref right) => {
-                let layout = if binop_left_homogeneous(bin_op) { Some(dest.layout) } else { None };
+                let layout = binop_left_homogeneous(bin_op).to_option(dest.layout);
                 let left = self.read_immediate(self.eval_operand(left, layout)?)?;
-                let layout = if binop_right_homogeneous(bin_op) { Some(left.layout) } else { None };
+                let layout = binop_right_homogeneous(bin_op).to_option(left.layout);
                 let right = self.read_immediate(self.eval_operand(right, layout)?)?;
                 self.binop_ignore_overflow(
                     bin_op,
@@ -172,7 +172,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             CheckedBinaryOp(bin_op, ref left, ref right) => {
                 // Due to the extra boolean in the result, we can never reuse the `dest.layout`.
                 let left = self.read_immediate(self.eval_operand(left, None)?)?;
-                let layout = if binop_right_homogeneous(bin_op) { Some(left.layout) } else { None };
+                let layout = binop_right_homogeneous(bin_op).to_option(left.layout);
                 let right = self.read_immediate(self.eval_operand(right, layout)?)?;
                 self.binop_with_overflow(
                     bin_op,

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -8,6 +8,7 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(in_band_lifetimes)]
 #![feature(inner_deref)]
 #![feature(slice_patterns)]
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]

--- a/src/librustc_mir/lib.rs
+++ b/src/librustc_mir/lib.rs
@@ -28,7 +28,6 @@ Rust MIR: a lowered representation of Rust. Also: an experiment!
 #![feature(associated_type_bounds)]
 #![feature(range_is_empty)]
 #![feature(stmt_expr_attributes)]
-#![feature(bool_to_option)]
 #![feature(trait_alias)]
 #![feature(matches_macro)]
 

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -761,11 +761,7 @@ fn compute_codegen_unit_name(
             .iter()
             .map(|part| part.data.as_symbol());
 
-        let volatile_suffix = if volatile {
-            Some("volatile")
-        } else {
-            None
-        };
+        let volatile_suffix = volatile.to_option("volatile");
 
         name_builder.build_cgu_name(def_path.krate, components, volatile_suffix)
     }).clone()

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -761,7 +761,7 @@ fn compute_codegen_unit_name(
             .iter()
             .map(|part| part.data.as_symbol());
 
-        let volatile_suffix = volatile.to_option("volatile");
+        let volatile_suffix = volatile.then_some("volatile");
 
         name_builder.build_cgu_name(def_path.krate, components, volatile_suffix)
     }).clone()

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -658,7 +658,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
     let mut unsafe_blocks: Vec<_> = unsafe_blocks.into_iter().collect();
     unsafe_blocks.sort_by_cached_key(|(hir_id, _)| tcx.hir().hir_to_node_id(*hir_id));
     let used_unsafe: FxHashSet<_> = unsafe_blocks.iter()
-        .flat_map(|&&(id, used)| if used { Some(id) } else { None })
+        .flat_map(|&&(id, used)| used.to_option(id))
         .collect();
     for &(block_id, is_used) in unsafe_blocks {
         if !is_used {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -658,7 +658,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: DefId) {
     let mut unsafe_blocks: Vec<_> = unsafe_blocks.into_iter().collect();
     unsafe_blocks.sort_by_cached_key(|(hir_id, _)| tcx.hir().hir_to_node_id(*hir_id));
     let used_unsafe: FxHashSet<_> = unsafe_blocks.iter()
-        .flat_map(|&&(id, used)| used.to_option(id))
+        .flat_map(|&&(id, used)| used.then_some(id))
         .collect();
     for &(block_id, is_used) in unsafe_blocks {
         if !is_used {

--- a/src/librustc_mir/transform/uninhabited_enum_branching.rs
+++ b/src/librustc_mir/transform/uninhabited_enum_branching.rs
@@ -29,7 +29,7 @@ fn get_switched_on_type<'tcx>(
     // Only bother checking blocks which terminate by switching on a local.
     if let Some(local) = get_discriminant_local(&terminator.kind) {
         let stmt_before_term = (block_data.statements.len() > 0)
-            .then_with(|| &block_data.statements[block_data.statements.len() - 1].kind);
+            .then(|| &block_data.statements[block_data.statements.len() - 1].kind);
 
         if let Some(StatementKind::Assign(box (l, Rvalue::Discriminant(place)))) = stmt_before_term
         {
@@ -59,7 +59,7 @@ fn variant_discriminants<'tcx>(
             .iter_enumerated()
             .filter_map(|(idx, layout)| {
                 (layout.abi != Abi::Uninhabited)
-                    .then_with(|| ty.discriminant_for_variant(tcx, idx).unwrap().val)
+                    .then(|| ty.discriminant_for_variant(tcx, idx).unwrap().val)
             })
             .collect(),
     }

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -75,7 +75,7 @@ macro_rules! configure {
 impl<'a> StripUnconfigured<'a> {
     pub fn configure<T: HasAttrs>(&mut self, mut node: T) -> Option<T> {
         self.process_cfg_attrs(&mut node);
-        if self.in_cfg(node.attrs()) { Some(node) } else { None }
+        self.in_cfg(node.attrs()).to_option(node)
     }
 
     /// Parse and expand all `cfg_attr` attributes into a list of attributes

--- a/src/librustc_parse/config.rs
+++ b/src/librustc_parse/config.rs
@@ -75,7 +75,7 @@ macro_rules! configure {
 impl<'a> StripUnconfigured<'a> {
     pub fn configure<T: HasAttrs>(&mut self, mut node: T) -> Option<T> {
         self.process_cfg_attrs(&mut node);
-        self.in_cfg(node.attrs()).to_option(node)
+        self.in_cfg(node.attrs()).then_some(node)
     }
 
     /// Parse and expand all `cfg_attr` attributes into a list of attributes

--- a/src/librustc_parse/lib.rs
+++ b/src/librustc_parse/lib.rs
@@ -1,5 +1,6 @@
 //! The main parser interface.
 
+#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 
 use syntax::ast;

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -422,7 +422,7 @@ impl<'a> Resolver<'a> {
                 Scope::MacroUsePrelude => {
                     suggestions.extend(this.macro_use_prelude.iter().filter_map(|(name, binding)| {
                         let res = binding.res();
-                        filter_fn(res).to_option(TypoSuggestion::from_res(*name, res))
+                        filter_fn(res).then_some(TypoSuggestion::from_res(*name, res))
                     }));
                 }
                 Scope::BuiltinAttrs => {
@@ -436,7 +436,7 @@ impl<'a> Resolver<'a> {
                 Scope::ExternPrelude => {
                     suggestions.extend(this.extern_prelude.iter().filter_map(|(ident, _)| {
                         let res = Res::Def(DefKind::Mod, DefId::local(CRATE_DEF_INDEX));
-                        filter_fn(res).to_option(TypoSuggestion::from_res(ident.name, res))
+                        filter_fn(res).then_some(TypoSuggestion::from_res(ident.name, res))
                     }));
                 }
                 Scope::ToolPrelude => {
@@ -459,7 +459,7 @@ impl<'a> Resolver<'a> {
                     suggestions.extend(
                         primitive_types.iter().flat_map(|(name, prim_ty)| {
                             let res = Res::PrimTy(*prim_ty);
-                            filter_fn(res).to_option(TypoSuggestion::from_res(*name, res))
+                            filter_fn(res).then_some(TypoSuggestion::from_res(*name, res))
                         })
                     )
                 }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -422,11 +422,7 @@ impl<'a> Resolver<'a> {
                 Scope::MacroUsePrelude => {
                     suggestions.extend(this.macro_use_prelude.iter().filter_map(|(name, binding)| {
                         let res = binding.res();
-                        if filter_fn(res) {
-                            Some(TypoSuggestion::from_res(*name, res))
-                        } else {
-                            None
-                        }
+                        filter_fn(res).to_option(TypoSuggestion::from_res(*name, res))
                     }));
                 }
                 Scope::BuiltinAttrs => {
@@ -440,11 +436,7 @@ impl<'a> Resolver<'a> {
                 Scope::ExternPrelude => {
                     suggestions.extend(this.extern_prelude.iter().filter_map(|(ident, _)| {
                         let res = Res::Def(DefKind::Mod, DefId::local(CRATE_DEF_INDEX));
-                        if filter_fn(res) {
-                            Some(TypoSuggestion::from_res(ident.name, res))
-                        } else {
-                            None
-                        }
+                        filter_fn(res).to_option(TypoSuggestion::from_res(ident.name, res))
                     }));
                 }
                 Scope::ToolPrelude => {
@@ -467,11 +459,7 @@ impl<'a> Resolver<'a> {
                     suggestions.extend(
                         primitive_types.iter().flat_map(|(name, prim_ty)| {
                             let res = Res::PrimTy(*prim_ty);
-                            if filter_fn(res) {
-                                Some(TypoSuggestion::from_res(*name, res))
-                            } else {
-                                None
-                            }
+                            filter_fn(res).to_option(TypoSuggestion::from_res(*name, res))
                         })
                     )
                 }

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -496,11 +496,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LateResolutionVisitor<'a, '_> {
                 GenericParamKind::Lifetime { .. } => None,
                 GenericParamKind::Type { ref default, .. } => {
                     found_default |= default.is_some();
-                    if found_default {
-                        Some((Ident::with_dummy_span(param.ident.name), Res::Err))
-                    } else {
-                        None
-                    }
+                    found_default.to_option((Ident::with_dummy_span(param.ident.name), Res::Err))
                 }
             }));
 

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -496,7 +496,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LateResolutionVisitor<'a, '_> {
                 GenericParamKind::Lifetime { .. } => None,
                 GenericParamKind::Type { ref default, .. } => {
                     found_default |= default.is_some();
-                    found_default.to_option((Ident::with_dummy_span(param.ident.name), Res::Err))
+                    found_default.then_some((Ident::with_dummy_span(param.ident.name), Res::Err))
                 }
             }));
 

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -9,6 +9,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(label_break_value)]
 #![feature(nll)]

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -752,7 +752,7 @@ impl Session {
     }
 
     pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<'_, PathBuf>> {
-        self.opts.incremental.is_some().to_option_with(|| self.incr_comp_session_dir())
+        self.opts.incremental.as_ref().map(|_| self.incr_comp_session_dir())
     }
 
     pub fn print_perf_stats(&self) {

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -752,11 +752,7 @@ impl Session {
     }
 
     pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<'_, PathBuf>> {
-        if self.opts.incremental.is_some() {
-            Some(self.incr_comp_session_dir())
-        } else {
-            None
-        }
+        self.opts.incremental.is_some().to_option(self.incr_comp_session_dir())
     }
 
     pub fn print_perf_stats(&self) {
@@ -1079,8 +1075,9 @@ fn build_session_(
                     None
                 }
             }
-        }
-        else { None };
+        } else {
+            None
+        };
 
     let host_triple = TargetTriple::from_triple(config::host_triple());
     let host = Target::search(&host_triple).unwrap_or_else(|e|

--- a/src/librustc_session/session.rs
+++ b/src/librustc_session/session.rs
@@ -752,7 +752,7 @@ impl Session {
     }
 
     pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<'_, PathBuf>> {
-        self.opts.incremental.is_some().to_option(self.incr_comp_session_dir())
+        self.opts.incremental.is_some().to_option_with(|| self.incr_comp_session_dir())
     }
 
     pub fn print_perf_stats(&self) {

--- a/src/librustc_target/abi/call/aarch64.rs
+++ b/src/librustc_target/abi/call/aarch64.rs
@@ -20,7 +20,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => size.bits() == 64 || size.bits() == 128
         };
 
-        valid_unit.to_option(Uniform { unit, total: size })
+        valid_unit.then_some(Uniform { unit, total: size })
     })
 }
 

--- a/src/librustc_target/abi/call/aarch64.rs
+++ b/src/librustc_target/abi/call/aarch64.rs
@@ -20,14 +20,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => size.bits() == 64 || size.bits() == 128
         };
 
-        if valid_unit {
-            Some(Uniform {
-                unit,
-                total: size
-            })
-        } else {
-            None
-        }
+        valid_unit.to_option(Uniform { unit, total: size })
     })
 }
 

--- a/src/librustc_target/abi/call/arm.rs
+++ b/src/librustc_target/abi/call/arm.rs
@@ -21,14 +21,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => size.bits() == 64 || size.bits() == 128
         };
 
-        if valid_unit {
-            Some(Uniform {
-                unit,
-                total: size
-            })
-        } else {
-            None
-        }
+        valid_unit.to_option(Uniform { unit, total: size })
     })
 }
 

--- a/src/librustc_target/abi/call/arm.rs
+++ b/src/librustc_target/abi/call/arm.rs
@@ -21,7 +21,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => size.bits() == 64 || size.bits() == 128
         };
 
-        valid_unit.to_option(Uniform { unit, total: size })
+        valid_unit.then_some(Uniform { unit, total: size })
     })
 }
 

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -416,7 +416,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
         // i686-pc-windows-msvc, it results in wrong stack offsets.
         // attrs.pointee_align = Some(self.layout.align.abi);
 
-        let extra_attrs = self.layout.is_unsized().to_option(ArgAttributes::new());
+        let extra_attrs = self.layout.is_unsized().then_some(ArgAttributes::new());
 
         self.mode = PassMode::Indirect(attrs, extra_attrs);
     }

--- a/src/librustc_target/abi/call/mod.rs
+++ b/src/librustc_target/abi/call/mod.rs
@@ -416,11 +416,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
         // i686-pc-windows-msvc, it results in wrong stack offsets.
         // attrs.pointee_align = Some(self.layout.align.abi);
 
-        let extra_attrs = if self.layout.is_unsized() {
-            Some(ArgAttributes::new())
-        } else {
-            None
-        };
+        let extra_attrs = self.layout.is_unsized().to_option(ArgAttributes::new());
 
         self.mode = PassMode::Indirect(attrs, extra_attrs);
     }

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -32,14 +32,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, abi: AB
             RegKind::Vector => arg.layout.size.bits() == 128
         };
 
-        if valid_unit {
-            Some(Uniform {
-                unit,
-                total: arg.layout.size
-            })
-        } else {
-            None
-        }
+        valid_unit.to_option(Uniform { unit, total: arg.layout.size })
     })
 }
 

--- a/src/librustc_target/abi/call/powerpc64.rs
+++ b/src/librustc_target/abi/call/powerpc64.rs
@@ -32,7 +32,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, abi: AB
             RegKind::Vector => arg.layout.size.bits() == 128
         };
 
-        valid_unit.to_option(Uniform { unit, total: arg.layout.size })
+        valid_unit.then_some(Uniform { unit, total: arg.layout.size })
     })
 }
 

--- a/src/librustc_target/abi/call/sparc64.rs
+++ b/src/librustc_target/abi/call/sparc64.rs
@@ -20,7 +20,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => arg.layout.size.bits() == 128
         };
 
-        valid_unit.to_option(Uniform { unit, total: arg.layout.size })
+        valid_unit.then_some(Uniform { unit, total: arg.layout.size })
     })
 }
 

--- a/src/librustc_target/abi/call/sparc64.rs
+++ b/src/librustc_target/abi/call/sparc64.rs
@@ -20,14 +20,7 @@ fn is_homogeneous_aggregate<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>)
             RegKind::Vector => arg.layout.size.bits() == 128
         };
 
-        if valid_unit {
-            Some(Uniform {
-                unit,
-                total: arg.layout.size
-            })
-        } else {
-            None
-        }
+        valid_unit.to_option(Uniform { unit, total: arg.layout.size })
     })
 }
 

--- a/src/librustc_target/lib.rs
+++ b/src/librustc_target/lib.rs
@@ -10,6 +10,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
 #![feature(box_syntax)]
+#![feature(bool_to_option)]
 #![feature(nll)]
 #![feature(slice_patterns)]
 

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1105,7 +1105,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             r.map(|mut pick| {
                 pick.autoderefs = step.autoderefs;
                 pick.autoref = Some(mutbl);
-                pick.unsize = step.unsize.to_option(self_ty);
+                pick.unsize = step.unsize.then_some(self_ty);
                 pick
             })
         })

--- a/src/librustc_typeck/check/method/probe.rs
+++ b/src/librustc_typeck/check/method/probe.rs
@@ -1105,11 +1105,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             r.map(|mut pick| {
                 pick.autoderefs = step.autoderefs;
                 pick.autoref = Some(mutbl);
-                pick.unsize = if step.unsize {
-                    Some(self_ty)
-                } else {
-                    None
-                };
+                pick.unsize = step.unsize.to_option(self_ty);
                 pick
             })
         })

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -114,11 +114,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         let infer_kind = if let UpvarSubsts::Closure(closure_substs) = substs {
-            if self.closure_kind(closure_def_id, closure_substs).is_none() {
-                Some(closure_substs)
-            } else {
-                None
-            }
+            self.closure_kind(closure_def_id, closure_substs).is_none().to_option(closure_substs)
         } else {
             None
         };

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -114,7 +114,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
 
         let infer_kind = if let UpvarSubsts::Closure(closure_substs) = substs {
-            self.closure_kind(closure_def_id, closure_substs).is_none().to_option(closure_substs)
+            self.closure_kind(closure_def_id, closure_substs).is_none().then_some(closure_substs)
         } else {
             None
         };

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -59,6 +59,7 @@ This API is completely unstable and subject to change.
 
 #![allow(non_camel_case_types)]
 
+#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(crate_visibility_modifier)]

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -7,6 +7,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/",
        test(attr(deny(warnings))))]
 
+#![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(const_fn)]
 #![feature(const_transmute)]

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -317,7 +317,7 @@ pub fn token_to_string(token: &Token) -> String {
 }
 
 fn token_to_string_ext(token: &Token, convert_dollar_crate: bool) -> String {
-    let convert_dollar_crate = if convert_dollar_crate { Some(token.span) } else { None };
+    let convert_dollar_crate = convert_dollar_crate.to_option(token.span);
     token_kind_to_string_ext(&token.kind, convert_dollar_crate)
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -317,7 +317,7 @@ pub fn token_to_string(token: &Token) -> String {
 }
 
 fn token_to_string_ext(token: &Token, convert_dollar_crate: bool) -> String {
-    let convert_dollar_crate = convert_dollar_crate.to_option(token.span);
+    let convert_dollar_crate = convert_dollar_crate.then_some(token.span);
     token_kind_to_string_ext(&token.kind, convert_dollar_crate)
 }
 

--- a/src/libsyntax/util/lev_distance.rs
+++ b/src/libsyntax/util/lev_distance.rs
@@ -77,6 +77,6 @@ pub fn find_best_match_for_name<'a, T>(iter_names: T,
     if let Some(candidate) = case_insensitive_match {
         Some(candidate) // exact case insensitive match has a higher priority
     } else {
-        if let Some((candidate, _)) = levenstein_match { Some(candidate) } else { None }
+        levenstein_match.map(|(candidate, _)| candidate)
     }
 }

--- a/src/libsyntax_ext/format_foreign.rs
+++ b/src/libsyntax_ext/format_foreign.rs
@@ -95,12 +95,12 @@ pub mod printf {
             };
 
             // Has a special form in Rust for numbers.
-            let fill = if c_zero { Some("0") } else { None };
+            let fill = c_zero.to_option("0");
 
-            let align = if c_left { Some("<") } else { None };
+            let align = c_left.to_option("<");
 
             // Rust doesn't have an equivalent to the `' '` flag.
-            let sign = if c_plus { Some("+") } else { None };
+            let sign = c_plus.to_option("+");
 
             // Not *quite* the same, depending on the type...
             let alt = c_alt;

--- a/src/libsyntax_ext/format_foreign.rs
+++ b/src/libsyntax_ext/format_foreign.rs
@@ -95,12 +95,12 @@ pub mod printf {
             };
 
             // Has a special form in Rust for numbers.
-            let fill = c_zero.to_option("0");
+            let fill = c_zero.then_some("0");
 
-            let align = c_left.to_option("<");
+            let align = c_left.then_some("<");
 
             // Rust doesn't have an equivalent to the `' '` flag.
-            let sign = c_plus.to_option("+");
+            let sign = c_plus.then_some("+");
 
             // Not *quite* the same, depending on the type...
             let alt = c_alt;

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -3,6 +3,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/")]
 
+#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
 #![feature(nll)]

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -563,7 +563,7 @@ fn run_test_in_process(
         None
     };
 
-    let start = report_time.to_option(Instant::now());
+    let start = report_time.then_some(Instant::now());
     let result = catch_unwind(AssertUnwindSafe(testfn));
     let exec_time = start.map(|start| {
         let duration = start.elapsed();
@@ -594,7 +594,7 @@ fn spawn_test_subprocess(
         let args = env::args().collect::<Vec<_>>();
         let current_exe = &args[0];
 
-        let start = report_time.to_option(Instant::now());
+        let start = report_time.then_some(Instant::now());
         let output = match Command::new(current_exe)
             .env(SECONDARY_TEST_INVOKER_VAR, desc.name.as_slice())
             .output() {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -563,7 +563,7 @@ fn run_test_in_process(
         None
     };
 
-    let start = report_time.then_some(Instant::now());
+    let start = report_time.then(Instant::now);
     let result = catch_unwind(AssertUnwindSafe(testfn));
     let exec_time = start.map(|start| {
         let duration = start.elapsed();
@@ -594,7 +594,7 @@ fn spawn_test_subprocess(
         let args = env::args().collect::<Vec<_>>();
         let current_exe = &args[0];
 
-        let start = report_time.then_some(Instant::now());
+        let start = report_time.then(Instant::now);
         let output = match Command::new(current_exe)
             .env(SECONDARY_TEST_INVOKER_VAR, desc.name.as_slice())
             .output() {

--- a/src/libtest/lib.rs
+++ b/src/libtest/lib.rs
@@ -24,6 +24,7 @@
 #![cfg_attr(any(unix, target_os = "cloudabi"), feature(libc))]
 #![feature(rustc_private)]
 #![feature(nll)]
+#![feature(bool_to_option)]
 #![feature(set_stdio)]
 #![feature(panic_unwind)]
 #![feature(staged_api)]
@@ -562,11 +563,7 @@ fn run_test_in_process(
         None
     };
 
-    let start = if report_time {
-        Some(Instant::now())
-    } else {
-        None
-    };
+    let start = report_time.to_option(Instant::now());
     let result = catch_unwind(AssertUnwindSafe(testfn));
     let exec_time = start.map(|start| {
         let duration = start.elapsed();
@@ -597,11 +594,7 @@ fn spawn_test_subprocess(
         let args = env::args().collect::<Vec<_>>();
         let current_exe = &args[0];
 
-        let start = if report_time {
-            Some(Instant::now())
-        } else {
-            None
-        };
+        let start = report_time.to_option(Instant::now());
         let output = match Command::new(current_exe)
             .env(SECONDARY_TEST_INVOKER_VAR, desc.name.as_slice())
             .output() {


### PR DESCRIPTION
Name change following https://github.com/rust-lang/rfcs/pull/2757. Also try it out throughout the compiler in places I think makes the code more readable.