### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -229,52 +229,6 @@ pub struct Cell<T: ?Sized> {
     value: UnsafeCell<T>,
 }
 
-impl<T:Copy> Cell<T> {
-    /// Returns a copy of the contained value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::cell::Cell;
-    ///
-    /// let c = Cell::new(5);
-    ///
-    /// let five = c.get();
-    /// ```
-    #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn get(&self) -> T {
-        unsafe{ *self.value.get() }
-    }
-
-    /// Updates the contained value using a function and returns the new value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(cell_update)]
-    ///
-    /// use std::cell::Cell;
-    ///
-    /// let c = Cell::new(5);
-    /// let new = c.update(|x| x + 1);
-    ///
-    /// assert_eq!(new, 6);
-    /// assert_eq!(c.get(), 6);
-    /// ```
-    #[inline]
-    #[unstable(feature = "cell_update", issue = "50186")]
-    pub fn update<F>(&self, f: F) -> T
-    where
-        F: FnOnce(T) -> T,
-    {
-        let old = self.get();
-        let new = f(old);
-        self.set(new);
-        new
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 
@@ -445,6 +399,52 @@ impl<T> Cell<T> {
     #[stable(feature = "move_cell", since = "1.17.0")]
     pub fn into_inner(self) -> T {
         self.value.into_inner()
+    }
+}
+
+impl<T:Copy> Cell<T> {
+    /// Returns a copy of the contained value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::cell::Cell;
+    ///
+    /// let c = Cell::new(5);
+    ///
+    /// let five = c.get();
+    /// ```
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn get(&self) -> T {
+        unsafe{ *self.value.get() }
+    }
+
+    /// Updates the contained value using a function and returns the new value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(cell_update)]
+    ///
+    /// use std::cell::Cell;
+    ///
+    /// let c = Cell::new(5);
+    /// let new = c.update(|x| x + 1);
+    ///
+    /// assert_eq!(new, 6);
+    /// assert_eq!(c.get(), 6);
+    /// ```
+    #[inline]
+    #[unstable(feature = "cell_update", issue = "50186")]
+    pub fn update<F>(&self, f: F) -> T
+    where
+        F: FnOnce(T) -> T,
+    {
+        let old = self.get();
+        let new = f(old);
+        self.set(new);
+        new
     }
 }
 

--- a/src/libcore/macros.rs
+++ b/src/libcore/macros.rs
@@ -519,15 +519,17 @@ macro_rules! unreachable {
     });
 }
 
-/// Indicates unfinished code.
+/// Indicates unfinished code by panicking with a message of "not yet implemented".
 ///
-/// This can be useful if you are prototyping and are just looking to have your
-/// code type-check, or if you're implementing a trait that requires multiple
-/// methods, and you're only planning on using one of them.
+/// This allows the your code to type-check, which is useful if you are prototyping or
+/// implementing a trait that requires multiple methods which you don't plan of using all of.
 ///
 /// # Panics
 ///
-/// This will always [panic!](macro.panic.html)
+/// This will always [panic!](macro.panic.html) because `unimplemented!` is just a
+/// shorthand for `panic!` with a fixed, specific message.
+///
+/// Like `panic!`, this macro has a second form for displaying custom values.
 ///
 /// # Examples
 ///
@@ -535,38 +537,53 @@ macro_rules! unreachable {
 ///
 /// ```
 /// trait Foo {
-///     fn bar(&self);
+///     fn bar(&self) -> u8;
 ///     fn baz(&self);
+///     fn qux(&self) -> Result<u64, ()>;
 /// }
 /// ```
 ///
-/// We want to implement `Foo` on one of our types, but we also want to work on
-/// just `bar()` first. In order for our code to compile, we need to implement
-/// `baz()`, so we can use `unimplemented!`:
+/// We want to implement `Foo` for 'MyStruct', but so far we only know how to
+/// implement the `bar()` function. `baz()` and `qux()` will still need to be defined
+/// in our implementation of `Foo`, but we can use `unimplemented!` in their definitions
+/// to allow our code to compile.
+///
+/// In the meantime, we want to have our program stop running once these
+/// unimplemented functions are reached.
 ///
 /// ```
 /// # trait Foo {
-/// #     fn bar(&self);
+/// #     fn bar(&self) -> u8;
 /// #     fn baz(&self);
+/// #     fn qux(&self) -> Result<u64, ()>;
 /// # }
 /// struct MyStruct;
 ///
 /// impl Foo for MyStruct {
-///     fn bar(&self) {
-///         // implementation goes here
+///     fn bar(&self) -> u8 {
+///         1 + 1
 ///     }
 ///
 ///     fn baz(&self) {
-///         // let's not worry about implementing baz() for now
+///         // We aren't sure how to even start writing baz yet,
+///         // so we have no logic here at all.
+///         // This will display "thread 'main' panicked at 'not yet implemented'".
 ///         unimplemented!();
+///     }
+///
+///     fn qux(&self) -> Result<u64, ()> {
+///         let n = self.bar();
+///         // We have some logic here,
+///         // so we can use unimplemented! to display what we have so far.
+///         // This will display:
+///         // "thread 'main' panicked at 'not yet implemented: we need to divide by 2'".
+///         unimplemented!("we need to divide by {}", n);
 ///     }
 /// }
 ///
 /// fn main() {
 ///     let s = MyStruct;
 ///     s.bar();
-///
-///     // we aren't even using baz() yet, so this is fine.
 /// }
 /// ```
 #[macro_export]

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -250,7 +250,9 @@ impl FlagComputation {
             ConstValue::Placeholder(_) => {
                 self.add_flags(TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_CT_PLACEHOLDER);
             }
-            _ => {},
+            ConstValue::Scalar(_) => { }
+            ConstValue::Slice { data: _, start: _, end: _ } => { }
+            ConstValue::ByRef { alloc: _, offset: _ } => { }
         }
     }
 

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -689,7 +689,7 @@ pub trait PrettyPrinter<'tcx>:
                 if self.tcx().sess.verbose() {
                     p!(write(
                         " closure_kind_ty={:?} closure_sig_ty={:?}",
-                        substs.as_closure().kind(did, self.tcx()),
+                        substs.as_closure().kind_ty(did, self.tcx()),
                         substs.as_closure().sig_ty(did, self.tcx())
                     ));
                 }
@@ -698,7 +698,9 @@ pub trait PrettyPrinter<'tcx>:
             },
             ty::Array(ty, sz) => {
                 p!(write("["), print(ty), write("; "));
-                if let ConstValue::Unevaluated(..) = sz.val {
+                if self.tcx().sess.verbose() {
+                    p!(write("{:?}", sz));
+                } else if let ConstValue::Unevaluated(..) = sz.val {
                     // do not try to evalute unevaluated constants. If we are const evaluating an
                     // array length anon const, rustc will (with debug assertions) print the
                     // constant's path. Which will end up here again.
@@ -854,6 +856,11 @@ pub trait PrettyPrinter<'tcx>:
         ct: &'tcx ty::Const<'tcx>,
     ) -> Result<Self::Const, Self::Error> {
         define_scoped_cx!(self);
+
+        if self.tcx().sess.verbose() {
+            p!(write("Const({:?}: {:?})", ct.val, ct.ty));
+            return Ok(self);
+        }
 
         let u8 = self.tcx().types.u8;
         if let ty::FnDef(did, substs) = ct.ty.kind {

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -2199,7 +2199,9 @@ impl<'tcx> TyS<'tcx> {
                 _ => bug!("cannot convert type `{:?}` to a closure kind", self),
             },
 
-            Infer(_) => None,
+            // "Bound" types appear in canonical queries when the
+            // closure type is not yet known
+            Bound(..) | Infer(_) => None,
 
             Error => Some(ty::ClosureKind::Fn),
 

--- a/src/librustc_passes/error_codes.rs
+++ b/src/librustc_passes/error_codes.rs
@@ -286,6 +286,34 @@ fn main() {
 ```
 "##,
 
+E0561: r##"
+A non-ident or non-wildcard pattern has been used as a parameter of a function
+pointer type.
+
+Erroneous code example:
+
+```compile_fail,E0561
+type A1 = fn(mut param: u8); // error!
+type A2 = fn(&param: u32); // error!
+```
+
+When using an alias over a function type, you cannot e.g. denote a parameter as
+being mutable.
+
+To fix the issue, remove patterns (`_` is allowed though). Example:
+
+```
+type A1 = fn(param: u8); // ok!
+type A2 = fn(_: u32); // ok!
+```
+
+You can also omit the parameter name:
+
+```
+type A3 = fn(i16); // ok!
+```
+"##,
+
 E0571: r##"
 A `break` statement with an argument appeared in a non-`loop` loop.
 
@@ -503,7 +531,6 @@ Switch to the Rust 2018 edition to use `async fn`.
 ;
     E0226, // only a single explicit lifetime bound is permitted
     E0472, // asm! is unsupported on this target
-    E0561, // patterns aren't allowed in function pointer types
     E0567, // auto traits can not have generic parameters
     E0568, // auto traits can not have super traits
     E0666, // nested `impl Trait` is illegal

--- a/src/librustc_traits/evaluate_obligation.rs
+++ b/src/librustc_traits/evaluate_obligation.rs
@@ -17,10 +17,12 @@ fn evaluate_obligation<'tcx>(
     tcx: TyCtxt<'tcx>,
     canonical_goal: CanonicalPredicateGoal<'tcx>,
 ) -> Result<EvaluationResult, OverflowError> {
+    debug!("evaluate_obligation(canonical_goal={:#?})", canonical_goal);
     tcx.infer_ctxt().enter_with_canonical(
         DUMMY_SP,
         &canonical_goal,
         |ref infcx, goal, _canonical_inference_vars| {
+            debug!("evaluate_obligation: goal={:#?}", goal);
             let ParamEnvAnd {
                 param_env,
                 value: predicate,

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -349,7 +349,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // If the span is from a macro, then it's hard to extract the text
         // and make a good suggestion, so don't bother.
-        let is_macro = sp.from_expansion();
+        let is_desugaring = match sp.desugaring_kind() {
+            Some(k) => sp.is_desugaring(k),
+            None => false
+        };
+        let is_macro = sp.from_expansion() && !is_desugaring;
 
         match (&expr.kind, &expected.kind, &checked_ty.kind) {
             (_, &ty::Ref(_, exp, _), &ty::Ref(_, check, _)) => match (&exp.kind, &check.kind) {

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -87,6 +87,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if let Some(mut err) = self.demand_suptype_diag(expr.span, expected_ty, ty) {
+            self.suggest_ref_or_into(&mut err, expr, expected_ty, ty);
+
             let expr = match &expr.kind {
                 ExprKind::DropTemps(expr) => expr,
                 _ => expr,

--- a/src/libstd/fs.rs
+++ b/src/libstd/fs.rs
@@ -3112,8 +3112,10 @@ mod tests {
 
         #[cfg(windows)]
         let invalid_options = 87; // ERROR_INVALID_PARAMETER
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "vxworks")))]
         let invalid_options = "Invalid argument";
+        #[cfg(target_os = "vxworks")]
+        let invalid_options = "invalid argument";
 
         // Test various combinations of creation modes and access modes.
         //

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -4,7 +4,7 @@ use crate::{maybe_whole, maybe_recover_from_interpolated_ty_qpath};
 use crate::ptr::P;
 use crate::ast::{self, Ty, TyKind, MutTy, BareFnTy, FunctionRetTy, GenericParam, Lifetime, Ident};
 use crate::ast::{TraitBoundModifier, TraitObjectSyntax, GenericBound, GenericBounds, PolyTraitRef};
-use crate::ast::{Mutability, AnonConst, FnDecl, Mac};
+use crate::ast::{Mutability, AnonConst, Mac};
 use crate::parse::token::{self, Token};
 use crate::source_map::Span;
 use crate::symbol::{kw};
@@ -288,12 +288,12 @@ impl<'a> Parser<'a> {
         };
 
         self.expect_keyword(kw::Fn)?;
-        let inputs = self.parse_fn_params(false, true)?;
-        let ret_ty = self.parse_ret_ty(false)?;
-        let decl = P(FnDecl {
-            inputs,
-            output: ret_ty,
-        });
+        let cfg = super::ParamCfg {
+            is_self_allowed: false,
+            allow_c_variadic: true,
+            is_name_required: |_| false,
+        };
+        let decl = self.parse_fn_decl(cfg, false)?;
         Ok(TyKind::BareFn(P(BareFnTy {
             abi,
             unsafety,

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -9,8 +9,6 @@ use crate::parse::token::{self, Token};
 use crate::source_map::Span;
 use crate::symbol::{kw};
 
-use rustc_target::spec::abi::Abi;
-
 use errors::{Applicability, pluralise};
 
 /// Returns `true` if `IDENT t` can start a type -- `IDENT::a::b`, `IDENT<u8, u8>`,
@@ -281,12 +279,7 @@ impl<'a> Parser<'a> {
         */
 
         let unsafety = self.parse_unsafety();
-        let abi = if self.eat_keyword(kw::Extern) {
-            self.parse_opt_abi()?.unwrap_or(Abi::C)
-        } else {
-            Abi::Rust
-        };
-
+        let abi = self.parse_extern_abi()?;
         self.expect_keyword(kw::Fn)?;
         let cfg = super::ParamCfg {
             is_self_allowed: false,

--- a/src/test/ui/const-generics/slice-const-param-mismatch.stderr
+++ b/src/test/ui/const-generics/slice-const-param-mismatch.stderr
@@ -12,8 +12,8 @@ error[E0308]: mismatched types
 LL |     let _: ConstString<"Hello"> = ConstString::<"World">;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^ expected `"Hello"`, found `"World"`
    |
-   = note: expected type `ConstString<>`
-              found type `ConstString<>`
+   = note: expected type `ConstString<"Hello">`
+              found type `ConstString<"World">`
 
 error[E0308]: mismatched types
   --> $DIR/slice-const-param-mismatch.rs:11:33
@@ -21,8 +21,8 @@ error[E0308]: mismatched types
 LL |     let _: ConstString<"ℇ㇈↦"> = ConstString::<"ℇ㇈↥">;
    |                                  ^^^^^^^^^^^^^^^^^^^^^ expected `"ℇ㇈↦"`, found `"ℇ㇈↥"`
    |
-   = note: expected type `ConstString<>`
-              found type `ConstString<>`
+   = note: expected type `ConstString<"ℇ㇈↦">`
+              found type `ConstString<"ℇ㇈↥">`
 
 error[E0308]: mismatched types
   --> $DIR/slice-const-param-mismatch.rs:13:33
@@ -30,8 +30,8 @@ error[E0308]: mismatched types
 LL |     let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">;
    |                                 ^^^^^^^^^^^^^^^^^^^^ expected `b"AAA"`, found `b"BBB"`
    |
-   = note: expected type `ConstBytes<>`
-              found type `ConstBytes<>`
+   = note: expected type `ConstBytes<b"AAA">`
+              found type `ConstBytes<b"BBB">`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/types-mismatch-const-args.rs
+++ b/src/test/ui/const-generics/types-mismatch-const-args.rs
@@ -1,0 +1,19 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+// tests the diagnostic output of type mismatches for types that have const generics arguments.
+
+use std::marker::PhantomData;
+
+struct A<'a, T, const X: u32, const Y: u32> {
+    data: PhantomData<&'a T>
+}
+
+fn a<'a, 'b>() {
+    let _: A<'a, u32, {2u32}, {3u32}> = A::<'a, u32, {4u32}, {3u32}> { data: PhantomData };
+    //~^ ERROR mismatched types
+    let _: A<'a, u16, {2u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data: PhantomData };
+    //~^ ERROR mismatched types
+}
+
+pub fn main() {}

--- a/src/test/ui/const-generics/types-mismatch-const-args.stderr
+++ b/src/test/ui/const-generics/types-mismatch-const-args.stderr
@@ -1,0 +1,29 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/types-mismatch-const-args.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0308]: mismatched types
+  --> $DIR/types-mismatch-const-args.rs:13:41
+   |
+LL |     let _: A<'a, u32, {2u32}, {3u32}> = A::<'a, u32, {4u32}, {3u32}> { data: PhantomData };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `2u32`, found `4u32`
+   |
+   = note: expected type `A<'_, _, 2u32, _>`
+              found type `A<'_, _, 4u32, _>`
+
+error[E0308]: mismatched types
+  --> $DIR/types-mismatch-const-args.rs:15:41
+   |
+LL |     let _: A<'a, u16, {2u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data: PhantomData };
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected u16, found u32
+   |
+   = note: expected type `A<'a, u16, _, _>`
+              found type `A<'b, u32, _, _>`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/if/if-no-match-bindings.stderr
+++ b/src/test/ui/if/if-no-match-bindings.stderr
@@ -73,7 +73,7 @@ LL |     while b_mut_ref() {}
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:26:11
    |
-26 |     while &true {}
+LL |     while &true {}
    |           ^^^^^
    |           |
    |           expected bool, found &bool
@@ -85,7 +85,7 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:27:11
    |
-27 |     while &mut true {}
+LL |     while &mut true {}
    |           ^^^^^^^^^
    |           |
    |           expected bool, found &mut bool

--- a/src/test/ui/if/if-no-match-bindings.stderr
+++ b/src/test/ui/if/if-no-match-bindings.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:18:8
    |
 LL |     if b_ref() {}
-   |        ^^^^^^^ expected bool, found &bool
+   |        ^^^^^^^
+   |        |
+   |        expected bool, found &bool
+   |        help: consider dereferencing the borrow: `*b_ref()`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -11,7 +14,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:19:8
    |
 LL |     if b_mut_ref() {}
-   |        ^^^^^^^^^^^ expected bool, found &mut bool
+   |        ^^^^^^^^^^^
+   |        |
+   |        expected bool, found &mut bool
+   |        help: consider dereferencing the borrow: `*b_mut_ref()`
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -20,7 +26,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:20:8
    |
 LL |     if &true {}
-   |        ^^^^^ expected bool, found &bool
+   |        ^^^^^
+   |        |
+   |        expected bool, found &bool
+   |        help: consider dereferencing the borrow: `*&true`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -29,7 +38,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:21:8
    |
 LL |     if &mut true {}
-   |        ^^^^^^^^^ expected bool, found &mut bool
+   |        ^^^^^^^^^
+   |        |
+   |        expected bool, found &mut bool
+   |        help: consider dereferencing the borrow: `*&mut true`
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -38,7 +50,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:24:11
    |
 LL |     while b_ref() {}
-   |           ^^^^^^^ expected bool, found &bool
+   |           ^^^^^^^
+   |           |
+   |           expected bool, found &bool
+   |           help: consider dereferencing the borrow: `*b_ref()`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -47,7 +62,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:25:11
    |
 LL |     while b_mut_ref() {}
-   |           ^^^^^^^^^^^ expected bool, found &mut bool
+   |           ^^^^^^^^^^^
+   |           |
+   |           expected bool, found &mut bool
+   |           help: consider dereferencing the borrow: `*b_mut_ref()`
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -55,8 +73,11 @@ LL |     while b_mut_ref() {}
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:26:11
    |
-LL |     while &true {}
-   |           ^^^^^ expected bool, found &bool
+26 |     while &true {}
+   |           ^^^^^
+   |           |
+   |           expected bool, found &bool
+   |           help: consider dereferencing the borrow: `*&true`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -64,8 +85,11 @@ LL |     while &true {}
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:27:11
    |
-LL |     while &mut true {}
-   |           ^^^^^^^^^ expected bool, found &mut bool
+27 |     while &mut true {}
+   |           ^^^^^^^^^
+   |           |
+   |           expected bool, found &mut bool
+   |           help: consider dereferencing the borrow: `*&mut true`
    |
    = note: expected type `bool`
               found type `&mut bool`

--- a/src/test/ui/no-patterns-in-args-macro.stderr
+++ b/src/test/ui/no-patterns-in-args-macro.stderr
@@ -18,5 +18,5 @@ LL |     m!((bad, pat));
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0130, E0642.
+Some errors have detailed explanations: E0130, E0561, E0642.
 For more information about an error, try `rustc --explain E0130`.

--- a/src/test/ui/no-patterns-in-args.stderr
+++ b/src/test/ui/no-patterns-in-args.stderr
@@ -30,4 +30,5 @@ LL | type A2 = fn(&arg: u8);
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0130`.
+Some errors have detailed explanations: E0130, E0561.
+For more information about an error, try `rustc --explain E0130`.

--- a/src/test/ui/parser/issue-33413.rs
+++ b/src/test/ui/parser/issue-33413.rs
@@ -3,6 +3,7 @@ struct S;
 impl S {
     fn f(*, a: u8) -> u8 {}
     //~^ ERROR expected parameter name, found `*`
+    //~| ERROR mismatched types
 }
 
 fn main() {}

--- a/src/test/ui/parser/issue-33413.stderr
+++ b/src/test/ui/parser/issue-33413.stderr
@@ -4,5 +4,17 @@ error: expected parameter name, found `*`
 LL |     fn f(*, a: u8) -> u8 {}
    |          ^ expected parameter name
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/issue-33413.rs:4:23
+   |
+LL |     fn f(*, a: u8) -> u8 {}
+   |        -              ^^ expected u8, found ()
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note: expected type `u8`
+              found type `()`
 
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -513,44 +513,6 @@ warning: the feature `let_chains` is incomplete and may cause the compiler to cr
 LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
    |            ^^^^^^^^^^
 
-warning: unnecessary parentheses around `if` condition
-  --> $DIR/disallowed-positions.rs:51:8
-   |
-LL |     if (true || let 0 = 0) {}
-   |        ^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-   |
-   = note: `#[warn(unused_parens)]` on by default
-
-warning: unnecessary parentheses around `while` condition
-  --> $DIR/disallowed-positions.rs:115:11
-   |
-LL |     while (true || let 0 = 0) {}
-   |           ^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-
-wrning: unnecessary parentheses around `let` head expression
-  --> $DIR/disallowed-positions.rs:160:41
-   |
-LL |     if let Range { start: _, end: _ } = (true..true || false) { }
-   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-
-warning: unnecessary parentheses around `let` head expression
-  --> $DIR/disallowed-positions.rs:162:41
-   |
-LL |     if let Range { start: _, end: _ } = (true..true && false) { }
-   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-
-warning: unnecessary parentheses around `let` head expression
-  --> $DIR/disallowed-positions.rs:164:44
-   |
-LL |     while let Range { start: _, end: _ } = (true..true || false) { }
-   |                                            ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-
-warning: unnecessary parentheses around `let` head expression
-  --> $DIR/disallowed-positions.rs:166:44
-   |
-LL |     while let Range { start: _, end: _ } = (true..true && false) { }
-   |                                            ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
-
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:32:8
    |

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -513,11 +513,52 @@ warning: the feature `let_chains` is incomplete and may cause the compiler to cr
 LL | #![feature(let_chains)] // Avoid inflating `.stderr` with overzealous gates in this test.
    |            ^^^^^^^^^^
 
+warning: unnecessary parentheses around `if` condition
+  --> $DIR/disallowed-positions.rs:51:8
+   |
+LL |     if (true || let 0 = 0) {}
+   |        ^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+   |
+   = note: `#[warn(unused_parens)]` on by default
+
+warning: unnecessary parentheses around `while` condition
+  --> $DIR/disallowed-positions.rs:115:11
+   |
+LL |     while (true || let 0 = 0) {}
+   |           ^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+
+wrning: unnecessary parentheses around `let` head expression
+  --> $DIR/disallowed-positions.rs:160:41
+   |
+LL |     if let Range { start: _, end: _ } = (true..true || false) { }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+
+warning: unnecessary parentheses around `let` head expression
+  --> $DIR/disallowed-positions.rs:162:41
+   |
+LL |     if let Range { start: _, end: _ } = (true..true && false) { }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+
+warning: unnecessary parentheses around `let` head expression
+  --> $DIR/disallowed-positions.rs:164:44
+   |
+LL |     while let Range { start: _, end: _ } = (true..true || false) { }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+
+warning: unnecessary parentheses around `let` head expression
+  --> $DIR/disallowed-positions.rs:166:44
+   |
+LL |     while let Range { start: _, end: _ } = (true..true && false) { }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^ help: remove these parentheses
+
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:32:8
    |
 LL |     if &let 0 = 0 {}
-   |        ^^^^^^^^^^ expected bool, found &bool
+   |        ^^^^^^^^^^
+   |        |
+   |        expected bool, found &bool
+   |        help: consider dereferencing the borrow: `*&let 0 = 0`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -702,7 +743,10 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:96:11
    |
 LL |     while &let 0 = 0 {}
-   |           ^^^^^^^^^^ expected bool, found &bool
+   |           ^^^^^^^^^^
+   |           |
+   |           expected bool, found &bool
+   |           help: consider dereferencing the borrow: `*&let 0 = 0`
    |
    = note: expected type `bool`
               found type `&bool`


### PR DESCRIPTION
Successful merges:

 - #64726 (rewrite documentation for unimplemented! to clarify use)
 - #65040 (syntax: more cleanups in item and function signature parsing)
 - #65046 (Make `Cell::new` method come first in documentation)
 - #65098 (Add long error explanation for E0561)
 - #65150 (Suggest dereferencing boolean reference when used in 'if' or 'while')
 - #65154 (Fix const generic arguments not displaying in types mismatch diagnostic)
 - #65181 (fix bug in folding for constants)
 - #65187 (use 'invalid argument' for vxWorks)

Failed merges:

 - #65179 (Add long error explanation for E0567)

r? @ghost