### PR TITLE
Add ?Sized bound to a supertrait listing in E0038 error documentation

### DIFF
--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -259,8 +259,8 @@ trait Foo {
 This is similar to the second sub-error, but subtler. It happens in situations
 like the following:
 
-```compile_fail
-trait Super<A> {}
+```
+trait Super<A: ?Sized> {}
 
 trait Trait: Super<Self> {
 }
@@ -275,8 +275,8 @@ impl Trait for Foo {}
 Here, the supertrait might have methods as follows:
 
 ```
-trait Super<A> {
-    fn get_a(&self) -> A; // note that this is object safe!
+trait Super<A: ?Sized> {
+    fn get_a(&self) -> &A; // note that this is object safe!
 }
 ```
 

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -280,7 +280,7 @@ trait Super<A: ?Sized> {
 }
 ```
 
-If the trait `Foo` was deriving from something like `Super<String>` or
+If the trait `Trait` was deriving from something like `Super<String>` or
 `Super<T>` (where `Foo` itself is `Foo<T>`), this is okay, because given a type
 `get_a()` will definitely return an object of that type.
 

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -259,7 +259,7 @@ trait Foo {
 This is similar to the second sub-error, but subtler. It happens in situations
 like the following:
 
-```
+```compile_fail,E0038
 trait Super<A: ?Sized> {}
 
 trait Trait: Super<Self> {
@@ -270,6 +270,10 @@ struct Foo;
 impl Super<Foo> for Foo{}
 
 impl Trait for Foo {}
+
+fn main() {
+    let x: Box<dyn Trait>;
+}
 ```
 
 Here, the supertrait might have methods as follows:


### PR DESCRIPTION
This example failed to compile because of implicit `Sized` bound for `A` parameter that wasn't required by `Trait`.