### PR TITLE
Ignore `ExprKind::DropTemps` for some ref suggestions

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1548,6 +1548,23 @@ impl Expr {
             }
         }
     }
+
+    /// If `Self.kind` is `ExprKind::DropTemps(expr)`, drill down until we get a non-`DropTemps`
+    /// `Expr`. This is used in suggestions to ignore this `ExprKind` as it is semantically
+    /// silent, only signaling the ownership system. By doing this, suggestions that check the
+    /// `ExprKind` of any given `Expr` for presentation don't have to care about `DropTemps`
+    /// beyond remembering to call this function before doing analysis on it.
+    pub fn peel_drop_temps(&self) -> &Self {
+        let mut base_expr = self;
+        loop {
+            match &base_expr.kind {
+                ExprKind::DropTemps(expr) => {
+                    base_expr = &expr;
+                }
+                _ => return base_expr,
+            }
+        }
+    }
 }
 
 impl fmt::Debug for Expr {

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1555,15 +1555,11 @@ impl Expr {
     /// `ExprKind` of any given `Expr` for presentation don't have to care about `DropTemps`
     /// beyond remembering to call this function before doing analysis on it.
     pub fn peel_drop_temps(&self) -> &Self {
-        let mut base_expr = self;
-        loop {
-            match &base_expr.kind {
-                ExprKind::DropTemps(expr) => {
-                    base_expr = &expr;
-                }
-                _ => return base_expr,
-            }
+        let mut expr = self;
+        while let ExprKind::DropTemps(inner) = &expr.kind {
+            expr = inner;
         }
+        expr
     }
 }
 

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -109,13 +109,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                               allow_two_phase: AllowTwoPhase)
                               -> (Ty<'tcx>, Option<DiagnosticBuilder<'tcx>>) {
         let expected = self.resolve_type_vars_with_obligations(expected);
-        let expr = expr.peel_drop_temps();
 
         let e = match self.try_coerce(expr, checked_ty, expected, allow_two_phase) {
             Ok(ty) => return (ty, None),
             Err(e) => e
         };
 
+        let expr = expr.peel_drop_temps();
         let cause = self.misc(expr.span);
         let expr_ty = self.resolve_type_vars_with_obligations(checked_ty);
         let mut err = self.report_mismatched_types(&cause, expected, expr_ty, e);

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -355,6 +355,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         };
         let is_macro = sp.from_expansion() && !is_desugaring;
 
+        // `ExprKind::DropTemps` is semantically irrelevant for these suggestions.
+        let expr = expr.peel_drop_temps();
+
         match (&expr.kind, &expected.kind, &checked_ty.kind) {
             (_, &ty::Ref(_, exp, _), &ty::Ref(_, check, _)) => match (&exp.kind, &check.kind) {
                 (&ty::Str, &ty::Array(arr, _)) |

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -109,6 +109,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                               allow_two_phase: AllowTwoPhase)
                               -> (Ty<'tcx>, Option<DiagnosticBuilder<'tcx>>) {
         let expected = self.resolve_type_vars_with_obligations(expected);
+        let expr = expr.peel_drop_temps();
 
         let e = match self.try_coerce(expr, checked_ty, expected, allow_two_phase) {
             Ok(ty) => return (ty, None),

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -87,12 +87,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
 
         if let Some(mut err) = self.demand_suptype_diag(expr.span, expected_ty, ty) {
+            let expr = expr.peel_drop_temps();
             self.suggest_ref_or_into(&mut err, expr, expected_ty, ty);
-
-            let expr = match &expr.kind {
-                ExprKind::DropTemps(expr) => expr,
-                _ => expr,
-            };
             extend_err(&mut err);
             // Error possibly reported in `check_assign` so avoid emitting error again.
             err.emit_unless(self.is_assign_to_bool(expr, expected_ty));

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -4216,20 +4216,21 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     pub fn suggest_mismatched_types_on_tail(
         &self,
         err: &mut DiagnosticBuilder<'tcx>,
-        expression: &'tcx hir::Expr,
+        expr: &'tcx hir::Expr,
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
         cause_span: Span,
         blk_id: hir::HirId,
     ) -> bool {
-        self.suggest_missing_semicolon(err, expression, expected, cause_span);
+        let expr = expr.peel_drop_temps();
+        self.suggest_missing_semicolon(err, expr, expected, cause_span);
         let mut pointing_at_return_type = false;
         if let Some((fn_decl, can_suggest)) = self.get_fn_decl(blk_id) {
             pointing_at_return_type = self.suggest_missing_return_type(
                 err, &fn_decl, expected, found, can_suggest);
         }
-        self.suggest_ref_or_into(err, expression, expected, found);
-        self.suggest_boxing_when_appropriate(err, expression, expected, found);
+        self.suggest_ref_or_into(err, expr, expected, found);
+        self.suggest_boxing_when_appropriate(err, expr, expected, found);
         pointing_at_return_type
     }
 

--- a/src/test/ui/if/if-no-match-bindings.stderr
+++ b/src/test/ui/if/if-no-match-bindings.stderr
@@ -2,7 +2,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:18:8
    |
 LL |     if b_ref() {}
-   |        ^^^^^^^ expected bool, found &bool
+   |        ^^^^^^^
+   |        |
+   |        expected bool, found &bool
+   |        help: consider dereferencing the borrow: `*b_ref()`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -11,7 +14,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:19:8
    |
 LL |     if b_mut_ref() {}
-   |        ^^^^^^^^^^^ expected bool, found &mut bool
+   |        ^^^^^^^^^^^
+   |        |
+   |        expected bool, found &mut bool
+   |        help: consider dereferencing the borrow: `*b_mut_ref()`
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -44,7 +50,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:24:11
    |
 LL |     while b_ref() {}
-   |           ^^^^^^^ expected bool, found &bool
+   |           ^^^^^^^
+   |           |
+   |           expected bool, found &bool
+   |           help: consider dereferencing the borrow: `*b_ref()`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -53,7 +62,10 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:25:11
    |
 LL |     while b_mut_ref() {}
-   |           ^^^^^^^^^^^ expected bool, found &mut bool
+   |           ^^^^^^^^^^^
+   |           |
+   |           expected bool, found &mut bool
+   |           help: consider dereferencing the borrow: `*b_mut_ref()`
    |
    = note: expected type `bool`
               found type `&mut bool`

--- a/src/test/ui/if/if-no-match-bindings.stderr
+++ b/src/test/ui/if/if-no-match-bindings.stderr
@@ -2,10 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:18:8
    |
 LL |     if b_ref() {}
-   |        ^^^^^^^
-   |        |
-   |        expected bool, found &bool
-   |        help: consider dereferencing the borrow: `*b_ref()`
+   |        ^^^^^^^ expected bool, found &bool
    |
    = note: expected type `bool`
               found type `&bool`
@@ -14,10 +11,7 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:19:8
    |
 LL |     if b_mut_ref() {}
-   |        ^^^^^^^^^^^
-   |        |
-   |        expected bool, found &mut bool
-   |        help: consider dereferencing the borrow: `*b_mut_ref()`
+   |        ^^^^^^^^^^^ expected bool, found &mut bool
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -29,7 +23,7 @@ LL |     if &true {}
    |        ^^^^^
    |        |
    |        expected bool, found &bool
-   |        help: consider dereferencing the borrow: `*&true`
+   |        help: consider removing the borrow: `true`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -41,7 +35,7 @@ LL |     if &mut true {}
    |        ^^^^^^^^^
    |        |
    |        expected bool, found &mut bool
-   |        help: consider dereferencing the borrow: `*&mut true`
+   |        help: consider removing the borrow: `true`
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -50,10 +44,7 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:24:11
    |
 LL |     while b_ref() {}
-   |           ^^^^^^^
-   |           |
-   |           expected bool, found &bool
-   |           help: consider dereferencing the borrow: `*b_ref()`
+   |           ^^^^^^^ expected bool, found &bool
    |
    = note: expected type `bool`
               found type `&bool`
@@ -62,10 +53,7 @@ error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:25:11
    |
 LL |     while b_mut_ref() {}
-   |           ^^^^^^^^^^^
-   |           |
-   |           expected bool, found &mut bool
-   |           help: consider dereferencing the borrow: `*b_mut_ref()`
+   |           ^^^^^^^^^^^ expected bool, found &mut bool
    |
    = note: expected type `bool`
               found type `&mut bool`
@@ -77,7 +65,7 @@ LL |     while &true {}
    |           ^^^^^
    |           |
    |           expected bool, found &bool
-   |           help: consider dereferencing the borrow: `*&true`
+   |           help: consider removing the borrow: `true`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -89,7 +77,7 @@ LL |     while &mut true {}
    |           ^^^^^^^^^
    |           |
    |           expected bool, found &mut bool
-   |           help: consider dereferencing the borrow: `*&mut true`
+   |           help: consider removing the borrow: `true`
    |
    = note: expected type `bool`
               found type `&mut bool`

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -520,7 +520,7 @@ LL |     if &let 0 = 0 {}
    |        ^^^^^^^^^^
    |        |
    |        expected bool, found &bool
-   |        help: consider dereferencing the borrow: `*&let 0 = 0`
+   |        help: consider removing the borrow: `let 0 = 0`
    |
    = note: expected type `bool`
               found type `&bool`
@@ -708,7 +708,7 @@ LL |     while &let 0 = 0 {}
    |           ^^^^^^^^^^
    |           |
    |           expected bool, found &bool
-   |           help: consider dereferencing the borrow: `*&let 0 = 0`
+   |           help: consider removing the borrow: `let 0 = 0`
    |
    = note: expected type `bool`
               found type `&bool`


### PR DESCRIPTION
Introduce `Expr::peel_drop_temps()` to ignore `ExprKind::DropTemps` for suggestions that depend on the `ExprKind` for accuracy.