### PR TITLE
remove break_value and PartialEq from LoopState to reduce compile time

### DIFF
--- a/src/libcore/iter/adapters/mod.rs
+++ b/src/libcore/iter/adapters/mod.rs
@@ -1003,7 +1003,10 @@ impl<B, I: DoubleEndedIterator, F> DoubleEndedIterator for FilterMap<I, F>
             }
         }
 
-        self.iter.try_rfold((), find(&mut self.f)).break_value()
+        match self.iter.try_rfold((), find(&mut self.f)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 
     #[inline]

--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -368,7 +368,6 @@ mod traits;
 mod adapters;
 
 /// Used to make try_fold closures more like normal loops
-#[derive(PartialEq)]
 enum LoopState<C, B> {
     Continue(C),
     Break(B),
@@ -388,16 +387,6 @@ impl<C, B> Try for LoopState<C, B> {
     fn from_error(v: Self::Error) -> Self { LoopState::Break(v) }
     #[inline]
     fn from_ok(v: Self::Ok) -> Self { LoopState::Continue(v) }
-}
-
-impl<C, B> LoopState<C, B> {
-    #[inline]
-    fn break_value(self) -> Option<B> {
-        match self {
-            LoopState::Continue(..) => None,
-            LoopState::Break(x) => Some(x),
-        }
-    }
 }
 
 impl<R: Try> LoopState<R::Ok, R> {

--- a/src/libcore/iter/traits/double_ended.rs
+++ b/src/libcore/iter/traits/double_ended.rs
@@ -290,7 +290,10 @@ pub trait DoubleEndedIterator: Iterator {
             }
         }
 
-        self.try_rfold((), check(predicate)).break_value()
+        match self.try_rfold((), check(predicate)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 }
 

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -1865,7 +1865,10 @@ pub trait Iterator {
                 else { LoopState::Break(()) }
             }
         }
-        self.try_fold((), check(f)) == LoopState::Continue(())
+        match self.try_fold((), check(f)) {
+             LoopState::Continue(_) => true,
+             _ => false,
+        }
     }
 
     /// Tests if any element of the iterator matches a predicate.
@@ -1919,7 +1922,10 @@ pub trait Iterator {
             }
         }
 
-        self.try_fold((), check(f)) == LoopState::Break(())
+        match self.try_fold((), check(f)) {
+            LoopState::Break(_) => true,
+            _ => false,
+        }
     }
 
     /// Searches for an element of an iterator that satisfies a predicate.
@@ -1980,7 +1986,10 @@ pub trait Iterator {
             }
         }
 
-        self.try_fold((), check(predicate)).break_value()
+        match self.try_fold((), check(predicate)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 
     /// Applies function to the elements of iterator and returns
@@ -2012,7 +2021,10 @@ pub trait Iterator {
             }
         }
 
-        self.try_fold((), check(f)).break_value()
+        match self.try_fold((), check(f)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 
     /// Searches for an element in an iterator, returning its index.
@@ -2086,7 +2098,10 @@ pub trait Iterator {
             }
         }
 
-        self.try_fold(0, check(predicate)).break_value()
+        match self.try_fold(0, check(predicate)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 
     /// Searches for an element in an iterator from the right, returning its
@@ -2147,7 +2162,10 @@ pub trait Iterator {
         }
 
         let n = self.len();
-        self.try_rfold(n, check(predicate)).break_value()
+        match self.try_rfold(n, check(predicate)) {
+            LoopState::Break(x) => Some(x),
+            _ => None,
+        }
     }
 
     /// Returns the maximum element of an iterator.


### PR DESCRIPTION
this is a follow up to the comment in https://github.com/rust-lang/rust/pull/64885/files#r330223576

r? @bluss  
cc @scottmcm 