### PR TITLE
add IntoFuture trait and support for await

### DIFF
--- a/src/libcore/future/future.rs
+++ b/src/libcore/future/future.rs
@@ -99,6 +99,21 @@ pub trait Future {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
 }
 
+/// Conversion into a `Future`.
+#[unstable(feature = "into_future", issue = "67644")]
+pub trait IntoFuture {
+    /// The output that the future will produce on completion.
+    #[unstable(feature = "into_future", issue = "67644")]
+    type Output;
+    /// Which kind of future are we turning this into?
+    #[unstable(feature = "into_future", issue = "67644")]
+    type Future: Future<Output = Self::Output>;
+
+    /// Creates a future from a value.
+    #[unstable(feature = "into_future", issue = "67644")]
+    fn into_future(self) -> Self::Future;
+}
+
 #[stable(feature = "futures_api", since = "1.36.0")]
 impl<F: ?Sized + Future + Unpin> Future for &mut F {
     type Output = F::Output;
@@ -117,5 +132,15 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::get_mut(self).as_mut().poll(cx)
+    }
+}
+
+#[unstable(feature = "into_future", issue = "67644")]
+impl<F: Future> IntoFuture for F {
+    type Output = F::Output;
+    type Future = F;
+
+    fn into_future(self) -> Self::Future {
+        self
     }
 }

--- a/src/libcore/future/mod.rs
+++ b/src/libcore/future/mod.rs
@@ -5,3 +5,6 @@
 mod future;
 #[stable(feature = "futures_api", since = "1.36.0")]
 pub use self::future::Future;
+
+#[unstable(feature = "into_future", issue = "67644")]
+pub use self::future::IntoFuture;

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -168,6 +168,7 @@ pub struct LoweringContext<'a, 'hir: 'a> {
 
     allow_try_trait: Option<Lrc<[Symbol]>>,
     allow_gen_future: Option<Lrc<[Symbol]>>,
+    allow_into_future: Option<Lrc<[Symbol]>>,
 }
 
 pub trait Resolver {
@@ -300,6 +301,7 @@ pub fn lower_crate<'a, 'hir>(
         in_scope_lifetimes: Vec::new(),
         allow_try_trait: Some([sym::try_trait][..].into()),
         allow_gen_future: Some([sym::gen_future][..].into()),
+        allow_into_future: Some([sym::into_future][..].into()),
     }
     .lower_crate(krate)
 }

--- a/src/librustc/hir/lowering/expr.rs
+++ b/src/librustc/hir/lowering/expr.rs
@@ -529,7 +529,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
 
     /// Desugar `<expr>.await` into:
     /// ```rust
-    /// match <expr> {
+    /// match ::std::future::IntoFuture::into_future(<expr>) {
     ///     mut pinned => loop {
     ///         match ::std::future::poll_with_tls_context(unsafe {
     ///             <::std::pin::Pin>::new_unchecked(&mut pinned)
@@ -653,11 +653,27 @@ impl<'hir> LoweringContext<'_, 'hir> {
         // mut pinned => loop { ... }
         let pinned_arm = self.arm(pinned_pat, loop_expr);
 
-        // match <expr> {
+        // `match ::std::future::IntoFuture::into_future(<expr>) { ... }`
+        let into_future_span = self.mark_span_with_reason(
+            DesugaringKind::Await,
+            await_span,
+            self.allow_into_future.clone(),
+        );
+        let expr = self.lower_expr_mut(expr);
+        let into_future_expr = self.expr_call_std_path(
+            into_future_span,
+            &[sym::future, sym::IntoFuture, sym::into_future],
+            arena_vec![self; expr],
+        );
+
+        // match <into_future_expr> {
         //     mut pinned => loop { .. }
         // }
-        let expr = self.lower_expr(expr);
-        hir::ExprKind::Match(expr, arena_vec![self; pinned_arm], hir::MatchSource::AwaitDesugar)
+        hir::ExprKind::Match(
+            into_future_expr,
+            arena_vec![self; pinned_arm],
+            hir::MatchSource::AwaitDesugar,
+        )
     }
 
     fn lower_expr_closure(

--- a/src/libstd/future.rs
+++ b/src/libstd/future.rs
@@ -10,7 +10,11 @@ use core::task::{Context, Poll};
 
 #[doc(inline)]
 #[stable(feature = "futures_api", since = "1.36.0")]
-pub use core::future::*;
+pub use core::future::Future;
+
+#[doc(inline)]
+#[unstable(feature = "into_future", issue = "67644")]
+pub use core::future::IntoFuture;
 
 /// Wrap a generator in a future.
 ///

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -269,6 +269,7 @@
 #![feature(hashmap_internals)]
 #![feature(int_error_internals)]
 #![feature(int_error_matching)]
+#![feature(into_future)]
 #![feature(integer_atomics)]
 #![feature(lang_items)]
 #![feature(libc)]

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -379,6 +379,8 @@ symbols! {
         infer_static_outlives_requirements,
         inline,
         intel,
+        into_future,
+        IntoFuture,
         into_iter,
         IntoIterator,
         into_result,

--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -112,7 +112,7 @@ async fn mixed_sizes() {
 fn main() {
     assert_eq!(1028, std::mem::size_of_val(&single()));
     assert_eq!(1032, std::mem::size_of_val(&single_with_noop()));
-    assert_eq!(3084, std::mem::size_of_val(&joined()));
-    assert_eq!(3084, std::mem::size_of_val(&joined_with_noop()));
-    assert_eq!(7188, std::mem::size_of_val(&mixed_sizes()));
+    assert_eq!(3080, std::mem::size_of_val(&joined()));
+    assert_eq!(3080, std::mem::size_of_val(&joined_with_noop()));
+    assert_eq!(6164, std::mem::size_of_val(&mixed_sizes()));
 }

--- a/src/test/ui/async-await/await-into-future.rs
+++ b/src/test/ui/async-await/await-into-future.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+// edition:2018
+
+#![feature(into_future)]
+
+use std::{future::{Future, IntoFuture}, pin::Pin};
+
+struct AwaitMe;
+
+impl IntoFuture for AwaitMe {
+    type Output = i32;
+    type Future = Pin<Box<dyn Future<Output = i32>>>;
+
+    fn into_future(self) -> Self::Future {
+        Box::pin(me())
+    }
+}
+
+async fn me() -> i32 {
+    41
+}
+
+async fn run() {
+    assert_eq!(AwaitMe.await, 41);
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -32,11 +32,8 @@ error[E0277]: the trait bound `[closure@$DIR/issue-62009-1.rs:13:5: 13:15]: std:
    |
 LL |     (|_| 2333).await;
    |     ^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `[closure@$DIR/issue-62009-1.rs:13:5: 13:15]`
-   | 
-  ::: $SRC_DIR/libstd/future.rs:LL:COL
    |
-LL |     F: Future,
-   |        ------ required by this bound in `std::future::poll_with_tls_context`
+   = note: required by `std::future::IntoFuture::into_future`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
The [async-await RFC](https://rust-lang.github.io/rfcs/2394-async_await.html#the-await-compiler-built-in) mentions being able to `await` anything implementing `IntoFuture`. Somewhere along the way, it was left out.