### PR TITLE
resolve: fix error title regarding private constructors

### DIFF
--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2379,26 +2379,38 @@ impl<'a> Resolver<'a> {
         let mut reported_spans = FxHashSet::default();
         for &PrivacyError(dedup_span, ident, binding) in &self.privacy_errors {
             if reported_spans.insert(dedup_span) {
-                let mut err = struct_span_err!(
-                    self.session,
-                    ident.span,
-                    E0603,
-                    "{} `{}` is private",
-                    binding.res().descr(),
-                    ident.name,
-                );
-                if let NameBindingKind::Res(
+                let session = &self.session;
+                let mk_struct_span_error = |is_constructor| {
+                    struct_span_err!(
+                        session,
+                        ident.span,
+                        E0603,
+                        "{}{} `{}` is private",
+                        binding.res().descr(),
+                        if is_constructor { " constructor"} else { "" },
+                        ident.name,
+                    )
+                };
+
+                let mut err = if let NameBindingKind::Res(
                     Res::Def(DefKind::Ctor(CtorOf::Struct, CtorKind::Fn), ctor_def_id), _
                 ) = binding.kind {
                     let def_id = (&*self).parent(ctor_def_id).expect("no parent for a constructor");
                     if let Some(fields) = self.field_names.get(&def_id) {
+                        let mut err = mk_struct_span_error(true);
                         let first_field = fields.first().expect("empty field list in the map");
                         err.span_label(
                             fields.iter().fold(first_field.span, |acc, field| acc.to(field.span)),
                             "a tuple struct constructor is private if any of its fields is private",
                         );
+                        err
+                    } else {
+                        mk_struct_span_error(false)
                     }
-                }
+                } else {
+                    mk_struct_span_error(false)
+                };
+
                 err.emit();
             }
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -2401,7 +2401,7 @@ impl<'a> Resolver<'a> {
                         let first_field = fields.first().expect("empty field list in the map");
                         err.span_label(
                             fields.iter().fold(first_field.span, |acc, field| acc.to(field.span)),
-                            "a tuple struct constructor is private if any of its fields is private",
+                            "a constructor is private if any of the fields is private",
                         );
                         err
                     } else {

--- a/src/test/ui/privacy/privacy5.rs
+++ b/src/test/ui/privacy/privacy5.rs
@@ -48,31 +48,31 @@ mod a {
 }
 
 fn this_crate() {
-    let a = a::A(()); //~ ERROR tuple struct `A` is private
-    let b = a::B(2); //~ ERROR tuple struct `B` is private
-    let c = a::C(2, 3); //~ ERROR tuple struct `C` is private
+    let a = a::A(()); //~ ERROR tuple struct constructor `A` is private
+    let b = a::B(2); //~ ERROR tuple struct constructor `B` is private
+    let c = a::C(2, 3); //~ ERROR tuple struct constructor `C` is private
     let d = a::D(4);
 
-    let a::A(()) = a; //~ ERROR tuple struct `A` is private
-    let a::A(_) = a; //~ ERROR tuple struct `A` is private
-    match a { a::A(()) => {} } //~ ERROR tuple struct `A` is private
-    match a { a::A(_) => {} } //~ ERROR tuple struct `A` is private
+    let a::A(()) = a; //~ ERROR tuple struct constructor `A` is private
+    let a::A(_) = a; //~ ERROR tuple struct constructor `A` is private
+    match a { a::A(()) => {} } //~ ERROR tuple struct constructor `A` is private
+    match a { a::A(_) => {} } //~ ERROR tuple struct constructor `A` is private
 
-    let a::B(_) = b; //~ ERROR tuple struct `B` is private
-    let a::B(_b) = b; //~ ERROR tuple struct `B` is private
-    match b { a::B(_) => {} } //~ ERROR tuple struct `B` is private
-    match b { a::B(_b) => {} } //~ ERROR tuple struct `B` is private
-    match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct `B` is private
-                                            //~^ ERROR tuple struct `B` is private
+    let a::B(_) = b; //~ ERROR tuple struct constructor `B` is private
+    let a::B(_b) = b; //~ ERROR tuple struct constructor `B` is private
+    match b { a::B(_) => {} } //~ ERROR tuple struct constructor `B` is private
+    match b { a::B(_b) => {} } //~ ERROR tuple struct constructor `B` is private
+    match b { a::B(1) => {} a::B(_) => {} } //~ ERROR tuple struct constructor `B` is private
+                                            //~^ ERROR tuple struct constructor `B` is private
 
-    let a::C(_, _) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-    let a::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-    match c { a::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-    match c { a::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
+    let a::C(_, _) = c; //~ ERROR tuple struct constructor `C` is private
+    let a::C(_a, _) = c; //~ ERROR tuple struct constructor `C` is private
+    let a::C(_, _b) = c; //~ ERROR tuple struct constructor `C` is private
+    let a::C(_a, _b) = c; //~ ERROR tuple struct constructor `C` is private
+    match c { a::C(_, _) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { a::C(_a, _) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { a::C(_, _b) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { a::C(_a, _b) => {} } //~ ERROR tuple struct constructor `C` is private
 
     let a::D(_) = d;
     let a::D(_d) = d;
@@ -80,38 +80,38 @@ fn this_crate() {
     match d { a::D(_d) => {} }
     match d { a::D(1) => {} a::D(_) => {} }
 
-    let a2 = a::A; //~ ERROR tuple struct `A` is private
-    let b2 = a::B; //~ ERROR tuple struct `B` is private
-    let c2 = a::C; //~ ERROR tuple struct `C` is private
+    let a2 = a::A; //~ ERROR tuple struct constructor `A` is private
+    let b2 = a::B; //~ ERROR tuple struct constructor `B` is private
+    let c2 = a::C; //~ ERROR tuple struct constructor `C` is private
     let d2 = a::D;
 }
 
 fn xcrate() {
-    let a = other::A(()); //~ ERROR tuple struct `A` is private
-    let b = other::B(2); //~ ERROR tuple struct `B` is private
-    let c = other::C(2, 3); //~ ERROR tuple struct `C` is private
+    let a = other::A(()); //~ ERROR tuple struct constructor `A` is private
+    let b = other::B(2); //~ ERROR tuple struct constructor `B` is private
+    let c = other::C(2, 3); //~ ERROR tuple struct constructor `C` is private
     let d = other::D(4);
 
-    let other::A(()) = a; //~ ERROR tuple struct `A` is private
-    let other::A(_) = a; //~ ERROR tuple struct `A` is private
-    match a { other::A(()) => {} } //~ ERROR tuple struct `A` is private
-    match a { other::A(_) => {} } //~ ERROR tuple struct `A` is private
+    let other::A(()) = a; //~ ERROR tuple struct constructor `A` is private
+    let other::A(_) = a; //~ ERROR tuple struct constructor `A` is private
+    match a { other::A(()) => {} } //~ ERROR tuple struct constructor `A` is private
+    match a { other::A(_) => {} } //~ ERROR tuple struct constructor `A` is private
 
-    let other::B(_) = b; //~ ERROR tuple struct `B` is private
-    let other::B(_b) = b; //~ ERROR tuple struct `B` is private
-    match b { other::B(_) => {} } //~ ERROR tuple struct `B` is private
-    match b { other::B(_b) => {} } //~ ERROR tuple struct `B` is private
-    match b { other::B(1) => {} other::B(_) => {} } //~ ERROR tuple struct `B` is private
-                                                    //~^ ERROR tuple struct `B` is private
+    let other::B(_) = b; //~ ERROR tuple struct constructor `B` is private
+    let other::B(_b) = b; //~ ERROR tuple struct constructor `B` is private
+    match b { other::B(_) => {} } //~ ERROR tuple struct constructor `B` is private
+    match b { other::B(_b) => {} } //~ ERROR tuple struct constructor `B` is private
+    match b { other::B(1) => {}//~ ERROR tuple struct constructor `B` is private
+        other::B(_) => {} }    //~ ERROR tuple struct constructor `B` is private
 
-    let other::C(_, _) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_a, _) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_, _b) = c; //~ ERROR tuple struct `C` is private
-    let other::C(_a, _b) = c; //~ ERROR tuple struct `C` is private
-    match c { other::C(_, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_a, _) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_, _b) => {} } //~ ERROR tuple struct `C` is private
-    match c { other::C(_a, _b) => {} } //~ ERROR tuple struct `C` is private
+    let other::C(_, _) = c; //~ ERROR tuple struct constructor `C` is private
+    let other::C(_a, _) = c; //~ ERROR tuple struct constructor `C` is private
+    let other::C(_, _b) = c; //~ ERROR tuple struct constructor `C` is private
+    let other::C(_a, _b) = c; //~ ERROR tuple struct constructor `C` is private
+    match c { other::C(_, _) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { other::C(_a, _) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { other::C(_, _b) => {} } //~ ERROR tuple struct constructor `C` is private
+    match c { other::C(_a, _b) => {} } //~ ERROR tuple struct constructor `C` is private
 
     let other::D(_) = d;
     let other::D(_d) = d;
@@ -119,9 +119,9 @@ fn xcrate() {
     match d { other::D(_d) => {} }
     match d { other::D(1) => {} other::D(_) => {} }
 
-    let a2 = other::A; //~ ERROR tuple struct `A` is private
-    let b2 = other::B; //~ ERROR tuple struct `B` is private
-    let c2 = other::C; //~ ERROR tuple struct `C` is private
+    let a2 = other::A; //~ ERROR tuple struct constructor `A` is private
+    let b2 = other::B; //~ ERROR tuple struct constructor `B` is private
+    let c2 = other::C; //~ ERROR tuple struct constructor `C` is private
     let d2 = other::D;
 }
 

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -2,7 +2,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:51:16
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a = a::A(());
    |                ^
@@ -11,7 +11,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:52:16
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let b = a::B(2);
    |                ^
@@ -20,7 +20,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:53:16
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let c = a::C(2, 3);
    |                ^
@@ -29,7 +29,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:56:12
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a::A(()) = a;
    |            ^
@@ -38,7 +38,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:57:12
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a::A(_) = a;
    |            ^
@@ -47,7 +47,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:58:18
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     match a { a::A(()) => {} }
    |                  ^
@@ -56,7 +56,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:59:18
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     match a { a::A(_) => {} }
    |                  ^
@@ -65,7 +65,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:61:12
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let a::B(_) = b;
    |            ^
@@ -74,7 +74,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:62:12
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let a::B(_b) = b;
    |            ^
@@ -83,7 +83,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:63:18
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(_) => {} }
    |                  ^
@@ -92,7 +92,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:64:18
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(_b) => {} }
    |                  ^
@@ -101,7 +101,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:65:18
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                  ^
@@ -110,7 +110,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:65:32
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^
@@ -119,7 +119,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:68:12
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_, _) = c;
    |            ^
@@ -128,7 +128,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:69:12
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_a, _) = c;
    |            ^
@@ -137,7 +137,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:70:12
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_, _b) = c;
    |            ^
@@ -146,7 +146,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:71:12
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let a::C(_a, _b) = c;
    |            ^
@@ -155,7 +155,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:72:18
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_, _) => {} }
    |                  ^
@@ -164,7 +164,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:73:18
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_a, _) => {} }
    |                  ^
@@ -173,7 +173,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:74:18
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_, _b) => {} }
    |                  ^
@@ -182,7 +182,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:75:18
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^
@@ -191,7 +191,7 @@ error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:83:17
    |
 LL |     pub struct A(());
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let a2 = a::A;
    |                 ^
@@ -200,7 +200,7 @@ error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:84:17
    |
 LL |     pub struct B(isize);
-   |                  ----- a tuple struct constructor is private if any of its fields is private
+   |                  ----- a constructor is private if any of the fields is private
 ...
 LL |     let b2 = a::B;
    |                 ^
@@ -209,7 +209,7 @@ error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:85:17
    |
 LL |     pub struct C(pub isize, isize);
-   |                  ---------------- a tuple struct constructor is private if any of its fields is private
+   |                  ---------------- a constructor is private if any of the fields is private
 ...
 LL |     let c2 = a::C;
    |                 ^
@@ -223,7 +223,7 @@ LL |     let a = other::A(());
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:91:20
@@ -234,7 +234,7 @@ LL |     let b = other::B(2);
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:92:20
@@ -245,7 +245,7 @@ LL |     let c = other::C(2, 3);
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:95:16
@@ -256,7 +256,7 @@ LL |     let other::A(()) = a;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:96:16
@@ -267,7 +267,7 @@ LL |     let other::A(_) = a;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:97:22
@@ -278,7 +278,7 @@ LL |     match a { other::A(()) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:98:22
@@ -289,7 +289,7 @@ LL |     match a { other::A(_) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:100:16
@@ -300,7 +300,7 @@ LL |     let other::B(_) = b;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:101:16
@@ -311,7 +311,7 @@ LL |     let other::B(_b) = b;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:102:22
@@ -322,7 +322,7 @@ LL |     match b { other::B(_) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:103:22
@@ -333,7 +333,7 @@ LL |     match b { other::B(_b) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:104:22
@@ -344,7 +344,7 @@ LL |     match b { other::B(1) => {}
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:105:16
@@ -355,7 +355,7 @@ LL |         other::B(_) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:107:16
@@ -366,7 +366,7 @@ LL |     let other::C(_, _) = c;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:108:16
@@ -377,7 +377,7 @@ LL |     let other::C(_a, _) = c;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:109:16
@@ -388,7 +388,7 @@ LL |     let other::C(_, _b) = c;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:110:16
@@ -399,7 +399,7 @@ LL |     let other::C(_a, _b) = c;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:111:22
@@ -410,7 +410,7 @@ LL |     match c { other::C(_, _) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:112:22
@@ -421,7 +421,7 @@ LL |     match c { other::C(_a, _) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:113:22
@@ -432,7 +432,7 @@ LL |     match c { other::C(_, _b) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:114:22
@@ -443,7 +443,7 @@ LL |     match c { other::C(_a, _b) => {} }
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:122:21
@@ -454,7 +454,7 @@ LL |     let a2 = other::A;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:1:14
    |
 LL | pub struct A(());
-   |              -- a tuple struct constructor is private if any of its fields is private
+   |              -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:123:21
@@ -465,7 +465,7 @@ LL |     let b2 = other::B;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
-   |              ----- a tuple struct constructor is private if any of its fields is private
+   |              ----- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:124:21
@@ -476,7 +476,7 @@ LL |     let c2 = other::C;
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:3:14
    |
 LL | pub struct C(pub isize, isize);
-   |              ---------------- a tuple struct constructor is private if any of its fields is private
+   |              ---------------- a constructor is private if any of the fields is private
 
 error: aborting due to 48 previous errors
 

--- a/src/test/ui/privacy/privacy5.stderr
+++ b/src/test/ui/privacy/privacy5.stderr
@@ -1,4 +1,4 @@
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:51:16
    |
 LL |     pub struct A(());
@@ -7,7 +7,7 @@ LL |     pub struct A(());
 LL |     let a = a::A(());
    |                ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:52:16
    |
 LL |     pub struct B(isize);
@@ -16,7 +16,7 @@ LL |     pub struct B(isize);
 LL |     let b = a::B(2);
    |                ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:53:16
    |
 LL |     pub struct C(pub isize, isize);
@@ -25,7 +25,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let c = a::C(2, 3);
    |                ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:56:12
    |
 LL |     pub struct A(());
@@ -34,7 +34,7 @@ LL |     pub struct A(());
 LL |     let a::A(()) = a;
    |            ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:57:12
    |
 LL |     pub struct A(());
@@ -43,7 +43,7 @@ LL |     pub struct A(());
 LL |     let a::A(_) = a;
    |            ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:58:18
    |
 LL |     pub struct A(());
@@ -52,7 +52,7 @@ LL |     pub struct A(());
 LL |     match a { a::A(()) => {} }
    |                  ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:59:18
    |
 LL |     pub struct A(());
@@ -61,7 +61,7 @@ LL |     pub struct A(());
 LL |     match a { a::A(_) => {} }
    |                  ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:61:12
    |
 LL |     pub struct B(isize);
@@ -70,7 +70,7 @@ LL |     pub struct B(isize);
 LL |     let a::B(_) = b;
    |            ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:62:12
    |
 LL |     pub struct B(isize);
@@ -79,7 +79,7 @@ LL |     pub struct B(isize);
 LL |     let a::B(_b) = b;
    |            ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:63:18
    |
 LL |     pub struct B(isize);
@@ -88,7 +88,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(_) => {} }
    |                  ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:64:18
    |
 LL |     pub struct B(isize);
@@ -97,7 +97,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(_b) => {} }
    |                  ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:65:18
    |
 LL |     pub struct B(isize);
@@ -106,7 +106,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                  ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:65:32
    |
 LL |     pub struct B(isize);
@@ -115,7 +115,7 @@ LL |     pub struct B(isize);
 LL |     match b { a::B(1) => {} a::B(_) => {} }
    |                                ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:68:12
    |
 LL |     pub struct C(pub isize, isize);
@@ -124,7 +124,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_, _) = c;
    |            ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:69:12
    |
 LL |     pub struct C(pub isize, isize);
@@ -133,7 +133,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_a, _) = c;
    |            ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:70:12
    |
 LL |     pub struct C(pub isize, isize);
@@ -142,7 +142,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_, _b) = c;
    |            ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:71:12
    |
 LL |     pub struct C(pub isize, isize);
@@ -151,7 +151,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let a::C(_a, _b) = c;
    |            ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:72:18
    |
 LL |     pub struct C(pub isize, isize);
@@ -160,7 +160,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_, _) => {} }
    |                  ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:73:18
    |
 LL |     pub struct C(pub isize, isize);
@@ -169,7 +169,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_a, _) => {} }
    |                  ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:74:18
    |
 LL |     pub struct C(pub isize, isize);
@@ -178,7 +178,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_, _b) => {} }
    |                  ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:75:18
    |
 LL |     pub struct C(pub isize, isize);
@@ -187,7 +187,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     match c { a::C(_a, _b) => {} }
    |                  ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:83:17
    |
 LL |     pub struct A(());
@@ -196,7 +196,7 @@ LL |     pub struct A(());
 LL |     let a2 = a::A;
    |                 ^
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:84:17
    |
 LL |     pub struct B(isize);
@@ -205,7 +205,7 @@ LL |     pub struct B(isize);
 LL |     let b2 = a::B;
    |                 ^
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:85:17
    |
 LL |     pub struct C(pub isize, isize);
@@ -214,7 +214,7 @@ LL |     pub struct C(pub isize, isize);
 LL |     let c2 = a::C;
    |                 ^
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:90:20
    |
 LL |     let a = other::A(());
@@ -225,7 +225,7 @@ LL |     let a = other::A(());
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:91:20
    |
 LL |     let b = other::B(2);
@@ -236,7 +236,7 @@ LL |     let b = other::B(2);
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:92:20
    |
 LL |     let c = other::C(2, 3);
@@ -247,7 +247,7 @@ LL |     let c = other::C(2, 3);
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:95:16
    |
 LL |     let other::A(()) = a;
@@ -258,7 +258,7 @@ LL |     let other::A(()) = a;
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:96:16
    |
 LL |     let other::A(_) = a;
@@ -269,7 +269,7 @@ LL |     let other::A(_) = a;
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:97:22
    |
 LL |     match a { other::A(()) => {} }
@@ -280,7 +280,7 @@ LL |     match a { other::A(()) => {} }
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:98:22
    |
 LL |     match a { other::A(_) => {} }
@@ -291,7 +291,7 @@ LL |     match a { other::A(_) => {} }
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:100:16
    |
 LL |     let other::B(_) = b;
@@ -302,7 +302,7 @@ LL |     let other::B(_) = b;
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:101:16
    |
 LL |     let other::B(_b) = b;
@@ -313,7 +313,7 @@ LL |     let other::B(_b) = b;
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:102:22
    |
 LL |     match b { other::B(_) => {} }
@@ -324,7 +324,7 @@ LL |     match b { other::B(_) => {} }
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:103:22
    |
 LL |     match b { other::B(_b) => {} }
@@ -335,10 +335,10 @@ LL |     match b { other::B(_b) => {} }
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:104:22
    |
-LL |     match b { other::B(1) => {} other::B(_) => {} }
+LL |     match b { other::B(1) => {}
    |                      ^
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
@@ -346,18 +346,18 @@ LL |     match b { other::B(1) => {} other::B(_) => {} }
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
-  --> $DIR/privacy5.rs:104:40
+error[E0603]: tuple struct constructor `B` is private
+  --> $DIR/privacy5.rs:105:16
    |
-LL |     match b { other::B(1) => {} other::B(_) => {} }
-   |                                        ^
+LL |         other::B(_) => {} }
+   |                ^
    | 
   ::: $DIR/auxiliary/privacy_tuple_struct.rs:2:14
    |
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:107:16
    |
 LL |     let other::C(_, _) = c;
@@ -368,7 +368,7 @@ LL |     let other::C(_, _) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:108:16
    |
 LL |     let other::C(_a, _) = c;
@@ -379,7 +379,7 @@ LL |     let other::C(_a, _) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:109:16
    |
 LL |     let other::C(_, _b) = c;
@@ -390,7 +390,7 @@ LL |     let other::C(_, _b) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:110:16
    |
 LL |     let other::C(_a, _b) = c;
@@ -401,7 +401,7 @@ LL |     let other::C(_a, _b) = c;
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:111:22
    |
 LL |     match c { other::C(_, _) => {} }
@@ -412,7 +412,7 @@ LL |     match c { other::C(_, _) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:112:22
    |
 LL |     match c { other::C(_a, _) => {} }
@@ -423,7 +423,7 @@ LL |     match c { other::C(_a, _) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:113:22
    |
 LL |     match c { other::C(_, _b) => {} }
@@ -434,7 +434,7 @@ LL |     match c { other::C(_, _b) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:114:22
    |
 LL |     match c { other::C(_a, _b) => {} }
@@ -445,7 +445,7 @@ LL |     match c { other::C(_a, _b) => {} }
 LL | pub struct C(pub isize, isize);
    |              ---------------- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `A` is private
+error[E0603]: tuple struct constructor `A` is private
   --> $DIR/privacy5.rs:122:21
    |
 LL |     let a2 = other::A;
@@ -456,7 +456,7 @@ LL |     let a2 = other::A;
 LL | pub struct A(());
    |              -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `B` is private
+error[E0603]: tuple struct constructor `B` is private
   --> $DIR/privacy5.rs:123:21
    |
 LL |     let b2 = other::B;
@@ -467,7 +467,7 @@ LL |     let b2 = other::B;
 LL | pub struct B(isize);
    |              ----- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `C` is private
+error[E0603]: tuple struct constructor `C` is private
   --> $DIR/privacy5.rs:124:21
    |
 LL |     let c2 = other::C;

--- a/src/test/ui/resolve/privacy-struct-ctor.rs
+++ b/src/test/ui/resolve/privacy-struct-ctor.rs
@@ -16,7 +16,7 @@ mod m {
 
     fn f() {
         n::Z;
-        //~^ ERROR tuple struct `Z` is private
+        //~^ ERROR tuple struct constructor `Z` is private
         Z;
         //~^ ERROR expected value, found struct `Z`
     }
@@ -27,21 +27,21 @@ use m::S2; // OK, only the type is imported
 
 fn main() {
     m::S;
-    //~^ ERROR tuple struct `S` is private
+    //~^ ERROR tuple struct constructor `S` is private
     let _: S = m::S(2);
-    //~^ ERROR tuple struct `S` is private
+    //~^ ERROR tuple struct constructor `S` is private
     S;
     //~^ ERROR expected value, found struct `S`
     m::n::Z;
-    //~^ ERROR tuple struct `Z` is private
+    //~^ ERROR tuple struct constructor `Z` is private
 
     S2;
     //~^ ERROR expected value, found struct `S2`
 
     xcrate::m::S;
-    //~^ ERROR tuple struct `S` is private
+    //~^ ERROR tuple struct constructor `S` is private
     xcrate::S;
     //~^ ERROR expected value, found struct `xcrate::S`
     xcrate::m::n::Z;
-    //~^ ERROR tuple struct `Z` is private
+    //~^ ERROR tuple struct constructor `Z` is private
 }

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -34,7 +34,7 @@ help: possible better candidate is found in another module, you can import it in
 LL | use m::S;
    |
 
-error[E0603]: tuple struct `Z` is private
+error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
@@ -43,7 +43,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
 LL |         n::Z;
    |            ^
 
-error[E0603]: tuple struct `S` is private
+error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:29:8
    |
 LL |     pub struct S(u8);
@@ -52,7 +52,7 @@ LL |     pub struct S(u8);
 LL |     m::S;
    |        ^
 
-error[E0603]: tuple struct `S` is private
+error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:31:19
    |
 LL |     pub struct S(u8);
@@ -61,7 +61,7 @@ LL |     pub struct S(u8);
 LL |     let _: S = m::S(2);
    |                   ^
 
-error[E0603]: tuple struct `Z` is private
+error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:35:11
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
@@ -70,7 +70,7 @@ LL |         pub(in m) struct Z(pub(in m::n) u8);
 LL |     m::n::Z;
    |           ^
 
-error[E0603]: tuple struct `S` is private
+error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:41:16
    |
 LL |     xcrate::m::S;
@@ -81,7 +81,7 @@ LL |     xcrate::m::S;
 LL |     pub struct S(u8);
    |                  -- a tuple struct constructor is private if any of its fields is private
 
-error[E0603]: tuple struct `Z` is private
+error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:45:19
    |
 LL |     xcrate::m::n::Z;

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -38,7 +38,7 @@ error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:18:12
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
-   |                            --------------- a tuple struct constructor is private if any of its fields is private
+   |                            --------------- a constructor is private if any of the fields is private
 ...
 LL |         n::Z;
    |            ^
@@ -47,7 +47,7 @@ error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:29:8
    |
 LL |     pub struct S(u8);
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     m::S;
    |        ^
@@ -56,7 +56,7 @@ error[E0603]: tuple struct constructor `S` is private
   --> $DIR/privacy-struct-ctor.rs:31:19
    |
 LL |     pub struct S(u8);
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 ...
 LL |     let _: S = m::S(2);
    |                   ^
@@ -65,7 +65,7 @@ error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:35:11
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
-   |                            --------------- a tuple struct constructor is private if any of its fields is private
+   |                            --------------- a constructor is private if any of the fields is private
 ...
 LL |     m::n::Z;
    |           ^
@@ -79,7 +79,7 @@ LL |     xcrate::m::S;
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:2:18
    |
 LL |     pub struct S(u8);
-   |                  -- a tuple struct constructor is private if any of its fields is private
+   |                  -- a constructor is private if any of the fields is private
 
 error[E0603]: tuple struct constructor `Z` is private
   --> $DIR/privacy-struct-ctor.rs:45:19
@@ -90,7 +90,7 @@ LL |     xcrate::m::n::Z;
   ::: $DIR/auxiliary/privacy-struct-ctor.rs:5:28
    |
 LL |         pub(in m) struct Z(pub(in m::n) u8);
-   |                            --------------- a tuple struct constructor is private if any of its fields is private
+   |                            --------------- a constructor is private if any of the fields is private
 
 error: aborting due to 10 previous errors
 

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.rs
@@ -21,7 +21,7 @@ fn main() {
     //~^ ERROR expected function, found struct `TupleStruct` [E0423]
 
     let ts_explicit = structs::TupleStruct(640, 480);
-    //~^ ERROR tuple struct `TupleStruct` is private [E0603]
+    //~^ ERROR tuple struct constructor `TupleStruct` is private [E0603]
 
     let TupleStruct { 0: first_field, 1: second_field } = ts;
     //~^ ERROR `..` required with struct marked as non-exhaustive

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -10,7 +10,7 @@ error[E0423]: expected value, found struct `UnitStruct`
 LL |     let us = UnitStruct;
    |              ^^^^^^^^^^ constructor is not visible here due to private fields
 
-error[E0603]: tuple struct `TupleStruct` is private
+error[E0603]: tuple struct constructor `TupleStruct` is private
   --> $DIR/struct.rs:23:32
    |
 LL |     let ts_explicit = structs::TupleStruct(640, 480);

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -19,7 +19,7 @@ LL |     let ts_explicit = structs::TupleStruct(640, 480);
   ::: $DIR/auxiliary/structs.rs:13:24
    |
 LL | pub struct TupleStruct(pub u16, pub u16);
-   |                        ---------------- a tuple struct constructor is private if any of its fields is private
+   |                        ---------------- a constructor is private if any of the fields is private
 
 error[E0603]: unit struct `UnitStruct` is private
   --> $DIR/struct.rs:32:32


### PR DESCRIPTION
One reason is that constructors can be private while their types can be
public.

Idea credit to @petrochenkov, discussed at #65153