### PR TITLE
WIP Add MIR argument for #[track_caller] (RFC 2091 3/N)

### DIFF
--- a/src/libcore/panic.rs
+++ b/src/libcore/panic.rs
@@ -162,6 +162,7 @@ impl fmt::Display for PanicInfo<'_> {
 ///
 /// panic!("Normal panic");
 /// ```
+#[cfg_attr(not(bootstrap), lang = "panic_location")]
 #[derive(Debug)]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub struct Location<'a> {

--- a/src/librustc/middle/lang_items.rs
+++ b/src/librustc/middle/lang_items.rs
@@ -366,6 +366,7 @@ language_item_table! {
     PanicFnLangItem,             "panic",              panic_fn,                Target::Fn;
     PanicBoundsCheckFnLangItem,  "panic_bounds_check", panic_bounds_check_fn,   Target::Fn;
     PanicInfoLangItem,           "panic_info",         panic_info,              Target::Struct;
+    PanicLocationLangItem,       "panic_location",     panic_location,          Target::Struct;
     PanicImplLangItem,           "panic_impl",         panic_impl,              Target::Fn;
     // Libstd panic entry point. Necessary for const eval to be able to catch it
     BeginPanicFnLangItem,        "begin_panic",        begin_panic_fn,          Target::Fn;

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -89,6 +89,25 @@ pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> Body<'_> {
                 _ => None,
             };
 
+            // if this fn has #[track_caller], it will receive an implicit argument with a location
+            let has_track_caller = tcx.codegen_fn_attrs(def_id).flags
+                .contains(hir::CodegenFnAttrFlags::TRACK_CALLER);
+            let location_argument = if has_track_caller {
+                #[cfg(not(bootstrap))]
+                {
+                    use rustc::middle::lang_items::PanicLocationLangItem;
+                    let panic_loc_item = tcx.require_lang_item(PanicLocationLangItem, None);
+                    let panic_loc_ty = tcx.type_of(panic_loc_item);
+                    Some(ArgInfo(panic_loc_ty, None, None, None))
+                }
+                #[cfg(bootstrap)]
+                {
+                    bug!("#[track_caller] can't be used during a bootstrap build (yet).");
+                }
+            } else {
+                None
+            };
+
             let safety = match fn_sig.unsafety {
                 hir::Unsafety::Normal => Safety::Safe,
                 hir::Unsafety::Unsafe => Safety::FnUnsafe,
@@ -141,7 +160,9 @@ pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> Body<'_> {
                         ArgInfo(ty, opt_ty_info, Some(&arg), self_arg)
                     });
 
-            let arguments = implicit_argument.into_iter().chain(explicit_arguments);
+            let arguments = implicit_argument.into_iter()
+                .chain(location_argument)
+                .chain(explicit_arguments);
 
             let (yield_ty, return_ty) = if body.generator_kind.is_some() {
                 let gen_sig = match ty.kind {

--- a/src/test/ui/rfc-2091-track-caller/pass.rs
+++ b/src/test/ui/rfc-2091-track-caller/pass.rs
@@ -1,9 +1,0 @@
-// run-pass
-#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
-
-#[track_caller]
-fn f() {}
-
-fn main() {
-    f();
-}

--- a/src/test/ui/rfc-2091-track-caller/pass.stderr
+++ b/src/test/ui/rfc-2091-track-caller/pass.stderr
@@ -1,8 +1,0 @@
-warning: the feature `track_caller` is incomplete and may cause the compiler to crash
-  --> $DIR/pass.rs:2:12
-   |
-LL | #![feature(track_caller)]
-   |            ^^^^^^^^^^^^
-   |
-   = note: `#[warn(incomplete_features)]` on by default
-

--- a/src/test/ui/rfc-2091-track-caller/should-pass.rs
+++ b/src/test/ui/rfc-2091-track-caller/should-pass.rs
@@ -1,0 +1,12 @@
+// failure-status: 101
+// normalize-stderr-test "note: rustc 1.* running on .*" -> "note: rustc VERSION running on TARGET"
+// normalize-stderr-test "note: compiler flags: .*" -> "note: compiler flags: FLAGS"
+
+#![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
+
+#[track_caller]
+fn f() {}
+
+fn main() {
+    f();
+}

--- a/src/test/ui/rfc-2091-track-caller/should-pass.stderr
+++ b/src/test/ui/rfc-2091-track-caller/should-pass.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-thread 'rustc' panicked at 'index out of bounds: the len is 0 but the index is 0', $SRC_DIR/libcore/slice/mod.rs:LL:COL
+thread 'rustc' panicked at 'assertion failed: !value.needs_subst()', src/librustc/traits/query/normalize_erasing_regions.rs:59:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic

--- a/src/test/ui/rfc-2091-track-caller/should-pass.stderr
+++ b/src/test/ui/rfc-2091-track-caller/should-pass.stderr
@@ -1,0 +1,21 @@
+warning: the feature `track_caller` is incomplete and may cause the compiler to crash
+  --> $DIR/should-pass.rs:5:12
+   |
+LL | #![feature(track_caller)]
+   |            ^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+thread 'rustc' panicked at 'index out of bounds: the len is 0 but the index is 0', $SRC_DIR/libcore/slice/mod.rs:LL:COL
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
+
+error: internal compiler error: unexpected panic
+
+note: the compiler unexpectedly panicked. this is a bug.
+
+note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports
+
+note: rustc VERSION running on TARGET
+
+note: compiler flags: FLAGS
+

--- a/src/test/ui/rfc-2091-track-caller/should-pass.stderr
+++ b/src/test/ui/rfc-2091-track-caller/should-pass.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-thread 'rustc' panicked at 'assertion failed: !value.needs_subst()', src/librustc/traits/query/normalize_erasing_regions.rs:59:9
+thread 'rustc' panicked at 'index out of bounds: the len is 0 but the index is 0', $SRC_DIR/libcore/slice/mod.rs:LL:COL
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
 
 error: internal compiler error: unexpected panic


### PR DESCRIPTION
Making this work requires making `core::panic::Location` a lang item, which is the first commit on this branch (prior are from the depended-on PR).

Depends on: https://github.com/rust-lang/rust/pull/65182
Tracking issue: https://github.com/rust-lang/rust/issues/47809
[RFC text](https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md)

TODO:

* [x] add a location parameter to MIR of `#[track_caller]` in rustc_mir::build (reference existing implicit arguments work if needed)
* [x] fix `ty::Instance::fn_sig` to contain the new type
  * [x] ~~note to self: check on by-val vs. by-ref for this arg~~ used &'static per @eddyb 
* [ ] add a "dummy" location parameter to calls from `ReifyShim` (see other shims for generating things in shims, ask @eddyb if fighting consteval)
* [ ] pass the "correct" location parameter to the function in all calls to `ty::Instance::resolve`
* [ ] wire up intrinsic::caller_location in MIR construction (reference move_val_init intrinsic)
* [ ] test it can't be called from non-caller-tracked functions (reference other intrinsics for how to type-check)
* [ ] make sure MIR inlining uses resolve, "change the ty::Instance::resolve callsite there"
* [ ] test that directly nested `#[track_caller]`s pass the same callsite
* [ ] test that indirectly nested `#[track_caller]`s pass distinct callsites
* [ ] check that all rfc-2091 tests are un-ice'd