### PR TITLE
Mark Path::join as must_use

### DIFF
--- a/src/libstd/path.rs
+++ b/src/libstd/path.rs
@@ -2219,6 +2219,7 @@ impl Path {
     /// assert_eq!(Path::new("/etc").join("passwd"), PathBuf::from("/etc/passwd"));
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use]
     pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
         self._join(path.as_ref())
     }


### PR DESCRIPTION
I've accidentally did `mut_path_buf.jon(a_path);`, expecting this to be an in-place modification. Seems like we can easily warn in such cases?