### PR TITLE
Lint ignored `#[inline]` on function prototypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2-rfc"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 arena = { path = "../libarena" }
-bitflags = "1.0"
+bitflags = "1.2.1"
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -2219,7 +2219,7 @@ rejected in your own crates.
 "##,
 
 E0736: r##"
-#[track_caller] and #[naked] cannot be applied to the same function.
+`#[track_caller]` and `#[naked]` cannot both be applied to the same function.
 
 Erroneous code example:
 
@@ -2233,6 +2233,57 @@ fn foo() {}
 
 This is primarily due to ABI incompatibilities between the two attributes.
 See [RFC 2091] for details on this and other limitations.
+
+[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
+"##,
+
+E0738: r##"
+`#[track_caller]` cannot be used in traits yet. This is due to limitations in
+the compiler which are likely to be temporary. See [RFC 2091] for details on
+this and other restrictions.
+
+Erroneous example with a trait method implementation:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    fn bar(&self);
+}
+
+impl Foo for u64 {
+    #[track_caller]
+    fn bar(&self) {}
+}
+```
+
+Erroneous example with a blanket trait method implementation:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    #[track_caller]
+    fn bar(&self) {}
+    fn baz(&self);
+}
+```
+
+Erroneous example with a trait method declaration:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    fn bar(&self) {}
+
+    #[track_caller]
+    fn baz(&self);
+}
+```
+
+Note that while the compiler may be able to support the attribute in traits in
+the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -278,7 +278,7 @@ impl CheckAttrVisitor<'tcx> {
     /// Checks if the `#[target_feature]` attribute on `item` is valid. Returns `true` if valid.
     fn check_target_feature(&self, attr: &Attribute, span: &Span, target: Target) -> bool {
         match target {
-            Target::Fn => true,
+            Target::Fn | Target::Method { body: true } => true,
             _ => {
                 self.tcx.sess
                     .struct_span_err(attr.span, "attribute should be applied to a function")

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -203,7 +203,7 @@ pub trait Visitor<'v>: Sized {
 
     /// Invoked to visit the body of a function, method or closure. Like
     /// visit_nested_item, does nothing by default unless you override
-    /// `nested_visit_map` to return other htan `None`, in which case it will walk
+    /// `nested_visit_map` to return other than `None`, in which case it will walk
     /// the body.
     fn visit_nested_body(&mut self, id: BodyId) {
         let opt_body = self.nested_visit_map().intra().map(|map| map.body(id));

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2756,10 +2756,10 @@ bitflags! {
         /// `#[used]`: indicates that LLVM can't eliminate this function (but the
         /// linker can!).
         const USED                      = 1 << 9;
-        /// #[ffi_returns_twice], indicates that an extern function can return
+        /// `#[ffi_returns_twice]`, indicates that an extern function can return
         /// multiple times
         const FFI_RETURNS_TWICE         = 1 << 10;
-        /// #[track_caller]: allow access to the caller location
+        /// `#[track_caller]`: allow access to the caller location
         const TRACK_CALLER              = 1 << 11;
     }
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2512,7 +2512,7 @@ pub enum ItemKind {
     Fn(P<FnDecl>, FnHeader, Generics, BodyId),
     /// A module.
     Mod(Mod),
-    /// An external module.
+    /// An external module, e.g. `extern { .. }`.
     ForeignMod(ForeignMod),
     /// Module-level inline assembly (from `global_asm!`).
     GlobalAsm(P<GlobalAsm>),

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -69,6 +69,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_ATTRIBUTES,
+    Warn,
+    "detects attributes that were not used by the compiler"
+}
+
+declare_lint! {
     pub UNREACHABLE_CODE,
     Warn,
     "detects unreachable code paths",

--- a/src/librustc_apfloat/Cargo.toml
+++ b/src/librustc_apfloat/Cargo.toml
@@ -9,5 +9,5 @@ name = "rustc_apfloat"
 path = "lib.rs"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 test = false
 
 [dependencies]
-bitflags = "1.0.4"
+bitflags = "1.2.1"
 cc = "1.0.1"
 num_cpus = "1.0"
 memmap = "0.6"

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::DefId;
 use rustc::lint;
+use rustc::lint::builtin::UNUSED_ATTRIBUTES;
 use rustc::ty::{self, Ty};
 use rustc::ty::adjustment;
 use rustc_data_structures::fx::FxHashMap;
@@ -275,12 +276,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
             }
         }
     }
-}
-
-declare_lint! {
-    pub UNUSED_ATTRIBUTES,
-    Warn,
-    "detects attributes that were not used by the compiler"
 }
 
 #[derive(Copy, Clone)]

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 doctest = false
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 log = "0.4"
 syntax = { path = "../libsyntax" }
 syntax_expand = { path = "../libsyntax_expand" }

--- a/src/librustc_target/Cargo.toml
+++ b/src/librustc_target/Cargo.toml
@@ -9,7 +9,7 @@ name = "rustc_target"
 path = "lib.rs"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 log = "0.4"
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -172,18 +172,6 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
         _ => None
     };
     check_associated_item(tcx, trait_item.hir_id, trait_item.span, method_sig);
-
-    // Prohibits applying `#[track_caller]` to trait decls
-    for attr in &trait_item.attrs {
-        if attr.check_name(sym::track_caller) {
-            struct_span_err!(
-                tcx.sess,
-                attr.span,
-                E0738,
-                "`#[track_caller]` is not supported in trait declarations."
-            ).emit();
-        }
-    }
 }
 
 pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {
@@ -194,29 +182,6 @@ pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {
         hir::ImplItemKind::Method(ref sig, _) => Some(sig),
         _ => None
     };
-
-    // Prohibits applying `#[track_caller]` to trait impls
-    if method_sig.is_some() {
-        let track_caller_attr = impl_item.attrs.iter()
-            .find(|a| a.check_name(sym::track_caller));
-        if let Some(tc_attr) = track_caller_attr {
-            let parent_hir_id = tcx.hir().get_parent_item(hir_id);
-            let containing_item = tcx.hir().expect_item(parent_hir_id);
-            let containing_impl_is_for_trait = match &containing_item.kind {
-                hir::ItemKind::Impl(_, _, _, _, tr, _, _) => tr.is_some(),
-                _ => bug!("parent of an ImplItem must be an Impl"),
-            };
-
-            if containing_impl_is_for_trait {
-                struct_span_err!(
-                    tcx.sess,
-                    tc_attr.span,
-                    E0738,
-                    "`#[track_caller]` is not supported in traits yet."
-                ).emit();
-            }
-        }
-    }
 
     check_associated_item(tcx, impl_item.hir_id, impl_item.span, method_sig);
 }

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2640,7 +2640,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     tcx.sess,
                     attr.span,
                     E0737,
-                    "rust ABI is required to use `#[track_caller]`"
+                    "Rust ABI is required to use `#[track_caller]`"
                 ).emit();
             }
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4938,7 +4938,7 @@ and the pin is required to keep it in the same place in memory.
 "##,
 
 E0737: r##"
-#[track_caller] requires functions to have the "Rust" ABI for implicitly
+`#[track_caller]` requires functions to have the `"Rust"` ABI for implicitly
 receiving caller location. See [RFC 2091] for details on this and other
 restrictions.
 
@@ -4950,57 +4950,6 @@ Erroneous code example:
 #[track_caller]
 extern "C" fn foo() {}
 ```
-
-[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
-"##,
-
-E0738: r##"
-#[track_caller] cannot be used in traits yet.  This is due to limitations in the
-compiler which are likely to be temporary. See [RFC 2091] for details on this
-and other restrictions.
-
-Erroneous example with a trait method implementation:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    fn bar(&self);
-}
-
-impl Foo for u64 {
-    #[track_caller]
-    fn bar(&self) {}
-}
-```
-
-Erroneous example with a blanket trait method implementation:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    #[track_caller]
-    fn bar(&self) {}
-    fn baz(&self);
-}
-```
-
-Erroneous example with a trait method declaration:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    fn bar(&self) {}
-
-    #[track_caller]
-    fn baz(&self);
-}
-```
-
-Note that while the compiler may be able to support the attribute in traits in
-the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 log = "0.4"
 scoped-tls = "1.0"

--- a/src/test/ui/issues/issue-52057.stderr
+++ b/src/test/ui/issues/issue-52057.stderr
@@ -1,0 +1,8 @@
+warning: `#[inline]` is ignored on function prototypes
+  --> $DIR/issue-52057.rs:10:5
+   |
+LL |     #[inline(always)]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_attributes)]` on by default
+

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,8 +1,11 @@
 #![feature(extern_types)]
 #![feature(type_alias_impl_trait)]
 
+#![warn(unused_attributes)]
+
 trait Trait {
-    #[inline] //~ ERROR attribute should be applied to function or closure
+    #[inline] //~ WARN `#[inline]` is ignored on constants
+    //~^ WARN this was previously accepted
     const X: u32;
 
     #[inline] //~ ERROR attribute should be applied to function or closure
@@ -12,7 +15,8 @@ trait Trait {
 }
 
 impl Trait for () {
-    #[inline] //~ ERROR attribute should be applied to function or closure
+    #[inline] //~ WARN `#[inline]` is ignored on constants
+    //~^ WARN this was previously accepted
     const X: u32 = 0;
 
     #[inline] //~ ERROR attribute should be applied to function or closure

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,0 +1,19 @@
+#![feature(extern_types)]
+
+trait Trait {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    const X: u32;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T;
+}
+
+extern {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    static X: u32;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T;
+}
+
+fn main() {}

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,4 +1,5 @@
 #![feature(extern_types)]
+#![feature(type_alias_impl_trait)]
 
 trait Trait {
     #[inline] //~ ERROR attribute should be applied to function or closure
@@ -6,6 +7,19 @@ trait Trait {
 
     #[inline] //~ ERROR attribute should be applied to function or closure
     type T;
+
+    type U;
+}
+
+impl Trait for () {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    const X: u32 = 0;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T = Self;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type U = impl Trait; //~ ERROR could not find defining uses
 }
 
 extern {

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,0 +1,35 @@
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:12:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     static X: u32;
+   |     -------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T;
+   |     ------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:4:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     const X: u32;
+   |     ------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:7:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T;
+   |     ------- not a function or closure
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,5 +1,5 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:12:5
+  --> $DIR/inline-trait-and-foreign-items.rs:26:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     static X: u32;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+  --> $DIR/inline-trait-and-foreign-items.rs:29:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:4:5
+  --> $DIR/inline-trait-and-foreign-items.rs:5:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -23,13 +23,43 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:7:5
+  --> $DIR/inline-trait-and-foreign-items.rs:8:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error: aborting due to 4 previous errors
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     const X: u32 = 0;
+   |     ----------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:18:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T = Self;
+   |     -------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:21:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type U = impl Trait;
+   |     -------------------- not a function or closure
+
+error: could not find defining uses
+  --> $DIR/inline-trait-and-foreign-items.rs:22:5
+   |
+LL |     type U = impl Trait;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,5 +1,5 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:26:5
+  --> $DIR/inline-trait-and-foreign-items.rs:30:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -7,39 +7,46 @@ LL |     static X: u32;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:29:5
+  --> $DIR/inline-trait-and-foreign-items.rs:33:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:5:5
+warning: `#[inline]` is ignored on constants
+  --> $DIR/inline-trait-and-foreign-items.rs:7:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
-LL |     const X: u32;
-   |     ------------- not a function or closure
+   |
+note: lint level defined here
+  --> $DIR/inline-trait-and-foreign-items.rs:4:9
+   |
+LL | #![warn(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:8:5
+  --> $DIR/inline-trait-and-foreign-items.rs:11:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:15:5
-   |
-LL |     #[inline]
-   |     ^^^^^^^^^
-LL |     const X: u32 = 0;
-   |     ----------------- not a function or closure
-
-error[E0518]: attribute should be applied to function or closure
+warning: `#[inline]` is ignored on constants
   --> $DIR/inline-trait-and-foreign-items.rs:18:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:22:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -47,7 +54,7 @@ LL |     type T = Self;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:21:5
+  --> $DIR/inline-trait-and-foreign-items.rs:25:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -55,11 +62,11 @@ LL |     type U = impl Trait;
    |     -------------------- not a function or closure
 
 error: could not find defining uses
-  --> $DIR/inline-trait-and-foreign-items.rs:22:5
+  --> $DIR/inline-trait-and-foreign-items.rs:26:5
    |
 LL |     type U = impl Trait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
@@ -1,0 +1,8 @@
+#![deny(unused_attributes)]
+
+trait Trait {
+    #[inline] //~ ERROR `#[inline]` is ignored on function prototypes
+    fn foo();
+}
+
+fn main() {}

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
@@ -5,4 +5,9 @@ trait Trait {
     fn foo();
 }
 
+extern {
+    #[inline] //~ ERROR `#[inline]` is ignored on function prototypes
+    fn foo();
+}
+
 fn main() {}

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -1,0 +1,14 @@
+error: `#[inline]` is ignored on function prototypes
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:9:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -10,5 +10,11 @@ note: lint level defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
+error: `#[inline]` is ignored on function prototypes
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:4:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
@@ -1,7 +1,6 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
-#[track_caller]
+#[track_caller] //~ ERROR Rust ABI is required to use `#[track_caller]`
 extern "C" fn f() {}
-//~^^ ERROR rust ABI is required to use `#[track_caller]`
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0737]: rust ABI is required to use `#[track_caller]`
+error[E0737]: Rust ABI is required to use `#[track_caller]`
   --> $DIR/error-with-invalid-abi.rs:3:1
    |
 LL | #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
@@ -1,9 +1,8 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self);
-    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 impl Trait for u64 {

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in trait declarations.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-decl.rs:4:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
@@ -1,9 +1,8 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
-    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in trait declarations.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-default-impl.rs:4:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
@@ -5,9 +5,8 @@ trait Trait {
 }
 
 impl Trait for u64 {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
-    //~^^ ERROR: `#[track_caller]` is not supported in traits yet.
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
@@ -1,3 +1,5 @@
+// check-fail
+
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
@@ -7,6 +9,13 @@ trait Trait {
 impl Trait for u64 {
     #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
+}
+
+struct S;
+
+impl S {
+    #[track_caller] // ok
+    fn foo() {}
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in traits yet.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-fn-impl.rs:8:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -1,5 +1,5 @@
 warning: the feature `track_caller` is incomplete and may cause the compiler to crash
-  --> $DIR/error-with-trait-fn-impl.rs:1:12
+  --> $DIR/error-with-trait-fn-impl.rs:3:12
    |
 LL | #![feature(track_caller)]
    |            ^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #![feature(track_caller)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0738]: `#[track_caller]` may not be used on trait methods
-  --> $DIR/error-with-trait-fn-impl.rs:8:5
+  --> $DIR/error-with-trait-fn-impl.rs:10:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/51280.

- Adds a `unused_attribute` lint for `#[inline]` on function prototypes.
- As a consequence, foreign items, impl items and trait items now have their attributes checked, which could cause some code to no longer compile (it was previously erroneously ignored).