### PR TITLE
deriving: avoid dummy Span on an artificial `type_ident` path

### DIFF
--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -192,7 +192,7 @@ use syntax::util::map_in_place::MapInPlace;
 use syntax::ptr::P;
 use syntax::symbol::{Symbol, kw, sym};
 use syntax::parse::ParseSess;
-use syntax_pos::{DUMMY_SP, Span};
+use syntax_pos::{Span};
 
 use ty::{LifetimeBounds, Path, Ptr, PtrTy, Self_, Ty};
 
@@ -1022,7 +1022,7 @@ impl<'a> MethodDef<'a> {
                                  // [fields of next Self arg], [etc]>
         let mut patterns = Vec::new();
         for i in 0..self_args.len() {
-            let struct_path = cx.path(DUMMY_SP, vec![type_ident]);
+            let struct_path = cx.path(trait_.span, vec![type_ident]);
             let (pat, ident_expr) = trait_.create_struct_pattern(cx,
                                                                  struct_path,
                                                                  struct_def,

--- a/src/test/ui/deprecation/derive_on_deprecated.rs
+++ b/src/test/ui/deprecation/derive_on_deprecated.rs
@@ -6,4 +6,10 @@
 #[derive(Default)]
 struct X;
 
+#[deprecated(note="Do not use this")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+pub struct Step<I> {
+    _skip: Option<I>,
+}
+
 fn main() {}


### PR DESCRIPTION
The dummy Span pointed to the beginning of the source file instead to where the `#[derive]` is located. Later, it tripped the `in_derive_expansion(span)` check at `src/librustc/middle/stability.rs`, causing a span-less deprecation warning to be emitted.

Fixes #56195, Fixes #55417.
