### PR TITLE
rustdoc: forward -Z options to rustc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -53,6 +53,8 @@ pub struct Options {
     pub codegen_options_strs: Vec<String>,
     /// Debugging (`-Z`) options to pass to the compiler.
     pub debugging_options: DebuggingOptions,
+    /// Debugging (`-Z`) options strings to pass to the compiler.
+    pub debugging_options_strs: Vec<String>,
     /// The target used to compile the crate against.
     pub target: TargetTriple,
     /// Edition used when reading the crate. Defaults to "2015". Also used by default when
@@ -481,6 +483,7 @@ impl Options {
         let generate_redirect_pages = matches.opt_present("generate-redirect-pages");
         let test_builder = matches.opt_str("test-builder").map(PathBuf::from);
         let codegen_options_strs = matches.opt_strs("C");
+        let debugging_options_strs = matches.opt_strs("Z");
         let lib_strs = matches.opt_strs("L");
         let extern_strs = matches.opt_strs("extern");
         let runtool = matches.opt_str("runtool");
@@ -502,6 +505,7 @@ impl Options {
             codegen_options,
             codegen_options_strs,
             debugging_options,
+            debugging_options_strs,
             target,
             edition,
             maybe_sysroot,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -279,6 +279,9 @@ fn run_test(
     for codegen_options_str in &options.codegen_options_strs {
         compiler.arg("-C").arg(&codegen_options_str);
     }
+    for debugging_option_str in &options.debugging_options_strs {
+        compiler.arg("-Z").arg(&debugging_option_str);
+    }
     if no_run {
         compiler.arg("--emit=metadata");
     }

--- a/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
@@ -6,13 +6,13 @@ failures:
 
 ---- $DIR/failed-doctest-missing-codes.rs - Foo (line 8) stdout ----
 error[E0308]: mismatched types
- --> $DIR/failed-doctest-missing-codes.rs:9:13
-  |
-3 | let x: () = 5i32;
-  |             ^^^^ expected (), found i32
-  |
-  = note: expected type `()`
-             found type `i32`
+  --> $DIR/failed-doctest-missing-codes.rs:9:13
+   |
+LL | let x: () = 5i32;
+   |             ^^^^ expected (), found i32
+   |
+   = note: expected type `()`
+              found type `i32`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -7,10 +7,10 @@ failures:
 
 ---- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:22:1
-  |
-3 | no
-  | ^^ not found in this scope
+  --> $DIR/failed-doctest-output.rs:22:1
+   |
+LL | no
+   | ^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/unparseable-doc-test.stdout
+++ b/src/test/rustdoc-ui/unparseable-doc-test.stdout
@@ -6,10 +6,10 @@ failures:
 
 ---- $DIR/unparseable-doc-test.rs - foo (line 6) stdout ----
 error: unterminated double quote string
- --> $DIR/unparseable-doc-test.rs:8:1
-  |
-2 | "unterminated
-  | ^^^^^^^^^^^^^
+  --> $DIR/unparseable-doc-test.rs:8:1
+   |
+LL | "unterminated
+   | ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc/sanitizer-option.rs
+++ b/src/test/rustdoc/sanitizer-option.rs
@@ -1,0 +1,17 @@
+// needs-sanitizer-support
+// compile-flags: --test -Z sanitizer=address
+//
+// #43031: Verify that rustdoc passes `-Z` options to rustc. Use an extern
+// function that is provided by the sanitizer runtime, if flag is not passed
+// correctly, then linking will fail.
+
+/// ```
+/// extern {
+///     fn __sanitizer_print_stack_trace();
+/// }
+///
+/// fn main() {
+///     unsafe { __sanitizer_print_stack_trace() };
+/// }
+/// ```
+pub fn z_flag_is_passed_to_rustc() {}


### PR DESCRIPTION
Currently rustdoc does not forward `-Z` options to rustc when building
test executables. This makes impossible to use rustdoc to run test
samples when crate under test is instrumented with one of sanitizers
`-Zsanitizer=...`, since the final linking step will not include
sanitizer runtime library.

Forward `-Z` options to rustc to solve the issue.

Helps with #43031.