### PR TITLE
make File::try_clone produce non-inheritable handles on Windows

### DIFF
--- a/src/libstd/sys/windows/fs.rs
+++ b/src/libstd/sys/windows/fs.rs
@@ -412,7 +412,7 @@ impl File {
 
     pub fn duplicate(&self) -> io::Result<File> {
         Ok(File {
-            handle: self.handle.duplicate(0, true, c::DUPLICATE_SAME_ACCESS)?,
+            handle: self.handle.duplicate(0, false, c::DUPLICATE_SAME_ACCESS)?,
         })
     }
 


### PR DESCRIPTION
~**NOT READY FOR REVIEW.** This PR is currently mainly to trigger CI so that I can see what happens. (Is there a better way to trigger CI?) I don't know whether this change makes sense yet.~ (Edit: @Mark-Simulacrum clarified that CI doesn't currently run on Windows.)

---

File handles shouldn't be inheritable in general.
`std::process::Command` takes care of making them inheritable when child
processes are spawned, and the `CREATE_PROCESS_LOCK` protects against
races in that section on Windows. But `File::try_clone` has been
creating inheritable file descriptors outside of that lock, which could
be leaking into other child processes unintentionally.

See also https://github.com/rust-lang/rust/pull/31069#discussion_r334117665.