### PR TITLE
[WIP] Add implicit named arguments for fmt macros

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -445,14 +445,13 @@ impl<'a, 'b> Context<'a, 'b> {
                         self.verify_arg_type(Exact(idx), ty)
                     }
                     None => {
-                        let msg = format!("there is no argument named `{}`", name);
-                        let sp = if self.is_literal {
-                            *self.arg_spans.get(self.curpiece).unwrap_or(&self.fmtsp)
-                        } else {
-                            self.fmtsp
-                        };
-                        let mut err = self.ecx.struct_span_err(sp, &msg[..]);
-                        err.emit();
+                        // Treat this name as implicitly passed named argument
+                        let idx = self.args.len();
+                        self.arg_types.push(Vec::new());
+                        self.arg_unique_types.push(Vec::new());
+                        self.args.push(self.ecx.expr_ident(self.fmtsp, ast::Ident::new(name, self.fmtsp)));
+                        self.names.insert(name, idx);
+                        self.verify_arg_type(Exact(idx), ty)
                     }
                 }
             }

--- a/src/test/ui/if/ifmt-bad-arg.rs
+++ b/src/test/ui/if/ifmt-bad-arg.rs
@@ -25,10 +25,10 @@ fn main() {
     //~^ ERROR: invalid reference to positional arguments 3, 4 and 5 (there are 3 arguments)
 
     format!("{} {foo} {} {bar} {}", 1, 2, 3);
-    //~^ ERROR: there is no argument named `foo`
-    //~^^ ERROR: there is no argument named `bar`
+    //~^ ERROR: cannot find value `foo` in this scope
+    //~^^ ERROR: cannot find value `bar` in this scope
 
-    format!("{foo}");                //~ ERROR: no argument named `foo`
+    format!("{foo}");                //~ ERROR: cannot find value `foo` in this scope
     format!("", 1, 2);               //~ ERROR: multiple unused formatting arguments
     format!("{}", 1, 2);             //~ ERROR: argument never used
     format!("{1}", 1, 2);            //~ ERROR: argument never used
@@ -43,7 +43,7 @@ fn main() {
     // bad named arguments, #35082
 
     format!("{valuea} {valueb}", valuea=5, valuec=7);
-    //~^ ERROR there is no argument named `valueb`
+    //~^ ERROR cannot find value `valueb` in this scope
     //~^^ ERROR named argument never used
 
     // bad syntax of the format string
@@ -60,7 +60,7 @@ fn main() {
         {foo}
 
     "##);
-    //~^^^ ERROR: there is no argument named `foo`
+    //~^^^^^ ERROR: cannot find value `foo` in this scope
 
     // bad syntax in format string with multiple newlines, #53836
     format!("first number: {}

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -58,24 +58,6 @@ LL |     format!("{name} {value} {} {} {} {} {} {}", 0, name=1, value=2);
    |
    = note: positional arguments are zero-based
 
-error: there is no argument named `foo`
-  --> $DIR/ifmt-bad-arg.rs:27:17
-   |
-LL |     format!("{} {foo} {} {bar} {}", 1, 2, 3);
-   |                 ^^^^^
-
-error: there is no argument named `bar`
-  --> $DIR/ifmt-bad-arg.rs:27:26
-   |
-LL |     format!("{} {foo} {} {bar} {}", 1, 2, 3);
-   |                          ^^^^^
-
-error: there is no argument named `foo`
-  --> $DIR/ifmt-bad-arg.rs:31:14
-   |
-LL |     format!("{foo}");
-   |              ^^^^^
-
 error: multiple unused formatting arguments
   --> $DIR/ifmt-bad-arg.rs:32:17
    |
@@ -154,12 +136,6 @@ LL |     format!("{foo} {} {}", foo=1, 2);
    |                                |
    |                                named argument
 
-error: there is no argument named `valueb`
-  --> $DIR/ifmt-bad-arg.rs:45:23
-   |
-LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
-   |                       ^^^^^^^^
-
 error: named argument never used
   --> $DIR/ifmt-bad-arg.rs:45:51
    |
@@ -203,12 +179,6 @@ LL |     format!("foo %s baz", "bar");
    |                  help: format specifiers use curly braces: `{}`
    |
    = note: printf formatting not supported; see the documentation for `std::fmt`
-
-error: there is no argument named `foo`
-  --> $DIR/ifmt-bad-arg.rs:60:9
-   |
-LL |         {foo}
-   |         ^^^^^
 
 error: invalid format string: expected `'}'`, found `'t'`
   --> $DIR/ifmt-bad-arg.rs:75:1
@@ -283,6 +253,41 @@ LL |     println!("{5} {:4$} {6:7$}", 1);
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
 
+error[E0425]: cannot find value `foo` in this scope
+  --> $DIR/ifmt-bad-arg.rs:27:13
+   |
+LL |     format!("{} {foo} {} {bar} {}", 1, 2, 3);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `bar` in this scope
+  --> $DIR/ifmt-bad-arg.rs:27:13
+   |
+LL |     format!("{} {foo} {} {bar} {}", 1, 2, 3);
+   |             ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `foo` in this scope
+  --> $DIR/ifmt-bad-arg.rs:31:13
+   |
+LL |     format!("{foo}");
+   |             ^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `valueb` in this scope
+  --> $DIR/ifmt-bad-arg.rs:45:13
+   |
+LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
+   |             ^^^^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0425]: cannot find value `foo` in this scope
+  --> $DIR/ifmt-bad-arg.rs:58:13
+   |
+LL |       format!(r##"
+   |  _____________^
+LL | |
+LL | |         {foo}
+LL | |
+LL | |     "##);
+   | |_______^ not found in this scope
+
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:78:32
    |
@@ -303,4 +308,5 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
 
 error: aborting due to 35 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0425.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
It struck me the other day that it would be really nice to omit the named argument to `println!` for lots of simple use cases, e.g.:

    let recipient = "World";
    println!("Hello, {}", recipient);                     // Most common style (I think)
    println!("Hello, {recipient}", recipient=recipient);  // We can do this already, clearer but longer

    // So how about this being sugar for the above?
    println!("Hello, {recipient}");

I believe adding this shorthand will make a lot of invocations to the `format` family of macros marginally shorter, and slightly easier to read. There's also a lot of precedent for it in high-level languages e.g. Javascript backticks, Python f-strings.

I actually opened a thread about this on internals a while ago: https://internals.rust-lang.org/t/println-use-named-arguments-from-scope/10633

The response on the thread was that it generally seems reasonable and ergonomic to extend these macros to implicitly use simple identifiers. We didn't think it was desirable to support arbitrary expressions. So I've gone ahead and implemented this little PR to write a test implementation. If this needs an RFC I can backtrack and write one.

If the concensus is that this is a nice addition to the macros, then I'll need to do a little more work:
- [ ] Add documentation to the `std::fmt` module to cover this new functionality
- [ ] Add some more thorough testing
- [ ] Error messages: if the identifier doesn't exist in scope we get the obvious enough "cannot find value `recipient` in this scope". In this simple first pass of the PR the error span is the whole format string for the macro. It really should be just underneath the invalid identifier.
- [ ] Possible extension to allow fields e.g. `println!("Hello, {self.recipient}")`, which would be even more flexible though could occasionally have side effects from dereferencing.

Hope you guys like the idea 😄 