### PR TITLE
Fix #[unwind(abort)] with Rust ABI

### DIFF
--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -502,24 +502,21 @@ macro_rules! unpack {
     };
 }
 
-fn should_abort_on_panic(tcx: TyCtxt<'_>, fn_def_id: DefId, abi: Abi) -> bool {
-    // Not callable from C, so we can safely unwind through these
-    if abi == Abi::Rust || abi == Abi::RustCall { return false; }
-
-    // Validate `#[unwind]` syntax regardless of platform-specific panic strategy
+fn should_abort_on_panic(tcx: TyCtxt<'_>, fn_def_id: DefId, _abi: Abi) -> bool {
+    // Validate `#[unwind]` syntax regardless of platform-specific panic strategy.
     let attrs = &tcx.get_attrs(fn_def_id);
     let unwind_attr = attr::find_unwind_attr(Some(tcx.sess.diagnostic()), attrs);
 
-    // We never unwind, so it's not relevant to stop an unwind
+    // We never unwind, so it's not relevant to stop an unwind.
     if tcx.sess.panic_strategy() != PanicStrategy::Unwind { return false; }
 
-    // We cannot add landing pads, so don't add one
+    // We cannot add landing pads, so don't add one.
     if tcx.sess.no_landing_pads() { return false; }
 
     // This is a special case: some functions have a C abi but are meant to
     // unwind anyway. Don't stop them.
     match unwind_attr {
-        None => false, // FIXME(#58794)
+        None => false, // FIXME(#58794); should be `!(abi == Abi::Rust || abi == Abi::RustCall)`
         Some(UnwindAttr::Allowed) => false,
         Some(UnwindAttr::Aborts) => true,
     }

--- a/src/test/ui/panics/abort-on-panic.rs
+++ b/src/test/ui/panics/abort-on-panic.rs
@@ -14,9 +14,14 @@ use std::io::prelude::*;
 use std::io;
 use std::process::{Command, Stdio};
 
-#[unwind(aborts)] // FIXME(#58794)
+#[unwind(aborts)] // FIXME(#58794) should work even without the attribute
 extern "C" fn panic_in_ffi() {
     panic!("Test");
+}
+
+#[unwind(aborts)]
+extern "Rust" fn panic_in_rust_abi() {
+    panic!("TestRust");
 }
 
 fn test() {
@@ -26,15 +31,34 @@ fn test() {
     let _ = io::stdout().flush();
 }
 
+fn testrust() {
+    let _ = panic::catch_unwind(|| { panic_in_rust_abi(); });
+    // The process should have aborted by now.
+    io::stdout().write(b"This should never be printed.\n");
+    let _ = io::stdout().flush();
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() > 1 && args[1] == "test" {
-        return test();
+    if args.len() > 1 {
+        // This is inside the self-executed command.
+        match &*args[1] {
+            "test" => return test(),
+            "testrust" => return testrust(),
+            _ => panic!("bad test"),
+        }
     }
 
+    // These end up calling the self-execution branches above.
     let mut p = Command::new(&args[0])
                         .stdout(Stdio::piped())
                         .stdin(Stdio::piped())
                         .arg("test").spawn().unwrap();
+    assert!(!p.wait().unwrap().success());
+
+    let mut p = Command::new(&args[0])
+                        .stdout(Stdio::piped())
+                        .stdin(Stdio::piped())
+                        .arg("testrust").spawn().unwrap();
     assert!(!p.wait().unwrap().success());
 }


### PR DESCRIPTION
Fixes #63883.