### PR TITLE
[WIP] Traits in scope and def-site hygiene

### DIFF
--- a/src/test/ui/hygiene/traits-in-scope-fixme.rs
+++ b/src/test/ui/hygiene/traits-in-scope-fixme.rs
@@ -1,0 +1,29 @@
+// check-pass
+
+#![feature(decl_macro)]
+
+mod single {
+    pub trait Single {
+        fn single(&self) {}
+    }
+
+    impl Single for u8 {}
+}
+mod glob {
+    pub trait Glob {
+        fn glob(&self) {}
+    }
+
+    impl Glob for u8 {}
+}
+
+macro gen_imports() {
+    use single::Single;
+    use glob::*;
+}
+gen_imports!();
+
+fn main() {
+    0u8.single(); // FIXME, should be an error, `Single` shouldn't be in scope here
+    0u8.glob(); // FIXME, should be an error, `Glob` shouldn't be in scope here
+}


### PR DESCRIPTION
This PR makes all traits defined in or imported into the module M to be in scope in that module for the purposes of method resolution, even if those traits or imports are produced by opaque macros.

We should probably redefine and reimplement the collection of traits in scope without hitting the issues described in the inline comments.
However, maybe it's not so urgent and we can make an issue and leave this as is for now? That will immediately unblock removal of gensyms and implementation of underscores in terms of def-site hygiene and unique macros.

cc https://github.com/rust-lang/rust/pull/64623
r? @matthewjasper 