### PR TITLE
BTreeSet difference, symmetric_difference & union optimized

### DIFF
--- a/src/liballoc/tests/btree/set.rs
+++ b/src/liballoc/tests/btree/set.rs
@@ -222,6 +222,18 @@ fn test_symmetric_difference() {
 }
 
 #[test]
+fn test_symmetric_difference_size_hint() {
+    let x: BTreeSet<i32> = [2, 4].iter().copied().collect();
+    let y: BTreeSet<i32> = [1, 2, 3].iter().copied().collect();
+    let mut iter = x.symmetric_difference(&y);
+    assert_eq!(iter.size_hint(), (0, Some(5)));
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.size_hint(), (0, Some(4)));
+    assert_eq!(iter.next(), Some(&3));
+    assert_eq!(iter.size_hint(), (0, Some(1)));
+}
+
+#[test]
 fn test_union() {
     fn check_union(a: &[i32], b: &[i32], expected: &[i32]) {
         check(a, b, expected, |x, y, f| x.union(y).all(f))
@@ -236,6 +248,18 @@ fn test_union() {
 }
 
 #[test]
+fn test_union_size_hint() {
+    let x: BTreeSet<i32> = [2, 4].iter().copied().collect();
+    let y: BTreeSet<i32> = [1, 2, 3].iter().copied().collect();
+    let mut iter = x.union(&y);
+    assert_eq!(iter.size_hint(), (3, Some(5)));
+    assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.size_hint(), (2, Some(4)));
+    assert_eq!(iter.next(), Some(&2));
+    assert_eq!(iter.size_hint(), (1, Some(2)));
+}
+
+#[test]
 // Only tests the simple function definition with respect to intersection
 fn test_is_disjoint() {
     let one = [1].iter().collect::<BTreeSet<_>>();
@@ -244,7 +268,7 @@ fn test_is_disjoint() {
 }
 
 #[test]
-// Also tests the trivial function definition of is_superset
+// Also implicitly tests the trivial function definition of is_superset
 fn test_is_subset() {
     fn is_subset(a: &[i32], b: &[i32]) -> bool {
         let set_a = a.iter().collect::<BTreeSet<_>>();


### PR DESCRIPTION
Alternative to #65226: instead of peeking specialized to MergeIter, an additional `Peeking` intermediate. More lines of code but more readable, I think. Though it stirs a can of worms about Peekable.

It obtains the same gains for symmetric_difference and union, and also boosts `difference` a few percent (if the left set is not much smaller than the right set), e.g.
```
test difference_random_100::vs_100                     ... bench:         680 ns/iter (+/- 5)
test difference_random_100::vs_100_future              ... bench:         675 ns/iter (+/- 9)
test difference_random_10k::vs_10k                     ... bench:     166,274 ns/iter (+/- 2,515)
test difference_random_10k::vs_10k_future              ... bench:     162,993 ns/iter (+/- 1,757)
test difference_subsets::_10_vs_100                    ... bench:         213 ns/iter (+/- 1)
test difference_subsets::_10_vs_100_future             ... bench:         194 ns/iter (+/- 5)
```
In addition, some cleanup of earlier changes suggested by clippy, which I can push to #65226 too.

r? @bluss