### PR TITLE
Clean up `contains()` `insert()` chains on HashSet

### DIFF
--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -905,11 +905,10 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
             // Warn if the user has enabled an already-stable lang feature.
             unnecessary_stable_feature_lint(tcx, span, feature, since);
         }
-        if lang_features.contains(&feature) {
+        if !lang_features.insert(feature) {
             // Warn if the user enables a lang feature multiple times.
             duplicate_feature_err(tcx.sess, span, feature);
         }
-        lang_features.insert(feature);
     }
 
     let declared_lib_features = &tcx.features().declared_lib_features;

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -2069,11 +2069,9 @@ fn set_members_of_composite_type(cx: &CodegenCx<'ll, 'tcx>,
     {
         let mut composite_types_completed =
             debug_context(cx).composite_types_completed.borrow_mut();
-        if composite_types_completed.contains(&composite_type_metadata) {
+        if !composite_types_completed.insert(&composite_type_metadata) {
             bug!("debuginfo::set_members_of_composite_type() - \
                   Already completed forward declaration re-encountered.");
-        } else {
-            composite_types_completed.insert(composite_type_metadata);
         }
     }
 

--- a/src/librustc_metadata/native_libs.rs
+++ b/src/librustc_metadata/native_libs.rs
@@ -198,12 +198,10 @@ impl Collector<'tcx> {
                     self.tcx.sess.err(&format!("renaming of the library `{}` was specified, \
                                                 however this crate contains no `#[link(...)]` \
                                                 attributes referencing this library.", name));
-                } else if renames.contains(name) {
+                } else if !renames.insert(name) {
                     self.tcx.sess.err(&format!("multiple renamings were \
                                                 specified for library `{}` .",
                                                name));
-                } else {
-                    renames.insert(name);
                 }
             }
         }

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -78,15 +78,13 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 .last()
                 .unwrap();
 
-            if self.uninitialized_error_reported.contains(&root_place) {
+            if !self.uninitialized_error_reported.insert(root_place) {
                 debug!(
                     "report_use_of_moved_or_uninitialized place: error about {:?} suppressed",
                     root_place
                 );
                 return;
             }
-
-            self.uninitialized_error_reported.insert(root_place);
 
             let item_msg = match self.describe_place_with_options(used_place,
                                                                   IncludingDowncast(true)) {

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -1217,7 +1217,7 @@ fn search_for_adt_without_structural_match<'tcx>(tcx: TyCtxt<'tcx>,
 
         // tracks ADT's previously encountered during search, so that
         // we will not recur on them again.
-        seen: FxHashSet<&'tcx AdtDef>,
+        seen: FxHashSet<hir::def_id::DefId>,
     }
 
     impl<'tcx> TypeVisitor<'tcx> for Search<'tcx> {
@@ -1257,13 +1257,11 @@ fn search_for_adt_without_structural_match<'tcx>(tcx: TyCtxt<'tcx>,
                 return true // Halt visiting!
             }
 
-            if self.seen.contains(adt_def) {
+            if !self.seen.insert(adt_def.did) {
                 debug!("Search already seen adt_def: {:?}", adt_def);
                 // let caller continue its search
                 return false;
             }
-
-            self.seen.insert(adt_def);
 
             // `#[structural_match]` does not care about the
             // instantiation of the generics in an ADT (it

--- a/src/librustc_mir/lints.rs
+++ b/src/librustc_mir/lints.rs
@@ -72,12 +72,10 @@ fn check_fn_for_unconditional_recursion(
     let caller_substs = &InternalSubsts::identity_for_item(tcx, def_id)[..trait_substs_count];
 
     while let Some(bb) = reachable_without_self_call_queue.pop() {
-        if visited.contains(bb) {
+        if !visited.insert(bb) {
             //already done
             continue;
         }
-
-        visited.insert(bb);
 
         let block = &basic_blocks[bb];
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -670,13 +670,12 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                     self.throw_unresolved_import_error(errors, None);
                     errors = vec![];
                 }
-                if !seen_spans.contains(&err.span) {
+                if seen_spans.insert(err.span) {
                     let path = import_path_to_string(
                         &import.module_path.iter().map(|seg| seg.ident).collect::<Vec<_>>(),
                         &import.subclass,
                         err.span,
                     );
-                    seen_spans.insert(err.span);
                     errors.push((path, err));
                     prev_root_id = import.root_id;
                 }


### PR DESCRIPTION
They can be merged to a single `insert()` call, which may avoid double-hashing/lookup of the value.