### PR TITLE
Don't recommend ONCE_INIT in std::sync::Once

### DIFF
--- a/src/libstd/sync/once.rs
+++ b/src/libstd/sync/once.rs
@@ -60,10 +60,9 @@ use crate::thread::{self, Thread};
 
 /// A synchronization primitive which can be used to run a one-time global
 /// initialization. Useful for one-time initialization for FFI or related
-/// functionality. This type can only be constructed with the [`ONCE_INIT`]
-/// value or the equivalent [`Once::new`] constructor.
+/// functionality. This type can only be constructed with the [`Once::new`]
+/// constructor.
 ///
-/// [`ONCE_INIT`]: constant.ONCE_INIT.html
 /// [`Once::new`]: struct.Once.html#method.new
 ///
 /// # Examples


### PR DESCRIPTION
ONCE_INIT is deprecated, and so suggesting it as not only being on par with, but before `Once::new` is a bad idea.