### PR TITLE
Don't hide ICEs from previous incremental compiles

### DIFF
--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -310,6 +310,9 @@ impl Session {
     pub fn has_errors(&self) -> bool {
         self.diagnostic().has_errors()
     }
+    pub fn has_errors_or_delayed_span_bugs(&self) -> bool {
+        self.diagnostic().has_errors_or_delayed_span_bugs()
+    }
     pub fn abort_if_errors(&self) {
         self.diagnostic().abort_if_errors();
     }

--- a/src/librustc_errors/lib.rs
+++ b/src/librustc_errors/lib.rs
@@ -704,6 +704,9 @@ impl Handler {
     pub fn has_errors(&self) -> bool {
         self.inner.borrow().has_errors()
     }
+    pub fn has_errors_or_delayed_span_bugs(&self) -> bool {
+        self.inner.borrow().has_errors_or_delayed_span_bugs()
+    }
 
     pub fn print_error_count(&self, registry: &Registry) {
         self.inner.borrow_mut().print_error_count(registry)
@@ -861,6 +864,9 @@ impl HandlerInner {
 
     fn has_errors(&self) -> bool {
         self.err_count() > 0
+    }
+    fn has_errors_or_delayed_span_bugs(&self) -> bool {
+        self.has_errors() || !self.delayed_span_bugs.is_empty()
     }
 
     fn abort_if_errors_and_should_abort(&mut self) {

--- a/src/librustc_incremental/persist/fs.rs
+++ b/src/librustc_incremental/persist/fs.rs
@@ -307,7 +307,7 @@ pub fn finalize_session_directory(sess: &Session, svh: Svh) {
 
     let incr_comp_session_dir: PathBuf = sess.incr_comp_session_dir().clone();
 
-    if sess.has_errors() {
+    if sess.has_errors_or_delayed_span_bugs() {
         // If there have been any errors during compilation, we don't want to
         // publish this session directory. Rather, we'll just delete it.
 

--- a/src/librustc_incremental/persist/save.rs
+++ b/src/librustc_incremental/persist/save.rs
@@ -22,6 +22,10 @@ pub fn save_dep_graph(tcx: TyCtxt<'_>) {
         if sess.opts.incremental.is_none() {
             return;
         }
+        // This is going to be deleted in finalize_session_directory, so let's not create it
+        if sess.has_errors_or_delayed_span_bugs() {
+            return;
+        }
 
         let query_cache_path = query_cache_path(sess);
         let dep_graph_path = dep_graph_path(sess);
@@ -59,6 +63,10 @@ pub fn save_work_product_index(sess: &Session,
                                new_work_products: FxHashMap<WorkProductId, WorkProduct>) {
     if sess.opts.incremental.is_none() {
         return;
+    }
+    // This is going to be deleted in finalize_session_directory, so let's not create it
+    if sess.has_errors_or_delayed_span_bugs() {
+            return;
     }
 
     debug!("save_work_product_index()");


### PR DESCRIPTION
I think this fixes #65401, the compiler does not fail to ICE after the first compilation, tested on the last snippet of [this comment](https://github.com/rust-lang/rust/issues/63154#issuecomment-541592381).
I am not very sure of the fix as I don't understand much of the structure of the compiler.