### PR TITLE
Split the rustc target libraries into separate rustc-dev component

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -443,6 +443,7 @@ impl<'a> Builder<'a> {
                 dist::Rustc,
                 dist::DebuggerScripts,
                 dist::Std,
+                dist::RustcDev,
                 dist::Analysis,
                 dist::Src,
                 dist::PlainSourceTarball,

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -55,6 +55,7 @@ impl Step for Std {
                   cargo,
                   args(builder.kind),
                   &libstd_stamp(builder, compiler, target),
+                  vec![],
                   true);
 
         let libdir = builder.sysroot_libdir(compiler, target);
@@ -103,6 +104,7 @@ impl Step for Rustc {
                   cargo,
                   args(builder.kind),
                   &librustc_stamp(builder, compiler, target),
+                  vec![],
                   true);
 
         let libdir = builder.sysroot_libdir(compiler, target);
@@ -155,6 +157,7 @@ impl Step for CodegenBackend {
                   cargo,
                   args(builder.kind),
                   &codegen_backend_stamp(builder, compiler, target, backend),
+                  vec![],
                   true);
     }
 }
@@ -199,6 +202,7 @@ impl Step for Rustdoc {
                   cargo,
                   args(builder.kind),
                   &rustdoc_stamp(builder, compiler, target),
+                  vec![],
                   true);
 
         let libdir = builder.sysroot_libdir(compiler, target);

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -69,7 +69,7 @@ impl Step for Std {
             return;
         }
 
-        builder.ensure(StartupObjects { compiler, target });
+        let mut target_deps = builder.ensure(StartupObjects { compiler, target });
 
         let compiler_to_use = builder.compiler_for(compiler.stage, compiler.host, target);
         if compiler_to_use != compiler {
@@ -91,7 +91,7 @@ impl Step for Std {
             return;
         }
 
-        copy_third_party_objects(builder, &compiler, target);
+        target_deps.extend(copy_third_party_objects(builder, &compiler, target).into_iter());
 
         let mut cargo = builder.cargo(compiler, Mode::Std, target, "build");
         std_cargo(builder, &compiler, target, &mut cargo);
@@ -102,6 +102,7 @@ impl Step for Std {
                   cargo,
                   vec![],
                   &libstd_stamp(builder, compiler, target),
+                  target_deps,
                   false);
 
         builder.ensure(StdLink {
@@ -113,8 +114,21 @@ impl Step for Std {
 }
 
 /// Copies third pary objects needed by various targets.
-fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: Interned<String>) {
+fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: Interned<String>)
+    -> Vec<PathBuf>
+{
     let libdir = builder.sysroot_libdir(*compiler, target);
+
+    let mut target_deps = vec![];
+
+    let mut copy_and_stamp = |sourcedir: &Path, name: &str| {
+        let target = libdir.join(name);
+        builder.copy(
+            &sourcedir.join(name),
+            &target,
+        );
+        target_deps.push(target);
+    };
 
     // Copies the crt(1,i,n).o startup objects
     //
@@ -123,19 +137,13 @@ fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: 
     // files. As those shipped with glibc won't work, copy the ones provided by
     // musl so we have them on linux-gnu hosts.
     if target.contains("musl") {
+        let srcdir = builder.musl_root(target).unwrap().join("lib");
         for &obj in &["crt1.o", "crti.o", "crtn.o"] {
-            builder.copy(
-                &builder.musl_root(target).unwrap().join("lib").join(obj),
-                &libdir.join(obj),
-            );
+            copy_and_stamp(&srcdir, obj);
         }
     } else if target.ends_with("-wasi") {
-        for &obj in &["crt1.o"] {
-            builder.copy(
-                &builder.wasi_root(target).unwrap().join("lib/wasm32-wasi").join(obj),
-                &libdir.join(obj),
-            );
-        }
+        let srcdir = builder.wasi_root(target).unwrap().join("lib/wasm32-wasi");
+        copy_and_stamp(&srcdir, "crt1.o");
     }
 
     // Copies libunwind.a compiled to be linked wit x86_64-fortanix-unknown-sgx.
@@ -145,11 +153,11 @@ fn copy_third_party_objects(builder: &Builder<'_>, compiler: &Compiler, target: 
     // which is provided by std for this target.
     if target == "x86_64-fortanix-unknown-sgx" {
         let src_path_env = "X86_FORTANIX_SGX_LIBS";
-        let obj = "libunwind.a";
         let src = env::var(src_path_env).expect(&format!("{} not found in env", src_path_env));
-        let src = Path::new(&src).join(obj);
-        builder.copy(&src, &libdir.join(obj));
+        copy_and_stamp(Path::new(&src), "libunwind.a");
     }
+
+    target_deps
 }
 
 /// Configure cargo to compile the standard library, adding appropriate env vars
@@ -307,7 +315,7 @@ pub struct StartupObjects {
 }
 
 impl Step for StartupObjects {
-    type Output = ();
+    type Output = Vec<PathBuf>;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.path("src/rtstartup")
@@ -326,12 +334,14 @@ impl Step for StartupObjects {
     /// They don't require any library support as they're just plain old object
     /// files, so we just use the nightly snapshot compiler to always build them (as
     /// no other compilers are guaranteed to be available).
-    fn run(self, builder: &Builder<'_>) {
+    fn run(self, builder: &Builder<'_>) -> Vec<PathBuf> {
         let for_compiler = self.compiler;
         let target = self.target;
         if !target.contains("windows-gnu") {
-            return
+            return vec![]
         }
+
+        let mut target_deps = vec![];
 
         let src_dir = &builder.src.join("src/rtstartup");
         let dst_dir = &builder.native_dir(target).join("rtstartup");
@@ -351,7 +361,9 @@ impl Step for StartupObjects {
                             .arg(src_file));
             }
 
-            builder.copy(dst_file, &sysroot_dir.join(file.to_string() + ".o"));
+            let target = sysroot_dir.join(file.to_string() + ".o");
+            builder.copy(dst_file, &target);
+            target_deps.push(target);
         }
 
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
@@ -359,8 +371,12 @@ impl Step for StartupObjects {
                                     builder.cc(target),
                                     target,
                                     obj);
-            builder.copy(&src, &sysroot_dir.join(obj));
+            let target = sysroot_dir.join(obj);
+            builder.copy(&src, &target);
+            target_deps.push(target);
         }
+
+        target_deps
     }
 }
 
@@ -438,6 +454,7 @@ impl Step for Rustc {
                   cargo,
                   vec![],
                   &librustc_stamp(builder, compiler, target),
+                  vec![],
                   false);
 
         builder.ensure(RustcLink {
@@ -586,7 +603,7 @@ impl Step for CodegenBackend {
 
         let tmp_stamp = out_dir.join(".tmp.stamp");
 
-        let files = run_cargo(builder, cargo, vec![], &tmp_stamp, false);
+        let files = run_cargo(builder, cargo, vec![], &tmp_stamp, vec![], false);
         if builder.config.dry_run {
             return;
         }
@@ -954,6 +971,7 @@ pub fn run_cargo(builder: &Builder<'_>,
                  cargo: Cargo,
                  tail_args: Vec<String>,
                  stamp: &Path,
+                 additional_target_deps: Vec<PathBuf>,
                  is_check: bool)
     -> Vec<PathBuf>
 {
@@ -1070,6 +1088,7 @@ pub fn run_cargo(builder: &Builder<'_>,
         deps.push((path_to_add.into(), false));
     }
 
+    deps.extend(additional_target_deps.into_iter().map(|d| (d, false)));
     deps.sort();
     let mut new_contents = Vec::new();
     for (dep, proc_macro) in deps.iter() {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1144,6 +1144,7 @@ impl Build {
     pub fn copy(&self, src: &Path, dst: &Path) {
         if self.config.dry_run { return; }
         self.verbose_than(1, &format!("Copy {:?} to {:?}", src, dst));
+        if src == dst { return; }
         let _ = fs::remove_file(&dst);
         let metadata = t!(src.symlink_metadata());
         if metadata.file_type().is_symlink() {

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -427,6 +427,13 @@ impl Builder {
             "rls-preview", "rust-src", "llvm-tools-preview",
             "lldb-preview", "rust-analysis", "miri-preview"
         ]);
+
+        // The compiler libraries are not stable for end users, but `rustc-dev` was only recently
+        // split out of `rust-std`. We'll include it by default as a transition for nightly users.
+        if self.rust_release == "nightly" {
+            self.extend_profile("default", &mut manifest.profiles, &["rustc-dev"]);
+            self.extend_profile("complete", &mut manifest.profiles, &["rustc-dev"]);
+        }
     }
 
     fn add_renames_to(&self, manifest: &mut Manifest) {
@@ -547,6 +554,14 @@ impl Builder {
                dst: &mut BTreeMap<String, Vec<String>>,
                pkgs: &[&str]) {
         dst.insert(profile_name.to_owned(), pkgs.iter().map(|s| (*s).to_owned()).collect());
+    }
+
+    fn extend_profile(&mut self,
+               profile_name: &str,
+               dst: &mut BTreeMap<String, Vec<String>>,
+               pkgs: &[&str]) {
+        dst.get_mut(profile_name).expect("existing profile")
+            .extend(pkgs.iter().map(|s| (*s).to_owned()));
     }
 
     fn package(&mut self,


### PR DESCRIPTION
This is re-applies a squashed version of #64823 as well as including #65337 to fix bugs noted after merging the first PR. 

The second PR is confirmed as fixing windows-gnu, and presumably also fixes other platforms, such as musl (i.e. #65335 should be fixed); `RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup toolchain install nightly-2019-10-16` can be installed to confirm that this is indeed the case.