### PR TITLE
Avoid ICE when checking `Destination` of `break` inside a closure

### DIFF
--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -536,10 +536,16 @@ pub struct EnclosingBreakables<'tcx> {
 
 impl<'tcx> EnclosingBreakables<'tcx> {
     fn find_breakable(&mut self, target_id: hir::HirId) -> &mut BreakableCtxt<'tcx> {
-        let ix = *self.by_id.get(&target_id).unwrap_or_else(|| {
+        self.opt_find_breakable(target_id).unwrap_or_else(|| {
             bug!("could not find enclosing breakable with id {}", target_id);
-        });
-        &mut self.stack[ix]
+        })
+    }
+
+    fn opt_find_breakable(&mut self, target_id: hir::HirId) -> Option<&mut BreakableCtxt<'tcx>> {
+        match self.by_id.get(&target_id) {
+            Some(ix) => Some(&mut self.stack[*ix]),
+            None => None,
+        }
     }
 }
 

--- a/src/test/ui/break-outside-loop.rs
+++ b/src/test/ui/break-outside-loop.rs
@@ -22,4 +22,12 @@ fn main() {
     let rs: Foo = Foo{t: pth};
 
     let unconstrained = break; //~ ERROR: `break` outside of a loop
+
+    // This used to ICE because `target_id` passed to `check_expr_break` would be the closure and
+    // not the `loop`, which failed in the call to `find_breakable`. (#65383)
+    'lab: loop {
+        || {
+            break 'lab; //~ ERROR `break` inside of a closure
+        };
+    }
 }

--- a/src/test/ui/break-outside-loop.stderr
+++ b/src/test/ui/break-outside-loop.stderr
@@ -33,7 +33,15 @@ error[E0268]: `break` outside of a loop
 LL |     let unconstrained = break;
    |                         ^^^^^ cannot `break` outside of a loop
 
-error: aborting due to 5 previous errors
+error[E0267]: `break` inside of a closure
+  --> $DIR/break-outside-loop.rs:30:13
+   |
+LL |         || {
+   |         -- enclosing closure
+LL |             break 'lab;
+   |             ^^^^^^^^^^ cannot `break` inside of a closure
+
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0267, E0268.
 For more information about an error, try `rustc --explain E0267`.


### PR DESCRIPTION
Fix #65383, fix #62480. This is a `[regression-from-stable-to-stable]` and a fairly small change to avoid the ICE by properly handling this case.