### PR TITLE
resolve: Turn the "non-empty glob must import something" error into a lint

### DIFF
--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -972,8 +972,9 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 if !is_prelude &&
                    max_vis.get() != ty::Visibility::Invisible && // Allow empty globs.
                    !max_vis.get().is_at_least(directive.vis.get(), &*self) {
-                    let msg = "A non-empty glob must import something with the glob's visibility";
-                    self.r.session.span_err(directive.span, msg);
+                    let msg =
+                        "glob import doesn't reexport anything because no candidate is public enough";
+                    self.r.session.buffer_lint(UNUSED_IMPORTS, directive.id, directive.span, msg);
                 }
                 return None;
             }

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -973,7 +973,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                    max_vis.get() != ty::Visibility::Invisible && // Allow empty globs.
                    !max_vis.get().is_at_least(directive.vis.get(), &*self) {
                     let msg =
-                        "glob import doesn't reexport anything because no candidate is public enough";
+                    "glob import doesn't reexport anything because no candidate is public enough";
                     self.r.session.buffer_lint(UNUSED_IMPORTS, directive.id, directive.span, msg);
                 }
                 return None;

--- a/src/test/ui/imports/reexports.rs
+++ b/src/test/ui/imports/reexports.rs
@@ -1,16 +1,21 @@
+#![warn(unused_imports)]
+
 mod a {
     fn foo() {}
     mod foo {}
 
     mod a {
         pub use super::foo; //~ ERROR cannot be re-exported
-        pub use super::*; //~ ERROR must import something with the glob's visibility
+        pub use super::*;
+        //~^ WARNING glob import doesn't reexport anything because no candidate is public enough
     }
 }
 
 mod b {
     pub fn foo() {}
-    mod foo { pub struct S; }
+    mod foo {
+        pub struct S;
+    }
 
     pub mod a {
         pub use super::foo; // This is OK since the value `foo` is visible enough.

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -1,29 +1,29 @@
 error[E0364]: `foo` is private, and cannot be re-exported
-  --> $DIR/reexports.rs:10:17
+  --> $DIR/reexports.rs:8:17
    |
 LL |         pub use super::foo;
    |                 ^^^^^^^^^^
    |
 note: consider marking `foo` as `pub` in the imported module
-  --> $DIR/reexports.rs:10:17
+  --> $DIR/reexports.rs:8:17
    |
 LL |         pub use super::foo;
    |                 ^^^^^^^^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:35:15
+  --> $DIR/reexports.rs:33:15
    |
 LL |     use b::a::foo::S;
    |               ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:36:15
+  --> $DIR/reexports.rs:34:15
    |
 LL |     use b::b::foo::S as T;
    |               ^^^
 
-warning: this glob doesn't reexport anything because no canditate is public enough
-  --> $DIR/reexports.rs:11:17
+warning: glob import doesn't reexport anything because no candidate is public enough
+  --> $DIR/reexports.rs:9:17
    |
 LL |         pub use super::*;
    |                 ^^^^^^^^

--- a/src/test/ui/imports/reexports.stderr
+++ b/src/test/ui/imports/reexports.stderr
@@ -1,34 +1,40 @@
 error[E0364]: `foo` is private, and cannot be re-exported
-  --> $DIR/reexports.rs:6:17
+  --> $DIR/reexports.rs:10:17
    |
 LL |         pub use super::foo;
    |                 ^^^^^^^^^^
    |
 note: consider marking `foo` as `pub` in the imported module
-  --> $DIR/reexports.rs:6:17
+  --> $DIR/reexports.rs:10:17
    |
 LL |         pub use super::foo;
    |                 ^^^^^^^^^^
 
-error: A non-empty glob must import something with the glob's visibility
-  --> $DIR/reexports.rs:7:17
-   |
-LL |         pub use super::*;
-   |                 ^^^^^^^^
-
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:28:15
+  --> $DIR/reexports.rs:35:15
    |
 LL |     use b::a::foo::S;
    |               ^^^
 
 error[E0603]: module `foo` is private
-  --> $DIR/reexports.rs:29:15
+  --> $DIR/reexports.rs:36:15
    |
 LL |     use b::b::foo::S as T;
    |               ^^^
 
-error: aborting due to 4 previous errors
+warning: this glob doesn't reexport anything because no canditate is public enough
+  --> $DIR/reexports.rs:11:17
+   |
+LL |         pub use super::*;
+   |                 ^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/reexports.rs:1:9
+   |
+LL | #![warn(unused_imports)]
+   |         ^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0364, E0603.
 For more information about an error, try `rustc --explain E0364`.


### PR DESCRIPTION
This fixes #62334 by changing the error to a lint warning the glob. I changed the test but I'm very unsure of what I did as I do not know how to correctly check for the warning