### PR TITLE
Avoid realloc in `CString::new`

### DIFF
--- a/src/librustc_codegen_llvm/back/lto.rs
+++ b/src/librustc_codegen_llvm/back/lto.rs
@@ -53,9 +53,7 @@ fn prepare_lto(cgcx: &CodegenContext<LlvmCodegenBackend>,
 
     let symbol_filter = &|&(ref name, level): &(String, SymbolExportLevel)| {
         if level.is_below_threshold(export_threshold) {
-            let mut bytes = Vec::with_capacity(name.len() + 1);
-            bytes.extend(name.bytes());
-            Some(CString::new(bytes).unwrap())
+            Some(CString::new(name.as_str()).unwrap())
         } else {
             None
         }

--- a/src/libstd/lib.rs
+++ b/src/libstd/lib.rs
@@ -297,6 +297,7 @@
 #![feature(slice_concat_ext)]
 #![feature(slice_internals)]
 #![feature(slice_patterns)]
+#![feature(specialization)]
 #![feature(staged_api)]
 #![feature(std_internals)]
 #![feature(stdsimd)]


### PR DESCRIPTION
If `&[u8]` or `&str` is given, `CString::new` allocates a new `Vec` with the exact capacity, and then `CString::from_vec_unchecked` calls `.reserve_exact(1)` for nul byte. This PR avoids the reallocation by allocationg `len + 1` bytes beforehand. In microbenchmark this PR speeds up `CString::new(&[u8])` by 30%.