### PR TITLE
rustc_metadata: use a table for super_predicates, fn_sig, impl_trait_ref.

### DIFF
--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -711,7 +711,7 @@ impl<'a, 'tcx> CrateMetadata {
         }
     }
 
-    fn get_impl_data(&self, id: DefIndex) -> ImplData<'tcx> {
+    fn get_impl_data(&self, id: DefIndex) -> ImplData {
         match self.kind(id) {
             EntryKind::Impl(data) => data.decode(self),
             _ => bug!(),
@@ -738,7 +738,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     crate fn get_impl_trait(&self, id: DefIndex, tcx: TyCtxt<'tcx>) -> Option<ty::TraitRef<'tcx>> {
-        self.get_impl_data(id).trait_ref.map(|tr| tr.decode((self, tcx)))
+        self.root.per_def.impl_trait_ref.get(self, id).map(|tr| tr.decode((self, tcx)))
     }
 
     /// Iterates over all the stability attributes in the given crate.

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -458,7 +458,7 @@ impl<'tcx> EntryKind<'tcx> {
             EntryKind::Impl(_) |
             EntryKind::Field |
             EntryKind::Generator(_) |
-            EntryKind::Closure(_) => return None,
+            EntryKind::Closure => return None,
         })
     }
 }
@@ -1239,16 +1239,7 @@ impl<'a, 'tcx> CrateMetadata {
     }
 
     crate fn fn_sig(&self, id: DefIndex, tcx: TyCtxt<'tcx>) -> ty::PolyFnSig<'tcx> {
-        let sig = match self.kind(id) {
-            EntryKind::Fn(data) |
-            EntryKind::ForeignFn(data) => data.decode(self).sig,
-            EntryKind::Method(data) => data.decode(self).fn_data.sig,
-            EntryKind::Variant(data) |
-            EntryKind::Struct(data, _) => data.decode(self).ctor_sig.unwrap(),
-            EntryKind::Closure(data) => data.decode(self).sig,
-            _ => bug!(),
-        };
-        sig.decode((self, tcx))
+        self.root.per_def.fn_sig.get(self, id).unwrap().decode((self, tcx))
     }
 
     #[inline]

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -239,6 +239,7 @@ crate struct LazyPerDefTables<'tcx> {
 
     pub ty: Lazy!(PerDefTable<Lazy!(Ty<'tcx>)>),
     pub fn_sig: Lazy!(PerDefTable<Lazy!(ty::PolyFnSig<'tcx>)>),
+    pub impl_trait_ref: Lazy!(PerDefTable<Lazy!(ty::TraitRef<'tcx>)>),
     pub inherent_impls: Lazy!(PerDefTable<Lazy<[DefIndex]>>),
     pub variances: Lazy!(PerDefTable<Lazy<[ty::Variance]>>),
     pub generics: Lazy!(PerDefTable<Lazy<ty::Generics>>),
@@ -276,7 +277,7 @@ crate enum EntryKind<'tcx> {
     Closure,
     Generator(Lazy!(GeneratorData<'tcx>)),
     Trait(Lazy<TraitData>),
-    Impl(Lazy!(ImplData<'tcx>)),
+    Impl(Lazy<ImplData>),
     Method(Lazy<MethodData>),
     AssocType(AssocContainer),
     AssocOpaqueTy(AssocContainer),
@@ -330,14 +331,14 @@ crate struct TraitData {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-crate struct ImplData<'tcx> {
+crate struct ImplData {
     pub polarity: ty::ImplPolarity,
     pub defaultness: hir::Defaultness,
     pub parent_impl: Option<DefId>,
 
     /// This is `Some` only for impls of `CoerceUnsized`.
+    // FIXME(eddyb) perhaps compute this on the fly if cheap enough?
     pub coerce_unsized_info: Option<ty::adjustment::CoerceUnsizedInfo>,
-    pub trait_ref: Option<Lazy!(ty::TraitRef<'tcx>)>,
 }
 
 

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -238,6 +238,7 @@ crate struct LazyPerDefTables<'tcx> {
     pub deprecation: Lazy!(PerDefTable<Lazy<attr::Deprecation>>),
 
     pub ty: Lazy!(PerDefTable<Lazy!(Ty<'tcx>)>),
+    pub fn_sig: Lazy!(PerDefTable<Lazy!(ty::PolyFnSig<'tcx>)>),
     pub inherent_impls: Lazy!(PerDefTable<Lazy<[DefIndex]>>),
     pub variances: Lazy!(PerDefTable<Lazy<[ty::Variance]>>),
     pub generics: Lazy!(PerDefTable<Lazy<ty::Generics>>),
@@ -265,18 +266,18 @@ crate enum EntryKind<'tcx> {
     OpaqueTy,
     Enum(ReprOptions),
     Field,
-    Variant(Lazy!(VariantData<'tcx>)),
-    Struct(Lazy!(VariantData<'tcx>), ReprOptions),
-    Union(Lazy!(VariantData<'tcx>), ReprOptions),
-    Fn(Lazy!(FnData<'tcx>)),
-    ForeignFn(Lazy!(FnData<'tcx>)),
+    Variant(Lazy<VariantData>),
+    Struct(Lazy<VariantData>, ReprOptions),
+    Union(Lazy<VariantData>, ReprOptions),
+    Fn(Lazy<FnData>),
+    ForeignFn(Lazy<FnData>),
     Mod(Lazy<ModData>),
     MacroDef(Lazy<MacroDef>),
-    Closure(Lazy!(ClosureData<'tcx>)),
+    Closure,
     Generator(Lazy!(GeneratorData<'tcx>)),
     Trait(Lazy<TraitData>),
     Impl(Lazy!(ImplData<'tcx>)),
-    Method(Lazy!(MethodData<'tcx>)),
+    Method(Lazy<MethodData>),
     AssocType(AssocContainer),
     AssocOpaqueTy(AssocContainer),
     AssocConst(AssocContainer, ConstQualif, Lazy<RenderedConst>),
@@ -306,22 +307,18 @@ crate struct MacroDef {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-crate struct FnData<'tcx> {
+crate struct FnData {
     pub asyncness: hir::IsAsync,
     pub constness: hir::Constness,
     pub param_names: Lazy<[ast::Name]>,
-    pub sig: Lazy!(ty::PolyFnSig<'tcx>),
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-crate struct VariantData<'tcx> {
+crate struct VariantData {
     pub ctor_kind: CtorKind,
     pub discr: ty::VariantDiscr,
     /// If this is unit or tuple-variant/struct, then this is the index of the ctor id.
     pub ctor: Option<DefIndex>,
-    /// If this is a tuple struct or variant
-    /// ctor, this is its "function" signature.
-    pub ctor_sig: Option<Lazy!(ty::PolyFnSig<'tcx>)>,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
@@ -383,15 +380,10 @@ impl AssocContainer {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-crate struct MethodData<'tcx> {
-    pub fn_data: FnData<'tcx>,
+crate struct MethodData {
+    pub fn_data: FnData,
     pub container: AssocContainer,
     pub has_self: bool,
-}
-
-#[derive(RustcEncodable, RustcDecodable)]
-crate struct ClosureData<'tcx> {
-    pub sig: Lazy!(ty::PolyFnSig<'tcx>),
 }
 
 #[derive(RustcEncodable, RustcDecodable)]

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -243,6 +243,7 @@ crate struct LazyPerDefTables<'tcx> {
     pub generics: Lazy!(PerDefTable<Lazy<ty::Generics>>),
     pub predicates: Lazy!(PerDefTable<Lazy!(ty::GenericPredicates<'tcx>)>),
     pub predicates_defined_on: Lazy!(PerDefTable<Lazy!(ty::GenericPredicates<'tcx>)>),
+    pub super_predicates: Lazy!(PerDefTable<Lazy!(ty::GenericPredicates<'tcx>)>),
 
     pub mir: Lazy!(PerDefTable<Lazy!(mir::Body<'tcx>)>),
     pub promoted_mir: Lazy!(PerDefTable<Lazy!(IndexVec<mir::Promoted, mir::Body<'tcx>>)>),
@@ -273,13 +274,13 @@ crate enum EntryKind<'tcx> {
     MacroDef(Lazy<MacroDef>),
     Closure(Lazy!(ClosureData<'tcx>)),
     Generator(Lazy!(GeneratorData<'tcx>)),
-    Trait(Lazy!(TraitData<'tcx>)),
+    Trait(Lazy<TraitData>),
     Impl(Lazy!(ImplData<'tcx>)),
     Method(Lazy!(MethodData<'tcx>)),
     AssocType(AssocContainer),
     AssocOpaqueTy(AssocContainer),
     AssocConst(AssocContainer, ConstQualif, Lazy<RenderedConst>),
-    TraitAlias(Lazy!(TraitAliasData<'tcx>)),
+    TraitAlias,
 }
 
 /// Additional data for EntryKind::Const and EntryKind::AssocConst
@@ -324,17 +325,11 @@ crate struct VariantData<'tcx> {
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
-crate struct TraitData<'tcx> {
+crate struct TraitData {
     pub unsafety: hir::Unsafety,
     pub paren_sugar: bool,
     pub has_auto_impl: bool,
     pub is_marker: bool,
-    pub super_predicates: Lazy!(ty::GenericPredicates<'tcx>),
-}
-
-#[derive(RustcEncodable, RustcDecodable)]
-crate struct TraitAliasData<'tcx> {
-    pub super_predicates: Lazy!(ty::GenericPredicates<'tcx>),
 }
 
 #[derive(RustcEncodable, RustcDecodable)]


### PR DESCRIPTION
This is an attempt at a part of #65407, i.e. moving parts of cross-crate "metadata" into tables that match queries more closely.

Three new tables should be enough to see some perf/metadata size changes.
(need to do something similar to https://github.com/rust-lang/rust/pull/59953#issuecomment-542521919)

There are other bits of data that could be made into tables, but they can be more compact so the impact would likely be not as bad, and they're also more work to set up.