### PR TITLE
add test for calling non-const fn

### DIFF
--- a/src/test/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.rs
@@ -1,0 +1,12 @@
+// compile-flags: -Zunleash-the-miri-inside-of-you
+#![allow(const_err)]
+
+// A test demonstrating that we prevent calling non-const fn during CTFE.
+
+fn foo() {}
+
+const C: () = foo(); //~ WARN: skipping const checks
+
+fn main() {
+    println!("{:?}", C); //~ ERROR: evaluation of constant expression failed
+}

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.rs
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.rs
@@ -1,11 +1,12 @@
 // compile-flags: -Zunleash-the-miri-inside-of-you
-#![allow(const_err)]
+#![warn(const_err)]
 
 // A test demonstrating that we prevent calling non-const fn during CTFE.
 
 fn foo() {}
 
 const C: () = foo(); //~ WARN: skipping const checks
+//~^ WARN any use of this value will cause an error
 
 fn main() {
     println!("{:?}", C); //~ ERROR: evaluation of constant expression failed

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -1,0 +1,15 @@
+warning: skipping const checks
+  --> $DIR/non_const_fn.rs:8:15
+   |
+LL | const C: () = foo();
+   |               ^^^^^
+
+error[E0080]: evaluation of constant expression failed
+  --> $DIR/non_const_fn.rs:11:22
+   |
+LL |     println!("{:?}", C);
+   |                      ^ referenced constant has errors
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
+++ b/src/test/ui/consts/miri_unleashed/non_const_fn.stderr
@@ -4,8 +4,22 @@ warning: skipping const checks
 LL | const C: () = foo();
    |               ^^^^^
 
+warning: any use of this value will cause an error
+  --> $DIR/non_const_fn.rs:8:15
+   |
+LL | const C: () = foo();
+   | --------------^^^^^-
+   |               |
+   |               calling non-const function `foo`
+   |
+note: lint level defined here
+  --> $DIR/non_const_fn.rs:2:9
+   |
+LL | #![warn(const_err)]
+   |         ^^^^^^^^^
+
 error[E0080]: evaluation of constant expression failed
-  --> $DIR/non_const_fn.rs:11:22
+  --> $DIR/non_const_fn.rs:12:22
    |
 LL |     println!("{:?}", C);
    |                      ^ referenced constant has errors


### PR DESCRIPTION
The good news is that there is an error. But I expected to see [this error](https://github.com/rust-lang/rust/blob/9578272d681c8691ca2ff3f5c4230b491bc1c694/src/librustc_mir/const_eval.rs#L346) surface. @oli-obk any idea why that message is not shown anywhere?

r? @oli-obk 