### PR TITLE
Remove unneeded `ref` from docs

### DIFF
--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -64,7 +64,7 @@
 //!
 //! fn check_optional(optional: Option<Box<i32>>) {
 //!     match optional {
-//!         Some(ref p) => println!("has value {}", p),
+//!         Some(p) => println!("has value {}", p),
 //!         None => println!("has no value"),
 //!     }
 //! }
@@ -83,7 +83,7 @@
 //! let msg = Some("howdy");
 //!
 //! // Take a reference to the contained string
-//! if let Some(ref m) = msg {
+//! if let Some(m) = &msg {
 //!     println!("{}", *m);
 //! }
 //!


### PR DESCRIPTION
Will reduce confusion like in https://users.rust-lang.org/t/help-understanding-the-ref-t-syntax/33779 since match ergonomics means you (almost) never have to say `ref` anymore!

There might be more like this, but I don't have a checkout on my computer right this second and I'm on slow wifi and GitHub search isn't powerful enough and that's my story.