### PR TITLE
Preserve whitespace inside one-backtick codeblocks

### DIFF
--- a/src/librustdoc/html/static/rustdoc.css
+++ b/src/librustdoc/html/static/rustdoc.css
@@ -376,7 +376,7 @@ nav.sub {
 	text-overflow: ellipsis;
 	margin: 0;
 }
-.docblock-short code {
+.docblock code, .docblock-short code {
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Previously this was only done inside short docblocks (e.g., summary
lines), but we should also do so in general.

Fixes #65555