### PR TITLE
Improve error message for APIT with explicit generic arguments

### DIFF
--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -232,8 +232,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 tcx.sess,
                 span,
                 E0632,
-                "cannot provide explicit type parameters when `impl Trait` is \
-                 used in argument position."
+                "cannot provide explicit generic arguments when `impl Trait` is \
+                 used in argument position"
             };
 
             err.emit();

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -5048,8 +5048,8 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 //  E0612, // merged into E0609
 //  E0613, // Removed (merged with E0609)
     E0627, // yield statement outside of generator literal
-    E0632, // cannot provide explicit type parameters when `impl Trait` is used
-           // in argument position.
+    E0632, // cannot provide explicit generic arguments when `impl Trait` is
+           // used in argument position
     E0634, // type has conflicting packed representaton hints
     E0640, // infer outlives requirements
     E0641, // cannot cast to/from a pointer with an unknown kind

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.rs
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.rs
@@ -5,5 +5,5 @@ use std::fmt::Debug;
 fn foo<T>(x: impl Debug) { }
 
 fn main() {
-    foo::<String>('a'); //~ ERROR cannot provide explicit type parameters
+    foo::<String>('a'); //~ ERROR cannot provide explicit generic arguments
 }

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -1,4 +1,4 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/universal-issue-48703.rs:8:5
    |
 LL |     foo::<String>('a');

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.rs
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.rs
@@ -12,6 +12,6 @@ struct TestEvent(i32);
 fn main() {
     let mut evt = EventHandler {};
     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
-        //~^ ERROR cannot provide explicit type parameters
+        //~^ ERROR cannot provide explicit generic arguments
     });
 }

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
@@ -1,4 +1,4 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/universal-turbofish-in-method-issue-50950.rs:14:9
    |
 LL |     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {

--- a/src/test/ui/synthetic-param.rs
+++ b/src/test/ui/synthetic-param.rs
@@ -17,12 +17,12 @@ impl<S> Bar<S> {
 }
 
 fn main() {
-    func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     func(42); // Ok
 
-    Foo::func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    Foo::func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     Foo::func(42); // Ok
 
-    Bar::<i8>::func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    Bar::<i8>::func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     Bar::<i8>::func(42); // Ok
 }

--- a/src/test/ui/synthetic-param.stderr
+++ b/src/test/ui/synthetic-param.stderr
@@ -1,16 +1,16 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:20:5
    |
 LL |     func::<u8>(42);
    |     ^^^^^^^^^^
 
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:23:5
    |
 LL |     Foo::func::<u8>(42);
    |     ^^^^^^^^^^^^^^^
 
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:26:5
    |
 LL |     Bar::<i8>::func::<u8>(42);


### PR DESCRIPTION
This is disallowed with type or const generics. cc https://github.com/rust-lang/rust/issues/61410.