### PR TITLE
Correctly note code as Ok not error for E0573

### DIFF
--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -1682,7 +1682,7 @@ enum Wizard {
 }
 
 trait Isengard {
-    fn wizard(w: Wizard) { // error!
+    fn wizard(w: Wizard) { // ok!
         match w {
             Wizard::Saruman => {
                 // do something


### PR DESCRIPTION
Hi, this is my first pull request to the Rust project.

The fix is very small one just to fix an oversight in a comment.

Namely, [this documentation PR](https://github.com/rust-lang/rust/pull/65234) added a longer explanation for E0573. It illustrated the error using erroneous/corrected contrasting examples. But it accidentally forgot to remove `// error` from the corrected example.

Sadly, I found the error after the PR got merged. [As suggested by the original author](https://github.com/rust-lang/rust/pull/65234/files#r336518549) of the PR, I created an PR to fix this.

Part of #61137.