### PR TITLE
constify is_power_of_two

### DIFF
--- a/src/libcore/num/mod.rs
+++ b/src/libcore/num/mod.rs
@@ -3757,8 +3757,8 @@ assert!(!10", stringify!($SelfT), ".is_power_of_two());", $EndFeature, "
 ```"),
             #[stable(feature = "rust1", since = "1.0.0")]
             #[inline]
-            pub fn is_power_of_two(self) -> bool {
-                (self.wrapping_sub(1)) & self == 0 && !(self == 0)
+            pub const fn is_power_of_two(self) -> bool {
+                (self.wrapping_sub(1) & self == 0) & (self != 0)
             }
         }
 


### PR DESCRIPTION
See this [godbolt link][1] for the difference in debug and optimized build of old and new code.

[1]: https://rust.godbolt.org/z/vXiV5U