### PR TITLE
Remove `borrowck_graphviz_postflow` from test

### DIFF
--- a/src/test/ui/consts/const-eval/issue-65394.rs
+++ b/src/test/ui/consts/const-eval/issue-65394.rs
@@ -1,8 +1,5 @@
 // Test for absence of validation mismatch ICE in #65394
 
-#![feature(rustc_attrs)]
-
-#[rustc_mir(borrowck_graphviz_postflow="hello.dot")]
 const _: Vec<i32> = {
     let mut x = Vec::<i32>::new();
     let r = &mut x; //~ ERROR references in constants may only refer to immutable values

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -1,11 +1,11 @@
 error[E0017]: references in constants may only refer to immutable values
-  --> $DIR/issue-65394.rs:8:13
+  --> $DIR/issue-65394.rs:5:13
    |
 LL |     let r = &mut x;
    |             ^^^^^^ constants require immutable values
 
-[ERROR rustc_mir::transform::qualify_consts] old validator: [($DIR/issue-65394.rs:8:13: 8:19, "MutBorrow(Mut { allow_two_phase_borrow: false })")]
-[ERROR rustc_mir::transform::qualify_consts] new validator: [($DIR/issue-65394.rs:8:13: 8:19, "MutBorrow(Mut { allow_two_phase_borrow: false })"), ($DIR/issue-65394.rs:7:9: 7:14, "LiveDrop")]
+[ERROR rustc_mir::transform::qualify_consts] old validator: [($DIR/issue-65394.rs:5:13: 5:19, "MutBorrow(Mut { allow_two_phase_borrow: false })")]
+[ERROR rustc_mir::transform::qualify_consts] new validator: [($DIR/issue-65394.rs:5:13: 5:19, "MutBorrow(Mut { allow_two_phase_borrow: false })"), ($DIR/issue-65394.rs:4:9: 4:14, "LiveDrop")]
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0017`.


### PR DESCRIPTION
Resolves #65071 (again).

Sorry. I've added a commit hook to prevent this from happening in the future.

r? @petrochenkov 