### PR TITLE
Check all files in `src/test` for `borrowck_graphviz_postflow`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ config.stamp
 Session.vim
 .cargo
 no_llvm_build
+# Generated when dumping Graphviz output for debugging:
+/mir_dump/
+/*.dot

--- a/src/tools/tidy/src/debug_artifacts.rs
+++ b/src/tools/tidy/src/debug_artifacts.rs
@@ -1,0 +1,24 @@
+//! Tidy check to prevent creation of unnecessary debug artifacts.
+
+use std::path::{Path, PathBuf};
+
+const GRAPHVIZ_POSTFLOW_MSG: &'static str =
+    "`borrowck_graphviz_postflow` attribute in test";
+
+pub fn check(path: &Path, bad: &mut bool) {
+    let test_dir: PathBuf = path.join("test");
+
+    super::walk(&test_dir, &mut super::filter_dirs, &mut |entry, contents| {
+        let filename = entry.path();
+        let is_rust = filename.extension().map_or(false, |ext| ext == "rs");
+        if !is_rust {
+            return;
+        }
+
+        for (i, line) in contents.lines().enumerate() {
+            if line.contains("borrowck_graphviz_postflow") {
+                tidy_error!(bad, "{}:{}: {}", filename.display(), i + 1, GRAPHVIZ_POSTFLOW_MSG);
+            }
+        }
+    });
+}

--- a/src/tools/tidy/src/lib.rs
+++ b/src/tools/tidy/src/lib.rs
@@ -31,6 +31,7 @@ macro_rules! tidy_error {
 
 pub mod bins;
 pub mod style;
+pub mod debug_artifacts;
 pub mod errors;
 pub mod features;
 pub mod cargo;

--- a/src/tools/tidy/src/main.rs
+++ b/src/tools/tidy/src/main.rs
@@ -22,6 +22,7 @@ fn main() {
     let verbose = args.iter().any(|s| *s == "--verbose");
     bins::check(&path, &mut bad);
     style::check(&path, &mut bad);
+    debug_artifacts::check(&path, &mut bad);
     errors::check(&path, &mut bad);
     cargo::check(&path, &mut bad);
     edition::check(&path, &mut bad);


### PR DESCRIPTION
This attribute causes DOT files to be generated in the top-level directory. It is intended to be used only temporarily and should never appear on master. This also tells git to ignore DOT files in the root or the  `mir_dump` directory, which `-Z dump-mir` uses by default.

This will prevent #65071 from occurring again. It needs to be merged after #65629, otherwise `tidy` will start failing.

r? @Mark-Simulacrum 