### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/src/libcore/iter/traits/collect.rs
+++ b/src/libcore/iter/traits/collect.rs
@@ -167,7 +167,7 @@ pub trait FromIterator<A>: Sized {
 /// // and we'll implement IntoIterator
 /// impl IntoIterator for MyCollection {
 ///     type Item = i32;
-///     type IntoIter = ::std::vec::IntoIter<Self::Item>;
+///     type IntoIter = std::vec::IntoIter<Self::Item>;
 ///
 ///     fn into_iter(self) -> Self::IntoIter {
 ///         self.0.into_iter()

--- a/src/libcore/ops/unsize.rs
+++ b/src/libcore/ops/unsize.rs
@@ -76,7 +76,7 @@ impl<T: ?Sized+Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
 /// ```
 /// # #![feature(dispatch_from_dyn, unsize)]
 /// # use std::{ops::DispatchFromDyn, marker::Unsize};
-/// # struct Rc<T: ?Sized>(::std::rc::Rc<T>);
+/// # struct Rc<T: ?Sized>(std::rc::Rc<T>);
 /// impl<T: ?Sized, U: ?Sized> DispatchFromDyn<Rc<U>> for Rc<T>
 /// where
 ///     T: Unsize<U>,

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -395,10 +395,10 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn unwrap_or(self, def: T) -> T {
+    pub fn unwrap_or(self, default: T) -> T {
         match self {
             Some(x) => x,
-            None => def,
+            None => default,
         }
     }
 

--- a/src/libcore/str/mod.rs
+++ b/src/libcore/str/mod.rs
@@ -176,7 +176,7 @@ Section: Creating a string
 /// ```
 /// fn from_utf8_lossy<F>(mut input: &[u8], mut push: F) where F: FnMut(&str) {
 ///     loop {
-///         match ::std::str::from_utf8(input) {
+///         match std::str::from_utf8(input) {
 ///             Ok(valid) => {
 ///                 push(valid);
 ///                 break
@@ -184,7 +184,7 @@ Section: Creating a string
 ///             Err(error) => {
 ///                 let (valid, after_valid) = input.split_at(error.valid_up_to());
 ///                 unsafe {
-///                     push(::std::str::from_utf8_unchecked(valid))
+///                     push(std::str::from_utf8_unchecked(valid))
 ///                 }
 ///                 push("\u{FFFD}");
 ///

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -518,12 +518,13 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                 }
             }
 
-            // Work around: avoid ICE in miri.
-            // FIXME(wesleywiser) we don't currently handle the case where we try to make a ref
-            // from a function argument that hasn't been assigned to in this function. The main
-            // issue is if an arg is a fat-pointer, miri `expects()` to be able to read the value
-            // of that pointer to get size info. However, since this is `ConstProp`, that argument
-            // doesn't actually have a backing value and so this causes an ICE.
+            // Work around: avoid ICE in miri. FIXME(wesleywiser)
+            // The Miri engine ICEs when taking a reference to an uninitialized unsized
+            // local. There's nothing it can do here: taking a reference needs an allocation
+            // which needs to know the size. Normally that's okay as during execution
+            // (e.g. for CTFE) it can never happen. But here in const_prop
+            // we leave function arguments uninitialized, so if one of these is unsized
+            // and has a reference taken, we get an ICE.
             Rvalue::Ref(_, _, Place { base: PlaceBase::Local(local), projection: box [] }) => {
                 trace!("checking Ref({:?})", place);
                 let alive =
@@ -531,14 +532,15 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                         true
                     } else { false };
 
+                // local 0 is the return place; locals 1..=arg_count are the arguments.
                 if local.as_usize() <= self.ecx.frame().body.arg_count && !alive {
                     trace!("skipping Ref({:?})", place);
                     return None;
                 }
             }
 
-            // Work around: avoid extra unnecessary locals.
-            // FIXME(wesleywiser): const eval will turn this into a `const Scalar(<ZST>)` that
+            // Work around: avoid extra unnecessary locals. FIXME(wesleywiser)
+            // Const eval will turn this into a `const Scalar(<ZST>)` that
             // `SimplifyLocals` doesn't know it can remove.
             Rvalue::Aggregate(_, operands) if operands.len() == 0 => {
                 return None;

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -232,8 +232,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 tcx.sess,
                 span,
                 E0632,
-                "cannot provide explicit type parameters when `impl Trait` is \
-                 used in argument position."
+                "cannot provide explicit generic arguments when `impl Trait` is \
+                 used in argument position"
             };
 
             err.emit();

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -5048,8 +5048,8 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 //  E0612, // merged into E0609
 //  E0613, // Removed (merged with E0609)
     E0627, // yield statement outside of generator literal
-    E0632, // cannot provide explicit type parameters when `impl Trait` is used
-           // in argument position.
+    E0632, // cannot provide explicit generic arguments when `impl Trait` is
+           // used in argument position
     E0634, // type has conflicting packed representaton hints
     E0640, // infer outlives requirements
     E0641, // cannot cast to/from a pointer with an unknown kind

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -53,6 +53,8 @@ pub struct Options {
     pub codegen_options_strs: Vec<String>,
     /// Debugging (`-Z`) options to pass to the compiler.
     pub debugging_options: DebuggingOptions,
+    /// Debugging (`-Z`) options strings to pass to the compiler.
+    pub debugging_options_strs: Vec<String>,
     /// The target used to compile the crate against.
     pub target: TargetTriple,
     /// Edition used when reading the crate. Defaults to "2015". Also used by default when
@@ -481,6 +483,7 @@ impl Options {
         let generate_redirect_pages = matches.opt_present("generate-redirect-pages");
         let test_builder = matches.opt_str("test-builder").map(PathBuf::from);
         let codegen_options_strs = matches.opt_strs("C");
+        let debugging_options_strs = matches.opt_strs("Z");
         let lib_strs = matches.opt_strs("L");
         let extern_strs = matches.opt_strs("extern");
         let runtool = matches.opt_str("runtool");
@@ -502,6 +505,7 @@ impl Options {
             codegen_options,
             codegen_options_strs,
             debugging_options,
+            debugging_options_strs,
             target,
             edition,
             maybe_sysroot,

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -279,6 +279,9 @@ fn run_test(
     for codegen_options_str in &options.codegen_options_strs {
         compiler.arg("-C").arg(&codegen_options_str);
     }
+    for debugging_option_str in &options.debugging_options_strs {
+        compiler.arg("-Z").arg(&debugging_option_str);
+    }
     if no_run {
         compiler.arg("--emit=metadata");
     }

--- a/src/libstd/io/stdio.rs
+++ b/src/libstd/io/stdio.rs
@@ -762,7 +762,7 @@ pub fn set_print(sink: Option<Box<dyn Write + Send>>) -> Option<Box<dyn Write + 
 /// otherwise. `label` identifies the stream in a panic message.
 ///
 /// This function is used to print error messages, so it takes extra
-/// care to avoid causing a panic when `local_stream` is unusable.
+/// care to avoid causing a panic when `local_s` is unusable.
 /// For instance, if the TLS key for the local stream is
 /// already destroyed, or if the local stream is locked by another
 /// thread, it will just fall back to the global stream.

--- a/src/libstd/net/udp.rs
+++ b/src/libstd/net/udp.rs
@@ -202,7 +202,7 @@ impl UdpSocket {
     ///
     /// let socket = UdpSocket::bind("127.0.0.1:34254").expect("couldn't bind to address");
     /// assert_eq!(socket.peer_addr().unwrap_err().kind(),
-    ///            ::std::io::ErrorKind::NotConnected);
+    ///            std::io::ErrorKind::NotConnected);
     /// ```
     #[stable(feature = "udp_peer_addr", since = "1.40.0")]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {

--- a/src/libstd/process.rs
+++ b/src/libstd/process.rs
@@ -1488,12 +1488,12 @@ impl Child {
 /// }
 ///
 /// fn main() {
-///     ::std::process::exit(match run_app() {
-///        Ok(_) => 0,
-///        Err(err) => {
-///            eprintln!("error: {:?}", err);
-///            1
-///        }
+///     std::process::exit(match run_app() {
+///         Ok(_) => 0,
+///         Err(err) => {
+///             eprintln!("error: {:?}", err);
+///             1
+///         }
 ///     });
 /// }
 /// ```

--- a/src/libsyntax_expand/expand.rs
+++ b/src/libsyntax_expand/expand.rs
@@ -1418,7 +1418,14 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                         return noop_visit_attribute(at, self);
                     }
 
-                    let filename = self.cx.resolve_path(&*file.as_str(), it.span());
+                    let filename = match self.cx.resolve_path(&*file.as_str(), it.span()) {
+                        Ok(filename) => filename,
+                        Err(mut err) => {
+                            err.emit();
+                            continue;
+                        }
+                    };
+
                     match self.cx.source_map().load_file(&filename) {
                         Ok(source_file) => {
                             let src = source_file.src.as_ref()

--- a/src/libsyntax_ext/source_util.rs
+++ b/src/libsyntax_ext/source_util.rs
@@ -76,7 +76,13 @@ pub fn expand_include<'cx>(cx: &'cx mut ExtCtxt<'_>, sp: Span, tts: TokenStream)
         None => return DummyResult::any(sp),
     };
     // The file will be added to the code map by the parser
-    let file = cx.resolve_path(file, sp);
+    let file = match cx.resolve_path(file, sp) {
+        Ok(f) => f,
+        Err(mut err) => {
+            err.emit();
+            return DummyResult::any(sp);
+        },
+    };
     let directory_ownership = DirectoryOwnership::Owned { relative: None };
     let p = parse::new_sub_parser_from_file(cx.parse_sess(), &file, directory_ownership, None, sp);
 
@@ -122,7 +128,13 @@ pub fn expand_include_str(cx: &mut ExtCtxt<'_>, sp: Span, tts: TokenStream)
         Some(f) => f,
         None => return DummyResult::any(sp)
     };
-    let file = cx.resolve_path(file, sp);
+    let file = match cx.resolve_path(file, sp) {
+        Ok(f) => f,
+        Err(mut err) => {
+            err.emit();
+            return DummyResult::any(sp);
+        },
+    };
     match cx.source_map().load_binary_file(&file) {
         Ok(bytes) => match std::str::from_utf8(&bytes) {
             Ok(src) => {
@@ -147,7 +159,13 @@ pub fn expand_include_bytes(cx: &mut ExtCtxt<'_>, sp: Span, tts: TokenStream)
         Some(f) => f,
         None => return DummyResult::any(sp)
     };
-    let file = cx.resolve_path(file, sp);
+    let file = match cx.resolve_path(file, sp) {
+        Ok(f) => f,
+        Err(mut err) => {
+            err.emit();
+            return DummyResult::any(sp);
+        },
+    };
     match cx.source_map().load_binary_file(&file) {
         Ok(bytes) => {
             base::MacEager::expr(cx.expr_lit(sp, ast::LitKind::ByteStr(Lrc::new(bytes))))

--- a/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-missing-codes.stdout
@@ -6,13 +6,13 @@ failures:
 
 ---- $DIR/failed-doctest-missing-codes.rs - Foo (line 8) stdout ----
 error[E0308]: mismatched types
- --> $DIR/failed-doctest-missing-codes.rs:9:13
-  |
-3 | let x: () = 5i32;
-  |             ^^^^ expected (), found i32
-  |
-  = note: expected type `()`
-             found type `i32`
+  --> $DIR/failed-doctest-missing-codes.rs:9:13
+   |
+LL | let x: () = 5i32;
+   |             ^^^^ expected (), found i32
+   |
+   = note: expected type `()`
+              found type `i32`
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -7,10 +7,10 @@ failures:
 
 ---- $DIR/failed-doctest-output.rs - OtherStruct (line 21) stdout ----
 error[E0425]: cannot find value `no` in this scope
- --> $DIR/failed-doctest-output.rs:22:1
-  |
-3 | no
-  | ^^ not found in this scope
+  --> $DIR/failed-doctest-output.rs:22:1
+   |
+LL | no
+   | ^^ not found in this scope
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc-ui/unparseable-doc-test.stdout
+++ b/src/test/rustdoc-ui/unparseable-doc-test.stdout
@@ -6,10 +6,10 @@ failures:
 
 ---- $DIR/unparseable-doc-test.rs - foo (line 6) stdout ----
 error: unterminated double quote string
- --> $DIR/unparseable-doc-test.rs:8:1
-  |
-2 | "unterminated
-  | ^^^^^^^^^^^^^
+  --> $DIR/unparseable-doc-test.rs:8:1
+   |
+LL | "unterminated
+   | ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/rustdoc/sanitizer-option.rs
+++ b/src/test/rustdoc/sanitizer-option.rs
@@ -1,0 +1,17 @@
+// needs-sanitizer-support
+// compile-flags: --test -Z sanitizer=address
+//
+// #43031: Verify that rustdoc passes `-Z` options to rustc. Use an extern
+// function that is provided by the sanitizer runtime, if flag is not passed
+// correctly, then linking will fail.
+
+/// ```
+/// extern {
+///     fn __sanitizer_print_stack_trace();
+/// }
+///
+/// fn main() {
+///     unsafe { __sanitizer_print_stack_trace() };
+/// }
+/// ```
+pub fn z_flag_is_passed_to_rustc() {}

--- a/src/test/ui/consts/const-eval/issue-65394.rs
+++ b/src/test/ui/consts/const-eval/issue-65394.rs
@@ -1,8 +1,5 @@
 // Test for absence of validation mismatch ICE in #65394
 
-#![feature(rustc_attrs)]
-
-#[rustc_mir(borrowck_graphviz_postflow="hello.dot")]
 const _: Vec<i32> = {
     let mut x = Vec::<i32>::new();
     let r = &mut x; //~ ERROR references in constants may only refer to immutable values

--- a/src/test/ui/consts/const-eval/issue-65394.stderr
+++ b/src/test/ui/consts/const-eval/issue-65394.stderr
@@ -1,11 +1,11 @@
 error[E0017]: references in constants may only refer to immutable values
-  --> $DIR/issue-65394.rs:8:13
+  --> $DIR/issue-65394.rs:5:13
    |
 LL |     let r = &mut x;
    |             ^^^^^^ constants require immutable values
 
-[ERROR rustc_mir::transform::qualify_consts] old validator: [($DIR/issue-65394.rs:8:13: 8:19, "MutBorrow(Mut { allow_two_phase_borrow: false })")]
-[ERROR rustc_mir::transform::qualify_consts] new validator: [($DIR/issue-65394.rs:8:13: 8:19, "MutBorrow(Mut { allow_two_phase_borrow: false })"), ($DIR/issue-65394.rs:7:9: 7:14, "LiveDrop")]
+[ERROR rustc_mir::transform::qualify_consts] old validator: [($DIR/issue-65394.rs:5:13: 5:19, "MutBorrow(Mut { allow_two_phase_borrow: false })")]
+[ERROR rustc_mir::transform::qualify_consts] new validator: [($DIR/issue-65394.rs:5:13: 5:19, "MutBorrow(Mut { allow_two_phase_borrow: false })"), ($DIR/issue-65394.rs:4:9: 4:14, "LiveDrop")]
 error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0017`.

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.rs
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.rs
@@ -5,5 +5,5 @@ use std::fmt::Debug;
 fn foo<T>(x: impl Debug) { }
 
 fn main() {
-    foo::<String>('a'); //~ ERROR cannot provide explicit type parameters
+    foo::<String>('a'); //~ ERROR cannot provide explicit generic arguments
 }

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -1,4 +1,4 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/universal-issue-48703.rs:8:5
    |
 LL |     foo::<String>('a');

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.rs
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.rs
@@ -12,6 +12,6 @@ struct TestEvent(i32);
 fn main() {
     let mut evt = EventHandler {};
     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {
-        //~^ ERROR cannot provide explicit type parameters
+        //~^ ERROR cannot provide explicit generic arguments
     });
 }

--- a/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
+++ b/src/test/ui/impl-trait/issues/universal-turbofish-in-method-issue-50950.stderr
@@ -1,4 +1,4 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/universal-turbofish-in-method-issue-50950.rs:14:9
    |
 LL |     evt.handle_event::<TestEvent, fn(TestEvent)>(|_evt| {

--- a/src/test/ui/synthetic-param.rs
+++ b/src/test/ui/synthetic-param.rs
@@ -17,12 +17,12 @@ impl<S> Bar<S> {
 }
 
 fn main() {
-    func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     func(42); // Ok
 
-    Foo::func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    Foo::func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     Foo::func(42); // Ok
 
-    Bar::<i8>::func::<u8>(42); //~ ERROR cannot provide explicit type parameters
+    Bar::<i8>::func::<u8>(42); //~ ERROR cannot provide explicit generic arguments
     Bar::<i8>::func(42); // Ok
 }

--- a/src/test/ui/synthetic-param.stderr
+++ b/src/test/ui/synthetic-param.stderr
@@ -1,16 +1,16 @@
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:20:5
    |
 LL |     func::<u8>(42);
    |     ^^^^^^^^^^
 
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:23:5
    |
 LL |     Foo::func::<u8>(42);
    |     ^^^^^^^^^^^^^^^
 
-error[E0632]: cannot provide explicit type parameters when `impl Trait` is used in argument position.
+error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
   --> $DIR/synthetic-param.rs:26:5
    |
 LL |     Bar::<i8>::func::<u8>(42);


### PR DESCRIPTION
Successful merges:

 - #65314 (rustdoc: forward -Z options to rustc)
 - #65592 (clarify const_prop ICE protection comment)
 - #65603 (Avoid ICE when include! is used by stdin crate)
 - #65614 (Improve error message for APIT with explicit generic arguments)
 - #65629 (Remove `borrowck_graphviz_postflow` from test)
 - #65633 (Remove leading :: from paths in doc examples)
 - #65638 (Rename the default argument 'def' to 'default')
 - #65639 (Fix parameter name in documentation)

Failed merges:


r? @ghost