### PR TITLE
Fix `canonicalize_const_var` leaking inference variables

### DIFF
--- a/src/librustc/infer/canonical/canonicalizer.rs
+++ b/src/librustc/infer/canonical/canonicalizer.rs
@@ -701,7 +701,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
             self.tcx().mk_const(
                 ty::Const {
                     val: ConstValue::Infer(InferConst::Canonical(self.binder_index, var.into())),
-                    ty: const_var.ty,
+                    ty: self.fold_ty(const_var.ty),
                 }
             )
         }

--- a/src/test/incremental/const-generics/issue-61338.rs
+++ b/src/test/incremental/const-generics/issue-61338.rs
@@ -1,0 +1,14 @@
+// revisions:rpass1
+
+#![feature(const_generics)]
+
+struct Struct<T>(T);
+
+impl<T, const N: usize> Struct<[T; N]> {
+    fn f() {}
+    fn g() { Self::f(); }
+}
+
+fn main() {
+    Struct::<[u32; 3]>::g();
+}

--- a/src/test/incremental/const-generics/issue-61516.rs
+++ b/src/test/incremental/const-generics/issue-61516.rs
@@ -1,0 +1,16 @@
+// revisions:rpass1
+
+#![feature(const_generics)]
+
+struct FakeArray<T, const N: usize>(T);
+
+impl<T, const N: usize> FakeArray<T, { N }> {
+    fn len(&self) -> usize {
+        N
+    }
+}
+
+fn main() {
+    let fa = FakeArray::<u32, { 32 }>(1);
+    assert_eq!(fa.len(), 32);
+}

--- a/src/test/incremental/const-generics/issue-62536.rs
+++ b/src/test/incremental/const-generics/issue-62536.rs
@@ -1,0 +1,12 @@
+// revisions:cfail1
+#![feature(const_generics)]
+//[cfail1]~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+struct S<T, const N: usize>([T; N]);
+
+fn f<T, const N: usize>(x: T) -> S<T, {N}> { panic!() }
+
+fn main() {
+    f(0u8);
+    //[cfail1]~^ ERROR type annotations needed
+}

--- a/src/test/incremental/const-generics/issue-64087.rs
+++ b/src/test/incremental/const-generics/issue-64087.rs
@@ -1,0 +1,11 @@
+// revisions:cfail1
+#![feature(const_generics)]
+//[cfail1]~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+fn combinator<T, const S: usize>() -> [T; S] {}
+//[cfail1]~^ ERROR mismatched types
+
+fn main() {
+    combinator().into_iter();
+    //[cfail1]~^ ERROR type annotations needed
+}

--- a/src/test/incremental/const-generics/issue-65623.rs
+++ b/src/test/incremental/const-generics/issue-65623.rs
@@ -1,0 +1,14 @@
+// revisions:rpass1
+#![feature(const_generics)]
+
+pub struct Foo<T, const N: usize>([T; 0]);
+
+impl<T, const N: usize> Foo<T, {N}> {
+    pub fn new() -> Self {
+        Foo([])
+    }
+}
+
+fn main() {
+    let _: Foo<u32, 0> = Foo::new();
+}


### PR DESCRIPTION
Fixes #61338
Fixes #61516
Fixes #62536
Fixes #64087
Fixes #64863
Fixes #65623 

I added regression tests for all these issues apart from #64863, which is very similar to #61338.

r? @varkor 