### PR TITLE
Remove `InternedString`

### DIFF
--- a/src/librustc/dep_graph/dep_node.rs
+++ b/src/librustc/dep_graph/dep_node.rs
@@ -59,7 +59,7 @@ use crate::ich::{Fingerprint, StableHashingContext};
 use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 use std::fmt;
 use std::hash::Hash;
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 use crate::traits;
 use crate::traits::query::{
     CanonicalProjectionGoal, CanonicalTyGoal, CanonicalTypeOpAscribeUserTypeGoal,
@@ -426,7 +426,7 @@ rustc_dep_node_append!([define_dep_nodes!][ <'tcx>
 
     [anon] TraitSelect,
 
-    [] CompileCodegenUnit(InternedString),
+    [] CompileCodegenUnit(Symbol),
 
     [eval_always] Analysis(CrateNum),
 ]);

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -792,15 +792,15 @@ impl<'a> LoweringContext<'a> {
         // really show up for end-user.
         let (str_name, kind) = match hir_name {
             ParamName::Plain(ident) => (
-                ident.as_interned_str(),
+                ident.name,
                 hir::LifetimeParamKind::InBand,
             ),
             ParamName::Fresh(_) => (
-                kw::UnderscoreLifetime.as_interned_str(),
+                kw::UnderscoreLifetime,
                 hir::LifetimeParamKind::Elided,
             ),
             ParamName::Error => (
-                kw::UnderscoreLifetime.as_interned_str(),
+                kw::UnderscoreLifetime,
                 hir::LifetimeParamKind::Error,
             ),
         };
@@ -1590,7 +1590,7 @@ impl<'a> LoweringContext<'a> {
                     self.context.resolver.definitions().create_def_with_parent(
                         self.parent,
                         def_node_id,
-                        DefPathData::LifetimeNs(name.ident().as_interned_str()),
+                        DefPathData::LifetimeNs(name.ident().name),
                         ExpnId::root(),
                         lifetime.span);
 

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -186,13 +186,13 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
             });
 
         let mut upstream_crates: Vec<_> = cstore.crates_untracked().iter().map(|&cnum| {
-            let name = cstore.crate_name_untracked(cnum).as_interned_str();
+            let name = cstore.crate_name_untracked(cnum);
             let disambiguator = cstore.crate_disambiguator_untracked(cnum).to_fingerprint();
             let hash = cstore.crate_hash_untracked(cnum);
             (name, disambiguator, hash)
         }).collect();
 
-        upstream_crates.sort_unstable_by_key(|&(name, dis, _)| (name, dis));
+        upstream_crates.sort_unstable_by_key(|&(name, dis, _)| (name.as_str(), dis));
 
         // We hash the final, remapped names of all local source files so we
         // don't have to include the path prefix remapping commandline args.

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -57,7 +57,7 @@ impl<'a> DefCollector<'a> {
 
         // For async functions, we need to create their inner defs inside of a
         // closure to match their desugared representation.
-        let fn_def_data = DefPathData::ValueNs(name.as_interned_str());
+        let fn_def_data = DefPathData::ValueNs(name);
         let fn_def = self.create_def(id, fn_def_data, span);
         return self.with_parent(fn_def, |this| {
             this.create_def(return_impl_trait_id, DefPathData::ImplTrait, span);
@@ -83,8 +83,7 @@ impl<'a> DefCollector<'a> {
                 .unwrap_or_else(|| {
                     let node_id = NodeId::placeholder_from_expn_id(self.expansion);
                     sym::integer(self.definitions.placeholder_field_indices[&node_id])
-                })
-                .as_interned_str();
+                });
             let def = self.create_def(field.id, DefPathData::ValueNs(name), field.span);
             self.with_parent(def, |this| visit::walk_struct_field(this, field));
         }
@@ -109,7 +108,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             ItemKind::Mod(..) | ItemKind::Trait(..) | ItemKind::TraitAlias(..) |
             ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..) |
             ItemKind::OpaqueTy(..) | ItemKind::ExternCrate(..) | ItemKind::ForeignMod(..) |
-            ItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.as_interned_str()),
+            ItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.name),
             ItemKind::Fn(
                 ref decl,
                 ref header,
@@ -127,8 +126,8 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                 )
             }
             ItemKind::Static(..) | ItemKind::Const(..) | ItemKind::Fn(..) =>
-                DefPathData::ValueNs(i.ident.as_interned_str()),
-            ItemKind::MacroDef(..) => DefPathData::MacroNs(i.ident.as_interned_str()),
+                DefPathData::ValueNs(i.ident.name),
+            ItemKind::MacroDef(..) => DefPathData::MacroNs(i.ident.name),
             ItemKind::Mac(..) => return self.visit_macro_invoc(i.id),
             ItemKind::GlobalAsm(..) => DefPathData::Misc,
             ItemKind::Use(..) => {
@@ -162,7 +161,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
         }
 
         let def = self.create_def(foreign_item.id,
-                                  DefPathData::ValueNs(foreign_item.ident.as_interned_str()),
+                                  DefPathData::ValueNs(foreign_item.ident.name),
                                   foreign_item.span);
 
         self.with_parent(def, |this| {
@@ -175,7 +174,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             return self.visit_macro_invoc(v.id);
         }
         let def = self.create_def(v.id,
-                                  DefPathData::TypeNs(v.ident.as_interned_str()),
+                                  DefPathData::TypeNs(v.ident.name),
                                   v.span);
         self.with_parent(def, |this| {
             if let Some(ctor_hir_id) = v.data.ctor_id() {
@@ -202,7 +201,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             self.visit_macro_invoc(param.id);
             return;
         }
-        let name = param.ident.as_interned_str();
+        let name = param.ident.name;
         let def_path_data = match param.kind {
             GenericParamKind::Lifetime { .. } => DefPathData::LifetimeNs(name),
             GenericParamKind::Type { .. } => DefPathData::TypeNs(name),
@@ -216,9 +215,9 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
     fn visit_trait_item(&mut self, ti: &'a TraitItem) {
         let def_data = match ti.kind {
             TraitItemKind::Method(..) | TraitItemKind::Const(..) =>
-                DefPathData::ValueNs(ti.ident.as_interned_str()),
+                DefPathData::ValueNs(ti.ident.name),
             TraitItemKind::Type(..) => {
-                DefPathData::TypeNs(ti.ident.as_interned_str())
+                DefPathData::TypeNs(ti.ident.name)
             },
             TraitItemKind::Macro(..) => return self.visit_macro_invoc(ti.id),
         };
@@ -243,12 +242,10 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
                     body,
                 )
             }
-            ImplItemKind::Method(..) | ImplItemKind::Const(..) =>
-                DefPathData::ValueNs(ii.ident.as_interned_str()),
+            ImplItemKind::Method(..) |
+            ImplItemKind::Const(..) => DefPathData::ValueNs(ii.ident.name),
             ImplItemKind::TyAlias(..) |
-            ImplItemKind::OpaqueTy(..) => {
-                DefPathData::TypeNs(ii.ident.as_interned_str())
-            },
+            ImplItemKind::OpaqueTy(..) => DefPathData::TypeNs(ii.ident.name),
             ImplItemKind::Macro(..) => return self.visit_macro_invoc(ii.id),
         };
 

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -18,7 +18,7 @@ use std::fmt::Write;
 use std::hash::Hash;
 use syntax::ast;
 use syntax_expand::hygiene::ExpnId;
-use syntax::symbol::{Symbol, sym, InternedString};
+use syntax::symbol::{Symbol, sym};
 use syntax_pos::{Span, DUMMY_SP};
 
 /// The `DefPathTable` maps `DefIndex`es to `DefKey`s and vice versa.
@@ -136,7 +136,9 @@ impl DefKey {
 
         ::std::mem::discriminant(data).hash(&mut hasher);
         if let Some(name) = data.get_opt_name() {
-            name.hash(&mut hasher);
+            // Get a stable hash by considering the symbol chars rather than
+            // the symbol index.
+            name.as_str().hash(&mut hasher);
         }
 
         disambiguator.hash(&mut hasher);
@@ -218,7 +220,7 @@ impl DefPath {
         for component in &self.data {
             write!(s,
                    "::{}[{}]",
-                   component.data.as_interned_str(),
+                   component.data.as_symbol(),
                    component.disambiguator)
                 .unwrap();
         }
@@ -238,11 +240,11 @@ impl DefPath {
 
         for component in &self.data {
             if component.disambiguator == 0 {
-                write!(s, "::{}", component.data.as_interned_str()).unwrap();
+                write!(s, "::{}", component.data.as_symbol()).unwrap();
             } else {
                 write!(s,
                        "{}[{}]",
-                       component.data.as_interned_str(),
+                       component.data.as_symbol(),
                        component.disambiguator)
                        .unwrap();
             }
@@ -262,11 +264,11 @@ impl DefPath {
             opt_delimiter.map(|d| s.push(d));
             opt_delimiter = Some('-');
             if component.disambiguator == 0 {
-                write!(s, "{}", component.data.as_interned_str()).unwrap();
+                write!(s, "{}", component.data.as_symbol()).unwrap();
             } else {
                 write!(s,
                        "{}[{}]",
-                       component.data.as_interned_str(),
+                       component.data.as_symbol(),
                        component.disambiguator)
                        .unwrap();
             }
@@ -290,13 +292,13 @@ pub enum DefPathData {
     /// An impl.
     Impl,
     /// Something in the type namespace.
-    TypeNs(InternedString),
+    TypeNs(Symbol),
     /// Something in the value namespace.
-    ValueNs(InternedString),
+    ValueNs(Symbol),
     /// Something in the macro namespace.
-    MacroNs(InternedString),
+    MacroNs(Symbol),
     /// Something in the lifetime namespace.
-    LifetimeNs(InternedString),
+    LifetimeNs(Symbol),
     /// A closure expression.
     ClosureExpr,
 
@@ -311,7 +313,7 @@ pub enum DefPathData {
     /// Identifies a piece of crate metadata that is global to a whole crate
     /// (as opposed to just one item). `GlobalMetaData` components are only
     /// supposed to show up right below the crate root.
-    GlobalMetaData(InternedString),
+    GlobalMetaData(Symbol),
 }
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Debug,
@@ -545,7 +547,7 @@ impl Definitions {
 }
 
 impl DefPathData {
-    pub fn get_opt_name(&self) -> Option<InternedString> {
+    pub fn get_opt_name(&self) -> Option<Symbol> {
         use self::DefPathData::*;
         match *self {
             TypeNs(name) |
@@ -564,15 +566,15 @@ impl DefPathData {
         }
     }
 
-    pub fn as_interned_str(&self) -> InternedString {
+    pub fn as_symbol(&self) -> Symbol {
         use self::DefPathData::*;
-        let s = match *self {
+        match *self {
             TypeNs(name) |
             ValueNs(name) |
             MacroNs(name) |
             LifetimeNs(name) |
             GlobalMetaData(name) => {
-                return name
+                name
             }
             // Note that this does not show up in user print-outs.
             CrateRoot => sym::double_braced_crate,
@@ -582,13 +584,11 @@ impl DefPathData {
             Ctor => sym::double_braced_constructor,
             AnonConst => sym::double_braced_constant,
             ImplTrait => sym::double_braced_opaque,
-        };
-
-        s.as_interned_str()
+        }
     }
 
     pub fn to_string(&self) -> String {
-        self.as_interned_str().to_string()
+        self.as_symbol().to_string()
     }
 }
 
@@ -611,7 +611,7 @@ macro_rules! define_global_metadata_kind {
                     definitions.create_def_with_parent(
                         CRATE_DEF_INDEX,
                         ast::DUMMY_NODE_ID,
-                        DefPathData::GlobalMetaData(instance.name().as_interned_str()),
+                        DefPathData::GlobalMetaData(instance.name()),
                         ExpnId::root(),
                         DUMMY_SP
                     );
@@ -625,7 +625,7 @@ macro_rules! define_global_metadata_kind {
                 let def_key = DefKey {
                     parent: Some(CRATE_DEF_INDEX),
                     disambiguated_data: DisambiguatedDefPathData {
-                        data: DefPathData::GlobalMetaData(self.name().as_interned_str()),
+                        data: DefPathData::GlobalMetaData(self.name()),
                         disambiguator: 0,
                     }
                 };

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -19,7 +19,7 @@ use crate::ty::query::Providers;
 use crate::util::nodemap::{NodeMap, FxHashSet};
 
 use errors::FatalError;
-use syntax_pos::{Span, DUMMY_SP, symbol::InternedString, MultiSpan};
+use syntax_pos::{Span, DUMMY_SP, MultiSpan};
 use syntax::source_map::Spanned;
 use syntax::ast::{self, CrateSugar, Ident, Name, NodeId, AsmDialect};
 use syntax::ast::{Attribute, Label, LitKind, StrStyle, FloatTy, IntTy, UintTy};
@@ -628,9 +628,9 @@ impl Generics {
         own_counts
     }
 
-    pub fn get_named(&self, name: InternedString) -> Option<&GenericParam> {
+    pub fn get_named(&self, name: Symbol) -> Option<&GenericParam> {
         for param in &self.params {
-            if name == param.name.ident().as_interned_str() {
+            if name == param.name.ident().name {
                 return Some(param);
             }
         }

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -9,7 +9,7 @@ use std::mem;
 use syntax::ast;
 use syntax::feature_gate;
 use syntax::parse::token;
-use syntax::symbol::InternedString;
+use syntax::symbol::LocalInternedString;
 use syntax::tokenstream;
 use syntax_pos::SourceFile;
 
@@ -18,20 +18,21 @@ use crate::hir::def_id::{DefId, CrateNum, CRATE_DEF_INDEX};
 use smallvec::SmallVec;
 use rustc_data_structures::stable_hasher::{HashStable, ToStableHashKey, StableHasher};
 
-impl<'a> HashStable<StableHashingContext<'a>> for InternedString {
+impl<'a> HashStable<StableHashingContext<'a>> for LocalInternedString {
     #[inline]
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
-        self.with(|s| s.hash_stable(hcx, hasher))
+        let str = self as &str;
+        str.hash_stable(hcx, hasher)
     }
 }
 
-impl<'a> ToStableHashKey<StableHashingContext<'a>> for InternedString {
-    type KeyType = InternedString;
+impl<'a> ToStableHashKey<StableHashingContext<'a>> for LocalInternedString {
+    type KeyType = LocalInternedString;
 
     #[inline]
     fn to_stable_hash_key(&self,
                           _: &StableHashingContext<'a>)
-                          -> InternedString {
+                          -> LocalInternedString {
         self.clone()
     }
 }
@@ -44,13 +45,13 @@ impl<'a> HashStable<StableHashingContext<'a>> for ast::Name {
 }
 
 impl<'a> ToStableHashKey<StableHashingContext<'a>> for ast::Name {
-    type KeyType = InternedString;
+    type KeyType = LocalInternedString;
 
     #[inline]
     fn to_stable_hash_key(&self,
                           _: &StableHashingContext<'a>)
-                          -> InternedString {
-        self.as_interned_str()
+                          -> LocalInternedString {
+        self.as_str()
     }
 }
 

--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -542,7 +542,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 disambiguated_data: &DisambiguatedDefPathData,
             ) -> Result<Self::Path, Self::Error> {
                 let mut path = print_prefix(self)?;
-                path.push(disambiguated_data.data.as_interned_str().to_string());
+                path.push(disambiguated_data.data.as_symbol().to_string());
                 Ok(path)
             }
             fn path_generic_args(

--- a/src/librustc/infer/mod.rs
+++ b/src/librustc/infer/mod.rs
@@ -32,7 +32,7 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::BTreeMap;
 use std::fmt;
 use syntax::ast;
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 use syntax_pos::Span;
 
 use self::combine::CombineFields;
@@ -392,7 +392,7 @@ pub enum RegionVariableOrigin {
     Coercion(Span),
 
     /// Region variables created as the values for early-bound regions
-    EarlyBoundRegion(Span, InternedString),
+    EarlyBoundRegion(Span, Symbol),
 
     /// Region variables created for bound regions
     /// in a function or method that is called

--- a/src/librustc/infer/type_variable.rs
+++ b/src/librustc/infer/type_variable.rs
@@ -1,4 +1,4 @@
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 use syntax_pos::Span;
 use crate::ty::{self, Ty, TyVid};
 
@@ -49,7 +49,7 @@ pub enum TypeVariableOriginKind {
     MiscVariable,
     NormalizeProjectionType,
     TypeInference,
-    TypeParameterDefinition(InternedString),
+    TypeParameterDefinition(Symbol),
 
     /// One of the upvars or closure kind parameters in a `ClosureSubsts`
     /// (before it has been determined).

--- a/src/librustc/infer/unify_key.rs
+++ b/src/librustc/infer/unify_key.rs
@@ -3,7 +3,7 @@ use crate::mir::interpret::ConstValue;
 use rustc_data_structures::unify::{NoError, EqUnifyValue, UnifyKey, UnifyValue, UnificationTable};
 use rustc_data_structures::unify::InPlace;
 use syntax_pos::{Span, DUMMY_SP};
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 
 use std::cmp;
 use std::marker::PhantomData;
@@ -90,7 +90,7 @@ pub struct ConstVariableOrigin {
 pub enum ConstVariableOriginKind {
     MiscVariable,
     ConstInference,
-    ConstParameterDefinition(InternedString),
+    ConstParameterDefinition(Symbol),
     SubstitutionPlaceholder,
 }
 

--- a/src/librustc/lint/context.rs
+++ b/src/librustc/lint/context.rs
@@ -875,7 +875,7 @@ impl<'a, 'tcx> LateContext<'a, 'tcx> {
                     _ => {}
                 }
 
-                path.push(disambiguated_data.data.as_interned_str().as_symbol());
+                path.push(disambiguated_data.data.as_symbol());
                 Ok(path)
             }
 

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -37,7 +37,7 @@ use std::slice;
 use std::vec::IntoIter;
 use std::{iter, mem, option, u32};
 use syntax::ast::Name;
-use syntax::symbol::{InternedString, Symbol};
+use syntax::symbol::Symbol;
 use syntax_pos::{Span, DUMMY_SP};
 
 pub use crate::mir::interpret::AssertMessage;
@@ -2736,8 +2736,8 @@ pub enum UnsafetyViolationKind {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, RustcEncodable, RustcDecodable, HashStable)]
 pub struct UnsafetyViolation {
     pub source_info: SourceInfo,
-    pub description: InternedString,
-    pub details: InternedString,
+    pub description: Symbol,
+    pub details: Symbol,
     pub kind: UnsafetyViolationKind,
 }
 

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -1,6 +1,6 @@
 use crate::hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
 use crate::hir::HirId;
-use syntax::symbol::InternedString;
+use syntax::symbol::{InternedString, Symbol};
 use syntax::attr::InlineAttr;
 use syntax::source_map::Span;
 use crate::ty::{Instance, InstanceDef, TyCtxt, SymbolName, subst::InternalSubsts};
@@ -80,7 +80,7 @@ impl<'tcx> MonoItem<'tcx> {
             MonoItem::GlobalAsm(hir_id) => {
                 let def_id = tcx.hir().local_def_id(hir_id);
                 SymbolName {
-                    name: InternedString::intern(&format!("global_asm_{:?}", def_id))
+                    name: Symbol::intern(&format!("global_asm_{:?}", def_id))
                 }
             }
         }

--- a/src/librustc/mir/mono.rs
+++ b/src/librustc/mir/mono.rs
@@ -1,6 +1,6 @@
 use crate::hir::def_id::{DefId, CrateNum, LOCAL_CRATE};
 use crate::hir::HirId;
-use syntax::symbol::{InternedString, Symbol};
+use syntax::symbol::Symbol;
 use syntax::attr::InlineAttr;
 use syntax::source_map::Span;
 use crate::ty::{Instance, InstanceDef, TyCtxt, SymbolName, subst::InternalSubsts};
@@ -246,7 +246,7 @@ pub struct CodegenUnit<'tcx> {
     /// name be unique amongst **all** crates. Therefore, it should
     /// contain something unique to this crate (e.g., a module path)
     /// as well as the crate name and disambiguator.
-    name: InternedString,
+    name: Symbol,
     items: FxHashMap<MonoItem<'tcx>, (Linkage, Visibility)>,
     size_estimate: Option<usize>,
 }
@@ -294,7 +294,7 @@ impl_stable_hash_for!(enum self::Visibility {
 });
 
 impl<'tcx> CodegenUnit<'tcx> {
-    pub fn new(name: InternedString) -> CodegenUnit<'tcx> {
+    pub fn new(name: Symbol) -> CodegenUnit<'tcx> {
         CodegenUnit {
             name: name,
             items: Default::default(),
@@ -302,11 +302,11 @@ impl<'tcx> CodegenUnit<'tcx> {
         }
     }
 
-    pub fn name(&self) -> &InternedString {
-        &self.name
+    pub fn name(&self) -> Symbol {
+        self.name
     }
 
-    pub fn set_name(&mut self, name: InternedString) {
+    pub fn set_name(&mut self, name: Symbol) {
         self.name = name;
     }
 
@@ -474,7 +474,7 @@ impl CodegenUnitNameBuilder<'tcx> {
                                    cnum: CrateNum,
                                    components: I,
                                    special_suffix: Option<S>)
-                                   -> InternedString
+                                   -> Symbol
         where I: IntoIterator<Item=C>,
               C: fmt::Display,
               S: fmt::Display,
@@ -487,7 +487,7 @@ impl CodegenUnitNameBuilder<'tcx> {
             cgu_name
         } else {
             let cgu_name = &cgu_name.as_str()[..];
-            InternedString::intern(&CodegenUnit::mangle_name(cgu_name))
+            Symbol::intern(&CodegenUnit::mangle_name(cgu_name))
         }
     }
 
@@ -497,7 +497,7 @@ impl CodegenUnitNameBuilder<'tcx> {
                                              cnum: CrateNum,
                                              components: I,
                                              special_suffix: Option<S>)
-                                             -> InternedString
+                                             -> Symbol
         where I: IntoIterator<Item=C>,
               C: fmt::Display,
               S: fmt::Display,
@@ -543,6 +543,6 @@ impl CodegenUnitNameBuilder<'tcx> {
             write!(cgu_name, ".{}", special_suffix).unwrap();
         }
 
-        InternedString::intern(&cgu_name[..])
+        Symbol::intern(&cgu_name[..])
     }
 }

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -15,7 +15,7 @@ use crate::traits::query::{
 };
 
 use std::borrow::Cow;
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 
 // Each of these queries corresponds to a function pointer field in the
 // `Providers` struct for requesting a value of that type, and a method
@@ -924,7 +924,7 @@ rustc_queries! {
             desc { "collect_and_partition_mono_items" }
         }
         query is_codegened_item(_: DefId) -> bool {}
-        query codegen_unit(_: InternedString) -> Arc<CodegenUnit<'tcx>> {
+        query codegen_unit(_: Symbol) -> Arc<CodegenUnit<'tcx>> {
             no_force
             desc { "codegen_unit" }
         }

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -406,7 +406,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 },
                 GenericParamDefKind::Lifetime => continue,
             };
-            let name = param.name.as_symbol();
+            let name = param.name;
             flags.push((name, Some(value)));
         }
 

--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -19,7 +19,7 @@ use crate::ty::subst::{Subst, InternalSubsts};
 use std::borrow::Cow;
 use std::iter::{self};
 use syntax::ast::{self};
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 use syntax_pos::{Span, DUMMY_SP};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -560,7 +560,7 @@ impl<'tcx> TyCtxt<'tcx> {
         // are implemented
         let unsized_self_ty: Ty<'tcx> = self.mk_ty_param(
             ::std::u32::MAX,
-            InternedString::intern("RustaceansAreAwesome"),
+            Symbol::intern("RustaceansAreAwesome"),
         );
 
         // `Receiver[Self => U]`

--- a/src/librustc/traits/on_unimplemented.rs
+++ b/src/librustc/traits/on_unimplemented.rs
@@ -250,7 +250,7 @@ impl<'tcx> OnUnimplementedFormatString {
                     Position::ArgumentNamed(s) if s == sym::from_desugaring => (),
                     // So is `{A}` if A is a type parameter
                     Position::ArgumentNamed(s) => match generics.params.iter().find(|param| {
-                        param.name.as_symbol() == s
+                        param.name == s
                     }) {
                         Some(_) => (),
                         None => {
@@ -289,7 +289,7 @@ impl<'tcx> OnUnimplementedFormatString {
                 },
                 GenericParamDefKind::Lifetime => return None
             };
-            let name = param.name.as_symbol();
+            let name = param.name;
             Some((name, value))
         }).collect::<FxHashMap<Symbol, String>>();
         let empty_string = String::new();

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -4,7 +4,7 @@ use crate::traits;
 use crate::traits::project::Normalized;
 use crate::ty::fold::{TypeFoldable, TypeFolder, TypeVisitor};
 use crate::ty::{self, Lift, Ty, TyCtxt};
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 
 use std::fmt;
 use std::rc::Rc;
@@ -261,11 +261,11 @@ impl fmt::Display for traits::QuantifierKind {
 /// for debug output in tests anyway.
 struct BoundNamesCollector {
     // Just sort by name because `BoundRegion::BrNamed` does not have a `BoundVar` index anyway.
-    regions: BTreeSet<InternedString>,
+    regions: BTreeSet<Symbol>,
 
     // Sort by `BoundVar` index, so usually this should be equivalent to the order given
     // by the list of type parameters.
-    types: BTreeMap<u32, InternedString>,
+    types: BTreeMap<u32, Symbol>,
 
     binder_index: ty::DebruijnIndex,
 }
@@ -319,7 +319,7 @@ impl<'tcx> TypeVisitor<'tcx> for BoundNamesCollector {
                     match bound_ty.kind {
                         ty::BoundTyKind::Param(name) => name,
                         ty::BoundTyKind::Anon =>
-                            InternedString::intern(&format!("^{}", bound_ty.var.as_u32()),
+                            Symbol::intern(&format!("^{}", bound_ty.var.as_u32()),
                         ),
                     }
                 );
@@ -340,7 +340,7 @@ impl<'tcx> TypeVisitor<'tcx> for BoundNamesCollector {
                     }
 
                     ty::BoundRegion::BrAnon(var) => {
-                        self.regions.insert(InternedString::intern(&format!("'^{}", var)));
+                        self.regions.insert(Symbol::intern(&format!("'^{}", var)));
                     }
 
                     _ => (),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -72,7 +72,7 @@ use syntax::ast;
 use syntax::attr;
 use syntax::source_map::MultiSpan;
 use syntax::feature_gate;
-use syntax::symbol::{Symbol, InternedString, kw, sym};
+use syntax::symbol::{Symbol, kw, sym};
 use syntax_pos::Span;
 
 pub struct AllArenas {
@@ -949,7 +949,7 @@ impl<'tcx> CommonTypes<'tcx> {
             f64: mk(Float(ast::FloatTy::F64)),
             self_param: mk(ty::Param(ty::ParamTy {
                 index: 0,
-                name: kw::SelfUpper.as_interned_str(),
+                name: kw::SelfUpper,
             })),
 
             trait_object_dummy_self: mk(Infer(ty::FreshTy(0))),
@@ -2552,7 +2552,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     #[inline]
-    pub fn mk_ty_param(self, index: u32, name: InternedString) -> Ty<'tcx> {
+    pub fn mk_ty_param(self, index: u32, name: Symbol) -> Ty<'tcx> {
         self.mk_ty(Param(ParamTy { index, name: name }))
     }
 
@@ -2560,7 +2560,7 @@ impl<'tcx> TyCtxt<'tcx> {
     pub fn mk_const_param(
         self,
         index: u32,
-        name: InternedString,
+        name: Symbol,
         ty: Ty<'tcx>
     ) -> &'tcx Const<'tcx> {
         self.mk_const(ty::Const {

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -3019,7 +3019,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     }),
                 _ => def_key.disambiguated_data.data.get_opt_name().unwrap_or_else(|| {
                     bug!("item_name: no name for {:?}", self.def_path(id));
-                }).as_symbol(),
+                }),
             }
         }
     }

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -849,7 +849,7 @@ impl ty::EarlyBoundRegion {
     /// Does this early bound region have a name? Early bound regions normally
     /// always have names except when using anonymous lifetimes (`'_`).
     pub fn has_name(&self) -> bool {
-        self.name != kw::UnderscoreLifetime.as_interned_str()
+        self.name != kw::UnderscoreLifetime
     }
 }
 
@@ -866,7 +866,7 @@ pub enum GenericParamDefKind {
 
 #[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub struct GenericParamDef {
-    pub name: InternedString,
+    pub name: Symbol,
     pub def_id: DefId,
     pub index: u32,
 

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -46,7 +46,7 @@ use std::ops::Range;
 use syntax::ast::{self, Name, Ident, NodeId};
 use syntax::attr;
 use syntax_expand::hygiene::ExpnId;
-use syntax::symbol::{kw, sym, Symbol, InternedString};
+use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;
 
 use smallvec;
@@ -3429,11 +3429,11 @@ pub struct CrateInherentImpls {
     pub inherent_impls: DefIdMap<Vec<DefId>>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable)]
 pub struct SymbolName {
     // FIXME: we don't rely on interning or equality here - better have
     // this be a `&'tcx str`.
-    pub name: InternedString
+    pub name: Symbol
 }
 
 impl_stable_hash_for!(struct self::SymbolName {
@@ -3443,8 +3443,21 @@ impl_stable_hash_for!(struct self::SymbolName {
 impl SymbolName {
     pub fn new(name: &str) -> SymbolName {
         SymbolName {
-            name: InternedString::intern(name)
+            name: Symbol::intern(name)
         }
+    }
+}
+
+impl PartialOrd for SymbolName {
+    fn partial_cmp(&self, other: &SymbolName) -> Option<Ordering> {
+        self.name.as_str().partial_cmp(&other.name.as_str())
+    }
+}
+
+/// Ordering must use the chars to ensure reproducible builds.
+impl Ord for SymbolName {
+    fn cmp(&self, other: &SymbolName) -> Ordering {
+        self.name.as_str().cmp(&other.name.as_str())
     }
 }
 

--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -218,9 +218,9 @@ impl DefPathBasedNames<'tcx> {
         // foo::bar::ItemName::
         for part in self.tcx.def_path(def_id).data {
             if self.omit_disambiguators {
-                write!(output, "{}::", part.data.as_interned_str()).unwrap();
+                write!(output, "{}::", part.data.as_symbol()).unwrap();
             } else {
-                write!(output, "{}[{}]::", part.data.as_interned_str(), part.disambiguator)
+                write!(output, "{}[{}]::", part.data.as_symbol(), part.disambiguator)
                     .unwrap();
             }
         }

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -14,7 +14,7 @@ use rustc_apfloat::Float;
 use rustc_target::spec::abi::Abi;
 use syntax::ast;
 use syntax::attr::{SignedInt, UnsignedInt};
-use syntax::symbol::{kw, InternedString};
+use syntax::symbol::{kw, Symbol};
 
 use std::cell::Cell;
 use std::fmt::{self, Write as _};
@@ -992,7 +992,7 @@ pub struct FmtPrinterData<'a, 'tcx, F> {
     empty_path: bool,
     in_value: bool,
 
-    used_region_names: FxHashSet<InternedString>,
+    used_region_names: FxHashSet<Symbol>,
     region_index: usize,
     binder_depth: usize,
 
@@ -1332,16 +1332,16 @@ impl<F: fmt::Write> PrettyPrinter<'tcx> for FmtPrinter<'_, 'tcx, F> {
 
         match *region {
             ty::ReEarlyBound(ref data) => {
-                data.name.as_symbol() != kw::Invalid &&
-                data.name.as_symbol() != kw::UnderscoreLifetime
+                data.name != kw::Invalid &&
+                data.name != kw::UnderscoreLifetime
             }
 
             ty::ReLateBound(_, br) |
             ty::ReFree(ty::FreeRegion { bound_region: br, .. }) |
             ty::RePlaceholder(ty::Placeholder { name: br, .. }) => {
                 if let ty::BrNamed(_, name) = br {
-                    if name.as_symbol() != kw::Invalid &&
-                       name.as_symbol() != kw::UnderscoreLifetime {
+                    if name != kw::Invalid &&
+                       name != kw::UnderscoreLifetime {
                         return true;
                     }
                 }
@@ -1397,7 +1397,7 @@ impl<F: fmt::Write> FmtPrinter<'_, '_, F> {
         // `explain_region()` or `note_and_explain_region()`.
         match *region {
             ty::ReEarlyBound(ref data) => {
-                if data.name.as_symbol() != kw::Invalid {
+                if data.name != kw::Invalid {
                     p!(write("{}", data.name));
                     return Ok(self);
                 }
@@ -1406,8 +1406,8 @@ impl<F: fmt::Write> FmtPrinter<'_, '_, F> {
             ty::ReFree(ty::FreeRegion { bound_region: br, .. }) |
             ty::RePlaceholder(ty::Placeholder { name: br, .. }) => {
                 if let ty::BrNamed(_, name) = br {
-                    if name.as_symbol() != kw::Invalid &&
-                       name.as_symbol() != kw::UnderscoreLifetime {
+                    if name != kw::Invalid &&
+                       name != kw::UnderscoreLifetime {
                         p!(write("{}", name));
                         return Ok(self);
                     }
@@ -1474,11 +1474,11 @@ impl<F: fmt::Write> FmtPrinter<'_, 'tcx, F> {
     where
         T: Print<'tcx, Self, Output = Self, Error = fmt::Error> + TypeFoldable<'tcx>,
     {
-        fn name_by_region_index(index: usize) -> InternedString {
+        fn name_by_region_index(index: usize) -> Symbol {
             match index {
-                0 => InternedString::intern("'r"),
-                1 => InternedString::intern("'s"),
-                i => InternedString::intern(&format!("'t{}", i-2)),
+                0 => Symbol::intern("'r"),
+                1 => Symbol::intern("'s"),
+                i => Symbol::intern(&format!("'t{}", i-2)),
             }
         }
 
@@ -1541,7 +1541,7 @@ impl<F: fmt::Write> FmtPrinter<'_, 'tcx, F> {
         where T: TypeFoldable<'tcx>
     {
 
-        struct LateBoundRegionNameCollector<'a>(&'a mut FxHashSet<InternedString>);
+        struct LateBoundRegionNameCollector<'a>(&'a mut FxHashSet<Symbol>);
         impl<'tcx> ty::fold::TypeVisitor<'tcx> for LateBoundRegionNameCollector<'_> {
             fn visit_region(&mut self, r: ty::Region<'tcx>) -> bool {
                 match *r {

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -384,7 +384,7 @@ pub trait PrettyPrinter<'tcx>:
                 let reexport = self.tcx().item_children(visible_parent)
                     .iter()
                     .find(|child| child.res.def_id() == def_id)
-                    .map(|child| child.ident.as_interned_str());
+                    .map(|child| child.ident.name);
                 if let Some(reexport) = reexport {
                     *name = reexport;
                 }
@@ -392,7 +392,7 @@ pub trait PrettyPrinter<'tcx>:
             // Re-exported `extern crate` (#43189).
             DefPathData::CrateRoot => {
                 data = DefPathData::TypeNs(
-                    self.tcx().original_crate_name(def_id.krate).as_interned_str(),
+                    self.tcx().original_crate_name(def_id.krate),
                 );
             }
             _ => {}
@@ -1222,7 +1222,7 @@ impl<F: fmt::Write> Printer<'tcx> for FmtPrinter<'_, 'tcx, F> {
 
         // FIXME(eddyb) `name` should never be empty, but it
         // currently is for `extern { ... }` "foreign modules".
-        let name = disambiguated_data.data.as_interned_str().as_str();
+        let name = disambiguated_data.data.as_symbol().as_str();
         if !name.is_empty() {
             if !self.empty_path {
                 write!(self, "::")?;

--- a/src/librustc/ty/query/keys.rs
+++ b/src/librustc/ty/query/keys.rs
@@ -11,7 +11,7 @@ use crate::mir;
 use std::fmt::Debug;
 use std::hash::Hash;
 use syntax_pos::{Span, DUMMY_SP};
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 
 /// The `Key` trait controls what types can legally be used as the key
 /// for a query.
@@ -190,7 +190,7 @@ impl<'tcx> Key for traits::Environment<'tcx> {
     }
 }
 
-impl Key for InternedString {
+impl Key for Symbol {
     fn query_crate(&self) -> CrateNum {
         LOCAL_CRATE
     }

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -55,7 +55,6 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::any::type_name;
 use syntax_pos::{Span, DUMMY_SP};
-use syntax_pos::symbol::InternedString;
 use syntax::attr;
 use syntax::ast;
 use syntax::feature_gate;

--- a/src/librustc/ty/query/values.rs
+++ b/src/librustc/ty/query/values.rs
@@ -1,7 +1,7 @@
 use crate::ty::{self, Ty, TyCtxt, AdtSizedConstraint};
 use crate::ty::util::NeedsDrop;
 
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 
 pub(super) trait Value<'tcx>: Sized {
     fn from_cycle_error(tcx: TyCtxt<'tcx>) -> Self;
@@ -22,7 +22,7 @@ impl<'tcx> Value<'tcx> for Ty<'tcx> {
 
 impl<'tcx> Value<'tcx> for ty::SymbolName {
     fn from_cycle_error(_: TyCtxt<'tcx>) -> Self {
-        ty::SymbolName { name: InternedString::intern("<error>") }
+        ty::SymbolName { name: Symbol::intern("<error>") }
     }
 }
 

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -24,7 +24,7 @@ use std::marker::PhantomData;
 use std::ops::Range;
 use rustc_target::spec::abi;
 use syntax::ast::{self, Ident};
-use syntax::symbol::{kw, InternedString};
+use syntax::symbol::{kw, Symbol};
 
 use self::InferTy::*;
 use self::TyKind::*;
@@ -55,7 +55,7 @@ pub enum BoundRegion {
     ///
     /// The `DefId` is needed to distinguish free regions in
     /// the event of shadowing.
-    BrNamed(DefId, InternedString),
+    BrNamed(DefId, Symbol),
 
     /// Anonymous region for the implicit env pointer parameter
     /// to a closure
@@ -1123,16 +1123,16 @@ pub type CanonicalPolyFnSig<'tcx> = Canonical<'tcx, Binder<FnSig<'tcx>>>;
          Hash, RustcEncodable, RustcDecodable, HashStable)]
 pub struct ParamTy {
     pub index: u32,
-    pub name: InternedString,
+    pub name: Symbol,
 }
 
 impl<'tcx> ParamTy {
-    pub fn new(index: u32, name: InternedString) -> ParamTy {
+    pub fn new(index: u32, name: Symbol) -> ParamTy {
         ParamTy { index, name: name }
     }
 
     pub fn for_self() -> ParamTy {
-        ParamTy::new(0, kw::SelfUpper.as_interned_str())
+        ParamTy::new(0, kw::SelfUpper)
     }
 
     pub fn for_def(def: &ty::GenericParamDef) -> ParamTy {
@@ -1148,11 +1148,11 @@ impl<'tcx> ParamTy {
          Eq, PartialEq, Ord, PartialOrd, HashStable)]
 pub struct ParamConst {
     pub index: u32,
-    pub name: InternedString,
+    pub name: Symbol,
 }
 
 impl<'tcx> ParamConst {
-    pub fn new(index: u32, name: InternedString) -> ParamConst {
+    pub fn new(index: u32, name: Symbol) -> ParamConst {
         ParamConst { index, name }
     }
 
@@ -1325,7 +1325,7 @@ impl<'tcx> rustc_serialize::UseSpecializedDecodable for Region<'tcx> {}
 pub struct EarlyBoundRegion {
     pub def_id: DefId,
     pub index: u32,
-    pub name: InternedString,
+    pub name: Symbol,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, RustcEncodable, RustcDecodable)]
@@ -1389,7 +1389,7 @@ pub struct BoundTy {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, RustcEncodable, RustcDecodable)]
 pub enum BoundTyKind {
     Anon,
-    Param(InternedString),
+    Param(Symbol),
 }
 
 impl_stable_hash_for!(struct BoundTy { var, kind });

--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -36,7 +36,7 @@ use rustc_codegen_ssa::back::write::submit_codegened_module_to_llvm;
 
 use std::ffi::CString;
 use std::time::Instant;
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 use rustc::hir::CodegenFnAttrs;
 
 use crate::value::Value;
@@ -105,7 +105,7 @@ pub fn iter_globals(llmod: &'ll llvm::Module) -> ValueIter<'ll> {
 
 pub fn compile_codegen_unit(
     tcx: TyCtxt<'tcx>,
-    cgu_name: InternedString,
+    cgu_name: Symbol,
     tx_to_llvm_workers: &std::sync::mpsc::Sender<Box<dyn std::any::Any + Send>>,
 ) {
     let prof_timer = tcx.prof.generic_activity("codegen_module");
@@ -131,7 +131,7 @@ pub fn compile_codegen_unit(
 
     fn module_codegen(
         tcx: TyCtxt<'_>,
-        cgu_name: InternedString,
+        cgu_name: Symbol,
     ) -> ModuleCodegen<ModuleLlvm> {
         let cgu = tcx.codegen_unit(cgu_name);
         // Instantiate monomorphizations without filling out definitions yet...

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -221,7 +221,7 @@ impl CodegenCx<'ll, 'tcx> {
                  def_id);
 
         let ty = instance.ty(self.tcx);
-        let sym = self.tcx.symbol_name(instance).name.as_symbol();
+        let sym = self.tcx.symbol_name(instance).name;
 
         debug!("get_static: sym={} instance={:?}", sym, instance);
 

--- a/src/librustc_codegen_llvm/debuginfo/metadata.rs
+++ b/src/librustc_codegen_llvm/debuginfo/metadata.rs
@@ -46,7 +46,7 @@ use std::iter;
 use std::ptr;
 use std::path::{Path, PathBuf};
 use syntax::ast;
-use syntax::symbol::{Interner, InternedString};
+use syntax::symbol::{Interner, Symbol};
 use syntax_pos::{self, Span, FileName};
 
 impl PartialEq for llvm::Metadata {
@@ -2127,7 +2127,7 @@ fn compute_type_parameters(cx: &CodegenCx<'ll, 'tcx>, ty: Ty<'tcx>) -> Option<&'
 
     fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                            generics: &ty::Generics)
-                           -> Vec<InternedString> {
+                           -> Vec<Symbol> {
         let mut names = generics.parent.map_or(vec![], |def_id| {
             get_parameter_names(cx, cx.tcx.generics_of(def_id))
         });

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -36,7 +36,7 @@ use std::ffi::{CStr, CString};
 
 use syntax_pos::{self, Span, Pos};
 use syntax::ast;
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt};
 use rustc_codegen_ssa::traits::*;
 
@@ -490,7 +490,7 @@ impl DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         fn get_parameter_names(cx: &CodegenCx<'_, '_>,
                                generics: &ty::Generics)
-                               -> Vec<InternedString> {
+                               -> Vec<Symbol> {
             let mut names = generics.parent.map_or(vec![], |def_id| {
                 get_parameter_names(cx, cx.tcx.generics_of(def_id))
             });

--- a/src/librustc_codegen_llvm/debuginfo/namespace.rs
+++ b/src/librustc_codegen_llvm/debuginfo/namespace.rs
@@ -35,7 +35,7 @@ pub fn item_namespace(cx: &CodegenCx<'ll, '_>, def_id: DefId) -> &'ll DIScope {
 
     let namespace_name = match def_key.disambiguated_data.data {
         DefPathData::CrateRoot => cx.tcx.crate_name(def_id.krate).as_str(),
-        data => data.as_interned_str().as_str()
+        data => data.as_symbol().as_str()
     };
 
     let namespace_name = SmallCStr::new(&namespace_name);

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -50,7 +50,6 @@ use rustc_codegen_ssa::CompiledModule;
 use errors::{FatalError, Handler};
 use rustc::dep_graph::WorkProduct;
 use syntax_expand::allocator::AllocatorKind;
-use syntax_pos::symbol::InternedString;
 pub use llvm_util::target_features;
 use std::any::Any;
 use std::sync::Arc;
@@ -123,7 +122,7 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
     }
     fn compile_codegen_unit(
         &self, tcx: TyCtxt<'_>,
-        cgu_name: InternedString,
+        cgu_name: Symbol,
         tx: &std::sync::mpsc::Sender<Box<dyn Any + Send>>,
     ) {
         base::compile_codegen_unit(tcx, cgu_name, tx);

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -515,7 +515,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     // unnecessarily.
     if tcx.dep_graph.is_fully_enabled() {
         for cgu in &codegen_units {
-            tcx.codegen_unit(cgu.name().clone());
+            tcx.codegen_unit(cgu.name());
         }
     }
 
@@ -603,7 +603,7 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
         match cgu_reuse {
             CguReuse::No => {
                 let start_time = Instant::now();
-                backend.compile_codegen_unit(tcx, *cgu.name(), &ongoing_codegen.coordinator_send);
+                backend.compile_codegen_unit(tcx, cgu.name(), &ongoing_codegen.coordinator_send);
                 total_codegen_time += start_time.elapsed();
                 false
             }

--- a/src/librustc_codegen_ssa/debuginfo/type_names.rs
+++ b/src/librustc_codegen_ssa/debuginfo/type_names.rs
@@ -221,7 +221,7 @@ pub fn push_debuginfo_type_name<'tcx>(
             output.push_str(&tcx.crate_name(def_id.krate).as_str());
             for path_element in tcx.def_path(def_id).data {
                 output.push_str("::");
-                output.push_str(&path_element.data.as_interned_str().as_str());
+                output.push_str(&path_element.data.as_symbol().as_str());
             }
         } else {
             output.push_str(&tcx.item_name(def_id).as_str());

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -10,7 +10,7 @@ use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use std::sync::Arc;
 use std::sync::mpsc;
 use syntax_expand::allocator::AllocatorKind;
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 
 pub trait BackendTypes {
     type Value: CodegenObject;
@@ -50,7 +50,7 @@ pub trait ExtraBackendMethods: CodegenBackend + WriteBackendMethods + Sized + Se
     fn compile_codegen_unit(
         &self,
         tcx: TyCtxt<'_>,
-        cgu_name: InternedString,
+        cgu_name: Symbol,
         tx_to_llvm_workers: &mpsc::Sender<Box<dyn std::any::Any + Send>>,
     );
     // If find_features is true this won't access `sess.crate_types` by assuming

--- a/src/librustc_codegen_utils/symbol_names.rs
+++ b/src/librustc_codegen_utils/symbol_names.rs
@@ -95,7 +95,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::{self, TyCtxt, Instance};
 use rustc::mir::mono::{MonoItem, InstantiationMode};
 
-use syntax_pos::symbol::InternedString;
+use syntax_pos::symbol::Symbol;
 
 use log::debug;
 
@@ -112,7 +112,7 @@ pub fn provide(providers: &mut Providers<'_>) {
     };
 }
 
-fn symbol_name(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> InternedString {
+fn symbol_name(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> Symbol {
     let def_id = instance.def_id();
     let substs = instance.substs;
 
@@ -123,13 +123,11 @@ fn symbol_name(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> InternedString {
     if def_id.is_local() {
         if tcx.plugin_registrar_fn(LOCAL_CRATE) == Some(def_id) {
             let disambiguator = tcx.sess.local_crate_disambiguator();
-            return
-                InternedString::intern(&tcx.sess.generate_plugin_registrar_symbol(disambiguator));
+            return Symbol::intern(&tcx.sess.generate_plugin_registrar_symbol(disambiguator));
         }
         if tcx.proc_macro_decls_static(LOCAL_CRATE) == Some(def_id) {
             let disambiguator = tcx.sess.local_crate_disambiguator();
-            return
-                InternedString::intern(&tcx.sess.generate_proc_macro_decls_symbol(disambiguator));
+            return Symbol::intern(&tcx.sess.generate_proc_macro_decls_symbol(disambiguator));
         }
     }
 
@@ -146,22 +144,21 @@ fn symbol_name(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> InternedString {
     let attrs = tcx.codegen_fn_attrs(def_id);
     if is_foreign {
         if let Some(name) = attrs.link_name {
-            return name.as_interned_str();
+            return name;
         }
         // Don't mangle foreign items.
-        return tcx.item_name(def_id).as_interned_str();
+        return tcx.item_name(def_id);
     }
 
-    if let Some(name) = &attrs.export_name {
+    if let Some(name) = attrs.export_name {
         // Use provided name
-        return name.as_interned_str();
+        return name;
     }
 
     if attrs.flags.contains(CodegenFnAttrFlags::NO_MANGLE) {
         // Don't mangle
-        return tcx.item_name(def_id).as_interned_str();
+        return tcx.item_name(def_id);
     }
-
 
     let is_generic = substs.non_erasable_generics().next().is_some();
     let avoid_cross_crate_conflicts =
@@ -222,5 +219,5 @@ fn symbol_name(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> InternedString {
         SymbolManglingVersion::V0 => v0::mangle(tcx, instance, instantiating_crate),
     };
 
-    InternedString::intern(&mangled)
+    Symbol::intern(&mangled)
 }

--- a/src/librustc_codegen_utils/symbol_names/legacy.rs
+++ b/src/librustc_codegen_utils/symbol_names/legacy.rs
@@ -335,7 +335,7 @@ impl Printer<'tcx> for SymbolPrinter<'tcx> {
             self.path.finalize_pending_component();
         }
 
-        self.write_str(&disambiguated_data.data.as_interned_str().as_str())?;
+        self.write_str(&disambiguated_data.data.as_symbol().as_str())?;
         Ok(self)
     }
     fn path_generic_args(

--- a/src/librustc_incremental/assert_module_sources.rs
+++ b/src/librustc_incremental/assert_module_sources.rs
@@ -27,7 +27,7 @@ use rustc::mir::mono::CodegenUnitNameBuilder;
 use rustc::ty::TyCtxt;
 use std::collections::BTreeSet;
 use syntax::ast;
-use syntax::symbol::{InternedString, Symbol, sym};
+use syntax::symbol::{Symbol, sym};
 use rustc::ich::{ATTR_PARTITION_REUSED, ATTR_PARTITION_CODEGENED,
                  ATTR_EXPECTED_CGU_REUSE};
 
@@ -45,8 +45,8 @@ pub fn assert_module_sources(tcx: TyCtxt<'_>) {
             .collect_and_partition_mono_items(LOCAL_CRATE)
             .1
             .iter()
-            .map(|cgu| *cgu.name())
-            .collect::<BTreeSet<InternedString>>();
+            .map(|cgu| cgu.name())
+            .collect::<BTreeSet<Symbol>>();
 
         let ams = AssertModuleSource {
             tcx,
@@ -61,7 +61,7 @@ pub fn assert_module_sources(tcx: TyCtxt<'_>) {
 
 struct AssertModuleSource<'tcx> {
     tcx: TyCtxt<'tcx>,
-    available_cgus: BTreeSet<InternedString>,
+    available_cgus: BTreeSet<Symbol>,
 }
 
 impl AssertModuleSource<'tcx> {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -460,7 +460,7 @@ impl cstore::CStore {
 
         LoadedMacro::MacroDef(ast::Item {
             // FIXME: cross-crate hygiene
-            ident: ast::Ident::with_dummy_span(name.as_symbol()),
+            ident: ast::Ident::with_dummy_span(name),
             id: ast::DUMMY_NODE_ID,
             span: local_span,
             attrs: attrs.iter().cloned().collect(),

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -35,7 +35,7 @@ use syntax::ast::{self, Ident};
 use syntax::source_map::{self, respan, Spanned};
 use syntax::symbol::{Symbol, sym};
 use syntax_expand::base::{MacroKind, SyntaxExtensionKind, SyntaxExtension};
-use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, symbol::{InternedString}};
+use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP};
 use log::debug;
 use proc_macro::bridge::client::ProcMacro;
 use syntax_expand::proc_macro::{AttrProcMacro, ProcMacroDerive, BangProcMacro};
@@ -514,7 +514,6 @@ impl<'a, 'tcx> CrateMetadata {
                 .data
                 .get_opt_name()
                 .expect("no name in item_name")
-                .as_symbol()
         } else {
             Symbol::intern(self.raw_proc_macro(item_index).name())
         }
@@ -864,7 +863,7 @@ impl<'a, 'tcx> CrateMetadata {
                 let span = self.get_span(child_index, sess);
                 if let (Some(kind), Some(name)) =
                     (self.def_kind(child_index), def_key.disambiguated_data.data.get_opt_name()) {
-                    let ident = Ident::from_interned_str(name);
+                    let ident = Ident::with_dummy_span(name);
                     let vis = self.get_visibility(child_index);
                     let def_id = self.local_def_id(child_index);
                     let res = Res::Def(kind, def_id);
@@ -987,7 +986,7 @@ impl<'a, 'tcx> CrateMetadata {
         };
 
         ty::AssocItem {
-            ident: Ident::from_interned_str(name),
+            ident: Ident::with_dummy_span(name),
             kind,
             vis: self.get_visibility(id),
             defaultness: container.defaultness(),
@@ -1262,7 +1261,7 @@ impl<'a, 'tcx> CrateMetadata {
         let mut key = self.def_path_table.def_key(index);
         if self.is_proc_macro(index) {
             let name = self.raw_proc_macro(index).name();
-            key.disambiguated_data.data = DefPathData::MacroNs(InternedString::intern(name));
+            key.disambiguated_data.data = DefPathData::MacroNs(Symbol::intern(name));
         }
         key
     }

--- a/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
+++ b/src/librustc_mir/borrow_check/nll/region_infer/error_reporting/region_name.rs
@@ -18,14 +18,14 @@ use rustc::ty::print::RegionHighlightMode;
 use rustc_errors::DiagnosticBuilder;
 use syntax::symbol::kw;
 use rustc_data_structures::fx::FxHashMap;
-use syntax_pos::{Span, symbol::InternedString};
+use syntax_pos::{Span, symbol::Symbol};
 
 /// A name for a particular region used in emitting diagnostics. This name could be a generated
 /// name like `'1`, a name used by the user like `'a`, or a name like `'static`.
 #[derive(Debug, Clone)]
 crate struct RegionName {
     /// The name of the region (interned).
-    crate name: InternedString,
+    crate name: Symbol,
     /// Where the region comes from.
     crate source: RegionNameSource,
 }
@@ -109,7 +109,7 @@ impl RegionName {
     }
 
     #[allow(dead_code)]
-    crate fn name(&self) -> InternedString {
+    crate fn name(&self) -> Symbol {
         self.name
     }
 
@@ -273,7 +273,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             }
 
             ty::ReStatic => Some(RegionName {
-                name: kw::StaticLifetime.as_interned_str(),
+                name: kw::StaticLifetime,
                 source: RegionNameSource::Static
             }),
 
@@ -360,7 +360,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         &self,
         tcx: TyCtxt<'tcx>,
         error_region: &RegionKind,
-        name: InternedString,
+        name: Symbol,
     ) -> Span {
         let scope = error_region.free_region_binding_scope(tcx);
         let node = tcx.hir().as_local_hir_id(scope).unwrap_or(hir::DUMMY_HIR_ID);
@@ -837,10 +837,10 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     }
 
     /// Creates a synthetic region named `'1`, incrementing the counter.
-    fn synthesize_region_name(&self, renctx: &mut RegionErrorNamingCtx) -> InternedString {
+    fn synthesize_region_name(&self, renctx: &mut RegionErrorNamingCtx) -> Symbol {
         let c = renctx.counter;
         renctx.counter += 1;
 
-        InternedString::intern(&format!("'{:?}", c))
+        Symbol::intern(&format!("'{:?}", c))
     }
 }

--- a/src/librustc_mir/borrow_check/nll/universal_regions.rs
+++ b/src/librustc_mir/borrow_check/nll/universal_regions.rs
@@ -790,7 +790,7 @@ fn for_each_late_bound_region_defined_on<'tcx>(
                 owner: fn_def_id.index,
                 local_id: *late_bound,
             };
-            let name = tcx.hir().name(hir_id).as_interned_str();
+            let name = tcx.hir().name(hir_id);
             let region_def_id = tcx.hir().local_def_id(hir_id);
             let liberated_region = tcx.mk_region(ty::ReFree(ty::FreeRegion {
                 scope: fn_def_id,

--- a/src/librustc_mir/hair/cx/expr.rs
+++ b/src/librustc_mir/hair/cx/expr.rs
@@ -908,7 +908,7 @@ fn convert_path_expr<'a, 'tcx>(
             let generics = cx.tcx.generics_of(item_def_id);
             let local_def_id = cx.tcx.hir().local_def_id(hir_id);
             let index = generics.param_def_id_to_index[&local_def_id];
-            let name = cx.tcx.hir().name(hir_id).as_interned_str();
+            let name = cx.tcx.hir().name(hir_id);
             let val = ConstValue::Param(ty::ParamConst::new(index, name));
             ExprKind::Literal {
                 literal: cx.tcx.mk_const(

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -148,7 +148,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
 
         self.path.push_str("::");
 
-        self.path.push_str(&disambiguated_data.data.as_interned_str().as_str());
+        self.path.push_str(&disambiguated_data.data.as_symbol().as_str());
         Ok(self)
     }
 

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -762,7 +762,7 @@ fn compute_codegen_unit_name(
         let components = def_path
             .data
             .iter()
-            .map(|part| part.data.as_interned_str());
+            .map(|part| part.data.as_symbol());
 
         let volatile_suffix = if volatile {
             Some("volatile")

--- a/src/librustc_mir/monomorphize/partitioning.rs
+++ b/src/librustc_mir/monomorphize/partitioning.rs
@@ -96,7 +96,7 @@ use std::collections::hash_map::Entry;
 use std::cmp;
 use std::sync::Arc;
 
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 use rustc::hir::CodegenFnAttrFlags;
 use rustc::hir::def::DefKind;
 use rustc::hir::def_id::{CrateNum, DefId, LOCAL_CRATE, CRATE_DEF_INDEX};
@@ -121,7 +121,7 @@ pub enum PartitioningStrategy {
 }
 
 // Anything we can't find a proper codegen unit for goes into this.
-fn fallback_cgu_name(name_builder: &mut CodegenUnitNameBuilder<'_>) -> InternedString {
+fn fallback_cgu_name(name_builder: &mut CodegenUnitNameBuilder<'_>) -> Symbol {
     name_builder.build_cgu_name(LOCAL_CRATE, &["fallback"], Some("cgu"))
 }
 
@@ -185,9 +185,7 @@ where
         internalization_candidates: _,
     } = post_inlining;
 
-    result.sort_by(|cgu1, cgu2| {
-        cgu1.name().cmp(cgu2.name())
-    });
+    result.sort_by_cached_key(|cgu| cgu.name().as_str());
 
     result
 }
@@ -203,7 +201,7 @@ struct PreInliningPartitioning<'tcx> {
 /// to keep track of that.
 #[derive(Clone, PartialEq, Eq, Debug)]
 enum MonoItemPlacement {
-    SingleCgu { cgu_name: InternedString },
+    SingleCgu { cgu_name: Symbol },
     MultipleCgus,
 }
 
@@ -251,8 +249,8 @@ where
             None => fallback_cgu_name(cgu_name_builder),
         };
 
-        let codegen_unit = codegen_units.entry(codegen_unit_name.clone())
-            .or_insert_with(|| CodegenUnit::new(codegen_unit_name.clone()));
+        let codegen_unit = codegen_units.entry(codegen_unit_name)
+            .or_insert_with(|| CodegenUnit::new(codegen_unit_name));
 
         let mut can_be_internalized = true;
         let (linkage, visibility) = mono_item_linkage_and_visibility(
@@ -273,8 +271,7 @@ where
     // crate with just types (for example), we could wind up with no CGU.
     if codegen_units.is_empty() {
         let codegen_unit_name = fallback_cgu_name(cgu_name_builder);
-        codegen_units.insert(codegen_unit_name.clone(),
-                             CodegenUnit::new(codegen_unit_name.clone()));
+        codegen_units.insert(codegen_unit_name, CodegenUnit::new(codegen_unit_name));
     }
 
     PreInliningPartitioning {
@@ -492,7 +489,7 @@ fn merge_codegen_units<'tcx>(
     // smallest into each other) we're sure to start off with a deterministic
     // order (sorted by name). This'll mean that if two cgus have the same size
     // the stable sort below will keep everything nice and deterministic.
-    codegen_units.sort_by_key(|cgu| *cgu.name());
+    codegen_units.sort_by_cached_key(|cgu| cgu.name().as_str());
 
     // Merge the two smallest codegen units until the target size is reached.
     while codegen_units.len() > target_cgu_count {
@@ -537,7 +534,7 @@ fn place_inlined_mono_items<'tcx>(initial_partitioning: PreInliningPartitioning<
             follow_inlining(*root, inlining_map, &mut reachable);
         }
 
-        let mut new_codegen_unit = CodegenUnit::new(old_codegen_unit.name().clone());
+        let mut new_codegen_unit = CodegenUnit::new(old_codegen_unit.name());
 
         // Add all monomorphizations that are not already there.
         for mono_item in reachable {
@@ -564,8 +561,8 @@ fn place_inlined_mono_items<'tcx>(initial_partitioning: PreInliningPartitioning<
                     Entry::Occupied(e) => {
                         let placement = e.into_mut();
                         debug_assert!(match *placement {
-                            MonoItemPlacement::SingleCgu { ref cgu_name } => {
-                                *cgu_name != *new_codegen_unit.name()
+                            MonoItemPlacement::SingleCgu { cgu_name } => {
+                                cgu_name != new_codegen_unit.name()
                             }
                             MonoItemPlacement::MultipleCgus => true,
                         });
@@ -573,7 +570,7 @@ fn place_inlined_mono_items<'tcx>(initial_partitioning: PreInliningPartitioning<
                     }
                     Entry::Vacant(e) => {
                         e.insert(MonoItemPlacement::SingleCgu {
-                            cgu_name: new_codegen_unit.name().clone()
+                            cgu_name: new_codegen_unit.name()
                         });
                     }
                 }
@@ -638,7 +635,7 @@ fn internalize_symbols<'tcx>(
     // accessed from outside its defining codegen unit.
     for cgu in &mut partitioning.codegen_units {
         let home_cgu = MonoItemPlacement::SingleCgu {
-            cgu_name: cgu.name().clone()
+            cgu_name: cgu.name()
         };
 
         for (accessee, linkage_and_visibility) in cgu.items_mut() {
@@ -717,7 +714,7 @@ fn characteristic_def_id_of_mono_item<'tcx>(
     }
 }
 
-type CguNameCache = FxHashMap<(DefId, bool), InternedString>;
+type CguNameCache = FxHashMap<(DefId, bool), Symbol>;
 
 fn compute_codegen_unit_name(
     tcx: TyCtxt<'_>,
@@ -725,7 +722,7 @@ fn compute_codegen_unit_name(
     def_id: DefId,
     volatile: bool,
     cache: &mut CguNameCache,
-) -> InternedString {
+) -> Symbol {
     // Find the innermost module that is not nested within a function.
     let mut current_def_id = def_id;
     let mut cgu_def_id = None;
@@ -777,7 +774,7 @@ fn compute_codegen_unit_name(
 fn numbered_codegen_unit_name(
     name_builder: &mut CodegenUnitNameBuilder<'_>,
     index: usize,
-) -> InternedString {
+) -> Symbol {
     name_builder.build_cgu_name_no_mangle(LOCAL_CRATE, &["cgu"], Some(index))
 }
 
@@ -929,7 +926,7 @@ fn collect_and_partition_mono_items(
             for (&mono_item, &linkage) in cgu.items() {
                 item_to_cgus.entry(mono_item)
                             .or_default()
-                            .push((cgu.name().clone(), linkage));
+                            .push((cgu.name(), linkage));
             }
         }
 
@@ -991,7 +988,7 @@ pub fn provide(providers: &mut Providers<'_>) {
     providers.codegen_unit = |tcx, name| {
         let (_, all) = tcx.collect_and_partition_mono_items(LOCAL_CRATE);
         all.iter()
-            .find(|cgu| *cgu.name() == name)
+            .find(|cgu| cgu.name() == name)
             .cloned()
             .unwrap_or_else(|| panic!("failed to find cgu with name {:?}", name))
     };

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -12,7 +12,7 @@ use rustc::lint::builtin::{SAFE_EXTERN_STATICS, SAFE_PACKED_BORROWS, UNUSED_UNSA
 use rustc::mir::*;
 use rustc::mir::visit::{PlaceContext, Visitor, MutatingUseContext};
 
-use syntax::symbol::{InternedString, sym};
+use syntax::symbol::{Symbol, sym};
 
 use std::ops::Bound;
 
@@ -167,9 +167,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                     (CastTy::FnPtr, CastTy::Int(_)) => {
                         self.register_violations(&[UnsafetyViolation {
                             source_info: self.source_info,
-                            description: InternedString::intern("cast of pointer to int"),
-                            details: InternedString::intern(
-                                "casting pointers to integers in constants"),
+                            description: Symbol::intern("cast of pointer to int"),
+                            details: Symbol::intern("casting pointers to integers in constants"),
                             kind: UnsafetyViolationKind::General,
                         }], &[]);
                     },
@@ -185,8 +184,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                 if let ty::RawPtr(_) | ty::FnPtr(..) = lhs.ty(self.body, self.tcx).kind {
                     self.register_violations(&[UnsafetyViolation {
                         source_info: self.source_info,
-                        description: InternedString::intern("pointer operation"),
-                        details: InternedString::intern("operations on pointers in constants"),
+                        description: Symbol::intern("pointer operation"),
+                        details: Symbol::intern("operations on pointers in constants"),
                         kind: UnsafetyViolationKind::General,
                     }], &[]);
                 }
@@ -219,8 +218,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                         self.source_scope_local_data[source_info.scope].lint_root;
                     self.register_violations(&[UnsafetyViolation {
                         source_info,
-                        description: InternedString::intern("use of extern static"),
-                        details: InternedString::intern(
+                        description: Symbol::intern("use of extern static"),
+                        details: Symbol::intern(
                             "extern statics are not controlled by the Rust type system: \
                             invalid data, aliasing violations or data races will cause \
                             undefined behavior"),
@@ -240,8 +239,8 @@ impl<'a, 'tcx> Visitor<'tcx> for UnsafetyChecker<'a, 'tcx> {
                         self.source_scope_local_data[source_info.scope].lint_root;
                     self.register_violations(&[UnsafetyViolation {
                         source_info,
-                        description: InternedString::intern("borrow of packed field"),
-                        details: InternedString::intern(
+                        description: Symbol::intern("borrow of packed field"),
+                        details: Symbol::intern(
                             "fields of packed structs might be misaligned: dereferencing a \
                             misaligned pointer or even just creating a misaligned reference \
                             is undefined behavior"),
@@ -334,8 +333,8 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
         let source_info = self.source_info;
         self.register_violations(&[UnsafetyViolation {
             source_info,
-            description: InternedString::intern(description),
-            details: InternedString::intern(details),
+            description: Symbol::intern(description),
+            details: Symbol::intern(details),
             kind,
         }], &[]);
     }
@@ -438,8 +437,8 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
                                 let source_info = self.source_info;
                                 self.register_violations(&[UnsafetyViolation {
                                     source_info,
-                                    description: InternedString::intern(description),
-                                    details: InternedString::intern(details),
+                                    description: Symbol::intern(description),
+                                    details: Symbol::intern(details),
                                     kind: UnsafetyViolationKind::GeneralAndConstFn,
                                 }], &[]);
                             }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -110,14 +110,14 @@ impl<'a> Resolver<'a> {
         }
 
         let (name, parent) = if def_id.index == CRATE_DEF_INDEX {
-            (self.cstore.crate_name_untracked(def_id.krate).as_interned_str(), None)
+            (self.cstore.crate_name_untracked(def_id.krate), None)
         } else {
             let def_key = self.cstore.def_key(def_id);
             (def_key.disambiguated_data.data.get_opt_name().unwrap(),
              Some(self.get_module(DefId { index: def_key.parent.unwrap(), ..def_id })))
         };
 
-        let kind = ModuleKind::Def(DefKind::Mod, def_id, name.as_symbol());
+        let kind = ModuleKind::Def(DefKind::Mod, def_id, name);
         let module = self.arenas.alloc_module(ModuleData::new(
             parent, kind, def_id, ExpnId::root(), DUMMY_SP
         ));

--- a/src/librustc_typeck/astconv.rs
+++ b/src/librustc_typeck/astconv.rs
@@ -131,7 +131,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     {
         let tcx = self.tcx();
         let lifetime_name = |def_id| {
-            tcx.hir().name(tcx.hir().as_local_hir_id(def_id).unwrap()).as_interned_str()
+            tcx.hir().name(tcx.hir().as_local_hir_id(def_id).unwrap())
         };
 
         let r = match tcx.named_region(lifetime.hir_id) {
@@ -2023,7 +2023,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 let item_def_id = tcx.hir().local_def_id(item_id);
                 let generics = tcx.generics_of(item_def_id);
                 let index = generics.param_def_id_to_index[&def_id];
-                tcx.mk_ty_param(index, tcx.hir().name(hir_id).as_interned_str())
+                tcx.mk_ty_param(index, tcx.hir().name(hir_id))
             }
             Res::SelfTy(Some(_), None) => {
                 // `Self` in trait or type alias.
@@ -2204,7 +2204,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             let item_def_id = tcx.hir().local_def_id(item_id);
             let generics = tcx.generics_of(item_def_id);
             let index = generics.param_def_id_to_index[&tcx.hir().local_def_id(hir_id)];
-            let name = tcx.hir().name(hir_id).as_interned_str();
+            let name = tcx.hir().name(hir_id);
             const_.val = ConstValue::Param(ty::ParamConst::new(index, name));
         }
 

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -7,7 +7,7 @@ use rustc::ty::subst::Subst;
 use crate::require_same_types;
 
 use rustc_target::spec::abi::Abi;
-use syntax::symbol::InternedString;
+use syntax::symbol::Symbol;
 
 use rustc::hir;
 
@@ -80,7 +80,7 @@ pub fn intrinsic_operation_unsafety(intrinsic: &str) -> hir::Unsafety {
 /// Remember to add all intrinsics here, in librustc_codegen_llvm/intrinsic.rs,
 /// and in libcore/intrinsics.rs
 pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
-    let param = |n| tcx.mk_ty_param(n, InternedString::intern(&format!("P{}", n)));
+    let param = |n| tcx.mk_ty_param(n, Symbol::intern(&format!("P{}", n)));
     let name = it.ident.as_str();
 
     let mk_va_list_ty = |mutbl| {
@@ -387,7 +387,7 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
 /// Type-check `extern "platform-intrinsic" { ... }` functions.
 pub fn check_platform_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
     let param = |n| {
-        let name = InternedString::intern(&format!("P{}", n));
+        let name = Symbol::intern(&format!("P{}", n));
         tcx.mk_ty_param(n, name)
     };
 

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -36,7 +36,7 @@ use syntax::ast;
 use syntax::ast::{Ident, MetaItemKind};
 use syntax::attr::{InlineAttr, OptimizeAttr, list_contains_name, mark_used};
 use syntax::feature_gate;
-use syntax::symbol::{InternedString, kw, Symbol, sym};
+use syntax::symbol::{kw, Symbol, sym};
 use syntax_pos::{Span, DUMMY_SP};
 
 use rustc::hir::def::{CtorKind, Res, DefKind};
@@ -265,7 +265,7 @@ fn type_param_predicates(
     let param_owner_def_id = tcx.hir().local_def_id(param_owner);
     let generics = tcx.generics_of(param_owner_def_id);
     let index = generics.param_def_id_to_index[&def_id];
-    let ty = tcx.mk_ty_param(index, tcx.hir().ty_param_name(param_id).as_interned_str());
+    let ty = tcx.mk_ty_param(index, tcx.hir().ty_param_name(param_id));
 
     // Don't look for bounds where the type parameter isn't in scope.
     let parent = if item_def_id == param_owner_def_id {
@@ -961,7 +961,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
 
                     opt_self = Some(ty::GenericParamDef {
                         index: 0,
-                        name: kw::SelfUpper.as_interned_str(),
+                        name: kw::SelfUpper,
                         def_id: tcx.hir().local_def_id(param_id),
                         pure_wrt_drop: false,
                         kind: ty::GenericParamDefKind::Type {
@@ -1006,7 +1006,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
         early_lifetimes
             .enumerate()
             .map(|(i, param)| ty::GenericParamDef {
-                name: param.name.ident().as_interned_str(),
+                name: param.name.ident().name,
                 index: own_start + i as u32,
                 def_id: tcx.hir().local_def_id(param.hir_id),
                 pure_wrt_drop: param.pure_wrt_drop,
@@ -1060,7 +1060,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
 
                 let param_def = ty::GenericParamDef {
                     index: type_start + i as u32,
-                    name: param.name.ident().as_interned_str(),
+                    name: param.name.ident().name,
                     def_id: tcx.hir().local_def_id(param.hir_id),
                     pure_wrt_drop: param.pure_wrt_drop,
                     kind,
@@ -1090,7 +1090,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
                 .enumerate()
                 .map(|(i, &arg)| ty::GenericParamDef {
                     index: type_start + i as u32,
-                    name: InternedString::intern(arg),
+                    name: Symbol::intern(arg),
                     def_id,
                     pure_wrt_drop: false,
                     kind: ty::GenericParamDefKind::Type {
@@ -1105,7 +1105,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> &ty::Generics {
             params.extend(upvars.iter().zip((dummy_args.len() as u32)..).map(|(_, i)| {
                 ty::GenericParamDef {
                     index: type_start + i,
-                    name: InternedString::intern("<upvar>"),
+                    name: Symbol::intern("<upvar>"),
                     def_id,
                     pure_wrt_drop: false,
                     kind: ty::GenericParamDefKind::Type {
@@ -2198,7 +2198,7 @@ fn explicit_predicates_of(
         let region = tcx.mk_region(ty::ReEarlyBound(ty::EarlyBoundRegion {
             def_id: tcx.hir().local_def_id(param.hir_id),
             index,
-            name: param.name.ident().as_interned_str(),
+            name: param.name.ident().name,
         }));
         index += 1;
 
@@ -2221,7 +2221,7 @@ fn explicit_predicates_of(
     // type parameter (e.g., `<T: Foo>`).
     for param in &ast_generics.params {
         if let GenericParamKind::Type { .. } = param.kind {
-            let name = param.name.ident().as_interned_str();
+            let name = param.name.ident().name;
             let param_ty = ty::ParamTy::new(index, name).to_ty(tcx);
             index += 1;
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -31,7 +31,6 @@ use syntax::attr;
 use syntax_expand::base::MacroKind;
 use syntax::source_map::DUMMY_SP;
 use syntax::symbol::{Symbol, kw, sym};
-use syntax::symbol::InternedString;
 use syntax_pos::{self, Pos, FileName};
 
 use std::collections::hash_map::Entry;
@@ -3695,13 +3694,6 @@ impl Clean<String> for Ident {
 }
 
 impl Clean<String> for ast::Name {
-    #[inline]
-    fn clean(&self, _: &DocContext<'_>) -> String {
-        self.to_string()
-    }
-}
-
-impl Clean<String> for InternedString {
     #[inline]
     fn clean(&self, _: &DocContext<'_>) -> String {
         self.to_string()

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1682,7 +1682,7 @@ impl<'a, 'tcx> Clean<Generics> for (&'a ty::Generics, ty::GenericPredicates<'tcx
             .filter_map(|param| match param.kind {
                 ty::GenericParamDefKind::Lifetime => None,
                 ty::GenericParamDefKind::Type { synthetic, .. } => {
-                    if param.name.as_symbol() == kw::SelfUpper {
+                    if param.name == kw::SelfUpper {
                         assert_eq!(param.index, 0);
                         return None;
                     }

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -9,7 +9,7 @@ use rustc_macros::symbols;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_serialize::{UseSpecializedDecodable, UseSpecializedEncodable};
 
-use std::cmp::{PartialEq, Ordering, PartialOrd, Ord};
+use std::cmp::{PartialEq, PartialOrd, Ord};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str;
@@ -766,11 +766,6 @@ impl Ident {
         Ident::with_dummy_span(kw::Invalid)
     }
 
-    /// Maps an interned string to an identifier with an empty syntax context.
-    pub fn from_interned_str(string: InternedString) -> Ident {
-        Ident::with_dummy_span(string.as_symbol())
-    }
-
     /// Maps a string to an identifier with a dummy span.
     pub fn from_str(string: &str) -> Ident {
         Ident::with_dummy_span(Symbol::intern(string))
@@ -812,11 +807,6 @@ impl Ident {
     /// operation because it requires locking the symbol interner.
     pub fn as_str(self) -> LocalInternedString {
         self.name.as_str()
-    }
-
-    /// Convert the name to an `InternedString`.
-    pub fn as_interned_str(self) -> InternedString {
-        self.name.as_interned_str()
     }
 }
 
@@ -903,15 +893,6 @@ impl Symbol {
         })
     }
 
-    /// Access two symbols' chars. This is a slowish operation because it
-    /// requires locking the symbol interner, but it is faster than calling
-    /// `with()` twice.
-    fn with2<F: FnOnce(&str, &str) -> R, R>(self, other: Symbol, f: F) -> R {
-        with_interner(|interner| {
-            f(interner.get(self), interner.get(other))
-        })
-    }
-
     /// Convert to a `LocalInternedString`. This is a slowish operation because
     /// it requires locking the symbol interner.
     pub fn as_str(self) -> LocalInternedString {
@@ -920,11 +901,6 @@ impl Symbol {
                 string: std::mem::transmute::<&str, &str>(interner.get(self))
             }
         })
-    }
-
-    /// Convert to an `InternedString`.
-    pub fn as_interned_str(self) -> InternedString {
-        InternedString { symbol: self }
     }
 
     pub fn as_u32(self) -> u32 {
@@ -1105,9 +1081,9 @@ fn with_interner<T, F: FnOnce(&mut Interner) -> T>(f: F) -> T {
     GLOBALS.with(|globals| f(&mut *globals.symbol_interner.lock()))
 }
 
-/// An alternative to `Symbol` and `InternedString`, useful when the chars
-/// within the symbol need to be accessed. It deliberately has limited
-/// functionality and should only be used for temporary values.
+/// An alternative to `Symbol`, useful when the chars within the symbol need to
+/// be accessed. It deliberately has limited functionality and should only be
+/// used for temporary values.
 ///
 /// Because the interner outlives any thread which uses this type, we can
 /// safely treat `string` which points to interner data, as an immortal string,
@@ -1116,7 +1092,7 @@ fn with_interner<T, F: FnOnce(&mut Interner) -> T>(f: F) -> T {
 // FIXME: ensure that the interner outlives any thread which uses
 // `LocalInternedString`, by creating a new thread right after constructing the
 // interner.
-#[derive(Eq, PartialOrd, Ord)]
+#[derive(Clone, Eq, PartialOrd, Ord)]
 pub struct LocalInternedString {
     string: &'static str,
 }
@@ -1155,91 +1131,5 @@ impl fmt::Debug for LocalInternedString {
 impl fmt::Display for LocalInternedString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.string, f)
-    }
-}
-
-/// An alternative to `Symbol` that is focused on string contents.
-///
-/// Its implementations of `Hash`, `PartialOrd` and `Ord` work with the
-/// string chars rather than the symbol integer. This is useful when hash
-/// stability is required across compile sessions, or a guaranteed sort
-/// ordering is required.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct InternedString {
-    symbol: Symbol,
-}
-
-impl InternedString {
-    /// Maps a string to its interned representation.
-    pub fn intern(string: &str) -> Self {
-        InternedString {
-            symbol: Symbol::intern(string)
-        }
-    }
-
-    pub fn with<F: FnOnce(&str) -> R, R>(self, f: F) -> R {
-        self.symbol.with(f)
-    }
-
-    fn with2<F: FnOnce(&str, &str) -> R, R>(self, other: &InternedString, f: F) -> R {
-        self.symbol.with2(other.symbol, f)
-    }
-
-    pub fn as_symbol(self) -> Symbol {
-        self.symbol
-    }
-
-    /// Convert to a `LocalInternedString`. This is a slowish operation because it
-    /// requires locking the symbol interner.
-    pub fn as_str(self) -> LocalInternedString {
-        self.symbol.as_str()
-    }
-}
-
-impl Hash for InternedString {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.with(|str| str.hash(state))
-    }
-}
-
-impl PartialOrd<InternedString> for InternedString {
-    fn partial_cmp(&self, other: &InternedString) -> Option<Ordering> {
-        if self.symbol == other.symbol {
-            return Some(Ordering::Equal);
-        }
-        self.with2(other, |self_str, other_str| self_str.partial_cmp(other_str))
-    }
-}
-
-impl Ord for InternedString {
-    fn cmp(&self, other: &InternedString) -> Ordering {
-        if self.symbol == other.symbol {
-            return Ordering::Equal;
-        }
-        self.with2(other, |self_str, other_str| self_str.cmp(other_str))
-    }
-}
-
-impl fmt::Debug for InternedString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with(|str| fmt::Debug::fmt(&str, f))
-    }
-}
-
-impl fmt::Display for InternedString {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.with(|str| fmt::Display::fmt(&str, f))
-    }
-}
-
-impl Decodable for InternedString {
-    fn decode<D: Decoder>(d: &mut D) -> Result<InternedString, D::Error> {
-        Ok(InternedString::intern(&d.read_str()?))
-    }
-}
-
-impl Encodable for InternedString {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        self.with(|string| s.emit_str(string))
     }
 }

--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -126,7 +126,6 @@ fn check(cache: &mut Cache,
     // FIXME(#32129)
     if file.ends_with("std/string/struct.String.html") ||
        file.ends_with("interpret/struct.ImmTy.html") ||
-       file.ends_with("symbol/struct.InternedString.html") ||
        file.ends_with("ast/struct.ThinVec.html") ||
        file.ends_with("util/struct.ThinVec.html") ||
        file.ends_with("layout/struct.TyLayout.html") ||


### PR DESCRIPTION
This PR removes `InternedString` by converting all occurrences to `Symbol`. There are a handful of places that need to use the symbol chars instead of the symbol index, e.g. for stable sorting; local conversions `LocalInternedString` is used in those places.

r? @eddyb 