### PR TITLE
Deprecated proc_macro doesn't trigger warning on build library

### DIFF
--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -416,6 +416,16 @@ fn mk_decls(
     ).map(|mut i| {
         let attr = cx.meta_word(span, sym::rustc_proc_macro_decls);
         i.attrs.push(cx.attribute(attr));
+
+        let deprecated_attr = attr::mk_nested_word_item(
+            Ident::new(sym::deprecated, span)
+        );
+        let allow_deprecated_attr = attr::mk_list_item(
+            Ident::new(sym::allow, span),
+            vec![deprecated_attr]
+        );
+        i.attrs.push(cx.attribute(allow_deprecated_attr));
+
         i
     });
 

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -337,6 +337,7 @@ impl<'a> Visitor<'a> for CollectProcMacros<'a> {
 //          use proc_macro::bridge::client::ProcMacro;
 //
 //          #[rustc_proc_macro_decls]
+//          #[allow(deprecated)]
 //          static DECLS: &[ProcMacro] = &[
 //              ProcMacro::custom_derive($name_trait1, &[], ::$name1);
 //              ProcMacro::custom_derive($name_trait2, &["attribute_name"], ::$name2);

--- a/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
+++ b/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
@@ -1,0 +1,15 @@
+// build-pass
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::*;
+
+#[proc_macro]
+#[deprecated(since = "1.0.0", note = "test")]
+pub fn test_compile_without_warning_with_deprecated(_: TokenStream) -> TokenStream {
+    "
+    extern crate proc_macro;
+    fn foo() { }
+    ".parse().unwrap()
+}

--- a/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
+++ b/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
@@ -1,4 +1,6 @@
 // check-pass
+// force-host
+// no-prefer-dynamic
 
 #![deny(deprecated)]
 

--- a/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
+++ b/src/test/ui/proc-macro/proc-macro-deprecated-attr.rs
@@ -1,4 +1,6 @@
-// build-pass
+// check-pass
+
+#![deny(deprecated)]
 
 #![crate_type = "proc-macro"]
 
@@ -8,8 +10,5 @@ use proc_macro::*;
 #[proc_macro]
 #[deprecated(since = "1.0.0", note = "test")]
 pub fn test_compile_without_warning_with_deprecated(_: TokenStream) -> TokenStream {
-    "
-    extern crate proc_macro;
-    fn foo() { }
-    ".parse().unwrap()
+    TokenStream::new()
 }


### PR DESCRIPTION
Fix #65189