### PR TITLE
Use 1-based indexing for columns in debuginfo

### DIFF
--- a/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
+++ b/src/librustc_codegen_llvm/debuginfo/create_scope_map.rs
@@ -81,13 +81,14 @@ fn make_mir_scope(cx: &CodegenCx<'ll, '_>,
                                       &loc.file.name,
                                       debug_context.defining_crate);
 
+    let col1 = loc.col.to_usize() + 1; // One-based column index
     let scope_metadata = unsafe {
         Some(llvm::LLVMRustDIBuilderCreateLexicalBlock(
             DIB(cx),
             parent_scope.scope_metadata.unwrap(),
             file_metadata,
             loc.line as c_uint,
-            loc.col.to_usize() as c_uint))
+            col1 as c_uint))
     };
     debug_context.scopes[scope] = DebugScope {
         scope_metadata,

--- a/src/librustc_codegen_llvm/debuginfo/mod.rs
+++ b/src/librustc_codegen_llvm/debuginfo/mod.rs
@@ -35,7 +35,7 @@ use std::cell::RefCell;
 use std::ffi::{CStr, CString};
 
 use smallvec::SmallVec;
-use syntax_pos::{self, BytePos, Span, Pos};
+use syntax_pos::{self, BytePos, Span};
 use syntax::ast;
 use syntax::symbol::Symbol;
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt, Size};
@@ -209,8 +209,10 @@ impl DebugInfoBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 align.bytes() as u32,
             )
         };
-        source_loc::set_debug_location(self,
-            InternalDebugLocation::new(scope_metadata, loc.line, loc.col.to_usize()));
+
+        let debug_loc = InternalDebugLocation::from_span(cx, scope_metadata, span);
+        source_loc::set_debug_location(self, debug_loc);
+
         unsafe {
             let debug_loc = llvm::LLVMGetCurrentDebugLocation(self.llbuilder);
             let instr = llvm::LLVMRustDIBuilderInsertDeclareAtEnd(

--- a/src/librustc_codegen_llvm/debuginfo/source_loc.rs
+++ b/src/librustc_codegen_llvm/debuginfo/source_loc.rs
@@ -60,7 +60,7 @@ pub fn set_debug_location(
             let col_used =  if bx.sess().target.target.options.is_like_msvc {
                 UNKNOWN_COLUMN_NUMBER
             } else {
-                col as c_uint
+                (col + 1) as c_uint
             };
             debug!("setting debug location to {} {}", line, col);
 

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -280,6 +280,13 @@ impl Span {
         self.data().with_ctxt(ctxt)
     }
 
+    #[inline]
+    /// Returns `true` if this `Span` contains no text.
+    pub fn is_empty(self) -> bool {
+        let span = self.data();
+        span.lo == span.hi
+    }
+
     /// Returns `true` if this is a dummy span with any hygienic context.
     #[inline]
     pub fn is_dummy(self) -> bool {

--- a/src/test/codegen/debug-column-1-based.rs
+++ b/src/test/codegen/debug-column-1-based.rs
@@ -1,0 +1,22 @@
+// Ensure that columns emitted in DWARF are 1-based
+
+// ignore-windows
+// compile-flags: -g -C no-prepopulate-passes
+
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_assignments)]
+
+fn main() {      // 10
+    let x = 32;  // 11
+}                // 12
+//  |   |
+//  |   |
+//  5   9        column index
+
+// CHECK-LABEL: !DISubprogram(name: "main"
+// CHECK:       !DILocalVariable(name: "x",{{.*}}line: 11{{[^0-9]}}
+// CHECK-NEXT:  !DILexicalBlock({{.*}}line: 11, column: 5{{[^0-9]}}
+// CHECK-NEXT:  !DILocation(line: 11, column: 9{{[^0-9]}}
+// CHECK:       !DILocation(line: 12, column: 1{{[^0-9]}}
+// CHECK-EMPTY:


### PR DESCRIPTION
**edited from original**

Resolves #65437.

This fixes an off-by-one error when writing column numbers in DWARF, which uses 1-based indexing.

For the newly added test, the resulting debuginfo is:

```llvm
!129 = distinct !DISubprogram(name: "main", linkageName: "_ZN20debug_column_1_based4main17h2f9f746428050388E", scope: !130, file: !18, line: 16, type: !12, scopeLine: 16, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized | DISPFlagMainSubprogram, unit: !17, templateParams: !4, retainedNodes: !131)
!130 = !DINamespace(name: "debug_column_1_based", scope: null)
!131 = !{!132}
!132 = !DILocalVariable(name: "x", scope: !133, file: !18, line: 11, type: !46, align: 4)
!133 = distinct !DILexicalBlock(scope: !129, file: !18, line: 11, column: 5)
!134 = !DILocation(line: 11, column: 9, scope: !133)
!135 = !DILocation(line: 11, column: 9, scope: !129)
!136 = !DILocation(line: 11, column: 13, scope: !129)
!137 = !DILocation(line: 12, column: 1, scope: !129)
```

You can see that the locations for `x` and `32` are correct (columns 9 and 13 respectively), the `DILexicalBlock` for `main` begins at column 5 (the first `let` statement) and the implicit return statement has column 1 (the closing `}`).

r? @michaelwoerister