### PR TITLE
Dual proc macro hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "syn 0.15.35",
  "url 2.1.0",
  "winapi 0.3.6",
 ]

--- a/src/librustc/middle/cstore.rs
+++ b/src/librustc/middle/cstore.rs
@@ -216,6 +216,7 @@ pub trait CrateStore {
     fn crate_is_private_dep_untracked(&self, cnum: CrateNum) -> bool;
     fn crate_disambiguator_untracked(&self, cnum: CrateNum) -> CrateDisambiguator;
     fn crate_hash_untracked(&self, cnum: CrateNum) -> Svh;
+    fn crate_host_hash_untracked(&self, cnum: CrateNum) -> Option<Svh>;
     fn item_generics_cloned_untracked(&self, def: DefId, sess: &Session) -> ty::Generics;
     fn postorder_cnums_untracked(&self) -> Vec<CrateNum>;
 

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -754,6 +754,10 @@ rustc_queries! {
             eval_always
             desc { "looking up the hash a crate" }
         }
+        query crate_host_hash(_: CrateNum) -> Option<Svh> {
+            eval_always
+            desc { "looking up the hash of a host version of a crate" }
+        }
         query original_crate_name(_: CrateNum) -> Symbol {
             eval_always
             desc { "looking up the original name a crate" }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -3015,6 +3015,10 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
         assert_eq!(cnum, LOCAL_CRATE);
         tcx.arena.alloc_slice(&tcx.cstore.crates_untracked())
     };
+    providers.crate_host_hash = |tcx, cnum| {
+        assert_ne!(cnum, LOCAL_CRATE);
+        tcx.cstore.crate_host_hash_untracked(cnum)
+    };
     providers.postorder_cnums = |tcx, cnum| {
         assert_eq!(cnum, LOCAL_CRATE);
         tcx.arena.alloc_slice(&tcx.cstore.postorder_cnums_untracked())

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -10,6 +10,7 @@ use rustc::mir::interpret::AllocDecodingState;
 use rustc_index::vec::IndexVec;
 use rustc::util::nodemap::FxHashMap;
 use rustc_data_structures::sync::{Lrc, Lock, MetadataRef, Once, AtomicCell};
+use rustc_data_structures::svh::Svh;
 use syntax::ast;
 use syntax::edition::Edition;
 use syntax_expand::base::SyntaxExtension;
@@ -87,6 +88,8 @@ crate struct CrateMetadata {
     /// Whether or not this crate should be consider a private dependency
     /// for purposes of the 'exported_private_dependencies' lint
     crate private_dep: bool,
+    /// The hash for the host proc macro. Used to support `-Z dual-proc-macro`.
+    crate host_hash: Option<Svh>,
 
     // --- Data used only for improving diagnostics ---
 

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -505,6 +505,10 @@ impl CrateStore for cstore::CStore {
         self.get_crate_data(cnum).root.hash
     }
 
+    fn crate_host_hash_untracked(&self, cnum: CrateNum) -> Option<Svh> {
+        self.get_crate_data(cnum).host_hash
+    }
+
     /// Returns the `DefKey` for a given `DefId`. This indicates the
     /// parent `DefId` as well as some idea of what kind of data the
     /// `DefId` refers to.

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -1418,6 +1418,7 @@ impl EncodeContext<'tcx> {
                 let dep = CrateDep {
                     name: self.tcx.original_crate_name(cnum),
                     hash: self.tcx.crate_hash(cnum),
+                    host_hash: self.tcx.crate_host_hash(cnum),
                     kind: self.tcx.dep_kind(cnum),
                     extra_filename: self.tcx.extra_filename(cnum),
                 };

--- a/src/librustc_metadata/locator.rs
+++ b/src/librustc_metadata/locator.rs
@@ -258,6 +258,7 @@ crate struct Context<'a> {
     pub span: Span,
     pub crate_name: Symbol,
     pub hash: Option<&'a Svh>,
+    pub host_hash: Option<&'a Svh>,
     pub extra_filename: Option<&'a str>,
     // points to either self.sess.target.target or self.sess.host, must match triple
     pub target: &'a Target,
@@ -929,6 +930,7 @@ pub fn find_plugin_registrar(
         span,
         crate_name: name,
         hash: None,
+        host_hash: None,
         extra_filename: None,
         filesearch: sess.host_filesearch(PathKind::Crate),
         target: &sess.host,

--- a/src/librustc_metadata/schema.rs
+++ b/src/librustc_metadata/schema.rs
@@ -217,6 +217,7 @@ crate struct CrateRoot<'tcx> {
 crate struct CrateDep {
     pub name: ast::Name,
     pub hash: Svh,
+    pub host_hash: Option<Svh>,
     pub kind: DepKind,
     pub extra_filename: String,
 }

--- a/src/tools/rustc-workspace-hack/Cargo.toml
+++ b/src/tools/rustc-workspace-hack/Cargo.toml
@@ -64,7 +64,7 @@ serde = { version = "1.0.82", features = ['derive'] }
 serde_json = { version = "1.0.31", features = ["raw_value"] }
 smallvec = { version = "0.6", features = ['union', 'may_dangle'] }
 url = { version = "2.0", features = ['serde'] }
-
+syn = { version = "0.15", features = ['full'] }
 
 [target.'cfg(not(windows))'.dependencies]
 openssl = { version = "0.10.12", optional = true }


### PR DESCRIPTION
This PR changes current `-Z dual-proc-macro` mechanism from resolving only by name to including the hash of the host crate inside the transistive dependency information to prevent name conflicts.
Fix partially #62558