### PR TITLE
Add FFI bindings for LLVM's Module::getInstructionCount()

### DIFF
--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1729,6 +1729,7 @@ extern "C" {
                                ) -> LLVMRustResult;
     pub fn LLVMRustSetLLVMOptions(Argc: c_int, Argv: *const *const c_char);
     pub fn LLVMRustPrintPasses();
+    pub fn LLVMRustGetInstructionCount(M: &Module) -> u32;
     pub fn LLVMRustSetNormalizedTarget(M: &Module, triple: *const c_char);
     pub fn LLVMRustAddAlwaysInlinePass(P: &PassManagerBuilder, AddLifetimes: bool);
     pub fn LLVMRustRunRestrictionPass(M: &Module, syms: *const *const c_char, len: size_t);

--- a/src/rustllvm/RustWrapper.cpp
+++ b/src/rustllvm/RustWrapper.cpp
@@ -87,6 +87,14 @@ extern "C" char *LLVMRustGetLastError(void) {
   return Ret;
 }
 
+extern "C" unsigned int LLVMRustGetInstructionCount(LLVMModuleRef M) {
+#if LLVM_VERSION_GE(7, 0)
+  return unwrap(M)->getInstructionCount();
+#else
+  report_fatal_error("Module::getInstructionCount not available before LLVM 7");
+#endif
+}
+
 extern "C" void LLVMRustSetLastError(const char *Err) {
   free((void *)LastError);
   LastError = strdup(Err);


### PR DESCRIPTION
Just to make it usable for profiling and such inside
rustc itself.  It was vaguely useful in
https://wiki.alopex.li/WhereRustcSpendsItsTime and I figured
I might as well upstream it; I may or may not ever get around
to doing more with it (hopefully I will), but it may be useful
for others.