### PR TITLE
Fix promotion in a `const` when projections are present

### DIFF
--- a/src/test/ui/consts/promote_borrowed_field.rs
+++ b/src/test/ui/consts/promote_borrowed_field.rs
@@ -1,0 +1,12 @@
+// run-pass
+
+// From https://github.com/rust-lang/rust/issues/65727
+
+const _: &i32 = {
+    let x = &(5, false).0;
+    x
+};
+
+fn main() {
+    let _: &'static i32 = &(5, false).0;
+}


### PR DESCRIPTION
Resolves #65727.

This marks the entire local as "needs promotion" when only a projection of that local appears in a promotable context. This should only affect promotion in a `const` or `static`, not in a `fn` or `const fn`, which is handled in `promote_consts.rs`.

r? @eddyb 