### PR TITLE
Coherence should allow fundamental types to impl traits when they are local

### DIFF
--- a/src/test/ui/coherence/impl-foreign-for-locally-defined-fundamental.rs
+++ b/src/test/ui/coherence/impl-foreign-for-locally-defined-fundamental.rs
@@ -1,0 +1,16 @@
+#![feature(fundamental)]
+#![feature(re_rebalance_coherence)]
+
+// compile-flags:--crate-name=test
+// aux-build:coherence_lib.rs
+// check-pass
+
+extern crate coherence_lib as lib;
+use lib::*;
+
+#[fundamental]
+struct Local;
+
+impl Remote for Local {}
+
+fn main() {}

--- a/src/test/ui/coherence/impl-foreign-for-locally-defined-fundamental[foreign].rs
+++ b/src/test/ui/coherence/impl-foreign-for-locally-defined-fundamental[foreign].rs
@@ -1,0 +1,16 @@
+#![feature(fundamental)]
+#![feature(re_rebalance_coherence)]
+
+// compile-flags:--crate-name=test
+// aux-build:coherence_lib.rs
+// check-pass
+
+extern crate coherence_lib as lib;
+use lib::*;
+
+#[fundamental]
+struct MyBox<T>(T);
+
+impl<T> Remote for MyBox<T> {}
+
+fn main() {}


### PR DESCRIPTION
After #64414, `impl<T> Remote for Box<T> { }` is disallowed, but it is also disallowed in liballoc, where `Box` is a local type!

Enabling `#![feature(re_rebalance_coherence)]` in `liballoc` results in:
```
error[E0210]: type parameter `F` must be used as the type parameter for some local type (e.g., `MyStruct<F>`)
    --> src\liballoc\boxed.rs:1098:1
     |
1098 | impl<F: ?Sized + Future + Unpin> Future for Box<F> {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `F` must be used as the type parameter for some local type
```

This PR relaxes `uncover_fundamental_ty` to skip local fundamental types.
I didn't add a test since `liballoc` already fails to compile, but I can add one if needed.

r? @nikomatsakis 

cc #63599