### PR TITLE
Improve documentation of `Vec::split_off(...)`

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1333,10 +1333,10 @@ impl<T> Vec<T> {
 
     /// Splits the collection into two at the given index.
     ///
-    /// Returns a newly allocated `Self`. `self` contains elements `[0, at)`,
-    /// and the returned `Self` contains elements `[at, len)`.
-    ///
-    /// Note that the capacity of `self` does not change.
+    /// Copies the range from `[at, len)` to a newly allocated `Self`
+    /// and returns the result. The original `Self` will contain the
+    /// range from `[0, at)`. Note that the capacity of `self` does
+    /// not change.
     ///
     /// # Panics
     ///

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1333,10 +1333,9 @@ impl<T> Vec<T> {
 
     /// Splits the collection into two at the given index.
     ///
-    /// Copies the range from `[at, len)` to a newly allocated `Self`
-    /// and returns the result. The original `Self` will contain the
-    /// range from `[0, at)`. Note that the capacity of `self` does
-    /// not change.
+    /// Returns a newly allocated vector containing the elements in the range
+    /// `[at, len)`. After the call, the original vector will be left containing
+    /// the elements `[0, at)` with its previous capacity unchanged.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
The previous ordering of the sentences kept switching between the return
value and the value of `self` after execution, making it hard to follow.

Additionally, as rendered in the browser, the period in "`Self`. `self`"
was difficult to make out as being a sentence separator and not one code
block.