### PR TITLE
Fix default "disable-shortcuts" feature value

### DIFF
--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -79,7 +79,7 @@ function getSearchElement() {
                      "derive",
                      "traitalias"];
 
-    var disableShortcuts = getCurrentValue("rustdoc-disable-shortcuts") !== "true";
+    var disableShortcuts = getCurrentValue("rustdoc-disable-shortcuts") === "true";
     var search_input = getSearchInput();
 
     // On the search screen, so you remain on the last tab you opened.


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rust/pull/65656

It fixes the bad handling of the default value of the feature (which would disable shortcut by default, which is bad!).

r? @Dylan-DPC 
cc @kinnison 