### PR TITLE
Adjust the tracking issue for `untagged_unions`.

### DIFF
--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -330,8 +330,13 @@ declare_features! (
     /// Allows exhaustive pattern matching on types that contain uninhabited types.
     (active, exhaustive_patterns, "1.13.0", Some(51085), None),
 
-    /// Allows untagged unions `union U { ... }`.
-    (active, untagged_unions, "1.13.0", Some(32836), None),
+    /// Allows `union`s to implement `Drop`. Moreover, `union`s may now include fields
+    /// that don't implement `Copy` as long as they don't have any drop glue.
+    /// This is checked recursively. On encountering type variable where no progress can be made,
+    /// `T: Copy` is used as a substitute for "no drop glue".
+    ///
+    /// NOTE: A limited form of `union U { ... }` was accepted in 1.19.0.
+    (active, untagged_unions, "1.13.0", Some(55149), None),
 
     /// Allows `#[link(..., cfg(..))]`.
     (active, link_cfg, "1.14.0", Some(37406), None),
@@ -522,13 +527,16 @@ declare_features! (
     /// Allows the definition of `const extern fn` and `const unsafe extern fn`.
     (active, const_extern_fn, "1.40.0", Some(64926), None),
 
-    // Allows the use of raw-dylibs (RFC 2627).
+    /// Allows the use of raw-dylibs (RFC 2627).
     (active, raw_dylib, "1.40.0", Some(58713), None),
 
-    /// Enable accurate caller location reporting during panic (RFC 2091).
+    /// Allows `#[track_caller]` to be used which provides
+    /// accurate caller location reporting during panic (RFC 2091).
     (active, track_caller, "1.40.0", Some(47809), None),
 
-    /// Non-object safe trait objects safe to use but cannot be created in safe rust
+    /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
+    /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
+    /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
     (active, object_safe_for_dispatch, "1.40.0", Some(43561), None),
 
     // -------------------------------------------------------------------------

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -6,7 +6,7 @@ LL | |     a: String,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32836
+   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with non-`Copy` fields are unstable
@@ -17,7 +17,7 @@ LL | |     a: T,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32836
+   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0658]: unions with `Drop` implementations are unstable
@@ -28,7 +28,7 @@ LL | |     a: u8,
 LL | | }
    | |_^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/32836
+   = note: for more information, see https://github.com/rust-lang/rust/issues/55149
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
 error[E0740]: unions may not contain fields that need dropping


### PR DESCRIPTION
Makes https://github.com/rust-lang/rust/issues/55149 the new tracking issue for `untagged_unions`.
Closes https://github.com/rust-lang/rust/issues/32836 which is the old tracking issue.

r? @varkor 