### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6587d09be37fb98a11cb08b9000a3f592451c1b1b613ca69d949160e313a430a"
+checksum = "3cd9867f119b19fecb08cd5c326ad4488d7a1da4bf75b4d95d71db742525aaab"
 dependencies = [
  "autocfg",
  "compiler_builtins",
@@ -4146,7 +4146,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown 0.6.1",
+ "hashbrown 0.6.2",
  "libc",
  "panic_abort",
  "panic_unwind",

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -4,7 +4,7 @@ pub use self::Variance::*;
 pub use self::AssocItemContainer::*;
 pub use self::BorrowKind::*;
 pub use self::IntVarValue::*;
-pub use self::fold::TypeFoldable;
+pub use self::fold::{TypeFoldable, TypeVisitor};
 
 use crate::hir::{map as hir_map, GlobMap, TraitMap};
 use crate::hir::Node;
@@ -50,7 +50,7 @@ use syntax::symbol::{kw, sym, Symbol, InternedString};
 use syntax_pos::Span;
 
 use smallvec;
-use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::stable_hasher::{StableHasher, HashStable};
 use rustc_index::vec::{Idx, IndexVec};
 
@@ -3393,6 +3393,119 @@ fn asyncness(tcx: TyCtxt<'_>, def_id: DefId) -> hir::IsAsync {
     fn_like.asyncness()
 }
 
+/// This method traverses the structure of `ty`, trying to find an
+/// instance of an ADT (i.e. struct or enum) that was declared without
+/// the `#[structural_match]` attribute.
+///
+/// The "structure of a type" includes all components that would be
+/// considered when doing a pattern match on a constant of that
+/// type.
+///
+///  * This means this method descends into fields of structs/enums,
+///    and also descends into the inner type `T` of `&T` and `&mut T`
+///
+///  * The traversal doesn't dereference unsafe pointers (`*const T`,
+///    `*mut T`), and it does not visit the type arguments of an
+///    instantiated generic like `PhantomData<T>`.
+///
+/// The reason we do this search is Rust currently require all ADTs
+/// reachable from a constant's type to be annotated with
+/// `#[structural_match]`, an attribute which essentially says that
+/// the implementation of `PartialEq::eq` behaves *equivalently* to a
+/// comparison against the unfolded structure.
+///
+/// For more background on why Rust has this requirement, and issues
+/// that arose when the requirement was not enforced completely, see
+/// Rust RFC 1445, rust-lang/rust#61188, and rust-lang/rust#62307.
+pub fn search_for_adt_without_structural_match<'tcx>(tcx: TyCtxt<'tcx>,
+                                                 ty: Ty<'tcx>)
+                                                 -> Option<&'tcx AdtDef>
+{
+    let mut search = Search { tcx, found: None, seen: FxHashSet::default() };
+    ty.visit_with(&mut search);
+    return search.found;
+
+    struct Search<'tcx> {
+        tcx: TyCtxt<'tcx>,
+
+        // records the first ADT we find without `#[structural_match`
+        found: Option<&'tcx AdtDef>,
+
+        // tracks ADT's previously encountered during search, so that
+        // we will not recur on them again.
+        seen: FxHashSet<hir::def_id::DefId>,
+    }
+
+    impl<'tcx> TypeVisitor<'tcx> for Search<'tcx> {
+        fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
+            debug!("Search visiting ty: {:?}", ty);
+
+            let (adt_def, substs) = match ty.kind {
+                ty::Adt(adt_def, substs) => (adt_def, substs),
+                ty::RawPtr(..) => {
+                    // `#[structural_match]` ignores substructure of
+                    // `*const _`/`*mut _`, so skip super_visit_with
+                    //
+                    // (But still tell caller to continue search.)
+                    return false;
+                }
+                ty::FnDef(..) | ty::FnPtr(..) => {
+                    // types of formals and return in `fn(_) -> _` are also irrelevant
+                    //
+                    // (But still tell caller to continue search.)
+                    return false;
+                }
+                ty::Array(_, n) if n.try_eval_usize(self.tcx, ty::ParamEnv::reveal_all()) == Some(0)
+                => {
+                    // rust-lang/rust#62336: ignore type of contents
+                    // for empty array.
+                    return false;
+                }
+                _ => {
+                    ty.super_visit_with(self);
+                    return false;
+                }
+            };
+
+            if !self.tcx.has_attr(adt_def.did, sym::structural_match) {
+                self.found = Some(&adt_def);
+                debug!("Search found adt_def: {:?}", adt_def);
+                return true // Halt visiting!
+            }
+
+            if !self.seen.insert(adt_def.did) {
+                debug!("Search already seen adt_def: {:?}", adt_def);
+                // let caller continue its search
+                return false;
+            }
+
+            // `#[structural_match]` does not care about the
+            // instantiation of the generics in an ADT (it
+            // instead looks directly at its fields outside
+            // this match), so we skip super_visit_with.
+            //
+            // (Must not recur on substs for `PhantomData<T>` cf
+            // rust-lang/rust#55028 and rust-lang/rust#55837; but also
+            // want to skip substs when only uses of generic are
+            // behind unsafe pointers `*const T`/`*mut T`.)
+
+            // even though we skip super_visit_with, we must recur on
+            // fields of ADT.
+            let tcx = self.tcx;
+            for field_ty in adt_def.all_fields().map(|field| field.ty(tcx, substs)) {
+                if field_ty.visit_with(self) {
+                    // found an ADT without `#[structural_match]`; halt visiting!
+                    assert!(self.found.is_some());
+                    return true;
+                }
+            }
+
+            // Even though we do not want to recur on substs, we do
+            // want our caller to continue its own search.
+            false
+        }
+    }
+}
 
 pub fn provide(providers: &mut ty::query::Providers<'_>) {
     context::provide(providers);

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -557,10 +557,9 @@ pub fn super_relate_consts<R: TypeRelation<'tcx>>(
         x.val
     };
 
-    // Currently, the values that can be unified are those that
-    // implement both `PartialEq` and `Eq`, corresponding to
-    // `structural_match` types.
-    // FIXME(const_generics): check for `structural_match` synthetic attribute.
+    // Currently, the values that can be unified are primitive types,
+    // and those that derive both `PartialEq` and `Eq`, corresponding
+    // to `structural_match` types.
     let new_const_val = match (eagerly_eval(a), eagerly_eval(b)) {
         (ConstValue::Infer(_), _) | (_, ConstValue::Infer(_)) => {
             // The caller should handle these cases!

--- a/src/librustc_mir/hair/pattern/mod.rs
+++ b/src/librustc_mir/hair/pattern/mod.rs
@@ -25,7 +25,6 @@ use rustc::hir::pat_util::EnumerateAndAdjustIterator;
 use rustc::hir::ptr::P;
 
 use rustc_index::vec::Idx;
-use rustc_data_structures::fx::FxHashSet;
 
 use std::cmp::Ordering;
 use std::fmt;
@@ -1000,7 +999,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
         if self.include_lint_checks && !saw_error {
             // If we were able to successfully convert the const to some pat, double-check
             // that the type of the const obeys `#[structural_match]` constraint.
-            if let Some(adt_def) = search_for_adt_without_structural_match(self.tcx, cv.ty) {
+            if let Some(adt_def) = ty::search_for_adt_without_structural_match(self.tcx, cv.ty) {
 
                 let path = self.tcx.def_path_str(adt_def.did);
                 let msg = format!(
@@ -1165,125 +1164,6 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
             span,
             ty: cv.ty,
             kind: Box::new(kind),
-        }
-    }
-}
-
-/// This method traverses the structure of `ty`, trying to find an
-/// instance of an ADT (i.e. struct or enum) that was declared without
-/// the `#[structural_match]` attribute.
-///
-/// The "structure of a type" includes all components that would be
-/// considered when doing a pattern match on a constant of that
-/// type.
-///
-///  * This means this method descends into fields of structs/enums,
-///    and also descends into the inner type `T` of `&T` and `&mut T`
-///
-///  * The traversal doesn't dereference unsafe pointers (`*const T`,
-///    `*mut T`), and it does not visit the type arguments of an
-///    instantiated generic like `PhantomData<T>`.
-///
-/// The reason we do this search is Rust currently require all ADT's
-/// reachable from a constant's type to be annotated with
-/// `#[structural_match]`, an attribute which essentially says that
-/// the implementation of `PartialEq::eq` behaves *equivalently* to a
-/// comparison against the unfolded structure.
-///
-/// For more background on why Rust has this requirement, and issues
-/// that arose when the requirement was not enforced completely, see
-/// Rust RFC 1445, rust-lang/rust#61188, and rust-lang/rust#62307.
-fn search_for_adt_without_structural_match<'tcx>(tcx: TyCtxt<'tcx>,
-                                                 ty: Ty<'tcx>)
-                                                 -> Option<&'tcx AdtDef>
-{
-    // Import here (not mod level), because `TypeFoldable::fold_with`
-    // conflicts with `PatternFoldable::fold_with`
-    use crate::rustc::ty::fold::TypeVisitor;
-    use crate::rustc::ty::TypeFoldable;
-
-    let mut search = Search { tcx, found: None, seen: FxHashSet::default() };
-    ty.visit_with(&mut search);
-    return search.found;
-
-    struct Search<'tcx> {
-        tcx: TyCtxt<'tcx>,
-
-        // records the first ADT we find without `#[structural_match`
-        found: Option<&'tcx AdtDef>,
-
-        // tracks ADT's previously encountered during search, so that
-        // we will not recur on them again.
-        seen: FxHashSet<hir::def_id::DefId>,
-    }
-
-    impl<'tcx> TypeVisitor<'tcx> for Search<'tcx> {
-        fn visit_ty(&mut self, ty: Ty<'tcx>) -> bool {
-            debug!("Search visiting ty: {:?}", ty);
-
-            let (adt_def, substs) = match ty.kind {
-                ty::Adt(adt_def, substs) => (adt_def, substs),
-                ty::RawPtr(..) => {
-                    // `#[structural_match]` ignores substructure of
-                    // `*const _`/`*mut _`, so skip super_visit_with
-                    //
-                    // (But still tell caller to continue search.)
-                    return false;
-                }
-                ty::FnDef(..) | ty::FnPtr(..) => {
-                    // types of formals and return in `fn(_) -> _` are also irrelevant
-                    //
-                    // (But still tell caller to continue search.)
-                    return false;
-                }
-                ty::Array(_, n) if n.try_eval_usize(self.tcx, ty::ParamEnv::reveal_all()) == Some(0)
-                => {
-                    // rust-lang/rust#62336: ignore type of contents
-                    // for empty array.
-                    return false;
-                }
-                _ => {
-                    ty.super_visit_with(self);
-                    return false;
-                }
-            };
-
-            if !self.tcx.has_attr(adt_def.did, sym::structural_match) {
-                self.found = Some(&adt_def);
-                debug!("Search found adt_def: {:?}", adt_def);
-                return true // Halt visiting!
-            }
-
-            if !self.seen.insert(adt_def.did) {
-                debug!("Search already seen adt_def: {:?}", adt_def);
-                // let caller continue its search
-                return false;
-            }
-
-            // `#[structural_match]` does not care about the
-            // instantiation of the generics in an ADT (it
-            // instead looks directly at its fields outside
-            // this match), so we skip super_visit_with.
-            //
-            // (Must not recur on substs for `PhantomData<T>` cf
-            // rust-lang/rust#55028 and rust-lang/rust#55837; but also
-            // want to skip substs when only uses of generic are
-            // behind unsafe pointers `*const T`/`*mut T`.)
-
-            // even though we skip super_visit_with, we must recur on
-            // fields of ADT.
-            let tcx = self.tcx;
-            for field_ty in adt_def.all_fields().map(|field| field.ty(tcx, substs)) {
-                if field_ty.visit_with(self) {
-                    // found an ADT without `#[structural_match]`; halt visiting!
-                    assert!(self.found.is_some());
-                    return true;
-                }
-            }
-
-            // Even though we do not want to recur on substs, we do
-            // want our caller to continue its own search.
-            false
         }
     }
 }

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -268,9 +268,9 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
                                 if self.r.is_accessible_from(vis, parent_scope.module) {
                                     vis
                                 } else {
-                                    let msg =
-                                        "visibilities can only be restricted to ancestor modules";
-                                    self.r.session.span_err(path.span, msg);
+                                    struct_span_err!(self.r.session, path.span, E0741,
+                                        "visibilities can only be restricted to ancestor modules")
+                                        .emit();
                                     ty::Visibility::Public
                                 }
                             }

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -367,16 +367,6 @@ impl<'a> Resolver<'a> {
                     span, "`Self` in type parameter default".to_string());
                 err
             }
-            ResolutionError::ConstParamDependentOnTypeParam => {
-                let mut err = struct_span_err!(
-                    self.session,
-                    span,
-                    E0671,
-                    "const parameters cannot depend on type parameters"
-                );
-                err.span_label(span, format!("const parameter depends on type parameter"));
-                err
-            }
         }
     }
 

--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -1884,7 +1884,7 @@ E0671: r##"
 
 Const parameters cannot depend on type parameters.
 The following is therefore invalid:
-```compile_fail,E0740
+```compile_fail,E0741
 #![feature(const_generics)]
 
 fn const_id<T, const N: T>() -> T { // error

--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -1880,13 +1880,14 @@ fn main() {
 "##,
 
 E0671: r##"
+#### Note: this error code is no longer emitted by the compiler.
+
 Const parameters cannot depend on type parameters.
 The following is therefore invalid:
-```compile_fail,E0671
+```compile_fail,E0740
 #![feature(const_generics)]
 
-fn const_id<T, const N: T>() -> T { // error: const parameter
-                                    // depends on type parameter
+fn const_id<T, const N: T>() -> T { // error
     N
 }
 ```

--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -1918,4 +1918,5 @@ struct Foo<X = Box<Self>> {
     E0576,
     E0577,
     E0578,
+    E0740,
 }

--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -1897,6 +1897,44 @@ struct Foo<X = Box<Self>> {
 ```
 "##,
 
+E0741: r##"
+Visibility is restricted to a module which isn't an ancestor of the current
+item.
+
+Erroneous code example:
+
+```compile_fail,E0741,edition2018
+pub mod Sea {}
+
+pub (in crate::Sea) struct Shark; // error!
+
+fn main() {}
+```
+
+To fix this error, we need to move the `Shark` struct inside the `Sea` module:
+
+```edition2018
+pub mod Sea {
+    pub (in crate::Sea) struct Shark; // ok!
+}
+
+fn main() {}
+```
+
+Of course, you can do it as long as the module you're referring to is an
+ancestor:
+
+```edition2018
+pub mod Earth {
+    pub mod Sea {
+        pub (in crate::Earth) struct Shark; // ok!
+    }
+}
+
+fn main() {}
+```
+"##,
+
 ;
 //  E0153, unused error code
 //  E0157, unused error code
@@ -1918,5 +1956,4 @@ struct Foo<X = Box<Self>> {
     E0576,
     E0577,
     E0578,
-    E0740,
 }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2761,8 +2761,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let mut opaque_types = self.opaque_types.borrow_mut();
         for (ty, decl) in opaque_type_map {
-            let old_value = opaque_types.insert(ty, decl);
-            assert!(old_value.is_none(), "instantiated twice: {:?}/{:?}", ty, decl);
+            let _ = opaque_types.insert(ty, decl);
         }
 
         value

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1532,6 +1532,17 @@ pub fn checked_type_of(tcx: TyCtxt<'_>, def_id: DefId, fail: bool) -> Option<Ty<
                         );
                     };
                 }
+                if ty::search_for_adt_without_structural_match(tcx, ty).is_some() {
+                    struct_span_err!(
+                        tcx.sess,
+                        hir_ty.span,
+                        E0739,
+                        "the types of const generic parameters must derive `PartialEq` and `Eq`",
+                    ).span_label(
+                        hir_ty.span,
+                        format!("`{}` doesn't derive both `PartialEq` and `Eq`", ty),
+                    ).emit();
+                }
                 ty
             }
             x => {

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1532,11 +1532,11 @@ pub fn checked_type_of(tcx: TyCtxt<'_>, def_id: DefId, fail: bool) -> Option<Ty<
                         );
                     };
                 }
-                if ty::search_for_adt_without_structural_match(tcx, ty).is_some() {
+                if ty::search_for_structural_match_violation(tcx, ty).is_some() {
                     struct_span_err!(
                         tcx.sess,
                         hir_ty.span,
-                        E0739,
+                        E0740,
                         "the types of const generic parameters must derive `PartialEq` and `Eq`",
                     ).span_label(
                         hir_ty.span,

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1536,7 +1536,7 @@ pub fn checked_type_of(tcx: TyCtxt<'_>, def_id: DefId, fail: bool) -> Option<Ty<
                     struct_span_err!(
                         tcx.sess,
                         hir_ty.span,
-                        E0740,
+                        E0741,
                         "the types of const generic parameters must derive `PartialEq` and `Eq`",
                     ).span_label(
                         hir_ty.span,

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4978,11 +4978,11 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
-E0739: r##"
+E0740: r##"
 Only `structural_match` types (that is, types that derive `PartialEq` and `Eq`)
 may be used as the types of const generic parameters.
 
-```compile_fail,E0739
+```compile_fail,E0740
 #![feature(const_generics)]
 
 struct A;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4978,11 +4978,11 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
-E0740: r##"
+E0741: r##"
 Only `structural_match` types (that is, types that derive `PartialEq` and `Eq`)
 may be used as the types of const generic parameters.
 
-```compile_fail,E0740
+```compile_fail,E0741
 #![feature(const_generics)]
 
 struct A;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4978,6 +4978,30 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,
 
+E0739: r##"
+Only `structural_match` types (that is, types that derive `PartialEq` and `Eq`)
+may be used as the types of const generic parameters.
+
+```compile_fail,E0739
+#![feature(const_generics)]
+
+struct A;
+
+struct B<const X: A>; // error!
+```
+
+To fix this example, we derive `PartialEq` and `Eq`.
+
+```
+#![feature(const_generics)]
+
+#[derive(PartialEq, Eq)]
+struct A;
+
+struct B<const X: A>; // ok!
+```
+"##,
+
 ;
 //  E0035, merged into E0087/E0089
 //  E0036, merged into E0087/E0089

--- a/src/libstd/Cargo.toml
+++ b/src/libstd/Cargo.toml
@@ -23,7 +23,7 @@ libc = { version = "0.2.51", default-features = false, features = ['rustc-dep-of
 compiler_builtins = { version = "0.1.16" }
 profiler_builtins = { path = "../libprofiler_builtins", optional = true }
 unwind = { path = "../libunwind" }
-hashbrown = { version = "0.6.1", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { version = "0.6.2", default-features = false, features = ['rustc-dep-of-std'] }
 
 [dependencies.backtrace_rs]
 package = "backtrace"

--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -278,7 +278,7 @@ impl<'a, 'b> Context<'a, 'b> {
     /// format string.
     fn report_invalid_references(&self, numbered_position_args: bool) {
         let mut e;
-        let sp = if self.is_literal {
+        let sp = if self.is_literal { // Point at the formatting arguments.
             MultiSpan::from_spans(self.arg_spans.clone())
         } else {
             MultiSpan::from_span(self.fmtsp)
@@ -304,6 +304,9 @@ impl<'a, 'b> Context<'a, 'b> {
                     self.describe_num_args(),
                 ),
             );
+            for arg in &self.args { // Point at the arguments that will be formatted.
+                e.span_label(arg.span, "");
+            }
         } else {
             let (mut refs, spans): (Vec<_>, Vec<_>) = refs.unzip();
             // Avoid `invalid reference to positional arguments 7 and 7 (there is 1 argument)`

--- a/src/test/rustdoc/const-generics/const-impl.rs
+++ b/src/test/rustdoc/const-generics/const-impl.rs
@@ -4,6 +4,7 @@
 
 #![crate_name = "foo"]
 
+#[derive(PartialEq, Eq)]
 pub enum Order {
     Sorted,
     Unsorted,

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.rs
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
 struct B<T, const N: T>(PhantomData<[T; N]>); //~ ERROR const generics are unstable
-//~^ ERROR const parameters cannot depend on type parameters
+//~^ ERROR the types of const generic parameters must derive `PartialEq` and `Eq`
 
 fn main() {}

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -1,9 +1,3 @@
-error[E0671]: const parameters cannot depend on type parameters
-  --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:22
-   |
-LL | struct B<T, const N: T>(PhantomData<[T; N]>);
-   |                      ^ const parameter depends on type parameter
-
 error[E0658]: const generics are unstable
   --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:19
    |
@@ -13,7 +7,13 @@ LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
+error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:22
+   |
+LL | struct B<T, const N: T>(PhantomData<[T; N]>);
+   |                      ^ `T` doesn't derive both `PartialEq` and `Eq`
+
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0658, E0671.
+Some errors have detailed explanations: E0658, E0740.
 For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -7,7 +7,7 @@ LL | struct B<T, const N: T>(PhantomData<[T; N]>);
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
-error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
   --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:22
    |
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
@@ -15,5 +15,5 @@ LL | struct B<T, const N: T>(PhantomData<[T; N]>);
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0658, E0740.
+Some errors have detailed explanations: E0658, E0741.
 For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.rs
@@ -7,7 +7,6 @@
 // details.
 
 pub struct Dependent<T, const X: T>([(); X]);
-//~^ ERROR const parameters cannot depend on type parameters
-//~^^ ERROR parameter `T` is never used
+//~^ ERROR the types of const generic parameters must derive `PartialEq` and `Eq`
 
 fn main() {}

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -1,9 +1,3 @@
-error[E0671]: const parameters cannot depend on type parameters
-  --> $DIR/const-param-type-depends-on-type-param.rs:9:34
-   |
-LL | pub struct Dependent<T, const X: T>([(); X]);
-   |                                  ^ const parameter depends on type parameter
-
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
   --> $DIR/const-param-type-depends-on-type-param.rs:1:12
    |
@@ -12,15 +6,12 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0392]: parameter `T` is never used
-  --> $DIR/const-param-type-depends-on-type-param.rs:9:22
+error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/const-param-type-depends-on-type-param.rs:9:34
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
-   |                      ^ unused parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `std::marker::PhantomData`
+   |                                  ^ `T` doesn't derive both `PartialEq` and `Eq`
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0392, E0671.
-For more information about an error, try `rustc --explain E0392`.
+For more information about this error, try `rustc --explain E0740`.

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param.stderr
@@ -6,7 +6,7 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
   --> $DIR/const-param-type-depends-on-type-param.rs:9:34
    |
 LL | pub struct Dependent<T, const X: T>([(); X]);
@@ -14,4 +14,4 @@ LL | pub struct Dependent<T, const X: T>([(); X]);
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0740`.
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.rs
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.rs
@@ -1,0 +1,13 @@
+#![feature(const_generics)]
+//~^ WARN the feature `const_generics` is incomplete and may cause the compiler to crash
+
+#[derive(PartialEq, Eq)]
+struct A;
+
+struct B<const X: A>; // ok
+
+struct C;
+
+struct D<const X: C>; //~ ERROR the types of const generic parameters must derive
+
+fn main() {}

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -6,7 +6,7 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
+error[E0741]: the types of const generic parameters must derive `PartialEq` and `Eq`
   --> $DIR/forbid-non-structural_match-types.rs:11:19
    |
 LL | struct D<const X: C>;
@@ -14,4 +14,4 @@ LL | struct D<const X: C>;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0740`.
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -1,0 +1,17 @@
+warning: the feature `const_generics` is incomplete and may cause the compiler to crash
+  --> $DIR/forbid-non-structural_match-types.rs:1:12
+   |
+LL | #![feature(const_generics)]
+   |            ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0739]: the types of const generic parameters must derive `PartialEq` and `Eq`
+  --> $DIR/forbid-non-structural_match-types.rs:11:19
+   |
+LL | struct D<const X: C>;
+   |                   ^ `C` doesn't derive both `PartialEq` and `Eq`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0739`.

--- a/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
+++ b/src/test/ui/const-generics/forbid-non-structural_match-types.stderr
@@ -6,7 +6,7 @@ LL | #![feature(const_generics)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0739]: the types of const generic parameters must derive `PartialEq` and `Eq`
+error[E0740]: the types of const generic parameters must derive `PartialEq` and `Eq`
   --> $DIR/forbid-non-structural_match-types.rs:11:19
    |
 LL | struct D<const X: C>;
@@ -14,4 +14,4 @@ LL | struct D<const X: C>;
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0739`.
+For more information about this error, try `rustc --explain E0740`.

--- a/src/test/ui/fmt/format-string-error.rs
+++ b/src/test/ui/fmt/format-string-error.rs
@@ -48,4 +48,6 @@ fn main() {
 
 "###);
     //~^^^ ERROR invalid format string: unmatched `}` found
+    println!("{} {} {}", 1, 2);
+    //~^ ERROR 3 positional arguments in format string, but there are 2 arguments
 }

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -107,5 +107,11 @@ LL |         }
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
-error: aborting due to 12 previous errors
+error: 3 positional arguments in format string, but there are 2 arguments
+  --> $DIR/format-string-error.rs:51:15
+   |
+LL |     println!("{} {} {}", 1, 2);
+   |               ^^ ^^ ^^   -  -
+
+error: aborting due to 13 previous errors
 

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -224,8 +224,9 @@ error: 4 positional arguments in format string, but there are 3 arguments
   --> $DIR/ifmt-bad-arg.rs:78:15
    |
 LL |     println!("{} {:.*} {}", 1, 3.2, 4);
-   |               ^^ ^^--^ ^^      --- this parameter corresponds to the precision flag
-   |                    |
+   |               ^^ ^^--^ ^^   -  ---  -
+   |                    |           |
+   |                    |           this parameter corresponds to the precision flag
    |                    this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
    |
    = note: positional arguments are zero-based
@@ -235,8 +236,9 @@ error: 4 positional arguments in format string, but there are 3 arguments
   --> $DIR/ifmt-bad-arg.rs:81:15
    |
 LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
-   |               ^^ ^^^----^ ^^      --- this parameter corresponds to the precision flag
-   |                     | |
+   |               ^^ ^^^----^ ^^   -  ---  -
+   |                     | |           |
+   |                     | |           this parameter corresponds to the precision flag
    |                     | this precision flag adds an extra required argument at position 1, which is why there are 4 arguments expected
    |                     this width flag expects an `usize` argument at position 7, but there are 3 arguments
    |

--- a/src/test/ui/intrinsics/intrinsic-alignment.rs
+++ b/src/test/ui/intrinsics/intrinsic-alignment.rs
@@ -19,7 +19,8 @@ mod rusti {
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "vxworks"))]
 mod m {
     #[main]
     #[cfg(target_arch = "x86")]

--- a/src/test/ui/issues/issue-65611.rs
+++ b/src/test/ui/issues/issue-65611.rs
@@ -1,0 +1,63 @@
+use std::mem::MaybeUninit;
+use std::ops::Deref;
+
+pub unsafe trait Array {
+    /// The array’s element type
+    type Item;
+    #[doc(hidden)]
+    /// The smallest index type that indexes the array.
+    type Index: Index;
+    #[doc(hidden)]
+    fn as_ptr(&self) -> *const Self::Item;
+    #[doc(hidden)]
+    fn as_mut_ptr(&mut self) -> *mut Self::Item;
+    #[doc(hidden)]
+    fn capacity() -> usize;
+}
+
+pub trait Index : PartialEq + Copy {
+    fn to_usize(self) -> usize;
+    fn from(usize) -> Self;
+}
+
+impl Index for usize {
+    fn to_usize(self) -> usize { self }
+    fn from(val: usize) -> Self {
+        val
+    }
+}
+
+unsafe impl<T> Array for [T; 1] {
+    type Item = T;
+    type Index = usize;
+    fn as_ptr(&self) -> *const T { self as *const _ as *const _ }
+    fn as_mut_ptr(&mut self) -> *mut T { self as *mut _ as *mut _}
+    fn capacity() -> usize { 1 }
+}
+
+impl<A: Array> Deref for ArrayVec<A> {
+    type Target = [A::Item];
+    #[inline]
+    fn deref(&self) -> &[A::Item] {
+        panic!()
+    }
+}
+
+pub struct ArrayVec<A: Array> {
+    xs: MaybeUninit<A>,
+    len: usize,
+}
+
+impl<A: Array> ArrayVec<A> {
+    pub fn new() -> ArrayVec<A> {
+        panic!()
+    }
+}
+
+fn main() {
+    let mut buffer = ArrayVec::new();
+    let x = buffer.last().unwrap().0.clone();
+    //~^ ERROR type annotations needed
+    //~| ERROR no field `0` on type `&_`
+    buffer.reverse();
+}

--- a/src/test/ui/issues/issue-65611.stderr
+++ b/src/test/ui/issues/issue-65611.stderr
@@ -1,0 +1,18 @@
+error[E0282]: type annotations needed
+  --> $DIR/issue-65611.rs:59:20
+   |
+LL |     let x = buffer.last().unwrap().0.clone();
+   |                    ^^^^ cannot infer type for `T`
+   |
+   = note: type must be known at this point
+
+error[E0609]: no field `0` on type `&_`
+  --> $DIR/issue-65611.rs:59:36
+   |
+LL |     let x = buffer.last().unwrap().0.clone();
+   |                                    ^
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0282, E0609.
+For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/privacy/restricted/relative-2018.stderr
+++ b/src/test/ui/privacy/restricted/relative-2018.stderr
@@ -1,4 +1,4 @@
-error: visibilities can only be restricted to ancestor modules
+error[E0741]: visibilities can only be restricted to ancestor modules
   --> $DIR/relative-2018.rs:7:12
    |
 LL |     pub(in ::core) struct S4;
@@ -14,3 +14,4 @@ LL |     pub(in a::b) struct S5;
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/privacy/restricted/test.stderr
+++ b/src/test/ui/privacy/restricted/test.stderr
@@ -4,7 +4,7 @@ error[E0433]: failed to resolve: maybe a missing crate `bad`?
 LL |     pub(in bad::path) mod m1 {}
    |            ^^^ maybe a missing crate `bad`?
 
-error: visibilities can only be restricted to ancestor modules
+error[E0741]: visibilities can only be restricted to ancestor modules
   --> $DIR/test.rs:51:12
    |
 LL |     pub(in foo) mod m2 {}
@@ -78,5 +78,5 @@ LL |     u.h();
 
 error: aborting due to 12 previous errors
 
-Some errors have detailed explanations: E0364, E0433, E0603, E0616, E0624.
+Some errors have detailed explanations: E0364, E0433, E0603, E0616, E0624, E0741.
 For more information about an error, try `rustc --explain E0364`.

--- a/src/test/ui/proc-macro/issue-50493.stderr
+++ b/src/test/ui/proc-macro/issue-50493.stderr
@@ -1,4 +1,4 @@
-error: visibilities can only be restricted to ancestor modules
+error[E0741]: visibilities can only be restricted to ancestor modules
   --> $DIR/issue-50493.rs:8:12
    |
 LL |     pub(in restricted) field: usize,
@@ -12,4 +12,5 @@ LL | #[derive(Derive)]
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0616`.
+Some errors have detailed explanations: E0616, E0741.
+For more information about an error, try `rustc --explain E0616`.

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -53,7 +53,7 @@ LL | pub (xyz) fn xyz() {}
            `pub(super)`: visible only in the current module's parent
            `pub(in path::to::module)`: visible only on the specified path
 
-error: visibilities can only be restricted to ancestor modules
+error[E0741]: visibilities can only be restricted to ancestor modules
   --> $DIR/pub-restricted.rs:25:17
    |
 LL |         pub (in x) non_parent_invalid: usize,
@@ -61,4 +61,5 @@ LL |         pub (in x) non_parent_invalid: usize,
 
 error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0704`.
+Some errors have detailed explanations: E0704, E0741.
+For more information about an error, try `rustc --explain E0704`.

--- a/src/test/ui/resolve/resolve-bad-visibility.stderr
+++ b/src/test/ui/resolve/resolve-bad-visibility.stderr
@@ -10,7 +10,7 @@ error[E0577]: expected module, found trait `Tr`
 LL | pub(in Tr) struct Z;
    |        ^^ not a module
 
-error: visibilities can only be restricted to ancestor modules
+error[E0741]: visibilities can only be restricted to ancestor modules
   --> $DIR/resolve-bad-visibility.rs:6:8
    |
 LL | pub(in std::vec) struct F;
@@ -30,4 +30,5 @@ LL | pub(in too_soon) struct H;
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0433`.
+Some errors have detailed explanations: E0433, E0741.
+For more information about an error, try `rustc --explain E0433`.

--- a/src/test/ui/signal-alternate-stack-cleanup.rs
+++ b/src/test/ui/signal-alternate-stack-cleanup.rs
@@ -7,6 +7,7 @@
 // ignore-wasm32-bare no libc
 // ignore-windows
 // ignore-sgx no libc
+// ignore-vxworks no SIGWINCH in user space
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/src/test/ui/structs-enums/rec-align-u64.rs
+++ b/src/test/ui/structs-enums/rec-align-u64.rs
@@ -40,7 +40,8 @@ struct Outer {
           target_os = "macos",
           target_os = "netbsd",
           target_os = "openbsd",
-          target_os = "solaris"))]
+          target_os = "solaris",
+          target_os = "vxworks"))]
 mod m {
     #[cfg(target_arch = "x86")]
     pub mod m {

--- a/src/test/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-65679-inst-opaque-ty-from-val-twice.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+type T = impl Sized;
+// The concrete type referred by impl-trait-type-alias(`T`) is guaranteed
+// to be the same as where it occurs, whereas `impl Trait`'s instance is location sensitive;
+// so difference assertion should not be declared on impl-trait-type-alias's instances.
+// for details, check RFC-2515:
+// https://github.com/rust-lang/rfcs/blob/master/text/2515-type_alias_impl_trait.md
+
+fn take(_: fn() -> T) {}
+
+fn main() {
+    take(|| {});
+    take(|| {});
+}


### PR DESCRIPTION
Successful merges:

 - #65405 (Create new error E0741 and add long error explanation)
 - #65627 (Forbid non-`structural_match` types in const generics)
 - #65710 (Update cargo)
 - #65729 (Update test cases for vxWorks)
 - #65746 (Tweak format string error to point at arguments always)
 - #65753 (Don't assert for different instance on impl trait alias)
 - #65755 (Avoid ICE when adjusting bad self ty)
 - #65766 (Update hashbrown to 0.6.2)

Failed merges:

 - #65434 (Add long error explanation for E0577)

r? @ghost