### PR TITLE
Increase spacing for suggestions in diagnostics

### DIFF
--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1583,27 +1583,26 @@ impl EmitterWriter {
         Ok(())
     }
 
-    fn emit_messages_default(&mut self,
-                             level: &Level,
-                             message: &[(String, Style)],
-                             code: &Option<DiagnosticId>,
-                             span: &MultiSpan,
-                             children: &[SubDiagnostic],
-                             suggestions: &[CodeSuggestion]) {
+    fn emit_messages_default(
+        &mut self,
+        level: &Level,
+        message: &[(String, Style)],
+        code: &Option<DiagnosticId>,
+        span: &MultiSpan,
+        children: &[SubDiagnostic],
+        suggestions: &[CodeSuggestion],
+    ) {
         let max_line_num_len = if self.ui_testing {
             ANONYMIZED_LINE_NUM.len()
         } else {
             self.get_max_line_num(span, children).to_string().len()
         };
 
-        match self.emit_message_default(span,
-                                        message,
-                                        code,
-                                        level,
-                                        max_line_num_len,
-                                        false) {
+        match self.emit_message_default(span, message, code, level, max_line_num_len, false) {
             Ok(()) => {
-                if !children.is_empty() {
+                if !children.is_empty() || suggestions.iter().any(|s| {
+                    s.style != SuggestionStyle::CompletelyHidden
+                }) {
                     let mut buffer = StyledBuffer::new();
                     if !self.short_message {
                         draw_col_separator_no_space(&mut buffer, 0, max_line_num_len + 1);
@@ -1627,19 +1626,6 @@ impl EmitterWriter {
                         ) {
                             Err(e) => panic!("failed to emit error: {}", e),
                             _ => ()
-                        }
-                    }
-                    if children.is_empty() && suggestions.iter().any(|s| {
-                        s.style != SuggestionStyle::CompletelyHidden
-                    }) {
-                        let mut buffer = StyledBuffer::new();
-                        if !self.short_message {
-                            draw_col_separator_no_space(&mut buffer, 0, max_line_num_len + 1);
-                        }
-                        match emit_to_destination(&buffer.render(), level, &mut self.dst,
-                                                self.short_message) {
-                            Ok(()) => (),
-                            Err(e) => panic!("failed to emit error: {}", e)
                         }
                     }
                     for sugg in suggestions {

--- a/src/librustc_errors/emitter.rs
+++ b/src/librustc_errors/emitter.rs
@@ -1629,6 +1629,19 @@ impl EmitterWriter {
                             _ => ()
                         }
                     }
+                    if children.is_empty() && suggestions.iter().any(|s| {
+                        s.style != SuggestionStyle::CompletelyHidden
+                    }) {
+                        let mut buffer = StyledBuffer::new();
+                        if !self.short_message {
+                            draw_col_separator_no_space(&mut buffer, 0, max_line_num_len + 1);
+                        }
+                        match emit_to_destination(&buffer.render(), level, &mut self.dst,
+                                                self.short_message) {
+                            Ok(()) => (),
+                            Err(e) => panic!("failed to emit error: {}", e)
+                        }
+                    }
                     for sugg in suggestions {
                         if sugg.style == SuggestionStyle::CompletelyHidden {
                             // do not display this suggestion, it is meant only for tools

--- a/src/test/rustdoc-ui/intra-links-ambiguity.stderr
+++ b/src/test/rustdoc-ui/intra-links-ambiguity.stderr
@@ -23,6 +23,7 @@ error: `ambiguous` is both a struct and a function
    |
 LL | /// [ambiguous] is ambiguous.
    |      ^^^^^^^^^ ambiguous link
+   |
 help: to link to the struct, prefix with the item type
    |
 LL | /// [struct@ambiguous] is ambiguous.
@@ -37,6 +38,7 @@ error: `multi_conflict` is a struct, a function, and a macro
    |
 LL | /// [`multi_conflict`] is a three-way conflict.
    |      ^^^^^^^^^^^^^^^^ ambiguous link
+   |
 help: to link to the struct, prefix with the item type
    |
 LL | /// [`struct@multi_conflict`] is a three-way conflict.
@@ -55,6 +57,7 @@ error: `type_and_value` is both a module and a constant
    |
 LL | /// Ambiguous [type_and_value].
    |                ^^^^^^^^^^^^^^ ambiguous link
+   |
 help: to link to the module, prefix with the item type
    |
 LL | /// Ambiguous [module@type_and_value].
@@ -69,6 +72,7 @@ error: `foo::bar` is both an enum and a function
    |
 LL | /// Ambiguous non-implied shortcut link [`foo::bar`].
    |                                          ^^^^^^^^^^ ambiguous link
+   |
 help: to link to the enum, prefix with the item type
    |
 LL | /// Ambiguous non-implied shortcut link [`enum@foo::bar`].

--- a/src/test/rustdoc-ui/invalid-syntax.stderr
+++ b/src/test/rustdoc-ui/invalid-syntax.stderr
@@ -24,6 +24,7 @@ LL |   /// ```
 LL | | /// \__________pkt->size___________/          \_result->size_/ \__pkt->size__/
 LL | | /// ```
    | |_______^
+   |
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
@@ -34,6 +35,7 @@ error: unknown start of token: `
   |
 3 |    |     ^^^^^^ did you mean `baz::foobar`?
   |                              ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 3 |    |     ^^^^^^ did you mean 'baz::foobar`?
@@ -44,6 +46,7 @@ error: unknown start of token: `
   |
 3 |    |     ^^^^^^ did you mean `baz::foobar`?
   |                                          ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 3 |    |     ^^^^^^ did you mean `baz::foobar'?
@@ -59,6 +62,7 @@ LL | | /// LL | use foobar::Baz;
 LL | | ///    |     ^^^^^^ did you mean `baz::foobar`?
 LL | | /// ```
    | |_______^
+   |
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
@@ -78,6 +82,7 @@ LL |   /// ```
 LL | | /// \_
 LL | | /// ```
    | |_______^
+   |
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
@@ -117,6 +122,7 @@ error: unknown start of token: `
   |
 1 | ```
   | ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 1 | '``
@@ -127,6 +133,7 @@ error: unknown start of token: `
   |
 1 | ```
   |  ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 1 | `'`
@@ -137,6 +144,7 @@ error: unknown start of token: `
   |
 1 | ```
   |   ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 1 | ``'
@@ -196,6 +204,7 @@ LL | | ///
 LL | | ///
 LL | | /// ```
    | |_______^
+   |
 help: mark blocks that do not contain Rust code as text
    |
 LL | /// ```text
@@ -236,6 +245,7 @@ error: unknown start of token: `
   |
 1 | ```
   | ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 1 | '``
@@ -264,6 +274,7 @@ error: unknown start of token: `
   |
 3 |    |     ^^^^^^ did you mean `baz::foobar`?
   |                              ^
+  |
 help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it is not
   |
 3 |    |     ^^^^^^ did you mean 'baz::foobar`?

--- a/src/test/ui/associated-types/associated-types-path-2.stderr
+++ b/src/test/ui/associated-types/associated-types-path-2.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     f1(2i32, 4i32);
    |              ^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     f1(2i32, 4u32);
@@ -43,6 +44,7 @@ error[E0308]: mismatched types
    |
 LL |     let _: i32 = f2(2i32);
    |                  ^^^^^^^^ expected i32, found u32
+   |
 help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     let _: i32 = f2(2i32).try_into().unwrap();

--- a/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `await`
    |
 LL |     pub mod await {
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     pub mod r#await {
@@ -13,6 +14,7 @@ error: expected identifier, found keyword `await`
    |
 LL |         pub struct await;
    |                    ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |         pub struct r#await;
@@ -23,6 +25,7 @@ error: expected identifier, found keyword `await`
    |
 LL | use self::outer_mod::await::await;
    |                      ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::r#await::await;
@@ -33,6 +36,7 @@ error: expected identifier, found keyword `await`
    |
 LL | use self::outer_mod::await::await;
    |                             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::await::r#await;
@@ -43,6 +47,7 @@ error: expected identifier, found keyword `await`
    |
 LL | struct Foo { await: () }
    |              ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | struct Foo { r#await: () }
@@ -53,6 +58,7 @@ error: expected identifier, found keyword `await`
    |
 LL | impl Foo { fn await() {} }
    |               ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | impl Foo { fn r#await() {} }
@@ -63,6 +69,7 @@ error: expected identifier, found keyword `await`
    |
 LL | macro_rules! await {
    |              ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | macro_rules! r#await {

--- a/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `await`
    |
 LL |     pub mod await {
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     pub mod r#await {
@@ -13,6 +14,7 @@ error: expected identifier, found keyword `await`
    |
 LL |         pub struct await;
    |                    ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |         pub struct r#await;
@@ -23,6 +25,7 @@ error: expected identifier, found keyword `await`
    |
 LL | use self::outer_mod::await::await;
    |                      ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::r#await::await;
@@ -33,6 +36,7 @@ error: expected identifier, found keyword `await`
    |
 LL | use self::outer_mod::await::await;
    |                             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use self::outer_mod::await::r#await;
@@ -43,6 +47,7 @@ error: expected identifier, found keyword `await`
    |
 LL | macro_rules! await { () => {}; }
    |              ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | macro_rules! r#await { () => {}; }

--- a/src/test/ui/async-await/no-const-async.stderr
+++ b/src/test/ui/async-await/no-const-async.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `async`
    |
 LL | pub const async fn x() {}
    |           ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | pub const r#async fn x() {}

--- a/src/test/ui/bad/bad-crate-name.stderr
+++ b/src/test/ui/bad/bad-crate-name.stderr
@@ -3,6 +3,7 @@ error: crate name using dashes are not valid in `extern crate` statements
    |
 LL | extern crate krate-name-here;
    |              ^^^^^^^^^^^^^^^ dash-separated idents are not valid
+   |
 help: if the original crate name uses dashes you need to use underscores in the code
    |
 LL | extern crate krate_name_here;

--- a/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
+++ b/src/test/ui/borrowck/borrowck-vec-pattern-nesting.stderr
@@ -33,6 +33,7 @@ LL |         &mut [_a,
    |               |
    |               data moved here
    |               move occurs because `_a` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+   |
 help: consider removing the `&mut`
    |
 LL |         [_a,
@@ -64,6 +65,7 @@ LL |          _b] => {}
    |          |
    |          data moved here
    |          move occurs because `_b` has type `std::boxed::Box<isize>`, which does not implement the `Copy` trait
+   |
 help: consider removing the `&mut`
    |
 LL |         [

--- a/src/test/ui/class-missing-self.stderr
+++ b/src/test/ui/class-missing-self.stderr
@@ -9,6 +9,7 @@ error[E0425]: cannot find function `sleep` in this scope
    |
 LL |       sleep();
    |       ^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use std::thread::sleep;

--- a/src/test/ui/confuse-field-and-method/issue-18343.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-18343.stderr
@@ -6,6 +6,7 @@ LL | struct Obj<F> where F: FnMut() -> u32 {
 ...
 LL |     o.closure();
    |       ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (o.closure)();

--- a/src/test/ui/confuse-field-and-method/issue-2392.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-2392.stderr
@@ -6,6 +6,7 @@ LL | struct Obj<F> where F: FnOnce() -> u32 {
 ...
 LL |     o_closure.closure();
    |               ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (o_closure.closure)();
@@ -30,6 +31,7 @@ LL | struct Obj<F> where F: FnOnce() -> u32 {
 ...
 LL |     o_func.closure();
    |            ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (o_func.closure)();
@@ -43,6 +45,7 @@ LL | struct BoxedObj {
 ...
 LL |     boxed_fn.boxed_closure();
    |              ^^^^^^^^^^^^^ field, not a method
+   |
 help: to call the function stored in `boxed_closure`, surround the field access with parentheses
    |
 LL |     (boxed_fn.boxed_closure)();
@@ -56,6 +59,7 @@ LL | struct BoxedObj {
 ...
 LL |     boxed_closure.boxed_closure();
    |                   ^^^^^^^^^^^^^ field, not a method
+   |
 help: to call the function stored in `boxed_closure`, surround the field access with parentheses
    |
 LL |     (boxed_closure.boxed_closure)();
@@ -69,6 +73,7 @@ LL | struct Obj<F> where F: FnOnce() -> u32 {
 ...
 LL |     w.wrap.closure();
    |            ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (w.wrap.closure)();
@@ -93,6 +98,7 @@ LL | struct Obj<F> where F: FnOnce() -> u32 {
 ...
 LL |     check_expression().closure();
    |                        ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (check_expression().closure)();
@@ -106,6 +112,7 @@ LL | struct FuncContainer {
 ...
 LL |             (*self.container).f1(1);
    |                               ^^ field, not a method
+   |
 help: to call the function stored in `f1`, surround the field access with parentheses
    |
 LL |             ((*self.container).f1)(1);
@@ -119,6 +126,7 @@ LL | struct FuncContainer {
 ...
 LL |             (*self.container).f2(1);
    |                               ^^ field, not a method
+   |
 help: to call the function stored in `f2`, surround the field access with parentheses
    |
 LL |             ((*self.container).f2)(1);
@@ -132,6 +140,7 @@ LL | struct FuncContainer {
 ...
 LL |             (*self.container).f3(1);
    |                               ^^ field, not a method
+   |
 help: to call the function stored in `f3`, surround the field access with parentheses
    |
 LL |             ((*self.container).f3)(1);

--- a/src/test/ui/confuse-field-and-method/issue-32128.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-32128.stderr
@@ -6,6 +6,7 @@ LL | struct Example {
 ...
 LL |     demo.example(1);
    |          ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `example`, surround the field access with parentheses
    |
 LL |     (demo.example)(1);

--- a/src/test/ui/confuse-field-and-method/issue-33784.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-33784.stderr
@@ -3,6 +3,7 @@ error[E0599]: no method named `closure` found for type `&Obj<[closure@$DIR/issue
    |
 LL |     p.closure();
    |       ^^^^^^^ field, not a method
+   |
 help: to call the function stored in `closure`, surround the field access with parentheses
    |
 LL |     (p.closure)();
@@ -13,6 +14,7 @@ error[E0599]: no method named `fn_ptr` found for type `&&Obj<[closure@$DIR/issue
    |
 LL |     q.fn_ptr();
    |       ^^^^^^ field, not a method
+   |
 help: to call the function stored in `fn_ptr`, surround the field access with parentheses
    |
 LL |     (q.fn_ptr)();
@@ -23,6 +25,7 @@ error[E0599]: no method named `c_fn_ptr` found for type `&D` in the current scop
    |
 LL |     s.c_fn_ptr();
    |       ^^^^^^^^ field, not a method
+   |
 help: to call the function stored in `c_fn_ptr`, surround the field access with parentheses
    |
 LL |     (s.c_fn_ptr)();

--- a/src/test/ui/consts/enum-discr-type-err.stderr
+++ b/src/test/ui/consts/enum-discr-type-err.stderr
@@ -9,6 +9,7 @@ LL | |     A = F,
 LL | |     B = T,
 LL | | }
    | |_- in this macro invocation
+   |
 help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |             $( $v = $s::V.try_into().unwrap(), )*

--- a/src/test/ui/crate-in-paths.stderr
+++ b/src/test/ui/crate-in-paths.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find value `Foo` in this scope
    |
 LL |     Foo;
    |     ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use crate::bar::Foo;

--- a/src/test/ui/deprecation/invalid-literal.stderr
+++ b/src/test/ui/deprecation/invalid-literal.stderr
@@ -3,6 +3,7 @@ error: malformed `deprecated` attribute input
    |
 LL | #[deprecated = b"test"]
    | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: the following are the possible correct uses
    |
 LL | #[deprecated]

--- a/src/test/ui/did_you_mean/issue-40396.stderr
+++ b/src/test/ui/did_you_mean/issue-40396.stderr
@@ -3,6 +3,7 @@ error: chained comparison operators require parentheses
    |
 LL |     (0..13).collect<Vec<i32>>();
    |                    ^^^^^
+   |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     (0..13).collect::<Vec<i32>>();
@@ -13,6 +14,7 @@ error: chained comparison operators require parentheses
    |
 LL |     Vec<i32>::new();
    |        ^^^^^
+   |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     Vec::<i32>::new();
@@ -23,6 +25,7 @@ error: chained comparison operators require parentheses
    |
 LL |     (0..13).collect<Vec<i32>();
    |                    ^^^^^
+   |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     (0..13).collect::<Vec<i32>();

--- a/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
+++ b/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
@@ -3,6 +3,7 @@ error[E0423]: expected function, found enum `Option`
    |
 LL |     let x = Option(1);
    |             ^^^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |     let x = std::option::Option::None(1);
@@ -15,6 +16,7 @@ error[E0532]: expected tuple struct/variant, found enum `Option`
    |
 LL |     if let Option(_) = x {
    |            ^^^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |     if let std::option::Option::None(_) = x {
@@ -27,6 +29,7 @@ error[E0532]: expected tuple struct/variant, found enum `Example`
    |
 LL |     if let Example(_) = y {
    |            ^^^^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |     if let Example::Ex(_) = y {
@@ -45,6 +48,7 @@ error[E0423]: expected function, found enum `ManyVariants`
    |
 LL |     let z = ManyVariants();
    |             ^^^^^^^^^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |     let z = ManyVariants::One();

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -3,6 +3,7 @@ error: unexpected `,` in pattern
    |
 LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
    |                 ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |     while let (b1, b2, b3) = reading_frame.next().expect("there should be a start codon") {
@@ -17,6 +18,7 @@ error: unexpected `,` in pattern
    |
 LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
    |              ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |     if let (b1, b2, b3) = reading_frame.next().unwrap() {
@@ -31,6 +33,7 @@ error: unexpected `,` in pattern
    |
 LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
    |                            ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
@@ -45,6 +48,7 @@ error: unexpected `,` in pattern
    |
 LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
    |          ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |     for (x, _barr_body) in women.iter().map(|woman| woman.allosomes.clone()) {
@@ -59,6 +63,7 @@ error: unexpected `,` in pattern
    |
 LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
    |          ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |     for (x, y @ Allosome::Y(_)) in men.iter().map(|man| man.allosomes.clone()) {
@@ -73,6 +78,7 @@ error: unexpected `,` in pattern
    |
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |              ^
+   |
 help: try adding parentheses to match on a tuple..
    |
 LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()

--- a/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/src/test/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -9,6 +9,7 @@ error: unknown start of token: \u{2212}
    |
 LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
    |                                                     ^
+   |
 help: Unicode character '−' (Minus Sign) looks like '-' (Minus/Hyphen), but it is not
    |
 LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²

--- a/src/test/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
+++ b/src/test/ui/did_you_mean/issue-56028-there-is-an-enum-variant.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Set` in this scope
    |
 LL | fn setup() -> Set { Set }
    |               ^^^ not found in this scope
+   |
 help: there is an enum variant `AffixHeart::Set` and 7 others; try using the variant's enum
    |
 LL | fn setup() -> AffixHeart { Set }
@@ -20,6 +21,7 @@ error[E0425]: cannot find value `Set` in this scope
    |
 LL | fn setup() -> Set { Set }
    |                     ^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use AffixHeart::Set;

--- a/src/test/ui/discrim/discrim-ill-typed.stderr
+++ b/src/test/ui/discrim/discrim-ill-typed.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_u8,
    |                ^^^^ expected i8, found u8
+   |
 help: change the type of the numeric literal from `u8` to `i8`
    |
 LL |         OhNo = 0_i8,
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_i8,
    |                ^^^^ expected u8, found i8
+   |
 help: change the type of the numeric literal from `i8` to `u8`
    |
 LL |         OhNo = 0_u8,
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_u16,
    |                ^^^^^ expected i16, found u16
+   |
 help: change the type of the numeric literal from `u16` to `i16`
    |
 LL |         OhNo = 0_i16,
@@ -33,6 +36,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_i16,
    |                ^^^^^ expected u16, found i16
+   |
 help: change the type of the numeric literal from `i16` to `u16`
    |
 LL |         OhNo = 0_u16,
@@ -43,6 +47,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_u32,
    |                ^^^^^ expected i32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |         OhNo = 0_i32,
@@ -53,6 +58,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_i32,
    |                ^^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |         OhNo = 0_u32,
@@ -63,6 +69,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_u64,
    |                ^^^^^ expected i64, found u64
+   |
 help: change the type of the numeric literal from `u64` to `i64`
    |
 LL |         OhNo = 0_i64,
@@ -73,6 +80,7 @@ error[E0308]: mismatched types
    |
 LL |         OhNo = 0_i64,
    |                ^^^^^ expected u64, found i64
+   |
 help: change the type of the numeric literal from `i64` to `u64`
    |
 LL |         OhNo = 0_u64,

--- a/src/test/ui/dotdotdot-expr.stderr
+++ b/src/test/ui/dotdotdot-expr.stderr
@@ -3,6 +3,7 @@ error: unexpected token: `...`
    |
 LL |     let _redemptive = 1...21;
    |                        ^^^
+   |
 help: use `..` for an exclusive range
    |
 LL |     let _redemptive = 1..21;

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `async`
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut r#async = 1;
@@ -13,6 +14,7 @@ error: expected identifier, found keyword `async`
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     module::r#async();

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `async`
    |
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut r#async = 1;
@@ -13,6 +14,7 @@ error: expected identifier, found keyword `async`
    |
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     module::r#async();

--- a/src/test/ui/empty/empty-struct-unit-expr.stderr
+++ b/src/test/ui/empty/empty-struct-unit-expr.stderr
@@ -19,6 +19,7 @@ LL |     let e4 = E::Empty4();
    |              ^^^^^^^^^--
    |              |
    |              call expression requires function
+   |
 help: `E::Empty4` is a unit variant, you need to write it without the parenthesis
    |
 LL |     let e4 = E::Empty4;
@@ -39,6 +40,7 @@ LL |     let xe4 = XE::XEmpty4();
    |               ^^^^^^^^^^^--
    |               |
    |               call expression requires function
+   |
 help: `XE::XEmpty4` is a unit variant, you need to write it without the parenthesis
    |
 LL |     let xe4 = XE::XEmpty4;

--- a/src/test/ui/error-codes/E0023.stderr
+++ b/src/test/ui/error-codes/E0023.stderr
@@ -33,6 +33,7 @@ LL |     Orange((String, String)),
 ...
 LL |         Fruit::Orange(a, b) => {},
    |         ^^^^^^^^^^^^^^^^^^^ expected 1 field, found 2
+   |
 help: missing parenthesis
    |
 LL |         Fruit::Orange((a, b)) => {},
@@ -46,6 +47,7 @@ LL |     Banana(()),
 ...
 LL |         Fruit::Banana() => {},
    |         ^^^^^^^^^^^^^^^ expected 1 field, found 0
+   |
 help: missing parenthesis
    |
 LL |         Fruit::Banana(()) => {},

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -3,6 +3,7 @@ error: struct literals are not allowed here
    |
 LL |     if let S { x: _x, y: 2 } = S { x: 1, y: 2 } { println!("Ok"); }
    |                                ^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if let S { x: _x, y: 2 } = (S { x: 1, y: 2 }) { println!("Ok"); }
@@ -19,6 +20,7 @@ error: struct literals are not allowed here
    |
 LL |     for _ in std::ops::Range { start: 0, end: 10 } {}
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     for _ in (std::ops::Range { start: 0, end: 10 }) {}

--- a/src/test/ui/error-codes/E0617.stderr
+++ b/src/test/ui/error-codes/E0617.stderr
@@ -33,6 +33,7 @@ error[E0617]: can't pass `unsafe extern "C" fn(*const i8, ...) {printf}` to vari
    |
 LL |         printf(::std::ptr::null(), printf);
    |                                    ^^^^^^
+   |
 help: cast the value to `unsafe extern "C" fn(*const i8, ...)`
    |
 LL |         printf(::std::ptr::null(), printf as unsafe extern "C" fn(*const i8, ...));

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -8,6 +8,7 @@ LL |     X::Entry();
    |     ^^^^^^^^--
    |     |
    |     call expression requires function
+   |
 help: `X::Entry` is a unit variant, you need to write it without the parenthesis
    |
 LL |     X::Entry;

--- a/src/test/ui/error-codes/E0642.stderr
+++ b/src/test/ui/error-codes/E0642.stderr
@@ -3,6 +3,7 @@ error[E0642]: patterns aren't allowed in methods without bodies
    |
 LL |     fn foo((x, y): (i32, i32));
    |            ^^^^^^
+   |
 help: give this argument a name or use an underscore to ignore it
    |
 LL |     fn foo(_: (i32, i32));
@@ -13,6 +14,7 @@ error[E0642]: patterns aren't allowed in methods without bodies
    |
 LL |     fn bar((x, y): (i32, i32)) {}
    |            ^^^^^^
+   |
 help: give this argument a name or use an underscore to ignore it
    |
 LL |     fn bar(_: (i32, i32)) {}
@@ -23,6 +25,7 @@ error[E0642]: patterns aren't allowed in methods without bodies
    |
 LL |     fn method(S { .. }: S) {}
    |               ^^^^^^^^
+   |
 help: give this argument a name or use an underscore to ignore it
    |
 LL |     fn method(_: S) {}

--- a/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-macro_use.stderr
@@ -21,6 +21,7 @@ error: malformed `macro_use` attribute input
    |
 LL |     #[macro_use = "2700"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^
+   |
 help: the following are the possible correct uses
    |
 LL |     #[macro_use] struct S;

--- a/src/test/ui/float-literal-inference-restrictions.stderr
+++ b/src/test/ui/float-literal-inference-restrictions.stderr
@@ -15,6 +15,7 @@ error[E0308]: mismatched types
    |
 LL |     let y: f32 = 1f64;
    |                  ^^^^ expected f32, found f64
+   |
 help: change the type of the numeric literal from `f64` to `f32`
    |
 LL |     let y: f32 = 1f32;

--- a/src/test/ui/fn/fn-compare-mismatch.stderr
+++ b/src/test/ui/fn/fn-compare-mismatch.stderr
@@ -5,6 +5,7 @@ LL |     let x = f == g;
    |             - ^^ - fn() {main::g}
    |             |
    |             fn() {main::f}
+   |
 help: you might have forgotten to call this function
    |
 LL |     let x = f() == g;

--- a/src/test/ui/glob-resolve1.stderr
+++ b/src/test/ui/glob-resolve1.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find function `fpriv` in this scope
    |
 LL |     fpriv();
    |     ^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use bar::fpriv;
@@ -13,6 +14,7 @@ error[E0425]: cannot find function `epriv` in this scope
    |
 LL |     epriv();
    |     ^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use bar::epriv;
@@ -29,6 +31,7 @@ error[E0425]: cannot find value `C` in this scope
    |
 LL |     C;
    |     ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use bar::C;
@@ -45,6 +48,7 @@ error[E0412]: cannot find type `A` in this scope
    |
 LL |     foo::<A>();
    |           ^
+   |
 help: an enum with a similar name exists
    |
 LL |     foo::<B>();
@@ -59,6 +63,7 @@ error[E0412]: cannot find type `C` in this scope
    |
 LL |     foo::<C>();
    |           ^
+   |
 help: an enum with a similar name exists
    |
 LL |     foo::<B>();
@@ -73,6 +78,7 @@ error[E0412]: cannot find type `D` in this scope
    |
 LL |     foo::<D>();
    |           ^
+   |
 help: an enum with a similar name exists
    |
 LL |     foo::<B>();

--- a/src/test/ui/hygiene/expansion-info-reset.stderr
+++ b/src/test/ui/hygiene/expansion-info-reset.stderr
@@ -3,6 +3,7 @@ error: format argument must be a string literal
    |
 LL |     format_args!({ #[derive(Clone)] struct S; });
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     format_args!("{}", { #[derive(Clone)] struct S; });

--- a/src/test/ui/hygiene/globs.stderr
+++ b/src/test/ui/hygiene/globs.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find function `f` in this scope
    |
 LL |         f();
    |         ^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use foo::f;
@@ -24,6 +25,7 @@ LL | |         g();
 LL | |         f();
 LL | |     }
    | |_____- in this macro invocation
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use bar::g;

--- a/src/test/ui/if/ifmt-bad-format-args.stderr
+++ b/src/test/ui/if/ifmt-bad-format-args.stderr
@@ -9,6 +9,7 @@ error: format argument must be a string literal
    |
 LL |     format_args!(|| {});
    |                  ^^^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     format_args!("{}", || {});

--- a/src/test/ui/impl-trait/impl-generic-mismatch.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch.stderr
@@ -6,6 +6,7 @@ LL |     fn foo(&self, _: &impl Debug);
 ...
 LL |     fn foo<U: Debug>(&self, _: &U) { }
    |            ^ expected `impl Trait`, found generic parameter
+   |
 help: try removing the generic parameter and using `impl Trait` instead
    |
 LL |     fn foo(&self, _: &impl Debug) { }
@@ -19,6 +20,7 @@ LL |     fn bar<U: Debug>(&self, _: &U);
 ...
 LL |     fn bar(&self, _: &impl Debug) { }
    |                       ^^^^^^^^^^ expected generic parameter, found `impl Trait`
+   |
 help: try changing the `impl Trait` argument to a generic parameter
    |
 LL |     fn bar<U: Debug>(&self, _: &U) { }

--- a/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
+++ b/src/test/ui/impl-trait/multiple-lifetimes/error-handling.stderr
@@ -3,6 +3,7 @@ error: lifetime may not live long enough
    |
 LL | fn foo<'a, 'b, 'c>(x: &'static i32, mut y: &'a i32) -> E<'b, 'c> {
    |        -- lifetime `'a` defined here                   ^^^^^^^^^ opaque type requires that `'a` must outlive `'static`
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a constraint
    |
 LL | type E<'a, 'b> = impl Sized; + 'a

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -5,6 +5,7 @@ LL | fn elided(x: &i32) -> impl Copy { x }
    |              -        ^^^^^^^^^ opaque type requires that `'1` must outlive `'static`
    |              |
    |              let's call the lifetime of this reference `'1`
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, add `'_` as a constraint
    |
 LL | fn elided(x: &i32) -> impl Copy + '_ { x }
@@ -17,6 +18,7 @@ LL | fn explicit<'a>(x: &'a i32) -> impl Copy { x }
    |             --                 ^^^^^^^^^ opaque type requires that `'a` must outlive `'static`
    |             |
    |             lifetime `'a` defined here
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a constraint
    |
 LL | fn explicit<'a>(x: &'a i32) -> impl Copy + 'a { x }

--- a/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
+++ b/src/test/ui/impl-trait/static-return-lifetime-infered.nll.stderr
@@ -5,6 +5,7 @@ LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> {
    |                         -         ^^^^^^^^^^^^^^^^^^^^^^^ opaque type requires that `'1` must outlive `'static`
    |                         |
    |                         let's call the lifetime of this reference `'1`
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, add `'_` as a constraint
    |
 LL |     fn iter_values_anon(&self) -> impl Iterator<Item=u32> + '_ {
@@ -17,6 +18,7 @@ LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> {
    |                    --               ^^^^^^^^^^^^^^^^^^^^^^^ opaque type requires that `'a` must outlive `'static`
    |                    |
    |                    lifetime `'a` defined here
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'a`, add `'a` as a constraint
    |
 LL |     fn iter_values<'a>(&'a self) -> impl Iterator<Item=u32> + 'a {

--- a/src/test/ui/impl-trait/universal_wrong_bounds.stderr
+++ b/src/test/ui/impl-trait/universal_wrong_bounds.stderr
@@ -3,6 +3,7 @@ error[E0404]: expected trait, found derive macro `Debug`
    |
 LL | fn wants_debug(g: impl Debug) { }
    |                        ^^^^^ not a trait
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::fmt::Debug;
@@ -13,6 +14,7 @@ error[E0404]: expected trait, found derive macro `Debug`
    |
 LL | fn wants_display(g: impl Debug) { }
    |                          ^^^^^ not a trait
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::fmt::Debug;

--- a/src/test/ui/indexing-requires-a-uint.stderr
+++ b/src/test/ui/indexing-requires-a-uint.stderr
@@ -12,6 +12,7 @@ error[E0308]: mismatched types
    |
 LL |     bar::<isize>(i);  // i should not be re-coerced back to an isize
    |                  ^ expected isize, found usize
+   |
 help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     bar::<isize>(i.try_into().unwrap());  // i should not be re-coerced back to an isize

--- a/src/test/ui/inference/cannot-infer-closure.stderr
+++ b/src/test/ui/inference/cannot-infer-closure.stderr
@@ -3,6 +3,7 @@ error[E0282]: type annotations needed for the closure `fn((), ()) -> std::result
    |
 LL |         Err(a)?;
    |         ^^^^^^^ cannot infer type
+   |
 help: give this closure an explicit return type without `_` placeholders
    |
 LL |     let x = |a: (), b: ()| -> std::result::Result<(), _> {

--- a/src/test/ui/integer-literal-suffix-inference.stderr
+++ b/src/test/ui/integer-literal-suffix-inference.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(a16);
    |           ^^^ expected i8, found i16
+   |
 help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a16.try_into().unwrap());
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(a32);
    |           ^^^ expected i8, found i32
+   |
 help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a32.try_into().unwrap());
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(a64);
    |           ^^^ expected i8, found i64
+   |
 help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(a64.try_into().unwrap());
@@ -42,6 +45,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i16(a32);
    |            ^^^ expected i16, found i32
+   |
 help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(a32.try_into().unwrap());
@@ -52,6 +56,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i16(a64);
    |            ^^^ expected i16, found i64
+   |
 help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(a64.try_into().unwrap());
@@ -80,6 +85,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i32(a64);
    |            ^^^ expected i32, found i64
+   |
 help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     id_i32(a64.try_into().unwrap());
@@ -117,6 +123,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(c16);
    |           ^^^ expected i8, found i16
+   |
 help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c16.try_into().unwrap());
@@ -127,6 +134,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(c32);
    |           ^^^ expected i8, found i32
+   |
 help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c32.try_into().unwrap());
@@ -137,6 +145,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i8(c64);
    |           ^^^ expected i8, found i64
+   |
 help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     id_i8(c64.try_into().unwrap());
@@ -156,6 +165,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i16(c32);
    |            ^^^ expected i16, found i32
+   |
 help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(c32.try_into().unwrap());
@@ -166,6 +176,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i16(c64);
    |            ^^^ expected i16, found i64
+   |
 help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     id_i16(c64.try_into().unwrap());
@@ -194,6 +205,7 @@ error[E0308]: mismatched types
    |
 LL |     id_i32(c64);
    |            ^^^ expected i32, found i64
+   |
 help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     id_i32(c64.try_into().unwrap());
@@ -231,6 +243,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u8(b16);
    |           ^^^ expected u8, found u16
+   |
 help: you can convert an `u16` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b16.try_into().unwrap());
@@ -241,6 +254,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u8(b32);
    |           ^^^ expected u8, found u32
+   |
 help: you can convert an `u32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b32.try_into().unwrap());
@@ -251,6 +265,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u8(b64);
    |           ^^^ expected u8, found u64
+   |
 help: you can convert an `u64` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     id_u8(b64.try_into().unwrap());
@@ -270,6 +285,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u16(b32);
    |            ^^^ expected u16, found u32
+   |
 help: you can convert an `u32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b32.try_into().unwrap());
@@ -280,6 +296,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u16(b64);
    |            ^^^ expected u16, found u64
+   |
 help: you can convert an `u64` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     id_u16(b64.try_into().unwrap());
@@ -308,6 +325,7 @@ error[E0308]: mismatched types
    |
 LL |     id_u32(b64);
    |            ^^^ expected u32, found u64
+   |
 help: you can convert an `u64` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     id_u32(b64.try_into().unwrap());

--- a/src/test/ui/issues/issue-13359.stderr
+++ b/src/test/ui/issues/issue-13359.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     foo(1*(1 as isize));
    |         ^^^^^^^^^^^^^^ expected i16, found isize
+   |
 help: you can convert an `isize` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo((1*(1 as isize)).try_into().unwrap());
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     bar(1*(1 as usize));
    |         ^^^^^^^^^^^^^^ expected u32, found usize
+   |
 help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     bar((1*(1 as usize)).try_into().unwrap());

--- a/src/test/ui/issues/issue-1362.stderr
+++ b/src/test/ui/issues/issue-1362.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |   let x: u32 = 20i32;
    |                ^^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |   let x: u32 = 20u32;

--- a/src/test/ui/issues/issue-1448-2.stderr
+++ b/src/test/ui/issues/issue-1448-2.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     println!("{}", foo(10i32));
    |                        ^^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     println!("{}", foo(10u32));

--- a/src/test/ui/issues/issue-17546.stderr
+++ b/src/test/ui/issues/issue-17546.stderr
@@ -3,6 +3,7 @@ error[E0573]: expected type, found variant `NoResult`
    |
 LL |     fn new() -> NoResult<MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: try using the variant's enum
    |
 LL |     fn new() -> foo::MyEnum {
@@ -17,6 +18,7 @@ error[E0573]: expected type, found variant `Result`
    |
 LL |     fn new() -> Result<foo::MyEnum, String> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |     use std::fmt::Result;
@@ -34,6 +36,7 @@ error[E0573]: expected type, found variant `Result`
    |
 LL | fn new() -> Result<foo::MyEnum, String> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a type
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use std::fmt::Result;
@@ -51,6 +54,7 @@ error[E0573]: expected type, found variant `NoResult`
    |
 LL | fn newer() -> NoResult<foo::MyEnum, String> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: try using the variant's enum
    |
 LL | fn newer() -> foo::MyEnum {

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -50,6 +50,7 @@ LL |                    <
    |                    ^ not interpreted as comparison
 LL |                    4);
    |                    - interpreted as generic arguments
+   |
 help: try comparing the cast value
    |
 LL |     println!("{}", (a
@@ -64,6 +65,7 @@ LL |                    <
    |                    ^ not interpreted as comparison
 LL |                    5);
    |                    - interpreted as generic arguments
+   |
 help: try comparing the cast value
    |
 LL |     println!("{}", (a

--- a/src/test/ui/issues/issue-22933-3.stderr
+++ b/src/test/ui/issues/issue-22933-3.stderr
@@ -3,6 +3,7 @@ error[E0599]: no associated item named `MIN` found for type `u8` in the current 
    |
 LL | const FOO: [u32; u8::MIN as usize] = [];
    |                      ^^^ associated item not found in `u8`
+   |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL | const FOO: [u32; std::u8::MIN as usize] = [];

--- a/src/test/ui/issues/issue-31910.stderr
+++ b/src/test/ui/issues/issue-31910.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     X = Trait::Number,
    |         ^^^^^^^^^^^^^ expected isize, found i32
+   |
 help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     X = Trait::Number.try_into().unwrap(),

--- a/src/test/ui/issues/issue-35075.stderr
+++ b/src/test/ui/issues/issue-35075.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Foo` in this scope
    |
 LL |     inner: Foo<T>
    |            ^^^ not found in this scope
+   |
 help: there is an enum variant `Baz::Foo`; try using the variant's enum
    |
 LL |     inner: Baz
@@ -13,6 +14,7 @@ error[E0412]: cannot find type `Foo` in this scope
    |
 LL |     Foo(Foo<T>)
    |         ^^^ not found in this scope
+   |
 help: there is an enum variant `Baz::Foo`; try using the variant's enum
    |
 LL |     Foo(Baz)

--- a/src/test/ui/issues/issue-35675.stderr
+++ b/src/test/ui/issues/issue-35675.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Apple` in this scope
    |
 LL | fn should_return_fruit() -> Apple {
    |                             ^^^^^ not found in this scope
+   |
 help: there is an enum variant `Fruit::Apple`; try using the variant's enum
    |
 LL | fn should_return_fruit() -> Fruit {
@@ -13,6 +14,7 @@ error[E0425]: cannot find function `Apple` in this scope
    |
 LL |     Apple(5)
    |     ^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use Fruit::Apple;
@@ -32,6 +34,7 @@ error[E0425]: cannot find function `Apple` in this scope
    |
 LL |     Apple(5)
    |     ^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use Fruit::Apple;
@@ -51,6 +54,7 @@ error[E0412]: cannot find type `Variant3` in this scope
    |
 LL | fn bar() -> Variant3 {
    |             ^^^^^^^^ not found in this scope
+   |
 help: there is an enum variant `x::Enum::Variant3`; try using the variant's enum
    |
 LL | fn bar() -> x::Enum {

--- a/src/test/ui/issues/issue-35976.stderr
+++ b/src/test/ui/issues/issue-35976.stderr
@@ -3,6 +3,7 @@ error: the `wait` method cannot be invoked on a trait object
    |
 LL |     arg.wait();
    |         ^^^^
+   |
 help: another candidate was found in the following trait, perhaps add a `use` for it:
    |
 LL | use private::Future;

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -3,6 +3,7 @@ error[E0404]: expected trait, found derive macro `Hash`
    |
 LL | struct Foo<T: ?Hash> { }
    |                ^^^^ not a trait
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::hash::Hash;

--- a/src/test/ui/issues/issue-38293.stderr
+++ b/src/test/ui/issues/issue-38293.stderr
@@ -9,6 +9,7 @@ error[E0423]: expected function, found module `baz`
    |
 LL |     baz();
    |     ^^^ not a function
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use bar::baz;

--- a/src/test/ui/issues/issue-41652/issue-41652.stderr
+++ b/src/test/ui/issues/issue-41652/issue-41652.stderr
@@ -3,6 +3,7 @@ error[E0689]: can't call method `f` on ambiguous numeric type `{integer}`
    |
 LL |         3.f()
    |           ^
+   |
 help: you must specify a concrete type for this numeric value, like `i32`
    |
 LL |         3_i32.f()

--- a/src/test/ui/issues/issue-42944.stderr
+++ b/src/test/ui/issues/issue-42944.stderr
@@ -9,6 +9,7 @@ error[E0425]: cannot find function `B` in this scope
    |
 LL |         B(());
    |         ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |     use foo::B;

--- a/src/test/ui/issues/issue-4366-2.stderr
+++ b/src/test/ui/issues/issue-4366-2.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Bar` in this scope
    |
 LL |         fn sub() -> Bar { 1 }
    |                     ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |         use a::b::Bar;
@@ -13,6 +14,7 @@ error[E0423]: expected function, found module `foo`
    |
 LL |     foo();
    |     ^^^ not a function
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use foo::foo;

--- a/src/test/ui/issues/issue-4366.stderr
+++ b/src/test/ui/issues/issue-4366.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find function `foo` in this scope
    |
 LL |         fn sub() -> isize { foo(); 1 }
    |                             ^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use foo::foo;

--- a/src/test/ui/issues/issue-44406.stderr
+++ b/src/test/ui/issues/issue-44406.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `true`
    |
 LL |     foo!(true);
    |          ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     foo!(r#true);

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -6,6 +6,7 @@ LL |      let _a = b + ", World!";
    |               | |
    |               | `+` cannot be used to concatenate two `&str` strings
    |               &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |      let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -6,6 +6,7 @@ LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
    |                                      | |
    |                                      | `+` cannot be used to concatenate two `&str` strings
    |                                      &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-49257.stderr
+++ b/src/test/ui/issues/issue-49257.stderr
@@ -6,6 +6,7 @@ LL |     let Point { .., y, } = p;
    |                 | |
    |                 | expected `}`
    |                 `..` must be at the end and cannot have a trailing comma
+   |
 help: move the `..` to the end of the field list
    |
 LL |     let Point { y, .. } = p;
@@ -19,6 +20,7 @@ LL |     let Point { .., y } = p;
    |                 | |
    |                 | expected `}`
    |                 `..` must be at the end and cannot have a trailing comma
+   |
 help: move the `..` to the end of the field list
    |
 LL |     let Point { y , .. } = p;

--- a/src/test/ui/issues/issue-50571.stderr
+++ b/src/test/ui/issues/issue-50571.stderr
@@ -3,6 +3,7 @@ error[E0642]: patterns aren't allowed in methods without bodies
    |
 LL |     fn foo([a, b]: [i32; 2]) {}
    |            ^^^^^^
+   |
 help: give this argument a name or use an underscore to ignore it
    |
 LL |     fn foo(_: [i32; 2]) {}

--- a/src/test/ui/issues/issue-50599.stderr
+++ b/src/test/ui/issues/issue-50599.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find value `LOG10_2` in module `std::f64`
    |
 LL |     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
    |                                                ^^^^^^^ not found in `std::f64`
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use std::f32::consts::LOG10_2;

--- a/src/test/ui/issues/issue-51874.stderr
+++ b/src/test/ui/issues/issue-51874.stderr
@@ -3,6 +3,7 @@ error[E0689]: can't call method `pow` on ambiguous numeric type `{float}`
    |
 LL |     let a = (1.0).pow(1.0);
    |                   ^^^
+   |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |     let a = (1.0_f32).pow(1.0);

--- a/src/test/ui/issues/issue-5239-1.stderr
+++ b/src/test/ui/issues/issue-5239-1.stderr
@@ -5,6 +5,7 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              -^^^^^
    |                              |
    |                              cannot use `+=` on type `&isize`
+   |
 help: `+=` can be used on 'isize', you can dereference `x`
    |
 LL |     let x = |ref x: isize| { *x += 1; };

--- a/src/test/ui/issues/issue-56685.stderr
+++ b/src/test/ui/issues/issue-56685.stderr
@@ -19,6 +19,7 @@ error: unused variable: `x`
    |
 LL |         F::A(x, y) | F::B(x, y) => { y },
    |              ^            ^
+   |
 help: consider prefixing with an underscore
    |
 LL |         F::A(_x, y) | F::B(_x, y) => { y },
@@ -41,6 +42,7 @@ error: unused variable: `x`
    |
 LL |     let _ = if let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |                         ^            ^
+   |
 help: consider prefixing with an underscore
    |
 LL |     let _ = if let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {
@@ -51,6 +53,7 @@ error: unused variable: `x`
    |
 LL |     while let F::A(x, y) | F::B(x, y) = F::A(1, 2) {
    |                    ^            ^
+   |
 help: consider prefixing with an underscore
    |
 LL |     while let F::A(_x, y) | F::B(_x, y) = F::A(1, 2) {

--- a/src/test/ui/issues/issue-57198.stderr
+++ b/src/test/ui/issues/issue-57198.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `for`
    |
 LL |     m::for();
    |        ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     m::r#for();

--- a/src/test/ui/issues/issue-58857.stderr
+++ b/src/test/ui/issues/issue-58857.stderr
@@ -3,6 +3,7 @@ error: negative trait bounds are not supported
    |
 LL | impl<A: !Valid> Conj<A>{}
    |       ^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bound
 
 error: aborting due to previous error

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -41,6 +41,7 @@ LL |     foo > foo;
    |     --- ^ --- fn() -> i32 {foo}
    |     |
    |     fn() -> i32 {foo}
+   |
 help: you might have forgotten to call this function
    |
 LL |     foo() > foo;

--- a/src/test/ui/issues/issue-62554.stderr
+++ b/src/test/ui/issues/issue-62554.stderr
@@ -18,6 +18,7 @@ LL | fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s 
    |                 --    ^^^^^^^^^^^ expected `{`
    |                 |
    |                 this `if` statement has a condition, but no block
+   |
 help: try placing this code inside a block
    |
 LL | fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {

--- a/src/test/ui/issues/issue-64732.stderr
+++ b/src/test/ui/issues/issue-64732.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let _foo = b'hello\0';
    |                 ^^^^^^^^^
+   |
 help: if you meant to write a byte string literal, use double quotes
    |
 LL |     let _foo = b"hello\0";
@@ -13,6 +14,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let _bar = 'hello';
    |                ^^^^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let _bar = "hello";

--- a/src/test/ui/issues/issue-8761.stderr
+++ b/src/test/ui/issues/issue-8761.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     A = 1i64,
    |         ^^^^ expected isize, found i64
+   |
 help: change the type of the numeric literal from `i64` to `isize`
    |
 LL |     A = 1isize,
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     B = 2u8
    |         ^^^ expected isize, found u8
+   |
 help: change the type of the numeric literal from `u8` to `isize`
    |
 LL |     B = 2isize

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-pat.stderr
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-pat.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `extern`
    |
 LL |     let extern = 0;
    |         ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#extern = 0;

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `extern`
    |
 LL | use extern::foo;
    |     ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use r#extern::foo;

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -3,6 +3,7 @@ error[E0574]: expected struct, variant or union type, found type parameter `T`
    |
 LL |     let t = T { i: 0 };
    |             ^ not a struct, variant or union type
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use T;

--- a/src/test/ui/lifetime_starts_expressions.stderr
+++ b/src/test/ui/lifetime_starts_expressions.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `loop`
    |
 LL |     loop { break 'label: loop { break 'label 42; }; }
    |                          ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     loop { break 'label: r#loop { break 'label 42; }; }

--- a/src/test/ui/lint/use_suggestion_json.stderr
+++ b/src/test/ui/lint/use_suggestion_json.stderr
@@ -385,6 +385,7 @@ mod foo {
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0m    let x: Iter;\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0m           \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9m^^^^\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;9mnot found in this scope\u001b[0m
+\u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
 \u001b[0m\u001b[1m\u001b[38;5;14mhelp\u001b[0m\u001b[0m: possible candidates are found in other modules, you can import them into scope\u001b[0m
 \u001b[0m   \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m|\u001b[0m
 \u001b[0m\u001b[1m\u001b[38;5;12mLL\u001b[0m\u001b[0m \u001b[0m\u001b[0m\u001b[1m\u001b[38;5;12m| \u001b[0m\u001b[0muse std::collections::binary_heap::Iter;\u001b[0m

--- a/src/test/ui/loops/loop-break-value-no-repeat.stderr
+++ b/src/test/ui/loops/loop-break-value-no-repeat.stderr
@@ -3,6 +3,7 @@ error[E0571]: `break` with value from a `for` loop
    |
 LL |         break 22
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `for` loop
    |
 LL |         break

--- a/src/test/ui/loops/loop-break-value.stderr
+++ b/src/test/ui/loops/loop-break-value.stderr
@@ -11,6 +11,7 @@ error[E0571]: `break` with value from a `while` loop
    |
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `while` loop
    |
 LL |         break;
@@ -21,6 +22,7 @@ error[E0571]: `break` with value from a `while` loop
    |
 LL |             break 'while_loop 123;
    |             ^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `while` loop
    |
 LL |             break;
@@ -31,6 +33,7 @@ error[E0571]: `break` with value from a `while let` loop
    |
 LL |         if break () {
    |            ^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `while let` loop
    |
 LL |         if break {
@@ -41,6 +44,7 @@ error[E0571]: `break` with value from a `while let` loop
    |
 LL |         break None;
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `while let` loop
    |
 LL |         break;
@@ -51,6 +55,7 @@ error[E0571]: `break` with value from a `while let` loop
    |
 LL |             break 'while_let_loop "nope";
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `while let` loop
    |
 LL |             break;
@@ -61,6 +66,7 @@ error[E0571]: `break` with value from a `for` loop
    |
 LL |         break ();
    |         ^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `for` loop
    |
 LL |         break;
@@ -71,6 +77,7 @@ error[E0571]: `break` with value from a `for` loop
    |
 LL |         break [()];
    |         ^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `for` loop
    |
 LL |         break;
@@ -81,6 +88,7 @@ error[E0571]: `break` with value from a `for` loop
    |
 LL |             break 'for_loop Some(17);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ can only break with a value inside `loop` or breakable block
+   |
 help: instead, use `break` on its own without a value inside this `for` loop
    |
 LL |             break;

--- a/src/test/ui/macros/bad_hello.stderr
+++ b/src/test/ui/macros/bad_hello.stderr
@@ -3,6 +3,7 @@ error: format argument must be a string literal
    |
 LL |     println!(3 + 4);
    |              ^^^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     println!("{}", 3 + 4);
@@ -13,6 +14,7 @@ error: format argument must be a string literal
    |
 LL |     println!(3, 4);
    |              ^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     println!("{} {}", 3, 4);

--- a/src/test/ui/macros/derive-in-eager-expansion-hang.stderr
+++ b/src/test/ui/macros/derive-in-eager-expansion-hang.stderr
@@ -11,6 +11,7 @@ LL | |     }
 ...
 LL |       format_args!(hang!());
    |                    ------- in this macro invocation
+   |
 help: you might be missing a string literal to format with
    |
 LL |     format_args!("{}", hang!());

--- a/src/test/ui/macros/format-parse-errors.stderr
+++ b/src/test/ui/macros/format-parse-errors.stderr
@@ -43,6 +43,7 @@ error: format argument must be a string literal
    |
 LL |     format!(123);
    |             ^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     format!("{}", 123);

--- a/src/test/ui/macros/issue-30143.stderr
+++ b/src/test/ui/macros/issue-30143.stderr
@@ -3,6 +3,7 @@ error: format argument must be a string literal
    |
 LL |     println!(0);
    |              ^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     println!("{}", 0);
@@ -13,6 +14,7 @@ error: format argument must be a string literal
    |
 LL |     eprintln!('a');
    |               ^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     eprintln!("{}", 'a');
@@ -23,6 +25,7 @@ error: format argument must be a string literal
    |
 LL |     writeln!(s, true).unwrap();
    |                 ^^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     writeln!(s, "{}", true).unwrap();

--- a/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
+++ b/src/test/ui/macros/macro-backtrace-invalid-internals.stderr
@@ -33,6 +33,7 @@ LL |           2.0.neg()
 ...
 LL |     real_method_stmt!();
    |     -------------------- in this macro invocation
+   |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()
@@ -73,6 +74,7 @@ LL |           2.0.neg()
 ...
 LL |     let _ = real_method_expr!();
    |             ------------------- in this macro invocation
+   |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |           2.0_f32.neg()

--- a/src/test/ui/macros/macro-outer-attributes.stderr
+++ b/src/test/ui/macros/macro-outer-attributes.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find function `bar` in module `a`
    |
 LL |     a::bar();
    |        ^^^ not found in `a`
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use b::bar;

--- a/src/test/ui/macros/macros-nonfatal-errors.stderr
+++ b/src/test/ui/macros/macros-nonfatal-errors.stderr
@@ -45,6 +45,7 @@ error: format argument must be a string literal
    |
 LL |     format!(invalid);
    |             ^^^^^^^
+   |
 help: you might be missing a string literal to format with
    |
 LL |     format!("{}", invalid);

--- a/src/test/ui/malformed/malformed-unwind-2.stderr
+++ b/src/test/ui/malformed/malformed-unwind-2.stderr
@@ -3,6 +3,7 @@ error[E0633]: malformed `unwind` attribute input
    |
 LL | #[unwind(allowed, aborts)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid argument
+   |
 help: the allowed arguments are `allowed` and `aborts`
    |
 LL | #[unwind(allowed)]
@@ -15,6 +16,7 @@ error[E0633]: malformed `unwind` attribute input
    |
 LL | #[unwind(unsupported)]
    | ^^^^^^^^^^^^^^^^^^^^^^ invalid argument
+   |
 help: the allowed arguments are `allowed` and `aborts`
    |
 LL | #[unwind(allowed)]

--- a/src/test/ui/meta-expected-error-correct-rev.a.stderr
+++ b/src/test/ui/meta-expected-error-correct-rev.a.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     let x: u32 = 22_usize;
    |                  ^^^^^^^^ expected u32, found usize
+   |
 help: change the type of the numeric literal from `usize` to `u32`
    |
 LL |     let x: u32 = 22_u32;

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -11,6 +11,7 @@ error[E0308]: mismatched types
    |
 LL |     let y: usize = x.foo();
    |                    ^^^^^^^ expected usize, found isize
+   |
 help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     let y: usize = x.foo().try_into().unwrap();

--- a/src/test/ui/methods/method-on-ambiguous-numeric-type.stderr
+++ b/src/test/ui/methods/method-on-ambiguous-numeric-type.stderr
@@ -3,6 +3,7 @@ error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
    |
 LL |     let x = 2.0.neg();
    |                 ^^^
+   |
 help: you must specify a concrete type for this numeric value, like `f32`
    |
 LL |     let x = 2.0_f32.neg();
@@ -13,6 +14,7 @@ error[E0689]: can't call method `neg` on ambiguous numeric type `{float}`
    |
 LL |     let x = y.neg();
    |               ^^^
+   |
 help: you must specify a type for this binding, like `f32`
    |
 LL |     let y: f32 = 2.0;
@@ -31,6 +33,7 @@ error[E0689]: can't call method `pow` on ambiguous numeric type `{integer}`
    |
 LL |     local_bar.pow(2);
    |               ^^^
+   |
 help: you must specify a type for this binding, like `i32`
    |
 LL |     ($ident:ident) => { let $ident: i32 = 42; }

--- a/src/test/ui/mismatched_types/closure-arg-count-expected-type-issue-47244.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count-expected-type-issue-47244.stderr
@@ -5,6 +5,7 @@ LL |     let _n = m.iter().map(|_, b| {
    |                       ^^^ ------ takes 2 distinct arguments
    |                       |
    |                       expected closure that takes a single 2-tuple as argument
+   |
 help: change the closure to accept a tuple instead of individual arguments
    |
 LL |     let _n = m.iter().map(|(_, b)| {

--- a/src/test/ui/mismatched_types/closure-arg-count.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-count.stderr
@@ -5,6 +5,7 @@ LL |     [1, 2, 3].sort_by(|| panic!());
    |               ^^^^^^^ -- takes 0 arguments
    |               |
    |               expected closure that takes 2 arguments
+   |
 help: consider changing the closure to take and ignore the expected arguments
    |
 LL |     [1, 2, 3].sort_by(|_, _| panic!());
@@ -25,6 +26,7 @@ LL |     [1, 2, 3].sort_by(|(tuple, tuple2)| panic!());
    |               ^^^^^^^ ----------------- takes a single 2-tuple as argument
    |               |
    |               expected closure that takes 2 distinct arguments
+   |
 help: change the closure to take multiple arguments instead of a single tuple
    |
 LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
@@ -37,6 +39,7 @@ LL |     [1, 2, 3].sort_by(|(tuple, tuple2): (usize, _)| panic!());
    |               ^^^^^^^ ----------------------------- takes a single 2-tuple as argument
    |               |
    |               expected closure that takes 2 distinct arguments
+   |
 help: change the closure to take multiple arguments instead of a single tuple
    |
 LL |     [1, 2, 3].sort_by(|tuple, tuple2| panic!());
@@ -52,6 +55,7 @@ LL |     f(|| panic!());
    |     ^ -- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
+   |
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(|_| panic!());
@@ -67,6 +71,7 @@ LL |     f(  move    || panic!());
    |     ^   ---------- takes 0 arguments
    |     |
    |     expected closure that takes 1 argument
+   |
 help: consider changing the closure to take and ignore the expected argument
    |
 LL |     f(  move    |_| panic!());
@@ -79,6 +84,7 @@ LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i, x| i);
    |                                                     ^^^ ------ takes 2 distinct arguments
    |                                                     |
    |                                                     expected closure that takes a single 2-tuple as argument
+   |
 help: change the closure to accept a tuple instead of individual arguments
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|(i, x)| i);
@@ -91,6 +97,7 @@ LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|i: usize, x| i);
    |                                                     ^^^ ------------- takes 2 distinct arguments
    |                                                     |
    |                                                     expected closure that takes a single 2-tuple as argument
+   |
 help: change the closure to accept a tuple instead of individual arguments
    |
 LL |     let _it = vec![1, 2, 3].into_iter().enumerate().map(|(i, x)| i);

--- a/src/test/ui/mismatched_types/issue-26480.stderr
+++ b/src/test/ui/mismatched_types/issue-26480.stderr
@@ -6,6 +6,7 @@ LL |                   $arr.len() * size_of($arr[0]));
 ...
 LL |     write!(hello);
    |     -------------- in this macro invocation
+   |
 help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |                   ($arr.len() * size_of($arr[0])).try_into().unwrap());

--- a/src/test/ui/mismatched_types/numeric-literal-cast.stderr
+++ b/src/test/ui/mismatched_types/numeric-literal-cast.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     foo(1u8);
    |         ^^^ expected u16, found u8
+   |
 help: change the type of the numeric literal from `u8` to `u16`
    |
 LL |     foo(1u16);
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     foo1(2f32);
    |          ^^^^ expected f64, found f32
+   |
 help: change the type of the numeric literal from `f32` to `f64`
    |
 LL |     foo1(2f64);
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |     foo2(3i16);
    |          ^^^^ expected i32, found i16
+   |
 help: change the type of the numeric literal from `i16` to `i32`
    |
 LL |     foo2(3i32);

--- a/src/test/ui/mismatched_types/recovered-block.stderr
+++ b/src/test/ui/mismatched_types/recovered-block.stderr
@@ -3,6 +3,7 @@ error: missing `struct` for struct definition
    |
 LL |     pub Foo { text }
    |        ^
+   |
 help: add `struct` here to parse `Foo` as a public struct
    |
 LL |     pub struct Foo { text }

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -42,6 +42,7 @@ LL |         V {},
 ...
 LL |     check(m7::V);
    |           ^^^^^ did you mean `m7::V { /* fields */ }`?
+   |
 help: a tuple variant with a similar name exists
    |
 LL |     check(m7::TV);
@@ -58,6 +59,7 @@ error[E0423]: expected value, found struct variant `xm7::V`
    |
 LL |     check(xm7::V);
    |           ^^^^^^ did you mean `xm7::V { /* fields */ }`?
+   |
 help: a tuple variant with a similar name exists
    |
 LL |     check(xm7::TV);

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -3,6 +3,7 @@ error[E0621]: explicit lifetime required in the type of `x`
    |
 LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
    |                         ^^^^^^^^^^^^ lifetime `ReEarlyBound(0, 'a)` required
+   |
 help: add explicit lifetime `ReEarlyBound(0, 'a)` to the type of `x`
    |
 LL | fn foo<'a, T>(x: &ReEarlyBound(0, 'a) T) -> impl Foo<'a> {

--- a/src/test/ui/no-implicit-prelude-nested.stderr
+++ b/src/test/ui/no-implicit-prelude-nested.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `Add` in this scope
    |
 LL |         impl Add for Test {}
    |              ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |         use std::ops::Add;
@@ -13,6 +14,7 @@ error[E0404]: expected trait, found derive macro `Clone`
    |
 LL |         impl Clone for Test {}
    |              ^^^^^ not a trait
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |         use std::clone::Clone;
@@ -25,6 +27,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
    |
 LL |         impl Iterator for Test {}
    |              ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::iter::Iterator;
@@ -37,6 +40,7 @@ error[E0405]: cannot find trait `ToString` in this scope
    |
 LL |         impl ToString for Test {}
    |              ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::prelude::v1::ToString;
@@ -55,6 +59,7 @@ error[E0425]: cannot find function `drop` in this scope
    |
 LL |             drop(2)
    |             ^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::mem::drop;
@@ -67,6 +72,7 @@ error[E0405]: cannot find trait `Add` in this scope
    |
 LL |     impl Add for Test {}
    |          ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |     use std::ops::Add;
@@ -77,6 +83,7 @@ error[E0404]: expected trait, found derive macro `Clone`
    |
 LL |     impl Clone for Test {}
    |          ^^^^^ not a trait
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |     use std::clone::Clone;
@@ -89,6 +96,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
    |
 LL |     impl Iterator for Test {}
    |          ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |     use std::iter::Iterator;
@@ -101,6 +109,7 @@ error[E0405]: cannot find trait `ToString` in this scope
    |
 LL |     impl ToString for Test {}
    |          ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |     use std::prelude::v1::ToString;
@@ -119,6 +128,7 @@ error[E0425]: cannot find function `drop` in this scope
    |
 LL |         drop(2)
    |         ^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |     use std::mem::drop;
@@ -131,6 +141,7 @@ error[E0405]: cannot find trait `Add` in this scope
    |
 LL |         impl Add for Test {}
    |              ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |         use std::ops::Add;
@@ -141,6 +152,7 @@ error[E0404]: expected trait, found derive macro `Clone`
    |
 LL |         impl Clone for Test {}
    |              ^^^^^ not a trait
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL |         use std::clone::Clone;
@@ -153,6 +165,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
    |
 LL |         impl Iterator for Test {}
    |              ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::iter::Iterator;
@@ -165,6 +178,7 @@ error[E0405]: cannot find trait `ToString` in this scope
    |
 LL |         impl ToString for Test {}
    |              ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::prelude::v1::ToString;
@@ -183,6 +197,7 @@ error[E0425]: cannot find function `drop` in this scope
    |
 LL |             drop(2)
    |             ^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL |         use std::mem::drop;

--- a/src/test/ui/no-implicit-prelude.stderr
+++ b/src/test/ui/no-implicit-prelude.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `Add` in this scope
    |
 LL | impl Add for Test {}
    |      ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use std::ops::Add;
@@ -13,6 +14,7 @@ error[E0404]: expected trait, found derive macro `Clone`
    |
 LL | impl Clone for Test {}
    |      ^^^^^ not a trait
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use std::clone::Clone;
@@ -25,6 +27,7 @@ error[E0405]: cannot find trait `Iterator` in this scope
    |
 LL | impl Iterator for Test {}
    |      ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use std::iter::Iterator;
@@ -37,6 +40,7 @@ error[E0405]: cannot find trait `ToString` in this scope
    |
 LL | impl ToString for Test {}
    |      ^^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use std::prelude::v1::ToString;
@@ -55,6 +59,7 @@ error[E0425]: cannot find function `drop` in this scope
    |
 LL |     drop(2)
    |     ^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use std::mem::drop;

--- a/src/test/ui/numeric/const-scope.stderr
+++ b/src/test/ui/numeric/const-scope.stderr
@@ -27,6 +27,7 @@ error[E0308]: mismatched types
    |
 LL |     let c: i32 = 1i8;
    |                  ^^^ expected i32, found i8
+   |
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL |     let c: i32 = 1i32;
@@ -37,6 +38,7 @@ error[E0308]: mismatched types
    |
 LL |     let d: i8 = c;
    |                 ^ expected i8, found i32
+   |
 help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     let d: i8 = c.try_into().unwrap();

--- a/src/test/ui/numeric/len.stderr
+++ b/src/test/ui/numeric/len.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     test(array.len());
    |          ^^^^^^^^^^^ expected u32, found usize
+   |
 help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     test(array.len().try_into().unwrap());

--- a/src/test/ui/numeric/numeric-cast-2.stderr
+++ b/src/test/ui/numeric/numeric-cast-2.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     let x: u16 = foo();
    |                  ^^^^^ expected u16, found i32
+   |
 help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     let x: u16 = foo().try_into().unwrap();
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     let y: i64 = x + x;
    |                  ^^^^^ expected i64, found u16
+   |
 help: you can convert an `u16` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     let y: i64 = (x + x).try_into().unwrap();
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |     let z: i32 = x + x;
    |                  ^^^^^ expected i32, found u16
+   |
 help: you can convert an `u16` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     let z: i32 = (x + x).try_into().unwrap();

--- a/src/test/ui/numeric/numeric-cast.stderr
+++ b/src/test/ui/numeric/numeric-cast.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_u64);
    |                  ^^^^^ expected usize, found u64
+   |
 help: you can convert an `u64` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u64.try_into().unwrap());
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_u32);
    |                  ^^^^^ expected usize, found u32
+   |
 help: you can convert an `u32` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u32.try_into().unwrap());
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_u16);
    |                  ^^^^^ expected usize, found u16
+   |
 help: you can convert an `u16` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u16.try_into().unwrap());
@@ -33,6 +36,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_u8);
    |                  ^^^^ expected usize, found u8
+   |
 help: you can convert an `u8` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_u8.try_into().unwrap());
@@ -43,6 +47,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_isize);
    |                  ^^^^^^^ expected usize, found isize
+   |
 help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_isize.try_into().unwrap());
@@ -53,6 +58,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_i64);
    |                  ^^^^^ expected usize, found i64
+   |
 help: you can convert an `i64` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i64.try_into().unwrap());
@@ -63,6 +69,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_i32);
    |                  ^^^^^ expected usize, found i32
+   |
 help: you can convert an `i32` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i32.try_into().unwrap());
@@ -73,6 +80,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_i16);
    |                  ^^^^^ expected usize, found i16
+   |
 help: you can convert an `i16` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i16.try_into().unwrap());
@@ -83,6 +91,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(x_i8);
    |                  ^^^^ expected usize, found i8
+   |
 help: you can convert an `i8` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<usize>(x_i8.try_into().unwrap());
@@ -93,6 +102,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_usize);
    |                  ^^^^^^^ expected isize, found usize
+   |
 help: you can convert an `usize` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_usize.try_into().unwrap());
@@ -103,6 +113,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_u64);
    |                  ^^^^^ expected isize, found u64
+   |
 help: you can convert an `u64` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u64.try_into().unwrap());
@@ -113,6 +124,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_u32);
    |                  ^^^^^ expected isize, found u32
+   |
 help: you can convert an `u32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u32.try_into().unwrap());
@@ -123,6 +135,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_u16);
    |                  ^^^^^ expected isize, found u16
+   |
 help: you can convert an `u16` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u16.try_into().unwrap());
@@ -133,6 +146,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_u8);
    |                  ^^^^ expected isize, found u8
+   |
 help: you can convert an `u8` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_u8.try_into().unwrap());
@@ -143,6 +157,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_i64);
    |                  ^^^^^ expected isize, found i64
+   |
 help: you can convert an `i64` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i64.try_into().unwrap());
@@ -153,6 +168,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_i32);
    |                  ^^^^^ expected isize, found i32
+   |
 help: you can convert an `i32` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i32.try_into().unwrap());
@@ -163,6 +179,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_i16);
    |                  ^^^^^ expected isize, found i16
+   |
 help: you can convert an `i16` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i16.try_into().unwrap());
@@ -173,6 +190,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(x_i8);
    |                  ^^^^ expected isize, found i8
+   |
 help: you can convert an `i8` to `isize` and panic if the converted value wouldn't fit
    |
 LL |     foo::<isize>(x_i8.try_into().unwrap());
@@ -183,6 +201,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_usize);
    |                ^^^^^^^ expected u64, found usize
+   |
 help: you can convert an `usize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_usize.try_into().unwrap());
@@ -220,6 +239,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_isize);
    |                ^^^^^^^ expected u64, found isize
+   |
 help: you can convert an `isize` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_isize.try_into().unwrap());
@@ -230,6 +250,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_i64);
    |                ^^^^^ expected u64, found i64
+   |
 help: you can convert an `i64` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i64.try_into().unwrap());
@@ -240,6 +261,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_i32);
    |                ^^^^^ expected u64, found i32
+   |
 help: you can convert an `i32` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i32.try_into().unwrap());
@@ -250,6 +272,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_i16);
    |                ^^^^^ expected u64, found i16
+   |
 help: you can convert an `i16` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i16.try_into().unwrap());
@@ -260,6 +283,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(x_i8);
    |                ^^^^ expected u64, found i8
+   |
 help: you can convert an `i8` to `u64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u64>(x_i8.try_into().unwrap());
@@ -270,6 +294,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_usize);
    |                ^^^^^^^ expected i64, found usize
+   |
 help: you can convert an `usize` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_usize.try_into().unwrap());
@@ -280,6 +305,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_u64);
    |                ^^^^^ expected i64, found u64
+   |
 help: you can convert an `u64` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u64.try_into().unwrap());
@@ -290,6 +316,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_u32);
    |                ^^^^^ expected i64, found u32
+   |
 help: you can convert an `u32` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u32.try_into().unwrap());
@@ -300,6 +327,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_u16);
    |                ^^^^^ expected i64, found u16
+   |
 help: you can convert an `u16` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u16.try_into().unwrap());
@@ -310,6 +338,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_u8);
    |                ^^^^ expected i64, found u8
+   |
 help: you can convert an `u8` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_u8.try_into().unwrap());
@@ -320,6 +349,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(x_isize);
    |                ^^^^^^^ expected i64, found isize
+   |
 help: you can convert an `isize` to `i64` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i64>(x_isize.try_into().unwrap());
@@ -357,6 +387,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_usize);
    |                ^^^^^^^ expected u32, found usize
+   |
 help: you can convert an `usize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_usize.try_into().unwrap());
@@ -367,6 +398,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_u64);
    |                ^^^^^ expected u32, found u64
+   |
 help: you can convert an `u64` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_u64.try_into().unwrap());
@@ -395,6 +427,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_isize);
    |                ^^^^^^^ expected u32, found isize
+   |
 help: you can convert an `isize` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_isize.try_into().unwrap());
@@ -405,6 +438,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_i64);
    |                ^^^^^ expected u32, found i64
+   |
 help: you can convert an `i64` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i64.try_into().unwrap());
@@ -415,6 +449,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_i32);
    |                ^^^^^ expected u32, found i32
+   |
 help: you can convert an `i32` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i32.try_into().unwrap());
@@ -425,6 +460,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_i16);
    |                ^^^^^ expected u32, found i16
+   |
 help: you can convert an `i16` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i16.try_into().unwrap());
@@ -435,6 +471,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(x_i8);
    |                ^^^^ expected u32, found i8
+   |
 help: you can convert an `i8` to `u32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u32>(x_i8.try_into().unwrap());
@@ -445,6 +482,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_usize);
    |                ^^^^^^^ expected i32, found usize
+   |
 help: you can convert an `usize` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_usize.try_into().unwrap());
@@ -455,6 +493,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_u64);
    |                ^^^^^ expected i32, found u64
+   |
 help: you can convert an `u64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u64.try_into().unwrap());
@@ -465,6 +504,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_u32);
    |                ^^^^^ expected i32, found u32
+   |
 help: you can convert an `u32` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u32.try_into().unwrap());
@@ -475,6 +515,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_u16);
    |                ^^^^^ expected i32, found u16
+   |
 help: you can convert an `u16` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u16.try_into().unwrap());
@@ -485,6 +526,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_u8);
    |                ^^^^ expected i32, found u8
+   |
 help: you can convert an `u8` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_u8.try_into().unwrap());
@@ -495,6 +537,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_isize);
    |                ^^^^^^^ expected i32, found isize
+   |
 help: you can convert an `isize` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_isize.try_into().unwrap());
@@ -505,6 +548,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(x_i64);
    |                ^^^^^ expected i32, found i64
+   |
 help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i32>(x_i64.try_into().unwrap());
@@ -533,6 +577,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_usize);
    |                ^^^^^^^ expected u16, found usize
+   |
 help: you can convert an `usize` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_usize.try_into().unwrap());
@@ -543,6 +588,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_u64);
    |                ^^^^^ expected u16, found u64
+   |
 help: you can convert an `u64` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u64.try_into().unwrap());
@@ -553,6 +599,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_u32);
    |                ^^^^^ expected u16, found u32
+   |
 help: you can convert an `u32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_u32.try_into().unwrap());
@@ -572,6 +619,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_isize);
    |                ^^^^^^^ expected u16, found isize
+   |
 help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_isize.try_into().unwrap());
@@ -582,6 +630,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_i64);
    |                ^^^^^ expected u16, found i64
+   |
 help: you can convert an `i64` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i64.try_into().unwrap());
@@ -592,6 +641,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_i32);
    |                ^^^^^ expected u16, found i32
+   |
 help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i32.try_into().unwrap());
@@ -602,6 +652,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_i16);
    |                ^^^^^ expected u16, found i16
+   |
 help: you can convert an `i16` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i16.try_into().unwrap());
@@ -612,6 +663,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(x_i8);
    |                ^^^^ expected u16, found i8
+   |
 help: you can convert an `i8` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u16>(x_i8.try_into().unwrap());
@@ -622,6 +674,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_usize);
    |                ^^^^^^^ expected i16, found usize
+   |
 help: you can convert an `usize` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_usize.try_into().unwrap());
@@ -632,6 +685,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_u64);
    |                ^^^^^ expected i16, found u64
+   |
 help: you can convert an `u64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u64.try_into().unwrap());
@@ -642,6 +696,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_u32);
    |                ^^^^^ expected i16, found u32
+   |
 help: you can convert an `u32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u32.try_into().unwrap());
@@ -652,6 +707,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_u16);
    |                ^^^^^ expected i16, found u16
+   |
 help: you can convert an `u16` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u16.try_into().unwrap());
@@ -662,6 +718,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_u8);
    |                ^^^^ expected i16, found u8
+   |
 help: you can convert an `u8` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_u8.try_into().unwrap());
@@ -672,6 +729,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_isize);
    |                ^^^^^^^ expected i16, found isize
+   |
 help: you can convert an `isize` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_isize.try_into().unwrap());
@@ -682,6 +740,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_i64);
    |                ^^^^^ expected i16, found i64
+   |
 help: you can convert an `i64` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_i64.try_into().unwrap());
@@ -692,6 +751,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(x_i32);
    |                ^^^^^ expected i16, found i32
+   |
 help: you can convert an `i32` to `i16` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i16>(x_i32.try_into().unwrap());
@@ -711,6 +771,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_usize);
    |               ^^^^^^^ expected u8, found usize
+   |
 help: you can convert an `usize` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_usize.try_into().unwrap());
@@ -721,6 +782,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_u64);
    |               ^^^^^ expected u8, found u64
+   |
 help: you can convert an `u64` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u64.try_into().unwrap());
@@ -731,6 +793,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_u32);
    |               ^^^^^ expected u8, found u32
+   |
 help: you can convert an `u32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u32.try_into().unwrap());
@@ -741,6 +804,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_u16);
    |               ^^^^^ expected u8, found u16
+   |
 help: you can convert an `u16` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_u16.try_into().unwrap());
@@ -751,6 +815,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_isize);
    |               ^^^^^^^ expected u8, found isize
+   |
 help: you can convert an `isize` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_isize.try_into().unwrap());
@@ -761,6 +826,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_i64);
    |               ^^^^^ expected u8, found i64
+   |
 help: you can convert an `i64` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i64.try_into().unwrap());
@@ -771,6 +837,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_i32);
    |               ^^^^^ expected u8, found i32
+   |
 help: you can convert an `i32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i32.try_into().unwrap());
@@ -781,6 +848,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_i16);
    |               ^^^^^ expected u8, found i16
+   |
 help: you can convert an `i16` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i16.try_into().unwrap());
@@ -791,6 +859,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(x_i8);
    |               ^^^^ expected u8, found i8
+   |
 help: you can convert an `i8` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<u8>(x_i8.try_into().unwrap());
@@ -801,6 +870,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_usize);
    |               ^^^^^^^ expected i8, found usize
+   |
 help: you can convert an `usize` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_usize.try_into().unwrap());
@@ -811,6 +881,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_u64);
    |               ^^^^^ expected i8, found u64
+   |
 help: you can convert an `u64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u64.try_into().unwrap());
@@ -821,6 +892,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_u32);
    |               ^^^^^ expected i8, found u32
+   |
 help: you can convert an `u32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u32.try_into().unwrap());
@@ -831,6 +903,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_u16);
    |               ^^^^^ expected i8, found u16
+   |
 help: you can convert an `u16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u16.try_into().unwrap());
@@ -841,6 +914,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_u8);
    |               ^^^^ expected i8, found u8
+   |
 help: you can convert an `u8` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_u8.try_into().unwrap());
@@ -851,6 +925,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_isize);
    |               ^^^^^^^ expected i8, found isize
+   |
 help: you can convert an `isize` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_isize.try_into().unwrap());
@@ -861,6 +936,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_i64);
    |               ^^^^^ expected i8, found i64
+   |
 help: you can convert an `i64` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i64.try_into().unwrap());
@@ -871,6 +947,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_i32);
    |               ^^^^^ expected i8, found i32
+   |
 help: you can convert an `i32` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i32.try_into().unwrap());
@@ -881,6 +958,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(x_i16);
    |               ^^^^^ expected i8, found i16
+   |
 help: you can convert an `i16` to `i8` and panic if the converted value wouldn't fit
    |
 LL |     foo::<i8>(x_i16.try_into().unwrap());
@@ -891,6 +969,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_usize);
    |                ^^^^^^^ expected f64, found usize
+   |
 help: you can cast an `usize to `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_usize as f64);
@@ -901,6 +980,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_u64);
    |                ^^^^^ expected f64, found u64
+   |
 help: you can cast an `u64 to `f64`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f64>(x_u64 as f64);
@@ -911,6 +991,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_u32);
    |                ^^^^^ expected f64, found u32
+   |
 help: you can convert an `u32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u32.into());
@@ -921,6 +1002,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_u16);
    |                ^^^^^ expected f64, found u16
+   |
 help: you can convert an `u16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u16.into());
@@ -931,6 +1013,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_u8);
    |                ^^^^ expected f64, found u8
+   |
 help: you can convert an `u8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_u8.into());
@@ -941,6 +1024,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_isize);
    |                ^^^^^^^ expected f64, found isize
+   |
 help: you can convert an `isize` to `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_isize as f64);
@@ -951,6 +1035,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_i64);
    |                ^^^^^ expected f64, found i64
+   |
 help: you can convert an `i64` to `f64`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f64>(x_i64 as f64);
@@ -961,6 +1046,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_i32);
    |                ^^^^^ expected f64, found i32
+   |
 help: you can convert an `i32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i32.into());
@@ -971,6 +1057,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_i16);
    |                ^^^^^ expected f64, found i16
+   |
 help: you can convert an `i16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i16.into());
@@ -981,6 +1068,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(x_i8);
    |                ^^^^ expected f64, found i8
+   |
 help: you can convert an `i8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(x_i8.into());
@@ -1000,6 +1088,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_usize);
    |                ^^^^^^^ expected f32, found usize
+   |
 help: you can cast an `usize to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_usize as f32);
@@ -1010,6 +1099,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_u64);
    |                ^^^^^ expected f32, found u64
+   |
 help: you can cast an `u64 to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u64 as f32);
@@ -1020,6 +1110,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_u32);
    |                ^^^^^ expected f32, found u32
+   |
 help: you can cast an `u32 to `f32`, producing the floating point representation of the integer,
    |                                              rounded if necessary
 LL |     foo::<f32>(x_u32 as f32);
@@ -1030,6 +1121,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_u16);
    |                ^^^^^ expected f32, found u16
+   |
 help: you can convert an `u16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u16.into());
@@ -1040,6 +1132,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_u8);
    |                ^^^^ expected f32, found u8
+   |
 help: you can convert an `u8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_u8.into());
@@ -1050,6 +1143,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_isize);
    |                ^^^^^^^ expected f32, found isize
+   |
 help: you can convert an `isize` to `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_isize as f32);
@@ -1060,6 +1154,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_i64);
    |                ^^^^^ expected f32, found i64
+   |
 help: you can convert an `i64` to `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i64 as f32);
@@ -1070,6 +1165,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_i32);
    |                ^^^^^ expected f32, found i32
+   |
 help: you can convert an `i32` to `f32`, producing the floating point representation of the integer, rounded if necessary
    |
 LL |     foo::<f32>(x_i32 as f32);
@@ -1080,6 +1176,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_i16);
    |                ^^^^^ expected f32, found i16
+   |
 help: you can convert an `i16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i16.into());
@@ -1090,6 +1187,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(x_i8);
    |                ^^^^ expected f32, found i8
+   |
 help: you can convert an `i8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(x_i8.into());

--- a/src/test/ui/numeric/numeric-suffix.stderr
+++ b/src/test/ui/numeric/numeric-suffix.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_u64);
    |                  ^^^^^^ expected usize, found u64
+   |
 help: change the type of the numeric literal from `u64` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_u32);
    |                  ^^^^^^ expected usize, found u32
+   |
 help: change the type of the numeric literal from `u32` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -23,6 +25,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_u16);
    |                  ^^^^^^ expected usize, found u16
+   |
 help: change the type of the numeric literal from `u16` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -33,6 +36,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_u8);
    |                  ^^^^^ expected usize, found u8
+   |
 help: change the type of the numeric literal from `u8` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -43,6 +47,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_isize);
    |                  ^^^^^^^^ expected usize, found isize
+   |
 help: change the type of the numeric literal from `isize` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -53,6 +58,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_i64);
    |                  ^^^^^^ expected usize, found i64
+   |
 help: change the type of the numeric literal from `i64` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -63,6 +69,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_i32);
    |                  ^^^^^^ expected usize, found i32
+   |
 help: change the type of the numeric literal from `i32` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -73,6 +80,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_i16);
    |                  ^^^^^^ expected usize, found i16
+   |
 help: change the type of the numeric literal from `i16` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -83,6 +91,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42_i8);
    |                  ^^^^^ expected usize, found i8
+   |
 help: change the type of the numeric literal from `i8` to `usize`
    |
 LL |     foo::<usize>(42_usize);
@@ -93,6 +102,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42.0_f64);
    |                  ^^^^^^^^ expected usize, found f64
+   |
 help: change the type of the numeric literal from `f64` to `usize`
    |
 LL |     foo::<usize>(42usize);
@@ -103,6 +113,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<usize>(42.0_f32);
    |                  ^^^^^^^^ expected usize, found f32
+   |
 help: change the type of the numeric literal from `f32` to `usize`
    |
 LL |     foo::<usize>(42usize);
@@ -113,6 +124,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_usize);
    |                  ^^^^^^^^ expected isize, found usize
+   |
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -123,6 +135,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_u64);
    |                  ^^^^^^ expected isize, found u64
+   |
 help: change the type of the numeric literal from `u64` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -133,6 +146,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_u32);
    |                  ^^^^^^ expected isize, found u32
+   |
 help: change the type of the numeric literal from `u32` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -143,6 +157,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_u16);
    |                  ^^^^^^ expected isize, found u16
+   |
 help: change the type of the numeric literal from `u16` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -153,6 +168,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_u8);
    |                  ^^^^^ expected isize, found u8
+   |
 help: change the type of the numeric literal from `u8` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -163,6 +179,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_i64);
    |                  ^^^^^^ expected isize, found i64
+   |
 help: change the type of the numeric literal from `i64` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -173,6 +190,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_i32);
    |                  ^^^^^^ expected isize, found i32
+   |
 help: change the type of the numeric literal from `i32` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -183,6 +201,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_i16);
    |                  ^^^^^^ expected isize, found i16
+   |
 help: change the type of the numeric literal from `i16` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -193,6 +212,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42_i8);
    |                  ^^^^^ expected isize, found i8
+   |
 help: change the type of the numeric literal from `i8` to `isize`
    |
 LL |     foo::<isize>(42_isize);
@@ -203,6 +223,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42.0_f64);
    |                  ^^^^^^^^ expected isize, found f64
+   |
 help: change the type of the numeric literal from `f64` to `isize`
    |
 LL |     foo::<isize>(42isize);
@@ -213,6 +234,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<isize>(42.0_f32);
    |                  ^^^^^^^^ expected isize, found f32
+   |
 help: change the type of the numeric literal from `f32` to `isize`
    |
 LL |     foo::<isize>(42isize);
@@ -223,6 +245,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_usize);
    |                ^^^^^^^^ expected u64, found usize
+   |
 help: change the type of the numeric literal from `usize` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -233,6 +256,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_u32);
    |                ^^^^^^ expected u64, found u32
+   |
 help: change the type of the numeric literal from `u32` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -243,6 +267,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_u16);
    |                ^^^^^^ expected u64, found u16
+   |
 help: change the type of the numeric literal from `u16` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -253,6 +278,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_u8);
    |                ^^^^^ expected u64, found u8
+   |
 help: change the type of the numeric literal from `u8` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -263,6 +289,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_isize);
    |                ^^^^^^^^ expected u64, found isize
+   |
 help: change the type of the numeric literal from `isize` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -273,6 +300,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_i64);
    |                ^^^^^^ expected u64, found i64
+   |
 help: change the type of the numeric literal from `i64` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -283,6 +311,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_i32);
    |                ^^^^^^ expected u64, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -293,6 +322,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_i16);
    |                ^^^^^^ expected u64, found i16
+   |
 help: change the type of the numeric literal from `i16` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -303,6 +333,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42_i8);
    |                ^^^^^ expected u64, found i8
+   |
 help: change the type of the numeric literal from `i8` to `u64`
    |
 LL |     foo::<u64>(42_u64);
@@ -313,6 +344,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42.0_f64);
    |                ^^^^^^^^ expected u64, found f64
+   |
 help: change the type of the numeric literal from `f64` to `u64`
    |
 LL |     foo::<u64>(42u64);
@@ -323,6 +355,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u64>(42.0_f32);
    |                ^^^^^^^^ expected u64, found f32
+   |
 help: change the type of the numeric literal from `f32` to `u64`
    |
 LL |     foo::<u64>(42u64);
@@ -333,6 +366,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_usize);
    |                ^^^^^^^^ expected i64, found usize
+   |
 help: change the type of the numeric literal from `usize` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -343,6 +377,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_u64);
    |                ^^^^^^ expected i64, found u64
+   |
 help: change the type of the numeric literal from `u64` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -353,6 +388,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_u32);
    |                ^^^^^^ expected i64, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -363,6 +399,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_u16);
    |                ^^^^^^ expected i64, found u16
+   |
 help: change the type of the numeric literal from `u16` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -373,6 +410,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_u8);
    |                ^^^^^ expected i64, found u8
+   |
 help: change the type of the numeric literal from `u8` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -383,6 +421,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_isize);
    |                ^^^^^^^^ expected i64, found isize
+   |
 help: change the type of the numeric literal from `isize` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -393,6 +432,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_i32);
    |                ^^^^^^ expected i64, found i32
+   |
 help: change the type of the numeric literal from `i32` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -403,6 +443,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_i16);
    |                ^^^^^^ expected i64, found i16
+   |
 help: change the type of the numeric literal from `i16` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -413,6 +454,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42_i8);
    |                ^^^^^ expected i64, found i8
+   |
 help: change the type of the numeric literal from `i8` to `i64`
    |
 LL |     foo::<i64>(42_i64);
@@ -423,6 +465,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42.0_f64);
    |                ^^^^^^^^ expected i64, found f64
+   |
 help: change the type of the numeric literal from `f64` to `i64`
    |
 LL |     foo::<i64>(42i64);
@@ -433,6 +476,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i64>(42.0_f32);
    |                ^^^^^^^^ expected i64, found f32
+   |
 help: change the type of the numeric literal from `f32` to `i64`
    |
 LL |     foo::<i64>(42i64);
@@ -443,6 +487,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_usize);
    |                ^^^^^^^^ expected u32, found usize
+   |
 help: change the type of the numeric literal from `usize` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -453,6 +498,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_u64);
    |                ^^^^^^ expected u32, found u64
+   |
 help: change the type of the numeric literal from `u64` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -463,6 +509,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_u16);
    |                ^^^^^^ expected u32, found u16
+   |
 help: change the type of the numeric literal from `u16` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -473,6 +520,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_u8);
    |                ^^^^^ expected u32, found u8
+   |
 help: change the type of the numeric literal from `u8` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -483,6 +531,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_isize);
    |                ^^^^^^^^ expected u32, found isize
+   |
 help: change the type of the numeric literal from `isize` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -493,6 +542,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_i64);
    |                ^^^^^^ expected u32, found i64
+   |
 help: change the type of the numeric literal from `i64` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -503,6 +553,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_i32);
    |                ^^^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -513,6 +564,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_i16);
    |                ^^^^^^ expected u32, found i16
+   |
 help: change the type of the numeric literal from `i16` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -523,6 +575,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42_i8);
    |                ^^^^^ expected u32, found i8
+   |
 help: change the type of the numeric literal from `i8` to `u32`
    |
 LL |     foo::<u32>(42_u32);
@@ -533,6 +586,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42.0_f64);
    |                ^^^^^^^^ expected u32, found f64
+   |
 help: change the type of the numeric literal from `f64` to `u32`
    |
 LL |     foo::<u32>(42u32);
@@ -543,6 +597,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u32>(42.0_f32);
    |                ^^^^^^^^ expected u32, found f32
+   |
 help: change the type of the numeric literal from `f32` to `u32`
    |
 LL |     foo::<u32>(42u32);
@@ -553,6 +608,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_usize);
    |                ^^^^^^^^ expected i32, found usize
+   |
 help: change the type of the numeric literal from `usize` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -563,6 +619,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_u64);
    |                ^^^^^^ expected i32, found u64
+   |
 help: change the type of the numeric literal from `u64` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -573,6 +630,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_u32);
    |                ^^^^^^ expected i32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -583,6 +641,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_u16);
    |                ^^^^^^ expected i32, found u16
+   |
 help: change the type of the numeric literal from `u16` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -593,6 +652,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_u8);
    |                ^^^^^ expected i32, found u8
+   |
 help: change the type of the numeric literal from `u8` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -603,6 +663,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_isize);
    |                ^^^^^^^^ expected i32, found isize
+   |
 help: change the type of the numeric literal from `isize` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -613,6 +674,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_i64);
    |                ^^^^^^ expected i32, found i64
+   |
 help: change the type of the numeric literal from `i64` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -623,6 +685,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_i16);
    |                ^^^^^^ expected i32, found i16
+   |
 help: change the type of the numeric literal from `i16` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -633,6 +696,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42_i8);
    |                ^^^^^ expected i32, found i8
+   |
 help: change the type of the numeric literal from `i8` to `i32`
    |
 LL |     foo::<i32>(42_i32);
@@ -643,6 +707,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42.0_f64);
    |                ^^^^^^^^ expected i32, found f64
+   |
 help: change the type of the numeric literal from `f64` to `i32`
    |
 LL |     foo::<i32>(42i32);
@@ -653,6 +718,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i32>(42.0_f32);
    |                ^^^^^^^^ expected i32, found f32
+   |
 help: change the type of the numeric literal from `f32` to `i32`
    |
 LL |     foo::<i32>(42i32);
@@ -663,6 +729,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_usize);
    |                ^^^^^^^^ expected u16, found usize
+   |
 help: change the type of the numeric literal from `usize` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -673,6 +740,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_u64);
    |                ^^^^^^ expected u16, found u64
+   |
 help: change the type of the numeric literal from `u64` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -683,6 +751,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_u32);
    |                ^^^^^^ expected u16, found u32
+   |
 help: change the type of the numeric literal from `u32` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -693,6 +762,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_u8);
    |                ^^^^^ expected u16, found u8
+   |
 help: change the type of the numeric literal from `u8` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -703,6 +773,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_isize);
    |                ^^^^^^^^ expected u16, found isize
+   |
 help: change the type of the numeric literal from `isize` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -713,6 +784,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_i64);
    |                ^^^^^^ expected u16, found i64
+   |
 help: change the type of the numeric literal from `i64` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -723,6 +795,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_i32);
    |                ^^^^^^ expected u16, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -733,6 +806,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_i16);
    |                ^^^^^^ expected u16, found i16
+   |
 help: change the type of the numeric literal from `i16` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -743,6 +817,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42_i8);
    |                ^^^^^ expected u16, found i8
+   |
 help: change the type of the numeric literal from `i8` to `u16`
    |
 LL |     foo::<u16>(42_u16);
@@ -753,6 +828,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42.0_f64);
    |                ^^^^^^^^ expected u16, found f64
+   |
 help: change the type of the numeric literal from `f64` to `u16`
    |
 LL |     foo::<u16>(42u16);
@@ -763,6 +839,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u16>(42.0_f32);
    |                ^^^^^^^^ expected u16, found f32
+   |
 help: change the type of the numeric literal from `f32` to `u16`
    |
 LL |     foo::<u16>(42u16);
@@ -773,6 +850,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_usize);
    |                ^^^^^^^^ expected i16, found usize
+   |
 help: change the type of the numeric literal from `usize` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -783,6 +861,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_u64);
    |                ^^^^^^ expected i16, found u64
+   |
 help: change the type of the numeric literal from `u64` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -793,6 +872,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_u32);
    |                ^^^^^^ expected i16, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -803,6 +883,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_u16);
    |                ^^^^^^ expected i16, found u16
+   |
 help: change the type of the numeric literal from `u16` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -813,6 +894,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_u8);
    |                ^^^^^ expected i16, found u8
+   |
 help: change the type of the numeric literal from `u8` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -823,6 +905,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_isize);
    |                ^^^^^^^^ expected i16, found isize
+   |
 help: change the type of the numeric literal from `isize` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -833,6 +916,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_i64);
    |                ^^^^^^ expected i16, found i64
+   |
 help: change the type of the numeric literal from `i64` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -843,6 +927,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_i32);
    |                ^^^^^^ expected i16, found i32
+   |
 help: change the type of the numeric literal from `i32` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -853,6 +938,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42_i8);
    |                ^^^^^ expected i16, found i8
+   |
 help: change the type of the numeric literal from `i8` to `i16`
    |
 LL |     foo::<i16>(42_i16);
@@ -863,6 +949,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42.0_f64);
    |                ^^^^^^^^ expected i16, found f64
+   |
 help: change the type of the numeric literal from `f64` to `i16`
    |
 LL |     foo::<i16>(42i16);
@@ -873,6 +960,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i16>(42.0_f32);
    |                ^^^^^^^^ expected i16, found f32
+   |
 help: change the type of the numeric literal from `f32` to `i16`
    |
 LL |     foo::<i16>(42i16);
@@ -883,6 +971,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_usize);
    |               ^^^^^^^^ expected u8, found usize
+   |
 help: change the type of the numeric literal from `usize` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -893,6 +982,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_u64);
    |               ^^^^^^ expected u8, found u64
+   |
 help: change the type of the numeric literal from `u64` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -903,6 +993,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_u32);
    |               ^^^^^^ expected u8, found u32
+   |
 help: change the type of the numeric literal from `u32` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -913,6 +1004,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_u16);
    |               ^^^^^^ expected u8, found u16
+   |
 help: change the type of the numeric literal from `u16` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -923,6 +1015,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_isize);
    |               ^^^^^^^^ expected u8, found isize
+   |
 help: change the type of the numeric literal from `isize` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -933,6 +1026,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_i64);
    |               ^^^^^^ expected u8, found i64
+   |
 help: change the type of the numeric literal from `i64` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -943,6 +1037,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_i32);
    |               ^^^^^^ expected u8, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -953,6 +1048,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_i16);
    |               ^^^^^^ expected u8, found i16
+   |
 help: change the type of the numeric literal from `i16` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -963,6 +1059,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42_i8);
    |               ^^^^^ expected u8, found i8
+   |
 help: change the type of the numeric literal from `i8` to `u8`
    |
 LL |     foo::<u8>(42_u8);
@@ -973,6 +1070,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42.0_f64);
    |               ^^^^^^^^ expected u8, found f64
+   |
 help: change the type of the numeric literal from `f64` to `u8`
    |
 LL |     foo::<u8>(42u8);
@@ -983,6 +1081,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<u8>(42.0_f32);
    |               ^^^^^^^^ expected u8, found f32
+   |
 help: change the type of the numeric literal from `f32` to `u8`
    |
 LL |     foo::<u8>(42u8);
@@ -993,6 +1092,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_usize);
    |               ^^^^^^^^ expected i8, found usize
+   |
 help: change the type of the numeric literal from `usize` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1003,6 +1103,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_u64);
    |               ^^^^^^ expected i8, found u64
+   |
 help: change the type of the numeric literal from `u64` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1013,6 +1114,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_u32);
    |               ^^^^^^ expected i8, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1023,6 +1125,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_u16);
    |               ^^^^^^ expected i8, found u16
+   |
 help: change the type of the numeric literal from `u16` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1033,6 +1136,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_u8);
    |               ^^^^^ expected i8, found u8
+   |
 help: change the type of the numeric literal from `u8` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1043,6 +1147,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_isize);
    |               ^^^^^^^^ expected i8, found isize
+   |
 help: change the type of the numeric literal from `isize` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1053,6 +1158,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_i64);
    |               ^^^^^^ expected i8, found i64
+   |
 help: change the type of the numeric literal from `i64` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1063,6 +1169,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_i32);
    |               ^^^^^^ expected i8, found i32
+   |
 help: change the type of the numeric literal from `i32` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1073,6 +1180,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42_i16);
    |               ^^^^^^ expected i8, found i16
+   |
 help: change the type of the numeric literal from `i16` to `i8`
    |
 LL |     foo::<i8>(42_i8);
@@ -1083,6 +1191,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42.0_f64);
    |               ^^^^^^^^ expected i8, found f64
+   |
 help: change the type of the numeric literal from `f64` to `i8`
    |
 LL |     foo::<i8>(42i8);
@@ -1093,6 +1202,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<i8>(42.0_f32);
    |               ^^^^^^^^ expected i8, found f32
+   |
 help: change the type of the numeric literal from `f32` to `i8`
    |
 LL |     foo::<i8>(42i8);
@@ -1103,6 +1213,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_usize);
    |                ^^^^^^^^ expected f64, found usize
+   |
 help: change the type of the numeric literal from `usize` to `f64`
    |
 LL |     foo::<f64>(42_f64);
@@ -1113,6 +1224,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_u64);
    |                ^^^^^^ expected f64, found u64
+   |
 help: change the type of the numeric literal from `u64` to `f64`
    |
 LL |     foo::<f64>(42_f64);
@@ -1123,6 +1235,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_u32);
    |                ^^^^^^ expected f64, found u32
+   |
 help: you can convert an `u32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u32.into());
@@ -1133,6 +1246,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_u16);
    |                ^^^^^^ expected f64, found u16
+   |
 help: you can convert an `u16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u16.into());
@@ -1143,6 +1257,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_u8);
    |                ^^^^^ expected f64, found u8
+   |
 help: you can convert an `u8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_u8.into());
@@ -1153,6 +1268,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_isize);
    |                ^^^^^^^^ expected f64, found isize
+   |
 help: change the type of the numeric literal from `isize` to `f64`
    |
 LL |     foo::<f64>(42_f64);
@@ -1163,6 +1279,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_i64);
    |                ^^^^^^ expected f64, found i64
+   |
 help: change the type of the numeric literal from `i64` to `f64`
    |
 LL |     foo::<f64>(42_f64);
@@ -1173,6 +1290,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_i32);
    |                ^^^^^^ expected f64, found i32
+   |
 help: you can convert an `i32` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i32.into());
@@ -1183,6 +1301,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_i16);
    |                ^^^^^^ expected f64, found i16
+   |
 help: you can convert an `i16` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i16.into());
@@ -1193,6 +1312,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42_i8);
    |                ^^^^^ expected f64, found i8
+   |
 help: you can convert an `i8` to `f64`, producing the floating point representation of the integer
    |
 LL |     foo::<f64>(42_i8.into());
@@ -1203,6 +1323,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f64>(42.0_f32);
    |                ^^^^^^^^ expected f64, found f32
+   |
 help: change the type of the numeric literal from `f32` to `f64`
    |
 LL |     foo::<f64>(42.0_f64);
@@ -1213,6 +1334,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_usize);
    |                ^^^^^^^^ expected f32, found usize
+   |
 help: change the type of the numeric literal from `usize` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1223,6 +1345,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_u64);
    |                ^^^^^^ expected f32, found u64
+   |
 help: change the type of the numeric literal from `u64` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1233,6 +1356,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_u32);
    |                ^^^^^^ expected f32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1243,6 +1367,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_u16);
    |                ^^^^^^ expected f32, found u16
+   |
 help: you can convert an `u16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u16.into());
@@ -1253,6 +1378,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_u8);
    |                ^^^^^ expected f32, found u8
+   |
 help: you can convert an `u8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_u8.into());
@@ -1263,6 +1389,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_isize);
    |                ^^^^^^^^ expected f32, found isize
+   |
 help: change the type of the numeric literal from `isize` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1273,6 +1400,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_i64);
    |                ^^^^^^ expected f32, found i64
+   |
 help: change the type of the numeric literal from `i64` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1283,6 +1411,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_i32);
    |                ^^^^^^ expected f32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `f32`
    |
 LL |     foo::<f32>(42_f32);
@@ -1293,6 +1422,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_i16);
    |                ^^^^^^ expected f32, found i16
+   |
 help: you can convert an `i16` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i16.into());
@@ -1303,6 +1433,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42_i8);
    |                ^^^^^ expected f32, found i8
+   |
 help: you can convert an `i8` to `f32`, producing the floating point representation of the integer
    |
 LL |     foo::<f32>(42_i8.into());
@@ -1313,6 +1444,7 @@ error[E0308]: mismatched types
    |
 LL |     foo::<f32>(42.0_f64);
    |                ^^^^^^^^ expected f32, found f64
+   |
 help: change the type of the numeric literal from `f64` to `f32`
    |
 LL |     foo::<f32>(42.0_f32);

--- a/src/test/ui/obsolete-in-place/bad.stderr
+++ b/src/test/ui/obsolete-in-place/bad.stderr
@@ -3,6 +3,7 @@ error: unexpected token: `<-`
    |
 LL |     x <- y;
    |       ^^
+   |
 help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
    |
 LL |     x < - y;

--- a/src/test/ui/on-unimplemented/bad-annotation.stderr
+++ b/src/test/ui/on-unimplemented/bad-annotation.stderr
@@ -3,6 +3,7 @@ error: malformed `rustc_on_unimplemented` attribute input
    |
 LL | #[rustc_on_unimplemented]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: the following are the possible correct uses
    |
 LL | #[rustc_on_unimplemented(/*opt*/ message = "...", /*opt*/ label = "...", /*opt*/ note = "...")]

--- a/src/test/ui/parenthesized-deref-suggestion.stderr
+++ b/src/test/ui/parenthesized-deref-suggestion.stderr
@@ -3,6 +3,7 @@ error[E0609]: no field `opts` on type `*const Session`
    |
 LL |     (sess as *const Session).opts;
    |                              ^^^^
+   |
 help: `(sess as *const Session)` is a raw pointer; try dereferencing it
    |
 LL |     (*(sess as *const Session)).opts;

--- a/src/test/ui/parser/associated-types-project-from-hrtb-explicit.stderr
+++ b/src/test/ui/parser/associated-types-project-from-hrtb-explicit.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `for`
    |
 LL | fn foo2<I>(x: <I as for<'x> Foo<&'x isize>>::A)
    |                     ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | fn foo2<I>(x: <I as r#for<'x> Foo<&'x isize>>::A)

--- a/src/test/ui/parser/bad-value-ident-false.stderr
+++ b/src/test/ui/parser/bad-value-ident-false.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `false`
    |
 LL | fn false() { }
    |    ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | fn r#false() { }

--- a/src/test/ui/parser/bad-value-ident-true.stderr
+++ b/src/test/ui/parser/bad-value-ident-true.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `true`
    |
 LL | fn true() { }
    |    ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | fn r#true() { }

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -35,6 +35,7 @@ error: expected expression, found `>`
    |
 LL |     } > 0
    |       ^ expected expression
+   |
 help: parentheses are required to parse this as an expression
    |
 LL |     (match x {

--- a/src/test/ui/parser/issue-15980.stderr
+++ b/src/test/ui/parser/issue-15980.stderr
@@ -6,6 +6,7 @@ LL |         Err(ref e) if e.kind == io::EndOfFile {
 LL |
 LL |             return
    |             ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |             r#return

--- a/src/test/ui/parser/issue-33418.stderr
+++ b/src/test/ui/parser/issue-33418.stderr
@@ -3,6 +3,7 @@ error: negative trait bounds are not supported
    |
 LL | trait Tr: !SuperA {}
    |         ^^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bound
 
 error: negative trait bounds are not supported
@@ -10,6 +11,7 @@ error: negative trait bounds are not supported
    |
 LL | trait Tr2: SuperA + !SuperB {}
    |                   ^^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bound
 
 error: negative trait bounds are not supported
@@ -17,6 +19,7 @@ error: negative trait bounds are not supported
    |
 LL | trait Tr3: !SuperA + SuperB {}
    |          ^^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bound
 
 error: negative trait bounds are not supported
@@ -26,6 +29,7 @@ LL | trait Tr4: !SuperA + SuperB
    |          ^^^^^^^^^
 LL |     + !SuperC + SuperD {}
    |     ^^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bounds
 
 error: negative trait bounds are not supported
@@ -35,6 +39,7 @@ LL | trait Tr5: !SuperA
    |          ^^^^^^^^^
 LL |     + !SuperB {}
    |     ^^^^^^^^^ negative trait bounds are not supported
+   |
    = help: remove the trait bounds
 
 error: aborting due to 5 previous errors

--- a/src/test/ui/parser/issue-62895.stderr
+++ b/src/test/ui/parser/issue-62895.stderr
@@ -15,6 +15,7 @@ error: missing `fn` for function definition
    |
 LL | pub    g() -> is
    |    ^^^^
+   |
 help: add `fn` here to parse `g` as a public function
    |
 LL | pub fn g() -> is

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -25,6 +25,7 @@ LL |   fn p() { match s { v, E { [) {) }
 LL | |
 LL | |
    | |_^
+   |
 help: surround the struct literal with parentheses
    |
 LL | fn p() { match (s { v, E { [) {) }

--- a/src/test/ui/parser/keyword-abstract.stderr
+++ b/src/test/ui/parser/keyword-abstract.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `abstract`
    |
 LL |     let abstract = ();
    |         ^^^^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#abstract = ();

--- a/src/test/ui/parser/keyword-as-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-as-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `as`
    |
 LL |     let as = "foo";
    |         ^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#as = "foo";

--- a/src/test/ui/parser/keyword-break-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-break-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `break`
    |
 LL |     let break = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#break = "foo";

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `const`
    |
 LL |     let const = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#const = "foo";

--- a/src/test/ui/parser/keyword-continue-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-continue-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `continue`
    |
 LL |     let continue = "foo";
    |         ^^^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#continue = "foo";

--- a/src/test/ui/parser/keyword-else-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-else-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `else`
    |
 LL |     let else = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#else = "foo";

--- a/src/test/ui/parser/keyword-enum-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-enum-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `enum`
    |
 LL |     let enum = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#enum = "foo";

--- a/src/test/ui/parser/keyword-final.stderr
+++ b/src/test/ui/parser/keyword-final.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `final`
    |
 LL |     let final = ();
    |         ^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#final = ();

--- a/src/test/ui/parser/keyword-fn-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-fn-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `fn`
    |
 LL |     let fn = "foo";
    |         ^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#fn = "foo";

--- a/src/test/ui/parser/keyword-for-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-for-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `for`
    |
 LL |     let for = "foo";
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#for = "foo";

--- a/src/test/ui/parser/keyword-if-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-if-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `if`
    |
 LL |     let if = "foo";
    |         ^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#if = "foo";

--- a/src/test/ui/parser/keyword-impl-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-impl-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `impl`
    |
 LL |     let impl = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#impl = "foo";

--- a/src/test/ui/parser/keyword-let-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-let-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `let`
    |
 LL |     let let = "foo";
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#let = "foo";

--- a/src/test/ui/parser/keyword-loop-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-loop-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `loop`
    |
 LL |     let loop = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#loop = "foo";

--- a/src/test/ui/parser/keyword-match-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-match-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `match`
    |
 LL |     let match = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#match = "foo";

--- a/src/test/ui/parser/keyword-mod-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-mod-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `mod`
    |
 LL |     let mod = "foo";
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#mod = "foo";

--- a/src/test/ui/parser/keyword-move-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-move-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `move`
    |
 LL |     let move = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#move = "foo";

--- a/src/test/ui/parser/keyword-override.stderr
+++ b/src/test/ui/parser/keyword-override.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `override`
    |
 LL |     let override = ();
    |         ^^^^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#override = ();

--- a/src/test/ui/parser/keyword-pub-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-pub-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `pub`
    |
 LL |     let pub = "foo";
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#pub = "foo";

--- a/src/test/ui/parser/keyword-return-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-return-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `return`
    |
 LL |     let return = "foo";
    |         ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#return = "foo";

--- a/src/test/ui/parser/keyword-static-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-static-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `static`
    |
 LL |     let static = "foo";
    |         ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#static = "foo";

--- a/src/test/ui/parser/keyword-struct-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-struct-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `struct`
    |
 LL |     let struct = "foo";
    |         ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#struct = "foo";

--- a/src/test/ui/parser/keyword-trait-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-trait-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `trait`
    |
 LL |     let trait = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#trait = "foo";

--- a/src/test/ui/parser/keyword-try-as-identifier-edition2018.stderr
+++ b/src/test/ui/parser/keyword-try-as-identifier-edition2018.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `try`
    |
 LL |     let try = "foo";
    |         ^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#try = "foo";

--- a/src/test/ui/parser/keyword-type-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-type-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `type`
    |
 LL |     let type = "foo";
    |         ^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#type = "foo";

--- a/src/test/ui/parser/keyword-typeof.stderr
+++ b/src/test/ui/parser/keyword-typeof.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `typeof`
    |
 LL |     let typeof = ();
    |         ^^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#typeof = ();

--- a/src/test/ui/parser/keyword-unsafe-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-unsafe-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `unsafe`
    |
 LL |     let unsafe = "foo";
    |         ^^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#unsafe = "foo";

--- a/src/test/ui/parser/keyword-use-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-use-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `use`
    |
 LL |     let use = "foo";
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#use = "foo";

--- a/src/test/ui/parser/keyword-where-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-where-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `where`
    |
 LL |     let where = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#where = "foo";

--- a/src/test/ui/parser/keyword-while-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-while-as-identifier.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `while`
    |
 LL |     let while = "foo";
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#while = "foo";

--- a/src/test/ui/parser/keyword.stderr
+++ b/src/test/ui/parser/keyword.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `break`
    |
 LL | pub mod break {
    |         ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | pub mod r#break {

--- a/src/test/ui/parser/lex-bad-char-literals-2.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-2.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL |     'nope'
    |     ^^^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     "nope"

--- a/src/test/ui/parser/lex-bad-char-literals-3.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-3.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL | static c: char = '●●';
    |                  ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL | static c: char = "●●";
@@ -13,6 +14,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let ch: &str = '●●';
    |                    ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let ch: &str = "●●";

--- a/src/test/ui/parser/lex-bad-char-literals-5.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-5.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL | static c: char = '\x10\x10';
    |                  ^^^^^^^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL | static c: char = "\x10\x10";
@@ -13,6 +14,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let ch: &str = '\x10\x10';
    |                    ^^^^^^^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let ch: &str = "\x10\x10";

--- a/src/test/ui/parser/lex-bad-char-literals-6.stderr
+++ b/src/test/ui/parser/lex-bad-char-literals-6.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let x: &str = 'ab';
    |                   ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let x: &str = "ab";
@@ -13,6 +14,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let y: char = 'cd';
    |                   ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let y: char = "cd";
@@ -23,6 +25,7 @@ error: character literal may only contain one codepoint
    |
 LL |     let z = 'ef';
    |             ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     let z = "ef";

--- a/src/test/ui/parser/macro-keyword.stderr
+++ b/src/test/ui/parser/macro-keyword.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `macro`
    |
 LL | fn macro() {
    |    ^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | fn r#macro() {

--- a/src/test/ui/parser/macros-no-semicolon-items.stderr
+++ b/src/test/ui/parser/macros-no-semicolon-items.stderr
@@ -3,6 +3,7 @@ error: macros that expand to items must be delimited with braces or followed by 
    |
 LL | macro_rules! foo()
    |                 ^^
+   |
 help: change the delimiters to curly braces
    |
 LL | macro_rules! foo {}
@@ -22,6 +23,7 @@ LL | |     blah
 LL | |     blah
 LL | | )
    | |_^
+   |
 help: change the delimiters to curly braces
    |
 LL | bar! {

--- a/src/test/ui/parser/match-arrows-block-then-binop.stderr
+++ b/src/test/ui/parser/match-arrows-block-then-binop.stderr
@@ -3,6 +3,7 @@ error: expected pattern, found `+`
    |
 LL |       } + 5
    |         ^ expected pattern
+   |
 help: parentheses are required to parse this as an expression
    |
 LL |       0 => ({

--- a/src/test/ui/parser/mut-patterns.stderr
+++ b/src/test/ui/parser/mut-patterns.stderr
@@ -47,6 +47,7 @@ error: expected identifier, found reserved keyword `yield`
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                 ^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut mut r#yield(become, await) = r#yield(0, 0);
@@ -57,6 +58,7 @@ error: expected identifier, found reserved keyword `become`
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                       ^^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut mut yield(r#become, await) = r#yield(0, 0);
@@ -67,6 +69,7 @@ error: expected identifier, found keyword `await`
    |
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                               ^^^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let mut mut yield(become, r#await) = r#yield(0, 0);

--- a/src/test/ui/parser/range_inclusive_dotdotdot.stderr
+++ b/src/test/ui/parser/range_inclusive_dotdotdot.stderr
@@ -3,6 +3,7 @@ error: unexpected token: `...`
    |
 LL |     return ...1;
    |            ^^^
+   |
 help: use `..` for an exclusive range
    |
 LL |     return ..1;
@@ -17,6 +18,7 @@ error: unexpected token: `...`
    |
 LL |     let x = ...0;
    |             ^^^
+   |
 help: use `..` for an exclusive range
    |
 LL |     let x = ..0;
@@ -31,6 +33,7 @@ error: unexpected token: `...`
    |
 LL |     let x = 5...5;
    |              ^^^
+   |
 help: use `..` for an exclusive range
    |
 LL |     let x = 5..5;
@@ -45,6 +48,7 @@ error: unexpected token: `...`
    |
 LL |     for _ in 0...1 {}
    |               ^^^
+   |
 help: use `..` for an exclusive range
    |
 LL |     for _ in 0..1 {}

--- a/src/test/ui/parser/recover-from-homoglyph.stderr
+++ b/src/test/ui/parser/recover-from-homoglyph.stderr
@@ -3,6 +3,7 @@ error: unknown start of token: \u{37e}
    |
 LL |     println!("");
    |                 ^
+   |
 help: Unicode character ';' (Greek Question Mark) looks like ';' (Semicolon), but it is not
    |
 LL |     println!("");

--- a/src/test/ui/parser/removed-syntax-field-let.stderr
+++ b/src/test/ui/parser/removed-syntax-field-let.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `let`
    |
 LL |     let foo: (),
    |     ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     r#let foo: (),

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -15,6 +15,7 @@ error: chained comparison operators require parentheses
    |
 LL |     f<X>();
    |      ^^^
+   |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     f::<X>();
@@ -25,6 +26,7 @@ error: chained comparison operators require parentheses
    |
 LL |     f<Result<Option<X>, Option<Option<X>>>(1, 2);
    |      ^^^^^^^^
+   |
 help: use `::<...>` instead of `<...>` to specify type arguments
    |
 LL |     f::<Result<Option<X>, Option<Option<X>>>(1, 2);

--- a/src/test/ui/parser/struct-literal-in-for.stderr
+++ b/src/test/ui/parser/struct-literal-in-for.stderr
@@ -6,6 +6,7 @@ LL |       for x in Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     for x in (Foo {

--- a/src/test/ui/parser/struct-literal-in-if.stderr
+++ b/src/test/ui/parser/struct-literal-in-if.stderr
@@ -6,6 +6,7 @@ LL |       if Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if (Foo {

--- a/src/test/ui/parser/struct-literal-in-match-discriminant.stderr
+++ b/src/test/ui/parser/struct-literal-in-match-discriminant.stderr
@@ -6,6 +6,7 @@ LL |       match Foo {
 LL | |         x: 3
 LL | |     } {
    | |_____^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     match (Foo {

--- a/src/test/ui/parser/struct-literal-in-while.stderr
+++ b/src/test/ui/parser/struct-literal-in-while.stderr
@@ -6,6 +6,7 @@ LL |       while Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     while (Foo {

--- a/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
+++ b/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
@@ -6,6 +6,7 @@ LL |       while || Foo {
 LL | |         x: 3
 LL | |     }.hi() {
    | |_____^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     while || (Foo {

--- a/src/test/ui/parser/unicode-chars.stderr
+++ b/src/test/ui/parser/unicode-chars.stderr
@@ -3,6 +3,7 @@ error: unknown start of token: \u{37e}
    |
 LL |     let y = 0;
    |              ^
+   |
 help: Unicode character ';' (Greek Question Mark) looks like ';' (Semicolon), but it is not
    |
 LL |     let y = 0;

--- a/src/test/ui/parser/unicode-quote-chars.stderr
+++ b/src/test/ui/parser/unicode-quote-chars.stderr
@@ -3,6 +3,7 @@ error: unknown start of token: \u{201c}
    |
 LL |     println!(“hello world”);
    |              ^
+   |
 help: Unicode characters '“' (Left Double Quotation Mark) and '”' (Right Double Quotation Mark) look like '"' (Quotation Mark), but are not
    |
 LL |     println!("hello world");
@@ -13,6 +14,7 @@ error: unknown start of token: \u{201d}
    |
 LL |     println!(“hello world”);
    |                          ^
+   |
 help: Unicode character '”' (Right Double Quotation Mark) looks like '"' (Quotation Mark), but it is not
    |
 LL |     println!(“hello world");

--- a/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.stderr
+++ b/src/test/ui/parser/use-as-where-use-ends-with-mod-sep.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `as`
    |
 LL | use std::any:: as foo;
    |                ^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | use std::any:: r#as foo;

--- a/src/test/ui/placement-syntax.stderr
+++ b/src/test/ui/placement-syntax.stderr
@@ -3,6 +3,7 @@ error: unexpected token: `<-`
    |
 LL |     if x<-1 {
    |         ^^
+   |
 help: if you meant to write a comparison against a negative value, add a space in between `<` and `-`
    |
 LL |     if x< -1 {

--- a/src/test/ui/pptypedef.stderr
+++ b/src/test/ui/pptypedef.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     let_in(3u32, |i| { assert!(i == 3i32); });
    |                                     ^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     let_in(3u32, |i| { assert!(i == 3u32); });
@@ -13,6 +14,7 @@ error[E0308]: mismatched types
    |
 LL |     let_in(3i32, |i| { assert!(i == 3u32); });
    |                                     ^^^^ expected i32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     let_in(3i32, |i| { assert!(i == 3i32); });

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -3,6 +3,7 @@ error[E0423]: expected function, found trait `Bar`
    |
 LL |     Bar();
    |     ^^^
+   |
 help: a unit struct with a similar name exists
    |
 LL |     Baz();
@@ -21,6 +22,7 @@ error[E0573]: expected type, found function `Bar`
    |
 LL |     let _x: Box<Bar>;
    |                 ^^^
+   |
 help: a struct with a similar name exists
    |
 LL |     let _x: Box<Baz>;
@@ -39,6 +41,7 @@ error[E0425]: cannot find function `Bar` in this scope
    |
 LL |     Bar();
    |     ^^^
+   |
 help: a unit struct with a similar name exists
    |
 LL |     Baz();
@@ -57,6 +60,7 @@ error[E0412]: cannot find type `Bar` in this scope
    |
 LL |     let _x: Box<Bar>;
    |                 ^^^
+   |
 help: a struct with a similar name exists
    |
 LL |     let _x: Box<Baz>;

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -3,6 +3,7 @@ error[E0423]: expected function, found trait `Bar`
    |
 LL |     Bar();
    |     ^^^ not a function
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use foo1::Bar;
@@ -17,6 +18,7 @@ error[E0423]: expected function, found trait `Bar`
    |
 LL |     Bar();
    |     ^^^
+   |
 help: a unit struct with a similar name exists
    |
 LL |     Baz();
@@ -35,6 +37,7 @@ error[E0573]: expected type, found function `Bar`
    |
 LL |     let _x : Box<Bar>;
    |                  ^^^ not a type
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use foo1::Bar;
@@ -49,6 +52,7 @@ error[E0573]: expected type, found function `Bar`
    |
 LL |     let _x: Box<Bar>;
    |                 ^^^
+   |
 help: a struct with a similar name exists
    |
 LL |     let _x: Box<Baz>;

--- a/src/test/ui/proc-macro/mixed-site-span.stderr
+++ b/src/test/ui/proc-macro/mixed-site-span.stderr
@@ -38,6 +38,7 @@ LL | | }
    |
 LL |   pass_dollar_crate!();
    |   --------------------- in this macro invocation
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use ItemUse;

--- a/src/test/ui/pub/pub-ident-fn-2.stderr
+++ b/src/test/ui/pub/pub-ident-fn-2.stderr
@@ -3,6 +3,7 @@ error: missing `fn` for function definition
    |
 LL | pub foo(s: usize) { bar() }
    |    ^
+   |
 help: add `fn` here to parse `foo` as a public function
    |
 LL | pub fn foo(s: usize) { bar() }

--- a/src/test/ui/pub/pub-ident-fn-with-lifetime-2.stderr
+++ b/src/test/ui/pub/pub-ident-fn-with-lifetime-2.stderr
@@ -3,6 +3,7 @@ error: missing `fn` for method definition
    |
 LL | pub   bar<'a>(&self, _s: &'a usize) -> bool { true }
    |    ^^^
+   |
 help: add `fn` here to parse `bar` as a public method
    |
 LL | pub fn bar<'a>(&self, _s: &'a usize) -> bool { true }

--- a/src/test/ui/pub/pub-ident-fn-with-lifetime.stderr
+++ b/src/test/ui/pub/pub-ident-fn-with-lifetime.stderr
@@ -3,6 +3,7 @@ error: missing `fn` for function definition
    |
 LL | pub   foo<'a>(_s: &'a usize) -> bool { true }
    |    ^^^
+   |
 help: add `fn` here to parse `foo` as a public function
    |
 LL | pub fn foo<'a>(_s: &'a usize) -> bool { true }

--- a/src/test/ui/pub/pub-ident-fn.stderr
+++ b/src/test/ui/pub/pub-ident-fn.stderr
@@ -3,6 +3,7 @@ error: missing `fn` for function definition
    |
 LL | pub   foo(_s: usize) -> bool { true }
    |    ^^^
+   |
 help: add `fn` here to parse `foo` as a public function
    |
 LL | pub fn foo(_s: usize) -> bool { true }

--- a/src/test/ui/pub/pub-ident-struct-with-lifetime.stderr
+++ b/src/test/ui/pub/pub-ident-struct-with-lifetime.stderr
@@ -3,6 +3,7 @@ error: missing `struct` for struct definition
    |
 LL | pub S<'a> {
    |    ^
+   |
 help: add `struct` here to parse `S` as a public struct
    |
 LL | pub struct S<'a> {

--- a/src/test/ui/pub/pub-ident-struct.stderr
+++ b/src/test/ui/pub/pub-ident-struct.stderr
@@ -3,6 +3,7 @@ error: missing `struct` for struct definition
    |
 LL | pub S {
    |    ^
+   |
 help: add `struct` here to parse `S` as a public struct
    |
 LL | pub struct S {

--- a/src/test/ui/repeat_count.stderr
+++ b/src/test/ui/repeat_count.stderr
@@ -42,6 +42,7 @@ error[E0308]: mismatched types
    |
 LL |     let f = [0; -4_isize];
    |                 ^^^^^^^^ expected usize, found isize
+   |
 help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     let f = [0; (-4_isize).try_into().unwrap()];
@@ -52,6 +53,7 @@ error[E0308]: mismatched types
    |
 LL |     let f = [0_usize; -1_isize];
    |                       ^^^^^^^^ expected usize, found isize
+   |
 help: you can convert an `isize` to `usize` and panic if the converted value wouldn't fit
    |
 LL |     let f = [0_usize; (-1_isize).try_into().unwrap()];

--- a/src/test/ui/reserved/reserved-become.stderr
+++ b/src/test/ui/reserved/reserved-become.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found reserved keyword `become`
    |
 LL |     let become = 0;
    |         ^^^^^^ expected identifier, found reserved keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |     let r#become = 0;

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -3,6 +3,7 @@ error[E0425]: cannot find value `A` in crate `namespaced_enums`
    |
 LL |     let _ = namespaced_enums::A;
    |                               ^ not found in `namespaced_enums`
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use namespaced_enums::Foo::A;
@@ -13,6 +14,7 @@ error[E0425]: cannot find function `B` in crate `namespaced_enums`
    |
 LL |     let _ = namespaced_enums::B(10);
    |                               ^ not found in `namespaced_enums`
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use namespaced_enums::Foo::B;
@@ -23,6 +25,7 @@ error[E0422]: cannot find struct, variant or union type `C` in crate `namespaced
    |
 LL |     let _ = namespaced_enums::C { a: 10 };
    |                               ^ not found in `namespaced_enums`
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use namespaced_enums::Foo::C;

--- a/src/test/ui/resolve/issue-16058.stderr
+++ b/src/test/ui/resolve/issue-16058.stderr
@@ -3,6 +3,7 @@ error[E0574]: expected struct, variant or union type, found enum `Result`
    |
 LL |         Result {
    |         ^^^^^^ not a struct, variant or union type
+   |
 help: possible better candidates are found in other modules, you can import them into scope
    |
 LL | use std::fmt::Result;

--- a/src/test/ui/resolve/issue-17518.stderr
+++ b/src/test/ui/resolve/issue-17518.stderr
@@ -3,6 +3,7 @@ error[E0422]: cannot find struct, variant or union type `E` in this scope
    |
 LL |     E { name: "foobar" };
    |     ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use SomeEnum::E;

--- a/src/test/ui/resolve/issue-21221-1.stderr
+++ b/src/test/ui/resolve/issue-21221-1.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `Mul` in this scope
    |
 LL | impl Mul for Foo {
    |      ^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use mul1::Mul;
@@ -17,6 +18,7 @@ error[E0412]: cannot find type `Mul` in this scope
    |
 LL | fn getMul() -> Mul {
    |                ^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use mul1::Mul;
@@ -40,6 +42,7 @@ error[E0405]: cannot find trait `Div` in this scope
    |
 LL | impl Div for Foo {
    |      ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use std::ops::Div;

--- a/src/test/ui/resolve/issue-21221-2.stderr
+++ b/src/test/ui/resolve/issue-21221-2.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `T` in this scope
    |
 LL | impl T for Foo { }
    |      ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use foo::bar::T;

--- a/src/test/ui/resolve/issue-21221-3.stderr
+++ b/src/test/ui/resolve/issue-21221-3.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `OuterTrait` in this scope
    |
 LL | impl OuterTrait for Foo {}
    |      ^^^^^^^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use issue_21221_3::outer::OuterTrait;

--- a/src/test/ui/resolve/issue-21221-4.stderr
+++ b/src/test/ui/resolve/issue-21221-4.stderr
@@ -3,6 +3,7 @@ error[E0405]: cannot find trait `T` in this scope
    |
 LL | impl T for Foo {}
    |      ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use issue_21221_4::T;

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -3,6 +3,7 @@ error[E0423]: expected value, found enum `n::Z`
    |
 LL |         n::Z;
    |         ^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |         m::Z::Fn;
@@ -17,6 +18,7 @@ error[E0423]: expected value, found enum `Z`
    |
 LL |         Z;
    |         ^
+   |
 help: a function with a similar name exists
    |
 LL |         f;
@@ -46,6 +48,7 @@ error[E0423]: expected value, found enum `m::E`
    |
 LL |     let _: E = m::E;
    |                ^^^^
+   |
 help: a function with a similar name exists
    |
 LL |     let _: E = m::f;
@@ -81,6 +84,7 @@ error[E0423]: expected value, found enum `E`
    |
 LL |     let _: E = E;
    |                ^
+   |
 help: try using one of the enum's variants
    |
 LL |     let _: E = E::Fn;
@@ -112,6 +116,7 @@ error[E0412]: cannot find type `Z` in this scope
    |
 LL |     let _: Z = m::n::Z;
    |            ^
+   |
 help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z;
@@ -126,6 +131,7 @@ error[E0423]: expected value, found enum `m::n::Z`
    |
 LL |     let _: Z = m::n::Z;
    |                ^^^^^^^
+   |
 help: try using one of the enum's variants
    |
 LL |     let _: Z = m::Z::Fn;
@@ -140,6 +146,7 @@ error[E0412]: cannot find type `Z` in this scope
    |
 LL |     let _: Z = m::n::Z::Fn;
    |            ^
+   |
 help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Fn;
@@ -154,6 +161,7 @@ error[E0412]: cannot find type `Z` in this scope
    |
 LL |     let _: Z = m::n::Z::Struct;
    |            ^
+   |
 help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Struct;
@@ -179,6 +187,7 @@ error[E0412]: cannot find type `Z` in this scope
    |
 LL |     let _: Z = m::n::Z::Unit {};
    |            ^
+   |
 help: an enum with a similar name exists
    |
 LL |     let _: E = m::n::Z::Unit {};
@@ -237,6 +246,7 @@ LL |         let _ = Z::Unit();
    |                 ^^^^^^^--
    |                 |
    |                 call expression requires function
+   |
 help: `Z::Unit` is a unit variant, you need to write it without the parenthesis
    |
 LL |         let _ = Z::Unit;
@@ -267,6 +277,7 @@ LL |     let _: E = m::E::Unit();
    |                ^^^^^^^^^^--
    |                |
    |                call expression requires function
+   |
 help: `m::E::Unit` is a unit variant, you need to write it without the parenthesis
    |
 LL |     let _: E = m::E::Unit;
@@ -297,6 +308,7 @@ LL |     let _: E = E::Unit();
    |                ^^^^^^^--
    |                |
    |                call expression requires function
+   |
 help: `E::Unit` is a unit variant, you need to write it without the parenthesis
    |
 LL |     let _: E = E::Unit;

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -29,6 +29,7 @@ error[E0423]: expected value, found struct `xcrate::S`
    |
 LL |     xcrate::S;
    |     ^^^^^^^^^ constructor is not visible here due to private fields
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use m::S;

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -27,6 +27,7 @@ error[E0423]: expected value, found module `a::b`
    |
 LL |     a::b.J
    |     ^^^^
+   |
 help: a constant with a similar name exists
    |
 LL |     a::I.J
@@ -57,6 +58,7 @@ error[E0423]: expected value, found module `a::b`
    |
 LL |     a::b.f()
    |     ^^^^
+   |
 help: a constant with a similar name exists
    |
 LL |     a::I.f()

--- a/src/test/ui/resolve/use_suggestion_placement.stderr
+++ b/src/test/ui/resolve/use_suggestion_placement.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Path` in this scope
    |
 LL |     type Bar = Path;
    |                ^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |     use std::path::Path;
@@ -13,6 +14,7 @@ error[E0425]: cannot find value `A` in this scope
    |
 LL |     let _ = A;
    |             ^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use m::A;
@@ -23,6 +25,7 @@ error[E0412]: cannot find type `HashMap` in this scope
    |
 LL |     type Dict<K, V> = HashMap<K, V>;
    |                       ^^^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use std::collections::HashMap;

--- a/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
+++ b/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
@@ -3,6 +3,7 @@ error: expected identifier, found keyword `dyn`
    |
 LL | type A1 = dyn::dyn;
    |                ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL | type A1 = dyn::r#dyn;

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
@@ -19,6 +19,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
    |                                                             ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -29,6 +30,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
    |                                                     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -39,6 +41,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
    |                                                ^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
@@ -49,6 +52,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
    |                                                ^^^^          ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
@@ -59,6 +63,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
    |                                              ^^^^    ^^^^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
@@ -69,6 +74,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
    |                                                                   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -79,6 +85,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
    |                                                     ^^^^              ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -89,6 +96,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
    |                                                     ^^^^                   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -99,6 +107,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
    |                                                                     ^^^^^^^   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -109,6 +118,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
    |                                                                     ^^^^^^^        ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -119,6 +129,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
    |                                      ^^^^   ^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeBee<'a, 'b, T> {
@@ -129,6 +140,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
    |                                        ^^^^   ^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b, T> {
@@ -139,6 +151,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
    |                                                       ^^^^     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
@@ -149,6 +162,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
    |                                                                    ^^^^^^^^   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -159,6 +173,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
    |                                                          ^^^^        ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -169,6 +184,7 @@ error: outlives requirements can be inferred
    |
 LL |         where U: 'a + Debug + 'b, 'b: 'a
    |                  ^^^^^     ^^^^^  ^^^^^^
+   |
 help: remove these bounds
    |
 LL |         where U: Debug, 
@@ -179,6 +195,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b>(&'a &'b T);
    |                                               ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
@@ -189,6 +206,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: 'a + Debug + 'b;
    |                                                                        ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
@@ -199,6 +217,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b>(T, &'a &'b U);
    |                                                     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
@@ -209,6 +228,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug>(&'a T, &'b U);
    |                                                ^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug>(&'a T, &'b U);
@@ -219,6 +239,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b>(&'a T, &'b U);
    |                                                ^^^^          ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug>(&'a T, &'b U);
@@ -229,6 +250,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b;
    |                                              ^^^^                   ^^^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U>(&'a T, &'b U) ;
@@ -239,6 +261,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + Debug + 'b;
    |                                                                                 ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug;
@@ -249,6 +272,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b + Debug;
    |                                                     ^^^^                            ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
@@ -259,6 +283,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: Debug + 'b;
    |                                                     ^^^^                                 ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
@@ -269,6 +294,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: 'b + Debug;
    |                                                                           ^^^^^^^   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
@@ -279,6 +305,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: Debug + 'b;
    |                                                                           ^^^^^^^        ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
@@ -289,6 +316,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b>(&'a &'b T);
    |                                      ^^^^   ^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeBee<'a, 'b, T>(&'a &'b T);
@@ -299,6 +327,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b>(&'a &'b T);
    |                                        ^^^^   ^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeAyBee<'a, 'b, T>(&'a &'b T);
@@ -309,6 +338,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b>(&'a &'b T);
    |                                                       ^^^^     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
@@ -319,6 +349,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + Debug + 'b;
    |                                                                       ^^^^^^^^   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
@@ -329,6 +360,7 @@ error: outlives requirements can be inferred
    |
 LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b>(T, &'a &'b U);
    |                                                          ^^^^        ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
@@ -339,6 +371,7 @@ error: outlives requirements can be inferred
    |
 LL |         where U: 'a + Debug + 'b, 'b: 'a;
    |                  ^^^^^     ^^^^^  ^^^^^^
+   |
 help: remove these bounds
    |
 LL |         where U: Debug, ;
@@ -349,6 +382,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
    |                                             ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
@@ -359,6 +393,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
    |                                                           ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -369,6 +404,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
    |                                                   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -379,6 +415,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
    |                                              ^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
@@ -389,6 +426,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
    |                                              ^^^^          ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
@@ -399,6 +437,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
    |                                            ^^^^    ^^^^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
@@ -409,6 +448,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
    |                                                                 ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -419,6 +459,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
    |                                                   ^^^^              ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -429,6 +470,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
    |                                                   ^^^^                   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -439,6 +481,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
    |                                                                   ^^^^^^^   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -449,6 +492,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
    |                                                                   ^^^^^^^        ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -459,6 +503,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
    |                                    ^^^^   ^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeOutlivesAyTeeBee<'a, 'b, T> {
@@ -469,6 +514,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
    |                                      ^^^^   ^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeOutlivesAyTeeAyBee<'a, 'b, T> {
@@ -479,6 +525,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
    |                                                     ^^^^     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
@@ -489,6 +536,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
    |                                                                  ^^^^^^^^   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -499,6 +547,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
    |                                                        ^^^^        ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -509,6 +558,7 @@ error: outlives requirements can be inferred
    |
 LL |     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
    |                                                                           ^^^^^     ^^^^^  ^^^^^^
+   |
 help: remove these bounds
    |
 LL |     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {
@@ -519,6 +569,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
    |                                              ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
@@ -529,6 +580,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
    |                                                            ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -539,6 +591,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
    |                                                    ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -549,6 +602,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
    |                                               ^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
@@ -559,6 +613,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
    |                                               ^^^^          ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
@@ -569,6 +624,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
    |                                             ^^^^    ^^^^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
@@ -579,6 +635,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
    |                                                                  ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -589,6 +646,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
    |                                                    ^^^^              ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -599,6 +657,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
    |                                                    ^^^^                   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -609,6 +668,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
    |                                                                    ^^^^^^^   ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
@@ -619,6 +679,7 @@ error: outlives requirements can be inferred
    |
 LL |     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
    |                                                                    ^^^^^^^        ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
@@ -629,6 +690,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
    |                                     ^^^^   ^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeOutlivesAyTeeBee<'a, 'b, T> {
@@ -639,6 +701,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
    |                                       ^^^^   ^^^^^^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeOutlivesAyTeeAyBee<'a, 'b, T> {
@@ -649,6 +712,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
    |                                                      ^^^^     ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
@@ -659,6 +723,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
    |                                                                   ^^^^^^^^   ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
@@ -669,6 +734,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
    |                                                         ^^^^        ^^^^^     ^^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
@@ -679,6 +745,7 @@ error: outlives requirements can be inferred
    |
 LL |     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
    |                                                                            ^^^^^     ^^^^^  ^^^^^^
+   |
 help: remove these bounds
    |
 LL |     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {

--- a/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
+++ b/src/test/ui/rust-2018/issue-52202-use-suggestions.stderr
@@ -3,6 +3,7 @@ error[E0422]: cannot find struct, variant or union type `Drain` in this scope
    |
 LL |     let _d = Drain {};
    |              ^^^^^ not found in this scope
+   |
 help: possible candidates are found in other modules, you can import them into scope
    |
 LL | use crate::plumbing::Drain;

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait-async.nll.stderr
@@ -5,6 +5,7 @@ LL |     async fn f(self: Pin<&Self>) -> impl Clone { self }
    |                          -                     ^^^^^^^^ returning this value requires that `'_` must outlive `'static`
    |                          |
    |                          lifetime `'_` defined here
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'_`, add `'_` as a constraint
    |
 LL |     async fn f(self: Pin<&Self>) -> impl Clone + '_ { self }

--- a/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.nll.stderr
+++ b/src/test/ui/self/arbitrary_self_types_pin_lifetime_impl_trait.nll.stderr
@@ -5,6 +5,7 @@ LL |     fn f(self: Pin<&Self>) -> impl Clone { self }
    |                    -          ^^^^^^^^^^ opaque type requires that `'1` must outlive `'static`
    |                    |
    |                    let's call the lifetime of this reference `'1`
+   |
 help: to allow this `impl Trait` to capture borrowed data with lifetime `'1`, add `'_` as a constraint
    |
 LL |     fn f(self: Pin<&Self>) -> impl Clone + '_ { self }

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -65,6 +65,7 @@ error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
    |
 LL |         mut Self => (),
    |             ^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use foo::Self;

--- a/src/test/ui/shift-various-bad-types.stderr
+++ b/src/test/ui/shift-various-bad-types.stderr
@@ -27,6 +27,7 @@ error[E0308]: mismatched types
    |
 LL |     let _: i32 = 22_i64 >> 1_i32;
    |                  ^^^^^^^^^^^^^^^ expected i32, found i64
+   |
 help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
    |
 LL |     let _: i32 = (22_i64 >> 1_i32).try_into().unwrap();

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
@@ -23,6 +23,7 @@ LL | fn center<'m>(_: Single<'m>) {}
    |           ^^            -- ...is used only here
    |           |
    |           this lifetime...
+   |
 help: elide the single-use lifetime
    |
 LL | fn center(_: Single<'_>) {}
@@ -33,6 +34,7 @@ error: lifetime parameter `'y` only used once
    |
 LL | fn left<'x, 'y>(foo: Double<'x, 'y>) -> &'x u32 { foo.f }
    |             ^^ this lifetime... -- ...is used only here
+   |
 help: elide the single-use lifetime
    |
 LL | fn left<'x>(foo: Double<'x, '_>) -> &'x u32 { foo.f }
@@ -43,6 +45,7 @@ error: lifetime parameter `'x` only used once
    |
 LL | fn right<'x, 'y>(foo: Double<'x, 'y>) -> &'y u32 { foo.f }
    |          ^^ this lifetime... -- ...is used only here
+   |
 help: elide the single-use lifetime
    |
 LL | fn right<'y>(foo: Double<'_, 'y>) -> &'y u32 { foo.f }

--- a/src/test/ui/span/issue-35987.stderr
+++ b/src/test/ui/span/issue-35987.stderr
@@ -3,6 +3,7 @@ error[E0404]: expected trait, found type parameter `Add`
    |
 LL | impl<T: Clone, Add> Add for Foo<T> {
    |                     ^^^ not a trait
+   |
 help: possible better candidate is found in another module, you can import it into scope
    |
 LL | use std::ops::Add;

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -6,6 +6,7 @@ LL |     let x = "Hello " + "World!";
    |             |        |
    |             |        `+` cannot be used to concatenate two `&str` strings
    |             &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + "World!";
@@ -29,6 +30,7 @@ LL |     let x = "Hello " + "World!".to_owned();
    |             |        |
    |             |        `+` cannot be used to concatenate a `&str` with a `String`
    |             &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + &"World!".to_owned();
@@ -42,6 +44,7 @@ LL |     let _ = &a + &b;
    |             |  |
    |             |  `+` cannot be used to concatenate two `&str` strings
    |             &std::string::String
+   |
 help: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = a + &b;
@@ -55,6 +58,7 @@ LL |     let _ = &a + b;
    |             |  |
    |             |  `+` cannot be used to concatenate a `&str` with a `String`
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = a + &b;
@@ -80,6 +84,7 @@ LL |     let _ = e + b;
    |             | |
    |             | `+` cannot be used to concatenate a `&str` with a `String`
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &b;
@@ -93,6 +98,7 @@ LL |     let _ = e + &b;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &b;
@@ -106,6 +112,7 @@ LL |     let _ = e + d;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + d;
@@ -119,6 +126,7 @@ LL |     let _ = e + &d;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &d;
@@ -152,6 +160,7 @@ LL |     let _ = c + &d;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = c.to_owned() + &d;
@@ -165,6 +174,7 @@ LL |     let _ = c + d;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = c.to_owned() + d;

--- a/src/test/ui/span/missing-unit-argument.stderr
+++ b/src/test/ui/span/missing-unit-argument.stderr
@@ -3,6 +3,7 @@ error[E0061]: this function takes 1 parameter but 0 parameters were supplied
    |
 LL |     let _: Result<(), String> = Ok();
    |                                 ^^^^
+   |
 help: expected the unit value `()`; create it with empty parentheses
    |
 LL |     let _: Result<(), String> = Ok(());
@@ -34,6 +35,7 @@ LL | fn bar(():()) {}
 ...
 LL |     bar();
    |     ^^^^^
+   |
 help: expected the unit value `()`; create it with empty parentheses
    |
 LL |     bar(());
@@ -47,6 +49,7 @@ LL |     fn baz(self, (): ()) { }
 ...
 LL |     S.baz();
    |       ^^^
+   |
 help: expected the unit value `()`; create it with empty parentheses
    |
 LL |     S.baz(());
@@ -60,6 +63,7 @@ LL |     fn generic<T>(self, _: T) { }
 ...
 LL |     S.generic::<()>();
    |       ^^^^^^^
+   |
 help: expected the unit value `()`; create it with empty parentheses
    |
 LL |     S.generic::<()>(());

--- a/src/test/ui/str/str-as-char.stderr
+++ b/src/test/ui/str/str-as-char.stderr
@@ -3,6 +3,7 @@ error: character literal may only contain one codepoint
    |
 LL |     println!('●●');
    |              ^^^^
+   |
 help: if you meant to write a `str` literal, use double quotes
    |
 LL |     println!("●●");

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -6,6 +6,7 @@ LL |     let c = a + b;
    |             | |
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &std::string::String
+   |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let c = a.to_owned() + b;

--- a/src/test/ui/struct-literal-variant-in-if.stderr
+++ b/src/test/ui/struct-literal-variant-in-if.stderr
@@ -3,6 +3,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::I { field1: true, field2: 42 } {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if x == (E::I { field1: true, field2: 42 }) {}
@@ -13,6 +14,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::V { field: false } {}
    |             ^^^^^^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if x == (E::V { field: false }) {}
@@ -23,6 +25,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::J { field: -42 } {}
    |             ^^^^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if x == (E::J { field: -42 }) {}
@@ -33,6 +36,7 @@ error: struct literals are not allowed here
    |
 LL |     if x == E::K { field: "" } {}
    |             ^^^^^^^^^^^^^^^^^^
+   |
 help: surround the struct literal with parentheses
    |
 LL |     if x == (E::K { field: "" }) {}

--- a/src/test/ui/suggestions/no-extern-crate-in-type.stderr
+++ b/src/test/ui/suggestions/no-extern-crate-in-type.stderr
@@ -3,6 +3,7 @@ error[E0412]: cannot find type `Foo` in this scope
    |
 LL | type Output = Option<Foo>;
    |                      ^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL | use foo::Foo;

--- a/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
@@ -3,6 +3,7 @@ error[E0282]: type annotations needed for the closure `fn() -> [_; 0]`
    |
 LL |     let _v = || -> _ { [] };
    |                        ^^ cannot infer type
+   |
 help: give this closure an explicit return type without `_` placeholders
    |
 LL |     let _v = || -> [_; 0] { [] };

--- a/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
@@ -3,6 +3,7 @@ error[E0282]: type annotations needed for the closure `fn() -> [_; 0]`
    |
 LL |     let _v = || { [] };
    |                   ^^ cannot infer type
+   |
 help: give this closure an explicit return type without `_` placeholders
    |
 LL |     let _v = || -> [_; 0] { [] };

--- a/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
@@ -3,6 +3,7 @@ error[E0282]: type annotations needed for the closure `fn() -> [_; 0]`
    |
 LL |     let _v = || [];
    |                 ^^ cannot infer type
+   |
 help: give this closure an explicit return type without `_` placeholders
    |
 LL |     let _v = || -> [_; 0] { [] };

--- a/src/test/ui/suggestions/suggest-labels.stderr
+++ b/src/test/ui/suggestions/suggest-labels.stderr
@@ -3,6 +3,7 @@ error[E0426]: use of undeclared label `'fo`
    |
 LL |         break 'fo;
    |               ^^^
+   |
 help: a label with a similar name exists in this scope
    |
 LL |         break 'foo;
@@ -13,6 +14,7 @@ error[E0426]: use of undeclared label `'bor`
    |
 LL |         continue 'bor;
    |                  ^^^^
+   |
 help: a label with a similar name exists in this scope
    |
 LL |         continue 'bar;
@@ -23,6 +25,7 @@ error[E0426]: use of undeclared label `'longlable`
    |
 LL |             break 'longlable;
    |                   ^^^^^^^^^^
+   |
 help: a label with a similar name exists in this scope
    |
 LL |             break 'longlabel1;

--- a/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
+++ b/src/test/ui/suggestions/suggest-on-bare-closure-call.stderr
@@ -5,6 +5,7 @@ LL |     let _ = ||{}();
    |               ^^--
    |               |
    |               call expression requires function
+   |
 help: if you meant to create this closure and immediately call it, surround the closure with parenthesis
    |
 LL |     let _ = (||{})();

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -3,6 +3,7 @@ error[E0223]: ambiguous associated type
    |
 LL |     let pi = f32::consts::PI;
    |              ^^^^^^^^^^^^^^^
+   |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL |     let pi = std::f32::consts::PI;
@@ -13,6 +14,7 @@ error[E0599]: no function or associated item named `from_utf8` found for type `s
    |
 LL |         str::from_utf8(bytes)
    |              ^^^^^^^^^ function or associated item not found in `str`
+   |
 help: you are looking for the module in `std`, not the primitive type
    |
 LL |         std::str::from_utf8(bytes)

--- a/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
+++ b/src/test/ui/suggestions/use-type-argument-instead-of-assoc-type.stderr
@@ -20,6 +20,7 @@ LL |     i: Box<dyn T<usize, usize, usize, usize, B=usize>>,
    |            |
    |            associated type `A` must be specified
    |            associated type `C` must be specified
+   |
 help: if you meant to specify the associated types, write
    |
 LL |     i: Box<dyn T<usize, usize, A = usize, C = usize, B=usize>>,

--- a/src/test/ui/traits/traits-multidispatch-bad.stderr
+++ b/src/test/ui/traits/traits-multidispatch-bad.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     test(22i32, 44i32);
    |                 ^^^^^ expected u32, found i32
+   |
 help: change the type of the numeric literal from `i32` to `u32`
    |
 LL |     test(22i32, 44u32);

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection-error.stderr
@@ -6,6 +6,7 @@ LL | fn global_bound_is_hidden() -> u8
 ...
 LL |     B::get_x()
    |     ^^^^^^^^^^ expected u8, found i32
+   |
 help: you can convert an `i32` to `u8` and panic if the converted value wouldn't fit
    |
 LL |     B::get_x().try_into().unwrap()

--- a/src/test/ui/try-block/try-block-in-edition2015.stderr
+++ b/src/test/ui/try-block/try-block-in-edition2015.stderr
@@ -6,6 +6,7 @@ LL |     let try_result: Option<_> = try {
 LL |
 LL |         let x = 5;
    |         ^^^ expected identifier, found keyword
+   |
 help: you can escape reserved keywords to use them as identifiers
    |
 LL |         r#let x = 5;

--- a/src/test/ui/tutorial-suffix-inference-test.stderr
+++ b/src/test/ui/tutorial-suffix-inference-test.stderr
@@ -12,6 +12,7 @@ error[E0308]: mismatched types
    |
 LL |     identity_u16(y);
    |                  ^ expected u16, found i32
+   |
 help: you can convert an `i32` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     identity_u16(y.try_into().unwrap());
@@ -22,6 +23,7 @@ error[E0308]: mismatched types
    |
 LL |     identity_u16(a);
    |                  ^ expected u16, found isize
+   |
 help: you can convert an `isize` to `u16` and panic if the converted value wouldn't fit
    |
 LL |     identity_u16(a.try_into().unwrap());

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -26,6 +26,7 @@ LL |     Alias::Unit();
    |     ^^^^^^^^^^^--
    |     |
    |     call expression requires function
+   |
 help: `<Alias>::Unit` is a unit variant, you need to write it without the parenthesis
    |
 LL |     <Alias>::Unit;

--- a/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/src/test/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -11,6 +11,7 @@ error[E0308]: mismatched types
    |
 LL |     <i32 as Add<i32>>::add(1u32, 2);
    |                            ^^^^ expected i32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     <i32 as Add<i32>>::add(1i32, 2);
@@ -21,6 +22,7 @@ error[E0308]: mismatched types
    |
 LL |     <i32 as Add<i32>>::add(1, 2u32);
    |                               ^^^^ expected i32, found u32
+   |
 help: change the type of the numeric literal from `u32` to `i32`
    |
 LL |     <i32 as Add<i32>>::add(1, 2i32);

--- a/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-type-mismatch.stderr
@@ -3,6 +3,7 @@ error[E0308]: mismatched types
    |
 LL |     let z = f(1_usize, 2);
    |               ^^^^^^^ expected isize, found usize
+   |
 help: change the type of the numeric literal from `usize` to `isize`
    |
 LL |     let z = f(1_isize, 2);

--- a/src/test/ui/use/use-super-global-path.stderr
+++ b/src/test/ui/use/use-super-global-path.stderr
@@ -15,6 +15,7 @@ error[E0425]: cannot find function `main` in this scope
    |
 LL |         main();
    |         ^^^^ not found in this scope
+   |
 help: possible candidate is found in another module, you can import it into scope
    |
 LL |     use main;

--- a/src/test/ui/variants/variant-used-as-type.stderr
+++ b/src/test/ui/variants/variant-used-as-type.stderr
@@ -3,6 +3,7 @@ error[E0573]: expected type, found variant `Ty::A`
    |
 LL |     B(Ty::A),
    |       ^^^^^ not a type
+   |
 help: try using the variant's enum
    |
 LL |     B(E),
@@ -15,6 +16,7 @@ error[E0573]: expected type, found variant `E::A`
    |
 LL | impl E::A {}
    |      ^^^^ not a type
+   |
 help: try using the variant's enum
    |
 LL | impl E {}


### PR DESCRIPTION
Make the spacing between the code snippet and verbose structured
suggestions consistent with note and help messages.

r? @Centril 