### PR TITLE
Use the recorded types in MIR to determine generator auto-trait implementations

### DIFF
--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -89,6 +89,10 @@ impl HirId {
     }
 }
 
+CloneTypeFoldableImpls! {
+    HirId,
+}
+
 impl rustc_serialize::UseSpecializedEncodable for HirId {
     fn default_encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         let HirId {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -38,7 +38,7 @@ use syntax::symbol::Symbol;
 use syntax_pos::{Span, DUMMY_SP};
 
 pub use crate::mir::interpret::AssertMessage;
-pub use crate::mir::cache::{BodyCache, ReadOnlyBodyCache};
+pub use crate::mir::cache::{Cache, BodyCache, ReadOnlyBodyCache};
 pub use crate::read_only;
 
 mod cache;
@@ -117,6 +117,8 @@ pub struct Body<'tcx> {
     /// to be created.
     pub generator_kind: Option<GeneratorKind>,
 
+    pub generator_interior_tys: Option<Vec<Ty<'tcx>>>,
+
     /// Declarations of locals.
     ///
     /// The first local is the return value pointer, followed by `arg_count`
@@ -184,6 +186,7 @@ impl<'tcx> Body<'tcx> {
             generator_drop: None,
             generator_layout: None,
             generator_kind,
+            generator_interior_tys: None,
             local_decls,
             user_type_annotations,
             arg_count,

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -108,6 +108,11 @@ rustc_queries! {
         /// unreachable code.
         query mir_built(_: DefId) -> &'tcx Steal<mir::BodyCache<'tcx>> {}
 
+        /// Compute the generator interior types for a given `DefId`
+        /// (if it corresponds to a generator), for use in determining
+        /// generator auto trait implementation
+        query mir_generator_interior(_: DefId) -> &'tcx Steal<mir::BodyCache<'tcx>> {}
+
         /// Fetch the MIR for a given `DefId` up till the point where it is
         /// ready for const evaluation.
         ///

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -931,6 +931,10 @@ rustc_queries! {
         query all_traits(_: CrateNum) -> &'tcx [DefId] {
             desc { "fetching all foreign and local traits" }
         }
+
+        query uses_generator_mir_traits(_: CrateNum) -> bool {
+            desc { "determining whether crate uses generator MIR traits" }
+        }
     }
 
     Linking {

--- a/src/librustc/traits/engine.rs
+++ b/src/librustc/traits/engine.rs
@@ -105,7 +105,7 @@ impl dyn TraitEngine<'tcx> {
     /// Creates a `TraitEngine` in a special 'delay generator witness' mode.
     /// This imposes additional requirements for the caller in order to avoid
     /// accepting unsound code, and should only be used by `FnCtxt`. All other
-    /// users of `TraitEngine` should use `TraitEngine::new`
+    /// users of `TraitEngine` should use `TraitEngine::new`.
     ///
     /// A `TraitEngine` returned by this constructor will not attempt
     /// to resolve any `GeneratorWitness` predicates involving auto traits,

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2181,7 +2181,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         ty::Adt(ty::AdtDef { did, .. }, ..) if
                             self.tcx.is_diagnostic_item(sym::gen_future, *did) => {},
                         ty::Generator(did, ..) => generator = generator.or(Some(did)),
-                        ty::GeneratorWitness(_) | ty::Opaque(..) => {},
+                        ty::GeneratorWitness(..) | ty::Opaque(..) => {},
                         _ => return false,
                     }
 

--- a/src/librustc/traits/fulfill.rs
+++ b/src/librustc/traits/fulfill.rs
@@ -69,7 +69,7 @@ pub struct FulfillmentContext<'tcx> {
     // not available when `FnCxtxt` is run.
     has_delayed_generator_witness: bool,
     // The delayed generator witness predicates. This is only
-    // used when `has_delayed_generator_witness:` is `true`
+    // used when `has_delayed_generator_witness:` is `true`.
     delayed_generator_witness: DelayedGenerators<'tcx>,
 }
 
@@ -91,7 +91,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             register_region_obligations: true,
             usable_in_snapshot: false,
             delayed_generator_witness: None,
-            has_delayed_generator_witness: false
+            has_delayed_generator_witness: false,
         }
     }
 
@@ -101,7 +101,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             register_region_obligations: true,
             usable_in_snapshot: false,
             delayed_generator_witness: Some(Vec::new()),
-            has_delayed_generator_witness: true
+            has_delayed_generator_witness: true,
         }
     }
 
@@ -111,7 +111,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             register_region_obligations: true,
             usable_in_snapshot: true,
             delayed_generator_witness: None,
-            has_delayed_generator_witness: false
+            has_delayed_generator_witness: false,
         }
     }
 
@@ -121,7 +121,7 @@ impl<'a, 'tcx> FulfillmentContext<'tcx> {
             register_region_obligations: false,
             usable_in_snapshot: false,
             delayed_generator_witness: None,
-            has_delayed_generator_witness: false
+            has_delayed_generator_witness: false,
         }
     }
 

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -36,7 +36,7 @@ use crate::ty::fold::{TypeFolder, TypeFoldable, TypeVisitor};
 use crate::util::common::ErrorReported;
 
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use self::SelectionError::*;
 pub use self::FulfillmentErrorCode::*;
@@ -390,7 +390,7 @@ pub struct DerivedObligationCause<'tcx> {
     parent_trait_ref: ty::PolyTraitRef<'tcx>,
 
     /// The parent trait had this cause.
-    parent_code: Rc<ObligationCauseCode<'tcx>>
+    parent_code: Arc<ObligationCauseCode<'tcx>>
 }
 
 BraceStructTypeFoldableImpl! {

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -135,7 +135,8 @@ pub type TraitObligation<'tcx> = Obligation<'tcx, ty::PolyTraitPredicate<'tcx>>;
 static_assert_size!(PredicateObligation<'_>, 112);
 
 /// The reason why we incurred this obligation; used for error reporting.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct ObligationCause<'tcx> {
     pub span: Span,
 
@@ -165,13 +166,8 @@ impl<'tcx> ObligationCause<'tcx> {
     }
 }
 
-BraceStructTypeFoldableImpl! {
-    impl<'tcx> TypeFoldable<'tcx> for ObligationCause<'tcx> {
-        span, body_id, code
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub enum ObligationCauseCode<'tcx> {
     /// Not well classified or should be obvious from the span.
     MiscObligation,
@@ -292,7 +288,8 @@ pub enum ObligationCauseCode<'tcx> {
     AssocTypeBound(Box<AssocTypeBoundData>),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct AssocTypeBoundData {
     pub impl_span: Option<Span>,
     pub original: Span,
@@ -303,57 +300,8 @@ pub struct AssocTypeBoundData {
 #[cfg(target_arch = "x86_64")]
 static_assert_size!(ObligationCauseCode<'_>, 32);
 
-EnumTypeFoldableImpl! {
-    impl<'tcx> TypeFoldable<'tcx> for ObligationCauseCode<'tcx> {
-        (ObligationCauseCode::MiscObligation),
-        (ObligationCauseCode::SliceOrArrayElem),
-        (ObligationCauseCode::TupleElem),
-        (ObligationCauseCode::ProjectionWf)(a),
-        (ObligationCauseCode::ItemObligation)(a),
-        (ObligationCauseCode::BindingObligation)(a, b),
-        (ObligationCauseCode::ReferenceOutlivesReferent)(a),
-        (ObligationCauseCode::ObjectTypeBound)(a, b),
-        (ObligationCauseCode::ObjectCastObligation)(a),
-        (ObligationCauseCode::Coercion){source, target},
-        (ObligationCauseCode::AssignmentLhsSized),
-        (ObligationCauseCode::TupleInitializerSized),
-        (ObligationCauseCode::StructInitializerSized),
-        (ObligationCauseCode::VariableType)(a),
-        (ObligationCauseCode::SizedArgumentType),
-        (ObligationCauseCode::SizedReturnType),
-        (ObligationCauseCode::SizedYieldType),
-        (ObligationCauseCode::RepeatVec),
-        (ObligationCauseCode::FieldSized){ adt_kind, last },
-        (ObligationCauseCode::ConstSized),
-        (ObligationCauseCode::SharedStatic),
-        (ObligationCauseCode::BuiltinDerivedObligation)(a),
-        (ObligationCauseCode::ImplDerivedObligation)(a),
-        (ObligationCauseCode::CompareImplMethodObligation){
-            item_name,
-            impl_item_def_id,
-            trait_item_def_id
-        },
-        (ObligationCauseCode::ExprAssignable),
-        (ObligationCauseCode::MatchExpressionArm)(a),
-        (ObligationCauseCode::MatchExpressionArmPattern){
-            span,
-            ty
-        },
-        (ObligationCauseCode::IfExpression)(a),
-        (ObligationCauseCode::IfExpressionWithNoElse),
-        (ObligationCauseCode::MainFunctionType),
-        (ObligationCauseCode::StartFunctionType),
-        (ObligationCauseCode::IntrinsicType),
-        (ObligationCauseCode::MethodReceiver),
-        (ObligationCauseCode::ReturnNoExpression),
-        (ObligationCauseCode::ReturnValue)(a),
-        (ObligationCauseCode::ReturnType),
-        (ObligationCauseCode::BlockTailExpression)(a),
-        (ObligationCauseCode::TrivialBound),
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct MatchExpressionArmCause<'tcx> {
     pub arm_span: Span,
     pub source: hir::MatchSource,
@@ -362,26 +310,16 @@ pub struct MatchExpressionArmCause<'tcx> {
     pub discrim_hir_id: hir::HirId,
 }
 
-BraceStructTypeFoldableImpl! {
-    impl<'tcx> TypeFoldable<'tcx> for MatchExpressionArmCause<'tcx> {
-        arm_span, source, prior_arms, last_ty, discrim_hir_id
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct IfExpressionCause {
     pub then: Span,
     pub outer: Option<Span>,
     pub semicolon: Option<Span>,
 }
 
-BraceStructTypeFoldableImpl! {
-    impl<'tcx> TypeFoldable<'tcx> for IfExpressionCause {
-        then, outer, semicolon
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct DerivedObligationCause<'tcx> {
     /// The trait reference of the parent obligation that led to the
     /// current obligation. Note that only trait obligations lead to
@@ -392,13 +330,6 @@ pub struct DerivedObligationCause<'tcx> {
     /// The parent trait had this cause.
     parent_code: Arc<ObligationCauseCode<'tcx>>
 }
-
-BraceStructTypeFoldableImpl! {
-    impl<'tcx> TypeFoldable<'tcx> for DerivedObligationCause<'tcx> {
-        parent_trait_ref, parent_code
-    }
-}
-
 
 pub type Obligations<'tcx, O> = Vec<Obligation<'tcx, O>>;
 pub type PredicateObligations<'tcx> = Vec<PredicateObligation<'tcx>>;

--- a/src/librustc/traits/project.rs
+++ b/src/librustc/traits/project.rs
@@ -26,7 +26,7 @@ use crate::util::common::FN_OUTPUT_NAME;
 
 /// Depending on the stage of compilation, we want projection to be
 /// more or less conservative.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, HashStable)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable)]
 pub enum Reveal {
     /// At type-checking time, we refuse to project any associated
     /// type that is marked `default`. Non-`default` ("final") types
@@ -85,7 +85,7 @@ pub enum ProjectionTyError<'tcx> {
     TraitSelectionError(SelectionError<'tcx>),
 }
 
-#[derive(Clone)]
+#[derive(Clone, RustcEncodable, RustcDecodable, HashStable)]
 pub struct MismatchedProjectionTypes<'tcx> {
     pub err: ty::error::TypeError<'tcx>
 }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2180,11 +2180,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 ty::Generator(..)
                     if self.tcx().lang_items().freeze_trait() == Some(def_id) =>
                 {
-                    // Generators are always Freeze - it's impossible to do anything
-                    // with them unless you have a mutable reference, so any interior
-                    // mutability of types 'inside' them is not observable from
-                    // outside the generator
-                    candidates.vec.push(BuiltinCandidate { has_nested: false });
+                    // For now, always consider generators to be !Freeze
                 }
 
                 _ => candidates.vec.push(AutoImplCandidate(def_id.clone())),

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2807,10 +2807,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 let mut used_types = Vec::new();
 
-                // Note - while we use `optimized_mir`, the .generator_interior_tys
-                // field is only set during construction of the original MIR,
-                // and is unaffected by optimizations
-                let interior_tys = self.tcx().optimized_mir(did).generator_interior_tys
+                // We use `mir_validated` since earlier queries (e.g. `mir_const`)
+                // may be been stolen by the time this code runs. However, `generator_interior_tys`
+                // is computed early on and never modified, so it's fine to use
+                // a later query.
+                let mir = self.tcx().mir_validated(did).0.borrow();
+                let interior_tys = mir.generator_interior_tys
                     .as_ref().expect("Missing generator interior types!");
 
                 for ty in interior_tys {

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -49,7 +49,7 @@ use std::cell::{Cell, RefCell};
 use std::cmp;
 use std::fmt::{self, Display};
 use std::iter;
-use std::rc::Rc;
+use std::sync::Arc;
 use crate::util::nodemap::{FxHashMap, FxHashSet};
 
 pub struct SelectionContext<'cx, 'tcx> {
@@ -4078,7 +4078,7 @@ impl<'tcx> TraitObligation<'tcx> {
         if obligation.recursion_depth >= 0 {
             let derived_cause = DerivedObligationCause {
                 parent_trait_ref: obligation.predicate.to_poly_trait_ref(),
-                parent_code: Rc::new(obligation.cause.code.clone()),
+                parent_code: Arc::new(obligation.cause.code.clone()),
             };
             let derived_code = variant(derived_cause);
             ObligationCause::new(

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2177,11 +2177,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         }
                     }
                 }
-                ty::Generator(..)
-                    if self.tcx().lang_items().freeze_trait() == Some(def_id) =>
-                {
-                    // For now, always consider generators to be !Freeze
-                }
 
                 _ => candidates.vec.push(AutoImplCandidate(def_id.clone())),
             }

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2748,17 +2748,17 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             }
 
             ty::GeneratorWitness(did, types) => {
-				let use_mir = if did.is_local() {
+                let use_mir = if did.is_local() {
                     self.tcx().features().generator_mir_traits
                 } else {
                     self.tcx().uses_generator_mir_traits(did.krate)
                 };
 
                 if !use_mir {
-					// This is sound because no regions in the witness can refer to
-					// the binder outside the witness. So we'll effectivly reuse
-					// the implicit binder around the witness.
-					return types.skip_binder().to_vec()
+                    // This is sound because no regions in the witness can refer to
+                    // the binder outside the witness. So we'll effectivly reuse
+                    // the implicit binder around the witness.
+                    return types.skip_binder().to_vec()
                 }
                 // Note that we need to use optimized_mir here,
                 // in order to have the `StateTransform` pass run

--- a/src/librustc/traits/select.rs
+++ b/src/librustc/traits/select.rs
@@ -2755,9 +2755,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::GeneratorWitness(did, types) => {
                 // Note that we need to use optimized_mir here,
                 // in order to have the `StateTransform` pass run
-                let gen_mir = self.tcx().optimized_mir(did);
+                /*let gen_mir = self.tcx().optimized_mir(did);
                 let gen_layout = gen_mir.generator_layout.as_ref()
-                    .expect("Missing generator layout!");
+                    .expect("Missing generator layout!");*/
 
                 // We need to compare the types from the GeneratoWitness
                 // to the types from the MIR. Since the generator MIR (specifically
@@ -2806,7 +2806,14 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
                 let mut used_types = Vec::new();
 
-                for ty in &gen_layout.field_tys {
+                // Note - while we use `optimized_mir`, the .generator_interior_tys
+                // field is only set during construction of the original MIR,
+                // and is unaffected by optimizations
+                let interior_tys = self.tcx().optimized_mir(did).generator_interior_tys
+                    .as_ref().expect("Missing generator interior types!");
+
+                //for ty in &gen_layout.field_tys {
+                for ty in interior_tys {
                     if let Some(witness_ty) = erased_types.get(&self.tcx().erase_regions(ty)) {
                         used_types.push(**witness_ty);
                     }

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -7,7 +7,7 @@ use crate::ty::{self, Lift, Ty, TyCtxt};
 use syntax::symbol::Symbol;
 
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::collections::{BTreeSet, BTreeMap};
 
 // Structural impls for the structs in `traits`.
@@ -561,7 +561,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::DerivedObligationCause<'a> {
             tcx.lift(&*self.parent_code)
                .map(|code| traits::DerivedObligationCause {
                    parent_trait_ref: trait_ref,
-                   parent_code: Rc::new(code),
+                   parent_code: Arc::new(code),
                })
         )
     }

--- a/src/librustc/ty/codec.rs
+++ b/src/librustc/ty/codec.rs
@@ -272,6 +272,18 @@ where
 }
 
 #[inline]
+pub fn decode_predicate_slice<D>(
+    decoder: &mut D,
+) -> Result<&'tcx ty::List<ty::Predicate<'tcx>>, D::Error>
+where
+    D: TyDecoder<'tcx>,
+{
+    let len = decoder.read_usize()?;
+    Ok(decoder.tcx()
+              .mk_predicates((0..len).map(|_| Decodable::decode(decoder)))?)
+}
+
+#[inline]
 pub fn decode_canonical_var_infos<D>(decoder: &mut D) -> Result<CanonicalVarInfos<'tcx>, D::Error>
 where
     D: TyDecoder<'tcx>,
@@ -464,6 +476,14 @@ macro_rules! implement_ty_decoder {
                 fn specialized_decode(&mut self)
                     -> Result<&'tcx ty::List<ty::ExistentialPredicate<'tcx>>, Self::Error> {
                     decode_existential_predicate_slice(self)
+                }
+            }
+
+            impl<$($typaram),*> SpecializedDecoder<&'tcx ty::List<ty::Predicate<'tcx>>>
+                for $DecoderName<$($typaram),*> {
+                fn specialized_decode(&mut self)
+                    -> Result<&'tcx ty::List<ty::Predicate<'tcx>>, Self::Error> {
+                    decode_predicate_slice(self)
                 }
             }
 

--- a/src/librustc/ty/error.rs
+++ b/src/librustc/ty/error.rs
@@ -11,14 +11,15 @@ use syntax_pos::Span;
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, TypeFoldable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, RustcEncodable, RustcDecodable, HashStable,
+         TypeFoldable)]
 pub struct ExpectedFound<T> {
     pub expected: T,
     pub found: T,
 }
 
 // Data structures used in type unification
-#[derive(Clone, Debug, TypeFoldable)]
+#[derive(Clone, Debug, RustcEncodable, RustcDecodable, HashStable, TypeFoldable)]
 pub enum TypeError<'tcx> {
     Mismatch,
     UnsafetyMismatch(ExpectedFound<hir::Unsafety>),

--- a/src/librustc/ty/fast_reject.rs
+++ b/src/librustc/ty/fast_reject.rs
@@ -90,7 +90,7 @@ pub fn simplify_type(
         ty::Generator(def_id, _, _) => {
             Some(GeneratorSimplifiedType(def_id))
         }
-        ty::GeneratorWitness(ref tys) => {
+        ty::GeneratorWitness(_, ref tys) => {
             Some(GeneratorWitnessSimplifiedType(tys.skip_binder().len()))
         }
         ty::Never => Some(NeverSimplifiedType),

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -96,7 +96,7 @@ impl FlagComputation {
                 self.add_substs(substs);
             }
 
-            &ty::GeneratorWitness(ref ts) => {
+            &ty::GeneratorWitness(_, ref ts) => {
                 let mut computation = FlagComputation::new();
                 computation.add_tys(&ts.skip_binder()[..]);
                 self.add_bound_computation(&computation);

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -810,7 +810,7 @@ pub struct ClosureUpvar<'tcx> {
     pub ty: Ty<'tcx>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, HashStable)]
 pub enum IntVarValue {
     IntType(ast::IntTy),
     UintType(ast::UintTy),
@@ -1632,7 +1632,8 @@ pub type PlaceholderConst = Placeholder<BoundVar>;
 /// When type checking, we use the `ParamEnv` to track
 /// details about the set of where-clauses that are in scope at this
 /// particular point.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, HashStable, TypeFoldable)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, HashStable, RustcEncodable, RustcDecodable,
+         TypeFoldable)]
 pub struct ParamEnv<'tcx> {
     /// `Obligation`s that the caller must satisfy. This is basically
     /// the set of bounds on the in-scope type parameters, translated
@@ -2006,7 +2007,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for AdtDef {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, HashStable, RustcEncodable, RustcDecodable)]
 pub enum AdtKind { Struct, Union, Enum }
 
 impl Into<DataTypeKind> for AdtKind {

--- a/src/librustc/ty/print/obsolete.rs
+++ b/src/librustc/ty/print/obsolete.rs
@@ -151,7 +151,7 @@ impl DefPathBasedNames<'tcx> {
             | ty::UnnormalizedProjection(..)
             | ty::Projection(..)
             | ty::Param(_)
-            | ty::GeneratorWitness(_)
+            | ty::GeneratorWitness(..)
             | ty::Opaque(..) => {
                 if debug {
                     output.push_str(&format!("`{:?}`", t));

--- a/src/librustc/ty/print/pretty.rs
+++ b/src/librustc/ty/print/pretty.rs
@@ -672,8 +672,10 @@ pub trait PrettyPrinter<'tcx>:
 
                 p!(write(" "), print(witness), write("]"))
             },
-            ty::GeneratorWitness(types) => {
+            ty::GeneratorWitness(did, types) => {
+                p!(write("[witness@{:?}", did));
                 p!(in_binder(&types));
+                p!(write("]"));
             }
             ty::Closure(did, substs) => {
                 let upvar_tys = substs.as_closure().upvar_tys(did, self.tcx());

--- a/src/librustc/ty/relate.rs
+++ b/src/librustc/ty/relate.rs
@@ -417,7 +417,8 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
             Ok(tcx.mk_generator(a_id, substs, movability))
         }
 
-        (&ty::GeneratorWitness(a_types), &ty::GeneratorWitness(b_types)) =>
+        (&ty::GeneratorWitness(a_id, a_types), &ty::GeneratorWitness(b_id, b_types))
+            if a_id == b_id =>
         {
             // Wrap our types with a temporary GeneratorWitness struct
             // inside the binder so we can related them
@@ -425,7 +426,7 @@ pub fn super_relate_tys<R: TypeRelation<'tcx>>(
             let b_types = b_types.map_bound(GeneratorWitness);
             // Then remove the GeneratorWitness for the result
             let types = relation.relate(&a_types, &b_types)?.map_bound(|witness| witness.0);
-            Ok(tcx.mk_generator_witness(types))
+            Ok(tcx.mk_generator_witness(a_id, types))
         }
 
         (&ty::Closure(a_id, a_substs),

--- a/src/librustc/ty/structural_impls.rs
+++ b/src/librustc/ty/structural_impls.rs
@@ -1015,7 +1015,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
                     substs.fold_with(folder),
                     movability)
             }
-            ty::GeneratorWitness(types) => ty::GeneratorWitness(types.fold_with(folder)),
+            ty::GeneratorWitness(did, types) => ty::GeneratorWitness(did, types.fold_with(folder)),
             ty::Closure(did, substs) => ty::Closure(did, substs.fold_with(folder)),
             ty::Projection(ref data) => ty::Projection(data.fold_with(folder)),
             ty::UnnormalizedProjection(ref data) => {
@@ -1064,7 +1064,7 @@ impl<'tcx> TypeFoldable<'tcx> for Ty<'tcx> {
             ty::Generator(_did, ref substs, _) => {
                 substs.visit_with(visitor)
             }
-            ty::GeneratorWitness(ref types) => types.visit_with(visitor),
+            ty::GeneratorWitness(_, ref types) => types.visit_with(visitor),
             ty::Closure(_did, ref substs) => substs.visit_with(visitor),
             ty::Projection(ref data) | ty::UnnormalizedProjection(ref data) => {
                 data.visit_with(visitor)

--- a/src/librustc/ty/sty.rs
+++ b/src/librustc/ty/sty.rs
@@ -170,7 +170,9 @@ pub enum TyKind<'tcx> {
 
     /// A type representin the types stored inside a generator.
     /// This should only appear in GeneratorInteriors.
-    GeneratorWitness(Binder<&'tcx List<Ty<'tcx>>>),
+    /// The `DefId` refers to the generator corresponding
+    /// to this `GeneratorWitness
+    GeneratorWitness(DefId, Binder<&'tcx List<Ty<'tcx>>>),
 
     /// The never type `!`
     Never,
@@ -643,6 +645,7 @@ impl<'tcx> Binder<ExistentialPredicate<'tcx>> {
     }
 }
 
+impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx List<ty::Predicate<'tcx>> {}
 impl<'tcx> rustc_serialize::UseSpecializedDecodable for &'tcx List<ExistentialPredicate<'tcx>> {}
 
 impl<'tcx> List<ExistentialPredicate<'tcx>> {
@@ -897,7 +900,8 @@ impl<T> Binder<T> {
     pub fn dummy<'tcx>(value: T) -> Binder<T>
         where T: TypeFoldable<'tcx>
     {
-        debug_assert!(!value.has_escaping_bound_vars());
+        debug_assert!(!value.has_escaping_bound_vars(),
+            "Value has escaping vars: {:?}", value);
         Binder(value)
     }
 

--- a/src/librustc/ty/walk.rs
+++ b/src/librustc/ty/walk.rs
@@ -113,7 +113,7 @@ fn push_subtypes<'tcx>(stack: &mut TypeWalkerStack<'tcx>, parent_ty: Ty<'tcx>) {
         | ty::Generator(_, ref substs, _) => {
             stack.extend(substs.types().rev());
         }
-        ty::GeneratorWitness(ts) => {
+        ty::GeneratorWitness(_, ts) => {
             stack.extend(ts.skip_binder().iter().cloned().rev());
         }
         ty::Tuple(..) => {

--- a/src/librustc_codegen_utils/symbol_names/v0.rs
+++ b/src/librustc_codegen_utils/symbol_names/v0.rs
@@ -460,7 +460,7 @@ impl Printer<'tcx> for SymbolMangler<'tcx> {
                 self = r.print(self)?;
             }
 
-            ty::GeneratorWitness(_) => {
+            ty::GeneratorWitness(..) => {
                 bug!("symbol_names: unexpected `GeneratorWitness`")
             }
         }

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -526,7 +526,7 @@ declare_features! (
     /// Allows using `&mut` in constant functions.
     (active, const_mut_refs, "1.41.0", Some(57349), None),
 
-    (active, generator_mir_traits, "1.41.0", None, None),
+    (active, generator_mir_traits, "1.41.0", Some(0), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/librustc_feature/active.rs
+++ b/src/librustc_feature/active.rs
@@ -526,6 +526,8 @@ declare_features! (
     /// Allows using `&mut` in constant functions.
     (active, const_mut_refs, "1.41.0", Some(57349), None),
 
+    (active, generator_mir_traits, "1.41.0", None, None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
+++ b/src/librustc_metadata/rmeta/decoder/cstore_impl.rs
@@ -240,6 +240,10 @@ provide! { <'tcx> tcx, def_id, other, cdata,
 
         Arc::new(syms)
     }
+
+    uses_generator_mir_traits => {
+        cdata.root.generator_mir_traits
+    }
 }
 
 pub fn provide(providers: &mut Providers<'_>) {

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -544,6 +544,7 @@ impl<'tcx> EncodeContext<'tcx> {
             exported_symbols,
             interpret_alloc_index,
             per_def,
+            generator_mir_traits: tcx.features().generator_mir_traits
         });
 
         let total_bytes = self.position();

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -214,6 +214,7 @@ crate struct CrateRoot<'tcx> {
     profiler_runtime: bool,
     sanitizer_runtime: bool,
     symbol_mangling_version: SymbolManglingVersion,
+    generator_mir_traits: bool
 }
 
 #[derive(RustcEncodable, RustcDecodable)]

--- a/src/librustc_mir/interpret/intrinsics/type_name.rs
+++ b/src/librustc_mir/interpret/intrinsics/type_name.rs
@@ -71,7 +71,7 @@ impl<'tcx> Printer<'tcx> for AbsolutePathPrinter<'tcx> {
             | ty::Generator(def_id, substs, _) => self.print_def_path(def_id, substs),
             ty::Foreign(def_id) => self.print_def_path(def_id, &[]),
 
-            ty::GeneratorWitness(_) => {
+            ty::GeneratorWitness(..) => {
                 bug!("type_name: unexpected `GeneratorWitness`")
             }
         }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -766,7 +766,7 @@ fn compute_layout<'tcx>(
     // MIR types
     let allowed_upvars = tcx.erase_regions(upvars);
     let allowed = match interior.kind {
-        ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(&s),
+        ty::GeneratorWitness(_, s) => tcx.erase_late_bound_regions(&s),
         _ => bug!(),
     };
 
@@ -1197,6 +1197,8 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
             }
             _ => bug!(),
         };
+
+        debug!("MIR generator type: {:?}", gen_ty);
 
         // Compute GeneratorState<yield_ty, return_ty>
         let state_did = tcx.lang_items().gen_state().unwrap();

--- a/src/librustc_typeck/check/generator_interior.rs
+++ b/src/librustc_typeck/check/generator_interior.rs
@@ -101,6 +101,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
 pub fn resolve_interior<'a, 'tcx>(
     fcx: &'a FnCtxt<'a, 'tcx>,
     def_id: DefId,
+    gen_def_id: DefId,
     body_id: hir::BodyId,
     interior: Ty<'tcx>,
     kind: hir::GeneratorKind,
@@ -152,7 +153,7 @@ pub fn resolve_interior<'a, 'tcx>(
     // Extract type components
     let type_list = fcx.tcx.mk_type_list(types.into_iter().map(|t| (t.0).ty));
 
-    let witness = fcx.tcx.mk_generator_witness(ty::Binder::bind(type_list));
+    let witness = fcx.tcx.mk_generator_witness(gen_def_id, ty::Binder::bind(type_list));
 
     debug!("types in generator after region replacement {:?}, span = {:?}",
             witness, body.value.span);

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -30,8 +30,13 @@ use std::mem;
 // so instead all of the replacement happens at the end in
 // resolve_type_vars_in_body, which creates a new TypeTables which
 // doesn't contain any inference types.
+
+
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
-    pub fn resolve_type_vars_in_body(&self, body: &'tcx hir::Body) -> &'tcx ty::TypeckTables<'tcx> {
+    pub fn resolve_type_vars_in_body(
+        &self,
+        body: &'tcx hir::Body,
+    ) -> &'tcx ty::TypeckTables<'tcx> {
         let item_id = self.tcx.hir().body_owner(body.id());
         let item_def_id = self.tcx.hir().local_def_id(item_id);
 
@@ -78,6 +83,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
 
         wbcx.tables.tainted_by_errors = self.is_tainted_by_errors();
+        wbcx.tables.generator_obligations = self.process_generators();
 
         debug!(
             "writeback: tables for {:?} are {:#?}",

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -334,6 +334,7 @@ symbols! {
         FxHashSet,
         FxHashMap,
         gen_future,
+        generator_mir_traits,
         generators,
         generic_associated_types,
         generic_param_attrs,

--- a/src/test/ui/async-await/async-fn-nonsend.rs
+++ b/src/test/ui/async-await/async-fn-nonsend.rs
@@ -37,7 +37,6 @@ async fn non_send_temporary_in_match() {
 }
 
 async fn non_sync_with_method_call() {
-    // FIXME: it'd be nice for this to work.
     let f: &mut std::fmt::Formatter = panic!();
     if non_sync().fmt(f).unwrap() == () {
         fut().await;
@@ -48,10 +47,9 @@ fn assert_send(_: impl Send) {}
 
 pub fn pass_assert() {
     assert_send(local_dropped_before_await());
-    //~^ ERROR `std::rc::Rc<()>` cannot be sent between threads safely
     assert_send(non_send_temporary_in_match());
     //~^ ERROR `std::rc::Rc<()>` cannot be sent between threads safely
     assert_send(non_sync_with_method_call());
-    //~^ ERROR `dyn std::fmt::Write` cannot be sent between threads safely
-    //~^^ ERROR `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
 }
+
+fn main() {}

--- a/src/test/ui/async-await/async-fn-nonsend.rs
+++ b/src/test/ui/async-await/async-fn-nonsend.rs
@@ -2,6 +2,8 @@
 // edition:2018
 // compile-flags: --crate-type lib
 
+#![feature(generator_mir_traits)]
+
 use std::{
     cell::RefCell,
     fmt::Debug,

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -4,76 +4,18 @@ error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
 LL | fn assert_send(_: impl Send) {}
    |    -----------         ---- required by this bound in `assert_send`
 ...
-LL |     assert_send(local_dropped_before_await());
-   |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
-   |
-   = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
-   = note: required because it appears within the type `impl std::fmt::Debug`
-   = note: required because it appears within the type `{impl std::fmt::Debug, impl std::future::Future, impl std::future::Future, ()}`
-   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:21:39: 26:2 {impl std::fmt::Debug, impl std::future::Future, impl std::future::Future, ()}]`
-   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:21:39: 26:2 {impl std::fmt::Debug, impl std::future::Future, impl std::future::Future, ()}]>`
-   = note: required because it appears within the type `impl std::future::Future`
-   = note: required because it appears within the type `impl std::future::Future`
-
-error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
-  --> $DIR/async-fn-nonsend.rs:52:5
-   |
-LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
-...
 LL |     assert_send(non_send_temporary_in_match());
    |     ^^^^^^^^^^^ `std::rc::Rc<()>` cannot be sent between threads safely
    |
    = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<()>`
    = note: required because it appears within the type `impl std::fmt::Debug`
-   = note: required because it appears within the type `{impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}`
-   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 {impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]`
-   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 {impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]>`
+   = note: required because it appears within the type `std::option::Option<impl std::fmt::Debug>`
+   = note: required because it appears within the type `[witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]`
+   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]`
+   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
 
-error[E0277]: `dyn std::fmt::Write` cannot be sent between threads safely
-  --> $DIR/async-fn-nonsend.rs:54:5
-   |
-LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
-...
-LL |     assert_send(non_sync_with_method_call());
-   |     ^^^^^^^^^^^ `dyn std::fmt::Write` cannot be sent between threads safely
-   |
-   = help: the trait `std::marker::Send` is not implemented for `dyn std::fmt::Write`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `&mut dyn std::fmt::Write`
-   = note: required because it appears within the type `std::fmt::Formatter<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `&mut std::fmt::Formatter<'_>`
-   = note: required because it appears within the type `for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}`
-   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}]`
-   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}]>`
-   = note: required because it appears within the type `impl std::future::Future`
-   = note: required because it appears within the type `impl std::future::Future`
-
-error[E0277]: `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
-  --> $DIR/async-fn-nonsend.rs:54:5
-   |
-LL | fn assert_send(_: impl Send) {}
-   |    -----------         ---- required by this bound in `assert_send`
-...
-LL |     assert_send(non_sync_with_method_call());
-   |     ^^^^^^^^^^^ `*mut (dyn std::ops::Fn() + 'static)` cannot be shared between threads safely
-   |
-   = help: within `std::fmt::ArgumentV1<'_>`, the trait `std::marker::Sync` is not implemented for `*mut (dyn std::ops::Fn() + 'static)`
-   = note: required because it appears within the type `std::marker::PhantomData<*mut (dyn std::ops::Fn() + 'static)>`
-   = note: required because it appears within the type `core::fmt::Void`
-   = note: required because it appears within the type `&core::fmt::Void`
-   = note: required because it appears within the type `std::fmt::ArgumentV1<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `std::slice::Iter<'_, std::fmt::ArgumentV1<'_>>`
-   = note: required because it appears within the type `std::fmt::Formatter<'_>`
-   = note: required because of the requirements on the impl of `std::marker::Send` for `&mut std::fmt::Formatter<'_>`
-   = note: required because it appears within the type `for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}`
-   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}]`
-   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:39:38: 45:2 for<'r, 's> {&'r mut std::fmt::Formatter<'s>, bool, bool, impl std::future::Future, impl std::future::Future, ()}]>`
-   = note: required because it appears within the type `impl std::future::Future`
-   = note: required because it appears within the type `impl std::future::Future`
-
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/async-await/async-fn-nonsend.stderr
+++ b/src/test/ui/async-await/async-fn-nonsend.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `std::rc::Rc<()>` cannot be sent between threads safely
-  --> $DIR/async-fn-nonsend.rs:50:5
+  --> $DIR/async-fn-nonsend.rs:52:5
    |
 LL | fn assert_send(_: impl Send) {}
    |    -----------         ---- required by this bound in `assert_send`
@@ -11,8 +11,8 @@ LL |     assert_send(non_send_temporary_in_match());
    = note: required because it appears within the type `impl std::fmt::Debug`
    = note: required because it appears within the type `std::option::Option<impl std::fmt::Debug>`
    = note: required because it appears within the type `[witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]`
-   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]`
-   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:28:40: 37:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]>`
+   = note: required because it appears within the type `[static generator@$DIR/async-fn-nonsend.rs:30:40: 39:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]`
+   = note: required because it appears within the type `std::future::GenFuture<[static generator@$DIR/async-fn-nonsend.rs:30:40: 39:2 [witness@DefId(0:25 ~ async_fn_nonsend[8787]::non_send_temporary_in_match[0]::{{closure}}[0]){impl std::fmt::Debug, std::option::Option<impl std::fmt::Debug>, impl std::future::Future, impl std::future::Future, ()}]]>`
    = note: required because it appears within the type `impl std::future::Future`
    = note: required because it appears within the type `impl std::future::Future`
 

--- a/src/test/ui/async-await/generator-mir-traits.rs
+++ b/src/test/ui/async-await/generator-mir-traits.rs
@@ -1,0 +1,17 @@
+// edition:2018
+// check-pass
+
+#![feature(generator_mir_traits)]
+
+fn is_send<T: Send>(val: T) {}
+
+async fn dummy() {}
+
+async fn not_send() {
+    let val: *const ();
+    dummy().await;
+}
+
+fn main() {
+    is_send(not_send());
+}

--- a/src/test/ui/feature-gate/feature-gate-generator_mir_traits.rs
+++ b/src/test/ui/feature-gate/feature-gate-generator_mir_traits.rs
@@ -1,0 +1,16 @@
+// compile-fail
+// edition:2018
+
+fn is_send<T: Send>(val: T) {}
+
+async fn dummy() {}
+
+async fn not_send() {
+    let val: *const ();
+    dummy().await;
+}
+
+fn main() {
+    is_send(not_send());
+    //~^ ERROR  `*const ()` cannot be sent between threads safely
+}

--- a/src/test/ui/feature-gate/feature-gate-generator_mir_traits.stderr
+++ b/src/test/ui/feature-gate/feature-gate-generator_mir_traits.stderr
@@ -1,0 +1,23 @@
+error[E0277]: `*const ()` cannot be sent between threads safely
+  --> $DIR/feature-gate-generator_mir_traits.rs:14:5
+   |
+LL | fn is_send<T: Send>(val: T) {}
+   |    -------    ---- required by this bound in `is_send`
+...
+LL |     is_send(not_send());
+   |     ^^^^^^^ `*const ()` cannot be sent between threads safely
+   |
+   = help: within `impl std::future::Future`, the trait `std::marker::Send` is not implemented for `*const ()`
+note: future does not implement `std::marker::Send` as this value is used across an await
+  --> $DIR/feature-gate-generator_mir_traits.rs:10:5
+   |
+LL |     let val: *const ();
+   |         --- has type `*const ()`
+LL |     dummy().await;
+   |     ^^^^^^^^^^^^^ await occurs here, with `val` maybe used later
+LL | }
+   | - `val` is later dropped here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generator/auto-trait-regions.rs
+++ b/src/test/ui/generator/auto-trait-regions.rs
@@ -40,8 +40,10 @@ fn main() {
     assert_foo(gen); // ok
 
     // Disallow impls which relates lifetimes in the generator interior
-    let gen = || {
-        let a = A(&mut true, &mut true, No);
+    let gen = static || {
+        let first = &mut true;
+        let second = &mut true;
+        let a = A(first, second, No);
         yield;
         assert_foo(a);
     };

--- a/src/test/ui/generator/auto-trait-regions.stderr
+++ b/src/test/ui/generator/auto-trait-regions.stderr
@@ -11,7 +11,7 @@ LL |     assert_foo(gen);
    = note: ...but `Foo` is actually implemented for the type `&'1 OnlyFooIfStaticRef`, for some specific lifetime `'1`
 
 error: implementation of `Foo` is not general enough
-  --> $DIR/auto-trait-regions.rs:48:5
+  --> $DIR/auto-trait-regions.rs:50:5
    |
 LL | auto trait Foo {}
    | ----------------- trait `Foo` defined here

--- a/src/test/ui/generator/not-send-sync.rs
+++ b/src/test/ui/generator/not-send-sync.rs
@@ -7,7 +7,6 @@ fn main() {
     fn assert_send<T: Send>(_: T) {}
 
     assert_sync(|| {
-        //~^ ERROR: E0277
         let a = Cell::new(2);
         yield;
     });

--- a/src/test/ui/generator/not-send-sync.stderr
+++ b/src/test/ui/generator/not-send-sync.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
-  --> $DIR/not-send-sync.rs:16:5
+  --> $DIR/not-send-sync.rs:15:5
    |
 LL |     fn assert_send<T: Send>(_: T) {}
    |        -----------    ---- required by this bound in `main::assert_send`
@@ -9,21 +9,8 @@ LL |     assert_send(|| {
    |
    = help: the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
    = note: required because of the requirements on the impl of `std::marker::Send` for `&std::cell::Cell<i32>`
-   = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:16:17: 20:6 a:&std::cell::Cell<i32> _]`
+   = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:15:17: 19:6 a:&std::cell::Cell<i32> _]`
 
-error[E0277]: `std::cell::Cell<i32>` cannot be shared between threads safely
-  --> $DIR/not-send-sync.rs:9:5
-   |
-LL |     fn assert_sync<T: Sync>(_: T) {}
-   |        -----------    ---- required by this bound in `main::assert_sync`
-...
-LL |     assert_sync(|| {
-   |     ^^^^^^^^^^^ `std::cell::Cell<i32>` cannot be shared between threads safely
-   |
-   = help: within `[generator@$DIR/not-send-sync.rs:9:17: 13:6 {std::cell::Cell<i32>, ()}]`, the trait `std::marker::Sync` is not implemented for `std::cell::Cell<i32>`
-   = note: required because it appears within the type `{std::cell::Cell<i32>, ()}`
-   = note: required because it appears within the type `[generator@$DIR/not-send-sync.rs:9:17: 13:6 {std::cell::Cell<i32>, ()}]`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
+++ b/src/test/ui/impl-trait/recursive-impl-trait-type-indirect.stderr
@@ -76,7 +76,7 @@ error[E0720]: opaque type expands to a recursive type
 LL | fn generator_capture() -> impl Sized {
    |                           ^^^^^^^^^^ expands to a recursive type
    |
-   = note: expanded type is `[generator@$DIR/recursive-impl-trait-type-indirect.rs:50:5: 50:26 x:impl Sized {()}]`
+   = note: expanded type is `[generator@$DIR/recursive-impl-trait-type-indirect.rs:50:5: 50:26 x:impl Sized [witness@DefId(0:27 ~ recursive_impl_trait_type_indirect[317d]::generator_capture[0]::{{closure}}[0]){()}]]`
 
 error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type-indirect.rs:53:26
@@ -92,7 +92,7 @@ error[E0720]: opaque type expands to a recursive type
 LL | fn generator_hold() -> impl Sized {
    |                        ^^^^^^^^^^ expands to a recursive type
    |
-   = note: expanded type is `[generator@$DIR/recursive-impl-trait-type-indirect.rs:58:5: 62:6 {impl Sized, ()}]`
+   = note: expanded type is `[generator@$DIR/recursive-impl-trait-type-indirect.rs:58:5: 62:6 [witness@DefId(0:33 ~ recursive_impl_trait_type_indirect[317d]::generator_hold[0]::{{closure}}[0]){impl Sized, ()}]]`
 
 error[E0720]: opaque type expands to a recursive type
   --> $DIR/recursive-impl-trait-type-indirect.rs:69:26


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/57017

When we construct a generator type, we build a `ty::GeneratorWitness`
from a list of types that may live across a suspend point. This types is
used to determine the 'constitutent types' for a generator when
selecting an auto-trait predicate. Any types appearing in the
GeneratorWitness are required to implement the auto trait (e.g. `Send`
or `Sync`).

This analysis
is based on the HIR - as a result, it is unable to take liveness of
variables into account. This often results in unecessary bounds being
computing (e.g requiring that a `Rc` be `Sync` even if it is dropped
before a suspend point), making generators and `async fn`s much less
ergonomic to write.

This commit uses the generator MIR to determine the actual 'constituent
types' of a generator. Specifically, a type in the generator witness is
considered to be a 'constituent type' of the witness if it appears in
the `field_tys` of the computed `GeneratorLayout`. Any type which is
stored across an suspend point must be a constituent type (since it could
be used again after a suspend), while any type that is not stored across
a suspend point cannot possible be a consituent type (since it is
impossible for it to be used again).

By re-using the existing generator layout computation logic, we get some
nice properties for free:
* Types which are dead before the suspend point are not considered
constituent types
* Types without Drop impls not considered consitutent types if their
scope extends across an await point (assuming that they are never used
after an await point).

Note that this only affects `ty::GeneratorWitness`, *not*
`ty::Generator` itself. Upvars (captured types from the parent scope)
are considered to be constituent types of the base `ty::Generator`, not
the inner `ty::GeneratorWitness`. This means that upvars are always
considered constituent types - this is because by defintion, they always
live across the first implicit suspend point.

-------

Implementation:

The most significant part of this PR is the introduction of a new
'delayed generator witness mode' to `TraitEngine`. As @nikomatsakis
pointed out, attmepting to compute generator MIR during type-checking
results in the following cycle:

1. We attempt to type-check a generator's parent function
2. During type checking of the parent function, we record a
   predicate of the form `<generator>: AutoTrait`
3. We add this predicate to a `TraitEngine`, and attempt to fulfill it.
4. When we atempt to select the predicate, we attempt to compute the MIR
   for `<generator>`
5. The MIR query attempts to compute `type_of(generator_def_id)`, which
   results in us attempting to type-check the generator's parent function.

To break this cycle, we defer processing of all auto-trait predicates
involving `ty::GeneratorWitness`. These predicates are recorded in the
`TypeckTables` for the parent function. During MIR type-checking of the
parent function, we actually attempt to fulfill these predicates,
reporting any errors that occur.

The rest of the PR is mostly fallout from this change:

* `ty::GeneratorWitness` now stores the `DefId` of its generator. This
allows us to retrieve the MIR for the generator when `SelectionContext`
processes a predicate involving a `ty::GeneratorWitness`
* Since we now store `PredicateObligations` in `TypeckTables`, several
different types have now become `RustcEncodable`/`RustcDecodable`. These
are purely mechanical changes (adding new `#[derives]`), with one
exception - a new `SpecializedDecoder` impl for `List<Predicate>`.
This was essentialy identical to other `SpecializedDecoder` imps, but it
would be good to have someone check it over.
* When we delay processing of a `Predicate`, we move it from one
`InferCtxt` to another. This requires us to prevent any inference
variables from leaking out from the first `InferCtxt` - if used in
another `InferCtxt`, they will either be non-existent or refer to the
the wrong variable. Fortunately, the predicate itself has no region
variables - the `ty::GeneratorWitness` has only late-bound regions,
while auto-traits have no generic parameters whatsoever.

However, we still need to deal with the `ObligationCause` stored by the
`PredicateObligation`. An `ObligationCause` (or a nested cause) may have
any number of region variables stored inside it (e.g. from stored
types). Luckily, `ObligationCause` is only uesd for error reporting, so
we can safely erase all regions variables from it, without affecting the
actual processing of the obligation.

To accomplish this, I took the somewhat unusual approach of implementing
`TypeFoldable` for `ObligationCause`, but did *not* change the `TypeFoldable`
implementation of `Obligation` to fold its contained
`ObligationCause. Other than this one odd case, all other callers of
`TypeFoldable` have no interest in folding an `ObligationCause`. As a
result, we explicitly fold the `ObligationCause` when computing our
deferred generator witness predicates. Since `ObligationCause` is only
used for displaying error messages, the worst that can happen is that a
slightly odd error message is displayed to a user.

With this change, several tests now have fewer errors than they did
previously, due to the improved generator analysis. Unfortunately, this
does not resolve issue #64960. The MIR generator transformation stores
format temporaries in the generator, due to the fact that the `format!`
macros takes a refernece to them. As a result, they are still considered
constituent types of the `GeneratorWitness`, and are still required to
implement `Send` and `Sync.