### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -424,6 +424,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
             ref lines,
             ref multibyte_chars,
             ref non_narrow_chars,
+            ref normalized_pos,
         } = *self;
 
         (name_hash as u64).hash_stable(hcx, hasher);
@@ -452,6 +453,12 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
         for &char_pos in non_narrow_chars.iter() {
             stable_non_narrow_char(char_pos, start_pos).hash_stable(hcx, hasher);
         }
+
+        normalized_pos.len().hash_stable(hcx, hasher);
+        for &char_pos in normalized_pos.iter() {
+            stable_normalized_pos(char_pos, start_pos).hash_stable(hcx, hasher);
+        }
+
     }
 }
 
@@ -480,6 +487,18 @@ fn stable_non_narrow_char(swc: ::syntax_pos::NonNarrowChar,
 
     (pos.0 - source_file_start.0, width as u32)
 }
+
+fn stable_normalized_pos(np: ::syntax_pos::NormalizedPos,
+                         source_file_start: ::syntax_pos::BytePos)
+                         -> (u32, u32) {
+    let ::syntax_pos::NormalizedPos {
+        pos,
+        diff
+    } = np;
+
+    (pos.0 - source_file_start.0, diff)
+}
+
 
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for feature_gate::Features {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1924,10 +1924,7 @@ impl<'tcx> Place<'tcx> {
     /// If this place represents a local variable like `_X` with no
     /// projections, return `Some(_X)`.
     pub fn as_local(&self) -> Option<Local> {
-        match self {
-            Place { projection: box [], base: PlaceBase::Local(l) } => Some(*l),
-            _ => None,
-        }
+        self.as_ref().as_local()
     }
 
     pub fn as_ref(&self) -> PlaceRef<'_, 'tcx> {
@@ -1968,6 +1965,15 @@ impl<'a, 'tcx> PlaceRef<'a, 'tcx> {
                 base: PlaceBase::Local(local),
                 projection: [ProjectionElem::Deref],
             } => Some(*local),
+            _ => None,
+        }
+    }
+
+    /// If this place represents a local variable like `_X` with no
+    /// projections, return `Some(_X)`.
+    pub fn as_local(&self) -> Option<Local> {
+        match self {
+            PlaceRef { base: PlaceBase::Local(l), projection: [] } => Some(*l),
             _ => None,
         }
     }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1908,15 +1908,15 @@ impl<'tcx> Place<'tcx> {
     //
     // FIXME: can we safely swap the semantics of `fn base_local` below in here instead?
     pub fn local_or_deref_local(&self) -> Option<Local> {
-        match self {
-            Place {
-                base: PlaceBase::Local(local),
-                projection: box [],
+        match self.as_ref() {
+            PlaceRef {
+                base: &PlaceBase::Local(local),
+                projection: &[],
             } |
-            Place {
-                base: PlaceBase::Local(local),
-                projection: box [ProjectionElem::Deref],
-            } => Some(*local),
+            PlaceRef {
+                base: &PlaceBase::Local(local),
+                projection: &[ProjectionElem::Deref],
+            } => Some(local),
             _ => None,
         }
     }

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1857,51 +1857,6 @@ impl<'tcx> Place<'tcx> {
         }
     }
 
-    pub fn field(self, f: Field, ty: Ty<'tcx>, tcx: TyCtxt<'tcx>) -> Place<'tcx> {
-        self.elem(ProjectionElem::Field(f, ty), tcx)
-    }
-
-    pub fn deref(self, tcx: TyCtxt<'tcx>) -> Place<'tcx> {
-        self.elem(ProjectionElem::Deref, tcx)
-    }
-
-    pub fn downcast(
-        self,
-        adt_def: &'tcx AdtDef,
-        variant_index: VariantIdx,
-        tcx: TyCtxt<'tcx>,
-    ) -> Place<'tcx> {
-        self.elem(
-            ProjectionElem::Downcast(
-                Some(adt_def.variants[variant_index].ident.name),
-                variant_index,
-            ),
-            tcx,
-        )
-    }
-
-    pub fn downcast_unnamed(self, variant_index: VariantIdx, tcx: TyCtxt<'tcx>) -> Place<'tcx> {
-        self.elem(ProjectionElem::Downcast(None, variant_index), tcx)
-    }
-
-    pub fn index(self, index: Local, tcx: TyCtxt<'tcx>) -> Place<'tcx> {
-        self.elem(ProjectionElem::Index(index), tcx)
-    }
-
-    /// This method copies `Place`'s projection, add an element and reintern it. Should not be used
-    /// to build a full `Place` it's just a convenient way to grab a projection and modify it in
-    /// flight.
-    // FIXME: It may be a better idea to move all these methods to `PlaceBuilder`
-    pub fn elem(self, elem: PlaceElem<'tcx>, tcx: TyCtxt<'tcx>) -> Place<'tcx> {
-        let mut projection = self.projection.to_vec();
-        projection.push(elem);
-
-        Place {
-            base: self.base,
-            projection: tcx.intern_place_elems(&projection),
-        }
-    }
-
     /// Returns `true` if this `Place` contains a `Deref` projection.
     ///
     /// If `Place::is_indirect` returns false, the caller knows that the `Place` refers to the

--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -1824,6 +1824,8 @@ impl<V, T> ProjectionElem<V, T> {
 /// and the index is a local.
 pub type PlaceElem<'tcx> = ProjectionElem<Local, Ty<'tcx>>;
 
+impl<'tcx> Copy for PlaceElem<'tcx> { }
+
 // At least on 64 bit systems, `PlaceElem` should not be larger than two pointers.
 #[cfg(target_arch = "x86_64")]
 static_assert_size!(PlaceElem<'_>, 16);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -2711,6 +2711,11 @@ impl<'tcx> TyCtxt<'tcx> {
         iter.intern_with(|xs| self.intern_substs(xs))
     }
 
+    pub fn mk_place_elems<I: InternAs<[PlaceElem<'tcx>],
+                          &'tcx List<PlaceElem<'tcx>>>>(self, iter: I) -> I::Output {
+        iter.intern_with(|xs| self.intern_place_elems(xs))
+    }
+
     pub fn mk_substs_trait(self,
                      self_ty: Ty<'tcx>,
                      rest: &[GenericArg<'tcx>])

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 //! Type context book-keeping.
 
 use crate::arena::Arena;

--- a/src/librustc_codegen_ssa/mir/analyze.rs
+++ b/src/librustc_codegen_ssa/mir/analyze.rs
@@ -191,10 +191,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
                     location: Location) {
         debug!("visit_assign(place={:?}, rvalue={:?})", place, rvalue);
 
-        if let mir::Place {
-            base: mir::PlaceBase::Local(index),
-            projection: box [],
-        } = *place {
+        if let Some(index) = place.as_local() {
             self.assign(index, location);
             let decl_span = self.fx.mir.local_decls[index].source_info.span;
             if !self.fx.rvalue_creates_operand(rvalue, decl_span) {

--- a/src/librustc_codegen_ssa/mir/block.rs
+++ b/src/librustc_codegen_ssa/mir/block.rs
@@ -2,7 +2,7 @@ use rustc_index::vec::Idx;
 use rustc::middle::lang_items;
 use rustc::ty::{self, Ty, TypeFoldable, Instance};
 use rustc::ty::layout::{self, LayoutOf, HasTyCtxt, FnTypeExt};
-use rustc::mir::{self, Place, PlaceBase, Static, StaticKind};
+use rustc::mir::{self, PlaceBase, Static, StaticKind};
 use rustc::mir::interpret::PanicInfo;
 use rustc_target::abi::call::{ArgType, FnType, PassMode};
 use rustc_target::spec::abi::Abi;
@@ -630,53 +630,43 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 // checked by const-qualification, which also
                 // promotes any complex rvalues to constants.
                 if i == 2 && intrinsic.unwrap().starts_with("simd_shuffle") {
-                    match *arg {
+                    match arg {
                         // The shuffle array argument is usually not an explicit constant,
                         // but specified directly in the code. This means it gets promoted
                         // and we can then extract the value by evaluating the promoted.
-                        mir::Operand::Copy(
-                            Place {
-                                base: PlaceBase::Static(box Static {
-                                    kind: StaticKind::Promoted(promoted, _),
+                        mir::Operand::Copy(place) | mir::Operand::Move(place) => {
+                            if let mir::PlaceRef {
+                                base:
+                                    &PlaceBase::Static(box Static {
+                                        kind: StaticKind::Promoted(promoted, _),
+                                        ty,
+                                        def_id: _,
+                                    }),
+                                projection: &[],
+                            } = place.as_ref()
+                            {
+                                let param_env = ty::ParamEnv::reveal_all();
+                                let cid = mir::interpret::GlobalId {
+                                    instance: self.instance,
+                                    promoted: Some(promoted),
+                                };
+                                let c = bx.tcx().const_eval(param_env.and(cid));
+                                let (llval, ty) = self.simd_shuffle_indices(
+                                    &bx,
+                                    terminator.source_info.span,
                                     ty,
-                                    def_id: _,
-                                }),
-                                projection: box [],
+                                    c,
+                                );
+                                return OperandRef {
+                                    val: Immediate(llval),
+                                    layout: bx.layout_of(ty),
+                                };
+                            } else {
+                                span_bug!(span, "shuffle indices must be constant");
                             }
-                        ) |
-                        mir::Operand::Move(
-                            Place {
-                                base: PlaceBase::Static(box Static {
-                                    kind: StaticKind::Promoted(promoted, _),
-                                    ty,
-                                    def_id: _,
-                                }),
-                                projection: box [],
-                            }
-                        ) => {
-                            let param_env = ty::ParamEnv::reveal_all();
-                            let cid = mir::interpret::GlobalId {
-                                instance: self.instance,
-                                promoted: Some(promoted),
-                            };
-                            let c = bx.tcx().const_eval(param_env.and(cid));
-                            let (llval, ty) = self.simd_shuffle_indices(
-                                &bx,
-                                terminator.source_info.span,
-                                ty,
-                                c,
-                            );
-                            return OperandRef {
-                                val: Immediate(llval),
-                                layout: bx.layout_of(ty),
-                            };
+                        }
 
-                        }
-                        mir::Operand::Copy(_) |
-                        mir::Operand::Move(_) => {
-                            span_bug!(span, "shuffle indices must be constant");
-                        }
-                        mir::Operand::Constant(ref constant) => {
+                        mir::Operand::Constant(constant) => {
                             let c = self.eval_mir_constant(constant);
                             let (llval, ty) = self.simd_shuffle_indices(
                                 &bx,
@@ -1117,10 +1107,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         if fn_ret.is_ignore() {
             return ReturnDest::Nothing;
         }
-        let dest = if let mir::Place {
-            base: mir::PlaceBase::Local(index),
-            projection: box [],
-        } = *dest {
+        let dest = if let Some(index) = dest.as_local() {
             match self.locals[index] {
                 LocalRef::Place(dest) => dest,
                 LocalRef::UnsizedPlace(_) => bug!("return type must be sized"),
@@ -1178,10 +1165,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         src: &mir::Operand<'tcx>,
         dst: &mir::Place<'tcx>
     ) {
-        if let mir::Place {
-            base: mir::PlaceBase::Local(index),
-            projection: box [],
-        } = *dst {
+        if let Some(index) = dst.as_local() {
             match self.locals[index] {
                 LocalRef::Place(place) => self.codegen_transmute_into(bx, src, place),
                 LocalRef::UnsizedPlace(_) => bug!("transmute must not involve unsized locals"),

--- a/src/librustc_codegen_ssa/mir/rvalue.rs
+++ b/src/librustc_codegen_ssa/mir/rvalue.rs
@@ -530,10 +530,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     ) -> Bx::Value {
         // ZST are passed as operands and require special handling
         // because codegen_place() panics if Local is operand.
-        if let mir::Place {
-            base: mir::PlaceBase::Local(index),
-            projection: box [],
-        } = *place {
+        if let Some(index) = place.as_local() {
             if let LocalRef::Operand(Some(op)) = self.locals[index] {
                 if let ty::Array(_, n) = op.layout.ty.kind {
                     let n = n.eval_usize(bx.cx().tcx(), ty::ParamEnv::reveal_all());

--- a/src/librustc_codegen_ssa/mir/statement.rs
+++ b/src/librustc_codegen_ssa/mir/statement.rs
@@ -17,11 +17,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         self.set_debug_loc(&mut bx, statement.source_info);
         match statement.kind {
             mir::StatementKind::Assign(box(ref place, ref rvalue)) => {
-                if let mir::Place {
-                    base: mir::PlaceBase::Local(index),
-                    projection: box [],
-                } = place {
-                    match self.locals[*index] {
+                if let Some(index) = place.as_local() {
+                    match self.locals[index] {
                         LocalRef::Place(cg_dest) => {
                             self.codegen_rvalue(bx, cg_dest, rvalue)
                         }
@@ -30,7 +27,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         }
                         LocalRef::Operand(None) => {
                             let (mut bx, operand) = self.codegen_rvalue_operand(bx, rvalue);
-                            if let Some(name) = self.mir.local_decls[*index].name {
+                            if let Some(name) = self.mir.local_decls[index].name {
                                 match operand.val {
                                     OperandValue::Ref(x, ..) |
                                     OperandValue::Immediate(x) => {
@@ -44,7 +41,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                     }
                                 }
                             }
-                            self.locals[*index] = LocalRef::Operand(Some(operand));
+                            self.locals[index] = LocalRef::Operand(Some(operand));
                             bx
                         }
                         LocalRef::Operand(Some(op)) => {

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1317,6 +1317,7 @@ impl<'a, 'tcx> CrateMetadata {
                                       mut lines,
                                       mut multibyte_chars,
                                       mut non_narrow_chars,
+                                      mut normalized_pos,
                                       name_hash,
                                       .. } = source_file_to_import;
 
@@ -1336,6 +1337,9 @@ impl<'a, 'tcx> CrateMetadata {
             for swc in &mut non_narrow_chars {
                 *swc = *swc - start_pos;
             }
+            for np in &mut normalized_pos {
+                np.pos = np.pos - start_pos;
+            }
 
             let local_version = local_source_map.new_imported_source_file(name,
                                                                    name_was_remapped,
@@ -1345,7 +1349,8 @@ impl<'a, 'tcx> CrateMetadata {
                                                                    source_length,
                                                                    lines,
                                                                    multibyte_chars,
-                                                                   non_narrow_chars);
+                                                                   non_narrow_chars,
+                                                                   normalized_pos);
             debug!("CrateMetaData::imported_source_files alloc \
                     source_file {:?} original (start_pos {:?} end_pos {:?}) \
                     translated (start_pos {:?} end_pos {:?})",

--- a/src/librustc_mir/borrow_check/borrow_set.rs
+++ b/src/librustc_mir/borrow_check/borrow_set.rs
@@ -315,10 +315,7 @@ impl<'a, 'tcx> GatherBorrows<'a, 'tcx> {
         //    TEMP = &foo
         //
         // so extract `temp`.
-        let temp = if let &mir::Place {
-            base: mir::PlaceBase::Local(temp),
-            projection: box [],
-        } = assigned_place {
+        let temp = if let Some(temp) = assigned_place.as_local() {
             temp
         } else {
             span_bug!(

--- a/src/librustc_mir/borrow_check/conflict_errors.rs
+++ b/src/librustc_mir/borrow_check/conflict_errors.rs
@@ -707,10 +707,12 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             _ => drop_span,
         };
 
+        let root_place_projection = self.infcx.tcx.intern_place_elems(root_place.projection);
+
         if self.access_place_error_reported
             .contains(&(Place {
                 base: root_place.base.clone(),
-                projection: root_place.projection.to_vec().into_boxed_slice(),
+                projection: root_place_projection,
             }, borrow_span))
         {
             debug!(
@@ -723,7 +725,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         self.access_place_error_reported
             .insert((Place {
                 base: root_place.base.clone(),
-                projection: root_place.projection.to_vec().into_boxed_slice(),
+                projection: root_place_projection,
             }, borrow_span));
 
         if let StorageDeadOrDrop::Destructor(dropped_ty) =

--- a/src/librustc_mir/borrow_check/error_reporting.rs
+++ b/src/librustc_mir/borrow_check/error_reporting.rs
@@ -838,12 +838,15 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             .get(location.statement_index)
         {
             Some(&Statement {
-                kind: StatementKind::Assign(box(Place {
-                    base: PlaceBase::Local(local),
-                    projection: box [],
-                }, _)),
+                kind: StatementKind::Assign(box(ref place, _)),
                 ..
-            }) => local,
+            }) => {
+                if let Some(local) = place.as_local() {
+                    local
+                } else {
+                    return OtherUse(use_span);
+                }
+            }
             _ => return OtherUse(use_span),
         };
 

--- a/src/librustc_mir/borrow_check/mutability_errors.rs
+++ b/src/librustc_mir/borrow_check/mutability_errors.rs
@@ -49,10 +49,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 projection: [],
             } => {
                 item_msg = format!("`{}`", access_place_desc.unwrap());
-                if let Place {
-                    base: PlaceBase::Local(_),
-                    projection: box [],
-                } = access_place {
+                if access_place.as_local().is_some() {
                     reason = ", as it is not declared as mutable".to_string();
                 } else {
                     let name = self.body.local_decls[*local]
@@ -153,10 +150,10 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     }),
                 projection: [],
             } => {
-                if let Place {
-                    base: PlaceBase::Static(_),
-                    projection: box [],
-                } = access_place {
+                if let PlaceRef {
+                    base: &PlaceBase::Static(_),
+                    projection: &[],
+                } = access_place.as_ref() {
                     item_msg = format!("immutable static item `{}`", access_place_desc.unwrap());
                     reason = String::new();
                 } else {

--- a/src/librustc_mir/borrow_check/nll/renumber.rs
+++ b/src/librustc_mir/borrow_check/nll/renumber.rs
@@ -1,5 +1,5 @@
 use rustc::ty::subst::SubstsRef;
-use rustc::ty::{self, Ty, TypeFoldable};
+use rustc::ty::{self, Ty, TyCtxt, TypeFoldable};
 use rustc::mir::{Body, Location, PlaceElem, Promoted};
 use rustc::mir::visit::{MutVisitor, TyContext};
 use rustc::infer::{InferCtxt, NLLRegionVariableOrigin};
@@ -54,6 +54,10 @@ impl<'a, 'tcx> NLLVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for NLLVisitor<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.infcx.tcx
+    }
+
     fn visit_ty(&mut self, ty: &mut Ty<'tcx>, ty_context: TyContext) {
         debug!("visit_ty(ty={:?}, ty_context={:?})", ty, ty_context);
 

--- a/src/librustc_mir/borrow_check/places_conflict.rs
+++ b/src/librustc_mir/borrow_check/places_conflict.rs
@@ -64,14 +64,8 @@ pub(super) fn borrow_conflicts_with_place<'tcx>(
 
     // This Local/Local case is handled by the more general code below, but
     // it's so common that it's a speed win to check for it first.
-    if let Place {
-        base: PlaceBase::Local(l1),
-        projection: box [],
-    } = borrow_place {
-        if let PlaceRef {
-            base: PlaceBase::Local(l2),
-            projection: [],
-        } = access_place {
+    if let Some(l1) = borrow_place.as_local() {
+        if let Some(l2) = access_place.as_local() {
             return l1 == l2;
         }
     }

--- a/src/librustc_mir/borrow_check/used_muts.rs
+++ b/src/librustc_mir/borrow_check/used_muts.rs
@@ -1,7 +1,5 @@
 use rustc::mir::visit::{PlaceContext, Visitor};
-use rustc::mir::{
-    Local, Location, Place, PlaceBase, Statement, StatementKind, TerminatorKind
-};
+use rustc::mir::{Local, Location, Place, PlaceBase, Statement, StatementKind, TerminatorKind};
 
 use rustc_data_structures::fx::FxHashSet;
 
@@ -118,10 +116,7 @@ impl<'visit, 'cx, 'tcx> Visitor<'tcx> for GatherUsedMutsVisitor<'visit, 'cx, 'tc
                     "assignment of {:?} to {:?}, adding {:?} to used mutable set",
                     path.place, local, path.place
                 );
-                if let Place {
-                    base: PlaceBase::Local(user_local),
-                    projection: box [],
-                } = path.place {
+                if let Some(user_local) = path.place.as_local() {
                     self.mbcx.used_mut.insert(user_local);
                 }
             }

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -496,14 +496,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
         let arg_place = unpack!(block = this.as_place(block, arg));
 
-        let mutability = match arg_place {
-            Place {
-                base: PlaceBase::Local(local),
-                projection: box [],
+        let mutability = match arg_place.as_ref() {
+            PlaceRef {
+                base: &PlaceBase::Local(local),
+                projection: &[],
             } => this.local_decls[local].mutability,
-            Place {
-                base: PlaceBase::Local(local),
-                projection: box [ProjectionElem::Deref],
+            PlaceRef {
+                base: &PlaceBase::Local(local),
+                projection: &[ProjectionElem::Deref],
             } => {
                 debug_assert!(
                     this.local_decls[local].is_ref_for_guard(),
@@ -511,13 +511,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 );
                 this.local_decls[local].mutability
             }
-            Place {
+            PlaceRef {
                 ref base,
-                projection: box [ref proj_base @ .., ProjectionElem::Field(upvar_index, _)],
+                projection: &[ref proj_base @ .., ProjectionElem::Field(upvar_index, _)],
             }
-            | Place {
+            | PlaceRef {
                 ref base,
-                projection: box [
+                projection: &[
                     ref proj_base @ ..,
                     ProjectionElem::Field(upvar_index, _),
                     ProjectionElem::Deref

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -139,7 +139,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // initialize the box contents:
                 unpack!(
                     block = this.into(
-                        &Place::from(result).deref(),
+                        &Place::from(result).deref(this.hir.tcx()),
                         block, value
                     )
                 );
@@ -296,8 +296,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .zip(field_types.into_iter())
                         .map(|(n, ty)| match fields_map.get(&n) {
                             Some(v) => v.clone(),
-                            None => this.consume_by_copy_or_move(base.clone().field(n, ty)),
-                        }).collect()
+                            None => this.consume_by_copy_or_move(base.clone().field(
+                                n,
+                                ty,
+                                this.hir.tcx(),
+                            )),
+                        })
+                        .collect()
                 } else {
                     field_names
                         .iter()
@@ -397,8 +402,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let val_fld = Field::new(0);
             let of_fld = Field::new(1);
 
-            let val = result_value.clone().field(val_fld, ty);
-            let of = result_value.field(of_fld, bool_ty);
+            let val = result_value.clone().field(val_fld, ty, self.hir.tcx());
+            let of = result_value.field(of_fld, bool_ty, self.hir.tcx());
 
             let err = PanicInfo::Overflow(op);
 

--- a/src/librustc_mir/build/expr/as_rvalue.rs
+++ b/src/librustc_mir/build/expr/as_rvalue.rs
@@ -139,7 +139,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 // initialize the box contents:
                 unpack!(
                     block = this.into(
-                        &Place::from(result).deref(this.hir.tcx()),
+                        &this.hir.tcx().mk_place_deref(Place::from(result)),
                         block, value
                     )
                 );
@@ -296,10 +296,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                         .zip(field_types.into_iter())
                         .map(|(n, ty)| match fields_map.get(&n) {
                             Some(v) => v.clone(),
-                            None => this.consume_by_copy_or_move(base.clone().field(
+                            None => this.consume_by_copy_or_move(this.hir.tcx().mk_place_field(
+                                base.clone(),
                                 n,
                                 ty,
-                                this.hir.tcx(),
                             )),
                         })
                         .collect()
@@ -402,8 +402,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let val_fld = Field::new(0);
             let of_fld = Field::new(1);
 
-            let val = result_value.clone().field(val_fld, ty, self.hir.tcx());
-            let of = result_value.field(of_fld, bool_ty, self.hir.tcx());
+            let tcx = self.hir.tcx();
+            let val = tcx.mk_place_field(result_value.clone(), val_fld, ty);
+            let of = tcx.mk_place_field(result_value, of_fld, bool_ty);
 
             let err = PanicInfo::Overflow(op);
 

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -235,7 +235,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     });
                     let ptr_temp = Place::from(ptr_temp);
                     let block = unpack!(this.into(&ptr_temp, block, ptr));
-                    this.into(&ptr_temp.deref(this.hir.tcx()), block, val)
+                    this.into(&this.hir.tcx().mk_place_deref(ptr_temp), block, val)
                 } else {
                     let args: Vec<_> = args
                         .into_iter()

--- a/src/librustc_mir/build/expr/into.rs
+++ b/src/librustc_mir/build/expr/into.rs
@@ -235,7 +235,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     });
                     let ptr_temp = Place::from(ptr_temp);
                     let block = unpack!(this.into(&ptr_temp, block, ptr));
-                    this.into(&ptr_temp.deref(), block, val)
+                    this.into(&ptr_temp.deref(this.hir.tcx()), block, val)
                 } else {
                     let args: Vec<_> = args
                         .into_iter()

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -1293,7 +1293,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // Insert a Shallow borrow of the prefixes of any fake borrows.
         for place in fake_borrows
         {
-            let mut cursor = &*place.projection;
+            let mut cursor = place.projection.as_ref();
             while let [proj_base @ .., elem] = cursor {
                 cursor = proj_base;
 

--- a/src/librustc_mir/build/matches/mod.rs
+++ b/src/librustc_mir/build/matches/mod.rs
@@ -948,7 +948,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
                     fake_borrows.insert(Place {
                         base: source.base.clone(),
-                        projection: proj_base.to_vec().into_boxed_slice(),
+                        projection: self.hir.tcx().intern_place_elems(proj_base),
                     });
                 }
             }
@@ -1488,7 +1488,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     BorrowKind::Shallow,
                     Place {
                         base: place.base.clone(),
-                        projection: place.projection.to_vec().into_boxed_slice(),
+                        projection: tcx.intern_place_elems(place.projection),
                     },
                 );
                 self.cfg.push_assign(

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -166,7 +166,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     }
                 });
                 if irrefutable {
-                    let place = match_pair.place.downcast(adt_def, variant_index);
+                    let place = match_pair.place.downcast(adt_def, variant_index, tcx);
                     candidate.match_pairs.extend(self.field_match_pairs(place, subpatterns));
                     Ok(())
                 } else {
@@ -191,7 +191,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             PatKind::Deref { ref subpattern } => {
-                let place = match_pair.place.deref();
+                let place = match_pair.place.deref(tcx);
                 candidate.match_pairs.push(MatchPair::new(place, subpattern));
                 Ok(())
             }

--- a/src/librustc_mir/build/matches/simplify.rs
+++ b/src/librustc_mir/build/matches/simplify.rs
@@ -166,7 +166,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     }
                 });
                 if irrefutable {
-                    let place = match_pair.place.downcast(adt_def, variant_index, tcx);
+                    let place = tcx.mk_place_downcast(match_pair.place, adt_def, variant_index);
                     candidate.match_pairs.extend(self.field_match_pairs(place, subpatterns));
                     Ok(())
                 } else {
@@ -191,7 +191,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             }
 
             PatKind::Deref { ref subpattern } => {
-                let place = match_pair.place.deref(tcx);
+                let place = tcx.mk_place_deref(match_pair.place);
                 candidate.match_pairs.push(MatchPair::new(place, subpattern));
                 Ok(())
             }

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -749,13 +749,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         // `(x as Variant).0 @ P1` and `(x as Variant).1 @ P1`.
         let elem = ProjectionElem::Downcast(
             Some(adt_def.variants[variant_index].ident.name), variant_index);
-        let downcast_place = match_pair.place.elem(elem); // `(x as Variant)`
+        let downcast_place = match_pair.place.elem(elem, self.hir.tcx()); // `(x as Variant)`
         let consequent_match_pairs =
             subpatterns.iter()
                        .map(|subpattern| {
                            // e.g., `(x as Variant).0`
                            let place = downcast_place.clone().field(subpattern.field,
-                                                                      subpattern.pattern.ty);
+                                                                    subpattern.pattern.ty,
+                                                                    self.hir.tcx());
                            // e.g., `(x as Variant).0 @ P1`
                            MatchPair::new(place, &subpattern.pattern)
                        });

--- a/src/librustc_mir/build/matches/test.rs
+++ b/src/librustc_mir/build/matches/test.rs
@@ -743,23 +743,21 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         candidate: &mut Candidate<'pat, 'tcx>,
     ) {
         let match_pair = candidate.match_pairs.remove(match_pair_index);
+        let tcx = self.hir.tcx();
 
         // So, if we have a match-pattern like `x @ Enum::Variant(P1, P2)`,
         // we want to create a set of derived match-patterns like
         // `(x as Variant).0 @ P1` and `(x as Variant).1 @ P1`.
         let elem = ProjectionElem::Downcast(
             Some(adt_def.variants[variant_index].ident.name), variant_index);
-        let downcast_place = match_pair.place.elem(elem, self.hir.tcx()); // `(x as Variant)`
-        let consequent_match_pairs =
-            subpatterns.iter()
-                       .map(|subpattern| {
-                           // e.g., `(x as Variant).0`
-                           let place = downcast_place.clone().field(subpattern.field,
-                                                                    subpattern.pattern.ty,
-                                                                    self.hir.tcx());
-                           // e.g., `(x as Variant).0 @ P1`
-                           MatchPair::new(place, &subpattern.pattern)
-                       });
+        let downcast_place = tcx.mk_place_elem(match_pair.place, elem); // `(x as Variant)`
+        let consequent_match_pairs = subpatterns.iter().map(|subpattern| {
+            // e.g., `(x as Variant).0`
+            let place =
+                tcx.mk_place_field(downcast_place.clone(), subpattern.field, subpattern.pattern.ty);
+            // e.g., `(x as Variant).0 @ P1`
+            MatchPair::new(place, &subpattern.pattern)
+        });
 
         candidate.match_pairs.extend(consequent_match_pairs);
     }

--- a/src/librustc_mir/build/matches/util.rs
+++ b/src/librustc_mir/build/matches/util.rs
@@ -13,7 +13,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         subpatterns.iter()
                    .map(|fieldpat| {
                        let place = place.clone().field(fieldpat.field,
-                                                       fieldpat.pattern.ty);
+                                                       fieldpat.pattern.ty,
+                                                       self.hir.tcx());
                        MatchPair::new(place, &fieldpat.pattern)
                    })
                    .collect()
@@ -37,7 +38,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                           min_length,
                           from_end: false,
                       };
-                      let place = place.clone().elem(elem);
+                      let place = place.clone().elem(elem, self.hir.tcx());
                       MatchPair::new(place, subpattern)
                   })
         );
@@ -46,7 +47,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             let subslice = place.clone().elem(ProjectionElem::Subslice {
                 from: prefix.len() as u32,
                 to: suffix.len() as u32
-            });
+            }, self.hir.tcx());
             match_pairs.push(MatchPair::new(subslice, subslice_pat));
         }
 
@@ -60,7 +61,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                           min_length,
                           from_end: true,
                       };
-                      let place = place.clone().elem(elem);
+                      let place = place.clone().elem(elem, self.hir.tcx());
                       MatchPair::new(place, subpattern)
                   })
         );

--- a/src/librustc_mir/dataflow/impls/storage_liveness.rs
+++ b/src/librustc_mir/dataflow/impls/storage_liveness.rs
@@ -157,10 +157,12 @@ impl<'mir, 'tcx> BitDenotation<'tcx> for RequiresStorage<'mir, 'tcx> {
         // Since `propagate_call_unwind` doesn't exist, we have to kill the
         // destination here, and then gen it again in `propagate_call_return`.
         if let TerminatorKind::Call {
-            destination: Some((Place { base: PlaceBase::Local(local), projection: box [] }, _)),
+            destination: Some((ref place, _)),
             ..
         } = self.body[loc.block].terminator().kind {
-            sets.kill(local);
+            if let Some(local) = place.as_local() {
+                sets.kill(local);
+            }
         }
         self.check_for_move(sets, loc);
     }

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -114,7 +114,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                         BorrowedContent {
                             target_place: Place {
                                 base: place.base.clone(),
-                                projection: proj.to_vec().into_boxed_slice(),
+                                projection: tcx.intern_place_elems(proj),
                             },
                         },
                     ));
@@ -172,7 +172,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                             Some(base),
                             Place {
                                 base: place.base.clone(),
-                                projection: proj.to_vec().into_boxed_slice(),
+                                projection: tcx.intern_place_elems(proj),
                             },
                         );
                         ent.insert(path);
@@ -274,7 +274,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     // Box starts out uninitialized - need to create a separate
                     // move-path for the interior so it will be separate from
                     // the exterior.
-                    self.create_move_path(&place.clone().deref());
+                    self.create_move_path(&place.clone().deref(self.builder.tcx));
                     self.gather_init(place.as_ref(), InitKind::Shallow);
                 } else {
                     self.gather_init(place.as_ref(), InitKind::Deep);

--- a/src/librustc_mir/dataflow/move_paths/builder.rs
+++ b/src/librustc_mir/dataflow/move_paths/builder.rs
@@ -274,7 +274,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
                     // Box starts out uninitialized - need to create a separate
                     // move-path for the interior so it will be separate from
                     // the exterior.
-                    self.create_move_path(&place.clone().deref(self.builder.tcx));
+                    self.create_move_path(&self.builder.tcx.mk_place_deref(place.clone()));
                     self.gather_init(place.as_ref(), InitKind::Shallow);
                 } else {
                     self.gather_init(place.as_ref(), InitKind::Deep);

--- a/src/librustc_mir/dataflow/move_paths/mod.rs
+++ b/src/librustc_mir/dataflow/move_paths/mod.rs
@@ -327,7 +327,7 @@ impl<'tcx> MoveData<'tcx> {
     pub fn base_local(&self, mut mpi: MovePathIndex) -> Option<Local> {
         loop {
             let path = &self.move_paths[mpi];
-            if let Place { base: PlaceBase::Local(l), projection: box [] } = path.place {
+            if let Some(l) = path.place.as_local() {
                 return Some(l);
             }
             if let Some(parent) = path.parent {

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -231,7 +231,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
                 tcx,
                 param_env
             };
-            let dropee = dropee_ptr.deref(tcx);
+            let dropee = tcx.mk_place_deref(dropee_ptr);
             let resume_block = elaborator.patch.resume_block();
             elaborate_drops::elaborate_drop(
                 &mut elaborator,
@@ -312,7 +312,7 @@ fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -
     let is_copy = self_ty.is_copy_modulo_regions(tcx, param_env, builder.span);
 
     let dest = Place::return_place();
-    let src = Place::from(Local::new(1+0)).deref(tcx);
+    let src = tcx.mk_place_deref(Place::from(Local::new(1+0)));
 
     match self_ty.kind {
         _ if is_copy => builder.copy_shim(),
@@ -415,7 +415,7 @@ impl CloneShimBuilder<'tcx> {
     }
 
     fn copy_shim(&mut self) {
-        let rcvr = Place::from(Local::new(1+0)).deref(self.tcx);
+        let rcvr = self.tcx.mk_place_deref(Place::from(Local::new(1+0)));
         let ret_statement = self.make_statement(
             StatementKind::Assign(
                 box(
@@ -561,8 +561,8 @@ impl CloneShimBuilder<'tcx> {
         // BB #2
         // `dest[i] = Clone::clone(src[beg])`;
         // Goto #3 if ok, #5 if unwinding happens.
-        let dest_field = dest.clone().index(beg, self.tcx);
-        let src_field = src.index(beg, self.tcx);
+        let dest_field = self.tcx.mk_place_index(dest.clone(), beg);
+        let src_field = self.tcx.mk_place_index(src, beg);
         self.make_clone_call(dest_field, src_field, ty, BasicBlock::new(3),
                              BasicBlock::new(5));
 
@@ -616,7 +616,7 @@ impl CloneShimBuilder<'tcx> {
         // BB #7 (cleanup)
         // `drop(dest[beg])`;
         self.block(vec![], TerminatorKind::Drop {
-            location: dest.index(beg, self.tcx),
+            location: self.tcx.mk_place_index(dest, beg),
             target: BasicBlock::new(8),
             unwind: None,
         }, true);
@@ -648,9 +648,9 @@ impl CloneShimBuilder<'tcx> {
         let mut previous_field = None;
         for (i, ity) in tys.enumerate() {
             let field = Field::new(i);
-            let src_field = src.clone().field(field, ity, self.tcx);
+            let src_field = self.tcx.mk_place_field(src.clone(), field, ity);
 
-            let dest_field = dest.clone().field(field, ity, self.tcx);
+            let dest_field = self.tcx.mk_place_field(dest.clone(), field, ity);
 
             // #(2i + 1) is the cleanup block for the previous clone operation
             let cleanup_block = self.block_index_offset(1);
@@ -721,14 +721,14 @@ fn build_call_shim<'tcx>(
 
     let rcvr = match rcvr_adjustment {
         Adjustment::Identity => Operand::Move(rcvr_l),
-        Adjustment::Deref => Operand::Copy(rcvr_l.deref(tcx)),
+        Adjustment::Deref => Operand::Copy(tcx.mk_place_deref(rcvr_l)),
         Adjustment::DerefMove => {
             // fn(Self, ...) -> fn(*mut Self, ...)
             let arg_ty = local_decls[rcvr_arg].ty;
             debug_assert!(tcx.generics_of(def_id).has_self && arg_ty == tcx.types.self_param);
             local_decls[rcvr_arg].ty = tcx.mk_mut_ptr(arg_ty);
 
-            Operand::Move(rcvr_l.deref(tcx))
+            Operand::Move(tcx.mk_place_deref(rcvr_l))
         }
         Adjustment::RefMut => {
             // let rcvr = &mut rcvr;
@@ -772,7 +772,7 @@ fn build_call_shim<'tcx>(
     if let Some(untuple_args) = untuple_args {
         args.extend(untuple_args.iter().enumerate().map(|(i, ity)| {
             let arg_place = Place::from(Local::new(1+1));
-            Operand::Move(arg_place.field(Field::new(i), *ity, tcx))
+            Operand::Move(tcx.mk_place_field(arg_place, Field::new(i), *ity))
         }));
     } else {
         args.extend((1..sig.inputs().len()).map(|i| {

--- a/src/librustc_mir/shim.rs
+++ b/src/librustc_mir/shim.rs
@@ -117,7 +117,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceDef<'tcx>) -> &'tcx 
 
     run_passes(tcx, &mut result, instance, None, MirPhase::Const, &[
         &add_moves_for_packed_drops::AddMovesForPackedDrops,
-        &no_landing_pads::NoLandingPads,
+        &no_landing_pads::NoLandingPads::new(tcx),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &simplify::SimplifyCfg::new("make_shim"),
         &add_call_guards::CriticalCallEdges,
@@ -231,7 +231,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
                 tcx,
                 param_env
             };
-            let dropee = dropee_ptr.deref();
+            let dropee = dropee_ptr.deref(tcx);
             let resume_block = elaborator.patch.resume_block();
             elaborate_drops::elaborate_drop(
                 &mut elaborator,
@@ -312,7 +312,7 @@ fn build_clone_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, self_ty: Ty<'tcx>) -
     let is_copy = self_ty.is_copy_modulo_regions(tcx, param_env, builder.span);
 
     let dest = Place::return_place();
-    let src = Place::from(Local::new(1+0)).deref();
+    let src = Place::from(Local::new(1+0)).deref(tcx);
 
     match self_ty.kind {
         _ if is_copy => builder.copy_shim(),
@@ -415,7 +415,7 @@ impl CloneShimBuilder<'tcx> {
     }
 
     fn copy_shim(&mut self) {
-        let rcvr = Place::from(Local::new(1+0)).deref();
+        let rcvr = Place::from(Local::new(1+0)).deref(self.tcx);
         let ret_statement = self.make_statement(
             StatementKind::Assign(
                 box(
@@ -561,8 +561,8 @@ impl CloneShimBuilder<'tcx> {
         // BB #2
         // `dest[i] = Clone::clone(src[beg])`;
         // Goto #3 if ok, #5 if unwinding happens.
-        let dest_field = dest.clone().index(beg);
-        let src_field = src.index(beg);
+        let dest_field = dest.clone().index(beg, self.tcx);
+        let src_field = src.index(beg, self.tcx);
         self.make_clone_call(dest_field, src_field, ty, BasicBlock::new(3),
                              BasicBlock::new(5));
 
@@ -616,7 +616,7 @@ impl CloneShimBuilder<'tcx> {
         // BB #7 (cleanup)
         // `drop(dest[beg])`;
         self.block(vec![], TerminatorKind::Drop {
-            location: dest.index(beg),
+            location: dest.index(beg, self.tcx),
             target: BasicBlock::new(8),
             unwind: None,
         }, true);
@@ -648,9 +648,9 @@ impl CloneShimBuilder<'tcx> {
         let mut previous_field = None;
         for (i, ity) in tys.enumerate() {
             let field = Field::new(i);
-            let src_field = src.clone().field(field, ity);
+            let src_field = src.clone().field(field, ity, self.tcx);
 
-            let dest_field = dest.clone().field(field, ity);
+            let dest_field = dest.clone().field(field, ity, self.tcx);
 
             // #(2i + 1) is the cleanup block for the previous clone operation
             let cleanup_block = self.block_index_offset(1);
@@ -721,14 +721,14 @@ fn build_call_shim<'tcx>(
 
     let rcvr = match rcvr_adjustment {
         Adjustment::Identity => Operand::Move(rcvr_l),
-        Adjustment::Deref => Operand::Copy(rcvr_l.deref()),
+        Adjustment::Deref => Operand::Copy(rcvr_l.deref(tcx)),
         Adjustment::DerefMove => {
             // fn(Self, ...) -> fn(*mut Self, ...)
             let arg_ty = local_decls[rcvr_arg].ty;
             debug_assert!(tcx.generics_of(def_id).has_self && arg_ty == tcx.types.self_param);
             local_decls[rcvr_arg].ty = tcx.mk_mut_ptr(arg_ty);
 
-            Operand::Move(rcvr_l.deref())
+            Operand::Move(rcvr_l.deref(tcx))
         }
         Adjustment::RefMut => {
             // let rcvr = &mut rcvr;
@@ -772,7 +772,7 @@ fn build_call_shim<'tcx>(
     if let Some(untuple_args) = untuple_args {
         args.extend(untuple_args.iter().enumerate().map(|(i, ity)| {
             let arg_place = Place::from(Local::new(1+1));
-            Operand::Move(arg_place.field(Field::new(i), *ity))
+            Operand::Move(arg_place.field(Field::new(i), *ity, tcx))
         }));
     } else {
         args.extend((1..sig.inputs().len()).map(|i| {
@@ -901,6 +901,7 @@ pub fn build_adt_ctor(tcx: TyCtxt<'_>, ctor_id: DefId) -> &Body<'_> {
             )),
         AggregateKind::Adt(adt_def, variant_index, substs, None, None),
         source_info,
+        tcx,
     ).collect();
 
     let start_block = BasicBlockData {

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -164,8 +164,8 @@ pub trait Qualif {
 
             Rvalue::Ref(_, _, ref place) => {
                 // Special-case reborrows to be more like a copy of the reference.
-                if let box [proj_base @ .., elem] = &place.projection {
-                    if ProjectionElem::Deref == *elem {
+                if let &[ref proj_base @ .., elem] = place.projection.as_ref() {
+                    if ProjectionElem::Deref == elem {
                         let base_ty = Place::ty_from(&place.base, proj_base, cx.body, cx.tcx).ty;
                         if let ty::Ref(..) = base_ty.kind {
                             return Self::in_place(cx, per_local, PlaceRef {

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -407,8 +407,8 @@ impl<'a, 'tcx> UnsafetyChecker<'a, 'tcx> {
         place: &Place<'tcx>,
         is_mut_use: bool,
     ) {
-        let mut cursor = &*place.projection;
-        while let [proj_base @ .., elem] = cursor {
+        let mut cursor = place.projection.as_ref();
+        while let &[ref proj_base @ .., elem] = cursor {
             cursor = proj_base;
 
             match elem {

--- a/src/librustc_mir/transform/cleanup_post_borrowck.rs
+++ b/src/librustc_mir/transform/cleanup_post_borrowck.rs
@@ -24,16 +24,22 @@ use crate::transform::{MirPass, MirSource};
 
 pub struct CleanupNonCodegenStatements;
 
-pub struct DeleteNonCodegenStatements;
+pub struct DeleteNonCodegenStatements<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
 
 impl<'tcx> MirPass<'tcx> for CleanupNonCodegenStatements {
-    fn run_pass(&self, _tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut Body<'tcx>) {
-        let mut delete = DeleteNonCodegenStatements;
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, _source: MirSource<'tcx>, body: &mut Body<'tcx>) {
+        let mut delete = DeleteNonCodegenStatements { tcx };
         delete.visit_body(body);
     }
 }
 
-impl<'tcx> MutVisitor<'tcx> for DeleteNonCodegenStatements {
+impl<'tcx> MutVisitor<'tcx> for DeleteNonCodegenStatements<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_statement(&mut self,
                        statement: &mut Statement<'tcx>,
                        location: Location) {

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -687,6 +687,10 @@ impl<'tcx> Visitor<'tcx> for CanConstProp {
 }
 
 impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_constant(
         &mut self,
         constant: &mut Constant<'tcx>,

--- a/src/librustc_mir/transform/const_prop.rs
+++ b/src/librustc_mir/transform/const_prop.rs
@@ -7,10 +7,9 @@ use std::cell::Cell;
 use rustc::hir::def::DefKind;
 use rustc::hir::def_id::DefId;
 use rustc::mir::{
-    AggregateKind, Constant, Location, Place, PlaceBase, Body, Operand, Rvalue,
-    Local, UnOp, StatementKind, Statement, LocalKind,
-    TerminatorKind, Terminator,  ClearCrossCrate, SourceInfo, BinOp,
-    SourceScope, SourceScopeLocalData, LocalDecl, BasicBlock,
+    AggregateKind, Constant, Location, Place, PlaceBase, Body, Operand, Rvalue, Local, UnOp,
+    StatementKind, Statement, LocalKind, TerminatorKind, Terminator,  ClearCrossCrate, SourceInfo,
+    BinOp, SourceScope, SourceScopeLocalData, LocalDecl, BasicBlock,
 };
 use rustc::mir::visit::{
     Visitor, PlaceContext, MutatingUseContext, MutVisitor, NonMutatingUseContext,
@@ -525,18 +524,21 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             // (e.g. for CTFE) it can never happen. But here in const_prop
             // unknown data is uninitialized, so if e.g. a function argument is unsized
             // and has a reference taken, we get an ICE.
-            Rvalue::Ref(_, _, Place { base: PlaceBase::Local(local), projection: box [] }) => {
-                trace!("checking Ref({:?})", place);
-                let alive =
-                    if let LocalValue::Live(_) = self.ecx.frame().locals[*local].value {
-                        true
-                    } else {
-                        false
-                    };
+            Rvalue::Ref(_, _, place_ref) => {
+                trace!("checking Ref({:?})", place_ref);
 
-                if !alive {
-                    trace!("skipping Ref({:?}) to uninitialized local", place);
-                    return None;
+                if let Some(local) = place_ref.as_local() {
+                    let alive =
+                        if let LocalValue::Live(_) = self.ecx.frame().locals[local].value {
+                            true
+                        } else {
+                            false
+                        };
+
+                    if !alive {
+                        trace!("skipping Ref({:?}) to uninitialized local", place);
+                        return None;
+                    }
                 }
             }
 
@@ -706,10 +708,7 @@ impl<'mir, 'tcx> MutVisitor<'tcx> for ConstPropagator<'mir, 'tcx> {
                 .ty(&self.local_decls, self.tcx)
                 .ty;
             if let Ok(place_layout) = self.tcx.layout_of(self.param_env.and(place_ty)) {
-                if let Place {
-                    base: PlaceBase::Local(local),
-                    projection: box [],
-                } = *place {
+                if let Some(local) = place.as_local() {
                     let source = statement.source_info;
                     if let Some(()) = self.const_prop(rval, place_layout, source, place) {
                         if self.can_const_prop[local] {

--- a/src/librustc_mir/transform/deaggregator.rs
+++ b/src/librustc_mir/transform/deaggregator.rs
@@ -45,6 +45,7 @@ impl<'tcx> MirPass<'tcx> for Deaggregator {
                     }),
                     *kind,
                     source_info,
+                    tcx,
                 ))
             });
         }

--- a/src/librustc_mir/transform/erase_regions.rs
+++ b/src/librustc_mir/transform/erase_regions.rs
@@ -23,6 +23,10 @@ impl EraseRegionsVisitor<'tcx> {
 }
 
 impl MutVisitor<'tcx> for EraseRegionsVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_ty(&mut self, ty: &mut Ty<'tcx>, _: TyContext) {
         *ty = self.tcx.erase_regions(ty);
     }

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -74,12 +74,17 @@ use crate::util::liveness;
 
 pub struct StateTransform;
 
-struct RenameLocalVisitor {
+struct RenameLocalVisitor<'tcx> {
     from: Local,
     to: Local,
+    tcx: TyCtxt<'tcx>,
 }
 
-impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor {
+impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(&mut self,
                    local: &mut Local,
                    _: PlaceContext,
@@ -102,9 +107,15 @@ impl<'tcx> MutVisitor<'tcx> for RenameLocalVisitor {
     }
 }
 
-struct DerefArgVisitor;
+struct DerefArgVisitor<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
 
-impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor {
+impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(&mut self,
                    local: &mut Local,
                    _: PlaceContext,
@@ -119,8 +130,8 @@ impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor {
         if place.base == PlaceBase::Local(self_arg()) {
             replace_base(place, Place {
                 base: PlaceBase::Local(self_arg()),
-                projection: Box::new([ProjectionElem::Deref]),
-            });
+                projection: self.tcx().intern_place_elems(&vec![ProjectionElem::Deref]),
+            }, self.tcx);
         } else {
             self.visit_place_base(&mut place.base, context, location);
 
@@ -135,9 +146,14 @@ impl<'tcx> MutVisitor<'tcx> for DerefArgVisitor {
 
 struct PinArgVisitor<'tcx> {
     ref_gen_ty: Ty<'tcx>,
+    tcx: TyCtxt<'tcx>,
 }
 
 impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(&mut self,
                    local: &mut Local,
                    _: PlaceContext,
@@ -145,15 +161,19 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
         assert_ne!(*local, self_arg());
     }
 
-    fn visit_place(&mut self,
-                    place: &mut Place<'tcx>,
-                    context: PlaceContext,
-                    location: Location) {
+    fn visit_place(&mut self, place: &mut Place<'tcx>, context: PlaceContext, location: Location) {
         if place.base == PlaceBase::Local(self_arg()) {
-            replace_base(place, Place {
-                base: PlaceBase::Local(self_arg()),
-                projection: Box::new([ProjectionElem::Field(Field::new(0), self.ref_gen_ty)]),
-            });
+            replace_base(
+                place,
+                Place {
+                    base: PlaceBase::Local(self_arg()),
+                    projection: self.tcx().intern_place_elems(&vec![ProjectionElem::Field(
+                            Field::new(0),
+                            self.ref_gen_ty,
+                    )]),
+                },
+                self.tcx,
+            );
         } else {
             self.visit_place_base(&mut place.base, context, location);
 
@@ -166,13 +186,13 @@ impl<'tcx> MutVisitor<'tcx> for PinArgVisitor<'tcx> {
     }
 }
 
-fn replace_base(place: &mut Place<'tcx>, new_base: Place<'tcx>) {
+fn replace_base<'tcx>(place: &mut Place<'tcx>, new_base: Place<'tcx>, tcx: TyCtxt<'tcx>) {
     place.base = new_base.base;
 
     let mut new_projection = new_base.projection.to_vec();
     new_projection.append(&mut place.projection.to_vec());
 
-    place.projection = new_projection.into_boxed_slice();
+    place.projection = tcx.intern_place_elems(&new_projection);
 }
 
 fn self_arg() -> Local {
@@ -226,13 +246,13 @@ impl TransformVisitor<'tcx> {
     // Create a Place referencing a generator struct field
     fn make_field(&self, variant_index: VariantIdx, idx: usize, ty: Ty<'tcx>) -> Place<'tcx> {
         let self_place = Place::from(self_arg());
-        let base = self_place.downcast_unnamed(variant_index);
+        let base = self_place.downcast_unnamed(variant_index, self.tcx);
         let mut projection = base.projection.to_vec();
         projection.push(ProjectionElem::Field(Field::new(idx), ty));
 
         Place {
             base: base.base,
-            projection: projection.into_boxed_slice(),
+            projection: self.tcx.intern_place_elems(&projection),
         }
     }
 
@@ -264,6 +284,10 @@ impl TransformVisitor<'tcx> {
 }
 
 impl MutVisitor<'tcx> for TransformVisitor<'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(&mut self,
                    local: &mut Local,
                    _: PlaceContext,
@@ -280,7 +304,7 @@ impl MutVisitor<'tcx> for TransformVisitor<'tcx> {
         if let PlaceBase::Local(l) = place.base {
             // Replace an Local in the remap with a generator struct access
             if let Some(&(ty, variant_index, idx)) = self.remap.get(&l) {
-                replace_base(place, self.make_field(variant_index, idx, ty));
+                replace_base(place, self.make_field(variant_index, idx, ty), self.tcx);
             }
         } else {
             self.visit_place_base(&mut place.base, context, location);
@@ -375,7 +399,7 @@ fn make_generator_state_argument_indirect<'tcx>(
     body.local_decls.raw[1].ty = ref_gen_ty;
 
     // Add a deref to accesses of the generator state
-    DerefArgVisitor.visit_body(body);
+    DerefArgVisitor { tcx }.visit_body(body);
 }
 
 fn make_generator_state_argument_pinned<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
@@ -390,12 +414,13 @@ fn make_generator_state_argument_pinned<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body
     body.local_decls.raw[1].ty = pin_ref_gen_ty;
 
     // Add the Pin field access to accesses of the generator state
-    PinArgVisitor { ref_gen_ty }.visit_body(body);
+    PinArgVisitor { ref_gen_ty, tcx }.visit_body(body);
 }
 
 fn replace_result_variable<'tcx>(
     ret_ty: Ty<'tcx>,
     body: &mut Body<'tcx>,
+    tcx: TyCtxt<'tcx>,
 ) -> Local {
     let source_info = source_info(body);
     let new_ret = LocalDecl {
@@ -416,6 +441,7 @@ fn replace_result_variable<'tcx>(
     RenameLocalVisitor {
         from: RETURN_PLACE,
         to: new_ret_local,
+        tcx,
     }.visit_body(body);
 
     new_ret_local
@@ -1182,7 +1208,7 @@ impl<'tcx> MirPass<'tcx> for StateTransform {
 
         // We rename RETURN_PLACE which has type mir.return_ty to new_ret_local
         // RETURN_PLACE then is a fresh unused local with type ret_ty.
-        let new_ret_local = replace_result_variable(ret_ty, body);
+        let new_ret_local = replace_result_variable(ret_ty, body, tcx);
 
         // Extract locals which are live across suspension point into `layout`
         // `remap` gives a mapping from local indices onto generator struct indices

--- a/src/librustc_mir/transform/generator.rs
+++ b/src/librustc_mir/transform/generator.rs
@@ -246,7 +246,7 @@ impl TransformVisitor<'tcx> {
     // Create a Place referencing a generator struct field
     fn make_field(&self, variant_index: VariantIdx, idx: usize, ty: Ty<'tcx>) -> Place<'tcx> {
         let self_place = Place::from(self_arg());
-        let base = self_place.downcast_unnamed(variant_index, self.tcx);
+        let base = self.tcx.mk_place_downcast_unnamed(self_place, variant_index);
         let mut projection = base.projection.to_vec();
         projection.push(ProjectionElem::Field(Field::new(idx), ty));
 

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -461,7 +461,7 @@ impl Inliner<'tcx> {
                     };
                     caller_body[callsite.bb]
                         .statements.push(stmt);
-                    tmp.deref(self.tcx)
+                    self.tcx.mk_place_deref(tmp)
                 } else {
                     destination.0
                 };
@@ -560,10 +560,10 @@ impl Inliner<'tcx> {
             let tuple_tmp_args =
                 tuple_tys.iter().enumerate().map(|(i, ty)| {
                     // This is e.g., `tuple_tmp.0` in our example above.
-                    let tuple_field = Operand::Move(tuple.clone().field(
+                    let tuple_field = Operand::Move(tcx.mk_place_field(
+                        tuple.clone(),
                         Field::new(i),
                         ty.expect_ty(),
-                        tcx,
                     ));
 
                     // Spill to a local to make e.g., `tmp0`.

--- a/src/librustc_mir/transform/inline.rs
+++ b/src/librustc_mir/transform/inline.rs
@@ -461,7 +461,7 @@ impl Inliner<'tcx> {
                     };
                     caller_body[callsite.bb]
                         .statements.push(stmt);
-                    tmp.deref()
+                    tmp.deref(self.tcx)
                 } else {
                     destination.0
                 };
@@ -481,6 +481,7 @@ impl Inliner<'tcx> {
                     return_block,
                     cleanup_block: cleanup,
                     in_cleanup_block: false,
+                    tcx: self.tcx,
                 };
 
 
@@ -562,6 +563,7 @@ impl Inliner<'tcx> {
                     let tuple_field = Operand::Move(tuple.clone().field(
                         Field::new(i),
                         ty.expect_ty(),
+                        tcx,
                     ));
 
                     // Spill to a local to make e.g., `tmp0`.
@@ -638,6 +640,7 @@ struct Integrator<'a, 'tcx> {
     return_block: BasicBlock,
     cleanup_block: Option<BasicBlock>,
     in_cleanup_block: bool,
+    tcx: TyCtxt<'tcx>,
 }
 
 impl<'a, 'tcx> Integrator<'a, 'tcx> {
@@ -665,6 +668,10 @@ impl<'a, 'tcx> Integrator<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for Integrator<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(
         &mut self,
         local: &mut Local,

--- a/src/librustc_mir/transform/instcombine.rs
+++ b/src/librustc_mir/transform/instcombine.rs
@@ -1,7 +1,8 @@
 //! Performs various peephole optimizations.
 
-use rustc::mir::{Constant, Location, Place, PlaceBase, Body, Operand, ProjectionElem, Rvalue,
-    Local};
+use rustc::mir::{
+    Constant, Location, Place, PlaceBase, PlaceRef, Body, Operand, ProjectionElem, Rvalue, Local
+};
 use rustc::mir::visit::{MutVisitor, Visitor};
 use rustc::ty::{self, TyCtxt};
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
@@ -40,20 +41,18 @@ impl<'tcx> MutVisitor<'tcx> for InstCombineVisitor<'tcx> {
     fn visit_rvalue(&mut self, rvalue: &mut Rvalue<'tcx>, location: Location) {
         if self.optimizations.and_stars.remove(&location) {
             debug!("replacing `&*`: {:?}", rvalue);
-            let new_place = match *rvalue {
-                Rvalue::Ref(_, _, Place {
-                    ref mut base,
-                    projection: ref mut projection @ box [.., _],
-                }) => {
-                    if let box [proj_l @ .., proj_r] = projection {
-                        let place = Place {
-                            // Replace with dummy
-                            base: mem::replace(base, PlaceBase::Local(Local::new(0))),
-                            projection: proj_l.to_vec().into_boxed_slice(),
-                        };
-                        *projection = vec![proj_r.clone()].into_boxed_slice();
+            let new_place = match rvalue {
+                Rvalue::Ref(_, _, place) => {
+                    if let &[ref proj_l @ .., proj_r] = place.projection.as_ref() {
+                        let new_projection = proj_l.to_vec().into_boxed_slice();
 
-                        place
+                        place.projection = vec![proj_r.clone()].into_boxed_slice();
+
+                        Place {
+                            // Replace with dummy
+                            base: mem::replace(&mut place.base, PlaceBase::Local(Local::new(0))),
+                            projection: new_projection,
+                        }
                     } else {
                         unreachable!();
                     }
@@ -91,12 +90,14 @@ impl OptimizationFinder<'b, 'tcx> {
 
 impl Visitor<'tcx> for OptimizationFinder<'b, 'tcx> {
     fn visit_rvalue(&mut self, rvalue: &Rvalue<'tcx>, location: Location) {
-        if let Rvalue::Ref(_, _, Place {
-            base,
-            projection: box [proj_base @ .., ProjectionElem::Deref],
-        }) = rvalue {
-            if Place::ty_from(base, proj_base, self.body, self.tcx).ty.is_region_ptr() {
-                self.optimizations.and_stars.insert(location);
+        if let Rvalue::Ref(_, _, place) = rvalue {
+            if let PlaceRef {
+                base,
+                projection: &[ref proj_base @ .., ProjectionElem::Deref],
+            } = place.as_ref() {
+                if Place::ty_from(base, proj_base, self.body, self.tcx).ty.is_region_ptr() {
+                    self.optimizations.and_stars.insert(location);
+                }
             }
         }
 

--- a/src/librustc_mir/transform/mod.rs
+++ b/src/librustc_mir/transform/mod.rs
@@ -228,7 +228,7 @@ fn run_optimization_passes<'tcx>(
 ) {
     run_passes(tcx, body, InstanceDef::Item(def_id), promoted, MirPhase::Optimized, &[
         // Remove all things only needed by analysis
-        &no_landing_pads::NoLandingPads,
+        &no_landing_pads::NoLandingPads::new(tcx),
         &simplify_branches::SimplifyBranches::new("initial"),
         &remove_noop_landing_pads::RemoveNoopLandingPads,
         &cleanup_post_borrowck::CleanupNonCodegenStatements,
@@ -238,7 +238,7 @@ fn run_optimization_passes<'tcx>(
         // These next passes must be executed together
         &add_call_guards::CriticalCallEdges,
         &elaborate_drops::ElaborateDrops,
-        &no_landing_pads::NoLandingPads,
+        &no_landing_pads::NoLandingPads::new(tcx),
         // AddMovesForPackedDrops needs to run after drop
         // elaboration.
         &add_moves_for_packed_drops::AddMovesForPackedDrops,
@@ -257,7 +257,7 @@ fn run_optimization_passes<'tcx>(
 
 
         // Optimizations begin.
-        &uniform_array_move_out::RestoreSubsliceArrayMoveOut,
+        &uniform_array_move_out::RestoreSubsliceArrayMoveOut::new(tcx),
         &inline::Inline,
 
         // Lowering generator control-flow and variables

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -17,7 +17,7 @@ use rustc::mir::*;
 use rustc::mir::visit::{PlaceContext, MutatingUseContext, MutVisitor, Visitor};
 use rustc::mir::traversal::ReversePostorder;
 use rustc::ty::subst::InternalSubsts;
-use rustc::ty::TyCtxt;
+use rustc::ty::{List, TyCtxt};
 use syntax_pos::Span;
 
 use rustc_index::vec::{IndexVec, Idx};
@@ -321,7 +321,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                         ty,
                         def_id,
                     }),
-                    projection: box [],
+                    projection: List::empty(),
                 }
             };
             let (blocks, local_decls) = self.source.basic_blocks_and_local_decls_mut();
@@ -339,7 +339,7 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
                                     &mut place.base,
                                     promoted_place(ty, span).base,
                                 ),
-                                projection: box [],
+                                projection: List::empty(),
                             })
                         }
                         _ => bug!()
@@ -396,6 +396,10 @@ impl<'a, 'tcx> Promoter<'a, 'tcx> {
 
 /// Replaces all temporaries with their promoted counterparts.
 impl<'a, 'tcx> MutVisitor<'tcx> for Promoter<'a, 'tcx> {
+    fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
     fn visit_local(&mut self,
                    local: &mut Local,
                    _: PlaceContext,

--- a/src/librustc_mir/transform/qualify_min_const_fn.rs
+++ b/src/librustc_mir/transform/qualify_min_const_fn.rs
@@ -259,8 +259,8 @@ fn check_place(
     def_id: DefId,
     body: &Body<'tcx>
 ) -> McfResult {
-    let mut cursor = &*place.projection;
-    while let [proj_base @ .., elem] = cursor {
+    let mut cursor = place.projection.as_ref();
+    while let &[ref proj_base @ .., elem] = cursor {
         cursor = proj_base;
         match elem {
             ProjectionElem::Downcast(..) => {

--- a/src/librustc_mir/transform/remove_noop_landing_pads.rs
+++ b/src/librustc_mir/transform/remove_noop_landing_pads.rs
@@ -32,7 +32,7 @@ impl RemoveNoopLandingPads {
         nop_landing_pads: &BitSet<BasicBlock>,
     ) -> bool {
         for stmt in &body[bb].statements {
-            match stmt.kind {
+            match &stmt.kind {
                 StatementKind::FakeRead(..) |
                 StatementKind::StorageLive(_) |
                 StatementKind::StorageDead(_) |
@@ -41,12 +41,13 @@ impl RemoveNoopLandingPads {
                     // These are all nops in a landing pad
                 }
 
-                StatementKind::Assign(box(Place {
-                    base: PlaceBase::Local(_),
-                    projection: box [],
-                }, Rvalue::Use(_))) => {
-                    // Writing to a local (e.g., a drop flag) does not
-                    // turn a landing pad to a non-nop
+                StatementKind::Assign(box(place, Rvalue::Use(_))) => {
+                    if place.as_local().is_some() {
+                        // Writing to a local (e.g., a drop flag) does not
+                        // turn a landing pad to a non-nop
+                    } else {
+                        return false;
+                    }
                 }
 
                 StatementKind::Assign { .. } |

--- a/src/librustc_mir/util/aggregate.rs
+++ b/src/librustc_mir/util/aggregate.rs
@@ -30,7 +30,7 @@ pub fn expand_aggregate<'tcx>(
                     },
                     source_info,
                 });
-                lhs = lhs.downcast(adt_def, variant_index, tcx);
+                lhs = tcx.mk_place_downcast(lhs, adt_def, variant_index);
             }
             active_field_index
         }
@@ -59,15 +59,15 @@ pub fn expand_aggregate<'tcx>(
             // FIXME(eddyb) `offset` should be u64.
             let offset = i as u32;
             assert_eq!(offset as usize, i);
-            lhs.clone().elem(ProjectionElem::ConstantIndex {
+            tcx.mk_place_elem(lhs.clone(), ProjectionElem::ConstantIndex {
                 offset,
                 // FIXME(eddyb) `min_length` doesn't appear to be used.
                 min_length: offset + 1,
                 from_end: false
-            }, tcx)
+            })
         } else {
             let field = Field::new(active_field_index.unwrap_or(i));
-            lhs.clone().field(field, ty, tcx)
+            tcx.mk_place_field(lhs.clone(), field, ty)
         };
         Statement {
             source_info,

--- a/src/librustc_mir/util/alignment.rs
+++ b/src/librustc_mir/util/alignment.rs
@@ -38,8 +38,8 @@ fn is_within_packed<'tcx, L>(tcx: TyCtxt<'tcx>, local_decls: &L, place: &Place<'
 where
     L: HasLocalDecls<'tcx>,
 {
-    let mut cursor = &*place.projection;
-    while let [proj_base @ .., elem] = cursor {
+    let mut cursor = place.projection.as_ref();
+    while let &[ref proj_base @ .., elem] = cursor {
         cursor = proj_base;
 
         match elem {

--- a/src/librustc_mir/util/elaborate_drops.rs
+++ b/src/librustc_mir/util/elaborate_drops.rs
@@ -200,13 +200,14 @@ where
         variant.fields.iter().enumerate().map(|(i, f)| {
             let field = Field::new(i);
             let subpath = self.elaborator.field_subpath(variant_path, field);
+            let tcx = self.tcx();
 
             assert_eq!(self.elaborator.param_env().reveal, Reveal::All);
-            let field_ty = self.tcx().normalize_erasing_regions(
+            let field_ty = tcx.normalize_erasing_regions(
                 self.elaborator.param_env(),
-                f.ty(self.tcx(), substs),
+                f.ty(tcx, substs),
             );
-            (base_place.clone().field(field, field_ty, self.tcx()), subpath)
+            (tcx.mk_place_field(base_place.clone(), field, field_ty), subpath)
         }).collect()
     }
 
@@ -323,7 +324,7 @@ where
         debug!("open_drop_for_tuple({:?}, {:?})", self, tys);
 
         let fields = tys.iter().enumerate().map(|(i, &ty)| {
-            (self.place.clone().field(Field::new(i), ty, self.tcx()),
+            (self.tcx().mk_place_field(self.place.clone(), Field::new(i), ty),
              self.elaborator.field_subpath(self.path, Field::new(i)))
         }).collect();
 
@@ -334,7 +335,7 @@ where
     fn open_drop_for_box(&mut self, adt: &'tcx ty::AdtDef, substs: SubstsRef<'tcx>) -> BasicBlock {
         debug!("open_drop_for_box({:?}, {:?}, {:?})", self, adt, substs);
 
-        let interior = self.place.clone().deref(self.tcx());
+        let interior = self.tcx().mk_place_deref(self.place.clone());
         let interior_path = self.elaborator.deref_subpath(self.path);
 
         let succ = self.succ; // FIXME(#43234)
@@ -406,14 +407,19 @@ where
         };
 
         let mut have_otherwise = false;
+        let tcx = self.tcx();
 
-        for (variant_index, discr) in adt.discriminants(self.tcx()) {
+        for (variant_index, discr) in adt.discriminants(tcx) {
             let subpath = self.elaborator.downcast_subpath(
                 self.path, variant_index);
             if let Some(variant_path) = subpath {
-                let base_place = self.place.clone().elem(
-                    ProjectionElem::Downcast(Some(adt.variants[variant_index].ident.name),
-                                             variant_index), self.tcx());
+                let base_place = tcx.mk_place_elem(
+                    self.place.clone(),
+                    ProjectionElem::Downcast(
+                        Some(adt.variants[variant_index].ident.name),
+                        variant_index,
+                    ),
+                );
                 let fields = self.move_paths_for_fields(
                     &base_place,
                     variant_path,
@@ -586,7 +592,7 @@ where
                 BorrowKind::Mut { allow_two_phase_borrow: false },
                 Place {
                     base: PlaceBase::Local(cur),
-                    projection: self.tcx().intern_place_elems(&vec![ProjectionElem::Deref]),
+                    projection: tcx.intern_place_elems(&vec![ProjectionElem::Deref]),
                 }
              ),
              Rvalue::BinaryOp(BinOp::Offset, move_(&Place::from(cur)), one))
@@ -594,7 +600,7 @@ where
             (Rvalue::Ref(
                  tcx.lifetimes.re_erased,
                  BorrowKind::Mut { allow_two_phase_borrow: false },
-                 self.place.clone().index(cur, self.tcx())),
+                 tcx.mk_place_index(self.place.clone(), cur)),
              Rvalue::BinaryOp(BinOp::Add, move_(&Place::from(cur)), one))
         };
 
@@ -627,7 +633,7 @@ where
         let loop_block = self.elaborator.patch().new_block(loop_block);
 
         self.elaborator.patch().patch_terminator(drop_block, TerminatorKind::Drop {
-            location: ptr.clone().deref(tcx),
+            location: tcx.mk_place_deref(ptr.clone()),
             target: loop_block,
             unwind: unwind.into_option()
         });
@@ -644,18 +650,27 @@ where
         //     ptr_based_loop
         // }
 
+        let tcx = self.tcx();
+
         if let Some(size) = opt_size {
             let size: u32 = size.try_into().unwrap_or_else(|_| {
                 bug!("move out check isn't implemented for array sizes bigger than u32::MAX");
             });
-            let fields: Vec<(Place<'tcx>, Option<D::Path>)> = (0..size).map(|i| {
-                (self.place.clone().elem(ProjectionElem::ConstantIndex{
-                    offset: i,
-                    min_length: size,
-                    from_end: false
-                }, self.tcx()),
-                 self.elaborator.array_subpath(self.path, i, size))
-            }).collect();
+            let fields: Vec<(Place<'tcx>, Option<D::Path>)> = (0..size)
+                .map(|i| {
+                    (
+                        tcx.mk_place_elem(
+                            self.place.clone(),
+                            ProjectionElem::ConstantIndex {
+                                offset: i,
+                                min_length: size,
+                                from_end: false,
+                            },
+                        ),
+                        self.elaborator.array_subpath(self.path, i, size),
+                    )
+                })
+                .collect();
 
             if fields.iter().any(|(_,path)| path.is_some()) {
                 let (succ, unwind) = self.drop_ladder_bottom();
@@ -664,7 +679,6 @@ where
         }
 
         let move_ = |place: &Place<'tcx>| Operand::Move(place.clone());
-        let tcx = self.tcx();
         let elem_size = &Place::from(self.new_temp(tcx.types.usize));
         let len = &Place::from(self.new_temp(tcx.types.usize));
 
@@ -900,8 +914,8 @@ where
         );
         let args = adt.variants[VariantIdx::new(0)].fields.iter().enumerate().map(|(i, f)| {
             let field = Field::new(i);
-            let field_ty = f.ty(self.tcx(), substs);
-            Operand::Move(self.place.clone().field(field, field_ty, self.tcx()))
+            let field_ty = f.ty(tcx, substs);
+            Operand::Move(tcx.mk_place_field(self.place.clone(), field, field_ty))
         }).collect();
 
         let call = TerminatorKind::Call {

--- a/src/librustdoc/html/static/main.js
+++ b/src/librustdoc/html/static/main.js
@@ -79,7 +79,7 @@ function getSearchElement() {
                      "derive",
                      "traitalias"];
 
-    var disableShortcuts = getCurrentValue("rustdoc-disable-shortcuts") !== "true";
+    var disableShortcuts = getCurrentValue("rustdoc-disable-shortcuts") === "true";
     var search_input = getSearchInput();
 
     // On the search screen, so you remain on the last tab you opened.

--- a/src/libstd/sys/unix/fs.rs
+++ b/src/libstd/sys/unix/fs.rs
@@ -124,64 +124,59 @@ cfg_has_statx! {{
         }
 
         match STATX_STATE.load(Ordering::Relaxed) {
-            // For the first time, we try to call on current working directory
-            // to check if it is available.
             0 => {
-                let mut buf: libc::statx = mem::zeroed();
-                let err = cvt(statx(
-                    libc::AT_FDCWD,
-                    b".\0".as_ptr().cast(),
-                    0,
-                    libc::STATX_ALL,
-                    &mut buf,
-                ))
+                // It is a trick to call `statx` with NULL pointers to check if the syscall
+                // is available. According to the manual, it is expected to fail with EFAULT.
+                // We do this mainly for performance, since it is nearly hundreds times
+                // faster than a normal successfull call.
+                let err = cvt(statx(0, ptr::null(), 0, libc::STATX_ALL, ptr::null_mut()))
                     .err()
                     .and_then(|e| e.raw_os_error());
-                // `seccomp` will emit `EPERM` on denied syscall.
+                // We don't check `err == Some(libc::ENOSYS)` because the syscall may be limited
+                // and returns `EPERM`. Listing all possible errors seems not a good idea.
                 // See: https://github.com/rust-lang/rust/issues/65662
-                if err == Some(libc::ENOSYS) || err == Some(libc::EPERM) {
+                if err != Some(libc::EFAULT) {
                     STATX_STATE.store(1, Ordering::Relaxed);
-                } else {
-                    STATX_STATE.store(2, Ordering::Relaxed);
+                    return None;
                 }
-                try_statx(fd, path, flags, mask)
+                STATX_STATE.store(2, Ordering::Relaxed);
             }
-            1 => None,
-            _ => {
-                let mut buf: libc::statx = mem::zeroed();
-                if let Err(err) = cvt(statx(fd, path, flags, mask, &mut buf)) {
-                    return Some(Err(err));
-                }
-
-                // We cannot fill `stat64` exhaustively because of private padding fields.
-                let mut stat: stat64 = mem::zeroed();
-                // `c_ulong` on gnu-mips, `dev_t` otherwise
-                stat.st_dev = libc::makedev(buf.stx_dev_major, buf.stx_dev_minor) as _;
-                stat.st_ino = buf.stx_ino as libc::ino64_t;
-                stat.st_nlink = buf.stx_nlink as libc::nlink_t;
-                stat.st_mode = buf.stx_mode as libc::mode_t;
-                stat.st_uid = buf.stx_uid as libc::uid_t;
-                stat.st_gid = buf.stx_gid as libc::gid_t;
-                stat.st_rdev = libc::makedev(buf.stx_rdev_major, buf.stx_rdev_minor) as _;
-                stat.st_size = buf.stx_size as off64_t;
-                stat.st_blksize = buf.stx_blksize as libc::blksize_t;
-                stat.st_blocks = buf.stx_blocks as libc::blkcnt64_t;
-                stat.st_atime = buf.stx_atime.tv_sec as libc::time_t;
-                // `i64` on gnu-x86_64-x32, `c_ulong` otherwise.
-                stat.st_atime_nsec = buf.stx_atime.tv_nsec as _;
-                stat.st_mtime = buf.stx_mtime.tv_sec as libc::time_t;
-                stat.st_mtime_nsec = buf.stx_mtime.tv_nsec as _;
-                stat.st_ctime = buf.stx_ctime.tv_sec as libc::time_t;
-                stat.st_ctime_nsec = buf.stx_ctime.tv_nsec as _;
-
-                let extra = StatxExtraFields {
-                    stx_mask: buf.stx_mask,
-                    stx_btime: buf.stx_btime,
-                };
-
-                Some(Ok(FileAttr { stat, statx_extra_fields: Some(extra) }))
-            }
+            1 => return None,
+            _ => {}
         }
+
+        let mut buf: libc::statx = mem::zeroed();
+        if let Err(err) = cvt(statx(fd, path, flags, mask, &mut buf)) {
+            return Some(Err(err));
+        }
+
+        // We cannot fill `stat64` exhaustively because of private padding fields.
+        let mut stat: stat64 = mem::zeroed();
+        // `c_ulong` on gnu-mips, `dev_t` otherwise
+        stat.st_dev = libc::makedev(buf.stx_dev_major, buf.stx_dev_minor) as _;
+        stat.st_ino = buf.stx_ino as libc::ino64_t;
+        stat.st_nlink = buf.stx_nlink as libc::nlink_t;
+        stat.st_mode = buf.stx_mode as libc::mode_t;
+        stat.st_uid = buf.stx_uid as libc::uid_t;
+        stat.st_gid = buf.stx_gid as libc::gid_t;
+        stat.st_rdev = libc::makedev(buf.stx_rdev_major, buf.stx_rdev_minor) as _;
+        stat.st_size = buf.stx_size as off64_t;
+        stat.st_blksize = buf.stx_blksize as libc::blksize_t;
+        stat.st_blocks = buf.stx_blocks as libc::blkcnt64_t;
+        stat.st_atime = buf.stx_atime.tv_sec as libc::time_t;
+        // `i64` on gnu-x86_64-x32, `c_ulong` otherwise.
+        stat.st_atime_nsec = buf.stx_atime.tv_nsec as _;
+        stat.st_mtime = buf.stx_mtime.tv_sec as libc::time_t;
+        stat.st_mtime_nsec = buf.stx_mtime.tv_nsec as _;
+        stat.st_ctime = buf.stx_ctime.tv_sec as libc::time_t;
+        stat.st_ctime_nsec = buf.stx_ctime.tv_nsec as _;
+
+        let extra = StatxExtraFields {
+            stx_mask: buf.stx_mask,
+            stx_btime: buf.stx_btime,
+        };
+
+        Some(Ok(FileAttr { stat, statx_extra_fields: Some(extra) }))
     }
 
 } else {

--- a/src/libsyntax/json.rs
+++ b/src/libsyntax/json.rs
@@ -25,6 +25,9 @@ use std::sync::{Arc, Mutex};
 
 use rustc_serialize::json::{as_json, as_pretty_json};
 
+#[cfg(test)]
+mod tests;
+
 pub struct JsonEmitter {
     dst: Box<dyn Write + Send>,
     registry: Option<Registry>,
@@ -332,8 +335,8 @@ impl DiagnosticSpan {
 
         DiagnosticSpan {
             file_name: start.file.name.to_string(),
-            byte_start: span.lo().0 - start.file.start_pos.0,
-            byte_end: span.hi().0 - start.file.start_pos.0,
+            byte_start: start.file.original_relative_byte_pos(span.lo()).0,
+            byte_end: start.file.original_relative_byte_pos(span.hi()).0,
             line_start: start.line,
             line_end: end.line,
             column_start: start.col.0 + 1,

--- a/src/libsyntax/json/tests.rs
+++ b/src/libsyntax/json/tests.rs
@@ -1,0 +1,186 @@
+use super::*;
+
+use crate::json::JsonEmitter;
+use crate::source_map::{FilePathMapping, SourceMap};
+use crate::tests::Shared;
+use crate::with_default_globals;
+
+use errors::emitter::{ColorConfig, HumanReadableErrorType};
+use errors::Handler;
+use rustc_serialize::json::decode;
+use syntax_pos::{BytePos, Span};
+
+use std::str;
+
+#[derive(RustcDecodable, Debug, PartialEq, Eq)]
+struct TestData {
+    spans: Vec<SpanTestData>,
+}
+
+#[derive(RustcDecodable, Debug, PartialEq, Eq)]
+struct SpanTestData {
+    pub byte_start: u32,
+    pub byte_end: u32,
+    pub line_start: u32,
+    pub column_start: u32,
+    pub line_end: u32,
+    pub column_end: u32,
+}
+
+/// Test the span yields correct positions in JSON.
+fn test_positions(code: &str, span: (u32, u32), expected_output: SpanTestData) {
+    let expected_output = TestData { spans: vec![expected_output] };
+
+    with_default_globals(|| {
+        let sm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
+        sm.new_source_file(Path::new("test.rs").to_owned().into(), code.to_owned());
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let je = JsonEmitter::new(
+            Box::new(Shared { data: output.clone() }),
+            None,
+            sm,
+            true,
+            HumanReadableErrorType::Short(ColorConfig::Never),
+            false,
+        );
+
+        let span = Span::with_root_ctxt(BytePos(span.0), BytePos(span.1));
+        let handler = Handler::with_emitter(true, None, Box::new(je));
+        handler.span_err(span, "foo");
+
+        let bytes = output.lock().unwrap();
+        let actual_output = str::from_utf8(&bytes).unwrap();
+        let actual_output: TestData = decode(actual_output).unwrap();
+
+        assert_eq!(expected_output, actual_output)
+    })
+}
+
+#[test]
+fn empty() {
+    test_positions(
+        " ",
+        (0, 1),
+        SpanTestData {
+            byte_start: 0,
+            byte_end: 1,
+            line_start: 1,
+            column_start: 1,
+            line_end: 1,
+            column_end: 2,
+        },
+    )
+}
+
+#[test]
+fn bom() {
+    test_positions(
+        "\u{feff} ",
+        (0, 1),
+        SpanTestData {
+            byte_start: 3,
+            byte_end: 4,
+            line_start: 1,
+            column_start: 1,
+            line_end: 1,
+            column_end: 2,
+        },
+    )
+}
+
+#[test]
+fn lf_newlines() {
+    test_positions(
+        "\nmod foo;\nmod bar;\n",
+        (5, 12),
+        SpanTestData {
+            byte_start: 5,
+            byte_end: 12,
+            line_start: 2,
+            column_start: 5,
+            line_end: 3,
+            column_end: 3,
+        },
+    )
+}
+
+#[test]
+fn crlf_newlines() {
+    test_positions(
+        "\r\nmod foo;\r\nmod bar;\r\n",
+        (5, 12),
+        SpanTestData {
+            byte_start: 6,
+            byte_end: 14,
+            line_start: 2,
+            column_start: 5,
+            line_end: 3,
+            column_end: 3,
+        },
+    )
+}
+
+#[test]
+fn crlf_newlines_with_bom() {
+    test_positions(
+        "\u{feff}\r\nmod foo;\r\nmod bar;\r\n",
+        (5, 12),
+        SpanTestData {
+            byte_start: 9,
+            byte_end: 17,
+            line_start: 2,
+            column_start: 5,
+            line_end: 3,
+            column_end: 3,
+        },
+    )
+}
+
+#[test]
+fn span_before_crlf() {
+    test_positions(
+        "foo\r\nbar",
+        (2, 3),
+        SpanTestData {
+            byte_start: 2,
+            byte_end: 3,
+            line_start: 1,
+            column_start: 3,
+            line_end: 1,
+            column_end: 4,
+        },
+    )
+}
+
+#[test]
+fn span_on_crlf() {
+    test_positions(
+        "foo\r\nbar",
+        (3, 4),
+        SpanTestData {
+            byte_start: 3,
+            byte_end: 5,
+            line_start: 1,
+            column_start: 4,
+            line_end: 2,
+            column_end: 1,
+        },
+    )
+}
+
+#[test]
+fn span_after_crlf() {
+    test_positions(
+        "foo\r\nbar",
+        (4, 5),
+        SpanTestData {
+            byte_start: 5,
+            byte_end: 6,
+            line_start: 2,
+            column_start: 1,
+            line_end: 2,
+            column_end: 2,
+        },
+    )
+}

--- a/src/libsyntax/source_map.rs
+++ b/src/libsyntax/source_map.rs
@@ -283,6 +283,7 @@ impl SourceMap {
         mut file_local_lines: Vec<BytePos>,
         mut file_local_multibyte_chars: Vec<MultiByteChar>,
         mut file_local_non_narrow_chars: Vec<NonNarrowChar>,
+        mut file_local_normalized_pos: Vec<NormalizedPos>,
     ) -> Lrc<SourceFile> {
         let start_pos = self.next_start_pos();
 
@@ -301,6 +302,10 @@ impl SourceMap {
             *swc = *swc + start_pos;
         }
 
+        for nc in &mut file_local_normalized_pos {
+            nc.pos = nc.pos + start_pos;
+        }
+
         let source_file = Lrc::new(SourceFile {
             name: filename,
             name_was_remapped,
@@ -314,6 +319,7 @@ impl SourceMap {
             lines: file_local_lines,
             multibyte_chars: file_local_multibyte_chars,
             non_narrow_chars: file_local_non_narrow_chars,
+            normalized_pos: file_local_normalized_pos,
             name_hash,
         });
 

--- a/src/libsyntax/tests.rs
+++ b/src/libsyntax/tests.rs
@@ -110,8 +110,8 @@ struct SpanLabel {
     label: &'static str,
 }
 
-struct Shared<T: Write> {
-    data: Arc<Mutex<T>>,
+crate struct Shared<T: Write> {
+    pub data: Arc<Mutex<T>>,
 }
 
 impl<T: Write> Write for Shared<T> {

--- a/src/libsyntax_pos/lib.rs
+++ b/src/libsyntax_pos/lib.rs
@@ -855,6 +855,15 @@ impl Sub<BytePos> for NonNarrowChar {
     }
 }
 
+/// Identifies an offset of a character that was normalized away from `SourceFile`.
+#[derive(Copy, Clone, RustcEncodable, RustcDecodable, Eq, PartialEq, Debug)]
+pub struct NormalizedPos {
+    /// The absolute offset of the character in the `SourceMap`.
+    pub pos: BytePos,
+    /// The difference between original and normalized string at position.
+    pub diff: u32,
+}
+
 /// The state of the lazy external source loading mechanism of a `SourceFile`.
 #[derive(PartialEq, Eq, Clone)]
 pub enum ExternalSource {
@@ -918,6 +927,8 @@ pub struct SourceFile {
     pub multibyte_chars: Vec<MultiByteChar>,
     /// Width of characters that are not narrow in the source code.
     pub non_narrow_chars: Vec<NonNarrowChar>,
+    /// Locations of characters removed during normalization.
+    pub normalized_pos: Vec<NormalizedPos>,
     /// A hash of the filename, used for speeding up hashing in incremental compilation.
     pub name_hash: u128,
 }
@@ -984,6 +995,9 @@ impl Encodable for SourceFile {
             })?;
             s.emit_struct_field("name_hash", 8, |s| {
                 self.name_hash.encode(s)
+            })?;
+            s.emit_struct_field("normalized_pos", 9, |s| {
+                self.normalized_pos.encode(s)
             })
         })
     }
@@ -1034,6 +1048,8 @@ impl Decodable for SourceFile {
                 d.read_struct_field("non_narrow_chars", 7, |d| Decodable::decode(d))?;
             let name_hash: u128 =
                 d.read_struct_field("name_hash", 8, |d| Decodable::decode(d))?;
+            let normalized_pos: Vec<NormalizedPos> =
+                d.read_struct_field("normalized_pos", 9, |d| Decodable::decode(d))?;
             Ok(SourceFile {
                 name,
                 name_was_remapped,
@@ -1050,6 +1066,7 @@ impl Decodable for SourceFile {
                 lines,
                 multibyte_chars,
                 non_narrow_chars,
+                normalized_pos,
                 name_hash,
             })
         })
@@ -1068,8 +1085,7 @@ impl SourceFile {
                unmapped_path: FileName,
                mut src: String,
                start_pos: BytePos) -> Result<SourceFile, OffsetOverflowError> {
-        remove_bom(&mut src);
-        normalize_newlines(&mut src);
+        let normalized_pos = normalize_src(&mut src, start_pos);
 
         let src_hash = {
             let mut hasher: StableHasher = StableHasher::new();
@@ -1102,6 +1118,7 @@ impl SourceFile {
             lines,
             multibyte_chars,
             non_narrow_chars,
+            normalized_pos,
             name_hash,
         })
     }
@@ -1228,12 +1245,44 @@ impl SourceFile {
     pub fn contains(&self, byte_pos: BytePos) -> bool {
         byte_pos >= self.start_pos && byte_pos <= self.end_pos
     }
+
+    /// Calculates the original byte position relative to the start of the file
+    /// based on the given byte position.
+    pub fn original_relative_byte_pos(&self, pos: BytePos) -> BytePos {
+
+        // Diff before any records is 0. Otherwise use the previously recorded
+        // diff as that applies to the following characters until a new diff
+        // is recorded.
+        let diff = match self.normalized_pos.binary_search_by(
+                            |np| np.pos.cmp(&pos)) {
+            Ok(i) => self.normalized_pos[i].diff,
+            Err(i) if i == 0 => 0,
+            Err(i) => self.normalized_pos[i-1].diff,
+        };
+
+        BytePos::from_u32(pos.0 - self.start_pos.0 + diff)
+    }
+}
+
+/// Normalizes the source code and records the normalizations.
+fn normalize_src(src: &mut String, start_pos: BytePos) -> Vec<NormalizedPos> {
+    let mut normalized_pos = vec![];
+    remove_bom(src, &mut normalized_pos);
+    normalize_newlines(src, &mut normalized_pos);
+
+    // Offset all the positions by start_pos to match the final file positions.
+    for np in &mut normalized_pos {
+        np.pos.0 += start_pos.0;
+    }
+
+    normalized_pos
 }
 
 /// Removes UTF-8 BOM, if any.
-fn remove_bom(src: &mut String) {
+fn remove_bom(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>) {
     if src.starts_with("\u{feff}") {
         src.drain(..3);
+        normalized_pos.push(NormalizedPos { pos: BytePos(0), diff: 3 });
     }
 }
 
@@ -1241,7 +1290,7 @@ fn remove_bom(src: &mut String) {
 /// Replaces `\r\n` with `\n` in-place in `src`.
 ///
 /// Returns error if there's a lone `\r` in the string
-fn normalize_newlines(src: &mut String) {
+fn normalize_newlines(src: &mut String, normalized_pos: &mut Vec<NormalizedPos>) {
     if !src.as_bytes().contains(&b'\r') {
         return;
     }
@@ -1254,6 +1303,8 @@ fn normalize_newlines(src: &mut String) {
     let mut buf = std::mem::replace(src, String::new()).into_bytes();
     let mut gap_len = 0;
     let mut tail = buf.as_mut_slice();
+    let mut cursor = 0;
+    let original_gap = normalized_pos.last().map_or(0, |l| l.diff);
     loop {
         let idx = match find_crlf(&tail[gap_len..]) {
             None => tail.len(),
@@ -1264,7 +1315,12 @@ fn normalize_newlines(src: &mut String) {
         if tail.len() == gap_len {
             break;
         }
+        cursor += idx - gap_len;
         gap_len += 1;
+        normalized_pos.push(NormalizedPos {
+            pos: BytePos::from_usize(cursor + 1),
+            diff: original_gap + gap_len as u32,
+        });
     }
 
     // Account for removed `\r`.

--- a/src/libsyntax_pos/tests.rs
+++ b/src/libsyntax_pos/tests.rs
@@ -19,20 +19,25 @@ fn test_lookup_line() {
 
 #[test]
 fn test_normalize_newlines() {
-    fn check(before: &str, after: &str) {
+    fn check(before: &str, after: &str, expected_positions: &[u32]) {
         let mut actual = before.to_string();
-        normalize_newlines(&mut actual);
+        let mut actual_positions = vec![];
+        normalize_newlines(&mut actual, &mut actual_positions);
+        let actual_positions : Vec<_> = actual_positions
+            .into_iter()
+            .map(|nc| nc.pos.0).collect();
         assert_eq!(actual.as_str(), after);
+        assert_eq!(actual_positions, expected_positions);
     }
-    check("", "");
-    check("\n", "\n");
-    check("\r", "\r");
-    check("\r\r", "\r\r");
-    check("\r\n", "\n");
-    check("hello world", "hello world");
-    check("hello\nworld", "hello\nworld");
-    check("hello\r\nworld", "hello\nworld");
-    check("\r\nhello\r\nworld\r\n", "\nhello\nworld\n");
-    check("\r\r\n", "\r\n");
-    check("hello\rworld", "hello\rworld");
+    check("", "", &[]);
+    check("\n", "\n", &[]);
+    check("\r", "\r", &[]);
+    check("\r\r", "\r\r", &[]);
+    check("\r\n", "\n", &[1]);
+    check("hello world", "hello world", &[]);
+    check("hello\nworld", "hello\nworld", &[]);
+    check("hello\r\nworld", "hello\nworld", &[6]);
+    check("\r\nhello\r\nworld\r\n", "\nhello\nworld\n", &[1, 7, 13]);
+    check("\r\r\n", "\r\n", &[2]);
+    check("hello\rworld", "hello\rworld", &[]);
 }

--- a/src/test/ui/.gitattributes
+++ b/src/test/ui/.gitattributes
@@ -1,3 +1,6 @@
 lexer-crlf-line-endings-string-literal-doc-comment.rs -text
+json-bom-plus-crlf.rs -text
+json-bom-plus-crlf-multifile.rs -text
+json-bom-plus-crlf-multifile-aux.rs -text
 trailing-carriage-return-in-string.rs -text
 *.bin -text

--- a/src/test/ui/json-bom-plus-crlf-multifile-aux.rs
+++ b/src/test/ui/json-bom-plus-crlf-multifile-aux.rs
@@ -1,0 +1,27 @@
+﻿// (This line has BOM so it's ignored by compiletest for directives)
+//
+// ignore-test Not a test. Used by other tests
+// ignore-tidy-cr
+
+// For easier verifying, the byte offsets in this file should match those
+// in the json-bom-plus-crlf.rs - given the actual fn is identical (just with
+// a different, but equally sized name), the easiest way to do this is to
+// ensure the two files are of equal size on disk.
+// Padding............................
+
+// N.B., this file needs CRLF line endings. The .gitattributes file in
+// this directory should enforce it.
+
+pub fn test() {
+
+    let s : String = 1;  // Error in the middle of line.
+
+    let s : String = 1
+    ;  // Error before the newline.
+
+    let s : String =
+1;  // Error after the newline.
+
+    let s : String = (
+    );  // Error spanning the newline.
+}

--- a/src/test/ui/json-bom-plus-crlf-multifile.rs
+++ b/src/test/ui/json-bom-plus-crlf-multifile.rs
@@ -1,0 +1,12 @@
+﻿// (This line has BOM so it's ignored by compiletest for directives)
+//
+// build-fail
+// compile-flags: --json=diagnostic-short --error-format=json
+// ignore-tidy-cr
+
+#[path = "json-bom-plus-crlf-multifile-aux.rs"]
+mod json_bom_plus_crlf_multifile_aux;
+
+fn main() {
+    json_bom_plus_crlf_multifile_aux::test();
+}

--- a/src/test/ui/json-bom-plus-crlf-multifile.stderr
+++ b/src/test/ui/json-bom-plus-crlf-multifile.stderr
@@ -1,0 +1,86 @@
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":621,"byte_end":622,"line_start":17,"line_end":17,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1;  // Error in the middle of line.","highlight_start":22,"highlight_end":23}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":621,"byte_end":622,"line_start":17,"line_end":17,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1;  // Error in the middle of line.","highlight_start":22,"highlight_end":23}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf-multifile-aux.rs:17:22: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":681,"byte_end":682,"line_start":19,"line_end":19,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1","highlight_start":22,"highlight_end":23}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":681,"byte_end":682,"line_start":19,"line_end":19,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1","highlight_start":22,"highlight_end":23}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf-multifile-aux.rs:19:22: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":745,"byte_end":746,"line_start":23,"line_end":23,"column_start":1,"column_end":2,"is_primary":true,"text":[{"text":"1;  // Error after the newline.","highlight_start":1,"highlight_end":2}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":745,"byte_end":746,"line_start":23,"line_end":23,"column_start":1,"column_end":2,"is_primary":true,"text":[{"text":"1;  // Error after the newline.","highlight_start":1,"highlight_end":2}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf-multifile-aux.rs:23:1: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf-multifile-aux.rs","byte_start":801,"byte_end":809,"line_start":25,"line_end":26,"column_start":22,"column_end":6,"is_primary":true,"text":[{"text":"    let s : String = (","highlight_start":22,"highlight_end":23},{"text":"    );  // Error spanning the newline.","highlight_start":1,"highlight_end":6}],"label":"expected struct `std::string::String`, found ()","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `()`","code":null,"level":"note","spans":[],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf-multifile-aux.rs:25:22: error[E0308]: mismatched types
+"}
+{"message":"aborting due to 4 previous errors","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to 4 previous errors
+"}

--- a/src/test/ui/json-bom-plus-crlf.rs
+++ b/src/test/ui/json-bom-plus-crlf.rs
@@ -1,0 +1,27 @@
+﻿// (This line has BOM so it's ignored by compiletest for directives)
+//
+// build-fail
+// compile-flags: --json=diagnostic-short --error-format=json
+// ignore-tidy-cr
+
+// For easier verifying, the byte offsets in this file should match those
+// in the json_bom_plus_crlf_multifile_aux.rs - given the actual fn is
+// identical (just with a different, but equally sized name), the easiest way
+// to do this is to ensure the two files are of equal size on disk.
+
+// N.B., this file needs CRLF line endings. The .gitattributes file in
+// this directory should enforce it.
+
+fn main() {
+
+    let s : String = 1;  // Error in the middle of line.
+
+    let s : String = 1
+    ;  // Error before the newline.
+
+    let s : String =
+1;  // Error after the newline.
+
+    let s : String = (
+    );  // Error spanning the newline.
+}

--- a/src/test/ui/json-bom-plus-crlf.stderr
+++ b/src/test/ui/json-bom-plus-crlf.stderr
@@ -1,0 +1,86 @@
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":621,"byte_end":622,"line_start":17,"line_end":17,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1;  // Error in the middle of line.","highlight_start":22,"highlight_end":23}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":621,"byte_end":622,"line_start":17,"line_end":17,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1;  // Error in the middle of line.","highlight_start":22,"highlight_end":23}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf.rs:17:22: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":681,"byte_end":682,"line_start":19,"line_end":19,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1","highlight_start":22,"highlight_end":23}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":681,"byte_end":682,"line_start":19,"line_end":19,"column_start":22,"column_end":23,"is_primary":true,"text":[{"text":"    let s : String = 1","highlight_start":22,"highlight_end":23}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf.rs:19:22: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":745,"byte_end":746,"line_start":23,"line_end":23,"column_start":1,"column_end":2,"is_primary":true,"text":[{"text":"1;  // Error after the newline.","highlight_start":1,"highlight_end":2}],"label":"expected struct `std::string::String`, found integer","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `{integer}`","code":null,"level":"note","spans":[],"children":[],"rendered":null},{"message":"try using a conversion method","code":null,"level":"help","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":745,"byte_end":746,"line_start":23,"line_end":23,"column_start":1,"column_end":2,"is_primary":true,"text":[{"text":"1;  // Error after the newline.","highlight_start":1,"highlight_end":2}],"label":null,"suggested_replacement":"1.to_string()","suggestion_applicability":"MaybeIncorrect","expansion":null}],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf.rs:23:1: error[E0308]: mismatched types
+"}
+{"message":"mismatched types","code":{"code":"E0308","explanation":"
+This error occurs when the compiler was unable to infer the concrete type of a
+variable. It can occur for several cases, the most common of which is a
+mismatch in the expected type that the compiler inferred for a variable's
+initializing expression, and the actual type explicitly assigned to the
+variable.
+
+For example:
+
+```compile_fail,E0308
+let x: i32 = \"I am not a number!\";
+//     ~~~   ~~~~~~~~~~~~~~~~~~~~
+//      |             |
+//      |    initializing expression;
+//      |    compiler infers type `&str`
+//      |
+//    type `i32` assigned to variable `x`
+```
+"},"level":"error","spans":[{"file_name":"$DIR/json-bom-plus-crlf.rs","byte_start":801,"byte_end":809,"line_start":25,"line_end":26,"column_start":22,"column_end":6,"is_primary":true,"text":[{"text":"    let s : String = (","highlight_start":22,"highlight_end":23},{"text":"    );  // Error spanning the newline.","highlight_start":1,"highlight_end":6}],"label":"expected struct `std::string::String`, found ()","suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"expected type `std::string::String`
+   found type `()`","code":null,"level":"note","spans":[],"children":[],"rendered":null}],"rendered":"$DIR/json-bom-plus-crlf.rs:25:22: error[E0308]: mismatched types
+"}
+{"message":"aborting due to 4 previous errors","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to 4 previous errors
+"}


### PR DESCRIPTION
Successful merges:

 - #65074 (Fix the start/end byte positions in the compiler JSON output)
 - #65315 (Intern place projection)
 - #65685 (Fix check of `statx` and handle EPERM)
 - #65731 (Prevent unnecessary allocation in PathBuf::set_extension.)
 - #65740 (Fix default "disable-shortcuts" feature value)

Failed merges:

 - #65434 (Add long error explanation for E0577)

r? @ghost