### PR TITLE
self-profiling: Update measureme to 0.4.0 and remove non-RAII methods from profiler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "measureme"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09de7dafa3aa334bc806447c7e4de69419723312f4b88b80b561dea66601ce8"
+checksum = "cd21b0e6e1af976b269ce062038fe5e1b9ca2f817ab7a3af09ec4210aebf0d30"
 dependencies = [
  "byteorder",
  "memmap",

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -37,4 +37,4 @@ byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }
 rustc_fs_util = { path = "../librustc_fs_util" }
 smallvec = { version = "0.6.8", features = ["union", "may_dangle"] }
-measureme = "0.3"
+measureme = "0.4"

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -131,32 +131,6 @@ impl SelfProfilerRef {
         })
     }
 
-    /// Start profiling a generic activity. Profiling continues until
-    /// `generic_activity_end` is called. The RAII-based `generic_activity`
-    /// usually is the better alternative.
-    #[inline(always)]
-    pub fn generic_activity_start(&self, event_id: &str) {
-        self.non_guard_generic_event(
-            |profiler| profiler.generic_activity_event_kind,
-            |profiler| profiler.profiler.alloc_string(event_id),
-            EventFilter::GENERIC_ACTIVITIES,
-            TimestampKind::Start,
-        );
-    }
-
-    /// End profiling a generic activity that was started with
-    /// `generic_activity_start`. The RAII-based `generic_activity` usually is
-    /// the better alternative.
-    #[inline(always)]
-    pub fn generic_activity_end(&self, event_id: &str) {
-        self.non_guard_generic_event(
-            |profiler| profiler.generic_activity_event_kind,
-            |profiler| profiler.profiler.alloc_string(event_id),
-            EventFilter::GENERIC_ACTIVITIES,
-            TimestampKind::End,
-        );
-    }
-
     /// Start profiling a query provider. Profiling continues until the
     /// TimingGuard returned from this call is dropped.
     #[inline(always)]
@@ -231,28 +205,6 @@ impl SelfProfilerRef {
             profiler.profiler.record_event(
                 event_kind(profiler),
                 event_id,
-                thread_id,
-                timestamp_kind,
-            );
-
-            TimingGuard::none()
-        }));
-    }
-
-    #[inline(always)]
-    fn non_guard_generic_event<F: FnOnce(&SelfProfiler) -> StringId>(
-        &self,
-        event_kind: fn(&SelfProfiler) -> StringId,
-        event_id: F,
-        event_filter: EventFilter,
-        timestamp_kind: TimestampKind
-    ) {
-        drop(self.exec(event_filter, |profiler| {
-            let thread_id = thread_id_to_u64(std::thread::current().id());
-
-            profiler.profiler.record_event(
-                event_kind(profiler),
-                event_id(profiler),
                 thread_id,
                 timestamp_kind,
             );


### PR DESCRIPTION
This PR removes all non-RAII based profiling methods from `SelfProfilerRef` :tada:
It also delegates the `TimingGuard` implementation to `measureme`, now that that is available there.

r? @wesleywiser 