### PR TITLE
SGX: Clear additional flag on enclave entry

### DIFF
--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -124,7 +124,6 @@ sgx_entry:
 
 /*  making sure AC flag is not set in rflags */
 /*  avoid using the 'clac' instruction to be compatible with older compilers */
-    push %rcx
     pushfq
     popq %rcx
     and $0xFFFFFFFFFFFBFFFF, %rcx

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -123,7 +123,9 @@ sgx_entry:
 /*  reset user state */
 /*    - DF flag: x86-64 ABI requires DF to be unset at function entry/exit */
 /*    - AC flag: AEX on misaligned memory accesses leaks side channel info */
+    pushfq
     andq $~0x40400, (%rsp)
+    popfq
 
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -121,6 +121,16 @@ sgx_entry:
     fnstcw %gs:tcsls_user_fcw
 /*  reset user state */
     cld /* x86-64 ABI requires DF to be unset at function entry/exit */
+
+/*  making sure AC flag is not set in rflags */
+/*  avoid using the 'clac' instruction to be compatible with older compilers */
+    push %rcx
+    pushfq
+    popq %rcx
+    and $0xFFFFFFFFFFFBFFFF, %rcx
+    push %rcx
+    popfq
+
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)
     jz .Lskip_debug_init

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -119,16 +119,11 @@ sgx_entry:
     mov %rbx,%gs:tcsls_tcs_addr
     stmxcsr %gs:tcsls_user_mxcsr
     fnstcw %gs:tcsls_user_fcw
-/*  reset user state */
-    cld /* x86-64 ABI requires DF to be unset at function entry/exit */
 
-/*  making sure AC flag is not set in rflags */
-/*  avoid using the 'clac' instruction to be compatible with older compilers */
-    pushfq
-    popq %rcx
-    and $0xFFFFFFFFFFFBFFFF, %rcx
-    push %rcx
-    popfq
+/*  reset user state */
+/*    - DF flag: x86-64 ABI requires DF to be unset at function entry/exit */
+/*    - AC flag: AEX on misaligned memory accesses leaks side channel info */
+    andq $~0x40400, (%rsp)
 
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)


### PR DESCRIPTION
An attacker could set both the AC flag in CR0 as in rflags. This causes the enclave to perform an AEX upon a misaligned memory access, and an attacker learns some information about the internal enclave state. 
The AC flag in rflags is copied from userspace upon an enclave entry. Upon AEX it is copied and later restored. This patch forces the rflag.AC bit to be reset right after an enter.