### PR TITLE
Recover on `mut $p = $e;` and `var/auto $p = $e` suggesting `let` instead.

### DIFF
--- a/src/libsyntax/parse/parser/stmt.rs
+++ b/src/libsyntax/parse/parser/stmt.rs
@@ -519,7 +519,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Returns `true` if the next token is Brace
-    fn is_next_brace(&self) -> bool { self.look_ahead(1, |t|  t.eq(&token::OpenDelim(token::Brace))) }
+    fn is_next_brace(&self) -> bool {
+        self.look_ahead(1, |t|  t.eq(&token::OpenDelim(token::Brace)))
+    }
 
     /// Returns `true` if the token is kw::Mut and next one is an Ident
     fn is_ident_mut(&self) -> bool {

--- a/src/libsyntax/parse/token.rs
+++ b/src/libsyntax/parse/token.rs
@@ -538,7 +538,7 @@ impl Token {
     }
 
     /// Returns `true` if the token is a non-raw identifier for which `pred` holds.
-    fn is_non_raw_ident_where(&self, pred: impl FnOnce(ast::Ident) -> bool) -> bool {
+    pub fn is_non_raw_ident_where(&self, pred: impl FnOnce(ast::Ident) -> bool) -> bool {
         match self.ident() {
             Some((id, false)) => pred(id),
             _ => false,

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -725,6 +725,7 @@ symbols! {
         usize,
         v1,
         val,
+        var,
         vec,
         Vec,
         vis,

--- a/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.rs
@@ -1,4 +1,3 @@
-
 #[allow(dead_code)]
 fn main() {
     auto n = 0;//~ ERROR invalid variable declaration

--- a/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.rs
@@ -1,0 +1,9 @@
+
+#[allow(dead_code)]
+fn main() {
+    auto n = 0;//~ ERROR invalid variable declaration
+    //~^ HELP to introduce a variable, write `let` instead of `auto`
+    auto m;//~ ERROR invalid variable declaration
+    //~^ HELP to introduce a variable, write `let` instead of `auto`
+    m = 0;
+}

--- a/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.stderr
+++ b/src/test/ui/parser/issue-65257--auto-instead-of-let-recovery.stderr
@@ -1,0 +1,14 @@
+error: invalid variable declaration
+  --> $DIR/issue-65257--auto-instead-of-let-recovery.rs:4:5
+   |
+LL |     auto n = 0;
+   |     ^^^^ help: to introduce a variable, write `let` instead of `auto`
+
+error: invalid variable declaration
+  --> $DIR/issue-65257--auto-instead-of-let-recovery.rs:6:5
+   |
+LL |     auto m;
+   |     ^^^^ help: to introduce a variable, write `let` instead of `auto`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.rs
@@ -1,4 +1,3 @@
-
 #[allow(dead_code)]
 fn main() {
     var n = 0;//~ ERROR invalid variable declaration

--- a/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.rs
@@ -1,0 +1,9 @@
+
+#[allow(dead_code)]
+fn main() {
+    var n = 0;//~ ERROR invalid variable declaration
+    //~^ HELP to introduce a variable, write `let` instead of `var`
+    var m;//~ ERROR invalid variable declaration
+    //~^ HELP to introduce a variable, write `let` instead of `var`
+    m = 0;
+}

--- a/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.stderr
+++ b/src/test/ui/parser/issue-65257--var-instead-of-let-recovery.stderr
@@ -1,0 +1,14 @@
+error: invalid variable declaration
+  --> $DIR/issue-65257--var-instead-of-let-recovery.rs:4:5
+   |
+LL |     var n = 0;
+   |     ^^^ help: to introduce a variable, write `let` instead of `var`
+
+error: invalid variable declaration
+  --> $DIR/issue-65257--var-instead-of-let-recovery.rs:6:5
+   |
+LL |     var m;
+   |     ^^^ help: to introduce a variable, write `let` instead of `var`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.rs
@@ -1,4 +1,3 @@
-
 #[allow(dead_code)]
 fn main() {
     mut n = 0;//~ ERROR invalid variable declaration

--- a/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.rs
+++ b/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.rs
@@ -1,0 +1,9 @@
+
+#[allow(dead_code)]
+fn main() {
+    mut n = 0;//~ ERROR invalid variable declaration
+    //~^ HELP missing `let`
+    mut var;//~ ERROR invalid variable declaration
+    //~^ HELP missing `let`
+    var = 0;
+}

--- a/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.stderr
+++ b/src/test/ui/parser/issue-65257-mut-instead-of-let-recovery.stderr
@@ -1,0 +1,14 @@
+error: invalid variable declaration
+  --> $DIR/issue-65257-mut-instead-of-let-recovery.rs:4:5
+   |
+LL |     mut n = 0;
+   |     ^^^ help: missing `let`
+
+error: invalid variable declaration
+  --> $DIR/issue-65257-mut-instead-of-let-recovery.rs:6:5
+   |
+LL |     mut var;
+   |     ^^^ help: missing `let`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/65257.

As discussed with @Centril 
https://github.com/rust-lang/rust/issues/65257#issuecomment-540315351