### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "measureme"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09de7dafa3aa334bc806447c7e4de69419723312f4b88b80b561dea66601ce8"
+checksum = "cd21b0e6e1af976b269ce062038fe5e1b9ca2f817ab7a3af09ec4210aebf0d30"
 dependencies = [
  "byteorder",
  "memmap",

--- a/src/libcore/array/iter.rs
+++ b/src/libcore/array/iter.rs
@@ -13,7 +13,7 @@ use super::LengthAtMost32;
 /// A by-value [array] iterator.
 ///
 /// [array]: ../../std/primitive.array.html
-#[unstable(feature = "array_value_iter", issue = "0")]
+#[unstable(feature = "array_value_iter", issue = "65798")]
 pub struct IntoIter<T, const N: usize>
 where
     [T; N]: LengthAtMost32,
@@ -49,7 +49,7 @@ where
     /// *Note*: this method might never get stabilized and/or removed in the
     /// future as there will likely be another, preferred way of obtaining this
     /// iterator (either via `IntoIterator` for arrays or via another way).
-    #[unstable(feature = "array_value_iter", issue = "0")]
+    #[unstable(feature = "array_value_iter", issue = "65798")]
     pub fn new(array: [T; N]) -> Self {
         // The transmute here is actually safe. The docs of `MaybeUninit`
         // promise:
@@ -95,7 +95,7 @@ where
 }
 
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> Iterator for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -141,7 +141,7 @@ where
     }
 }
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> DoubleEndedIterator for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -176,7 +176,7 @@ where
     }
 }
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> Drop for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -189,7 +189,7 @@ where
     }
 }
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> ExactSizeIterator for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -204,7 +204,7 @@ where
     }
 }
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> FusedIterator for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -214,13 +214,13 @@ where
 // elements (that will still be yielded) is the length of the range `alive`.
 // This range is decremented in length in either `next` or `next_back`. It is
 // always decremented by 1 in those methods, but only if `Some(_)` is returned.
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 unsafe impl<T, const N: usize> TrustedLen for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
 {}
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T: Clone, const N: usize> Clone for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,
@@ -251,7 +251,7 @@ where
     }
 }
 
-#[stable(feature = "array_value_iter_impls", since = "1.38.0")]
+#[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T: fmt::Debug, const N: usize> fmt::Debug for IntoIter<T, {N}>
 where
     [T; N]: LengthAtMost32,

--- a/src/libcore/array/mod.rs
+++ b/src/libcore/array/mod.rs
@@ -18,7 +18,7 @@ use crate::slice::{Iter, IterMut};
 mod iter;
 
 #[cfg(not(bootstrap))]
-#[unstable(feature = "array_value_iter", issue = "0")]
+#[unstable(feature = "array_value_iter", issue = "65798")]
 pub use iter::IntoIter;
 
 /// Utility trait implemented only on arrays of fixed size

--- a/src/libcore/intrinsics.rs
+++ b/src/libcore/intrinsics.rs
@@ -1339,6 +1339,10 @@ extern "rust-intrinsic" {
     /// Emits a `!nontemporal` store according to LLVM (see their docs).
     /// Probably will never become stable.
     pub fn nontemporal_store<T>(ptr: *mut T, val: T);
+
+    /// See documentation of `<*const T>::offset_from` for details.
+    #[cfg(not(bootstrap))]
+    pub fn ptr_offset_from<T>(ptr: *const T, base: *const T) -> isize;
 }
 
 // Some functions are defined here because they accidentally got made

--- a/src/libcore/ptr/mod.rs
+++ b/src/libcore/ptr/mod.rs
@@ -1286,7 +1286,22 @@ impl<T: ?Sized> *const T {
     /// }
     /// ```
     #[unstable(feature = "ptr_offset_from", issue = "41079")]
+    #[cfg(not(bootstrap))]
+    #[rustc_const_unstable(feature = "const_ptr_offset_from")]
     #[inline]
+    pub const unsafe fn offset_from(self, origin: *const T) -> isize where T: Sized {
+        let pointee_size = mem::size_of::<T>();
+        let ok = 0 < pointee_size && pointee_size <= isize::max_value() as usize;
+        // assert that the pointee size is valid in a const eval compatible way
+        // FIXME: do this with a real assert at some point
+        [()][(!ok) as usize];
+        intrinsics::ptr_offset_from(self, origin)
+    }
+
+    #[unstable(feature = "ptr_offset_from", issue = "41079")]
+    #[inline]
+    #[cfg(bootstrap)]
+    /// bootstrap
     pub unsafe fn offset_from(self, origin: *const T) -> isize where T: Sized {
         let pointee_size = mem::size_of::<T>();
         assert!(0 < pointee_size && pointee_size <= isize::max_value() as usize);
@@ -2013,8 +2028,9 @@ impl<T: ?Sized> *mut T {
     /// }
     /// ```
     #[unstable(feature = "ptr_offset_from", issue = "41079")]
+    #[rustc_const_unstable(feature = "const_ptr_offset_from")]
     #[inline]
-    pub unsafe fn offset_from(self, origin: *const T) -> isize where T: Sized {
+    pub const unsafe fn offset_from(self, origin: *const T) -> isize where T: Sized {
         (self as *const T).offset_from(origin)
     }
 

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -28,7 +28,7 @@ use crate::fmt;
 use crate::intrinsics::{assume, exact_div, unchecked_sub, is_aligned_and_not_null};
 use crate::isize;
 use crate::iter::*;
-use crate::ops::{FnMut, self};
+use crate::ops::{FnMut, Range, self};
 use crate::option::Option;
 use crate::option::Option::{None, Some};
 use crate::result::Result;
@@ -405,6 +405,65 @@ impl<T> [T] {
     #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut T {
         self as *mut [T] as *mut T
+    }
+
+    /// Returns the two raw pointers spanning the slice.
+    ///
+    /// The returned range is half-open, which means that the end pointer
+    /// points *one past* the last element of the slice. This way, an empty
+    /// slice is represented by two equal pointers, and the difference between
+    /// the two pointers represents the size of the size.
+    ///
+    /// See [`as_ptr`] for warnings on using these pointers. The end pointer
+    /// requires extra caution, as it does not point to a valid element in the
+    /// slice.
+    ///
+    /// This function is useful for interacting with foreign interfaces which
+    /// use two pointers to refer to a range of elements in memory, as is
+    /// common in C++.
+    ///
+    /// It can also be useful to check if a reference or pointer to an element
+    /// refers to an element of this slice:
+    ///
+    /// ```
+    /// let a = [1,2,3];
+    /// let x = &a[1];
+    /// let y = &5;
+    /// assert!(a.as_ptr_range().contains(x));
+    /// assert!(!a.as_ptr_range().contains(y));
+    /// ```
+    ///
+    /// [`as_ptr`]: #method.as_ptr
+    #[unstable(feature = "slice_ptr_range", issue = "0")]
+    #[inline]
+    pub fn as_ptr_range(&self) -> Range<*const T> {
+        let start = self.as_ptr();
+        let end = unsafe { start.add(self.len()) };
+        start..end
+    }
+
+    /// Returns the two unsafe mutable pointers spanning the slice.
+    ///
+    /// The returned range is half-open, which means that the end pointer
+    /// points *one past* the last element of the slice. This way, an empty
+    /// slice is represented by two equal pointers, and the difference between
+    /// the two pointers represents the size of the size.
+    ///
+    /// See [`as_mut_ptr`] for warnings on using these pointers. The end
+    /// pointer requires extra caution, as it does not point to a valid element
+    /// in the slice.
+    ///
+    /// This function is useful for interacting with foreign interfaces which
+    /// use two pointers to refer to a range of elements in memory, as is
+    /// common in C++.
+    ///
+    /// [`as_mut_ptr`]: #method.as_mut_ptr
+    #[unstable(feature = "slice_ptr_range", issue = "0")]
+    #[inline]
+    pub fn as_mut_ptr_range(&mut self) -> Range<*mut T> {
+        let start = self.as_mut_ptr();
+        let end = unsafe { start.add(self.len()) };
+        start..end
     }
 
     /// Swaps two elements in the slice.

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -434,7 +434,7 @@ impl<T> [T] {
     /// ```
     ///
     /// [`as_ptr`]: #method.as_ptr
-    #[unstable(feature = "slice_ptr_range", issue = "0")]
+    #[unstable(feature = "slice_ptr_range", issue = "65807")]
     #[inline]
     pub fn as_ptr_range(&self) -> Range<*const T> {
         let start = self.as_ptr();
@@ -458,7 +458,7 @@ impl<T> [T] {
     /// common in C++.
     ///
     /// [`as_mut_ptr`]: #method.as_mut_ptr
-    #[unstable(feature = "slice_ptr_range", issue = "0")]
+    #[unstable(feature = "slice_ptr_range", issue = "65807")]
     #[inline]
     pub fn as_mut_ptr_range(&mut self) -> Range<*mut T> {
         let start = self.as_mut_ptr();

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -37,4 +37,4 @@ byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }
 rustc_fs_util = { path = "../librustc_fs_util" }
 smallvec = { version = "0.6.8", features = ["union", "may_dangle"] }
-measureme = "0.3"
+measureme = "0.4"

--- a/src/librustc/util/profiling.rs
+++ b/src/librustc/util/profiling.rs
@@ -131,32 +131,6 @@ impl SelfProfilerRef {
         })
     }
 
-    /// Start profiling a generic activity. Profiling continues until
-    /// `generic_activity_end` is called. The RAII-based `generic_activity`
-    /// usually is the better alternative.
-    #[inline(always)]
-    pub fn generic_activity_start(&self, event_id: &str) {
-        self.non_guard_generic_event(
-            |profiler| profiler.generic_activity_event_kind,
-            |profiler| profiler.profiler.alloc_string(event_id),
-            EventFilter::GENERIC_ACTIVITIES,
-            TimestampKind::Start,
-        );
-    }
-
-    /// End profiling a generic activity that was started with
-    /// `generic_activity_start`. The RAII-based `generic_activity` usually is
-    /// the better alternative.
-    #[inline(always)]
-    pub fn generic_activity_end(&self, event_id: &str) {
-        self.non_guard_generic_event(
-            |profiler| profiler.generic_activity_event_kind,
-            |profiler| profiler.profiler.alloc_string(event_id),
-            EventFilter::GENERIC_ACTIVITIES,
-            TimestampKind::End,
-        );
-    }
-
     /// Start profiling a query provider. Profiling continues until the
     /// TimingGuard returned from this call is dropped.
     #[inline(always)]
@@ -231,28 +205,6 @@ impl SelfProfilerRef {
             profiler.profiler.record_event(
                 event_kind(profiler),
                 event_id,
-                thread_id,
-                timestamp_kind,
-            );
-
-            TimingGuard::none()
-        }));
-    }
-
-    #[inline(always)]
-    fn non_guard_generic_event<F: FnOnce(&SelfProfiler) -> StringId>(
-        &self,
-        event_kind: fn(&SelfProfiler) -> StringId,
-        event_id: F,
-        event_filter: EventFilter,
-        timestamp_kind: TimestampKind
-    ) {
-        drop(self.exec(event_filter, |profiler| {
-            let thread_id = thread_id_to_u64(std::thread::current().id());
-
-            profiler.profiler.record_event(
-                event_kind(profiler),
-                event_id(profiler),
                 thread_id,
                 timestamp_kind,
             );

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -697,7 +697,7 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
 
             "ptr_offset_from" => {
                 let ty = substs.type_at(0);
-                let pointee_size = self.layout_of(ty).size;
+                let pointee_size = self.size_of(ty);
 
                 // This is the same sequence that Clang emits for pointer subtraction.
                 // It can be neither `nsw` nor `nuw` because the input is treated as

--- a/src/librustc_codegen_llvm/intrinsic.rs
+++ b/src/librustc_codegen_llvm/intrinsic.rs
@@ -19,6 +19,7 @@ use rustc::mir::interpret::GlobalId;
 use rustc_codegen_ssa::common::{IntPredicate, TypeKind};
 use rustc::hir;
 use syntax::ast::{self, FloatTy};
+use rustc_target::abi::HasDataLayout;
 
 use rustc_codegen_ssa::traits::*;
 
@@ -694,6 +695,23 @@ impl IntrinsicCallMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 return;
             }
 
+            "ptr_offset_from" => {
+                let ty = substs.type_at(0);
+                let pointee_size = self.layout_of(ty).size;
+
+                // This is the same sequence that Clang emits for pointer subtraction.
+                // It can be neither `nsw` nor `nuw` because the input is treated as
+                // unsigned but then the output is treated as signed, so neither works.
+                let a = args[0].immediate();
+                let b = args[1].immediate();
+                let a = self.ptrtoint(a, self.type_isize());
+                let b = self.ptrtoint(b, self.type_isize());
+                let d = self.sub(a, b);
+                let pointee_size = self.const_usize(pointee_size.bytes());
+                // this is where the signed magic happens (notice the `s` in `exactsdiv`)
+                self.exactsdiv(d, pointee_size)
+            }
+
             _ => bug!("unknown intrinsic '{}'", name),
         };
 
@@ -1218,7 +1236,6 @@ fn generic_simd_intrinsic(
         // The `fn simd_bitmask(vector) -> unsigned integer` intrinsic takes a
         // vector mask and returns an unsigned integer containing the most
         // significant bit (MSB) of each lane.
-        use rustc_target::abi::HasDataLayout;
 
         // If the vector has less than 8 lanes, an u8 is returned with zeroed
         // trailing bits.

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -249,14 +249,9 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let usize_layout = self.layout_of(self.tcx.types.usize)?;
                 let a_offset = ImmTy::from_uint(a.offset.bytes(), usize_layout);
                 let b_offset = ImmTy::from_uint(b.offset.bytes(), usize_layout);
-                let (val, overflowed, _) = self.overflowing_binary_op(
+                let (val, _overflowed, _) = self.overflowing_binary_op(
                     BinOp::Sub, a_offset, b_offset,
                 )?;
-                if overflowed {
-                    throw_ub_format!(
-                        "second argument to `ptr_offset_from` must be smaller than first",
-                    );
-                }
                 let pointee_layout = self.layout_of(substs.type_at(0))?;
                 let isize_layout = self.layout_of(self.tcx.types.isize)?;
                 let val = ImmTy::from_scalar(val, isize_layout);

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -249,7 +249,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let usize_layout = self.layout_of(self.tcx.types.usize)?;
                 let a_offset = ImmTy::from_uint(a.offset.bytes(), usize_layout);
                 let b_offset = ImmTy::from_uint(b.offset.bytes(), usize_layout);
-                let (val, _overflowed, _) = self.overflowing_binary_op(
+                let (val, _overflowed, _ty) = self.overflowing_binary_op(
                     BinOp::Sub, a_offset, b_offset,
                 )?;
                 let pointee_layout = self.layout_of(substs.type_at(0))?;

--- a/src/librustc_mir/interpret/intrinsics.rs
+++ b/src/librustc_mir/interpret/intrinsics.rs
@@ -12,7 +12,7 @@ use rustc::mir::BinOp;
 use rustc::mir::interpret::{InterpResult, Scalar, GlobalId, ConstValue};
 
 use super::{
-    Machine, PlaceTy, OpTy, InterpCx,
+    Machine, PlaceTy, OpTy, InterpCx, ImmTy,
 };
 
 mod type_name;
@@ -236,6 +236,34 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let result = Scalar::from_uint(truncated_bits, layout.size);
                 self.write_scalar(result, dest)?;
             }
+
+            "ptr_offset_from" => {
+                let a = self.read_immediate(args[0])?.to_scalar()?.to_ptr()?;
+                let b = self.read_immediate(args[1])?.to_scalar()?.to_ptr()?;
+                if a.alloc_id != b.alloc_id {
+                    throw_ub_format!(
+                        "ptr_offset_from cannot compute offset of pointers into different \
+                        allocations.",
+                    );
+                }
+                let usize_layout = self.layout_of(self.tcx.types.usize)?;
+                let a_offset = ImmTy::from_uint(a.offset.bytes(), usize_layout);
+                let b_offset = ImmTy::from_uint(b.offset.bytes(), usize_layout);
+                let (val, overflowed, _) = self.overflowing_binary_op(
+                    BinOp::Sub, a_offset, b_offset,
+                )?;
+                if overflowed {
+                    throw_ub_format!(
+                        "second argument to `ptr_offset_from` must be smaller than first",
+                    );
+                }
+                let pointee_layout = self.layout_of(substs.type_at(0))?;
+                let isize_layout = self.layout_of(self.tcx.types.isize)?;
+                let val = ImmTy::from_scalar(val, isize_layout);
+                let size = ImmTy::from_int(pointee_layout.size.bytes(), isize_layout);
+                self.exact_div(val, size, dest)?;
+            }
+
             "transmute" => {
                 self.copy_op_transmute(args[0], dest)?;
             }
@@ -339,5 +367,31 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         } else {
             return Ok(false);
         }
+    }
+
+    pub fn exact_div(
+        &mut self,
+        a: ImmTy<'tcx, M::PointerTag>,
+        b: ImmTy<'tcx, M::PointerTag>,
+        dest: PlaceTy<'tcx, M::PointerTag>,
+    ) -> InterpResult<'tcx> {
+        // Performs an exact division, resulting in undefined behavior where
+        // `x % y != 0` or `y == 0` or `x == T::min_value() && y == -1`.
+        // First, check x % y != 0.
+        if self.binary_op(BinOp::Rem, a, b)?.to_bits()? != 0 {
+            // Then, check if `b` is -1, which is the "min_value / -1" case.
+            let minus1 = Scalar::from_int(-1, dest.layout.size);
+            let b = b.to_scalar().unwrap();
+            if b == minus1 {
+                throw_ub_format!("exact_div: result of dividing MIN by -1 cannot be represented")
+            } else {
+                throw_ub_format!(
+                    "exact_div: {} cannot be divided by {} without remainder",
+                    a.to_scalar().unwrap(),
+                    b,
+                )
+            }
+        }
+        self.binop_ignore_overflow(BinOp::Div, a, b, dest)
     }
 }

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -560,6 +560,7 @@ impl Qualif for IsNotPromotable {
                             | "transmute"
                             | "simd_insert"
                             | "simd_extract"
+                            | "ptr_offset_from"
                             => return true,
 
                             _ => {}

--- a/src/librustc_typeck/check/intrinsic.rs
+++ b/src/librustc_typeck/check/intrinsic.rs
@@ -307,6 +307,8 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem) {
                 (1, vec![param(0), param(0)],
                 tcx.intern_tup(&[param(0), tcx.types.bool])),
 
+            "ptr_offset_from" =>
+                (1, vec![ tcx.mk_imm_ptr(param(0)), tcx.mk_imm_ptr(param(0)) ], tcx.types.isize),
             "unchecked_div" | "unchecked_rem" | "exact_div" =>
                 (1, vec![param(0), param(0)], param(0)),
             "unchecked_shl" | "unchecked_shr" |

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -124,7 +124,6 @@ sgx_entry:
 
 /*  making sure AC flag is not set in rflags */
 /*  avoid using the 'clac' instruction to be compatible with older compilers */
-    push %rcx
     pushfq
     popq %rcx
     and $0xFFFFFFFFFFFBFFFF, %rcx

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -123,7 +123,9 @@ sgx_entry:
 /*  reset user state */
 /*    - DF flag: x86-64 ABI requires DF to be unset at function entry/exit */
 /*    - AC flag: AEX on misaligned memory accesses leaks side channel info */
+    pushfq
     andq $~0x40400, (%rsp)
+    popfq
 
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -121,6 +121,16 @@ sgx_entry:
     fnstcw %gs:tcsls_user_fcw
 /*  reset user state */
     cld /* x86-64 ABI requires DF to be unset at function entry/exit */
+
+/*  making sure AC flag is not set in rflags */
+/*  avoid using the 'clac' instruction to be compatible with older compilers */
+    push %rcx
+    pushfq
+    popq %rcx
+    and $0xFFFFFFFFFFFBFFFF, %rcx
+    push %rcx
+    popfq
+
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)
     jz .Lskip_debug_init

--- a/src/libstd/sys/sgx/abi/entry.S
+++ b/src/libstd/sys/sgx/abi/entry.S
@@ -119,16 +119,11 @@ sgx_entry:
     mov %rbx,%gs:tcsls_tcs_addr
     stmxcsr %gs:tcsls_user_mxcsr
     fnstcw %gs:tcsls_user_fcw
-/*  reset user state */
-    cld /* x86-64 ABI requires DF to be unset at function entry/exit */
 
-/*  making sure AC flag is not set in rflags */
-/*  avoid using the 'clac' instruction to be compatible with older compilers */
-    pushfq
-    popq %rcx
-    and $0xFFFFFFFFFFFBFFFF, %rcx
-    push %rcx
-    popfq
+/*  reset user state */
+/*    - DF flag: x86-64 ABI requires DF to be unset at function entry/exit */
+/*    - AC flag: AEX on misaligned memory accesses leaks side channel info */
+    andq $~0x40400, (%rsp)
 
 /*  check for debug buffer pointer */
     testb  $0xff,DEBUG(%rip)

--- a/src/test/ui/consts/offset_from.rs
+++ b/src/test/ui/consts/offset_from.rs
@@ -33,7 +33,15 @@ pub const OFFSET_2: usize = {
     offset as usize
 };
 
+pub const OVERFLOW: isize = {
+    let uninit = std::mem::MaybeUninit::<Struct2>::uninit();
+    let base_ptr: *const Struct2 = &uninit as *const _ as *const Struct2;
+    let field_ptr = unsafe { &(*base_ptr).field as *const u8 };
+    unsafe { (base_ptr as *const u8).offset_from(field_ptr) }
+};
+
 fn main() {
     assert_eq!(OFFSET, 0);
     assert_eq!(OFFSET_2, 1);
+    assert_eq!(OVERFLOW, -1);
 }

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -1,3 +1,6 @@
+// ingoring on musl because it's ui output hides libcore backtraces
+// ignore-musl
+
 #![feature(const_raw_ptr_deref)]
 #![feature(const_ptr_offset_from)]
 #![feature(ptr_offset_from)]

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -32,13 +32,4 @@ pub const NOT_MULTIPLE_OF_SIZE: usize = {
     offset as usize
 };
 
-pub const OVERFLOW: usize = {
-    //~^ NOTE
-    let uninit = std::mem::MaybeUninit::<Struct>::uninit();
-    let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
-    let field_ptr = unsafe { &(*base_ptr).field as *const u8 };
-    let offset = unsafe { (base_ptr as *const u8).offset_from(field_ptr) };
-    offset as usize
-};
-
 fn main() {}

--- a/src/test/ui/consts/offset_from_ub.rs
+++ b/src/test/ui/consts/offset_from_ub.rs
@@ -1,0 +1,44 @@
+#![feature(const_raw_ptr_deref)]
+#![feature(const_ptr_offset_from)]
+#![feature(ptr_offset_from)]
+
+#[repr(C)]
+struct Struct {
+    data: u8,
+    field: u8,
+}
+
+pub const DIFFERENT_ALLOC: usize = {
+    //~^ NOTE
+    let uninit = std::mem::MaybeUninit::<Struct>::uninit();
+    let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
+    let uninit2 = std::mem::MaybeUninit::<Struct>::uninit();
+    let field_ptr: *const Struct = &uninit2 as *const _ as *const Struct;
+    let offset = unsafe { field_ptr.offset_from(base_ptr) };
+    offset as usize
+};
+
+pub const NOT_PTR: usize = {
+    //~^ NOTE
+    unsafe { (42 as *const u8).offset_from(&5u8) as usize }
+};
+
+pub const NOT_MULTIPLE_OF_SIZE: usize = {
+    //~^ NOTE
+    let data = [5u8, 6, 7];
+    let base_ptr = data.as_ptr();
+    let field_ptr = &data[1] as *const u8 as *const u16;
+    let offset = unsafe { field_ptr.offset_from(base_ptr as *const u16) };
+    offset as usize
+};
+
+pub const OVERFLOW: usize = {
+    //~^ NOTE
+    let uninit = std::mem::MaybeUninit::<Struct>::uninit();
+    let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
+    let field_ptr = unsafe { &(*base_ptr).field as *const u8 };
+    let offset = unsafe { (base_ptr as *const u8).offset_from(field_ptr) };
+    offset as usize
+};
+
+fn main() {}

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -57,25 +57,5 @@ LL | |     offset as usize
 LL | | };
    | |__-
 
-error: any use of this value will cause an error
-  --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
-   |
-LL |           intrinsics::ptr_offset_from(self, origin)
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |           |
-   |           second argument to `ptr_offset_from` must be smaller than first
-   |           inside call to `std::ptr::<impl *const u8>::offset_from` at $DIR/offset_from_ub.rs:40:27
-   | 
-  ::: $DIR/offset_from_ub.rs:35:1
-   |
-LL | / pub const OVERFLOW: usize = {
-LL | |
-LL | |     let uninit = std::mem::MaybeUninit::<Struct>::uninit();
-LL | |     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
-...  |
-LL | |     offset as usize
-LL | | };
-   | |__-
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -5,9 +5,9 @@ LL |           intrinsics::ptr_offset_from(self, origin)
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |           |
    |           ptr_offset_from cannot compute offset of pointers into different allocations.
-   |           inside call to `std::ptr::<impl *const Struct>::offset_from` at $DIR/offset_from_ub.rs:17:27
+   |           inside call to `std::ptr::<impl *const Struct>::offset_from` at $DIR/offset_from_ub.rs:20:27
    | 
-  ::: $DIR/offset_from_ub.rs:11:1
+  ::: $DIR/offset_from_ub.rs:14:1
    |
 LL | / pub const DIFFERENT_ALLOC: usize = {
 LL | |
@@ -27,9 +27,9 @@ LL |           intrinsics::ptr_offset_from(self, origin)
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |           |
    |           a memory access tried to interpret some bytes as a pointer
-   |           inside call to `std::ptr::<impl *const u8>::offset_from` at $DIR/offset_from_ub.rs:23:14
+   |           inside call to `std::ptr::<impl *const u8>::offset_from` at $DIR/offset_from_ub.rs:26:14
    | 
-  ::: $DIR/offset_from_ub.rs:21:1
+  ::: $DIR/offset_from_ub.rs:24:1
    |
 LL | / pub const NOT_PTR: usize = {
 LL | |
@@ -44,9 +44,9 @@ LL |           intrinsics::ptr_offset_from(self, origin)
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |           |
    |           exact_div: 1 cannot be divided by 2 without remainder
-   |           inside call to `std::ptr::<impl *const u16>::offset_from` at $DIR/offset_from_ub.rs:31:27
+   |           inside call to `std::ptr::<impl *const u16>::offset_from` at $DIR/offset_from_ub.rs:34:27
    | 
-  ::: $DIR/offset_from_ub.rs:26:1
+  ::: $DIR/offset_from_ub.rs:29:1
    |
 LL | / pub const NOT_MULTIPLE_OF_SIZE: usize = {
 LL | |

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -1,0 +1,81 @@
+error: any use of this value will cause an error
+  --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+   |
+LL |           intrinsics::ptr_offset_from(self, origin)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           ptr_offset_from cannot compute offset of pointers into different allocations.
+   |           inside call to `std::ptr::<impl *const Struct>::offset_from` at $DIR/offset_from_ub.rs:17:27
+   | 
+  ::: $DIR/offset_from_ub.rs:11:1
+   |
+LL | / pub const DIFFERENT_ALLOC: usize = {
+LL | |
+LL | |     let uninit = std::mem::MaybeUninit::<Struct>::uninit();
+LL | |     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
+...  |
+LL | |     offset as usize
+LL | | };
+   | |__-
+   |
+   = note: `#[deny(const_err)]` on by default
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+   |
+LL |           intrinsics::ptr_offset_from(self, origin)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           a memory access tried to interpret some bytes as a pointer
+   |           inside call to `std::ptr::<impl *const u8>::offset_from` at $DIR/offset_from_ub.rs:23:14
+   | 
+  ::: $DIR/offset_from_ub.rs:21:1
+   |
+LL | / pub const NOT_PTR: usize = {
+LL | |
+LL | |     unsafe { (42 as *const u8).offset_from(&5u8) as usize }
+LL | | };
+   | |__-
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+   |
+LL |           intrinsics::ptr_offset_from(self, origin)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           exact_div: 1 cannot be divided by 2 without remainder
+   |           inside call to `std::ptr::<impl *const u16>::offset_from` at $DIR/offset_from_ub.rs:31:27
+   | 
+  ::: $DIR/offset_from_ub.rs:26:1
+   |
+LL | / pub const NOT_MULTIPLE_OF_SIZE: usize = {
+LL | |
+LL | |     let data = [5u8, 6, 7];
+LL | |     let base_ptr = data.as_ptr();
+...  |
+LL | |     offset as usize
+LL | | };
+   | |__-
+
+error: any use of this value will cause an error
+  --> $SRC_DIR/libcore/ptr/mod.rs:LL:COL
+   |
+LL |           intrinsics::ptr_offset_from(self, origin)
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           second argument to `ptr_offset_from` must be smaller than first
+   |           inside call to `std::ptr::<impl *const u8>::offset_from` at $DIR/offset_from_ub.rs:40:27
+   | 
+  ::: $DIR/offset_from_ub.rs:35:1
+   |
+LL | / pub const OVERFLOW: usize = {
+LL | |
+LL | |     let uninit = std::mem::MaybeUninit::<Struct>::uninit();
+LL | |     let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
+...  |
+LL | |     offset as usize
+LL | | };
+   | |__-
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/consts/offset_of.rs
+++ b/src/test/ui/consts/offset_of.rs
@@ -1,0 +1,39 @@
+// run-pass
+
+#![feature(const_raw_ptr_deref)]
+#![feature(const_ptr_offset_from)]
+#![feature(ptr_offset_from)]
+
+struct Struct {
+    field: (),
+}
+
+#[repr(C)]
+struct Struct2 {
+    data: u8,
+    field: u8,
+}
+
+pub const OFFSET: usize = {
+    let uninit = std::mem::MaybeUninit::<Struct>::uninit();
+    let base_ptr: *const Struct = &uninit as *const _ as *const Struct;
+    // The following statement is UB (taking the address of an uninitialized field).
+    // Const eval doesn't detect this right now, but it may stop compiling at some point
+    // in the future.
+    let field_ptr = unsafe { &(*base_ptr).field as *const () as *const u8 };
+    let offset = unsafe { field_ptr.offset_from(base_ptr as *const u8) };
+    offset as usize
+};
+
+pub const OFFSET_2: usize = {
+    let uninit = std::mem::MaybeUninit::<Struct2>::uninit();
+    let base_ptr: *const Struct2 = &uninit as *const _ as *const Struct2;
+    let field_ptr = unsafe { &(*base_ptr).field as *const u8 };
+    let offset = unsafe { field_ptr.offset_from(base_ptr as *const u8) };
+    offset as usize
+};
+
+fn main() {
+    assert_eq!(OFFSET, 0);
+    assert_eq!(OFFSET_2, 1);
+}

--- a/src/test/ui/offset_from.rs
+++ b/src/test/ui/offset_from.rs
@@ -1,0 +1,15 @@
+// run-pass
+
+#![feature(ptr_offset_from)]
+
+fn main() {
+    let mut a = [0; 5];
+    let ptr1: *mut i32 = &mut a[1];
+    let ptr2: *mut i32 = &mut a[3];
+    unsafe {
+        assert_eq!(ptr2.offset_from(ptr1), 2);
+        assert_eq!(ptr1.offset_from(ptr2), -2);
+        assert_eq!(ptr1.offset(2), ptr2);
+        assert_eq!(ptr2.offset(-2), ptr1);
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #63810 (Make <*const/mut T>::offset_from `const fn`)
 - #65799 (Fill tracking issue number for `array_value_iter`)
 - #65800 (self-profiling: Update measureme to 0.4.0 and remove non-RAII methods from profiler.)
 - #65806 (Add [T]::as_ptr_range() and [T]::as_mut_ptr_range().)
 - #65810 (SGX: Clear additional flag on enclave entry)

Failed merges:


r? @ghost