### PR TITLE
rustc: use IndexVec<DefIndex, T> instead of Vec<T>.

### DIFF
--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -149,7 +149,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         let mut collector = NodeCollector {
             krate,
             source_map: sess.source_map(),
-            map: vec![None; definitions.def_index_count()],
+            map: IndexVec::from_elem_n(IndexVec::new(), definitions.def_index_count()),
             parent_node: hir::CRATE_HIR_ID,
             current_signature_dep_index: root_mod_sig_dep_index,
             current_full_dep_index: root_mod_full_dep_index,
@@ -227,12 +227,8 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
 
     fn insert_entry(&mut self, id: HirId, entry: Entry<'hir>) {
         debug!("hir_map: {:?} => {:?}", id, entry);
-        let local_map = &mut self.map[id.owner.index()];
+        let local_map = &mut self.map[id.owner];
         let i = id.local_id.as_u32() as usize;
-        if local_map.is_none() {
-            *local_map = Some(IndexVec::with_capacity(i + 1));
-        }
-        let local_map = local_map.as_mut().unwrap();
         let len = local_map.len();
         if i >= len {
             local_map.extend(repeat(None).take(i - len + 1));

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -27,8 +27,8 @@ use syntax_pos::{Span, DUMMY_SP};
 /// There is one `DefPathTable` for each crate.
 #[derive(Clone, Default, RustcDecodable, RustcEncodable)]
 pub struct DefPathTable {
-    index_to_key: Vec<DefKey>,
-    def_path_hashes: Vec<DefPathHash>,
+    index_to_key: IndexVec<DefIndex, DefKey>,
+    def_path_hashes: IndexVec<DefIndex, DefPathHash>,
 }
 
 impl DefPathTable {
@@ -53,14 +53,14 @@ impl DefPathTable {
 
     #[inline(always)]
     pub fn def_key(&self, index: DefIndex) -> DefKey {
-        self.index_to_key[index.index()]
+        self.index_to_key[index]
     }
 
     #[inline(always)]
     pub fn def_path_hash(&self, index: DefIndex) -> DefPathHash {
-        let ret = self.def_path_hashes[index.index()];
-        debug!("def_path_hash({:?}) = {:?}", index, ret);
-        return ret
+        let hash = self.def_path_hashes[index];
+        debug!("def_path_hash({:?}) = {:?}", index, hash);
+        hash
     }
 
     pub fn add_def_path_hashes_to(&self,
@@ -92,7 +92,7 @@ impl DefPathTable {
 pub struct Definitions {
     table: DefPathTable,
     node_to_def_index: NodeMap<DefIndex>,
-    def_index_to_node: Vec<ast::NodeId>,
+    def_index_to_node: IndexVec<DefIndex, ast::NodeId>,
     pub(super) node_to_hir_id: IndexVec<ast::NodeId, hir::HirId>,
     /// If `ExpnId` is an ID of some macro expansion,
     /// then `DefId` is the normal module (`mod`) in which the expanded macro was defined.
@@ -375,7 +375,7 @@ impl Definitions {
     #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<ast::NodeId> {
         if def_id.krate == LOCAL_CRATE {
-            let node_id = self.def_index_to_node[def_id.index.index()];
+            let node_id = self.def_index_to_node[def_id.index];
             if node_id != ast::DUMMY_NODE_ID {
                 return Some(node_id);
             }
@@ -404,7 +404,7 @@ impl Definitions {
 
     #[inline]
     pub fn def_index_to_hir_id(&self, def_index: DefIndex) -> hir::HirId {
-        let node_id = self.def_index_to_node[def_index.index()];
+        let node_id = self.def_index_to_node[def_index];
         self.node_to_hir_id[node_id]
     }
 


### PR DESCRIPTION
Now that `DefIndex` is a proper index type, we can do that.
There was also an unnecessary `Option` I removed, I wonder if that has perf implications.