### PR TITLE
Derive Eq and Hash for SourceInfo again

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -467,7 +467,9 @@ impl<T: Decodable> rustc_serialize::UseSpecializedDecodable for ClearCrossCrate<
 /// Grouped information about the source code origin of a MIR entity.
 /// Intended to be inspected by diagnostics and debuginfo.
 /// Most passes can work with it as a whole, within a single function.
-#[derive(Copy, Clone, Debug, PartialEq, RustcEncodable, RustcDecodable, HashStable)]
+// The unoffical Cranelift backend, at least as of #65828, needs `SourceInfo` to implement `Eq` and
+// `Hash`. Please ping @bjorn3 if removing them.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, RustcEncodable, RustcDecodable, Hash, HashStable)]
 pub struct SourceInfo {
     /// The source span for the AST pertaining to this MIR entity.
     pub span: Span,


### PR DESCRIPTION
In https://github.com/bjorn3/rustc_codegen_cranelift/blob/75c24b9c9677600422ec86fa9f4c78fe3678d2ce/src/common.rs#L368 I store it in a `indexmap::IndexSet`, which requires `Eq` and `Hash`. Unfortunately they were removed in https://github.com/rust-lang/rust/pull/65647, so I can't update to latest nightly.