### PR TITLE
Remove lint callback from driver

### DIFF
--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -106,8 +106,6 @@ pub fn abort_on_err<T>(result: Result<T, ErrorReported>, sess: &Session) -> T {
 pub trait Callbacks {
     /// Called before creating the compiler instance
     fn config(&mut self, _config: &mut interface::Config) {}
-    /// Called early during compilation to allow other drivers to easily register lints.
-    fn extra_lints(&mut self, _ls: &mut lint::LintStore) {}
     /// Called after parsing. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     fn after_parsing(&mut self, _compiler: &interface::Compiler) -> Compilation {


### PR DESCRIPTION
This is leftover from a restructuring of lint registration for drivers; it should now happen via the register_lints field on Config rather than this function.

This is not used by anyone to my knowledge (including the compiler itself); it was introduced in an abandoned refactor in #65193.