### PR TITLE
Remove LintBuffer from Session

### DIFF
--- a/src/librustc/lint/levels.rs
+++ b/src/librustc/lint/levels.rs
@@ -44,8 +44,12 @@ impl LintLevelSets {
         return me
     }
 
-    pub fn builder<'a>(sess: &'a Session, store: &LintStore) -> LintLevelsBuilder<'a> {
-        LintLevelsBuilder::new(sess, LintLevelSets::new(sess, store))
+    pub fn builder<'a>(
+        sess: &'a Session,
+        warn_about_weird_lints: bool,
+        store: &LintStore,
+    ) -> LintLevelsBuilder<'a> {
+        LintLevelsBuilder::new(sess, warn_about_weird_lints, LintLevelSets::new(sess, store))
     }
 
     fn process_command_line(&mut self, sess: &Session, store: &LintStore) {
@@ -160,14 +164,18 @@ pub struct BuilderPush {
 }
 
 impl<'a> LintLevelsBuilder<'a> {
-    pub fn new(sess: &'a Session, sets: LintLevelSets) -> LintLevelsBuilder<'a> {
+    pub fn new(
+        sess: &'a Session,
+        warn_about_weird_lints: bool,
+        sets: LintLevelSets,
+    ) -> LintLevelsBuilder<'a> {
         assert_eq!(sets.list.len(), 1);
         LintLevelsBuilder {
             sess,
             sets,
             cur: 0,
             id_to_set: Default::default(),
-            warn_about_weird_lints: sess.buffered_lints.borrow().is_some(),
+            warn_about_weird_lints,
         }
     }
 

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -646,6 +646,27 @@ impl LintBuffer {
     fn take(&mut self, id: ast::NodeId) -> Vec<BufferedEarlyLint> {
         self.map.remove(&id).unwrap_or_default()
     }
+
+    pub fn buffer_lint<S: Into<MultiSpan>>(
+        &mut self,
+        lint: &'static Lint,
+        id: ast::NodeId,
+        sp: S,
+        msg: &str,
+    ) {
+        self.add_lint(lint, id, sp.into(), msg, BuiltinLintDiagnostics::Normal)
+    }
+
+    pub fn buffer_lint_with_diagnostic<S: Into<MultiSpan>>(
+        &mut self,
+        lint: &'static Lint,
+        id: ast::NodeId,
+        sp: S,
+        msg: &str,
+        diagnostic: BuiltinLintDiagnostics,
+    ) {
+        self.add_lint(lint, id, sp.into(), msg, diagnostic)
+    }
 }
 
 pub fn struct_lint_level<'a>(sess: &'a Session,

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -646,11 +646,6 @@ impl LintBuffer {
     pub fn take(&mut self, id: ast::NodeId) -> Vec<BufferedEarlyLint> {
         self.map.remove(&id).unwrap_or_default()
     }
-
-    pub fn get_any(&self) -> Option<&[BufferedEarlyLint]> {
-        let key = self.map.keys().next().map(|k| *k);
-        key.map(|k| &self.map[&k][..])
-    }
 }
 
 pub fn struct_lint_level<'a>(sess: &'a Session,

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -643,7 +643,7 @@ impl LintBuffer {
         }
     }
 
-    pub fn take(&mut self, id: ast::NodeId) -> Vec<BufferedEarlyLint> {
+    fn take(&mut self, id: ast::NodeId) -> Vec<BufferedEarlyLint> {
         self.map.remove(&id).unwrap_or_default()
     }
 }

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -795,7 +795,7 @@ fn lint_levels(tcx: TyCtxt<'_>, cnum: CrateNum) -> &LintLevelMap {
     assert_eq!(cnum, LOCAL_CRATE);
     let store = &tcx.lint_store;
     let mut builder = LintLevelMapBuilder {
-        levels: LintLevelSets::builder(tcx.sess, &store),
+        levels: LintLevelSets::builder(tcx.sess, false, &store),
         tcx: tcx,
         store: store,
     };

--- a/src/librustc/middle/stability.rs
+++ b/src/librustc/middle/stability.rs
@@ -586,7 +586,7 @@ pub fn rustc_deprecation_message(depr: &RustcDeprecation, path: &str) -> (String
 }
 
 pub fn early_report_deprecation(
-    sess: &Session,
+    lint_buffer: &'a mut lint::LintBuffer,
     message: &str,
     suggestion: Option<Symbol>,
     lint: &'static Lint,
@@ -597,7 +597,7 @@ pub fn early_report_deprecation(
     }
 
     let diag = BuiltinLintDiagnostics::DeprecatedMacro(suggestion, span);
-    sess.buffer_lint_with_diagnostic(lint, CRATE_NODE_ID, span, message, diag);
+    lint_buffer.buffer_lint_with_diagnostic(lint, CRATE_NODE_ID, span, message, diag);
 }
 
 fn late_report_deprecation(

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -1469,7 +1469,7 @@ options! {DebuggingOptions, DebuggingSetter, basic_debugging_options,
          (such as entering an empty infinite loop) by inserting llvm.sideeffect"),
 }
 
-pub fn default_lib_output() -> CrateType {
+pub const fn default_lib_output() -> CrateType {
     CrateType::Rlib
 }
 

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -366,7 +366,7 @@ impl Session {
         self.diagnostic().span_note_without_error(sp, msg)
     }
 
-    pub fn buffer_lint<S: Into<MultiSpan>>(
+    pub fn buffer_lint_late<S: Into<MultiSpan>>(
         &self,
         lint: &'static lint::Lint,
         id: ast::NodeId,
@@ -375,13 +375,13 @@ impl Session {
     ) {
         match *self.buffered_lints.borrow_mut() {
             Some(ref mut buffer) => {
-                buffer.add_lint(lint, id, sp.into(), msg, BuiltinLintDiagnostics::Normal)
+                buffer.buffer_lint(lint, id, sp, msg);
             }
             None => bug!("can't buffer lints after HIR lowering"),
         }
     }
 
-    pub fn buffer_lint_with_diagnostic<S: Into<MultiSpan>>(
+    pub fn buffer_lint_with_diagnostic_late<S: Into<MultiSpan>>(
         &self,
         lint: &'static lint::Lint,
         id: ast::NodeId,
@@ -390,7 +390,9 @@ impl Session {
         diagnostic: BuiltinLintDiagnostics,
     ) {
         match *self.buffered_lints.borrow_mut() {
-            Some(ref mut buffer) => buffer.add_lint(lint, id, sp.into(), msg, diagnostic),
+            Some(ref mut buffer) => buffer.buffer_lint_with_diagnostic(
+                lint, id, sp.into(), msg, diagnostic,
+            ),
             None => bug!("can't buffer lints after HIR lowering"),
         }
     }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -6,7 +6,6 @@ use crate::hir::def_id::CrateNum;
 use rustc_data_structures::fingerprint::Fingerprint;
 
 use crate::lint;
-use crate::lint::builtin::BuiltinLintDiagnostics;
 use crate::session::config::{OutputType, PrintRequest, Sanitizer, SwitchWithOptPath};
 use crate::session::search_paths::{PathKind, SearchPath};
 use crate::util::nodemap::{FxHashMap, FxHashSet};
@@ -76,13 +75,6 @@ pub struct Session {
     /// The directory the compiler has been executed in plus a flag indicating
     /// if the value stored here has been affected by path remapping.
     pub working_dir: (PathBuf, bool),
-
-    /// This is intended to be used from a single thread.
-    ///
-    /// FIXME: there was a previous comment about this not being thread safe,
-    /// but it's not clear how or why that's the case. The LintBuffer itself is certainly thread
-    /// safe at least from a "Rust safety" standpoint.
-    pub buffered_lints: Lock<Option<lint::LintBuffer>>,
 
     /// Set of `(DiagnosticId, Option<Span>, message)` tuples tracking
     /// (sub)diagnostics that have been set once, but should not be set again,
@@ -364,37 +356,6 @@ impl Session {
     }
     pub fn span_note_without_error<S: Into<MultiSpan>>(&self, sp: S, msg: &str) {
         self.diagnostic().span_note_without_error(sp, msg)
-    }
-
-    pub fn buffer_lint_late<S: Into<MultiSpan>>(
-        &self,
-        lint: &'static lint::Lint,
-        id: ast::NodeId,
-        sp: S,
-        msg: &str,
-    ) {
-        match *self.buffered_lints.borrow_mut() {
-            Some(ref mut buffer) => {
-                buffer.buffer_lint(lint, id, sp, msg);
-            }
-            None => bug!("can't buffer lints after HIR lowering"),
-        }
-    }
-
-    pub fn buffer_lint_with_diagnostic_late<S: Into<MultiSpan>>(
-        &self,
-        lint: &'static lint::Lint,
-        id: ast::NodeId,
-        sp: S,
-        msg: &str,
-        diagnostic: BuiltinLintDiagnostics,
-    ) {
-        match *self.buffered_lints.borrow_mut() {
-            Some(ref mut buffer) => buffer.buffer_lint_with_diagnostic(
-                lint, id, sp.into(), msg, diagnostic,
-            ),
-            None => bug!("can't buffer lints after HIR lowering"),
-        }
     }
 
     pub fn reserve_node_ids(&self, count: usize) -> ast::NodeId {
@@ -1220,7 +1181,6 @@ fn build_session_(
         sysroot,
         local_crate_source_file,
         working_dir,
-        buffered_lints: Lock::new(Some(Default::default())),
         one_time_diagnostics: Default::default(),
         plugin_llvm_passes: OneThread::new(RefCell::new(Vec::new())),
         plugin_attributes: Lock::new(Vec::new()),

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -270,12 +270,14 @@ fn configure_and_expand_inner<'a>(
             rustc_lint::BuiltinCombinedPreExpansionLintPass::new());
     });
 
+    let lint_buffer = lint::LintBuffer::default();
     let mut resolver = Resolver::new(
         sess,
         &krate,
         crate_name,
         metadata_loader,
         &resolver_arenas,
+        lint_buffer,
     );
     syntax_ext::register_builtin_macros(&mut resolver, sess.edition());
 
@@ -366,7 +368,7 @@ fn configure_and_expand_inner<'a>(
         for span in missing_fragment_specifiers {
             let lint = lint::builtin::MISSING_FRAGMENT_SPECIFIER;
             let msg = "missing fragment specifier";
-            sess.buffer_lint(lint, ast::CRATE_NODE_ID, span, msg);
+            resolver.lint_buffer.buffer_lint(lint, ast::CRATE_NODE_ID, span, msg);
         }
         if cfg!(windows) {
             env::set_var("PATH", &old_path);
@@ -395,7 +397,7 @@ fn configure_and_expand_inner<'a>(
     }
 
     let has_proc_macro_decls = time(sess, "AST validation", || {
-        ast_validation::check_crate(sess, &krate)
+        ast_validation::check_crate(sess, &krate, &mut resolver.lint_buffer)
     });
 
 
@@ -464,7 +466,7 @@ fn configure_and_expand_inner<'a>(
         info!("{} parse sess buffered_lints", buffered_lints.len());
         for BufferedEarlyLint{id, span, msg, lint_id} in buffered_lints.drain(..) {
             let lint = lint::Lint::from_parser_lint_id(lint_id);
-            sess.buffer_lint(lint, id, span, &msg);
+            resolver.lint_buffer.buffer_lint(lint, id, span, &msg);
         }
     });
 

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -267,17 +267,16 @@ fn configure_and_expand_inner<'a>(
             lint_store,
             &krate,
             true,
+            None,
             rustc_lint::BuiltinCombinedPreExpansionLintPass::new());
     });
 
-    let lint_buffer = lint::LintBuffer::default();
     let mut resolver = Resolver::new(
         sess,
         &krate,
         crate_name,
         metadata_loader,
         &resolver_arenas,
-        lint_buffer,
     );
     syntax_ext::register_builtin_macros(&mut resolver, sess.edition());
 
@@ -295,7 +294,7 @@ fn configure_and_expand_inner<'a>(
         krate
     });
 
-    util::check_attr_crate_type(&krate.attrs, &mut resolver.lint_buffer);
+    util::check_attr_crate_type(&krate.attrs, &mut resolver.lint_buffer());
 
     syntax_ext::plugin_macro_defs::inject(
         &mut krate, &mut resolver, plugin_info.syntax_exts, sess.edition()
@@ -370,7 +369,7 @@ fn configure_and_expand_inner<'a>(
         for span in missing_fragment_specifiers {
             let lint = lint::builtin::MISSING_FRAGMENT_SPECIFIER;
             let msg = "missing fragment specifier";
-            resolver.lint_buffer.buffer_lint(lint, ast::CRATE_NODE_ID, span, msg);
+            resolver.lint_buffer().buffer_lint(lint, ast::CRATE_NODE_ID, span, msg);
         }
         if cfg!(windows) {
             env::set_var("PATH", &old_path);
@@ -399,7 +398,7 @@ fn configure_and_expand_inner<'a>(
     }
 
     let has_proc_macro_decls = time(sess, "AST validation", || {
-        ast_validation::check_crate(sess, &krate, &mut resolver.lint_buffer)
+        ast_validation::check_crate(sess, &krate, &mut resolver.lint_buffer())
     });
 
 
@@ -468,7 +467,7 @@ fn configure_and_expand_inner<'a>(
         info!("{} parse sess buffered_lints", buffered_lints.len());
         for BufferedEarlyLint{id, span, msg, lint_id} in buffered_lints.drain(..) {
             let lint = lint::Lint::from_parser_lint_id(lint_id);
-            resolver.lint_buffer.buffer_lint(lint, id, span, &msg);
+            resolver.lint_buffer().buffer_lint(lint, id, span, &msg);
         }
     });
 
@@ -500,6 +499,7 @@ pub fn lower_to_hir(
             lint_store,
             &krate,
             false,
+            Some(std::mem::take(resolver.lint_buffer())),
             rustc_lint::BuiltinCombinedEarlyLintPass::new(),
         )
     });

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -295,6 +295,8 @@ fn configure_and_expand_inner<'a>(
         krate
     });
 
+    util::check_attr_crate_type(&krate.attrs, &mut resolver.lint_buffer);
+
     syntax_ext::plugin_macro_defs::inject(
         &mut krate, &mut resolver, plugin_info.syntax_exts, sess.edition()
     );

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -526,6 +526,63 @@ pub(crate) fn compute_crate_disambiguator(session: &Session) -> CrateDisambiguat
     CrateDisambiguator::from(hasher.finish::<Fingerprint>())
 }
 
+pub(crate) fn check_attr_crate_type(attrs: &[ast::Attribute], lint_buffer: &mut lint::LintBuffer) {
+    // Unconditionally collect crate types from attributes to make them used
+    for a in attrs.iter() {
+        if a.check_name(sym::crate_type) {
+            if let Some(n) = a.value_str() {
+                if let Some(_) = categorize_crate_type(n) {
+                    return;
+                }
+
+                if let ast::MetaItemKind::NameValue(spanned) = a.meta().unwrap().kind {
+                    let span = spanned.span;
+                    let lev_candidate = find_best_match_for_name(
+                        CRATE_TYPES.iter().map(|(k, _)| k),
+                        &n.as_str(),
+                        None
+                    );
+                    if let Some(candidate) = lev_candidate {
+                        lint_buffer.buffer_lint_with_diagnostic(
+                            lint::builtin::UNKNOWN_CRATE_TYPES,
+                            ast::CRATE_NODE_ID,
+                            span,
+                            "invalid `crate_type` value",
+                            lint::builtin::BuiltinLintDiagnostics::
+                                UnknownCrateTypes(
+                                    span,
+                                    "did you mean".to_string(),
+                                    format!("\"{}\"", candidate)
+                                )
+                        );
+                    } else {
+                        lint_buffer.buffer_lint(
+                            lint::builtin::UNKNOWN_CRATE_TYPES,
+                            ast::CRATE_NODE_ID,
+                            span,
+                            "invalid `crate_type` value"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+const CRATE_TYPES: &[(Symbol, config::CrateType)] = &[
+    (sym::rlib, config::CrateType::Rlib),
+    (sym::dylib, config::CrateType::Dylib),
+    (sym::cdylib, config::CrateType::Cdylib),
+    (sym::lib, config::default_lib_output()),
+    (sym::staticlib, config::CrateType::Staticlib),
+    (sym::proc_dash_macro, config::CrateType::ProcMacro),
+    (sym::bin, config::CrateType::Executable),
+];
+
+fn categorize_crate_type(s: Symbol) -> Option<config::CrateType> {
+    Some(CRATE_TYPES.iter().find(|(key, _)| *key == s)?.1)
+}
+
 pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<config::CrateType> {
     // Unconditionally collect crate types from attributes to make them used
     let attr_types: Vec<config::CrateType> = attrs
@@ -533,56 +590,8 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
         .filter_map(|a| {
             if a.check_name(sym::crate_type) {
                 match a.value_str() {
-                    Some(sym::rlib) => Some(config::CrateType::Rlib),
-                    Some(sym::dylib) => Some(config::CrateType::Dylib),
-                    Some(sym::cdylib) => Some(config::CrateType::Cdylib),
-                    Some(sym::lib) => Some(config::default_lib_output()),
-                    Some(sym::staticlib) => Some(config::CrateType::Staticlib),
-                    Some(sym::proc_dash_macro) => Some(config::CrateType::ProcMacro),
-                    Some(sym::bin) => Some(config::CrateType::Executable),
-                    Some(n) => {
-                        let crate_types = vec![
-                            sym::rlib,
-                            sym::dylib,
-                            sym::cdylib,
-                            sym::lib,
-                            sym::staticlib,
-                            sym::proc_dash_macro,
-                            sym::bin
-                        ];
-
-                        if let ast::MetaItemKind::NameValue(spanned) = a.meta().unwrap().kind {
-                            let span = spanned.span;
-                            let lev_candidate = find_best_match_for_name(
-                                crate_types.iter(),
-                                &n.as_str(),
-                                None
-                            );
-                            if let Some(candidate) = lev_candidate {
-                                session.buffer_lint_with_diagnostic_late(
-                                    lint::builtin::UNKNOWN_CRATE_TYPES,
-                                    ast::CRATE_NODE_ID,
-                                    span,
-                                    "invalid `crate_type` value",
-                                    lint::builtin::BuiltinLintDiagnostics::
-                                        UnknownCrateTypes(
-                                            span,
-                                            "did you mean".to_string(),
-                                            format!("\"{}\"", candidate)
-                                        )
-                                );
-                            } else {
-                                session.buffer_lint_late(
-                                    lint::builtin::UNKNOWN_CRATE_TYPES,
-                                    ast::CRATE_NODE_ID,
-                                    span,
-                                    "invalid `crate_type` value"
-                                );
-                            }
-                        }
-                        None
-                    }
-                    None => None
+                    Some(s) => categorize_crate_type(s),
+                    _ => None,
                 }
             } else {
                 None

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -559,7 +559,7 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
                                 None
                             );
                             if let Some(candidate) = lev_candidate {
-                                session.buffer_lint_with_diagnostic(
+                                session.buffer_lint_with_diagnostic_late(
                                     lint::builtin::UNKNOWN_CRATE_TYPES,
                                     ast::CRATE_NODE_ID,
                                     span,
@@ -572,7 +572,7 @@ pub fn collect_crate_types(session: &Session, attrs: &[ast::Attribute]) -> Vec<c
                                         )
                                 );
                             } else {
-                                session.buffer_lint(
+                                session.buffer_lint_late(
                                     lint::builtin::UNKNOWN_CRATE_TYPES,
                                     ast::CRATE_NODE_ID,
                                     span,

--- a/src/librustc_resolve/check_unused.rs
+++ b/src/librustc_resolve/check_unused.rs
@@ -232,7 +232,7 @@ impl Resolver<'_> {
                     directive.span.is_dummy() => {
                     if let ImportDirectiveSubclass::MacroUse = directive.subclass {
                         if !directive.span.is_dummy() {
-                            self.session.buffer_lint(
+                            self.lint_buffer.buffer_lint(
                                 lint::builtin::MACRO_USE_EXTERN_CRATE,
                                 directive.id,
                                 directive.span,
@@ -250,7 +250,7 @@ impl Resolver<'_> {
                 ImportDirectiveSubclass::MacroUse => {
                     let lint = lint::builtin::UNUSED_IMPORTS;
                     let msg = "unused `#[macro_use]` import";
-                    self.session.buffer_lint(lint, directive.id, directive.span, msg);
+                    self.lint_buffer.buffer_lint(lint, directive.id, directive.span, msg);
                 }
                 _ => {}
             }
@@ -312,7 +312,7 @@ impl Resolver<'_> {
                 "remove the unused import"
             };
 
-            visitor.r.session.buffer_lint_with_diagnostic(
+            visitor.r.lint_buffer.buffer_lint_with_diagnostic(
                 lint::builtin::UNUSED_IMPORTS,
                 unused.use_tree_id,
                 ms,

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -1548,7 +1548,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
                             if is_expected(ctor_res) &&
                                self.r.is_accessible_from(ctor_vis, self.parent_scope.module) {
                                 let lint = lint::builtin::LEGACY_CONSTRUCTOR_VISIBILITY;
-                                self.r.session.buffer_lint(lint, id, span,
+                                self.r.lint_buffer.buffer_lint(lint, id, span,
                                     "private struct constructors are not usable through \
                                      re-exports in outer modules",
                                 );
@@ -1774,7 +1774,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
             };
             if result.base_res() == unqualified_result {
                 let lint = lint::builtin::UNUSED_QUALIFICATIONS;
-                self.r.session.buffer_lint(lint, id, span, "unnecessary qualification")
+                self.r.lint_buffer.buffer_lint(lint, id, span, "unnecessary qualification")
             }
         }
 
@@ -2111,7 +2111,7 @@ impl<'a> Resolver<'a> {
         let mut late_resolution_visitor = LateResolutionVisitor::new(self);
         visit::walk_crate(&mut late_resolution_visitor, krate);
         for (id, span) in late_resolution_visitor.diagnostic_metadata.unused_labels.iter() {
-            self.session.buffer_lint(lint::builtin::UNUSED_LABELS, *id, *span, "unused label");
+            self.lint_buffer.buffer_lint(lint::builtin::UNUSED_LABELS, *id, *span, "unused label");
         }
     }
 }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -962,6 +962,8 @@ pub struct Resolver<'a> {
     /// Stores enum visibilities to properly build a reduced graph
     /// when visiting the correspondent variants.
     variant_vis: DefIdMap<ty::Visibility>,
+
+    pub lint_buffer: lint::LintBuffer,
 }
 
 /// Nothing really interesting here; it just provides memory for the rest of the crate.
@@ -1088,7 +1090,8 @@ impl<'a> Resolver<'a> {
                krate: &Crate,
                crate_name: &str,
                metadata_loader: &'a MetadataLoaderDyn,
-               arenas: &'a ResolverArenas<'a>)
+               arenas: &'a ResolverArenas<'a>,
+               lint_buffer: lint::LintBuffer)
                -> Resolver<'a> {
         let root_def_id = DefId::local(CRATE_DEF_INDEX);
         let root_module_kind = ModuleKind::Def(
@@ -1227,7 +1230,8 @@ impl<'a> Resolver<'a> {
                 features.declared_lib_features.iter().map(|(feat, ..)| *feat)
                     .chain(features.declared_lang_features.iter().map(|(feat, ..)| *feat))
                     .collect(),
-            variant_vis: Default::default()
+            variant_vis: Default::default(),
+            lint_buffer,
         }
     }
 
@@ -1653,7 +1657,7 @@ impl<'a> Resolver<'a> {
             match result {
                 Ok(binding) => {
                     if let Some(node_id) = poisoned {
-                        self.session.buffer_lint_with_diagnostic(
+                        self.lint_buffer.buffer_lint_with_diagnostic(
                             lint::builtin::PROC_MACRO_DERIVE_RESOLUTION_FALLBACK,
                             node_id, ident.span,
                             &format!("cannot find {} `{}` in this scope", ns.descr(), ident),
@@ -2118,7 +2122,7 @@ impl<'a> Resolver<'a> {
     }
 
     fn lint_if_path_starts_with_module(
-        &self,
+        &mut self,
         crate_lint: CrateLint,
         path: &[Segment],
         path_span: Span,
@@ -2169,7 +2173,7 @@ impl<'a> Resolver<'a> {
 
         let diag = lint::builtin::BuiltinLintDiagnostics
             ::AbsPathWithModule(diag_span);
-        self.session.buffer_lint_with_diagnostic(
+        self.lint_buffer.buffer_lint_with_diagnostic(
             lint::builtin::ABSOLUTE_PATHS_NOT_STARTING_WITH_CRATE,
             diag_id, diag_span,
             "absolute paths must start with `self`, `super`, \
@@ -2419,7 +2423,7 @@ impl<'a> Resolver<'a> {
         for &(span_use, span_def) in &self.macro_expanded_macro_export_errors {
             let msg = "macro-expanded `macro_export` macros from the current crate \
                        cannot be referred to by absolute paths";
-            self.session.buffer_lint_with_diagnostic(
+            self.lint_buffer.buffer_lint_with_diagnostic(
                 lint::builtin::MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
                 CRATE_NODE_ID, span_use, msg,
                 lint::builtin::BuiltinLintDiagnostics::

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -963,7 +963,7 @@ pub struct Resolver<'a> {
     /// when visiting the correspondent variants.
     variant_vis: DefIdMap<ty::Visibility>,
 
-    pub lint_buffer: lint::LintBuffer,
+    lint_buffer: lint::LintBuffer,
 }
 
 /// Nothing really interesting here; it just provides memory for the rest of the crate.
@@ -1094,8 +1094,7 @@ impl<'a> Resolver<'a> {
                krate: &Crate,
                crate_name: &str,
                metadata_loader: &'a MetadataLoaderDyn,
-               arenas: &'a ResolverArenas<'a>,
-               lint_buffer: lint::LintBuffer)
+               arenas: &'a ResolverArenas<'a>)
                -> Resolver<'a> {
         let root_def_id = DefId::local(CRATE_DEF_INDEX);
         let root_module_kind = ModuleKind::Def(
@@ -1235,8 +1234,12 @@ impl<'a> Resolver<'a> {
                     .chain(features.declared_lang_features.iter().map(|(feat, ..)| *feat))
                     .collect(),
             variant_vis: Default::default(),
-            lint_buffer,
+            lint_buffer: lint::LintBuffer::default(),
         }
+    }
+
+    pub fn lint_buffer(&mut self) -> &mut lint::LintBuffer {
+        &mut self.lint_buffer
     }
 
     pub fn arenas() -> ResolverArenas<'a> {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1083,6 +1083,10 @@ impl<'a> hir::lowering::Resolver for Resolver<'a> {
         let expn_id = self.definitions.expansion_that_defined(def_id.index);
         self.has_derives(expn_id, derives)
     }
+
+    fn lint_buffer(&mut self) -> &mut lint::LintBuffer {
+        &mut self.lint_buffer
+    }
 }
 
 impl<'a> Resolver<'a> {

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -496,7 +496,7 @@ impl<'a> Resolver<'a> {
                         if let (&NameBindingKind::Res(_, true), &NameBindingKind::Res(_, true)) =
                                (&old_binding.kind, &binding.kind) {
 
-                            this.session.buffer_lint_with_diagnostic(
+                            this.lint_buffer.buffer_lint_with_diagnostic(
                                 DUPLICATE_MACRO_EXPORTS,
                                 CRATE_NODE_ID,
                                 binding.span,
@@ -979,7 +979,9 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                    !max_vis.get().is_at_least(directive.vis.get(), &*self) {
                     let msg =
                     "glob import doesn't reexport anything because no candidate is public enough";
-                    self.r.session.buffer_lint(UNUSED_IMPORTS, directive.id, directive.span, msg);
+                    self.r.lint_buffer.buffer_lint(
+                        UNUSED_IMPORTS, directive.id, directive.span, msg,
+                    );
                 }
                 return None;
             }
@@ -1148,7 +1150,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                                    re-exported (error E0365), consider declaring with \
                                    `pub`",
                                    ident);
-                self.r.session.buffer_lint(PUB_USE_OF_PRIVATE_EXTERN_CRATE,
+                self.r.lint_buffer.buffer_lint(PUB_USE_OF_PRIVATE_EXTERN_CRATE,
                                          directive.id,
                                          directive.span,
                                          &msg);
@@ -1273,7 +1275,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
             let mut redundant_spans: Vec<_> = redundant_span.present_items().collect();
             redundant_spans.sort();
             redundant_spans.dedup();
-            self.r.session.buffer_lint_with_diagnostic(
+            self.r.lint_buffer.buffer_lint_with_diagnostic(
                 UNUSED_IMPORTS,
                 directive.id,
                 directive.span,

--- a/src/libsyntax_expand/base.rs
+++ b/src/libsyntax_expand/base.rs
@@ -858,7 +858,7 @@ pub trait Resolver {
         &mut self, invoc: &Invocation, eager_expansion_root: ExpnId, force: bool
     ) -> Result<InvocationRes, Indeterminate>;
 
-    fn check_unused_macros(&self);
+    fn check_unused_macros(&mut self);
 
     fn has_derives(&self, expn_id: ExpnId, derives: SpecialDerives) -> bool;
     fn add_derives(&mut self, expn_id: ExpnId, derives: SpecialDerives);
@@ -1053,7 +1053,7 @@ impl<'a> ExtCtxt<'a> {
         Symbol::intern(st)
     }
 
-    pub fn check_unused_macros(&self) {
+    pub fn check_unused_macros(&mut self) {
         self.resolver.check_unused_macros();
     }
 


### PR DESCRIPTION
This moves the `LintBuffer` from `Session` into the `Resolver`, where it is used until lowering is done and then consumed by early lint passes. This also happily removes the failure mode of buffering lints too late where it would have previously lead to ICEs; it is statically no longer possible to do so.

I suspect that with a bit more work a similar move could be done for the lint buffer inside `ParseSess`, but this PR doesn't touch it (in part to keep itself small).

The last commit is the "interesting" commit -- the ones before it don't work (though they compile) as they sort of prepare the various crates for the lint buffer to be passed in rather than accessed through Session.
