### PR TITLE
Update comments re type parameter hack in object safety

### DIFF
--- a/src/librustc/traits/object_safety.rs
+++ b/src/librustc/traits/object_safety.rs
@@ -520,9 +520,11 @@ impl<'tcx> TyCtxt<'tcx> {
     /// a pointer.
     ///
     /// In practice, we cannot use `dyn Trait` explicitly in the obligation because it would result
-    /// in a new check that `Trait` is object safe, creating a cycle. So instead, we fudge a little
-    /// by introducing a new type parameter `U` such that `Self: Unsize<U>` and `U: Trait + ?Sized`,
-    /// and use `U` in place of `dyn Trait`. Written as a chalk-style query:
+    /// in a new check that `Trait` is object safe, creating a cycle (until object_safe_for_dispatch
+    /// is stabilized, see tracking issue https://github.com/rust-lang/rust/issues/43561).
+    /// Instead, we fudge a little by introducing a new type parameter `U` such that
+    /// `Self: Unsize<U>` and `U: Trait + ?Sized`, and use `U` in place of `dyn Trait`.
+    /// Written as a chalk-style query:
     ///
     ///     forall (U: Trait + ?Sized) {
     ///         if (Self: Unsize<U>) {
@@ -556,8 +558,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
         // the type `U` in the query
         // use a bogus type parameter to mimick a forall(U) query using u32::MAX for now.
-        // FIXME(mikeyhew) this is a total hack, and we should replace it when real forall queries
-        // are implemented
+        // FIXME(mikeyhew) this is a total hack. Once object_safe_for_dispatch is stabilized, we can
+        // replace this with `dyn Trait`
         let unsized_self_ty: Ty<'tcx> = self.mk_ty_param(
             ::std::u32::MAX,
             Symbol::intern("RustaceansAreAwesome"),


### PR DESCRIPTION
To check if a method's receiver type is object safe, we create a new receiver type by substituting in a bogus type parameter (let's call it `U`) for `Self`, and checking that the unmodified receiver type implements `DispatchFromDyn<receiver type with Self = U>`. It would be better to use `dyn Trait` directly, and the only reason we don't is because it triggers another check that `Trait` is object safe, resulting in a query cycle. Once the feature `object_safe_for_dispatch` (tracking issue https://github.com/rust-lang/rust/issues/43561) is stabilized, this will no longer be the case, and we'll be able to use `dyn Trait` as the unsized `Self` type. I've updated the comments in object_safety.rs accordingly.

cc @Centril @nikomatsakis @bovinebuddha 