### PR TITLE
suggest `const_in_array_repeat_expression` flag

### DIFF
--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -2112,9 +2112,18 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 err.note(&format!("required by cast to type `{}`",
                                   self.ty_to_string(target)));
             }
-            ObligationCauseCode::RepeatVec => {
+            ObligationCauseCode::RepeatVec(suggest_const_in_array_repeat_expression) => {
                 err.note("the `Copy` trait is required because the \
                           repeated element will be copied");
+                if suggest_const_in_array_repeat_expression {
+                    err.note("this array initializer can be evaluated at compile-time, for more \
+                              information, see issue \
+                              https://github.com/rust-lang/rust/issues/49147");
+                    if tcx.sess.opts.unstable_features.is_nightly_build() {
+                        err.help("add `#![feature(const_in_array_repeat_expression)]` to the \
+                                  crate attributes to enable");
+                    }
+                }
             }
             ObligationCauseCode::VariableType(_) => {
                 err.note("all local variables must have a statically known size");

--- a/src/librustc/traits/mod.rs
+++ b/src/librustc/traits/mod.rs
@@ -206,8 +206,9 @@ pub enum ObligationCauseCode<'tcx> {
     SizedReturnType,
     /// Yield type must be Sized
     SizedYieldType,
-    /// [T,..n] --> T must be Copy
-    RepeatVec,
+    /// [T,..n] --> T must be Copy. If `true`, suggest `const_in_array_repeat_expression` feature
+    /// flag.
+    RepeatVec(bool),
 
     /// Types of fields (other than the last, except for packed structs) in a struct must be sized.
     FieldSized { adt_kind: AdtKind, last: bool },

--- a/src/librustc/traits/structural_impls.rs
+++ b/src/librustc/traits/structural_impls.rs
@@ -494,7 +494,7 @@ impl<'a, 'tcx> Lift<'tcx> for traits::ObligationCauseCode<'a> {
             super::SizedArgumentType => Some(super::SizedArgumentType),
             super::SizedReturnType => Some(super::SizedReturnType),
             super::SizedYieldType => Some(super::SizedYieldType),
-            super::RepeatVec => Some(super::RepeatVec),
+            super::RepeatVec(suggest_flag) => Some(super::RepeatVec(suggest_flag)),
             super::FieldSized { adt_kind, last } => Some(super::FieldSized { adt_kind, last }),
             super::ConstSized => Some(super::ConstSized),
             super::ConstPatternStructural => Some(super::ConstPatternStructural),

--- a/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.rs
@@ -3,8 +3,15 @@
 
 struct Bar;
 
+// This function would compile with the feature gate, and tests that it is suggested.
 fn foo() {
     let arr: [Option<String>; 2] = [None::<String>; 2];
+    //~^ ERROR the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied [E0277]
+}
+
+// This function would not compile with the feature gate, and tests that it is not suggested.
+fn bar() {
+    let arr: [Option<String>; 2] = [Some("foo".to_string()); 2];
     //~^ ERROR the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied [E0277]
 }
 

--- a/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_in_array_repeat_expressions.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied
-  --> $DIR/feature-gate-const_in_array_repeat_expressions.rs:7:36
+  --> $DIR/feature-gate-const_in_array_repeat_expressions.rs:8:36
    |
 LL |     let arr: [Option<String>; 2] = [None::<String>; 2];
    |                                    ^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::option::Option<std::string::String>`
@@ -7,7 +7,19 @@ LL |     let arr: [Option<String>; 2] = [None::<String>; 2];
    = help: the following implementations were found:
              <std::option::Option<T> as std::marker::Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
+   = note: this array initializer can be evaluated at compile-time, for more information, see issue https://github.com/rust-lang/rust/issues/49147
+   = help: add `#![feature(const_in_array_repeat_expression)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0277]: the trait bound `std::option::Option<std::string::String>: std::marker::Copy` is not satisfied
+  --> $DIR/feature-gate-const_in_array_repeat_expressions.rs:14:36
+   |
+LL |     let arr: [Option<String>; 2] = [Some("foo".to_string()); 2];
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::marker::Copy` is not implemented for `std::option::Option<std::string::String>`
+   |
+   = help: the following implementations were found:
+             <std::option::Option<T> as std::marker::Copy>
+   = note: the `Copy` trait is required because the repeated element will be copied
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This PR adds a suggestion to add the `#![feature(const_in_array_repeat_expression)]` attribute to the crate when a promotable expression is used in a repeat expression and the feature gate is not enabled.

Unfortunately, this ended up being a little bit more complex than I anticipated, which may not have been worth it given that this would all be removed when the feature is stabilized. However, with #65732 and #65737 being open, and the feature gate having not been being suggested to potential users, the feature might not be stabilized in a while, so maybe this is worth landing.

cc @Centril (addresses [this comment](https://github.com/rust-lang/rust/pull/61749#discussion_r307863857))
r? @ecstatic-morse (opened issues related to RFC 2203 recently)
