### PR TITLE
Add `Iterator::map_while`

### DIFF
--- a/src/libcore/iter/mod.rs
+++ b/src/libcore/iter/mod.rs
@@ -348,7 +348,7 @@ pub use self::traits::TrustedLen;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Rev, Cycle, Chain, Zip, Map, Filter, FilterMap, Enumerate};
 #[stable(feature = "rust1", since = "1.0.0")]
-pub use self::adapters::{Peekable, SkipWhile, TakeWhile, Skip, Take, Scan, FlatMap};
+pub use self::adapters::{Peekable, SkipWhile, TakeWhile, MapWhile, Skip, Take, Scan, FlatMap};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{Fuse, Inspect};
 #[stable(feature = "iter_cloned", since = "1.1.0")]

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -35,6 +35,7 @@
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
+#![feature(iter_map_while)]
 
 extern crate test;
 


### PR DESCRIPTION
This PR adds the `map_while` iterator method, that transforms elements until a transformation fails:
```rust
let iter = (0..).map_while(|x| std::char::from_digit(x, 16));
assert!(iter.eq("0123456789abcdef".chars()));
```
There are different ways of explaining what `map_while` is:
- it's like `take_while`, but instead of just taking elements, it maps them (hence the name)
- it's like `filter_map` except that it stops on the first `None`
- it's similar to [`while_some`](https://docs.rs/itertools/0.8.0/itertools/trait.Itertools.html#method.while_some) from itertools: `iter.map(f).while_some()`
- it's a stateless version of `scan`: `iter.scan((), |(), x| f(x))`

An alternative name could be `take_while_map` because it is to `take_while` what `filter_map` is to `filter` and what `find_map` is to `find`, but to me `map_while` is more descriptive and less confusing.

I'm submitting this PR because I semi-regularly see someone ask how to do this, and they usually end up with something like
```rust
iter.map(f).take_while(Option::is_some).map(Option::unwrap)
```

If this is considered worth adding I'll create a tracking issue. If not, I'm happy to add it to itertools instead.