### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,7 +3135,6 @@ dependencies = [
  "serialize",
  "smallvec",
  "syntax",
- "syntax_expand",
  "syntax_pos",
 ]
 
@@ -3451,7 +3450,6 @@ dependencies = [
  "rustc_target",
  "serialize",
  "syntax",
- "syntax_expand",
  "syntax_pos",
  "tempfile",
 ]
@@ -3707,7 +3705,6 @@ dependencies = [
  "rustc_index",
  "rustc_target",
  "syntax",
- "syntax_expand",
  "syntax_pos",
 ]
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -3,7 +3,6 @@
 #![feature(drain_filter)]
 #![feature(exact_size_is_empty)]
 #![feature(new_uninit)]
-#![feature(option_flattening)]
 #![feature(pattern)]
 #![feature(trusted_len)]
 #![feature(try_reserve)]

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -411,7 +411,11 @@ impl<T> Vec<T> {
     ///
     /// Violating these may cause problems like corrupting the allocator's
     /// internal data structures. For example it is **not** safe
-    /// to build a `Vec<u8>` from a pointer to a C `char` array and a `size_t`.
+    /// to build a `Vec<u8>` from a pointer to a C `char` array with length `size_t`.
+    /// It's also not safe to build one from a `Vec<u16>` and its length, because
+    /// the allocator cares about the alignment, and these two types have different
+    /// alignments. The buffer was allocated with alignment 2 (for `u16`), but after
+    /// turning it into a `Vec<u8>` it'll be deallocated with alignment 1.
     ///
     /// The ownership of `ptr` is effectively transferred to the
     /// `Vec<T>` which may then deallocate, reallocate or change the

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -384,6 +384,9 @@ pub trait Iterator {
     ///
     /// In other words, it links two iterators together, in a chain. 🔗
     ///
+    /// [`once`] is commonly used to adapt a single value into a chain of
+    /// other kinds of iteration.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -408,9 +411,6 @@ pub trait Iterator {
     /// [`Iterator`] itself. For example, slices (`&[T]`) implement
     /// [`IntoIterator`], and so can be passed to `chain()` directly:
     ///
-    /// [`IntoIterator`]: trait.IntoIterator.html
-    /// [`Iterator`]: trait.Iterator.html
-    ///
     /// ```
     /// let s1 = &[1, 2, 3];
     /// let s2 = &[4, 5, 6];
@@ -425,6 +425,21 @@ pub trait Iterator {
     /// assert_eq!(iter.next(), Some(&6));
     /// assert_eq!(iter.next(), None);
     /// ```
+    ///
+    /// If you work with Windows API, you may wish to convert [`OsStr`] to `Vec<u16>`:
+    ///
+    /// ```
+    /// #[cfg(windows)]
+    /// fn os_str_to_utf16(s: &OsStr) -> Vec<u16> {
+    ///     use std::os::windows::ffi::OsStrExt;
+    ///     s.encode_wide().chain(std::iter::once(0)).collect()
+    /// }
+    /// ```
+    ///
+    /// [`once`]: fn.once.html
+    /// [`Iterator`]: trait.Iterator.html
+    /// [`IntoIterator`]: trait.IntoIterator.html
+    /// [`OsStr`]: ../../std/ffi/struct.OsStr.html
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn chain<U>(self, other: U) -> Chain<Self, U::IntoIter> where

--- a/src/libcore/option.rs
+++ b/src/libcore/option.rs
@@ -1568,7 +1568,6 @@ impl<T> Option<Option<T>> {
     /// # Examples
     /// Basic usage:
     /// ```
-    /// #![feature(option_flattening)]
     /// let x: Option<Option<u32>> = Some(Some(6));
     /// assert_eq!(Some(6), x.flatten());
     ///
@@ -1580,13 +1579,12 @@ impl<T> Option<Option<T>> {
     /// ```
     /// Flattening once only removes one level of nesting:
     /// ```
-    /// #![feature(option_flattening)]
     /// let x: Option<Option<Option<u32>>> = Some(Some(Some(6)));
     /// assert_eq!(Some(Some(6)), x.flatten());
     /// assert_eq!(Some(6), x.flatten().flatten());
     /// ```
     #[inline]
-    #[unstable(feature = "option_flattening", issue = "60258")]
+    #[stable(feature = "option_flattening", since = "1.40.0")]
     pub fn flatten(self) -> Option<T> {
         self.and_then(convert::identity)
     }

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -29,7 +29,6 @@ rustc_index = { path = "../librustc_index" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 syntax = { path = "../libsyntax" }
-syntax_expand = { path = "../libsyntax_expand" }
 syntax_pos = { path = "../libsyntax_pos" }
 backtrace = "0.3.3"
 parking_lot = "0.9"

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -6,8 +6,8 @@ use crate::ty;
 use crate::util::nodemap::DefIdMap;
 
 use syntax::ast;
-use syntax_expand::base::MacroKind;
 use syntax::ast::NodeId;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::Span;
 use rustc_macros::HashStable;
 

--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -64,7 +64,7 @@ use syntax::ast;
 use syntax::ptr::P as AstP;
 use syntax::ast::*;
 use syntax::errors;
-use syntax_expand::base::SpecialDerives;
+use syntax::expand::SpecialDerives;
 use syntax::print::pprust;
 use syntax::parse::token::{self, Nonterminal, Token};
 use syntax::tokenstream::{TokenStream, TokenTree};

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -18,7 +18,7 @@ use smallvec::SmallVec;
 use syntax::attr;
 use syntax::ast::*;
 use syntax::visit::{self, Visitor};
-use syntax_expand::base::SpecialDerives;
+use syntax::expand::SpecialDerives;
 use syntax::source_map::{respan, DesugaringKind, Spanned};
 use syntax::symbol::{kw, sym};
 use syntax_pos::Span;

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -2,10 +2,10 @@ use crate::hir::map::definitions::*;
 use crate::hir::def_id::DefIndex;
 
 use syntax::ast::*;
-use syntax_expand::hygiene::ExpnId;
 use syntax::visit;
 use syntax::symbol::{kw, sym};
 use syntax::parse::token::{self, Token};
+use syntax_pos::hygiene::ExpnId;
 use syntax_pos::Span;
 
 /// Creates `DefId`s for nodes in the AST.

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -17,8 +17,8 @@ use std::borrow::Borrow;
 use std::fmt::Write;
 use std::hash::Hash;
 use syntax::ast;
-use syntax_expand::hygiene::ExpnId;
-use syntax::symbol::{Symbol, sym};
+use syntax_pos::symbol::{Symbol, sym};
+use syntax_pos::hygiene::ExpnId;
 use syntax_pos::{Span, DUMMY_SP};
 
 /// The `DefPathTable` maps `DefIndex`es to `DefKey`s and vice versa.

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -20,7 +20,7 @@ use rustc_data_structures::svh::Svh;
 use rustc_index::vec::IndexVec;
 use syntax::ast::{self, Name, NodeId};
 use syntax::source_map::Spanned;
-use syntax_expand::base::MacroKind;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::{Span, DUMMY_SP};
 
 pub mod blocks;

--- a/src/librustc/ich/hcx.rs
+++ b/src/librustc/ich/hcx.rs
@@ -13,11 +13,10 @@ use std::cell::RefCell;
 
 use syntax::ast;
 use syntax::source_map::SourceMap;
-use syntax_expand::hygiene::SyntaxContext;
 use syntax::symbol::Symbol;
 use syntax::tokenstream::DelimSpan;
 use syntax_pos::{Span, DUMMY_SP};
-use syntax_pos::hygiene;
+use syntax_pos::hygiene::{self, SyntaxContext};
 
 use rustc_data_structures::stable_hasher::{
     HashStable, StableHasher, ToStableHashKey,

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -60,7 +60,7 @@ impl_stable_hash_for!(enum ::syntax::ast::AsmDialect {
     Intel
 });
 
-impl_stable_hash_for!(enum ::syntax_expand::base::MacroKind {
+impl_stable_hash_for!(enum ::syntax_pos::hygiene::MacroKind {
     Bang,
     Attr,
     Derive,

--- a/src/librustc/lint/mod.rs
+++ b/src/librustc/lint/mod.rs
@@ -39,8 +39,8 @@ use syntax::ast;
 use syntax::source_map::{MultiSpan, ExpnKind, DesugaringKind};
 use syntax::early_buffered_lints::BufferedEarlyLintId;
 use syntax::edition::Edition;
-use syntax_expand::base::MacroKind;
 use syntax::symbol::{Symbol, sym};
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::Span;
 
 pub use crate::lint::context::{LateContext, EarlyContext, LintContext, LintStore,

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -24,7 +24,7 @@ use errors::emitter::HumanReadableErrorType;
 use errors::annotate_snippet_emitter_writer::{AnnotateSnippetEmitterWriter};
 use syntax::ast::{self, NodeId};
 use syntax::edition::Edition;
-use syntax_expand::allocator::AllocatorKind;
+use syntax::expand::allocator::AllocatorKind;
 use syntax::feature_gate::{self, AttributeType};
 use syntax::json::JsonEmitter;
 use syntax::source_map;

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -46,8 +46,8 @@ use std::{mem, ptr};
 use std::ops::Range;
 use syntax::ast::{self, Name, Ident, NodeId};
 use syntax::attr;
-use syntax_expand::hygiene::ExpnId;
-use syntax::symbol::{kw, sym, Symbol};
+use syntax_pos::symbol::{kw, sym, Symbol};
+use syntax_pos::hygiene::ExpnId;
 use syntax_pos::Span;
 
 use smallvec;

--- a/src/librustc_codegen_llvm/allocator.rs
+++ b/src/librustc_codegen_llvm/allocator.rs
@@ -3,7 +3,7 @@ use std::ffi::CString;
 use crate::attributes;
 use libc::c_uint;
 use rustc::ty::TyCtxt;
-use syntax_expand::allocator::{AllocatorKind, AllocatorTy, ALLOCATOR_METHODS};
+use syntax::expand::allocator::{AllocatorKind, AllocatorTy, ALLOCATOR_METHODS};
 
 use crate::ModuleLlvm;
 use crate::llvm::{self, False, True};

--- a/src/librustc_codegen_llvm/lib.rs
+++ b/src/librustc_codegen_llvm/lib.rs
@@ -39,7 +39,6 @@ extern crate rustc_driver as _;
 
 #[macro_use] extern crate log;
 extern crate syntax;
-extern crate syntax_expand;
 extern crate syntax_pos;
 extern crate rustc_errors as errors;
 
@@ -49,7 +48,7 @@ use rustc_codegen_ssa::back::lto::{SerializedModule, LtoModuleCodegen, ThinModul
 use rustc_codegen_ssa::CompiledModule;
 use errors::{FatalError, Handler};
 use rustc::dep_graph::WorkProduct;
-use syntax_expand::allocator::AllocatorKind;
+use syntax::expand::allocator::AllocatorKind;
 pub use llvm_util::target_features;
 use std::any::Any;
 use std::sync::Arc;

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -21,7 +21,6 @@ tempfile = "3.1"
 
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 syntax = { path = "../libsyntax" }
-syntax_expand = { path = "../libsyntax_expand" }
 syntax_pos = { path = "../libsyntax_pos" }
 rustc = { path = "../librustc" }
 rustc_apfloat = { path = "../librustc_apfloat" }

--- a/src/librustc_codegen_ssa/back/symbol_export.rs
+++ b/src/librustc_codegen_ssa/back/symbol_export.rs
@@ -14,7 +14,7 @@ use rustc::ty::query::Providers;
 use rustc::ty::subst::SubstsRef;
 use rustc::util::nodemap::{FxHashMap, DefIdMap};
 use rustc_index::vec::IndexVec;
-use syntax_expand::allocator::ALLOCATOR_METHODS;
+use syntax::expand::allocator::ALLOCATOR_METHODS;
 
 pub type ExportedSymbols = FxHashMap<
     CrateNum,

--- a/src/librustc_codegen_ssa/back/write.rs
+++ b/src/librustc_codegen_ssa/back/write.rs
@@ -27,7 +27,7 @@ use rustc_errors::{Handler, Level, FatalError, DiagnosticId, SourceMapperDyn};
 use rustc_errors::emitter::{Emitter};
 use rustc_target::spec::MergeFunctions;
 use syntax::attr;
-use syntax_expand::hygiene::ExpnId;
+use syntax_pos::hygiene::ExpnId;
 use syntax_pos::symbol::{Symbol, sym};
 use jobserver::{Client, Acquired};
 

--- a/src/librustc_codegen_ssa/traits/backend.rs
+++ b/src/librustc_codegen_ssa/traits/backend.rs
@@ -9,7 +9,7 @@ use rustc::ty::TyCtxt;
 use rustc_codegen_utils::codegen_backend::CodegenBackend;
 use std::sync::Arc;
 use std::sync::mpsc;
-use syntax_expand::allocator::AllocatorKind;
+use syntax::expand::allocator::AllocatorKind;
 use syntax_pos::symbol::Symbol;
 
 pub trait BackendTypes {

--- a/src/librustc_interface/passes.rs
+++ b/src/librustc_interface/passes.rs
@@ -502,7 +502,7 @@ pub fn lower_to_hir(
 
     // Discard hygiene data, which isn't required after lowering to HIR.
     if !sess.opts.debugging_opts.keep_hygiene_data {
-        syntax_expand::hygiene::clear_syntax_context_map();
+        syntax_pos::hygiene::clear_syntax_context_map();
     }
 
     Ok(hir_forest)

--- a/src/librustc_lexer/src/cursor.rs
+++ b/src/librustc_lexer/src/cursor.rs
@@ -1,5 +1,9 @@
 use std::str::Chars;
 
+/// Peekable iterator over a char sequence.
+///
+/// Next characters can be peeked via `nth_char` method,
+/// and position can be shifted forward via `bump` method.
 pub(crate) struct Cursor<'a> {
     initial_len: usize,
     chars: Chars<'a>,
@@ -18,7 +22,9 @@ impl<'a> Cursor<'a> {
             prev: EOF_CHAR,
         }
     }
+
     /// For debug assertions only
+    /// Returns the last eaten symbol (or '\0' in release builds).
     pub(crate) fn prev(&self) -> char {
         #[cfg(debug_assertions)]
         {
@@ -30,19 +36,30 @@ impl<'a> Cursor<'a> {
             '\0'
         }
     }
+
+    /// Returns nth character relative to the current cursor position.
+    /// If requested position doesn't exist, `EOF_CHAR` is returned.
+    /// However, getting `EOF_CHAR` doesn't always mean actual end of file,
+    /// it should be checked with `is_eof` method.
     pub(crate) fn nth_char(&self, n: usize) -> char {
         self.chars().nth(n).unwrap_or(EOF_CHAR)
     }
+
+    /// Checks if there is nothing more to consume.
     pub(crate) fn is_eof(&self) -> bool {
         self.chars.as_str().is_empty()
     }
+
+    /// Returns amount of already consumed symbols.
     pub(crate) fn len_consumed(&self) -> usize {
         self.initial_len - self.chars.as_str().len()
     }
-    /// Returns an iterator over the remaining characters.
+
+    /// Returns a `Chars` iterator over the remaining characters.
     fn chars(&self) -> Chars<'a> {
         self.chars.clone()
     }
+
     /// Moves to the next character.
     pub(crate) fn bump(&mut self) -> Option<char> {
         let c = self.chars.next()?;

--- a/src/librustc_metadata/creader.rs
+++ b/src/librustc_metadata/creader.rs
@@ -25,7 +25,7 @@ use std::{cmp, fs};
 
 use syntax::ast;
 use syntax::attr;
-use syntax_expand::allocator::{global_allocator_spans, AllocatorKind};
+use syntax::expand::allocator::{global_allocator_spans, AllocatorKind};
 use syntax::symbol::{Symbol, sym};
 use syntax::span_fatal;
 use syntax_pos::{Span, DUMMY_SP};

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -33,12 +33,12 @@ use rustc_serialize::{Decodable, Decoder, Encodable, SpecializedDecoder, opaque}
 use syntax::attr;
 use syntax::ast::{self, Ident};
 use syntax::source_map::{self, respan, Spanned};
-use syntax::symbol::{Symbol, sym};
-use syntax_expand::base::{MacroKind, SyntaxExtensionKind, SyntaxExtension};
-use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP};
+use syntax_expand::base::{SyntaxExtensionKind, SyntaxExtension};
+use syntax_expand::proc_macro::{AttrProcMacro, ProcMacroDerive, BangProcMacro};
+use syntax_pos::{self, Span, BytePos, Pos, DUMMY_SP, hygiene::MacroKind};
+use syntax_pos::symbol::{Symbol, sym};
 use log::debug;
 use proc_macro::bridge::client::ProcMacro;
-use syntax_expand::proc_macro::{AttrProcMacro, ProcMacroDerive, BangProcMacro};
 
 crate struct DecodeContext<'a, 'tcx> {
     opaque: opaque::Decoder<'a>,

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -32,7 +32,7 @@ use std::path::Path;
 use std::u32;
 use syntax::ast;
 use syntax::attr;
-use syntax_expand::proc_macro::is_proc_macro_attr;
+use syntax::expand::is_proc_macro_attr;
 use syntax::source_map::Spanned;
 use syntax::symbol::{kw, sym, Ident, Symbol};
 use syntax_pos::{self, FileName, SourceFile, Span};

--- a/src/librustc_passes/Cargo.toml
+++ b/src/librustc_passes/Cargo.toml
@@ -13,7 +13,6 @@ log = "0.4"
 rustc = { path = "../librustc" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 syntax = { path = "../libsyntax" }
-syntax_expand = { path = "../libsyntax_expand" }
 syntax_pos = { path = "../libsyntax_pos" }
 errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_target = { path = "../librustc_target" }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -14,7 +14,7 @@ use rustc::session::Session;
 use rustc_data_structures::fx::FxHashMap;
 use syntax::ast::*;
 use syntax::attr;
-use syntax_expand::proc_macro::is_proc_macro_attr;
+use syntax::expand::is_proc_macro_attr;
 use syntax::feature_gate::is_builtin_attr;
 use syntax::source_map::Spanned;
 use syntax::symbol::{kw, sym};

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -32,9 +32,6 @@ use syntax::attr;
 
 use syntax::ast::{self, Block, ForeignItem, ForeignItemKind, Item, ItemKind, NodeId};
 use syntax::ast::{MetaItemKind, StmtKind, TraitItem, TraitItemKind};
-use syntax_expand::base::{MacroKind, SyntaxExtension};
-use syntax_expand::expand::AstFragment;
-use syntax_expand::hygiene::ExpnId;
 use syntax::feature_gate::is_builtin_attr;
 use syntax::parse::token::{self, Token};
 use syntax::print::pprust;
@@ -42,7 +39,9 @@ use syntax::{span_err, struct_span_err};
 use syntax::source_map::{respan, Spanned};
 use syntax::symbol::{kw, sym};
 use syntax::visit::{self, Visitor};
-
+use syntax_expand::base::SyntaxExtension;
+use syntax_expand::expand::AstFragment;
+use syntax_pos::hygiene::{MacroKind, ExpnId};
 use syntax_pos::{Span, DUMMY_SP};
 
 use log::debug;

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -850,12 +850,14 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             Res::Def(kind @ DefKind::Mod, def_id)
             | Res::Def(kind @ DefKind::Enum, def_id)
             | Res::Def(kind @ DefKind::Trait, def_id) => {
-                let module = self.r.new_module(parent,
-                                             ModuleKind::Def(kind, def_id, ident.name),
-                                             def_id,
-                                             expansion,
-                                             span);
-                self.r.define(parent, ident, TypeNS, (module, vis, DUMMY_SP, expansion));
+                let module = self.r.new_module(
+                    parent,
+                    ModuleKind::Def(kind, def_id, ident.name),
+                    def_id,
+                    expansion,
+                    span,
+                );
+                self.r.define(parent, ident, TypeNS, (module, vis, span, expansion));
             }
             Res::Def(DefKind::Struct, _)
             | Res::Def(DefKind::Union, _)
@@ -868,17 +870,17 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
             | Res::Def(DefKind::AssocOpaqueTy, _)
             | Res::PrimTy(..)
             | Res::ToolMod =>
-                self.r.define(parent, ident, TypeNS, (res, vis, DUMMY_SP, expansion)),
+                self.r.define(parent, ident, TypeNS, (res, vis, span, expansion)),
             Res::Def(DefKind::Fn, _)
             | Res::Def(DefKind::Method, _)
             | Res::Def(DefKind::Static, _)
             | Res::Def(DefKind::Const, _)
             | Res::Def(DefKind::AssocConst, _)
             | Res::Def(DefKind::Ctor(..), _) =>
-                self.r.define(parent, ident, ValueNS, (res, vis, DUMMY_SP, expansion)),
+                self.r.define(parent, ident, ValueNS, (res, vis, span, expansion)),
             Res::Def(DefKind::Macro(..), _)
             | Res::NonMacroAttr(..) =>
-                self.r.define(parent, ident, MacroNS, (res, vis, DUMMY_SP, expansion)),
+                self.r.define(parent, ident, MacroNS, (res, vis, span, expansion)),
             Res::Def(DefKind::TyParam, _) | Res::Def(DefKind::ConstParam, _)
             | Res::Local(..) | Res::SelfTy(..) | Res::SelfCtor(..) | Res::Err =>
                 bug!("unexpected resolution: {:?}", res)

--- a/src/librustc_resolve/diagnostics.rs
+++ b/src/librustc_resolve/diagnostics.rs
@@ -10,12 +10,12 @@ use rustc::session::Session;
 use rustc::ty::{self, DefIdTree};
 use rustc::util::nodemap::FxHashSet;
 use syntax::ast::{self, Ident, Path};
-use syntax_expand::base::MacroKind;
 use syntax::feature_gate::BUILTIN_ATTRIBUTES;
 use syntax::source_map::SourceMap;
 use syntax::struct_span_err;
 use syntax::symbol::{Symbol, kw};
 use syntax::util::lev_distance::find_best_match_for_name;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::{BytePos, Span, MultiSpan};
 
 use crate::resolve_imports::{ImportDirective, ImportDirectiveSubclass, ImportResolver};

--- a/src/librustc_resolve/error_codes.rs
+++ b/src/librustc_resolve/error_codes.rs
@@ -974,7 +974,7 @@ function:
 struct Foo { a: bool };
 
 let f = Foo();
-// error: expected function, found `Foo`
+// error: expected function, tuple struct or tuple variant, found `Foo`
 // `Foo` is a struct name, but this expression uses it like a function name
 ```
 
@@ -992,7 +992,8 @@ yield this error:
 
 ```compile_fail,E0423
 println("");
-// error: expected function, found macro `println`
+// error: expected function, tuple struct or tuple variant,
+// found macro `println`
 // did you mean `println!(...)`? (notice the trailing `!`)
 ```
 
@@ -1592,7 +1593,7 @@ enum State {
 
 fn print_on_failure(state: &State) {
     match *state {
-        // error: expected unit struct/variant or constant, found tuple
+        // error: expected unit struct, unit variant or constant, found tuple
         //        variant `State::Failed`
         State::Failed => println!("Failed"),
         _ => ()

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -13,9 +13,9 @@ use rustc::hir::PrimTy;
 use rustc::session::config::nightly_options;
 use rustc::util::nodemap::FxHashSet;
 use syntax::ast::{self, Expr, ExprKind, Ident, NodeId, Path, Ty, TyKind};
-use syntax_expand::base::MacroKind;
 use syntax::symbol::kw;
 use syntax::util::lev_distance::find_best_match_for_name;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::Span;
 
 type Res = def::Res<ast::NodeId>;

--- a/src/librustc_resolve/late/diagnostics.rs
+++ b/src/librustc_resolve/late/diagnostics.rs
@@ -1,7 +1,7 @@
 use crate::{CrateLint, Module, ModuleKind, ModuleOrUniformRoot};
 use crate::{PathResult, PathSource, Segment};
 use crate::path_names_to_string;
-use crate::diagnostics::{add_typo_suggestion, ImportSuggestion, TypoSuggestion};
+use crate::diagnostics::{ImportSuggestion, TypoSuggestion};
 use crate::late::{LateResolutionVisitor, RibKind};
 
 use errors::{Applicability, DiagnosticBuilder, DiagnosticId};
@@ -237,18 +237,19 @@ impl<'a> LateResolutionVisitor<'a, '_> {
         }
 
         // Try Levenshtein algorithm.
-        let levenshtein_worked = add_typo_suggestion(
-            &mut err, self.lookup_typo_candidate(path, ns, is_expected, span), ident_span
-        );
+        let typo_sugg = self.lookup_typo_candidate(path, ns, is_expected, span);
+        let levenshtein_worked = self.r.add_typo_suggestion(&mut err, typo_sugg, ident_span);
 
         // Try context-dependent help if relaxed lookup didn't work.
         if let Some(res) = res {
-            if self.smart_resolve_context_dependent_help(&mut err,
-                                                         span,
-                                                         source,
-                                                         res,
-                                                         &path_str,
-                                                         &fallback_label) {
+            if self.smart_resolve_context_dependent_help(
+                &mut err,
+                span,
+                source,
+                res,
+                &path_str,
+                &fallback_label,
+            ) {
                 return (err, candidates);
             }
         }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -35,17 +35,18 @@ use rustc::span_bug;
 use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
 
-use syntax_expand::hygiene::{ExpnId, Transparency, SyntaxContext};
-use syntax_expand::base::{SyntaxExtension, MacroKind, SpecialDerives};
 use syntax::{struct_span_err, unwrap_or};
-use syntax::attr;
+use syntax::expand::SpecialDerives;
 use syntax::ast::{self, Name, NodeId, Ident, FloatTy, IntTy, UintTy};
-use syntax::ast::{ItemKind, Path, CRATE_NODE_ID, Crate};
+use syntax::ast::{CRATE_NODE_ID, Crate};
+use syntax::ast::{ItemKind, Path};
+use syntax::attr;
 use syntax::print::pprust;
 use syntax::symbol::{kw, sym};
 use syntax::source_map::Spanned;
 use syntax::visit::{self, Visitor};
-
+use syntax_expand::base::SyntaxExtension;
+use syntax_pos::hygiene::{MacroKind, ExpnId, Transparency, SyntaxContext};
 use syntax_pos::{Span, DUMMY_SP};
 use errors::{Applicability, DiagnosticBuilder};
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -14,20 +14,21 @@ use rustc::{ty, lint, span_bug};
 use syntax::ast::{self, NodeId, Ident};
 use syntax::attr::StabilityLevel;
 use syntax::edition::Edition;
-use syntax_expand::base::{self, InvocationRes, Indeterminate, SpecialDerives};
-use syntax_expand::base::{MacroKind, SyntaxExtension};
-use syntax_expand::expand::{AstFragment, AstFragmentKind, Invocation, InvocationKind};
-use syntax_expand::hygiene::{self, ExpnId, ExpnData, ExpnKind};
-use syntax_expand::compile_declarative_macro;
+use syntax::expand::SpecialDerives;
 use syntax::feature_gate::{emit_feature_err, is_builtin_attr_name};
 use syntax::feature_gate::GateIssue;
 use syntax::print::pprust;
 use syntax::symbol::{Symbol, kw, sym};
+use syntax_expand::base::{self, InvocationRes, Indeterminate};
+use syntax_expand::base::SyntaxExtension;
+use syntax_expand::expand::{AstFragment, AstFragmentKind, Invocation, InvocationKind};
+use syntax_expand::compile_declarative_macro;
+use syntax_pos::hygiene::{self, ExpnId, ExpnData, ExpnKind};
 use syntax_pos::{Span, DUMMY_SP};
 
 use std::{mem, ptr};
 use rustc_data_structures::sync::Lrc;
-use syntax_pos::hygiene::AstPass;
+use syntax_pos::hygiene::{MacroKind, AstPass};
 
 type Res = def::Res<NodeId>;
 

--- a/src/librustc_resolve/resolve_imports.rs
+++ b/src/librustc_resolve/resolve_imports.rs
@@ -28,10 +28,10 @@ use rustc::util::nodemap::FxHashSet;
 use rustc::{bug, span_bug};
 
 use syntax::ast::{Ident, Name, NodeId, CRATE_NODE_ID};
-use syntax_expand::hygiene::ExpnId;
 use syntax::symbol::kw;
 use syntax::util::lev_distance::find_best_match_for_name;
 use syntax::{struct_span_err, unwrap_or};
+use syntax_pos::hygiene::ExpnId;
 use syntax_pos::{MultiSpan, Span};
 
 use log::*;

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -2269,7 +2269,7 @@ pub fn check_enum<'tcx>(tcx: TyCtxt<'tcx>, sp: Span, vs: &'tcx [hir::Variant], i
 
 fn report_unexpected_variant_res(tcx: TyCtxt<'_>, res: Res, span: Span, qpath: &QPath) {
     span_err!(tcx.sess, span, E0533,
-              "expected unit struct/variant or constant, found {} `{}`",
+              "expected unit struct, unit variant or constant, found {} `{}`",
               res.descr(),
               hir::print::to_string(tcx.hir(), |s| s.print_qpath(qpath, false)));
 }

--- a/src/librustc_typeck/check/pat.rs
+++ b/src/librustc_typeck/check/pat.rs
@@ -613,9 +613,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
         let report_unexpected_res = |res: Res| {
-            let msg = format!("expected tuple struct/variant, found {} `{}`",
-                              res.descr(),
-                              hir::print::to_string(tcx.hir(), |s| s.print_qpath(qpath, false)));
+            let msg = format!(
+                "expected tuple struct or tuple variant, found {} `{}`",
+                res.descr(),
+                hir::print::to_string(tcx.hir(), |s| s.print_qpath(qpath, false)),
+            );
             let mut err = struct_span_err!(tcx.sess, pat.span, E0164, "{}", msg);
             match (res, &pat.kind) {
                 (Res::Def(DefKind::Fn, _), _) | (Res::Def(DefKind::Method, _), _) => {

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4346,11 +4346,12 @@ enum X {
     Entry,
 }
 
-X::Entry(); // error: expected function, found `X::Entry`
+X::Entry(); // error: expected function, tuple struct or tuple variant,
+            // found `X::Entry`
 
 // Or even simpler:
 let x = 0i32;
-x(); // error: expected function, found `i32`
+x(); // error: expected function, tuple struct or tuple variant, found `i32`
 ```
 
 Only functions and methods can be called using `()`. Example:

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -3,8 +3,8 @@
 use std::iter::once;
 
 use syntax::ast;
-use syntax_expand::base::MacroKind;
 use syntax::symbol::sym;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::Span;
 
 use rustc::hir;

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -28,10 +28,10 @@ use rustc::ty::layout::VariantIdx;
 use rustc::util::nodemap::{FxHashMap, FxHashSet};
 use syntax::ast::{self, Attribute, AttrStyle, AttrItem, Ident};
 use syntax::attr;
-use syntax_expand::base::MacroKind;
 use syntax::parse::lexer::comments;
 use syntax::source_map::DUMMY_SP;
-use syntax::symbol::{Symbol, kw, sym};
+use syntax_pos::symbol::{Symbol, kw, sym};
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::{self, Pos, FileName};
 
 use std::collections::hash_map::Entry;

--- a/src/librustdoc/doctree.rs
+++ b/src/librustdoc/doctree.rs
@@ -4,7 +4,7 @@ pub use self::StructType::*;
 
 use syntax::ast;
 use syntax::ast::Name;
-use syntax_expand::base::MacroKind;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::{self, Span};
 
 use rustc::hir;

--- a/src/librustdoc/html/item_type.rs
+++ b/src/librustdoc/html/item_type.rs
@@ -1,7 +1,7 @@
 //! Item types.
 
 use std::fmt;
-use syntax_expand::base::MacroKind;
+use syntax_pos::hygiene::MacroKind;
 use crate::clean;
 
 /// Item type. Corresponds to `clean::ItemEnum` variants.

--- a/src/librustdoc/html/render.rs
+++ b/src/librustdoc/html/render.rs
@@ -49,7 +49,7 @@ use syntax::feature_gate::UnstableFeatures;
 use syntax::print::pprust;
 use syntax::source_map::FileName;
 use syntax::symbol::{Symbol, sym};
-use syntax_expand::base::MacroKind;
+use syntax_pos::hygiene::MacroKind;
 use rustc::hir::def_id::DefId;
 use rustc::middle::privacy::AccessLevels;
 use rustc::middle::stability;

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -8,9 +8,9 @@ use rustc::middle::privacy::AccessLevel;
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
 use rustc::ty::TyCtxt;
 use syntax::ast;
-use syntax_expand::base::MacroKind;
 use syntax::source_map::Spanned;
 use syntax::symbol::sym;
+use syntax_pos::hygiene::MacroKind;
 use syntax_pos::{self, Span};
 
 use std::mem;

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -1015,7 +1015,8 @@ impl f32 {
     /// assert!((2.0f32).clamp(-2.0, 1.0) == 1.0);
     /// assert!((std::f32::NAN).clamp(-2.0, 1.0).is_nan());
     /// ```
-    #[must_use = "method returns a new number and does not mutate the original value"]
+    // The tests below invoke `clamp` without a return value in order to cause a `panic`.
+    // #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "clamp", issue = "44095")]
     #[inline]
     pub fn clamp(self, min: f32, max: f32) -> f32 {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -40,7 +40,7 @@ impl f32 {
     /// assert_eq!(g.floor(), 3.0);
     /// assert_eq!(h.floor(), -4.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f32 {
@@ -74,7 +74,7 @@ impl f32 {
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f32 {
@@ -97,7 +97,7 @@ impl f32 {
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f32 {
@@ -117,7 +117,7 @@ impl f32 {
     /// assert_eq!(g.trunc(), 3.0);
     /// assert_eq!(h.trunc(), -3.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f32 {
@@ -139,7 +139,7 @@ impl f32 {
     /// assert!(abs_difference_x <= f32::EPSILON);
     /// assert!(abs_difference_y <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f32 { self - self.trunc() }
@@ -163,7 +163,7 @@ impl f32 {
     ///
     /// assert!(f32::NAN.abs().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs(self) -> f32 {
@@ -188,7 +188,7 @@ impl f32 {
     ///
     /// assert!(f32::NAN.signum().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f32 {
@@ -221,7 +221,7 @@ impl f32 {
     /// assert!(f32::NAN.copysign(1.0).is_nan());
     /// ```
     #[inline]
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "copysign", since = "1.35.0")]
     pub fn copysign(self, sign: f32) -> f32 {
         unsafe { intrinsics::copysignf32(self, sign) }
@@ -374,7 +374,7 @@ impl f32 {
     /// assert!(abs_difference <= f32::EPSILON);
     /// assert!(negative.sqrt().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f32 {
@@ -401,7 +401,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp(self) -> f32 {
@@ -426,7 +426,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp2(self) -> f32 {
@@ -449,7 +449,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f32 {
@@ -496,7 +496,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f32 {
@@ -520,7 +520,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f32 {
@@ -578,7 +578,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f32 {
@@ -620,7 +620,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sin(self) -> f32 {
@@ -644,7 +644,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cos(self) -> f32 {
@@ -667,7 +667,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f32 {
@@ -690,7 +690,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f32 {
@@ -713,7 +713,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f32 {
@@ -735,7 +735,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f32 {
@@ -814,7 +814,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f32 {
@@ -836,7 +836,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f32 {
@@ -860,7 +860,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f32 {
@@ -884,7 +884,7 @@ impl f32 {
     /// // Same result
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f32 {
@@ -908,7 +908,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f32 {
@@ -929,7 +929,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f32 {
@@ -954,7 +954,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f32 {
@@ -978,7 +978,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= 1e-5);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atanh(self) -> f32 {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -220,8 +220,8 @@ impl f32 {
     ///
     /// assert!(f32::NAN.copysign(1.0).is_nan());
     /// ```
-    #[inline]
     #[must_use = "method returns a new number and does not mutate the original value"]
+    #[inline]
     #[stable(feature = "copysign", since = "1.35.0")]
     pub fn copysign(self, sign: f32) -> f32 {
         unsafe { intrinsics::copysignf32(self, sign) }
@@ -247,6 +247,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f32, b: f32) -> f32 {
@@ -270,6 +271,7 @@ impl f32 {
     /// assert_eq!(a.div_euclid(-b), -1.0); // 7.0 >= -4.0 * -1.0
     /// assert_eq!((-a).div_euclid(-b), 2.0); // -7.0 >= -4.0 * 2.0
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn div_euclid(self, rhs: f32) -> f32 {
@@ -303,6 +305,7 @@ impl f32 {
     /// // limitation due to round-off error
     /// assert!((-std::f32::EPSILON).rem_euclid(3.0) != 0.0);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f32) -> f32 {
@@ -329,6 +332,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powi(self, n: i32) -> f32 {
@@ -347,6 +351,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powf(self, n: f32) -> f32 {
@@ -478,6 +483,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log(self, base: f32) -> f32 { self.ln() / base.ln() }
@@ -550,6 +556,7 @@ impl f32 {
     /// assert!(abs_difference_x <= f32::EPSILON);
     /// assert!(abs_difference_y <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     #[rustc_deprecated(since = "1.10.0",
@@ -601,6 +608,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f32) -> f32 {
@@ -770,6 +778,7 @@ impl f32 {
     /// assert!(abs_difference_1 <= f32::EPSILON);
     /// assert!(abs_difference_2 <= f32::EPSILON);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan2(self, other: f32) -> f32 {
@@ -1006,6 +1015,7 @@ impl f32 {
     /// assert!((2.0f32).clamp(-2.0, 1.0) == 1.0);
     /// assert!((std::f32::NAN).clamp(-2.0, 1.0).is_nan());
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "clamp", issue = "44095")]
     #[inline]
     pub fn clamp(self, min: f32, max: f32) -> f32 {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -40,6 +40,7 @@ impl f32 {
     /// assert_eq!(g.floor(), 3.0);
     /// assert_eq!(h.floor(), -4.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f32 {
@@ -73,6 +74,7 @@ impl f32 {
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f32 {
@@ -95,6 +97,7 @@ impl f32 {
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f32 {
@@ -114,6 +117,7 @@ impl f32 {
     /// assert_eq!(g.trunc(), 3.0);
     /// assert_eq!(h.trunc(), -3.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f32 {
@@ -135,6 +139,7 @@ impl f32 {
     /// assert!(abs_difference_x <= f32::EPSILON);
     /// assert!(abs_difference_y <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f32 { self - self.trunc() }
@@ -158,6 +163,7 @@ impl f32 {
     ///
     /// assert!(f32::NAN.abs().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs(self) -> f32 {
@@ -182,6 +188,7 @@ impl f32 {
     ///
     /// assert!(f32::NAN.signum().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f32 {
@@ -367,6 +374,7 @@ impl f32 {
     /// assert!(abs_difference <= f32::EPSILON);
     /// assert!(negative.sqrt().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f32 {
@@ -393,6 +401,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp(self) -> f32 {
@@ -417,6 +426,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp2(self) -> f32 {
@@ -439,6 +449,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f32 {
@@ -485,6 +496,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f32 {
@@ -508,6 +520,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f32 {
@@ -565,6 +578,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f32 {
@@ -606,6 +620,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sin(self) -> f32 {
@@ -629,6 +644,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cos(self) -> f32 {
@@ -651,6 +667,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f32 {
@@ -673,6 +690,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f32 {
@@ -695,6 +713,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f32 {
@@ -716,6 +735,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f32 {
@@ -794,6 +814,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f32 {
@@ -815,6 +836,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f32 {
@@ -838,6 +860,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f32 {
@@ -861,6 +884,7 @@ impl f32 {
     /// // Same result
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f32 {
@@ -884,6 +908,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f32 {
@@ -904,6 +929,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f32 {
@@ -928,6 +954,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= f32::EPSILON);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f32 {
@@ -951,6 +978,7 @@ impl f32 {
     ///
     /// assert!(abs_difference <= 1e-5);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atanh(self) -> f32 {

--- a/src/libstd/f32.rs
+++ b/src/libstd/f32.rs
@@ -1015,8 +1015,7 @@ impl f32 {
     /// assert!((2.0f32).clamp(-2.0, 1.0) == 1.0);
     /// assert!((std::f32::NAN).clamp(-2.0, 1.0).is_nan());
     /// ```
-    // The tests below invoke `clamp` without a return value in order to cause a `panic`.
-    // #[must_use = "method returns a new number and does not mutate the original value"]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "clamp", issue = "44095")]
     #[inline]
     pub fn clamp(self, min: f32, max: f32) -> f32 {
@@ -1631,18 +1630,18 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_clamp_min_greater_than_max() {
-        1.0f32.clamp(3.0, 1.0);
+        let _ = 1.0f32.clamp(3.0, 1.0);
     }
 
     #[test]
     #[should_panic]
     fn test_clamp_min_is_nan() {
-        1.0f32.clamp(NAN, 1.0);
+        let _ = 1.0f32.clamp(NAN, 1.0);
     }
 
     #[test]
     #[should_panic]
     fn test_clamp_max_is_nan() {
-        1.0f32.clamp(3.0, NAN);
+        let _ = 1.0f32.clamp(3.0, NAN);
     }
 }

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -936,8 +936,7 @@ impl f64 {
     /// assert!((2.0f64).clamp(-2.0, 1.0) == 1.0);
     /// assert!((std::f64::NAN).clamp(-2.0, 1.0).is_nan());
     /// ```
-    // The tests below invoke `clamp` without a return value in order to cause a `panic`.
-    // #[must_use = "method returns a new number and does not mutate the original value"]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "clamp", issue = "44095")]
     #[inline]
     pub fn clamp(self, min: f64, max: f64) -> f64 {
@@ -1571,18 +1570,18 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_clamp_min_greater_than_max() {
-        1.0f64.clamp(3.0, 1.0);
+        let _ = 1.0f64.clamp(3.0, 1.0);
     }
 
     #[test]
     #[should_panic]
     fn test_clamp_min_is_nan() {
-        1.0f64.clamp(NAN, 1.0);
+        let _ = 1.0f64.clamp(NAN, 1.0);
     }
 
     #[test]
     #[should_panic]
     fn test_clamp_max_is_nan() {
-        1.0f64.clamp(3.0, NAN);
+        let _ = 1.0f64.clamp(3.0, NAN);
     }
 }

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -40,7 +40,7 @@ impl f64 {
     /// assert_eq!(g.floor(), 3.0);
     /// assert_eq!(h.floor(), -4.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f64 {
@@ -58,7 +58,7 @@ impl f64 {
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f64 {
@@ -77,7 +77,7 @@ impl f64 {
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f64 {
@@ -97,7 +97,7 @@ impl f64 {
     /// assert_eq!(g.trunc(), 3.0);
     /// assert_eq!(h.trunc(), -3.0);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f64 {
@@ -117,7 +117,7 @@ impl f64 {
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f64 { self - self.trunc() }
@@ -141,7 +141,7 @@ impl f64 {
     ///
     /// assert!(f64::NAN.abs().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs(self) -> f64 {
@@ -166,7 +166,7 @@ impl f64 {
     ///
     /// assert!(f64::NAN.signum().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f64 {
@@ -199,7 +199,7 @@ impl f64 {
     /// assert!(f64::NAN.copysign(1.0).is_nan());
     /// ```
     #[inline]
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "copysign", since = "1.35.0")]
     pub fn copysign(self, sign: f64) -> f64 {
         unsafe { intrinsics::copysignf64(self, sign) }
@@ -339,7 +339,7 @@ impl f64 {
     /// assert!(abs_difference < 1e-10);
     /// assert!(negative.sqrt().is_nan());
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f64 {
@@ -364,7 +364,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp(self) -> f64 {
@@ -383,7 +383,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp2(self) -> f64 {
@@ -404,7 +404,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f64 {
@@ -443,7 +443,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f64 {
@@ -467,7 +467,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f64 {
@@ -517,7 +517,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f64 {
@@ -557,7 +557,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sin(self) -> f64 {
@@ -577,7 +577,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cos(self) -> f64 {
@@ -596,7 +596,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-14);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f64 {
@@ -619,7 +619,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f64 {
@@ -642,7 +642,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f64 {
@@ -662,7 +662,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f64 {
@@ -739,7 +739,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f64 {
@@ -761,7 +761,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f64 {
@@ -785,7 +785,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f64 {
@@ -809,7 +809,7 @@ impl f64 {
     /// // Same result
     /// assert!(abs_difference < 1.0e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f64 {
@@ -833,7 +833,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f64 {
@@ -852,7 +852,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f64 {
@@ -875,7 +875,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f64 {
@@ -899,7 +899,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
-    #[must_use]
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atanh(self) -> f64 {

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -936,6 +936,8 @@ impl f64 {
     /// assert!((2.0f64).clamp(-2.0, 1.0) == 1.0);
     /// assert!((std::f64::NAN).clamp(-2.0, 1.0).is_nan());
     /// ```
+    // The tests below invoke `clamp` without a return value in order to cause a `panic`.
+    // #[must_use = "method returns a new number and does not mutate the original value"]
     #[unstable(feature = "clamp", issue = "44095")]
     #[inline]
     pub fn clamp(self, min: f64, max: f64) -> f64 {

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -198,9 +198,9 @@ impl f64 {
     ///
     /// assert!(f64::NAN.copysign(1.0).is_nan());
     /// ```
-    #[inline]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "copysign", since = "1.35.0")]
+    #[inline]
     pub fn copysign(self, sign: f64) -> f64 {
         unsafe { intrinsics::copysignf64(self, sign) }
     }
@@ -223,6 +223,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn mul_add(self, a: f64, b: f64) -> f64 {
@@ -246,6 +247,7 @@ impl f64 {
     /// assert_eq!(a.div_euclid(-b), -1.0); // 7.0 >= -4.0 * -1.0
     /// assert_eq!((-a).div_euclid(-b), 2.0); // -7.0 >= -4.0 * 2.0
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn div_euclid(self, rhs: f64) -> f64 {
@@ -279,6 +281,7 @@ impl f64 {
     /// // limitation due to round-off error
     /// assert!((-std::f64::EPSILON).rem_euclid(3.0) != 0.0);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f64) -> f64 {
@@ -302,6 +305,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powi(self, n: i32) -> f64 {
@@ -318,6 +322,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn powf(self, n: f64) -> f64 {
@@ -427,6 +432,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log(self, base: f64) -> f64 { self.ln() / base.ln() }
@@ -491,6 +497,7 @@ impl f64 {
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     #[rustc_deprecated(since = "1.10.0",
@@ -538,6 +545,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn hypot(self, other: f64) -> f64 {
@@ -697,6 +705,7 @@ impl f64 {
     /// assert!(abs_difference_1 < 1e-10);
     /// assert!(abs_difference_2 < 1e-10);
     /// ```
+    #[must_use = "method returns a new number and does not mutate the original value"]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan2(self, other: f64) -> f64 {

--- a/src/libstd/f64.rs
+++ b/src/libstd/f64.rs
@@ -40,6 +40,7 @@ impl f64 {
     /// assert_eq!(g.floor(), 3.0);
     /// assert_eq!(h.floor(), -4.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn floor(self) -> f64 {
@@ -57,6 +58,7 @@ impl f64 {
     /// assert_eq!(f.ceil(), 4.0);
     /// assert_eq!(g.ceil(), 4.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ceil(self) -> f64 {
@@ -75,6 +77,7 @@ impl f64 {
     /// assert_eq!(f.round(), 3.0);
     /// assert_eq!(g.round(), -3.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn round(self) -> f64 {
@@ -94,6 +97,7 @@ impl f64 {
     /// assert_eq!(g.trunc(), 3.0);
     /// assert_eq!(h.trunc(), -3.0);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn trunc(self) -> f64 {
@@ -113,6 +117,7 @@ impl f64 {
     /// assert!(abs_difference_x < 1e-10);
     /// assert!(abs_difference_y < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn fract(self) -> f64 { self - self.trunc() }
@@ -136,6 +141,7 @@ impl f64 {
     ///
     /// assert!(f64::NAN.abs().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn abs(self) -> f64 {
@@ -160,6 +166,7 @@ impl f64 {
     ///
     /// assert!(f64::NAN.signum().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn signum(self) -> f64 {
@@ -332,6 +339,7 @@ impl f64 {
     /// assert!(abs_difference < 1e-10);
     /// assert!(negative.sqrt().is_nan());
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sqrt(self) -> f64 {
@@ -356,6 +364,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp(self) -> f64 {
@@ -374,6 +383,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp2(self) -> f64 {
@@ -394,6 +404,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln(self) -> f64 {
@@ -432,6 +443,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log2(self) -> f64 {
@@ -455,6 +467,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn log10(self) -> f64 {
@@ -504,6 +517,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cbrt(self) -> f64 {
@@ -543,6 +557,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sin(self) -> f64 {
@@ -562,6 +577,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cos(self) -> f64 {
@@ -580,6 +596,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-14);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tan(self) -> f64 {
@@ -602,6 +619,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asin(self) -> f64 {
@@ -624,6 +642,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acos(self) -> f64 {
@@ -643,6 +662,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atan(self) -> f64 {
@@ -719,6 +739,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn exp_m1(self) -> f64 {
@@ -740,6 +761,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn ln_1p(self) -> f64 {
@@ -763,6 +785,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn sinh(self) -> f64 {
@@ -786,6 +809,7 @@ impl f64 {
     /// // Same result
     /// assert!(abs_difference < 1.0e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn cosh(self) -> f64 {
@@ -809,6 +833,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn tanh(self) -> f64 {
@@ -827,6 +852,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn asinh(self) -> f64 {
@@ -849,6 +875,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn acosh(self) -> f64 {
@@ -872,6 +899,7 @@ impl f64 {
     ///
     /// assert!(abs_difference < 1.0e-10);
     /// ```
+    #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[inline]
     pub fn atanh(self) -> f64 {

--- a/src/libsyntax/config.rs
+++ b/src/libsyntax/config.rs
@@ -10,6 +10,7 @@ use crate::attr;
 use crate::ast;
 use crate::edition::Edition;
 use crate::mut_visit::*;
+use crate::parse;
 use crate::ptr::P;
 use crate::sess::ParseSess;
 use crate::symbol::sym;
@@ -112,7 +113,8 @@ impl<'a> StripUnconfigured<'a> {
             return vec![];
         }
 
-        let (cfg_predicate, expanded_attrs) = match attr.parse(self.sess, |p| p.parse_cfg_attr()) {
+        let res = parse::parse_in_attr(self.sess, &attr, |p| p.parse_cfg_attr());
+        let (cfg_predicate, expanded_attrs) = match res {
             Ok(result) => result,
             Err(mut e) => {
                 e.emit();

--- a/src/libsyntax/expand/allocator.rs
+++ b/src/libsyntax/expand/allocator.rs
@@ -1,5 +1,5 @@
-use syntax::{ast, attr, visit};
-use syntax::symbol::{sym, Symbol};
+use crate::{ast, attr, visit};
+use syntax_pos::symbol::{sym, Symbol};
 use syntax_pos::Span;
 
 #[derive(Clone, Copy)]

--- a/src/libsyntax/expand/mod.rs
+++ b/src/libsyntax/expand/mod.rs
@@ -1,0 +1,21 @@
+//! Definitions shared by macros / syntax extensions and e.g. librustc.
+
+use crate::ast::Attribute;
+use syntax_pos::symbol::sym;
+
+pub mod allocator;
+
+bitflags::bitflags! {
+    /// Built-in derives that need some extra tracking beyond the usual macro functionality.
+    #[derive(Default)]
+    pub struct SpecialDerives: u8 {
+        const PARTIAL_EQ = 1 << 0;
+        const EQ         = 1 << 1;
+        const COPY       = 1 << 2;
+    }
+}
+
+pub fn is_proc_macro_attr(attr: &Attribute) -> bool {
+    [sym::proc_macro, sym::proc_macro_attribute, sym::proc_macro_derive]
+        .iter().any(|kind| attr.check_name(*kind))
+}

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -96,8 +96,7 @@ pub mod json;
 pub mod ast;
 pub mod attr;
 pub mod source_map;
-#[macro_use]
-pub mod config;
+#[macro_use] pub mod config;
 pub mod entry;
 pub mod feature_gate;
 pub mod mut_visit;

--- a/src/libsyntax/lib.rs
+++ b/src/libsyntax/lib.rs
@@ -95,6 +95,7 @@ pub mod json;
 
 pub mod ast;
 pub mod attr;
+pub mod expand;
 pub mod source_map;
 #[macro_use] pub mod config;
 pub mod entry;

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -288,6 +288,27 @@ pub fn stream_to_parser_with_base_dir<'a>(
     Parser::new(sess, stream, Some(base_dir), true, false, None)
 }
 
+/// Runs the given subparser `f` on the tokens of the given `attr`'s item.
+pub fn parse_in_attr<'a, T>(
+    sess: &'a ParseSess,
+    attr: &ast::Attribute,
+    mut f: impl FnMut(&mut Parser<'a>) -> PResult<'a, T>,
+) -> PResult<'a, T> {
+    let mut parser = Parser::new(
+        sess,
+        attr.tokens.clone(),
+        None,
+        false,
+        false,
+        Some("attribute"),
+    );
+    let result = f(&mut parser)?;
+    if parser.token != token::Eof {
+        parser.unexpected()?;
+    }
+    Ok(result)
+}
+
 // NOTE(Centril): The following probably shouldn't be here but it acknowledges the
 // fact that architecturally, we are using parsing (read on below to understand why).
 

--- a/src/libsyntax/parse/parser/path.rs
+++ b/src/libsyntax/parse/parser/path.rs
@@ -130,7 +130,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a list of paths inside `#[derive(path_0, ..., path_n)]`.
-    crate fn parse_derive_paths(&mut self) -> PResult<'a, Vec<Path>> {
+    pub fn parse_derive_paths(&mut self) -> PResult<'a, Vec<Path>> {
         self.expect(&token::OpenDelim(token::Paren))?;
         let mut list = Vec::new();
         while !self.eat(&token::CloseDelim(token::Paren)) {

--- a/src/libsyntax_expand/base.rs
+++ b/src/libsyntax_expand/base.rs
@@ -1,5 +1,4 @@
 use crate::expand::{self, AstFragment, Invocation};
-use crate::hygiene::ExpnId;
 
 use syntax::ast::{self, NodeId, Attribute, Name, PatKind};
 use syntax::attr::{self, HasAttrs, Stability, Deprecation};
@@ -14,11 +13,12 @@ use syntax::symbol::{kw, sym, Ident, Symbol};
 use syntax::{ThinVec, MACRO_ARGUMENTS};
 use syntax::tokenstream::{self, TokenStream};
 use syntax::visit::Visitor;
+crate use syntax::expand::SpecialDerives;
 
 use errors::{DiagnosticBuilder, DiagnosticId};
 use smallvec::{smallvec, SmallVec};
 use syntax_pos::{FileName, Span, MultiSpan, DUMMY_SP};
-use syntax_pos::hygiene::{AstPass, ExpnData, ExpnKind};
+use syntax_pos::hygiene::{AstPass, ExpnId, ExpnData, ExpnKind};
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::{self, Lrc};
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::default::Default;
 
-pub use syntax_pos::hygiene::MacroKind;
+crate use syntax_pos::hygiene::MacroKind;
 
 #[derive(Debug,Clone)]
 pub enum Annotatable {
@@ -836,16 +836,6 @@ pub enum InvocationRes {
 
 /// Error type that denotes indeterminacy.
 pub struct Indeterminate;
-
-bitflags::bitflags! {
-    /// Built-in derives that need some extra tracking beyond the usual macro functionality.
-    #[derive(Default)]
-    pub struct SpecialDerives: u8 {
-        const PARTIAL_EQ = 1 << 0;
-        const EQ         = 1 << 1;
-        const COPY       = 1 << 2;
-    }
-}
 
 pub trait Resolver {
     fn next_node_id(&mut self) -> NodeId;

--- a/src/libsyntax_expand/lib.rs
+++ b/src/libsyntax_expand/lib.rs
@@ -28,9 +28,8 @@ macro_rules! panictry {
 mod placeholders;
 mod proc_macro_server;
 
-pub use syntax_pos::hygiene;
+crate use syntax_pos::hygiene;
 pub use mbe::macro_rules::compile_declarative_macro;
-pub mod allocator;
 pub mod base;
 pub mod build;
 pub mod expand;

--- a/src/libsyntax_expand/proc_macro.rs
+++ b/src/libsyntax_expand/proc_macro.rs
@@ -200,7 +200,14 @@ crate fn collect_derives(cx: &mut ExtCtxt<'_>, attrs: &mut Vec<ast::Attribute>) 
             return false;
         }
 
-        match attr.parse_derive_paths(cx.parse_sess) {
+        let parse_derive_paths = |attr: &ast::Attribute| {
+            if attr.tokens.is_empty() {
+                return Ok(Vec::new());
+            }
+            parse::parse_in_attr(cx.parse_sess, attr, |p| p.parse_derive_paths())
+        };
+
+        match parse_derive_paths(attr) {
             Ok(traits) => {
                 result.extend(traits);
                 true

--- a/src/libsyntax_expand/proc_macro.rs
+++ b/src/libsyntax_expand/proc_macro.rs
@@ -178,11 +178,6 @@ impl<'a> Visitor<'a> for MarkAttrs<'a> {
     fn visit_mac(&mut self, _mac: &Mac) {}
 }
 
-pub fn is_proc_macro_attr(attr: &Attribute) -> bool {
-    [sym::proc_macro, sym::proc_macro_attribute, sym::proc_macro_derive]
-        .iter().any(|kind| attr.check_name(*kind))
-}
-
 crate fn collect_derives(cx: &mut ExtCtxt<'_>, attrs: &mut Vec<ast::Attribute>) -> Vec<ast::Path> {
     let mut result = Vec::new();
     attrs.retain(|attr| {

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -3,7 +3,8 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
-use syntax_expand::base::{Annotatable, ExtCtxt, SpecialDerives};
+use syntax::expand::SpecialDerives;
+use syntax_expand::base::{Annotatable, ExtCtxt};
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
 use syntax_pos::Span;

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -3,9 +3,10 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Ident, Expr, MetaItem, GenericArg};
-use syntax_expand::base::{Annotatable, ExtCtxt, SpecialDerives};
+use syntax::expand::SpecialDerives;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
+use syntax_expand::base::{Annotatable, ExtCtxt};
 use syntax_pos::Span;
 
 pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -3,10 +3,11 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{BinOpKind, Expr, MetaItem};
-use syntax_expand::base::{Annotatable, ExtCtxt, SpecialDerives};
+use syntax::expand::SpecialDerives;
 use syntax::ptr::P;
 use syntax::symbol::sym;
-use syntax_pos::{self, Span};
+use syntax_expand::base::{Annotatable, ExtCtxt};
+use syntax_pos::Span;
 
 pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
                                   span: Span,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -186,13 +186,14 @@ use rustc_target::spec::abi::Abi;
 use syntax::ast::{self, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
 use syntax::ast::{VariantData, GenericParamKind, GenericArg};
 use syntax::attr;
+use syntax::expand::SpecialDerives;
 use syntax::source_map::respan;
 use syntax::util::map_in_place::MapInPlace;
 use syntax::ptr::P;
 use syntax::sess::ParseSess;
 use syntax::symbol::{Symbol, kw, sym};
-use syntax_expand::base::{Annotatable, ExtCtxt, SpecialDerives};
-use syntax_pos::{Span};
+use syntax_expand::base::{Annotatable, ExtCtxt};
+use syntax_pos::Span;
 
 use ty::{LifetimeBounds, Path, Ptr, PtrTy, Self_, Ty};
 

--- a/src/libsyntax_ext/global_allocator.rs
+++ b/src/libsyntax_ext/global_allocator.rs
@@ -2,10 +2,10 @@ use crate::util::check_builtin_macro_attribute;
 
 use syntax::ast::{ItemKind, Mutability, Stmt, Ty, TyKind, Unsafety};
 use syntax::ast::{self, Param, Attribute, Expr, FnHeader, Generics, Ident};
-use syntax_expand::allocator::{AllocatorKind, AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
-use syntax_expand::base::{Annotatable, ExtCtxt};
+use syntax::expand::allocator::{AllocatorKind, AllocatorMethod, AllocatorTy, ALLOCATOR_METHODS};
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
+use syntax_expand::base::{Annotatable, ExtCtxt};
 use syntax_pos::Span;
 
 pub fn expand(

--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -3,6 +3,7 @@ use std::mem;
 use smallvec::smallvec;
 use syntax::ast::{self, Ident};
 use syntax::attr;
+use syntax::expand::is_proc_macro_attr;
 use syntax::print::pprust;
 use syntax::ptr::P;
 use syntax::sess::ParseSess;
@@ -10,7 +11,6 @@ use syntax::symbol::{kw, sym};
 use syntax::visit::{self, Visitor};
 use syntax_expand::base::{ExtCtxt, Resolver};
 use syntax_expand::expand::{AstFragment, ExpansionConfig};
-use syntax_expand::proc_macro::is_proc_macro_attr;
 use syntax_pos::{Span, DUMMY_SP};
 use syntax_pos::hygiene::AstPass;
 

--- a/src/libsyntax_ext/standard_library_imports.rs
+++ b/src/libsyntax_ext/standard_library_imports.rs
@@ -4,9 +4,9 @@ use syntax::ptr::P;
 use syntax::sess::ParseSess;
 use syntax::symbol::{Ident, Symbol, kw, sym};
 use syntax_expand::expand::ExpansionConfig;
-use syntax_expand::hygiene::AstPass;
 use syntax_expand::base::{ExtCtxt, Resolver};
 use syntax_pos::DUMMY_SP;
+use syntax_pos::hygiene::AstPass;
 
 pub fn inject(
     mut krate: ast::Crate,

--- a/src/test/ui/associated-types/associated-types-eq-1.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-1.stderr
@@ -1,6 +1,8 @@
 error[E0412]: cannot find type `A` in this scope
   --> $DIR/associated-types-eq-1.rs:10:12
    |
+LL | fn foo2<I: Foo>(x: I) {
+   |         - similarly named type parameter `I` defined here
 LL |     let _: A = x.boo();
    |            ^ help: a type parameter with a similar name exists: `I`
 

--- a/src/test/ui/class-missing-self.rs
+++ b/src/test/ui/class-missing-self.rs
@@ -7,7 +7,7 @@ impl Cat {
     fn meow(&self) {
       println!("Meow");
       meows += 1; //~ ERROR cannot find value `meows` in this scope
-      sleep();     //~ ERROR cannot find function `sleep` in this scope
+      sleep();     //~ ERROR cannot find function `sleep` in this
     }
 
 }

--- a/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
+++ b/src/test/ui/const-generics/struct-with-invalid-const-param.stderr
@@ -2,7 +2,10 @@ error[E0573]: expected type, found const parameter `C`
   --> $DIR/struct-with-invalid-const-param.rs:4:23
    |
 LL | struct S<const C: u8>(C);
-   |                       ^ help: a struct with a similar name exists: `S`
+   | ----------------------^--
+   | |                     |
+   | |                     help: a struct with a similar name exists: `S`
+   | similarly named struct `S` defined here
 
 warning: the feature `const_generics` is incomplete and may cause the compiler to crash
   --> $DIR/struct-with-invalid-const-param.rs:1:12

--- a/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.rs
+++ b/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.rs
@@ -16,21 +16,21 @@ enum ManyVariants {
 }
 
 fn result_test() {
-    let x = Option(1); //~ ERROR expected function, found enum
+    let x = Option(1); //~ ERROR expected function, tuple struct or tuple variant, found enum
 
-    if let Option(_) = x { //~ ERROR expected tuple struct/variant, found enum
+    if let Option(_) = x { //~ ERROR expected tuple struct or tuple variant, found enum
         println!("It is OK.");
     }
 
     let y = Example::Ex(String::from("test"));
 
-    if let Example(_) = y { //~ ERROR expected tuple struct/variant, found enum
+    if let Example(_) = y { //~ ERROR expected tuple struct or tuple variant, found enum
         println!("It is OK.");
     }
 
-    let y = Void(); //~ ERROR expected function, found enum
+    let y = Void(); //~ ERROR expected function, tuple struct or tuple variant, found enum
 
-    let z = ManyVariants(); //~ ERROR expected function, found enum
+    let z = ManyVariants(); //~ ERROR expected function, tuple struct or tuple variant, found enum
 }
 
 fn main() {}

--- a/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
+++ b/src/test/ui/did_you_mean/issue-43871-enum-instead-of-variant.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, found enum `Option`
+error[E0423]: expected function, tuple struct or tuple variant, found enum `Option`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:19:13
    |
 LL |     let x = Option(1);
@@ -11,7 +11,7 @@ LL |     let x = std::option::Option::None(1);
 LL |     let x = std::option::Option::Some(1);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0532]: expected tuple struct/variant, found enum `Option`
+error[E0532]: expected tuple struct or tuple variant, found enum `Option`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:21:12
    |
 LL |     if let Option(_) = x {
@@ -24,7 +24,7 @@ LL |     if let std::option::Option::None(_) = x {
 LL |     if let std::option::Option::Some(_) = x {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0532]: expected tuple struct/variant, found enum `Example`
+error[E0532]: expected tuple struct or tuple variant, found enum `Example`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:27:12
    |
 LL |     if let Example(_) = y {
@@ -37,13 +37,13 @@ LL |     if let Example::Ex(_) = y {
 LL |     if let Example::NotEx(_) = y {
    |            ^^^^^^^^^^^^^^
 
-error[E0423]: expected function, found enum `Void`
+error[E0423]: expected function, tuple struct or tuple variant, found enum `Void`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:31:13
    |
 LL |     let y = Void();
    |             ^^^^
 
-error[E0423]: expected function, found enum `ManyVariants`
+error[E0423]: expected function, tuple struct or tuple variant, found enum `ManyVariants`
   --> $DIR/issue-43871-enum-instead-of-variant.rs:33:13
    |
 LL |     let z = ManyVariants();

--- a/src/test/ui/empty/empty-struct-braces-expr.rs
+++ b/src/test/ui/empty/empty-struct-braces-expr.rs
@@ -13,12 +13,15 @@ enum E {
 
 fn main() {
     let e1 = Empty1; //~ ERROR expected value, found struct `Empty1`
-    let e1 = Empty1(); //~ ERROR expected function, found struct `Empty1`
+    let e1 = Empty1();
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct `Empty1`
     let e3 = E::Empty3; //~ ERROR expected value, found struct variant `E::Empty3`
-    let e3 = E::Empty3(); //~ ERROR expected function, found struct variant `E::Empty3`
+    let e3 = E::Empty3();
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct variant `E::Empty3`
 
     let xe1 = XEmpty1; //~ ERROR expected value, found struct `XEmpty1`
-    let xe1 = XEmpty1(); //~ ERROR expected function, found struct `XEmpty1`
+    let xe1 = XEmpty1();
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct `XEmpty1`
     let xe3 = XE::Empty3; //~ ERROR no variant or associated item named `Empty3` found for type
     let xe3 = XE::Empty3(); //~ ERROR no variant or associated item named `Empty3` found for type
 

--- a/src/test/ui/empty/empty-struct-braces-expr.stderr
+++ b/src/test/ui/empty/empty-struct-braces-expr.stderr
@@ -10,7 +10,7 @@ LL |     let e1 = Empty1;
    |              did you mean `Empty1 { /* fields */ }`?
    |              help: a unit struct with a similar name exists: `XEmpty2`
 
-error[E0423]: expected function, found struct `Empty1`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `Empty1`
   --> $DIR/empty-struct-braces-expr.rs:16:14
    |
 LL | struct Empty1 {}
@@ -23,7 +23,7 @@ LL |     let e1 = Empty1();
    |              help: a unit struct with a similar name exists: `XEmpty2`
 
 error[E0423]: expected value, found struct variant `E::Empty3`
-  --> $DIR/empty-struct-braces-expr.rs:17:14
+  --> $DIR/empty-struct-braces-expr.rs:18:14
    |
 LL |     Empty3 {}
    |     --------- `E::Empty3` defined here
@@ -31,8 +31,8 @@ LL |     Empty3 {}
 LL |     let e3 = E::Empty3;
    |              ^^^^^^^^^ did you mean `E::Empty3 { /* fields */ }`?
 
-error[E0423]: expected function, found struct variant `E::Empty3`
-  --> $DIR/empty-struct-braces-expr.rs:18:14
+error[E0423]: expected function, tuple struct or tuple variant, found struct variant `E::Empty3`
+  --> $DIR/empty-struct-braces-expr.rs:19:14
    |
 LL |     Empty3 {}
    |     --------- `E::Empty3` defined here
@@ -41,7 +41,7 @@ LL |     let e3 = E::Empty3();
    |              ^^^^^^^^^ did you mean `E::Empty3 { /* fields */ }`?
 
 error[E0423]: expected value, found struct `XEmpty1`
-  --> $DIR/empty-struct-braces-expr.rs:20:15
+  --> $DIR/empty-struct-braces-expr.rs:22:15
    |
 LL |     let xe1 = XEmpty1;
    |               ^^^^^^^
@@ -49,8 +49,8 @@ LL |     let xe1 = XEmpty1;
    |               did you mean `XEmpty1 { /* fields */ }`?
    |               help: a unit struct with a similar name exists: `XEmpty2`
 
-error[E0423]: expected function, found struct `XEmpty1`
-  --> $DIR/empty-struct-braces-expr.rs:21:15
+error[E0423]: expected function, tuple struct or tuple variant, found struct `XEmpty1`
+  --> $DIR/empty-struct-braces-expr.rs:23:15
    |
 LL |     let xe1 = XEmpty1();
    |               ^^^^^^^
@@ -59,7 +59,7 @@ LL |     let xe1 = XEmpty1();
    |               help: a unit struct with a similar name exists: `XEmpty2`
 
 error[E0599]: no variant or associated item named `Empty3` found for type `empty_struct::XE` in the current scope
-  --> $DIR/empty-struct-braces-expr.rs:22:19
+  --> $DIR/empty-struct-braces-expr.rs:25:19
    |
 LL |     let xe3 = XE::Empty3;
    |                   ^^^^^^
@@ -68,7 +68,7 @@ LL |     let xe3 = XE::Empty3;
    |                   help: there is a variant with a similar name: `XEmpty3`
 
 error[E0599]: no variant or associated item named `Empty3` found for type `empty_struct::XE` in the current scope
-  --> $DIR/empty-struct-braces-expr.rs:23:19
+  --> $DIR/empty-struct-braces-expr.rs:26:19
    |
 LL |     let xe3 = XE::Empty3();
    |                   ^^^^^^
@@ -77,7 +77,7 @@ LL |     let xe3 = XE::Empty3();
    |                   help: there is a variant with a similar name: `XEmpty3`
 
 error: no variant `Empty1` in enum `empty_struct::XE`
-  --> $DIR/empty-struct-braces-expr.rs:25:9
+  --> $DIR/empty-struct-braces-expr.rs:28:9
    |
 LL |     XE::Empty1 {};
    |         ^^^^^^ help: there is a variant with a similar name: `XEmpty3`

--- a/src/test/ui/empty/empty-struct-braces-pat-1.rs
+++ b/src/test/ui/empty/empty-struct-braces-pat-1.rs
@@ -22,13 +22,13 @@ fn main() {
     }
     match e3 {
         E::Empty3 => ()
-        //~^ ERROR expected unit struct/variant or constant, found struct variant `E::Empty3`
+        //~^ ERROR expected unit struct, unit variant or constant, found struct variant `E::Empty3`
     }
     match xe1 {
         XEmpty1 => () // Not an error, `XEmpty1` is interpreted as a new binding
     }
     match xe3 {
         XE::XEmpty3 => ()
-        //~^ ERROR expected unit struct/variant or constant, found struct variant `XE::XEmpty3`
+    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `XE::XEmpty3`
     }
 }

--- a/src/test/ui/empty/empty-struct-braces-pat-1.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-1.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected unit struct/variant or constant, found struct variant `E::Empty3`
+error[E0532]: expected unit struct, unit variant or constant, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-pat-1.rs:24:9
    |
 LL |     Empty3 {}
@@ -7,7 +7,7 @@ LL |     Empty3 {}
 LL |         E::Empty3 => ()
    |         ^^^^^^^^^ did you mean `E::Empty3 { /* fields */ }`?
 
-error[E0532]: expected unit struct/variant or constant, found struct variant `XE::XEmpty3`
+error[E0532]: expected unit struct, unit variant or constant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-1.rs:31:9
    |
 LL |         XE::XEmpty3 => ()

--- a/src/test/ui/empty/empty-struct-braces-pat-2.rs
+++ b/src/test/ui/empty/empty-struct-braces-pat-2.rs
@@ -12,15 +12,15 @@ fn main() {
     let xe1 = XEmpty1 {};
 
     match e1 {
-        Empty1() => () //~ ERROR expected tuple struct/variant, found struct `Empty1`
+        Empty1() => () //~ ERROR expected tuple struct or tuple variant, found struct `Empty1`
     }
     match xe1 {
-        XEmpty1() => () //~ ERROR expected tuple struct/variant, found struct `XEmpty1`
+        XEmpty1() => () //~ ERROR expected tuple struct or tuple variant, found struct `XEmpty1`
     }
     match e1 {
-        Empty1(..) => () //~ ERROR expected tuple struct/variant, found struct `Empty1`
+        Empty1(..) => () //~ ERROR expected tuple struct or tuple variant, found struct `Empty1`
     }
     match xe1 {
-        XEmpty1(..) => () //~ ERROR expected tuple struct/variant, found struct `XEmpty1`
+        XEmpty1(..) => () //~ ERROR expected tuple struct or tuple variant, found struct `XEmpty1`
     }
 }

--- a/src/test/ui/empty/empty-struct-braces-pat-2.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-2.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct/variant, found struct `Empty1`
+error[E0532]: expected tuple struct or tuple variant, found struct `Empty1`
   --> $DIR/empty-struct-braces-pat-2.rs:15:9
    |
 LL | struct Empty1 {}
@@ -10,7 +10,7 @@ LL |         Empty1() => ()
    |         did you mean `Empty1 { /* fields */ }`?
    |         help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found struct `XEmpty1`
+error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
   --> $DIR/empty-struct-braces-pat-2.rs:18:9
    |
 LL |         XEmpty1() => ()
@@ -19,7 +19,7 @@ LL |         XEmpty1() => ()
    |         did you mean `XEmpty1 { /* fields */ }`?
    |         help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found struct `Empty1`
+error[E0532]: expected tuple struct or tuple variant, found struct `Empty1`
   --> $DIR/empty-struct-braces-pat-2.rs:21:9
    |
 LL | struct Empty1 {}
@@ -31,7 +31,7 @@ LL |         Empty1(..) => ()
    |         did you mean `Empty1 { /* fields */ }`?
    |         help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found struct `XEmpty1`
+error[E0532]: expected tuple struct or tuple variant, found struct `XEmpty1`
   --> $DIR/empty-struct-braces-pat-2.rs:24:9
    |
 LL |         XEmpty1(..) => ()

--- a/src/test/ui/empty/empty-struct-braces-pat-3.rs
+++ b/src/test/ui/empty/empty-struct-braces-pat-3.rs
@@ -15,18 +15,18 @@ fn main() {
 
     match e3 {
         E::Empty3() => ()
-        //~^ ERROR expected tuple struct/variant, found struct variant `E::Empty3`
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `E::Empty3`
     }
     match xe3 {
         XE::XEmpty3() => ()
-        //~^ ERROR expected tuple struct/variant, found struct variant `XE::XEmpty3`
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `XE::XEmpty3`
     }
     match e3 {
         E::Empty3(..) => ()
-        //~^ ERROR expected tuple struct/variant, found struct variant `E::Empty3`
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `E::Empty3`
     }
     match xe3 {
         XE::XEmpty3(..) => ()
-        //~^ ERROR expected tuple struct/variant, found struct variant `XE::XEmpty3
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `XE::XEmpty3
     }
 }

--- a/src/test/ui/empty/empty-struct-braces-pat-3.stderr
+++ b/src/test/ui/empty/empty-struct-braces-pat-3.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct/variant, found struct variant `E::Empty3`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-pat-3.rs:17:9
    |
 LL |     Empty3 {}
@@ -7,7 +7,7 @@ LL |     Empty3 {}
 LL |         E::Empty3() => ()
    |         ^^^^^^^^^ did you mean `E::Empty3 { /* fields */ }`?
 
-error[E0532]: expected tuple struct/variant, found struct variant `XE::XEmpty3`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-3.rs:21:9
    |
 LL |         XE::XEmpty3() => ()
@@ -16,7 +16,7 @@ LL |         XE::XEmpty3() => ()
    |         |   help: a tuple variant with a similar name exists: `XEmpty5`
    |         did you mean `XE::XEmpty3 { /* fields */ }`?
 
-error[E0532]: expected tuple struct/variant, found struct variant `E::Empty3`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-pat-3.rs:25:9
    |
 LL |     Empty3 {}
@@ -25,7 +25,7 @@ LL |     Empty3 {}
 LL |         E::Empty3(..) => ()
    |         ^^^^^^^^^ did you mean `E::Empty3 { /* fields */ }`?
 
-error[E0532]: expected tuple struct/variant, found struct variant `XE::XEmpty3`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-3.rs:29:9
    |
 LL |         XE::XEmpty3(..) => ()

--- a/src/test/ui/empty/empty-struct-tuple-pat.rs
+++ b/src/test/ui/empty/empty-struct-tuple-pat.rs
@@ -27,11 +27,11 @@ fn main() {
 
     match e4 {
         E::Empty4 => ()
-        //~^ ERROR expected unit struct/variant or constant, found tuple variant `E::Empty4`
+        //~^ ERROR expected unit struct, unit variant or constant, found tuple variant `E::Empty4`
     }
     match xe5 {
         XE::XEmpty5 => (),
-        //~^ ERROR expected unit struct/variant or constant, found tuple variant `XE::XEmpty5`
+        //~^ ERROR expected unit struct, unit variant or constant, found tuple variant `XE::XEmpty5`
         _ => {},
     }
 }

--- a/src/test/ui/empty/empty-struct-tuple-pat.stderr
+++ b/src/test/ui/empty/empty-struct-tuple-pat.stderr
@@ -16,7 +16,7 @@ LL | use empty_struct::*;
 LL |         XEmpty6 => ()
    |         ^^^^^^^ cannot be named the same as a tuple struct
 
-error[E0532]: expected unit struct/variant or constant, found tuple variant `E::Empty4`
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `E::Empty4`
   --> $DIR/empty-struct-tuple-pat.rs:29:9
    |
 LL |     Empty4()
@@ -25,7 +25,7 @@ LL |     Empty4()
 LL |         E::Empty4 => ()
    |         ^^^^^^^^^ did you mean `E::Empty4( /* fields */ )`?
 
-error[E0532]: expected unit struct/variant or constant, found tuple variant `XE::XEmpty5`
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `XE::XEmpty5`
   --> $DIR/empty-struct-tuple-pat.rs:33:9
    |
 LL |         XE::XEmpty5 => (),

--- a/src/test/ui/empty/empty-struct-unit-pat.rs
+++ b/src/test/ui/empty/empty-struct-unit-pat.rs
@@ -18,32 +18,37 @@ fn main() {
     let xe4 = XE::XEmpty4;
 
     match e2 {
-        Empty2() => () //~ ERROR expected tuple struct/variant, found unit struct `Empty2`
+        Empty2() => () //~ ERROR expected tuple struct or tuple variant, found unit struct `Empty2`
     }
     match xe2 {
-        XEmpty2() => () //~ ERROR expected tuple struct/variant, found unit struct `XEmpty2`
+        XEmpty2() => ()
+        //~^ ERROR expected tuple struct or tuple variant, found unit struct `XEmpty2`
     }
     match e2 {
-        Empty2(..) => () //~ ERROR expected tuple struct/variant, found unit struct `Empty2`
+        Empty2(..) => ()
+        //~^ ERROR expected tuple struct or tuple variant, found unit struct `Empty2`
     }
     match xe2 {
-        XEmpty2(..) => () //~ ERROR expected tuple struct/variant, found unit struct `XEmpty2`
+        XEmpty2(..) => ()
+        //~^ ERROR expected tuple struct or tuple variant, found unit struct `XEmpty2`
     }
 
     match e4 {
-        E::Empty4() => () //~ ERROR expected tuple struct/variant, found unit variant `E::Empty4`
+        E::Empty4() => ()
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `E::Empty4`
     }
     match xe4 {
         XE::XEmpty4() => (),
-        //~^ ERROR expected tuple struct/variant, found unit variant `XE::XEmpty4`
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `XE::XEmpty4`
         _ => {},
     }
     match e4 {
-        E::Empty4(..) => () //~ ERROR expected tuple struct/variant, found unit variant `E::Empty4`
+        E::Empty4(..) => ()
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `E::Empty4`
     }
     match xe4 {
         XE::XEmpty4(..) => (),
-        //~^ ERROR expected tuple struct/variant, found unit variant `XE::XEmpty4`
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `XE::XEmpty4`
         _ => {},
     }
 }

--- a/src/test/ui/empty/empty-struct-unit-pat.stderr
+++ b/src/test/ui/empty/empty-struct-unit-pat.stderr
@@ -1,49 +1,49 @@
-error[E0532]: expected tuple struct/variant, found unit struct `Empty2`
+error[E0532]: expected tuple struct or tuple variant, found unit struct `Empty2`
   --> $DIR/empty-struct-unit-pat.rs:21:9
    |
 LL |         Empty2() => ()
    |         ^^^^^^ help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found unit struct `XEmpty2`
+error[E0532]: expected tuple struct or tuple variant, found unit struct `XEmpty2`
   --> $DIR/empty-struct-unit-pat.rs:24:9
    |
 LL |         XEmpty2() => ()
    |         ^^^^^^^ help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found unit struct `Empty2`
-  --> $DIR/empty-struct-unit-pat.rs:27:9
+error[E0532]: expected tuple struct or tuple variant, found unit struct `Empty2`
+  --> $DIR/empty-struct-unit-pat.rs:28:9
    |
 LL |         Empty2(..) => ()
    |         ^^^^^^ help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found unit struct `XEmpty2`
-  --> $DIR/empty-struct-unit-pat.rs:30:9
+error[E0532]: expected tuple struct or tuple variant, found unit struct `XEmpty2`
+  --> $DIR/empty-struct-unit-pat.rs:32:9
    |
 LL |         XEmpty2(..) => ()
    |         ^^^^^^^ help: a tuple struct with a similar name exists: `XEmpty6`
 
-error[E0532]: expected tuple struct/variant, found unit variant `E::Empty4`
-  --> $DIR/empty-struct-unit-pat.rs:34:9
+error[E0532]: expected tuple struct or tuple variant, found unit variant `E::Empty4`
+  --> $DIR/empty-struct-unit-pat.rs:37:9
    |
 LL |         E::Empty4() => ()
-   |         ^^^^^^^^^ not a tuple struct/variant
+   |         ^^^^^^^^^ not a tuple struct or tuple variant
 
-error[E0532]: expected tuple struct/variant, found unit variant `XE::XEmpty4`
-  --> $DIR/empty-struct-unit-pat.rs:37:9
+error[E0532]: expected tuple struct or tuple variant, found unit variant `XE::XEmpty4`
+  --> $DIR/empty-struct-unit-pat.rs:41:9
    |
 LL |         XE::XEmpty4() => (),
    |         ^^^^-------
    |             |
    |             help: a tuple variant with a similar name exists: `XEmpty5`
 
-error[E0532]: expected tuple struct/variant, found unit variant `E::Empty4`
-  --> $DIR/empty-struct-unit-pat.rs:42:9
+error[E0532]: expected tuple struct or tuple variant, found unit variant `E::Empty4`
+  --> $DIR/empty-struct-unit-pat.rs:46:9
    |
 LL |         E::Empty4(..) => ()
-   |         ^^^^^^^^^ not a tuple struct/variant
+   |         ^^^^^^^^^ not a tuple struct or tuple variant
 
-error[E0532]: expected tuple struct/variant, found unit variant `XE::XEmpty4`
-  --> $DIR/empty-struct-unit-pat.rs:45:9
+error[E0532]: expected tuple struct or tuple variant, found unit variant `XE::XEmpty4`
+  --> $DIR/empty-struct-unit-pat.rs:50:9
    |
 LL |         XE::XEmpty4(..) => (),
    |         ^^^^-------

--- a/src/test/ui/enums-pats-not-idents.rs
+++ b/src/test/ui/enums-pats-not-idents.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let a(1) = 13; //~ ERROR cannot find tuple struct/variant `a` in this scope
+    let a(1) = 13; //~ ERROR cannot find tuple struct or tuple variant `a` in this scope
 }

--- a/src/test/ui/enums-pats-not-idents.stderr
+++ b/src/test/ui/enums-pats-not-idents.stderr
@@ -1,4 +1,4 @@
-error[E0531]: cannot find tuple struct/variant `a` in this scope
+error[E0531]: cannot find tuple struct or tuple variant `a` in this scope
   --> $DIR/enums-pats-not-idents.rs:2:9
    |
 LL |     let a(1) = 13;

--- a/src/test/ui/error-codes/E0164.stderr
+++ b/src/test/ui/error-codes/E0164.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found associated constant `<Foo>::B`
+error[E0164]: expected tuple struct or tuple variant, found associated constant `<Foo>::B`
   --> $DIR/E0164.rs:9:9
    |
 LL |         Foo::B(i) => i,

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -26,17 +26,23 @@ help: surround the struct literal with parentheses
 LL |     for _ in (std::ops::Range { start: 0, end: 10 }) {}
    |              ^                                     ^
 
-error[E0423]: expected function, found struct `Foo`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `Foo`
   --> $DIR/E0423.rs:4:13
    |
-LL |     struct Foo { a: bool };
-   |     ---------------------- `Foo` defined here
+LL |       struct Foo { a: bool };
+   |       ---------------------- `Foo` defined here
 LL | 
-LL |     let f = Foo();
-   |             ^^^
-   |             |
-   |             did you mean `Foo { /* fields */ }`?
-   |             help: a function with a similar name exists (notice the capitalization): `foo`
+LL |       let f = Foo();
+   |               ^^^
+   |               |
+   |               did you mean `Foo { /* fields */ }`?
+   |               help: a function with a similar name exists (notice the capitalization): `foo`
+...
+LL | / fn foo() {
+LL | |     for _ in std::ops::Range { start: 0, end: 10 } {}
+LL | |
+LL | | }
+   | |_- similarly named function `foo` defined here
 
 error[E0423]: expected value, found struct `T`
   --> $DIR/E0423.rs:14:8

--- a/src/test/ui/error-codes/E0424.stderr
+++ b/src/test/ui/error-codes/E0424.stderr
@@ -7,7 +7,7 @@ LL | |         self.bar();
 LL | |     }
    | |_____- this function doesn't have a `self` parameter
 
-error[E0424]: expected unit struct/variant or constant, found module `self`
+error[E0424]: expected unit struct, unit variant or constant, found module `self`
   --> $DIR/E0424.rs:12:9
    |
 LL | / fn main () {

--- a/src/test/ui/error-codes/E0532.rs
+++ b/src/test/ui/error-codes/E0532.rs
@@ -3,7 +3,7 @@ fn main() {
 
     match SomeStruct(value) {
         StructConst1(_) => { },
-        //~^ ERROR expected tuple struct/variant, found constant `StructConst1`
+        //~^ ERROR expected tuple struct or tuple variant, found constant `StructConst1`
         _ => { },
     }
 

--- a/src/test/ui/error-codes/E0532.stderr
+++ b/src/test/ui/error-codes/E0532.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected tuple struct/variant, found constant `StructConst1`
+error[E0532]: expected tuple struct or tuple variant, found constant `StructConst1`
   --> $DIR/E0532.rs:5:9
    |
 LL |         StructConst1(_) => { },
-   |         ^^^^^^^^^^^^ not a tuple struct/variant
+   |         ^^^^^^^^^^^^ not a tuple struct or tuple variant
 
 error: aborting due to previous error
 

--- a/src/test/ui/fn-in-pat.rs
+++ b/src/test/ui/fn-in-pat.rs
@@ -8,7 +8,7 @@ fn hof<F>(_: F) where F: FnMut(()) {}
 
 fn ice() {
     hof(|c| match c {
-        A::new() => (), //~ ERROR expected tuple struct/variant, found method
+        A::new() => (), //~ ERROR expected tuple struct or tuple variant, found method
         _ => ()
     })
 }

--- a/src/test/ui/fn-in-pat.stderr
+++ b/src/test/ui/fn-in-pat.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<A>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `<A>::new`
   --> $DIR/fn-in-pat.rs:11:9
    |
 LL |         A::new() => (),

--- a/src/test/ui/glob-resolve1.stderr
+++ b/src/test/ui/glob-resolve1.stderr
@@ -46,6 +46,9 @@ LL |     import();
 error[E0412]: cannot find type `A` in this scope
   --> $DIR/glob-resolve1.rs:28:11
    |
+LL |     pub enum B { B1 }
+   |     ----------------- similarly named enum `B` defined here
+...
 LL |     foo::<A>();
    |           ^
    |
@@ -61,6 +64,9 @@ LL | use bar::A;
 error[E0412]: cannot find type `C` in this scope
   --> $DIR/glob-resolve1.rs:29:11
    |
+LL |     pub enum B { B1 }
+   |     ----------------- similarly named enum `B` defined here
+...
 LL |     foo::<C>();
    |           ^
    |
@@ -76,6 +82,9 @@ LL | use bar::C;
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/glob-resolve1.rs:30:11
    |
+LL |     pub enum B { B1 }
+   |     ----------------- similarly named enum `B` defined here
+...
 LL |     foo::<D>();
    |           ^
    |

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.rs
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.rs
@@ -1,3 +1,5 @@
+// ignore-x86
+// ^ due to stderr output differences
 // aux-build:two_macros.rs
 
 macro_rules! define_vec {

--- a/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
+++ b/src/test/ui/imports/extern-prelude-extern-crate-restricted-shadowing.stderr
@@ -1,5 +1,5 @@
 error: macro-expanded `extern crate` items cannot shadow names passed with `--extern`
-  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:19:9
+  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:21:9
    |
 LL |         extern crate std as core;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,20 +8,24 @@ LL | define_other_core!();
    | --------------------- in this macro invocation
 
 error[E0659]: `Vec` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
-  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:13:9
+  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:15:9
    |
 LL |         Vec::panic!();
    |         ^^^ ambiguous name
    |
-   = note: `Vec` could refer to a struct from prelude
-note: `Vec` could also refer to the crate imported here
-  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:5:9
+note: `Vec` could refer to the crate imported here
+  --> $DIR/extern-prelude-extern-crate-restricted-shadowing.rs:7:9
    |
 LL |         extern crate std as Vec;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL | define_vec!();
    | -------------- in this macro invocation
+note: `Vec` could also refer to the struct defined here
+  --> $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL | pub use crate::vec::Vec;
+   |         ^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-10200.rs
+++ b/src/test/ui/issues/issue-10200.rs
@@ -3,7 +3,7 @@ fn foo(_: usize) -> Foo { Foo(false) }
 
 fn main() {
     match Foo(true) {
-        foo(x) //~ ERROR expected tuple struct/variant, found function `foo`
+        foo(x) //~ ERROR expected tuple struct or tuple variant, found function `foo`
         => ()
     }
 }

--- a/src/test/ui/issues/issue-10200.stderr
+++ b/src/test/ui/issues/issue-10200.stderr
@@ -1,6 +1,9 @@
-error[E0532]: expected tuple struct/variant, found function `foo`
+error[E0532]: expected tuple struct or tuple variant, found function `foo`
   --> $DIR/issue-10200.rs:6:9
    |
+LL | struct Foo(bool);
+   | ----------------- similarly named tuple struct `Foo` defined here
+...
 LL |         foo(x)
    |         ^^^ help: a tuple struct with a similar name exists (notice the capitalization): `Foo`
 

--- a/src/test/ui/issues/issue-12863.rs
+++ b/src/test/ui/issues/issue-12863.rs
@@ -2,6 +2,7 @@ mod foo { pub fn bar() {} }
 
 fn main() {
     match () {
-        foo::bar => {} //~ ERROR expected unit struct/variant or constant, found function `foo::bar`
+        foo::bar => {}
+        //~^ ERROR expected unit struct, unit variant or constant, found function `foo::bar`
     }
 }

--- a/src/test/ui/issues/issue-12863.stderr
+++ b/src/test/ui/issues/issue-12863.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected unit struct/variant or constant, found function `foo::bar`
+error[E0532]: expected unit struct, unit variant or constant, found function `foo::bar`
   --> $DIR/issue-12863.rs:5:9
    |
 LL |         foo::bar => {}
-   |         ^^^^^^^^ not a unit struct/variant or constant
+   |         ^^^^^^^^ not a unit struct, unit variant or constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17933.rs
+++ b/src/test/ui/issues/issue-17933.rs
@@ -3,7 +3,7 @@ pub static X: usize = 1;
 fn main() {
     match 1 {
         self::X => { },
-        //~^ ERROR expected unit struct/variant or constant, found static `self::X`
+        //~^ ERROR expected unit struct, unit variant or constant, found static `self::X`
         _       => { },
     }
 }

--- a/src/test/ui/issues/issue-17933.stderr
+++ b/src/test/ui/issues/issue-17933.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected unit struct/variant or constant, found static `self::X`
+error[E0532]: expected unit struct, unit variant or constant, found static `self::X`
   --> $DIR/issue-17933.rs:5:9
    |
 LL |         self::X => { },
-   |         ^^^^^^^ not a unit struct/variant or constant
+   |         ^^^^^^^ not a unit struct, unit variant or constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19086.rs
+++ b/src/test/ui/issues/issue-19086.rs
@@ -8,6 +8,6 @@ fn main() {
     let f = FooB { x: 3, y: 4 };
     match f {
         FooB(a, b) => println!("{} {}", a, b),
-        //~^ ERROR expected tuple struct/variant, found struct variant `FooB`
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `FooB`
     }
 }

--- a/src/test/ui/issues/issue-19086.stderr
+++ b/src/test/ui/issues/issue-19086.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct/variant, found struct variant `FooB`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `FooB`
   --> $DIR/issue-19086.rs:10:9
    |
 LL |     FooB { x: i32, y: i32 }

--- a/src/test/ui/issues/issue-27033.rs
+++ b/src/test/ui/issues/issue-27033.rs
@@ -1,3 +1,5 @@
+// ignore-x86
+// ^ due to stderr output differences
 fn main() {
     match Some(1) {
         None @ _ => {} //~ ERROR match bindings cannot shadow unit variants

--- a/src/test/ui/issues/issue-27033.stderr
+++ b/src/test/ui/issues/issue-27033.stderr
@@ -1,11 +1,16 @@
 error[E0530]: match bindings cannot shadow unit variants
-  --> $DIR/issue-27033.rs:3:9
+  --> $DIR/issue-27033.rs:5:9
    |
 LL |         None @ _ => {}
    |         ^^^^ cannot be named the same as a unit variant
+   | 
+  ::: $SRC_DIR/libstd/prelude/v1.rs:LL:COL
+   |
+LL | pub use crate::option::Option::{self, Some, None};
+   |                                             ---- the unit variant `None` is defined here
 
 error[E0530]: match bindings cannot shadow constants
-  --> $DIR/issue-27033.rs:7:9
+  --> $DIR/issue-27033.rs:9:9
    |
 LL |     const C: u8 = 1;
    |     ---------------- the constant `C` is defined here

--- a/src/test/ui/issues/issue-28992-empty.rs
+++ b/src/test/ui/issues/issue-28992-empty.rs
@@ -10,7 +10,7 @@ impl S {
 }
 
 fn main() {
-    if let C1(..) = 0 {} //~ ERROR expected tuple struct/variant, found constant `C1`
+    if let C1(..) = 0 {} //~ ERROR expected tuple struct or tuple variant, found constant `C1`
     if let S::C2(..) = 0 {}
-    //~^ ERROR expected tuple struct/variant, found associated constant `<S>::C2`
+    //~^ ERROR expected tuple struct or tuple variant, found associated constant `<S>::C2`
 }

--- a/src/test/ui/issues/issue-28992-empty.stderr
+++ b/src/test/ui/issues/issue-28992-empty.stderr
@@ -1,10 +1,10 @@
-error[E0532]: expected tuple struct/variant, found constant `C1`
+error[E0532]: expected tuple struct or tuple variant, found constant `C1`
   --> $DIR/issue-28992-empty.rs:13:12
    |
 LL |     if let C1(..) = 0 {}
-   |            ^^ not a tuple struct/variant
+   |            ^^ not a tuple struct or tuple variant
 
-error[E0164]: expected tuple struct/variant, found associated constant `<S>::C2`
+error[E0164]: expected tuple struct or tuple variant, found associated constant `<S>::C2`
   --> $DIR/issue-28992-empty.rs:14:12
    |
 LL |     if let S::C2(..) = 0 {}

--- a/src/test/ui/issues/issue-31845.stderr
+++ b/src/test/ui/issues/issue-31845.stderr
@@ -1,8 +1,11 @@
 error[E0425]: cannot find function `g` in this scope
   --> $DIR/issue-31845.rs:7:12
    |
-LL |            g();
-   |            ^ help: a function with a similar name exists: `h`
+LL | /         fn h() {
+LL | |            g();
+   | |            ^ help: a function with a similar name exists: `h`
+LL | |         }
+   | |_________- similarly named function `h` defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-32004.rs
+++ b/src/test/ui/issues/issue-32004.rs
@@ -8,12 +8,12 @@ struct S;
 fn main() {
     match Foo::Baz {
         Foo::Bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found tuple variant `Foo::Bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found tuple variant `Foo::Bar`
         _ => {}
     }
 
     match S {
         S(()) => {}
-        //~^ ERROR expected tuple struct/variant, found unit struct `S`
+        //~^ ERROR expected tuple struct or tuple variant, found unit struct `S`
     }
 }

--- a/src/test/ui/issues/issue-32004.stderr
+++ b/src/test/ui/issues/issue-32004.stderr
@@ -1,8 +1,10 @@
-error[E0532]: expected unit struct/variant or constant, found tuple variant `Foo::Bar`
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `Foo::Bar`
   --> $DIR/issue-32004.rs:10:9
    |
 LL |     Bar(i32),
    |     -------- `Foo::Bar` defined here
+LL |     Baz
+   |     --- similarly named unit variant `Baz` defined here
 ...
 LL |         Foo::Bar => {}
    |         ^^^^^---
@@ -10,11 +12,11 @@ LL |         Foo::Bar => {}
    |         |    help: a unit variant with a similar name exists: `Baz`
    |         did you mean `Foo::Bar( /* fields */ )`?
 
-error[E0532]: expected tuple struct/variant, found unit struct `S`
+error[E0532]: expected tuple struct or tuple variant, found unit struct `S`
   --> $DIR/issue-32004.rs:16:9
    |
 LL |         S(()) => {}
-   |         ^ not a tuple struct/variant
+   |         ^ not a tuple struct or tuple variant
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-32086.rs
+++ b/src/test/ui/issues/issue-32086.rs
@@ -2,6 +2,6 @@ struct S(u8);
 const C: S = S(10);
 
 fn main() {
-    let C(a) = S(11); //~ ERROR expected tuple struct/variant, found constant `C`
-    let C(..) = S(11); //~ ERROR expected tuple struct/variant, found constant `C`
+    let C(a) = S(11); //~ ERROR expected tuple struct or tuple variant, found constant `C`
+    let C(..) = S(11); //~ ERROR expected tuple struct or tuple variant, found constant `C`
 }

--- a/src/test/ui/issues/issue-32086.stderr
+++ b/src/test/ui/issues/issue-32086.stderr
@@ -1,12 +1,18 @@
-error[E0532]: expected tuple struct/variant, found constant `C`
+error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/issue-32086.rs:5:9
    |
+LL | struct S(u8);
+   | ------------- similarly named tuple struct `S` defined here
+...
 LL |     let C(a) = S(11);
    |         ^ help: a tuple struct with a similar name exists: `S`
 
-error[E0532]: expected tuple struct/variant, found constant `C`
+error[E0532]: expected tuple struct or tuple variant, found constant `C`
   --> $DIR/issue-32086.rs:6:9
    |
+LL | struct S(u8);
+   | ------------- similarly named tuple struct `S` defined here
+...
 LL |     let C(..) = S(11);
    |         ^ help: a tuple struct with a similar name exists: `S`
 

--- a/src/test/ui/issues/issue-35675.rs
+++ b/src/test/ui/issues/issue-35675.rs
@@ -7,13 +7,13 @@ enum Fruit {
 fn should_return_fruit() -> Apple {
     //~^ ERROR cannot find type `Apple` in this scope
     Apple(5)
-    //~^ ERROR cannot find function `Apple` in this scope
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Apple` in this scope
 }
 
 fn should_return_fruit_too() -> Fruit::Apple {
     //~^ ERROR expected type, found variant `Fruit::Apple`
     Apple(5)
-    //~^ ERROR cannot find function `Apple` in this scope
+    //~^ ERROR cannot find function, tuple struct or tuple variant `Apple` in this scope
 }
 
 fn foo() -> Ok {

--- a/src/test/ui/issues/issue-35675.stderr
+++ b/src/test/ui/issues/issue-35675.stderr
@@ -9,7 +9,7 @@ help: there is an enum variant `Fruit::Apple`; try using the variant's enum
 LL | fn should_return_fruit() -> Fruit {
    |                             ^^^^^
 
-error[E0425]: cannot find function `Apple` in this scope
+error[E0425]: cannot find function, tuple struct or tuple variant `Apple` in this scope
   --> $DIR/issue-35675.rs:9:5
    |
 LL |     Apple(5)
@@ -29,7 +29,7 @@ LL | fn should_return_fruit_too() -> Fruit::Apple {
    |                                 not a type
    |                                 help: try using the variant's enum: `Fruit`
 
-error[E0425]: cannot find function `Apple` in this scope
+error[E0425]: cannot find function, tuple struct or tuple variant `Apple` in this scope
   --> $DIR/issue-35675.rs:15:5
    |
 LL |     Apple(5)

--- a/src/test/ui/issues/issue-38412.rs
+++ b/src/test/ui/issues/issue-38412.rs
@@ -1,6 +1,6 @@
 fn main() {
     let Box(a) = loop { };
-    //~^ ERROR expected tuple struct/variant, found struct `Box`
+    //~^ ERROR expected tuple struct or tuple variant, found struct `Box`
 
     // (The below is a trick to allow compiler to infer a type for
     // variable `a` without attempting to ascribe a type to the

--- a/src/test/ui/issues/issue-38412.stderr
+++ b/src/test/ui/issues/issue-38412.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct/variant, found struct `Box`
+error[E0532]: expected tuple struct or tuple variant, found struct `Box`
   --> $DIR/issue-38412.rs:2:9
    |
 LL |     let Box(a) = loop { };

--- a/src/test/ui/issues/issue-42944.rs
+++ b/src/test/ui/issues/issue-42944.rs
@@ -6,13 +6,15 @@ mod bar {
     use foo::B;
 
     fn foo() {
-        B(()); //~ ERROR expected function, found struct `B` [E0423]
+        B(());
+        //~^ ERROR expected function, tuple struct or tuple variant, found struct `B` [E0423]
     }
 }
 
 mod baz {
     fn foo() {
-        B(()); //~ ERROR cannot find function `B` in this scope [E0425]
+        B(());
+        //~^ ERROR cannot find function, tuple struct or tuple variant `B` in this scope [E0425]
     }
 }
 

--- a/src/test/ui/issues/issue-42944.stderr
+++ b/src/test/ui/issues/issue-42944.stderr
@@ -1,11 +1,11 @@
-error[E0423]: expected function, found struct `B`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `B`
   --> $DIR/issue-42944.rs:9:9
    |
 LL |         B(());
    |         ^ constructor is not visible here due to private fields
 
-error[E0425]: cannot find function `B` in this scope
-  --> $DIR/issue-42944.rs:15:9
+error[E0425]: cannot find function, tuple struct or tuple variant `B` in this scope
+  --> $DIR/issue-42944.rs:16:9
    |
 LL |         B(());
    |         ^ not found in this scope

--- a/src/test/ui/issues/issue-46332.stderr
+++ b/src/test/ui/issues/issue-46332.stderr
@@ -1,6 +1,9 @@
 error[E0422]: cannot find struct, variant or union type `TyUInt` in this scope
   --> $DIR/issue-46332.rs:9:5
    |
+LL | struct TyUint {}
+   | ---------------- similarly named struct `TyUint` defined here
+...
 LL |     TyUInt {};
    |     ^^^^^^ help: a struct with a similar name exists (notice the capitalization): `TyUint`
 

--- a/src/test/ui/issues/issue-55587.rs
+++ b/src/test/ui/issues/issue-55587.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
 
 fn main() {
-    let Path::new(); //~ ERROR expected tuple struct/variant
+    let Path::new(); //~ ERROR expected tuple struct or tuple variant
 }

--- a/src/test/ui/issues/issue-55587.stderr
+++ b/src/test/ui/issues/issue-55587.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
   --> $DIR/issue-55587.rs:4:9
    |
 LL |     let Path::new();

--- a/src/test/ui/issues/issue-56835.rs
+++ b/src/test/ui/issues/issue-56835.rs
@@ -3,7 +3,7 @@ pub struct Foo {}
 impl Foo {
     fn bar(Self(foo): Self) {}
     //~^ ERROR the `Self` constructor can only be used with tuple or unit structs
-    //~^^ ERROR expected tuple struct/variant, found self constructor `Self` [E0164]
+    //~^^ ERROR expected tuple struct or tuple variant, found self constructor `Self` [E0164]
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-56835.stderr
+++ b/src/test/ui/issues/issue-56835.stderr
@@ -4,7 +4,7 @@ error: the `Self` constructor can only be used with tuple or unit structs
 LL |     fn bar(Self(foo): Self) {}
    |            ^^^^^^^^^ help: use curly brackets: `Self { /* fields */ }`
 
-error[E0164]: expected tuple struct/variant, found self constructor `Self`
+error[E0164]: expected tuple struct or tuple variant, found self constructor `Self`
   --> $DIR/issue-56835.rs:4:12
    |
 LL |     fn bar(Self(foo): Self) {}

--- a/src/test/ui/issues/issue-58022.rs
+++ b/src/test/ui/issues/issue-58022.rs
@@ -11,7 +11,8 @@ impl Bar<[u8]> {
     const SIZE: usize = 32;
 
     fn new(slice: &[u8; Self::SIZE]) -> Self {
-        Foo(Box::new(*slice)) //~ ERROR: expected function, found trait `Foo`
+        Foo(Box::new(*slice))
+        //~^ ERROR: expected function, tuple struct or tuple variant, found trait `Foo`
     }
 }
 

--- a/src/test/ui/issues/issue-58022.stderr
+++ b/src/test/ui/issues/issue-58022.stderr
@@ -1,8 +1,8 @@
-error[E0423]: expected function, found trait `Foo`
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo`
   --> $DIR/issue-58022.rs:14:9
    |
 LL |         Foo(Box::new(*slice))
-   |         ^^^ not a function
+   |         ^^^ not a function, tuple struct or tuple variant
 
 error[E0283]: type annotations needed: cannot resolve `_: Foo`
   --> $DIR/issue-58022.rs:4:25

--- a/src/test/ui/issues/issue-5927.rs
+++ b/src/test/ui/issues/issue-5927.rs
@@ -1,6 +1,6 @@
 fn main() {
     let z = match 3 {
-        x(1) => x(1) //~ ERROR cannot find tuple struct/variant `x` in this scope
+        x(1) => x(1) //~ ERROR cannot find tuple struct or tuple variant `x` in this scope
         //~^ ERROR cannot find function `x` in this scope
     };
     assert!(z == 3);

--- a/src/test/ui/issues/issue-5927.stderr
+++ b/src/test/ui/issues/issue-5927.stderr
@@ -1,4 +1,4 @@
-error[E0531]: cannot find tuple struct/variant `x` in this scope
+error[E0531]: cannot find tuple struct or tuple variant `x` in this scope
   --> $DIR/issue-5927.rs:3:9
    |
 LL |         x(1) => x(1)

--- a/src/test/ui/issues/issue-63983.rs
+++ b/src/test/ui/issues/issue-63983.rs
@@ -6,9 +6,9 @@ enum MyEnum {
 fn foo(en: MyEnum) {
     match en {
         MyEnum::Tuple => "",
-        //~^ ERROR expected unit struct/variant or constant, found tuple variant `MyEnum::Tuple`
+//~^ ERROR expected unit struct, unit variant or constant, found tuple variant `MyEnum::Tuple`
         MyEnum::Struct => "",
-        //~^ ERROR expected unit struct/variant or constant, found struct variant `MyEnum::Struct`
+//~^ ERROR expected unit struct, unit variant or constant, found struct variant `MyEnum::Struct`
     };
 }
 

--- a/src/test/ui/issues/issue-63983.stderr
+++ b/src/test/ui/issues/issue-63983.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected unit struct/variant or constant, found tuple variant `MyEnum::Tuple`
+error[E0532]: expected unit struct, unit variant or constant, found tuple variant `MyEnum::Tuple`
   --> $DIR/issue-63983.rs:8:9
    |
 LL |     Tuple(i32),
@@ -7,7 +7,7 @@ LL |     Tuple(i32),
 LL |         MyEnum::Tuple => "",
    |         ^^^^^^^^^^^^^ did you mean `MyEnum::Tuple( /* fields */ )`?
 
-error[E0532]: expected unit struct/variant or constant, found struct variant `MyEnum::Struct`
+error[E0532]: expected unit struct, unit variant or constant, found struct variant `MyEnum::Struct`
   --> $DIR/issue-63983.rs:10:9
    |
 LL |     Struct{ s: i32 },

--- a/src/test/ui/issues/issue-64792-bad-unicode-ctor.rs
+++ b/src/test/ui/issues/issue-64792-bad-unicode-ctor.rs
@@ -1,5 +1,5 @@
 struct X {}
 
-const Y: X = X("ö"); //~ ERROR expected function, found struct `X`
+const Y: X = X("ö"); //~ ERROR expected function, tuple struct or tuple variant, found struct `X`
 
 fn main() {}

--- a/src/test/ui/issues/issue-64792-bad-unicode-ctor.stderr
+++ b/src/test/ui/issues/issue-64792-bad-unicode-ctor.stderr
@@ -1,14 +1,15 @@
-error[E0423]: expected function, found struct `X`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `X`
   --> $DIR/issue-64792-bad-unicode-ctor.rs:3:14
    |
 LL | struct X {}
    | ----------- `X` defined here
 LL | 
 LL | const Y: X = X("ö");
-   |              ^
-   |              |
-   |              did you mean `X { /* fields */ }`?
-   |              help: a constant with a similar name exists: `Y`
+   | -------------^------
+   | |            |
+   | |            did you mean `X { /* fields */ }`?
+   | |            help: a constant with a similar name exists: `Y`
+   | similarly named constant `Y` defined here
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-pr29383.rs
+++ b/src/test/ui/issues/issue-pr29383.rs
@@ -6,7 +6,9 @@ enum E {
 fn main() {
     match None {
         None => {}
-        Some(E::A(..)) => {} //~ ERROR expected tuple struct/variant, found unit variant `E::A`
-        Some(E::B(..)) => {} //~ ERROR expected tuple struct/variant, found unit variant `E::B`
+        Some(E::A(..)) => {}
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `E::A`
+        Some(E::B(..)) => {}
+        //~^ ERROR expected tuple struct or tuple variant, found unit variant `E::B`
     }
 }

--- a/src/test/ui/issues/issue-pr29383.stderr
+++ b/src/test/ui/issues/issue-pr29383.stderr
@@ -1,14 +1,14 @@
-error[E0532]: expected tuple struct/variant, found unit variant `E::A`
+error[E0532]: expected tuple struct or tuple variant, found unit variant `E::A`
   --> $DIR/issue-pr29383.rs:9:14
    |
 LL |         Some(E::A(..)) => {}
-   |              ^^^^ not a tuple struct/variant
+   |              ^^^^ not a tuple struct or tuple variant
 
-error[E0532]: expected tuple struct/variant, found unit variant `E::B`
-  --> $DIR/issue-pr29383.rs:10:14
+error[E0532]: expected tuple struct or tuple variant, found unit variant `E::B`
+  --> $DIR/issue-pr29383.rs:11:14
    |
 LL |         Some(E::B(..)) => {}
-   |              ^^^^ not a tuple struct/variant
+   |              ^^^^ not a tuple struct or tuple variant
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/keyword/keyword-self-as-identifier.rs
+++ b/src/test/ui/keyword/keyword-self-as-identifier.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let Self = 22; //~ ERROR cannot find unit struct/variant or constant `Self` in this scope
+    let Self = 22; //~ ERROR cannot find unit struct, unit variant or constant `Self` in this scope
 }

--- a/src/test/ui/keyword/keyword-self-as-identifier.stderr
+++ b/src/test/ui/keyword/keyword-self-as-identifier.stderr
@@ -1,4 +1,4 @@
-error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
+error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/keyword-self-as-identifier.rs:2:9
    |
 LL |     let Self = 22;

--- a/src/test/ui/macros/macro_undefined.stderr
+++ b/src/test/ui/macros/macro_undefined.stderr
@@ -1,8 +1,13 @@
 error: cannot find macro `k` in this scope
   --> $DIR/macro_undefined.rs:11:5
    |
-LL |     k!();
-   |     ^ help: a macro with a similar name exists: `kl`
+LL | /     macro_rules! kl {
+LL | |         () => ()
+LL | |     }
+   | |_____- similarly named macro `kl` defined here
+...
+LL |       k!();
+   |       ^ help: a macro with a similar name exists: `kl`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-fn-call.rs
+++ b/src/test/ui/match/match-fn-call.rs
@@ -4,9 +4,9 @@ fn main() {
     let path = Path::new("foo");
     match path {
         Path::new("foo") => println!("foo"),
-        //~^ ERROR expected tuple struct/variant
+        //~^ ERROR expected tuple struct or tuple variant
         Path::new("bar") => println!("bar"),
-        //~^ ERROR expected tuple struct/variant
+        //~^ ERROR expected tuple struct or tuple variant
         _ => (),
     }
 }

--- a/src/test/ui/match/match-fn-call.stderr
+++ b/src/test/ui/match/match-fn-call.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
   --> $DIR/match-fn-call.rs:6:9
    |
 LL |         Path::new("foo") => println!("foo"),
@@ -6,7 +6,7 @@ LL |         Path::new("foo") => println!("foo"),
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch18-00-patterns.html
 
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
   --> $DIR/match-fn-call.rs:8:9
    |
 LL |         Path::new("bar") => println!("bar"),

--- a/src/test/ui/match/match-pattern-field-mismatch-2.rs
+++ b/src/test/ui/match/match-pattern-field-mismatch-2.rs
@@ -10,7 +10,7 @@ fn main() {
           Color::Rgb(_, _, _) => { }
           Color::Cmyk(_, _, _, _) => { }
           Color::NoColor(_) => { }
-          //~^ ERROR expected tuple struct/variant, found unit variant `Color::NoColor`
+          //~^ ERROR expected tuple struct or tuple variant, found unit variant `Color::NoColor`
         }
     }
 }

--- a/src/test/ui/match/match-pattern-field-mismatch-2.stderr
+++ b/src/test/ui/match/match-pattern-field-mismatch-2.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected tuple struct/variant, found unit variant `Color::NoColor`
+error[E0532]: expected tuple struct or tuple variant, found unit variant `Color::NoColor`
   --> $DIR/match-pattern-field-mismatch-2.rs:12:11
    |
 LL |           Color::NoColor(_) => { }
-   |           ^^^^^^^^^^^^^^ not a tuple struct/variant
+   |           ^^^^^^^^^^^^^^ not a tuple struct or tuple variant
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-pattern-field-mismatch.rs
+++ b/src/test/ui/match/match-pattern-field-mismatch.rs
@@ -8,7 +8,7 @@ fn main() {
     fn foo(c: Color) {
         match c {
           Color::Rgb(_, _) => { }
-          //~^ ERROR this pattern has 2 fields, but the corresponding tuple variant has 3 fields
+          //~^ ERROR this pattern has 2 fields, but the corresponding tuple variant has 3
           Color::Cmyk(_, _, _, _) => { }
           Color::NoColor => { }
         }

--- a/src/test/ui/methods/method-path-in-pattern.rs
+++ b/src/test/ui/methods/method-path-in-pattern.rs
@@ -13,20 +13,20 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         Foo::bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
     }
     match 0u32 {
         <Foo>::bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
     }
     match 0u32 {
         <Foo>::trait_bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
     }
     if let Foo::bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
     if let <Foo>::bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
     if let Foo::trait_bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
 }

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -1,34 +1,34 @@
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
   --> $DIR/method-path-in-pattern.rs:15:9
    |
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
    |         ^^^^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
   --> $DIR/method-path-in-pattern.rs:26:12
    |
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}
    |            ^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
   --> $DIR/method-path-in-pattern.rs:30:12
    |
 LL |     if let Foo::trait_bar = 0u32 {}

--- a/src/test/ui/methods/method-resolvable-path-in-pattern.rs
+++ b/src/test/ui/methods/method-resolvable-path-in-pattern.rs
@@ -9,6 +9,6 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         <Foo as MyTrait>::trait_bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `MyTrait::trait_bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `MyTrait::trait_bar`
     }
 }

--- a/src/test/ui/methods/method-resolvable-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-resolvable-path-in-pattern.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected unit struct/variant or constant, found method `MyTrait::trait_bar`
+error[E0532]: expected unit struct, unit variant or constant, found method `MyTrait::trait_bar`
   --> $DIR/method-resolvable-path-in-pattern.rs:11:9
    |
 LL |         <Foo as MyTrait>::trait_bar => {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a unit struct/variant or constant
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a unit struct, unit variant or constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -1,6 +1,9 @@
 error[E0423]: expected value, found type alias `m1::S`
   --> $DIR/namespace-mix.rs:34:11
    |
+LL |     pub struct TS();
+   |     ---------------- similarly named tuple struct `TS` defined here
+...
 LL |     check(m1::S);
    |           ^^^^^
    |
@@ -39,6 +42,8 @@ error[E0423]: expected value, found struct variant `m7::V`
    |
 LL |         V {},
    |         ---- `m7::V` defined here
+LL |         TV(),
+   |         ---- similarly named tuple variant `TV` defined here
 ...
 LL |     check(m7::V);
    |           ^^^^^ did you mean `m7::V { /* fields */ }`?

--- a/src/test/ui/parser/recover-from-bad-variant.rs
+++ b/src/test/ui/parser/recover-from-bad-variant.rs
@@ -8,7 +8,7 @@ fn main() {
     //~^ ERROR expected type, found `3`
     match x {
         Enum::Foo(a, b) => {}
-        //~^ ERROR expected tuple struct/variant, found struct variant `Enum::Foo`
+        //~^ ERROR expected tuple struct or tuple variant, found struct variant `Enum::Foo`
         Enum::Bar(a, b) => {}
     }
 }

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -9,7 +9,7 @@ LL |     let x = Enum::Foo(a: 3, b: 4);
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
    = note: for more information, see https://github.com/rust-lang/rust/issues/23416
 
-error[E0532]: expected tuple struct/variant, found struct variant `Enum::Foo`
+error[E0532]: expected tuple struct or tuple variant, found struct variant `Enum::Foo`
   --> $DIR/recover-from-bad-variant.rs:10:9
    |
 LL |     Foo { a: usize, b: usize },

--- a/src/test/ui/pattern/pattern-error-continue.rs
+++ b/src/test/ui/pattern/pattern-error-continue.rs
@@ -15,7 +15,7 @@ fn f(_c: char) {}
 fn main() {
     match A::B(1, 2) {
         A::B(_, _, _) => (), //~ ERROR this pattern has 3 fields, but
-        A::D(_) => (),       //~ ERROR expected tuple struct/variant, found unit variant `A::D`
+        A::D(_) => (), //~ ERROR expected tuple struct or tuple variant, found unit variant `A::D`
         _ => ()
     }
     match 'c' {

--- a/src/test/ui/pattern/pattern-error-continue.stderr
+++ b/src/test/ui/pattern/pattern-error-continue.stderr
@@ -4,9 +4,12 @@ error[E0433]: failed to resolve: use of undeclared type or module `E`
 LL |         E::V => {}
    |         ^ use of undeclared type or module `E`
 
-error[E0532]: expected tuple struct/variant, found unit variant `A::D`
+error[E0532]: expected tuple struct or tuple variant, found unit variant `A::D`
   --> $DIR/pattern-error-continue.rs:18:9
    |
+LL |     B(isize, isize),
+   |     --------------- similarly named tuple variant `B` defined here
+...
 LL |         A::D(_) => (),
    |         ^^^-
    |            |

--- a/src/test/ui/privacy/privacy-ns1.rs
+++ b/src/test/ui/privacy/privacy-ns1.rs
@@ -17,7 +17,7 @@ pub mod foo1 {
 fn test_glob1() {
     use foo1::*;
 
-    Bar();  //~ ERROR expected function, found trait `Bar`
+    Bar();  //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
 }
 
 // private type, public value
@@ -47,7 +47,7 @@ pub mod foo3 {
 fn test_glob3() {
     use foo3::*;
 
-    Bar();  //~ ERROR cannot find function `Bar` in this scope
+    Bar();  //~ ERROR cannot find function, tuple struct or tuple variant `Bar` in this scope
     let _x: Box<Bar>;  //~ ERROR cannot find type `Bar` in this scope
 }
 

--- a/src/test/ui/privacy/privacy-ns1.stderr
+++ b/src/test/ui/privacy/privacy-ns1.stderr
@@ -1,6 +1,9 @@
-error[E0423]: expected function, found trait `Bar`
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
   --> $DIR/privacy-ns1.rs:20:5
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named unit struct `Baz` defined here
+...
 LL |     Bar();
    |     ^^^
    |
@@ -20,6 +23,9 @@ LL | use foo3::Bar;
 error[E0573]: expected type, found function `Bar`
   --> $DIR/privacy-ns1.rs:35:17
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named struct `Baz` defined here
+...
 LL |     let _x: Box<Bar>;
    |                 ^^^
    |
@@ -36,9 +42,12 @@ LL | use foo2::Bar;
 LL | use foo3::Bar;
    |
 
-error[E0425]: cannot find function `Bar` in this scope
+error[E0425]: cannot find function, tuple struct or tuple variant `Bar` in this scope
   --> $DIR/privacy-ns1.rs:50:5
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named unit struct `Baz` defined here
+...
 LL |     Bar();
    |     ^^^
    |
@@ -58,6 +67,9 @@ LL | use foo3::Bar;
 error[E0412]: cannot find type `Bar` in this scope
   --> $DIR/privacy-ns1.rs:51:17
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named struct `Baz` defined here
+...
 LL |     let _x: Box<Bar>;
    |                 ^^^
    |

--- a/src/test/ui/privacy/privacy-ns2.rs
+++ b/src/test/ui/privacy/privacy-ns2.rs
@@ -17,13 +17,13 @@ pub mod foo1 {
 fn test_single1() {
     use foo1::Bar;
 
-    Bar(); //~ ERROR expected function, found trait `Bar`
+    Bar(); //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
 }
 
 fn test_list1() {
     use foo1::{Bar,Baz};
 
-    Bar(); //~ ERROR expected function, found trait `Bar`
+    Bar(); //~ ERROR expected function, tuple struct or tuple variant, found trait `Bar`
 }
 
 // private type, public value

--- a/src/test/ui/privacy/privacy-ns2.stderr
+++ b/src/test/ui/privacy/privacy-ns2.stderr
@@ -1,8 +1,8 @@
-error[E0423]: expected function, found trait `Bar`
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
   --> $DIR/privacy-ns2.rs:20:5
    |
 LL |     Bar();
-   |     ^^^ not a function
+   |     ^^^ not a function, tuple struct or tuple variant
    |
 help: possible better candidates are found in other modules, you can import them into scope
    |
@@ -13,9 +13,12 @@ LL | use foo2::Bar;
 LL | use foo3::Bar;
    |
 
-error[E0423]: expected function, found trait `Bar`
+error[E0423]: expected function, tuple struct or tuple variant, found trait `Bar`
   --> $DIR/privacy-ns2.rs:26:5
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named unit struct `Baz` defined here
+...
 LL |     Bar();
    |     ^^^
    |
@@ -50,6 +53,9 @@ LL | use foo3::Bar;
 error[E0573]: expected type, found function `Bar`
   --> $DIR/privacy-ns2.rs:47:17
    |
+LL |     pub struct Baz;
+   |     --------------- similarly named struct `Baz` defined here
+...
 LL |     let _x: Box<Bar>;
    |                 ^^^
    |

--- a/src/test/ui/proc-macro/parent-source-spans.rs
+++ b/src/test/ui/proc-macro/parent-source-spans.rs
@@ -1,6 +1,4 @@
 // aux-build:parent-source-spans.rs
-
-
 #![feature(decl_macro, proc_macro_hygiene)]
 
 extern crate parent_source_spans;

--- a/src/test/ui/proc-macro/parent-source-spans.stderr
+++ b/src/test/ui/proc-macro/parent-source-spans.stderr
@@ -1,5 +1,5 @@
 error: first final: "hello"
-  --> $DIR/parent-source-spans.rs:17:12
+  --> $DIR/parent-source-spans.rs:15:12
    |
 LL |     three!($a, $b);
    |            ^^
@@ -8,7 +8,7 @@ LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
 
 error: second final: "world"
-  --> $DIR/parent-source-spans.rs:17:16
+  --> $DIR/parent-source-spans.rs:15:16
    |
 LL |     three!($a, $b);
    |                ^^
@@ -17,7 +17,7 @@ LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
 
 error: first parent: "hello"
-  --> $DIR/parent-source-spans.rs:11:5
+  --> $DIR/parent-source-spans.rs:9:5
    |
 LL |     two!($a, $b);
    |     ^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
 
 error: second parent: "world"
-  --> $DIR/parent-source-spans.rs:11:5
+  --> $DIR/parent-source-spans.rs:9:5
    |
 LL |     two!($a, $b);
    |     ^^^^^^^^^^^^^
@@ -35,31 +35,31 @@ LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
 
 error: first grandparent: "hello"
-  --> $DIR/parent-source-spans.rs:37:5
+  --> $DIR/parent-source-spans.rs:35:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: second grandparent: "world"
-  --> $DIR/parent-source-spans.rs:37:5
+  --> $DIR/parent-source-spans.rs:35:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: first source: "hello"
-  --> $DIR/parent-source-spans.rs:37:5
+  --> $DIR/parent-source-spans.rs:35:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: second source: "world"
-  --> $DIR/parent-source-spans.rs:37:5
+  --> $DIR/parent-source-spans.rs:35:5
    |
 LL |     one!("hello", "world");
    |     ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: first final: "yay"
-  --> $DIR/parent-source-spans.rs:17:12
+  --> $DIR/parent-source-spans.rs:15:12
    |
 LL |     three!($a, $b);
    |            ^^
@@ -68,7 +68,7 @@ LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
 
 error: second final: "rust"
-  --> $DIR/parent-source-spans.rs:17:16
+  --> $DIR/parent-source-spans.rs:15:16
    |
 LL |     three!($a, $b);
    |                ^^
@@ -77,55 +77,55 @@ LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
 
 error: first parent: "yay"
-  --> $DIR/parent-source-spans.rs:43:5
+  --> $DIR/parent-source-spans.rs:41:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: second parent: "rust"
-  --> $DIR/parent-source-spans.rs:43:5
+  --> $DIR/parent-source-spans.rs:41:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: first source: "yay"
-  --> $DIR/parent-source-spans.rs:43:5
+  --> $DIR/parent-source-spans.rs:41:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: second source: "rust"
-  --> $DIR/parent-source-spans.rs:43:5
+  --> $DIR/parent-source-spans.rs:41:5
    |
 LL |     two!("yay", "rust");
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: first final: "hip"
-  --> $DIR/parent-source-spans.rs:49:12
+  --> $DIR/parent-source-spans.rs:47:12
    |
 LL |     three!("hip", "hop");
    |            ^^^^^
 
 error: second final: "hop"
-  --> $DIR/parent-source-spans.rs:49:19
+  --> $DIR/parent-source-spans.rs:47:19
    |
 LL |     three!("hip", "hop");
    |                   ^^^^^
 
 error: first source: "hip"
-  --> $DIR/parent-source-spans.rs:49:12
+  --> $DIR/parent-source-spans.rs:47:12
    |
 LL |     three!("hip", "hop");
    |            ^^^^^
 
 error: second source: "hop"
-  --> $DIR/parent-source-spans.rs:49:19
+  --> $DIR/parent-source-spans.rs:47:19
    |
 LL |     three!("hip", "hop");
    |                   ^^^^^
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:30:5
+  --> $DIR/parent-source-spans.rs:28:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
@@ -134,7 +134,7 @@ LL |     one!("hello", "world");
    |     ----------------------- in this macro invocation
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:30:5
+  --> $DIR/parent-source-spans.rs:28:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`
@@ -143,7 +143,7 @@ LL |     two!("yay", "rust");
    |     -------------------- in this macro invocation
 
 error[E0425]: cannot find value `ok` in this scope
-  --> $DIR/parent-source-spans.rs:30:5
+  --> $DIR/parent-source-spans.rs:28:5
    |
 LL |     parent_source_spans!($($tokens)*);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: a tuple variant with a similar name exists: `Ok`

--- a/src/test/ui/proc-macro/resolve-error.stderr
+++ b/src/test/ui/proc-macro/resolve-error.stderr
@@ -13,14 +13,24 @@ LL |     Dlona!();
 error: cannot find macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:50:5
    |
-LL |     attr_proc_macra!();
-   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `attr_proc_mac`
+LL | / macro_rules! attr_proc_mac {
+LL | |     () => {}
+LL | | }
+   | |_- similarly named macro `attr_proc_mac` defined here
+...
+LL |       attr_proc_macra!();
+   |       ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `attr_proc_mac`
 
 error: cannot find macro `FooWithLongNama` in this scope
   --> $DIR/resolve-error.rs:47:5
    |
-LL |     FooWithLongNama!();
-   |     ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `FooWithLongNam`
+LL | / macro_rules! FooWithLongNam {
+LL | |     () => {}
+LL | | }
+   | |_- similarly named macro `FooWithLongNam` defined here
+...
+LL |       FooWithLongNama!();
+   |       ^^^^^^^^^^^^^^^ help: a macro with a similar name exists: `FooWithLongNam`
 
 error: cannot find derive macro `attr_proc_macra` in this scope
   --> $DIR/resolve-error.rs:42:10

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/resolve/enums-are-namespaced-xc.rs
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.rs
@@ -5,7 +5,7 @@ fn main() {
     let _ = namespaced_enums::A;
     //~^ ERROR cannot find value `A`
     let _ = namespaced_enums::B(10);
-    //~^ ERROR cannot find function `B`
+    //~^ ERROR cannot find function, tuple struct or tuple variant `B`
     let _ = namespaced_enums::C { a: 10 };
     //~^ ERROR cannot find struct, variant or union type `C`
 }

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -9,7 +9,7 @@ help: possible candidate is found in another module, you can import it into scop
 LL | use namespaced_enums::Foo::A;
    |
 
-error[E0425]: cannot find function `B` in crate `namespaced_enums`
+error[E0425]: cannot find function, tuple struct or tuple variant `B` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:7:31
    |
 LL |     let _ = namespaced_enums::B(10);

--- a/src/test/ui/resolve/issue-18252.rs
+++ b/src/test/ui/resolve/issue-18252.rs
@@ -4,5 +4,5 @@ enum Foo {
 
 fn main() {
     let f = Foo::Variant(42);
-    //~^ ERROR expected function, found struct variant `Foo::Variant`
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct variant `Foo::Variant`
 }

--- a/src/test/ui/resolve/issue-18252.stderr
+++ b/src/test/ui/resolve/issue-18252.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, found struct variant `Foo::Variant`
+error[E0423]: expected function, tuple struct or tuple variant, found struct variant `Foo::Variant`
   --> $DIR/issue-18252.rs:6:13
    |
 LL |     Variant { x: usize }

--- a/src/test/ui/resolve/issue-5035.stderr
+++ b/src/test/ui/resolve/issue-5035.stderr
@@ -7,6 +7,9 @@ LL | use ImportError;
 error[E0404]: expected trait, found type alias `K`
   --> $DIR/issue-5035.rs:3:6
    |
+LL | trait I {}
+   | ---------- similarly named trait `I` defined here
+LL | type K = dyn I;
 LL | impl K for isize {}
    |      ^
    |      |

--- a/src/test/ui/resolve/issue-6702.rs
+++ b/src/test/ui/resolve/issue-6702.rs
@@ -4,5 +4,6 @@ struct Monster {
 
 
 fn main() {
-    let _m = Monster(); //~ ERROR expected function, found struct `Monster`
+    let _m = Monster();
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct `Monster`
 }

--- a/src/test/ui/resolve/issue-6702.stderr
+++ b/src/test/ui/resolve/issue-6702.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, found struct `Monster`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `Monster`
   --> $DIR/issue-6702.rs:7:14
    |
 LL | / struct Monster {

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -7,6 +7,9 @@ LL | fn foo(c: esize) {} // Misspelled primitive type name.
 error[E0412]: cannot find type `Baz` in this scope
   --> $DIR/levenshtein.rs:10:10
    |
+LL | enum Bar { }
+   | ------------ similarly named enum `Bar` defined here
+LL | 
 LL | type A = Baz; // Misspelled type name.
    |          ^^^ help: an enum with a similar name exists: `Bar`
 
@@ -25,24 +28,36 @@ LL |     type A = Baz; // No suggestion here, Bar is not visible
 error[E0425]: cannot find value `MAXITEM` in this scope
   --> $DIR/levenshtein.rs:24:20
    |
+LL | const MAX_ITEM: usize = 10;
+   | --------------------------- similarly named constant `MAX_ITEM` defined here
+...
 LL |     let v = [0u32; MAXITEM]; // Misspelled constant name.
    |                    ^^^^^^^ help: a constant with a similar name exists: `MAX_ITEM`
 
 error[E0425]: cannot find function `foobar` in this scope
   --> $DIR/levenshtein.rs:26:5
    |
+LL | fn foo_bar() {}
+   | --------------- similarly named function `foo_bar` defined here
+...
 LL |     foobar(); // Misspelled function name.
    |     ^^^^^^ help: a function with a similar name exists: `foo_bar`
 
 error[E0412]: cannot find type `first` in module `m`
   --> $DIR/levenshtein.rs:28:15
    |
+LL |     pub struct First;
+   |     ----------------- similarly named struct `First` defined here
+...
 LL |     let b: m::first = m::second; // Misspelled item in module.
    |               ^^^^^ help: a struct with a similar name exists (notice the capitalization): `First`
 
 error[E0425]: cannot find value `second` in module `m`
   --> $DIR/levenshtein.rs:28:26
    |
+LL |     pub struct Second;
+   |     ------------------ similarly named unit struct `Second` defined here
+...
 LL |     let b: m::first = m::second; // Misspelled item in module.
    |                          ^^^^^^ help: a unit struct with a similar name exists (notice the capitalization): `Second`
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -16,8 +16,15 @@ LL |         m::Z::Unit;
 error[E0423]: expected value, found enum `Z`
   --> $DIR/privacy-enum-ctor.rs:25:9
    |
-LL |         Z;
-   |         ^
+LL | /     fn f() {
+LL | |         n::Z;
+LL | |
+LL | |         Z;
+   | |         ^
+...  |
+LL | |         // This is ok, it is equivalent to not having braces
+LL | |     }
+   | |_____- similarly named function `f` defined here
    |
 help: a function with a similar name exists
    |
@@ -46,8 +53,17 @@ LL |           let _: Z = Z::Struct;
 error[E0423]: expected value, found enum `m::E`
   --> $DIR/privacy-enum-ctor.rs:41:16
    |
-LL |     let _: E = m::E;
-   |                ^^^^
+LL | /     fn f() {
+LL | |         n::Z;
+LL | |
+LL | |         Z;
+...  |
+LL | |         // This is ok, it is equivalent to not having braces
+LL | |     }
+   | |_____- similarly named function `f` defined here
+...
+LL |       let _: E = m::E;
+   |                  ^^^^
    |
 help: a function with a similar name exists
    |
@@ -114,8 +130,17 @@ LL |       let _: E = E::Struct;
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:57:12
    |
-LL |     let _: Z = m::n::Z;
-   |            ^
+LL | /     pub enum E {
+LL | |         Fn(u8),
+LL | |         Struct {
+LL | |             s: u8,
+LL | |         },
+LL | |         Unit,
+LL | |     }
+   | |_____- similarly named enum `E` defined here
+...
+LL |       let _: Z = m::n::Z;
+   |              ^
    |
 help: an enum with a similar name exists
    |
@@ -144,8 +169,17 @@ LL |     let _: Z = m::Z::Unit;
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:61:12
    |
-LL |     let _: Z = m::n::Z::Fn;
-   |            ^
+LL | /     pub enum E {
+LL | |         Fn(u8),
+LL | |         Struct {
+LL | |             s: u8,
+LL | |         },
+LL | |         Unit,
+LL | |     }
+   | |_____- similarly named enum `E` defined here
+...
+LL |       let _: Z = m::n::Z::Fn;
+   |              ^
    |
 help: an enum with a similar name exists
    |
@@ -159,8 +193,17 @@ LL | use m::n::Z;
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:64:12
    |
-LL |     let _: Z = m::n::Z::Struct;
-   |            ^
+LL | /     pub enum E {
+LL | |         Fn(u8),
+LL | |         Struct {
+LL | |             s: u8,
+LL | |         },
+LL | |         Unit,
+LL | |     }
+   | |_____- similarly named enum `E` defined here
+...
+LL |       let _: Z = m::n::Z::Struct;
+   |              ^
    |
 help: an enum with a similar name exists
    |
@@ -185,8 +228,17 @@ LL |       let _: Z = m::n::Z::Struct;
 error[E0412]: cannot find type `Z` in this scope
   --> $DIR/privacy-enum-ctor.rs:68:12
    |
-LL |     let _: Z = m::n::Z::Unit {};
-   |            ^
+LL | /     pub enum E {
+LL | |         Fn(u8),
+LL | |         Struct {
+LL | |             s: u8,
+LL | |         },
+LL | |         Unit,
+LL | |     }
+   | |_____- similarly named enum `E` defined here
+...
+LL |       let _: Z = m::n::Z::Unit {};
+   |              ^
    |
 help: an enum with a similar name exists
    |

--- a/src/test/ui/resolve/privacy-struct-ctor.stderr
+++ b/src/test/ui/resolve/privacy-struct-ctor.stderr
@@ -1,6 +1,9 @@
 error[E0423]: expected value, found struct `Z`
   --> $DIR/privacy-struct-ctor.rs:20:9
    |
+LL |     pub struct S(u8);
+   |     ----------------- similarly named tuple struct `S` defined here
+...
 LL |         Z;
    |         ^
    |         |

--- a/src/test/ui/resolve/resolve-assoc-suggestions.rs
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.rs
@@ -16,21 +16,21 @@ impl Tr for S {
         let _: field;
         //~^ ERROR cannot find type `field`
         let field(..);
-        //~^ ERROR cannot find tuple struct/variant `field`
+        //~^ ERROR cannot find tuple struct or tuple variant `field`
         field;
         //~^ ERROR cannot find value `field`
 
         let _: Type;
         //~^ ERROR cannot find type `Type`
         let Type(..);
-        //~^ ERROR cannot find tuple struct/variant `Type`
+        //~^ ERROR cannot find tuple struct or tuple variant `Type`
         Type;
         //~^ ERROR cannot find value `Type`
 
         let _: method;
         //~^ ERROR cannot find type `method`
         let method(..);
-        //~^ ERROR cannot find tuple struct/variant `method`
+        //~^ ERROR cannot find tuple struct or tuple variant `method`
         method;
         //~^ ERROR cannot find value `method`
     }

--- a/src/test/ui/resolve/resolve-assoc-suggestions.stderr
+++ b/src/test/ui/resolve/resolve-assoc-suggestions.stderr
@@ -4,7 +4,7 @@ error[E0412]: cannot find type `field` in this scope
 LL |         let _: field;
    |                ^^^^^ not found in this scope
 
-error[E0531]: cannot find tuple struct/variant `field` in this scope
+error[E0531]: cannot find tuple struct or tuple variant `field` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:18:13
    |
 LL |         let field(..);
@@ -22,7 +22,7 @@ error[E0412]: cannot find type `Type` in this scope
 LL |         let _: Type;
    |                ^^^^ help: try: `Self::Type`
 
-error[E0531]: cannot find tuple struct/variant `Type` in this scope
+error[E0531]: cannot find tuple struct or tuple variant `Type` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:25:13
    |
 LL |         let Type(..);
@@ -40,7 +40,7 @@ error[E0412]: cannot find type `method` in this scope
 LL |         let _: method;
    |                ^^^^^^ not found in this scope
 
-error[E0531]: cannot find tuple struct/variant `method` in this scope
+error[E0531]: cannot find tuple struct or tuple variant `method` in this scope
   --> $DIR/resolve-assoc-suggestions.rs:32:13
    |
 LL |         let method(..);

--- a/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/src/test/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -25,6 +25,9 @@ LL |     a.b.J
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:32:5
    |
+LL |     pub const I: i32 = 1;
+   |     --------------------- similarly named constant `I` defined here
+...
 LL |     a::b.J
    |     ^^^^
    |
@@ -48,6 +51,9 @@ LL |     a.b.f();
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:40:12
    |
+LL |     pub const I: i32 = 1;
+   |     --------------------- similarly named constant `I` defined here
+...
 LL |     v.push(a::b);
    |            ^^^-
    |               |
@@ -56,6 +62,9 @@ LL |     v.push(a::b);
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:45:5
    |
+LL |     pub const I: i32 = 1;
+   |     --------------------- similarly named constant `I` defined here
+...
 LL |     a::b.f()
    |     ^^^^
    |
@@ -71,6 +80,9 @@ LL |     a::b::f()
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:50:5
    |
+LL |     pub const I: i32 = 1;
+   |     --------------------- similarly named constant `I` defined here
+...
 LL |     a::b
    |     ^^^-
    |        |
@@ -79,6 +91,9 @@ LL |     a::b
 error[E0423]: expected function, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:55:5
    |
+LL |     pub const I: i32 = 1;
+   |     --------------------- similarly named constant `I` defined here
+...
 LL |     a::b()
    |     ^^^-
    |        |

--- a/src/test/ui/resolve/tuple-struct-alias.rs
+++ b/src/test/ui/resolve/tuple-struct-alias.rs
@@ -4,6 +4,6 @@ type A = S;
 fn main() {
     let s = A(0, 1); //~ ERROR expected function
     match s {
-        A(..) => {} //~ ERROR expected tuple struct/variant
+        A(..) => {} //~ ERROR expected tuple struct or tuple variant
     }
 }

--- a/src/test/ui/resolve/tuple-struct-alias.stderr
+++ b/src/test/ui/resolve/tuple-struct-alias.stderr
@@ -1,14 +1,20 @@
-error[E0423]: expected function, found type alias `A`
+error[E0423]: expected function, tuple struct or tuple variant, found type alias `A`
   --> $DIR/tuple-struct-alias.rs:5:13
    |
+LL | struct S(u8, u16);
+   | ------------------ similarly named tuple struct `S` defined here
+...
 LL |     let s = A(0, 1);
    |             ^ help: a tuple struct with a similar name exists: `S`
    |
    = note: can't use a type alias as a constructor
 
-error[E0532]: expected tuple struct/variant, found type alias `A`
+error[E0532]: expected tuple struct or tuple variant, found type alias `A`
   --> $DIR/tuple-struct-alias.rs:7:9
    |
+LL | struct S(u8, u16);
+   | ------------------ similarly named tuple struct `S` defined here
+...
 LL |         A(..) => {}
    |         ^ help: a tuple struct with a similar name exists: `S`
    |

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.rs
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.rs
@@ -18,7 +18,7 @@ fn main() {
     //~^ ERROR `..` required with struct marked as non-exhaustive
 
     let ts = TupleStruct(640, 480);
-    //~^ ERROR expected function, found struct `TupleStruct` [E0423]
+    //~^ ERROR expected function, tuple struct or tuple variant, found struct `TupleStruct` [E0423]
 
     let ts_explicit = structs::TupleStruct(640, 480);
     //~^ ERROR tuple struct constructor `TupleStruct` is private [E0603]

--- a/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
+++ b/src/test/ui/rfc-2008-non-exhaustive/struct.stderr
@@ -1,4 +1,4 @@
-error[E0423]: expected function, found struct `TupleStruct`
+error[E0423]: expected function, tuple struct or tuple variant, found struct `TupleStruct`
   --> $DIR/struct.rs:20:14
    |
 LL |     let ts = TupleStruct(640, 480);

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
@@ -2,5 +2,5 @@
 
 fn main() {
     let crate = 0;
-    //~^ ERROR expected unit struct/variant or constant, found module `crate`
+    //~^ ERROR expected unit struct, unit variant or constant, found module `crate`
 }

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
@@ -1,8 +1,8 @@
-error[E0532]: expected unit struct/variant or constant, found module `crate`
+error[E0532]: expected unit struct, unit variant or constant, found module `crate`
   --> $DIR/keyword-crate-as-identifier.rs:4:9
    |
 LL |     let crate = 0;
-   |         ^^^^^ not a unit struct/variant or constant
+   |         ^^^^^ not a unit struct, unit variant or constant
 
 error: aborting due to previous error
 

--- a/src/test/ui/self/self_type_keyword-2.rs
+++ b/src/test/ui/self/self_type_keyword-2.rs
@@ -2,12 +2,12 @@ use self::Self as Foo; //~ ERROR unresolved import `self::Self`
 
 pub fn main() {
     let Self = 5;
-    //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
+    //~^ ERROR cannot find unit struct, unit variant or constant `Self` in this scope
 
     match 15 {
         Self => (),
-        //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
+        //~^ ERROR cannot find unit struct, unit variant or constant `Self` in this scope
         Foo { x: Self } => (),
-        //~^ ERROR cannot find unit struct/variant or constant `Self` in this scope
+        //~^ ERROR cannot find unit struct, unit variant or constant `Self` in this scope
     }
 }

--- a/src/test/ui/self/self_type_keyword-2.stderr
+++ b/src/test/ui/self/self_type_keyword-2.stderr
@@ -4,19 +4,19 @@ error[E0432]: unresolved import `self::Self`
 LL | use self::Self as Foo;
    |     ^^^^^^^^^^^^^^^^^ no `Self` in the root
 
-error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
+error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword-2.rs:4:9
    |
 LL |     let Self = 5;
    |         ^^^^ not found in this scope
 
-error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
+error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword-2.rs:8:9
    |
 LL |         Self => (),
    |         ^^^^ not found in this scope
 
-error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
+error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword-2.rs:10:18
    |
 LL |         Foo { x: Self } => (),

--- a/src/test/ui/self/self_type_keyword.rs
+++ b/src/test/ui/self/self_type_keyword.rs
@@ -15,7 +15,7 @@ pub fn main() {
         //~^ ERROR expected identifier, found keyword `Self`
         mut Self => (),
         //~^ ERROR `mut` must be followed by a named binding
-        //~| ERROR cannot find unit struct/variant or constant `Self`
+        //~| ERROR cannot find unit struct, unit variant or constant `Self`
         ref mut Self => (),
         //~^ ERROR expected identifier, found keyword `Self`
         Self!() => (),

--- a/src/test/ui/self/self_type_keyword.stderr
+++ b/src/test/ui/self/self_type_keyword.stderr
@@ -60,7 +60,7 @@ error: cannot find macro `Self` in this scope
 LL |         Self!() => (),
    |         ^^^^
 
-error[E0531]: cannot find unit struct/variant or constant `Self` in this scope
+error[E0531]: cannot find unit struct, unit variant or constant `Self` in this scope
   --> $DIR/self_type_keyword.rs:16:13
    |
 LL |         mut Self => (),

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -1,6 +1,8 @@
 error[E0423]: expected value, found struct variant `E::B`
   --> $DIR/fn-or-tuple-struct-without-args.rs:36:16
    |
+LL |     A(usize),
+   |     -------- similarly named tuple variant `A` defined here
 LL |     B { a: usize },
    |     -------------- `E::B` defined here
 ...

--- a/src/test/ui/traits/trait-impl-for-module.stderr
+++ b/src/test/ui/traits/trait-impl-for-module.stderr
@@ -1,8 +1,12 @@
 error[E0573]: expected type, found module `a`
   --> $DIR/trait-impl-for-module.rs:7:12
    |
-LL | impl A for a {
-   |            ^ help: a trait with a similar name exists: `A`
+LL | / trait A {
+LL | | }
+   | |_- similarly named trait `A` defined here
+LL | 
+LL |   impl A for a {
+   |              ^ help: a trait with a similar name exists: `A`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.rs
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.rs
@@ -6,7 +6,7 @@ impl Enum {
     fn foo(&self) -> () {
         match self {
             Self::A => (),
-            //~^ ERROR expected unit struct/variant or constant, found tuple variant
+            //~^ ERROR expected unit struct, unit variant or constant, found tuple variant
         }
     }
 }

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct/variant or constant, found tuple variant `<Self>::A`
+error[E0533]: expected unit struct, unit variant or constant, found tuple variant `<Self>::A`
   --> $DIR/incorrect-variant-form-through-Self-issue-58006.rs:8:13
    |
 LL |             Self::A => (),

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
@@ -8,14 +8,14 @@ type Alias = Enum;
 
 fn main() {
     Alias::Braced;
-    //~^ ERROR expected unit struct/variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced` [E0533]
     let Alias::Braced = panic!();
-    //~^ ERROR expected unit struct/variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced` [E0533]
     let Alias::Braced(..) = panic!();
-    //~^ ERROR expected tuple struct/variant, found struct variant `<Alias>::Braced` [E0164]
+    //~^ ERROR expected tuple struct or tuple variant, found struct variant `<Alias>::Braced` [E0164]
 
     Alias::Unit();
     //~^ ERROR expected function, found enum variant `<Alias>::Unit`
     let Alias::Unit() = panic!();
-    //~^ ERROR expected tuple struct/variant, found unit variant `<Alias>::Unit` [E0164]
+    //~^ ERROR expected tuple struct or tuple variant, found unit variant `<Alias>::Unit` [E0164]
 }

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -1,16 +1,16 @@
-error[E0533]: expected unit struct/variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:10:5
    |
 LL |     Alias::Braced;
    |     ^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:12:9
    |
 LL |     let Alias::Braced = panic!();
    |         ^^^^^^^^^^^^^
 
-error[E0164]: expected tuple struct/variant, found struct variant `<Alias>::Braced`
+error[E0164]: expected tuple struct or tuple variant, found struct variant `<Alias>::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:14:9
    |
 LL |     let Alias::Braced(..) = panic!();
@@ -32,7 +32,7 @@ help: `<Alias>::Unit` is a unit variant, you need to write it without the parent
 LL |     <Alias>::Unit;
    |     ^^^^^^^^^^^^^
 
-error[E0164]: expected tuple struct/variant, found unit variant `<Alias>::Unit`
+error[E0164]: expected tuple struct or tuple variant, found unit variant `<Alias>::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:19:9
    |
 LL |     let Alias::Unit() = panic!();

--- a/src/test/ui/ufcs/ufcs-partially-resolved.stderr
+++ b/src/test/ui/ufcs/ufcs-partially-resolved.stderr
@@ -13,6 +13,9 @@ LL |     <u8 as E::Y>::NN;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:19:24
    |
+LL |     type Y = u16;
+   |     ------------- similarly named associated type `Y` defined here
+...
 LL |     let _: <u8 as Tr>::N;
    |                        ^ help: an associated type with a similar name exists: `Y`
 
@@ -31,6 +34,9 @@ LL |     let _: <u8 as A>::N;
 error[E0576]: cannot find method or associated constant `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:22:17
    |
+LL |     fn Y() {}
+   |     --------- similarly named method `Y` defined here
+...
 LL |     <u8 as Tr>::N;
    |                 ^ help: a method with a similar name exists: `Y`
 
@@ -61,6 +67,9 @@ LL |     <u8 as E>::Y;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:30:24
    |
+LL |     type Y = u16;
+   |     ------------- similarly named associated type `Y` defined here
+...
 LL |     let _: <u8 as Tr>::N::NN;
    |                        ^ help: an associated type with a similar name exists: `Y`
 
@@ -79,6 +88,9 @@ LL |     let _: <u8 as A>::N::NN;
 error[E0576]: cannot find associated type `N` in trait `Tr`
   --> $DIR/ufcs-partially-resolved.rs:33:17
    |
+LL |     type Y = u16;
+   |     ------------- similarly named associated type `Y` defined here
+...
 LL |     <u8 as Tr>::N::NN;
    |                 ^ help: an associated type with a similar name exists: `Y`
 
@@ -157,6 +169,9 @@ LL |     <u8 as Tr::Y>::NN;
 error[E0575]: expected associated type, found method `Dr::Z`
   --> $DIR/ufcs-partially-resolved.rs:52:12
    |
+LL |     type X = u16;
+   |     ------------- similarly named associated type `X` defined here
+...
 LL |     let _: <u8 as Dr>::Z;
    |            ^^^^^^^^^^^^-
    |                        |
@@ -165,6 +180,9 @@ LL |     let _: <u8 as Dr>::Z;
 error[E0575]: expected method or associated constant, found associated type `Dr::X`
   --> $DIR/ufcs-partially-resolved.rs:53:5
    |
+LL |     fn Z() {}
+   |     --------- similarly named method `Z` defined here
+...
 LL |     <u8 as Dr>::X;
    |     ^^^^^^^^^^^^-
    |                 |
@@ -175,6 +193,9 @@ LL |     <u8 as Dr>::X;
 error[E0575]: expected associated type, found method `Dr::Z`
   --> $DIR/ufcs-partially-resolved.rs:54:12
    |
+LL |     type X = u16;
+   |     ------------- similarly named associated type `X` defined here
+...
 LL |     let _: <u8 as Dr>::Z::N;
    |            ^^^^^^^^^^^^-^^^
    |                        |

--- a/src/test/ui/ui-testing-optout.stderr
+++ b/src/test/ui/ui-testing-optout.stderr
@@ -2,17 +2,26 @@ error[E0412]: cannot find type `B` in this scope
  --> $DIR/ui-testing-optout.rs:4:10
   |
 4 | type A = B;
-  |          ^ help: a type alias with a similar name exists: `A`
+  | ---------^-
+  | |        |
+  | |        help: a type alias with a similar name exists: `A`
+  | similarly named type alias `A` defined here
 
 error[E0412]: cannot find type `D` in this scope
   --> $DIR/ui-testing-optout.rs:10:10
    |
+4  | type A = B;
+   | ----------- similarly named type alias `A` defined here
+...
 10 | type C = D;
    |          ^ help: a type alias with a similar name exists: `A`
 
 error[E0412]: cannot find type `F` in this scope
   --> $DIR/ui-testing-optout.rs:95:10
    |
+4  | type A = B;
+   | ----------- similarly named type alias `A` defined here
+...
 95 | type E = F;
    |          ^ help: a type alias with a similar name exists: `A`
 


### PR DESCRIPTION
Successful merges:

 - #63871 (Add #[must_use] to all functions 'fn(float) -> float')
 - #64747 (Stabilize `Option::flatten`)
 - #65421 (Point at local similarly named element and tweak references to variants)
 - #65792 (rustc, rustc_passes: reduce deps on rustc_expand)
 - #65849 (librustc_lexer: Enhance documentation)
 - #65873 (doc: explain why it is unsafe to construct Vec<u8> from Vec<u16>)
 - #65877 (doc: introduce `once` in `iter::chain` document)

Failed merges:


r? @ghost