### PR TITLE
Reorder `mir_const_qualif` to make promotion in consts more consistent

### DIFF
--- a/src/librustc/arena.rs
+++ b/src/librustc/arena.rs
@@ -45,7 +45,6 @@ macro_rules! arena_types {
             [decode] specialization_graph: rustc::traits::specialization_graph::Graph,
             [] region_scope_tree: rustc::middle::region::ScopeTree,
             [] item_local_set: rustc::util::nodemap::ItemLocalSet,
-            [decode] mir_const_qualif: rustc_index::bit_set::BitSet<rustc::mir::Local>,
             [] trait_impls_of: rustc::ty::trait_def::TraitImpls,
             [] dropck_outlives:
                 rustc::infer::canonical::Canonical<'tcx,

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -93,8 +93,8 @@ rustc_queries! {
         /// Maps DefId's that have an associated `mir::Body` to the result
         /// of the MIR qualify_consts pass. The actual meaning of
         /// the value isn't known except to the pass itself.
-        query mir_const_qualif(key: DefId) -> (u8, &'tcx BitSet<mir::Local>) {
-            desc { |tcx| "const checking `{}`", tcx.def_path_str(key) }
+        query mir_const_qualif(key: DefId) -> u8 {
+            desc { |tcx| "computing qualifs for `{}`", tcx.def_path_str(key) }
             cache_on_disk_if { key.is_local() }
         }
 
@@ -110,11 +110,8 @@ rustc_queries! {
             no_hash
         }
 
-        query mir_validated(_: DefId) ->
-            (
-                &'tcx Steal<mir::Body<'tcx>>,
-                &'tcx Steal<IndexVec<mir::Promoted, mir::Body<'tcx>>>
-            ) {
+        query mir_validated(key: DefId) -> mir::BodyAndPromoteds<'tcx> {
+            desc { |tcx| "promoting and checking `{}`", tcx.def_path_str(key) }
             no_hash
         }
 

--- a/src/librustc/ty/query/mod.rs
+++ b/src/librustc/ty/query/mod.rs
@@ -42,7 +42,6 @@ use crate::util::common::ErrorReported;
 use crate::util::profiling::ProfileCategory::*;
 
 use rustc_data_structures::svh::Svh;
-use rustc_index::bit_set::BitSet;
 use rustc_index::vec::IndexVec;
 use rustc_data_structures::fx::{FxIndexMap, FxHashMap, FxHashSet};
 use rustc_data_structures::stable_hasher::StableVec;

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -34,7 +34,6 @@ use syntax::parse::parser::emit_unclosed_delims;
 use syntax::source_map::Spanned;
 use syntax::symbol::Symbol;
 use syntax_pos::{Span, FileName};
-use rustc_index::bit_set::BitSet;
 
 macro_rules! provide {
     (<$lt:tt> $tcx:ident, $def_id:ident, $other:ident, $cdata:ident,
@@ -124,9 +123,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     }
     optimized_mir => { tcx.arena.alloc(cdata.get_optimized_mir(tcx, def_id.index)) }
     promoted_mir => { tcx.arena.alloc(cdata.get_promoted_mir(tcx, def_id.index)) }
-    mir_const_qualif => {
-        (cdata.mir_const_qualif(def_id.index), tcx.arena.alloc(BitSet::new_empty(0)))
-    }
+    mir_const_qualif => { cdata.mir_const_qualif(def_id.index) }
     fn_sig => { cdata.fn_sig(def_id.index, tcx) }
     inherent_impls => { cdata.get_inherent_implementations_for_type(tcx, def_id.index) }
     is_const_fn_raw => { cdata.is_const_fn_raw(def_id.index) }

--- a/src/librustc_metadata/encoder.rs
+++ b/src/librustc_metadata/encoder.rs
@@ -948,7 +948,7 @@ impl EncodeContext<'tcx> {
         record!(self.per_def.kind[def_id] <- match impl_item.kind {
             ty::AssocKind::Const => {
                 if let hir::ImplItemKind::Const(_, body_id) = ast_item.kind {
-                    let mir = self.tcx.at(ast_item.span).mir_const_qualif(def_id).0;
+                    let mir = self.tcx.at(ast_item.span).mir_const_qualif(def_id);
 
                     EntryKind::AssocConst(container,
                         ConstQualif { mir },
@@ -1081,7 +1081,7 @@ impl EncodeContext<'tcx> {
             hir::ItemKind::Static(_, hir::MutMutable, _) => EntryKind::MutStatic,
             hir::ItemKind::Static(_, hir::MutImmutable, _) => EntryKind::ImmStatic,
             hir::ItemKind::Const(_, body_id) => {
-                let mir = self.tcx.at(item.span).mir_const_qualif(def_id).0;
+                let mir = self.tcx.at(item.span).mir_const_qualif(def_id);
                 EntryKind::Const(
                     ConstQualif { mir },
                     self.encode_rendered_const_for_body(body_id)
@@ -1371,7 +1371,7 @@ impl EncodeContext<'tcx> {
         let id = self.tcx.hir().as_local_hir_id(def_id).unwrap();
         let body_id = self.tcx.hir().body_owned_by(id);
         let const_data = self.encode_rendered_const_for_body(body_id);
-        let mir = self.tcx.mir_const_qualif(def_id).0;
+        let mir = self.tcx.mir_const_qualif(def_id);
 
         record!(self.per_def.kind[def_id] <- EntryKind::Const(ConstQualif { mir }, const_data));
         record!(self.per_def.visibility[def_id] <- ty::Visibility::Public);

--- a/src/librustc_mir/borrow_check/mod.rs
+++ b/src/librustc_mir/borrow_check/mod.rs
@@ -86,13 +86,13 @@ pub fn provide(providers: &mut Providers<'_>) {
 }
 
 fn mir_borrowck(tcx: TyCtxt<'_>, def_id: DefId) -> BorrowCheckResult<'_> {
-    let (input_body, promoted) = tcx.mir_validated(def_id);
+    let validated_mir = tcx.mir_validated(def_id);
     debug!("run query mir_borrowck: {}", tcx.def_path_str(def_id));
 
     let opt_closure_req = tcx.infer_ctxt().enter(|infcx| {
-        let input_body: &Body<'_> = &input_body.borrow();
-        let promoted: &IndexVec<_, _> = &promoted.borrow();
-        do_mir_borrowck(&infcx, input_body, promoted, def_id)
+        let input_body: &Body<'_> = &validated_mir.body.borrow();
+        let promoteds: &IndexVec<_, _> = &validated_mir.promoteds.borrow();
+        do_mir_borrowck(&infcx, input_body, promoteds, def_id)
     });
     debug!("mir_borrowck done");
 

--- a/src/librustc_mir/transform/check_consts/qualifs.rs
+++ b/src/librustc_mir/transform/check_consts/qualifs.rs
@@ -123,7 +123,7 @@ pub trait Qualif {
                     if cx.tcx.trait_of_item(def_id).is_some() {
                         Self::in_any_value_of_ty(cx, constant.literal.ty)
                     } else {
-                        let (bits, _) = cx.tcx.at(constant.span).mir_const_qualif(def_id);
+                        let bits = cx.tcx.at(constant.span).mir_const_qualif(def_id);
 
                         let qualif = QualifSet(bits).contains::<Self>();
 

--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -525,7 +525,8 @@ impl<'tcx> Validator<'_, 'tcx> {
                         // is gone - we can always promote constants even if they
                         // fail to pass const-checking, as compilation would've
                         // errored independently and promotion can't change that.
-                        let (bits, _) = self.tcx.at(constant.span).mir_const_qualif(def_id);
+                        let bits = self.tcx.at(constant.span).mir_const_qualif(def_id);
+
                         if bits == super::qualify_consts::QUALIF_ERROR_BIT {
                             self.tcx.sess.delay_span_bug(
                                 constant.span,

--- a/src/librustc_mir/transform/qualify_consts.rs
+++ b/src/librustc_mir/transform/qualify_consts.rs
@@ -1857,8 +1857,10 @@ fn extend_lifetimes_and_suppress_moves_in_repeat_for_const_and_static(
                     _ => bug!("Can't find assign corresponding to repeat"),
                 };
 
+                // FIXME: Trying to fix #65732 by changing this `Move` to a `Copy` causes bugs
+                // later during type checking. Figure out what to do here.
                 if let Operand::Move(_) = op {
-                    *op = op.to_copy();
+                    // *op = op.to_copy();
                 }
             }
             Candidate::Ref(Location { block: bb, statement_index: stmt_idx }) => {

--- a/src/test/ui/issues/issue-17252.stderr
+++ b/src/test/ui/issues/issue-17252.stderr
@@ -1,11 +1,16 @@
-error[E0391]: cycle detected when const checking `FOO`
+error[E0391]: cycle detected when computing qualifs for `FOO`
+  --> $DIR/issue-17252.rs:1:1
+   |
+LL | const FOO: usize = FOO;
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: ...which requires promoting and checking `FOO`...
   --> $DIR/issue-17252.rs:1:20
    |
 LL | const FOO: usize = FOO;
    |                    ^^^
-   |
-   = note: ...which again requires const checking `FOO`, completing the cycle
-note: cycle used when const checking `main::{{constant}}#0`
+   = note: ...which again requires computing qualifs for `FOO`, completing the cycle
+note: cycle used when promoting and checking `main::{{constant}}#0`
   --> $DIR/issue-17252.rs:4:18
    |
 LL |     let _x: [u8; FOO]; // caused stack overflow prior to fix

--- a/src/test/ui/issues/issue-23302-1.stderr
+++ b/src/test/ui/issues/issue-23302-1.stderr
@@ -1,10 +1,15 @@
-error[E0391]: cycle detected when const checking `X::A::{{constant}}#0`
+error[E0391]: cycle detected when promoting and checking `X::A::{{constant}}#0`
   --> $DIR/issue-23302-1.rs:4:9
    |
 LL |     A = X::A as isize,
    |         ^^^^^^^^^^^^^
    |
-   = note: ...which again requires const checking `X::A::{{constant}}#0`, completing the cycle
+note: ...which requires computing qualifs for `X::A::{{constant}}#0`...
+  --> $DIR/issue-23302-1.rs:4:9
+   |
+LL |     A = X::A as isize,
+   |         ^^^^^^^^^^^^^
+   = note: ...which again requires promoting and checking `X::A::{{constant}}#0`, completing the cycle
 note: cycle used when processing `X::A::{{constant}}#0`
   --> $DIR/issue-23302-1.rs:4:9
    |

--- a/src/test/ui/issues/issue-23302-2.stderr
+++ b/src/test/ui/issues/issue-23302-2.stderr
@@ -1,10 +1,15 @@
-error[E0391]: cycle detected when const checking `Y::A::{{constant}}#0`
+error[E0391]: cycle detected when promoting and checking `Y::A::{{constant}}#0`
   --> $DIR/issue-23302-2.rs:4:9
    |
 LL |     A = Y::B as isize,
    |         ^^^^^^^^^^^^^
    |
-   = note: ...which again requires const checking `Y::A::{{constant}}#0`, completing the cycle
+note: ...which requires computing qualifs for `Y::A::{{constant}}#0`...
+  --> $DIR/issue-23302-2.rs:4:9
+   |
+LL |     A = Y::B as isize,
+   |         ^^^^^^^^^^^^^
+   = note: ...which again requires promoting and checking `Y::A::{{constant}}#0`, completing the cycle
 note: cycle used when processing `Y::A::{{constant}}#0`
   --> $DIR/issue-23302-2.rs:4:9
    |

--- a/src/test/ui/issues/issue-23302-3.stderr
+++ b/src/test/ui/issues/issue-23302-3.stderr
@@ -1,15 +1,25 @@
-error[E0391]: cycle detected when const checking `A`
+error[E0391]: cycle detected when promoting and checking `A`
   --> $DIR/issue-23302-3.rs:1:16
    |
 LL | const A: i32 = B;
    |                ^
    |
-note: ...which requires const checking `B`...
+note: ...which requires computing qualifs for `B`...
+  --> $DIR/issue-23302-3.rs:3:1
+   |
+LL | const B: i32 = A;
+   | ^^^^^^^^^^^^^^^^^
+note: ...which requires promoting and checking `B`...
   --> $DIR/issue-23302-3.rs:3:16
    |
 LL | const B: i32 = A;
    |                ^
-   = note: ...which again requires const checking `A`, completing the cycle
+note: ...which requires computing qualifs for `A`...
+  --> $DIR/issue-23302-3.rs:1:1
+   |
+LL | const A: i32 = B;
+   | ^^^^^^^^^^^^^^^^^
+   = note: ...which again requires promoting and checking `A`, completing the cycle
 note: cycle used when processing `A`
   --> $DIR/issue-23302-3.rs:1:1
    |

--- a/src/test/ui/issues/issue-36163.stderr
+++ b/src/test/ui/issues/issue-36163.stderr
@@ -1,15 +1,25 @@
-error[E0391]: cycle detected when const checking `Foo::B::{{constant}}#0`
+error[E0391]: cycle detected when promoting and checking `Foo::B::{{constant}}#0`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    |
-note: ...which requires const checking `A`...
+note: ...which requires computing qualifs for `A`...
+  --> $DIR/issue-36163.rs:1:1
+   |
+LL | const A: isize = Foo::B as isize;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires promoting and checking `A`...
   --> $DIR/issue-36163.rs:1:18
    |
 LL | const A: isize = Foo::B as isize;
    |                  ^^^^^^^^^^^^^^^
-   = note: ...which again requires const checking `Foo::B::{{constant}}#0`, completing the cycle
+note: ...which requires computing qualifs for `Foo::B::{{constant}}#0`...
+  --> $DIR/issue-36163.rs:4:9
+   |
+LL |     B = A,
+   |         ^
+   = note: ...which again requires promoting and checking `Foo::B::{{constant}}#0`, completing the cycle
 note: cycle used when processing `Foo::B::{{constant}}#0`
   --> $DIR/issue-36163.rs:4:9
    |


### PR DESCRIPTION
Computing `mir_const_qualif` requires running most of `QualifyAndPromoteConstants`, but no promotion is actually done until `mir_validated`. This required persisting a `BitSet` containing the promotable locals across queries and makes it difficult to properly handle promotion in `const`s, since the promotion context (`Candidate`) for each local is gone. This PR swaps the order of the two queries, and stores the result of `mir_const_qualif` (a single `u8`) in the result of `mir_validated`.  `mir_const_qualif` now simply invokes `mir_validated` and extracts this result.

I don't think this should do any more work, but I'm new to the query system. At the very least, this saves us from having to keep a `BitSet` in the arena for each `const`. It does, however, cause a small diagnostics regression for cyclical dependencies between `const`s, since there is an extra query in the cycle.

After this PR is merged, promotion for every item (non-const `fn`, `const`, etc.) will be done using a list of `Candidate`s. This makes it easier to fix places where promotion in a `const` acts differently than in regular `fn` such as #65732, and will allow us to create promoted MIR fragments for a `const` which (I think) will be needed to implement #52000. 

I initially intended for this to resolve issue #65732, but I wasn't able to fix the `nll::type_check` errors that were caused by converting `Move`s of promotable array initializers to `Copy`s within a `const`. The code that did this is commented out and a `FIXME` was added to this effect. I think the best solution may be to start creating promoted MIR fragments, but others should weigh in.

r? @eddyb
