### PR TITLE
Remove `PartialEq` and `Eq` from the `SpecialDerives`.

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -65,7 +65,6 @@ use syntax::ast;
 use syntax::ptr::P as AstP;
 use syntax::ast::*;
 use syntax::errors;
-use syntax::expand::SpecialDerives;
 use syntax::print::pprust;
 use syntax::parse::token::{self, Nonterminal, Token};
 use syntax::tokenstream::{TokenStream, TokenTree};
@@ -183,8 +182,6 @@ pub trait Resolver {
         components: &[Symbol],
         ns: Namespace,
     ) -> (ast::Path, Res<NodeId>);
-
-    fn has_derives(&self, node_id: NodeId, derives: SpecialDerives) -> bool;
 
     fn lint_buffer(&mut self) -> &mut lint::LintBuffer;
 }

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -18,7 +18,6 @@ use smallvec::SmallVec;
 use syntax::attr;
 use syntax::ast::*;
 use syntax::visit::{self, Visitor};
-use syntax::expand::SpecialDerives;
 use syntax::source_map::{respan, DesugaringKind, Spanned};
 use syntax::symbol::{kw, sym};
 use syntax_pos::Span;
@@ -227,13 +226,7 @@ impl LoweringContext<'_> {
     pub fn lower_item(&mut self, i: &Item) -> Option<hir::Item> {
         let mut ident = i.ident;
         let mut vis = self.lower_visibility(&i.vis, None);
-        let mut attrs = self.lower_attrs_extendable(&i.attrs);
-        if self.resolver.has_derives(i.id, SpecialDerives::PARTIAL_EQ | SpecialDerives::EQ) {
-            // Add `#[structural_match]` if the item derived both `PartialEq` and `Eq`.
-            let ident = Ident::new(sym::structural_match, i.span);
-            attrs.push(attr::mk_attr_outer(attr::mk_word_item(ident)));
-        }
-        let attrs = attrs.into();
+        let attrs = self.lower_attrs(&i.attrs);
 
         if let ItemKind::MacroDef(ref def) = i.kind {
             if !def.legacy || attr::contains_name(&i.attrs, sym::macro_export) {

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -937,8 +937,6 @@ pub struct Resolver<'a> {
     /// Some built-in derives mark items they are applied to so they are treated specially later.
     /// Derive macros cannot modify the item themselves and have to store the markers in the global
     /// context, so they attach the markers to derive container IDs using this resolver table.
-    /// FIXME: Find a way for `PartialEq` and `Eq` to emulate `#[structural_match]`
-    /// by marking the produced impls rather than the original items.
     special_derives: FxHashMap<ExpnId, SpecialDerives>,
     /// Parent scopes in which the macros were invoked.
     /// FIXME: `derives` are missing in these parent scopes and need to be taken from elsewhere.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -36,7 +36,6 @@ use rustc_metadata::creader::CrateLoader;
 use rustc_metadata::cstore::CStore;
 
 use syntax::{struct_span_err, unwrap_or};
-use syntax::expand::SpecialDerives;
 use syntax::ast::{self, Name, NodeId, Ident, FloatTy, IntTy, UintTy};
 use syntax::ast::{CRATE_NODE_ID, Crate};
 use syntax::ast::{ItemKind, Path};
@@ -934,10 +933,10 @@ pub struct Resolver<'a> {
     multi_segment_macro_resolutions: Vec<(Vec<Segment>, Span, MacroKind, ParentScope<'a>,
                                           Option<Res>)>,
     builtin_attrs: Vec<(Ident, ParentScope<'a>)>,
-    /// Some built-in derives mark items they are applied to so they are treated specially later.
+    /// `derive(Copy)` marks items they are applied to so they are treated specially later.
     /// Derive macros cannot modify the item themselves and have to store the markers in the global
     /// context, so they attach the markers to derive container IDs using this resolver table.
-    special_derives: FxHashMap<ExpnId, SpecialDerives>,
+    copy_derives: FxHashSet<ExpnId>,
     /// Parent scopes in which the macros were invoked.
     /// FIXME: `derives` are missing in these parent scopes and need to be taken from elsewhere.
     invocation_parent_scopes: FxHashMap<ExpnId, ParentScope<'a>>,
@@ -1074,12 +1073,6 @@ impl<'a> hir::lowering::Resolver for Resolver<'a> {
 
     fn definitions(&mut self) -> &mut Definitions {
         &mut self.definitions
-    }
-
-    fn has_derives(&self, node_id: NodeId, derives: SpecialDerives) -> bool {
-        let def_id = self.definitions.local_def_id(node_id);
-        let expn_id = self.definitions.expansion_that_defined(def_id.index);
-        self.has_derives(expn_id, derives)
     }
 
     fn lint_buffer(&mut self) -> &mut lint::LintBuffer {
@@ -1226,7 +1219,7 @@ impl<'a> Resolver<'a> {
             single_segment_macro_resolutions: Default::default(),
             multi_segment_macro_resolutions: Default::default(),
             builtin_attrs: Default::default(),
-            special_derives: Default::default(),
+            copy_derives: Default::default(),
             active_features:
                 features.declared_lib_features.iter().map(|(feat, ..)| *feat)
                     .chain(features.declared_lang_features.iter().map(|(feat, ..)| *feat))
@@ -1310,10 +1303,6 @@ impl<'a> Resolver<'a> {
                 None => ctxt.remove_mark(),
             };
         }
-    }
-
-    fn has_derives(&self, expn_id: ExpnId, markers: SpecialDerives) -> bool {
-        self.special_derives.get(&expn_id).map_or(false, |m| m.contains(markers))
     }
 
     /// Entry point to crate resolution.

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -936,7 +936,7 @@ pub struct Resolver<'a> {
     /// `derive(Copy)` marks items they are applied to so they are treated specially later.
     /// Derive macros cannot modify the item themselves and have to store the markers in the global
     /// context, so they attach the markers to derive container IDs using this resolver table.
-    copy_derives: FxHashSet<ExpnId>,
+    containers_deriving_copy: FxHashSet<ExpnId>,
     /// Parent scopes in which the macros were invoked.
     /// FIXME: `derives` are missing in these parent scopes and need to be taken from elsewhere.
     invocation_parent_scopes: FxHashMap<ExpnId, ParentScope<'a>>,
@@ -1219,7 +1219,7 @@ impl<'a> Resolver<'a> {
             single_segment_macro_resolutions: Default::default(),
             multi_segment_macro_resolutions: Default::default(),
             builtin_attrs: Default::default(),
-            copy_derives: Default::default(),
+            containers_deriving_copy: Default::default(),
             active_features:
                 features.declared_lib_features.iter().map(|(feat, ..)| *feat)
                     .chain(features.declared_lang_features.iter().map(|(feat, ..)| *feat))

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -14,7 +14,6 @@ use rustc::{ty, lint, span_bug};
 use syntax::ast::{self, NodeId, Ident};
 use syntax::attr::StabilityLevel;
 use syntax::edition::Edition;
-use syntax::expand::SpecialDerives;
 use syntax::feature_gate::{emit_feature_err, is_builtin_attr_name};
 use syntax::feature_gate::GateIssue;
 use syntax::print::pprust;
@@ -255,12 +254,12 @@ impl<'a> base::Resolver for Resolver<'a> {
         }
     }
 
-    fn has_derives(&self, expn_id: ExpnId, derives: SpecialDerives) -> bool {
-        self.has_derives(expn_id, derives)
+    fn has_derive_copy(&self, expn_id: ExpnId) -> bool {
+        self.copy_derives.contains(&expn_id)
     }
 
-    fn add_derives(&mut self, expn_id: ExpnId, derives: SpecialDerives) {
-        *self.special_derives.entry(expn_id).or_default() |= derives;
+    fn add_derive_copy(&mut self, expn_id: ExpnId) {
+        self.copy_derives.insert(expn_id);
     }
 }
 

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -255,11 +255,11 @@ impl<'a> base::Resolver for Resolver<'a> {
     }
 
     fn has_derive_copy(&self, expn_id: ExpnId) -> bool {
-        self.copy_derives.contains(&expn_id)
+        self.containers_deriving_copy.contains(&expn_id)
     }
 
     fn add_derive_copy(&mut self, expn_id: ExpnId) {
-        self.copy_derives.insert(expn_id);
+        self.containers_deriving_copy.insert(expn_id);
     }
 }
 

--- a/src/libsyntax/expand/mod.rs
+++ b/src/libsyntax/expand/mod.rs
@@ -5,14 +5,6 @@ use syntax_pos::symbol::sym;
 
 pub mod allocator;
 
-bitflags::bitflags! {
-    /// Built-in derives that need some extra tracking beyond the usual macro functionality.
-    #[derive(Default)]
-    pub struct SpecialDerives: u8 {
-        const COPY       = 1 << 2;
-    }
-}
-
 pub fn is_proc_macro_attr(attr: &Attribute) -> bool {
     [sym::proc_macro, sym::proc_macro_attribute, sym::proc_macro_derive]
         .iter().any(|kind| attr.check_name(*kind))

--- a/src/libsyntax/expand/mod.rs
+++ b/src/libsyntax/expand/mod.rs
@@ -9,8 +9,6 @@ bitflags::bitflags! {
     /// Built-in derives that need some extra tracking beyond the usual macro functionality.
     #[derive(Default)]
     pub struct SpecialDerives: u8 {
-        const PARTIAL_EQ = 1 << 0;
-        const EQ         = 1 << 1;
         const COPY       = 1 << 2;
     }
 }

--- a/src/libsyntax_expand/base.rs
+++ b/src/libsyntax_expand/base.rs
@@ -13,7 +13,6 @@ use syntax::symbol::{kw, sym, Ident, Symbol};
 use syntax::{ThinVec, MACRO_ARGUMENTS};
 use syntax::tokenstream::{self, TokenStream};
 use syntax::visit::Visitor;
-crate use syntax::expand::SpecialDerives;
 
 use errors::{DiagnosticBuilder, DiagnosticId};
 use smallvec::{smallvec, SmallVec};
@@ -860,8 +859,8 @@ pub trait Resolver {
 
     fn check_unused_macros(&mut self);
 
-    fn has_derives(&self, expn_id: ExpnId, derives: SpecialDerives) -> bool;
-    fn add_derives(&mut self, expn_id: ExpnId, derives: SpecialDerives);
+    fn has_derive_copy(&self, expn_id: ExpnId) -> bool;
+    fn add_derive_copy(&mut self, expn_id: ExpnId);
 }
 
 #[derive(Clone)]

--- a/src/libsyntax_expand/expand.rs
+++ b/src/libsyntax_expand/expand.rs
@@ -432,7 +432,7 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                     // can be in scope for all code produced by that container's expansion.
                     item.visit_with(&mut MarkAttrs(&helper_attrs));
                     if has_copy {
-                        self.cx.resolver.add_derives(invoc.expansion_data.id, SpecialDerives::COPY);
+                        self.cx.resolver.add_derive_copy(invoc.expansion_data.id);
                     }
 
                     let mut derive_placeholders = Vec::with_capacity(derives.len());

--- a/src/libsyntax_ext/deriving/clone.rs
+++ b/src/libsyntax_ext/deriving/clone.rs
@@ -3,7 +3,6 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Expr, GenericArg, Generics, ItemKind, MetaItem, VariantData};
-use syntax::expand::SpecialDerives;
 use syntax_expand::base::{Annotatable, ExtCtxt};
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
@@ -37,7 +36,7 @@ pub fn expand_deriving_clone(cx: &mut ExtCtxt<'_>,
                 ItemKind::Struct(_, Generics { ref params, .. }) |
                 ItemKind::Enum(_, Generics { ref params, .. }) => {
                     let container_id = cx.current_expansion.id.expn_data().parent;
-                    if cx.resolver.has_derives(container_id, SpecialDerives::COPY) &&
+                    if cx.resolver.has_derive_copy(container_id) &&
                         !params.iter().any(|param| match param.kind {
                             ast::GenericParamKind::Type { .. } => true,
                             _ => false,

--- a/src/libsyntax_ext/deriving/cmp/eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/eq.rs
@@ -3,7 +3,6 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{self, Ident, Expr, MetaItem, GenericArg};
-use syntax::expand::SpecialDerives;
 use syntax::ptr::P;
 use syntax::symbol::{sym, Symbol};
 use syntax_expand::base::{Annotatable, ExtCtxt};
@@ -14,8 +13,6 @@ pub fn expand_deriving_eq(cx: &mut ExtCtxt<'_>,
                           mitem: &MetaItem,
                           item: &Annotatable,
                           push: &mut dyn FnMut(Annotatable)) {
-    cx.resolver.add_derives(cx.current_expansion.id.expn_data().parent, SpecialDerives::EQ);
-
     let inline = cx.meta_word(span, sym::inline);
     let hidden = syntax::attr::mk_nested_word_item(Ident::new(sym::hidden, span));
     let doc = syntax::attr::mk_list_item(Ident::new(sym::doc, span), vec![hidden]);

--- a/src/libsyntax_ext/deriving/cmp/partial_eq.rs
+++ b/src/libsyntax_ext/deriving/cmp/partial_eq.rs
@@ -3,7 +3,6 @@ use crate::deriving::generic::*;
 use crate::deriving::generic::ty::*;
 
 use syntax::ast::{BinOpKind, Expr, MetaItem};
-use syntax::expand::SpecialDerives;
 use syntax::ptr::P;
 use syntax::symbol::sym;
 use syntax_expand::base::{Annotatable, ExtCtxt};
@@ -14,8 +13,6 @@ pub fn expand_deriving_partial_eq(cx: &mut ExtCtxt<'_>,
                                   mitem: &MetaItem,
                                   item: &Annotatable,
                                   push: &mut dyn FnMut(Annotatable)) {
-    cx.resolver.add_derives(cx.current_expansion.id.expn_data().parent, SpecialDerives::PARTIAL_EQ);
-
     // structures are equal if all fields are equal, and non equal, if
     // any fields are not equal or if the enum variants are different
     fn cs_op(cx: &mut ExtCtxt<'_>,

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -186,7 +186,6 @@ use rustc_target::spec::abi::Abi;
 use syntax::ast::{self, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
 use syntax::ast::{VariantData, GenericParamKind, GenericArg};
 use syntax::attr;
-use syntax::expand::SpecialDerives;
 use syntax::source_map::respan;
 use syntax::util::map_in_place::MapInPlace;
 use syntax::ptr::P;
@@ -427,10 +426,8 @@ impl<'a> TraitDef<'a> {
                     }
                 };
                 let container_id = cx.current_expansion.id.expn_data().parent;
-                let is_always_copy =
-                    cx.resolver.has_derives(container_id, SpecialDerives::COPY) &&
-                    has_no_type_params;
-                let use_temporaries = is_packed && is_always_copy;
+                let always_copy = has_no_type_params && cx.resolver.has_derive_copy(container_id);
+                let use_temporaries = is_packed && always_copy;
 
                 let newitem = match item.kind {
                     ast::ItemKind::Struct(ref struct_def, ref generics) => {


### PR DESCRIPTION
Now that PR #65519 landed, this is the follow-on work of removing `PartialEq` and `Eq` from the set of `SpecialDerives` .