### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -154,8 +154,8 @@ use crate::raw_vec::RawVec;
 /// println!("{}", v[6]); // it will panic!
 /// ```
 ///
-/// In conclusion: always check if the index you want to get really exists
-/// before doing it.
+/// Use [`get`] and [`get_mut`] if you want to check whether the index is in
+/// the `Vec`.
 ///
 /// # Slicing
 ///
@@ -277,6 +277,8 @@ use crate::raw_vec::RawVec;
 /// The order has changed in the past and may change again.
 ///
 /// [`vec!`]: ../../std/macro.vec.html
+/// [`get`]: ../../std/vec/struct.Vec.html#method.get
+/// [`get_mut`]: ../../std/vec/struct.Vec.html#method.get_mut
 /// [`Index`]: ../../std/ops/trait.Index.html
 /// [`String`]: ../../std/string/struct.String.html
 /// [`&str`]: ../../std/primitive.str.html

--- a/src/librustc/hir/map/collector.rs
+++ b/src/librustc/hir/map/collector.rs
@@ -149,7 +149,7 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
         let mut collector = NodeCollector {
             krate,
             source_map: sess.source_map(),
-            map: vec![None; definitions.def_index_count()],
+            map: IndexVec::from_elem_n(IndexVec::new(), definitions.def_index_count()),
             parent_node: hir::CRATE_HIR_ID,
             current_signature_dep_index: root_mod_sig_dep_index,
             current_full_dep_index: root_mod_full_dep_index,
@@ -227,12 +227,8 @@ impl<'a, 'hir> NodeCollector<'a, 'hir> {
 
     fn insert_entry(&mut self, id: HirId, entry: Entry<'hir>) {
         debug!("hir_map: {:?} => {:?}", id, entry);
-        let local_map = &mut self.map[id.owner.index()];
+        let local_map = &mut self.map[id.owner];
         let i = id.local_id.as_u32() as usize;
-        if local_map.is_none() {
-            *local_map = Some(IndexVec::with_capacity(i + 1));
-        }
-        let local_map = local_map.as_mut().unwrap();
         let len = local_map.len();
         if i >= len {
             local_map.extend(repeat(None).take(i - len + 1));

--- a/src/librustc/hir/map/definitions.rs
+++ b/src/librustc/hir/map/definitions.rs
@@ -27,8 +27,8 @@ use syntax_pos::{Span, DUMMY_SP};
 /// There is one `DefPathTable` for each crate.
 #[derive(Clone, Default, RustcDecodable, RustcEncodable)]
 pub struct DefPathTable {
-    index_to_key: Vec<DefKey>,
-    def_path_hashes: Vec<DefPathHash>,
+    index_to_key: IndexVec<DefIndex, DefKey>,
+    def_path_hashes: IndexVec<DefIndex, DefPathHash>,
 }
 
 impl DefPathTable {
@@ -53,14 +53,14 @@ impl DefPathTable {
 
     #[inline(always)]
     pub fn def_key(&self, index: DefIndex) -> DefKey {
-        self.index_to_key[index.index()]
+        self.index_to_key[index]
     }
 
     #[inline(always)]
     pub fn def_path_hash(&self, index: DefIndex) -> DefPathHash {
-        let ret = self.def_path_hashes[index.index()];
-        debug!("def_path_hash({:?}) = {:?}", index, ret);
-        return ret
+        let hash = self.def_path_hashes[index];
+        debug!("def_path_hash({:?}) = {:?}", index, hash);
+        hash
     }
 
     pub fn add_def_path_hashes_to(&self,
@@ -92,7 +92,7 @@ impl DefPathTable {
 pub struct Definitions {
     table: DefPathTable,
     node_to_def_index: NodeMap<DefIndex>,
-    def_index_to_node: Vec<ast::NodeId>,
+    def_index_to_node: IndexVec<DefIndex, ast::NodeId>,
     pub(super) node_to_hir_id: IndexVec<ast::NodeId, hir::HirId>,
     /// If `ExpnId` is an ID of some macro expansion,
     /// then `DefId` is the normal module (`mod`) in which the expanded macro was defined.
@@ -375,7 +375,7 @@ impl Definitions {
     #[inline]
     pub fn as_local_node_id(&self, def_id: DefId) -> Option<ast::NodeId> {
         if def_id.krate == LOCAL_CRATE {
-            let node_id = self.def_index_to_node[def_id.index.index()];
+            let node_id = self.def_index_to_node[def_id.index];
             if node_id != ast::DUMMY_NODE_ID {
                 return Some(node_id);
             }
@@ -404,7 +404,7 @@ impl Definitions {
 
     #[inline]
     pub fn def_index_to_hir_id(&self, def_index: DefIndex) -> hir::HirId {
-        let node_id = self.def_index_to_node[def_index.index()];
+        let node_id = self.def_index_to_node[def_index];
         self.node_to_hir_id[node_id]
     }
 

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1523,7 +1523,17 @@ impl<'a> State<'a> {
                                         colons_before_params)
             }
             hir::QPath::TypeRelative(ref qself, ref item_segment) => {
-                self.print_type(qself);
+                // If we've got a compound-qualified-path, let's push an additional pair of angle
+                // brackets, so that we pretty-print `<<A::B>::C>` as `<A::B>::C`, instead of just
+                // `A::B::C` (since the latter could be ambiguous to the user)
+                if let hir::TyKind::Path(hir::QPath::Resolved(None, _)) = &qself.kind {
+                    self.print_type(qself);
+                } else {
+                    self.s.word("<");
+                    self.print_type(qself);
+                    self.s.word(">");
+                }
+
                 self.s.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1523,9 +1523,7 @@ impl<'a> State<'a> {
                                         colons_before_params)
             }
             hir::QPath::TypeRelative(ref qself, ref item_segment) => {
-                self.s.word("<");
                 self.print_type(qself);
-                self.s.word(">");
                 self.s.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),

--- a/src/librustc/infer/error_reporting/nice_region_error/mod.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/mod.rs
@@ -12,6 +12,7 @@ mod named_anon_conflict;
 mod placeholder_error;
 mod outlives_closure;
 mod static_impl_trait;
+mod trait_impl_difference;
 mod util;
 
 impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
@@ -73,6 +74,7 @@ impl<'cx, 'tcx> NiceRegionError<'cx, 'tcx> {
             .or_else(|| self.try_report_anon_anon_conflict())
             .or_else(|| self.try_report_outlives_closure())
             .or_else(|| self.try_report_static_impl_trait())
+            .or_else(|| self.try_report_impl_not_conforming_to_trait())
     }
 
     pub fn get_regions(&self) -> (Span, ty::Region<'tcx>, ty::Region<'tcx>) {

--- a/src/librustc/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -1,0 +1,53 @@
+//! Error Reporting for `impl` items that do not match the obligations from their `trait`.
+
+use crate::infer::{ValuePairs, Subtype};
+use crate::infer::error_reporting::nice_region_error::NiceRegionError;
+use crate::infer::lexical_region_resolve::RegionResolutionError;
+use crate::util::common::ErrorReported;
+
+impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
+    /// Print the error message for lifetime errors when the `impl` doesn't conform to the `trait`.
+    pub(super) fn try_report_impl_not_conforming_to_trait(&self) -> Option<ErrorReported> {
+        if let Some(ref error) = self.error {
+            if let RegionResolutionError::SubSupConflict(
+                _,
+                var_origin,
+                sub_origin,
+                _sub,
+                sup_origin,
+                _sup,
+            ) = error.clone() {
+                match (&sup_origin, &sub_origin) {
+                    (&Subtype(ref sup_trace), &Subtype(ref sub_trace)) => {
+                        if let (
+                            ValuePairs::Types(sub_expected_found),
+                            ValuePairs::Types(sup_expected_found),
+                        ) = (&sub_trace.values, &sup_trace.values) {
+                            if sup_expected_found == sub_expected_found {
+                                let sp = var_origin.span();
+                                let mut err = self.tcx().sess.struct_span_err(
+                                    sp,
+                                    "`impl` item doesn't match `trait` item"
+                                );
+                                err.note(&format!(
+                                    "expected: {:?}\n   found: {:?}",
+                                    sub_expected_found.expected,
+                                    sub_expected_found.found,
+                                ));
+                                err.span_label(sp, &format!(
+                                    "found {:?}",
+                                    sub_expected_found.found,
+                                ));
+                                // FIXME: recover the `FnPtr`'s `HirId`/`Node` to point to it.
+                                err.emit();
+                                return Some(ErrorReported);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        None
+    }
+}

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -1408,6 +1408,7 @@ impl<'tcx> TyCtxt<'tcx> {
     }
 
     pub fn encode_metadata(self)-> EncodedMetadata {
+        let _prof_timer = self.prof.generic_activity("generate_crate_metadata");
         self.cstore.encode_metadata(self)
     }
 

--- a/src/librustc/ty/flags.rs
+++ b/src/librustc/ty/flags.rs
@@ -114,6 +114,7 @@ impl FlagComputation {
             }
 
             &ty::Placeholder(..) => {
+                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
                 self.add_flags(TypeFlags::HAS_TY_PLACEHOLDER);
             }
 
@@ -123,8 +124,7 @@ impl FlagComputation {
                 match infer {
                     ty::FreshTy(_) |
                     ty::FreshIntTy(_) |
-                    ty::FreshFloatTy(_) => {
-                    }
+                    ty::FreshFloatTy(_) => {}
 
                     ty::TyVar(_) |
                     ty::IntVar(_) |
@@ -245,14 +245,16 @@ impl FlagComputation {
                 }
             }
             ConstValue::Param(_) => {
-                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES | TypeFlags::HAS_PARAMS);
+                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
+                self.add_flags(TypeFlags::HAS_PARAMS);
             }
             ConstValue::Placeholder(_) => {
-                self.add_flags(TypeFlags::HAS_FREE_REGIONS | TypeFlags::HAS_CT_PLACEHOLDER);
+                self.add_flags(TypeFlags::HAS_FREE_LOCAL_NAMES);
+                self.add_flags(TypeFlags::HAS_CT_PLACEHOLDER);
             }
-            ConstValue::Scalar(_) => { }
-            ConstValue::Slice { data: _, start: _, end: _ } => { }
-            ConstValue::ByRef { alloc: _, offset: _ } => { }
+            ConstValue::Scalar(_) => {}
+            ConstValue::Slice { .. } => {}
+            ConstValue::ByRef { .. } => {}
         }
     }
 

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -574,8 +574,6 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
 
     if need_metadata_module {
         // Codegen the encoded metadata.
-        let _prof_timer = tcx.prof.generic_activity("codegen_crate_metadata");
-
         let metadata_cgu_name = cgu_name_builder.build_cgu_name(LOCAL_CRATE,
                                                                 &["crate"],
                                                                 Some("metadata")).as_str()

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -172,10 +172,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }).peekable();
 
             if compatible_variants.peek().is_some() {
-                let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
+                let expr_text = self.tcx.sess
+                    .source_map()
+                    .span_to_snippet(expr.span)
+                    .unwrap_or_else(|_| {
+                        print::to_string(print::NO_ANN, |s| s.print_expr(expr))
+                    });
                 let suggestions = compatible_variants
                     .map(|v| format!("{}({})", v, expr_text));
-                let msg = "try using a variant of the expected type";
+                let msg = "try using a variant of the expected enum";
                 err.span_suggestions(expr.span, msg, suggestions, Applicability::MaybeIncorrect);
             }
         }

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -3891,6 +3891,25 @@ details.
 [issue #33685]: https://github.com/rust-lang/rust/issues/33685
 "##,
 
+E0587: r##"
+A type has both `packed` and `align` representation hints.
+
+Erroneous code example:
+
+```compile_fail,E0587
+#[repr(packed, align(8))] // error!
+struct Umbrella(i32);
+```
+
+You cannot use `packed` and `align` hints on a same type. If you want to pack a
+type to a given size, you should provide a size to packed:
+
+```
+#[repr(packed)] // ok!
+struct Umbrella(i32);
+```
+"##,
+
 E0588: r##"
 A type with `packed` representation hint has a field with `align`
 representation hint.
@@ -5073,7 +5092,6 @@ the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 //  E0563, // cannot determine a type for this `impl Trait` removed in 6383de15
 //  E0564, // only named lifetimes are allowed in `impl Trait`,
            // but `{}` was found in the type `{}`
-    E0587, // type has conflicting packed and align representation hints
 //  E0611, // merged into E0616
 //  E0612, // merged into E0609
 //  E0613, // Removed (merged with E0609)

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -30,7 +30,7 @@ pub fn bar() ({
 
 
                   ((::alloc::fmt::format as
-                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::core::fmt::Arguments>::new_v1
+                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((::core::fmt::Arguments::new_v1
                                                                                                            as
                                                                                                            fn(&[&str], &[std::fmt::ArgumentV1<'_>]) -> std::fmt::Arguments<'_> {std::fmt::Arguments::<'_>::new_v1})((&([("test"
                                                                                                                                                                                                                             as

--- a/src/test/ui/conflicting-repr-hints.stderr
+++ b/src/test/ui/conflicting-repr-hints.stderr
@@ -66,4 +66,5 @@ LL | | }
 
 error: aborting due to 8 previous errors
 
-For more information about this error, try `rustc --explain E0566`.
+Some errors have detailed explanations: E0566, E0587.
+For more information about an error, try `rustc --explain E0566`.

--- a/src/test/ui/did_you_mean/issue-42764.rs
+++ b/src/test/ui/did_you_mean/issue-42764.rs
@@ -10,7 +10,7 @@ fn main() {
     let n: usize = 42;
     this_function_expects_a_double_option(n);
     //~^ ERROR mismatched types
-    //~| HELP try using a variant of the expected type
+    //~| HELP try using a variant of the expected enum
 }
 
 

--- a/src/test/ui/did_you_mean/issue-42764.stderr
+++ b/src/test/ui/did_you_mean/issue-42764.stderr
@@ -6,7 +6,7 @@ LL |     this_function_expects_a_double_option(n);
    |
    = note: expected type `DoubleOption<_>`
               found type `usize`
-help: try using a variant of the expected type
+help: try using a variant of the expected enum
    |
 LL |     this_function_expects_a_double_option(DoubleOption::FirstSome(n));
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/error-codes/E0164.stderr
+++ b/src/test/ui/error-codes/E0164.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found associated constant `<Foo>::B`
+error[E0164]: expected tuple struct/variant, found associated constant `Foo::B`
   --> $DIR/E0164.rs:9:9
    |
 LL |         Foo::B(i) => i,

--- a/src/test/ui/fn-in-pat.stderr
+++ b/src/test/ui/fn-in-pat.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<A>::new`
+error[E0164]: expected tuple struct/variant, found method `A::new`
   --> $DIR/fn-in-pat.rs:11:9
    |
 LL |         A::new() => (),

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
@@ -5,7 +5,7 @@ LL |     x = 5;
    |         ^
    |         |
    |         expected enum `std::option::Option`, found integer
-   |         help: try using a variant of the expected type: `Some(5)`
+   |         help: try using a variant of the expected enum: `Some(5)`
    |
    = note: expected type `std::option::Option<usize>`
               found type `{integer}`

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
@@ -6,9 +6,9 @@ struct Struct;
 impl Deref for Struct {
     type Target = dyn Trait;
     fn deref(&self) -> &dyn Trait {
+    //~^ ERROR `impl` item signature doesn't match `trait` item signature
         unimplemented!();
     }
 }
-//~^^^^ ERROR `impl` item signature doesn't match `trait` item signature
 
 fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
@@ -9,6 +9,6 @@ impl Deref for Struct {
         unimplemented!();
     }
 }
-//~^^^^ ERROR cannot infer an appropriate lifetime for lifetime parameter
+//~^^^^ ERROR `impl` item doesn't match `trait` item
 
 fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.rs
@@ -9,6 +9,6 @@ impl Deref for Struct {
         unimplemented!();
     }
 }
-//~^^^^ ERROR `impl` item doesn't match `trait` item
+//~^^^^ ERROR `impl` item signature doesn't match `trait` item signature
 
 fn main() {}

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -1,4 +1,4 @@
-error: `impl` item doesn't match `trait` item
+error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/mismatched_trait_impl-2.rs:8:5
    |
 LL |     fn deref(&self) -> &dyn Trait {

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -1,20 +1,11 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter in generic type due to conflicting requirements
+error: `impl` item doesn't match `trait` item
   --> $DIR/mismatched_trait_impl-2.rs:8:5
    |
 LL |     fn deref(&self) -> &dyn Trait {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&Struct) -> &dyn Trait
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 8:5...
-  --> $DIR/mismatched_trait_impl-2.rs:8:5
-   |
-LL | /     fn deref(&self) -> &dyn Trait {
-LL | |         unimplemented!();
-LL | |     }
-   | |_____^
-   = note: ...but the lifetime must also be valid for the static lifetime...
-   = note: ...so that the method type is compatible with trait:
-           expected fn(&Struct) -> &(dyn Trait + 'static)
-              found fn(&Struct) -> &dyn Trait
+   = note: expected: fn(&Struct) -> &(dyn Trait + 'static)
+              found: fn(&Struct) -> &dyn Trait
 
 error: aborting due to previous error
 

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl-2.stderr
@@ -3,10 +3,14 @@ error: `impl` item signature doesn't match `trait` item signature
    |
 LL |     fn deref(&self) -> &dyn Trait {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&Struct) -> &dyn Trait
+   | 
+  ::: $SRC_DIR/libcore/ops/deref.rs:LL:COL
    |
-   = note: expected: fn(&Struct) -> &(dyn Trait + 'static)
-              found: fn(&Struct) -> &dyn Trait
+LL |     fn deref(&self) -> &Self::Target;
+   |     --------------------------------- expected fn(&Struct) -> &(dyn Trait + 'static)
+   |
+   = note: expected `fn(&Struct) -> &(dyn Trait + 'static)`
+              found `fn(&Struct) -> &dyn Trait`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.nll.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.nll.stderr
@@ -1,25 +1,14 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 'a in generic type due to conflicting requirements
+error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/mismatched_trait_impl.rs:9:5
    |
+LL |     fn foo(&self, x: &'a u32, y: &u32) -> &'a u32;
+   |     ---------------------------------------------- expected fn(&i32, &'a u32, &u32) -> &'a u32
+...
 LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&i32, &u32, &u32) -> &u32
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 9:5...
-  --> $DIR/mismatched_trait_impl.rs:9:5
-   |
-LL | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-LL | |         x
-LL | |     }
-   | |_____^
-note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the method body at 9:32...
-  --> $DIR/mismatched_trait_impl.rs:9:32
-   |
-LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-   |                                ^^
-   = note: ...so that the method type is compatible with trait:
-           expected fn(&i32, &'a u32, &u32) -> &'a u32
-              found fn(&i32, &u32, &u32) -> &u32
+   = note: expected `fn(&i32, &'a u32, &u32) -> &'a u32`
+              found `fn(&i32, &u32, &u32) -> &u32`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
@@ -6,7 +6,7 @@ trait Get {
 }
 
 impl Get for i32 {
-    fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR `impl` item doesn't match `trait`
+    fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR `impl` item signature doesn't match
         x //~ ERROR lifetime mismatch
     }
 }

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.rs
@@ -6,7 +6,7 @@ trait Get {
 }
 
 impl Get for i32 {
-    fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR cannot infer
+    fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 { //~ ERROR `impl` item doesn't match `trait`
         x //~ ERROR lifetime mismatch
     }
 }

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -1,11 +1,14 @@
 error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/mismatched_trait_impl.rs:9:5
    |
+LL |     fn foo(&self, x: &'a u32, y: &u32) -> &'a u32;
+   |     ---------------------------------------------- expected fn(&i32, &'a u32, &u32) -> &'a u32
+...
 LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&i32, &u32, &u32) -> &u32
    |
-   = note: expected: fn(&i32, &'a u32, &u32) -> &'a u32
-              found: fn(&i32, &u32, &u32) -> &u32
+   = note: expected `fn(&i32, &'a u32, &u32) -> &'a u32`
+              found `fn(&i32, &u32, &u32) -> &u32`
 
 error[E0623]: lifetime mismatch
   --> $DIR/mismatched_trait_impl.rs:10:9
@@ -19,4 +22,3 @@ LL |         x
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0495`.

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -1,24 +1,11 @@
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter 'a in generic type due to conflicting requirements
+error: `impl` item doesn't match `trait` item
   --> $DIR/mismatched_trait_impl.rs:9:5
    |
 LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&i32, &u32, &u32) -> &u32
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #2 defined on the method body at 9:5...
-  --> $DIR/mismatched_trait_impl.rs:9:5
-   |
-LL | /     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-LL | |         x
-LL | |     }
-   | |_____^
-note: ...but the lifetime must also be valid for the lifetime `'a` as defined on the method body at 9:32...
-  --> $DIR/mismatched_trait_impl.rs:9:32
-   |
-LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {
-   |                                ^^
-   = note: ...so that the method type is compatible with trait:
-           expected fn(&i32, &'a u32, &u32) -> &'a u32
-              found fn(&i32, &u32, &u32) -> &u32
+   = note: expected: fn(&i32, &'a u32, &u32) -> &'a u32
+              found: fn(&i32, &u32, &u32) -> &u32
 
 error[E0623]: lifetime mismatch
   --> $DIR/mismatched_trait_impl.rs:10:9

--- a/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
+++ b/src/test/ui/in-band-lifetimes/mismatched_trait_impl.stderr
@@ -1,4 +1,4 @@
-error: `impl` item doesn't match `trait` item
+error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/mismatched_trait_impl.rs:9:5
    |
 LL |     fn foo(&self, x: &u32, y: &'a u32) -> &'a u32 {

--- a/src/test/ui/issues/issue-28992-empty.rs
+++ b/src/test/ui/issues/issue-28992-empty.rs
@@ -12,5 +12,5 @@ impl S {
 fn main() {
     if let C1(..) = 0 {} //~ ERROR expected tuple struct/variant, found constant `C1`
     if let S::C2(..) = 0 {}
-    //~^ ERROR expected tuple struct/variant, found associated constant `<S>::C2`
+    //~^ ERROR expected tuple struct/variant, found associated constant `S::C2`
 }

--- a/src/test/ui/issues/issue-28992-empty.stderr
+++ b/src/test/ui/issues/issue-28992-empty.stderr
@@ -4,7 +4,7 @@ error[E0532]: expected tuple struct/variant, found constant `C1`
 LL |     if let C1(..) = 0 {}
    |            ^^ not a tuple struct/variant
 
-error[E0164]: expected tuple struct/variant, found associated constant `<S>::C2`
+error[E0164]: expected tuple struct/variant, found associated constant `S::C2`
   --> $DIR/issue-28992-empty.rs:14:12
    |
 LL |     if let S::C2(..) = 0 {}

--- a/src/test/ui/issues/issue-46112.stderr
+++ b/src/test/ui/issues/issue-46112.stderr
@@ -5,7 +5,7 @@ LL | fn main() { test(Ok(())); }
    |                     ^^
    |                     |
    |                     expected enum `std::option::Option`, found ()
-   |                     help: try using a variant of the expected type: `Some(())`
+   |                     help: try using a variant of the expected enum: `Some(())`
    |
    = note: expected type `std::option::Option<()>`
               found type `()`

--- a/src/test/ui/issues/issue-55587.stderr
+++ b/src/test/ui/issues/issue-55587.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct/variant, found method `Path::new`
   --> $DIR/issue-55587.rs:4:9
    |
 LL |     let Path::new();

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.rs
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.rs
@@ -1,0 +1,12 @@
+trait Foo {
+    fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32;
+}
+
+impl Foo for () {
+    fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+    //~^ ERROR `impl` item doesn't match `trait` item
+        if x > y { x } else { y }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.rs
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.rs
@@ -4,7 +4,7 @@ trait Foo {
 
 impl Foo for () {
     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
-    //~^ ERROR `impl` item doesn't match `trait` item
+    //~^ ERROR `impl` item signature doesn't match `trait` item signature
         if x > y { x } else { y }
     }
 }

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
@@ -1,0 +1,11 @@
+error: `impl` item doesn't match `trait` item
+  --> $DIR/lifetime-mismatch-between-trait-and-impl.rs:6:5
+   |
+LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&i32, &i32) -> &i32
+   |
+   = note: expected: fn(&i32, &'a i32) -> &'a i32
+              found: fn(&i32, &i32) -> &i32
+
+error: aborting due to previous error
+

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
@@ -1,4 +1,4 @@
-error: `impl` item doesn't match `trait` item
+error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/lifetime-mismatch-between-trait-and-impl.rs:6:5
    |
 LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {

--- a/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-mismatch-between-trait-and-impl.stderr
@@ -1,11 +1,14 @@
 error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/lifetime-mismatch-between-trait-and-impl.rs:6:5
    |
+LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32;
+   |     ------------------------------------------- expected fn(&i32, &'a i32) -> &'a i32
+...
 LL |     fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found fn(&i32, &i32) -> &i32
    |
-   = note: expected: fn(&i32, &'a i32) -> &'a i32
-              found: fn(&i32, &i32) -> &i32
+   = note: expected `fn(&i32, &'a i32) -> &'a i32`
+              found `fn(&i32, &i32) -> &i32`
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-fn-call.stderr
+++ b/src/test/ui/match/match-fn-call.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct/variant, found method `Path::new`
   --> $DIR/match-fn-call.rs:6:9
    |
 LL |         Path::new("foo") => println!("foo"),
@@ -6,7 +6,7 @@ LL |         Path::new("foo") => println!("foo"),
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch18-00-patterns.html
 
-error[E0164]: expected tuple struct/variant, found method `<Path>::new`
+error[E0164]: expected tuple struct/variant, found method `Path::new`
   --> $DIR/match-fn-call.rs:8:9
    |
 LL |         Path::new("bar") => println!("bar"),

--- a/src/test/ui/methods/method-path-in-pattern.rs
+++ b/src/test/ui/methods/method-path-in-pattern.rs
@@ -13,20 +13,20 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         Foo::bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct/variant or constant, found method `Foo::bar`
     }
     match 0u32 {
         <Foo>::bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct/variant or constant, found method `Foo::bar`
     }
     match 0u32 {
         <Foo>::trait_bar => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+        //~^ ERROR expected unit struct/variant or constant, found method `Foo::trait_bar`
     }
     if let Foo::bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct/variant or constant, found method `Foo::bar`
     if let <Foo>::bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct/variant or constant, found method `Foo::bar`
     if let Foo::trait_bar = 0u32 {}
-    //~^ ERROR expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+    //~^ ERROR expected unit struct/variant or constant, found method `Foo::trait_bar`
 }

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -1,34 +1,34 @@
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:15:9
    |
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
    |         ^^^^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:26:12
    |
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}
    |            ^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct/variant or constant, found method `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:30:12
    |
 LL |     if let Foo::trait_bar = 0u32 {}

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
+        //~^ ERROR expected unit struct/variant or constant, found method `<S as Tr>::A::f<u8>`
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-        //~^ ERROR expected unit struct/variant or constant, found method `<S as Tr>::A::f<u8>`
+        //~^ ERROR expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct/variant or constant, found method `<S as Tr>::A::f<u8>`
+error[E0533]: expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct/variant or constant, found method `<<S as Tr>::A>::f<u8>`
+error[E0533]: expected unit struct/variant or constant, found method `<S as Tr>::A::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/reject-specialized-drops-8142.rs
+++ b/src/test/ui/reject-specialized-drops-8142.rs
@@ -52,6 +52,6 @@ impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
 //~^ ERROR Implementations of Drop cannot be specialized
 
 impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `impl` item doesn't match `trait` item
+//~^ ERROR `impl` item signature doesn't match `trait` item signature
 
 pub fn main() { }

--- a/src/test/ui/reject-specialized-drops-8142.rs
+++ b/src/test/ui/reject-specialized-drops-8142.rs
@@ -52,6 +52,6 @@ impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
 //~^ ERROR Implementations of Drop cannot be specialized
 
 impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR cannot infer an appropriate lifetime
+//~^ ERROR `impl` item doesn't match `trait` item
 
 pub fn main() { }

--- a/src/test/ui/reject-specialized-drops-8142.rs
+++ b/src/test/ui/reject-specialized-drops-8142.rs
@@ -52,6 +52,6 @@ impl<One>         Drop for V<One,One>     { fn drop(&mut self) { } } // REJECT
 //~^ ERROR Implementations of Drop cannot be specialized
 
 impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-//~^ ERROR `impl` item signature doesn't match `trait` item signature
+//~^ ERROR cannot infer an appropriate lifetime for lifetime parameter `'lw`
 
 pub fn main() { }

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -95,10 +95,10 @@ error: `impl` item signature doesn't match `trait` item signature
 LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found W<'_, '_>
    |
-   = note: expected: W<'l1, 'l2>
-              found: W<'_, '_>
+   = note: expected `W<'l1, 'l2>`
+              found `W<'_, '_>`
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0308, E0366, E0367, E0495.
+Some errors have detailed explanations: E0308, E0366, E0367.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -89,7 +89,7 @@ note: Use same sequence of generic type and region parameters that is on the str
 LL | struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `impl` item doesn't match `trait` item
+error: `impl` item signature doesn't match `trait` item signature
   --> $DIR/reject-specialized-drops-8142.rs:54:1
    |
 LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -89,16 +89,27 @@ note: Use same sequence of generic type and region parameters that is on the str
 LL | struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `impl` item signature doesn't match `trait` item signature
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'lw` due to conflicting requirements
   --> $DIR/reject-specialized-drops-8142.rs:54:1
    |
 LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found W<'_, '_>
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: expected `W<'l1, 'l2>`
-              found `W<'_, '_>`
+note: first, the lifetime cannot outlive the lifetime `'l1` as defined on the struct at 17:10...
+  --> $DIR/reject-specialized-drops-8142.rs:17:10
+   |
+LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
+   |          ^^^
+note: ...but the lifetime must also be valid for the lifetime `'l2` as defined on the struct at 17:15...
+  --> $DIR/reject-specialized-drops-8142.rs:17:15
+   |
+LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
+   |               ^^^
+   = note: ...so that the types are compatible:
+           expected W<'l1, 'l2>
+              found W<'_, '_>
 
 error: aborting due to 8 previous errors
 
-Some errors have detailed explanations: E0308, E0366, E0367.
+Some errors have detailed explanations: E0308, E0366, E0367, E0495.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/reject-specialized-drops-8142.stderr
+++ b/src/test/ui/reject-specialized-drops-8142.stderr
@@ -89,25 +89,14 @@ note: Use same sequence of generic type and region parameters that is on the str
 LL | struct V<Tva, Tvb> { x: *const Tva, y: *const Tvb }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'lw` due to conflicting requirements
+error: `impl` item doesn't match `trait` item
   --> $DIR/reject-specialized-drops-8142.rs:54:1
    |
 LL | impl<'lw>         Drop for W<'lw,'lw>     { fn drop(&mut self) { } } // REJECT
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found W<'_, '_>
    |
-note: first, the lifetime cannot outlive the lifetime `'l1` as defined on the struct at 17:10...
-  --> $DIR/reject-specialized-drops-8142.rs:17:10
-   |
-LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
-   |          ^^^
-note: ...but the lifetime must also be valid for the lifetime `'l2` as defined on the struct at 17:15...
-  --> $DIR/reject-specialized-drops-8142.rs:17:15
-   |
-LL | struct W<'l1, 'l2> { x: &'l1 i8, y: &'l2 u8 }
-   |               ^^^
-   = note: ...so that the types are compatible:
-           expected W<'l1, 'l2>
-              found W<'_, '_>
+   = note: expected: W<'l1, 'l2>
+              found: W<'_, '_>
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct/variant or constant, found tuple variant `<Self>::A`
+error[E0533]: expected unit struct/variant or constant, found tuple variant `Self::A`
   --> $DIR/incorrect-variant-form-through-Self-issue-58006.rs:8:13
    |
 LL |             Self::A => (),

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
@@ -8,14 +8,14 @@ type Alias = Enum;
 
 fn main() {
     Alias::Braced;
-    //~^ ERROR expected unit struct/variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct/variant or constant, found struct variant `Alias::Braced` [E0533]
     let Alias::Braced = panic!();
-    //~^ ERROR expected unit struct/variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct/variant or constant, found struct variant `Alias::Braced` [E0533]
     let Alias::Braced(..) = panic!();
-    //~^ ERROR expected tuple struct/variant, found struct variant `<Alias>::Braced` [E0164]
+    //~^ ERROR expected tuple struct/variant, found struct variant `Alias::Braced` [E0164]
 
     Alias::Unit();
-    //~^ ERROR expected function, found enum variant `<Alias>::Unit`
+    //~^ ERROR expected function, found enum variant `Alias::Unit`
     let Alias::Unit() = panic!();
-    //~^ ERROR expected tuple struct/variant, found unit variant `<Alias>::Unit` [E0164]
+    //~^ ERROR expected tuple struct/variant, found unit variant `Alias::Unit` [E0164]
 }

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -1,38 +1,38 @@
-error[E0533]: expected unit struct/variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct/variant or constant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:10:5
    |
 LL |     Alias::Braced;
    |     ^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct/variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct/variant or constant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:12:9
    |
 LL |     let Alias::Braced = panic!();
    |         ^^^^^^^^^^^^^
 
-error[E0164]: expected tuple struct/variant, found struct variant `<Alias>::Braced`
+error[E0164]: expected tuple struct/variant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:14:9
    |
 LL |     let Alias::Braced(..) = panic!();
    |         ^^^^^^^^^^^^^^^^^ not a tuple variant or struct
 
-error[E0618]: expected function, found enum variant `<Alias>::Unit`
+error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:17:5
    |
 LL | enum Enum { Braced {}, Unit, Tuple() }
-   |                        ---- `<Alias>::Unit` defined here
+   |                        ---- `Alias::Unit` defined here
 ...
 LL |     Alias::Unit();
    |     ^^^^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `<Alias>::Unit` is a unit variant, you need to write it without the parenthesis
+help: `Alias::Unit` is a unit variant, you need to write it without the parenthesis
    |
-LL |     <Alias>::Unit;
-   |     ^^^^^^^^^^^^^
+LL |     Alias::Unit;
+   |     ^^^^^^^^^^^
 
-error[E0164]: expected tuple struct/variant, found unit variant `<Alias>::Unit`
+error[E0164]: expected tuple struct/variant, found unit variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:19:9
    |
 LL |     let Alias::Unit() = panic!();


### PR DESCRIPTION
Successful merges:

 - #65068 (Custom lifetime error for `impl` item doesn't conform to `trait`)
 - #65562 (Improve the "try using a variant of the expected type" hint.)
 - #65563 (Add long error explanation for E0587)
 - #65643 (Correct handling of type flags with `ConstValue::Placeholder`)
 - #65825 (rustc: use IndexVec<DefIndex, T> instead of Vec<T>.)
 - #65887 (doc: mention `get(_mut)` in Vec)
 - #65891 (self-profiling: Record something more useful for crate metadata generation event.)

Failed merges:


r? @ghost