### PR TITLE
add basic HermitCore support within libtest

### DIFF
--- a/src/libtest/helpers/concurrency.rs
+++ b/src/libtest/helpers/concurrency.rs
@@ -57,7 +57,7 @@ pub fn get_concurrency() -> usize {
     #[cfg(target_os = "hermit")]
     fn num_cpus() -> usize {
         // FIXME: Implement num_cpus on HermitCore
-        1      
+        1
     }
 
     #[cfg(any(

--- a/src/libtest/helpers/concurrency.rs
+++ b/src/libtest/helpers/concurrency.rs
@@ -54,6 +54,12 @@ pub fn get_concurrency() -> usize {
         1
     }
 
+    #[cfg(target_os = "hermit")]
+    fn num_cpus() -> usize {
+        // FIXME: Implement num_cpus on HermitCore
+        1      
+    }
+
     #[cfg(any(
         all(target_arch = "wasm32", not(target_os = "emscripten")),
         all(target_vendor = "fortanix", target_env = "sgx")

--- a/src/libtest/helpers/isatty.rs
+++ b/src/libtest/helpers/isatty.rs
@@ -2,7 +2,7 @@
 //! if stdout is a tty.
 
 #[cfg(any(
-    target_os = "cloudabi",
+    target_os = "cloudabi", target_os = "hermit",
     all(target_arch = "wasm32", not(target_os = "emscripten")),
     all(target_vendor = "fortanix", target_env = "sgx")
 ))]


### PR DESCRIPTION
This an extension to #65167. The current pull request extend libtest to support HermitCore as target OS.