### PR TITLE
proc_macro: clean up bridge::client::__run_expand{1,2} a bit.

### DIFF
--- a/src/libproc_macro/bridge/client.rs
+++ b/src/libproc_macro/bridge/client.rs
@@ -389,7 +389,7 @@ impl Client<fn(crate::TokenStream) -> crate::TokenStream> {
     pub const fn expand1(f: fn(crate::TokenStream) -> crate::TokenStream) -> Self {
         extern "C" fn run(
             bridge: Bridge<'_>,
-            f: fn(crate::TokenStream) -> crate::TokenStream,
+            f: impl FnOnce(crate::TokenStream) -> crate::TokenStream,
         ) -> Buffer<u8> {
             run_client(bridge, |input| f(crate::TokenStream(input)).0)
         }
@@ -407,7 +407,7 @@ impl Client<fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream> {
     ) -> Self {
         extern "C" fn run(
             bridge: Bridge<'_>,
-            f: fn(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
+            f: impl FnOnce(crate::TokenStream, crate::TokenStream) -> crate::TokenStream,
         ) -> Buffer<u8> {
             run_client(bridge, |(input, input2)| {
                 f(crate::TokenStream(input), crate::TokenStream(input2)).0


### PR DESCRIPTION
See commit titles/diffs for more details.

The first commit is made possible by #53451 being fixed (almost a year ago).
The last commit should remove the need for `#[allow(improper_ctypes)]` in #65134.