### PR TITLE
Statically link libstdc++ on windows-gnu

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -657,11 +657,11 @@ pub fn build_codegen_backend(builder: &Builder<'_>,
             if let Some(ref s) = builder.config.llvm_ldflags {
                 cargo.env("LLVM_LINKER_FLAGS", s);
             }
-            // Building with a static libstdc++ is only supported on linux right now,
+            // Building with a static libstdc++ is only supported on linux and mingw right now,
             // not for MSVC or macOS
             if builder.config.llvm_static_stdcpp &&
                !target.contains("freebsd") &&
-               !target.contains("windows") &&
+               !target.contains("msvc") &&
                !target.contains("apple") {
                 let file = compiler_file(builder,
                                          builder.cxx(target).unwrap(),

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -236,7 +236,7 @@ fn make_win_dist(
     }
 
     let target_tools = ["gcc.exe", "ld.exe", "dlltool.exe", "libwinpthread-1.dll"];
-    let mut rustc_dlls = vec!["libstdc++-6.dll", "libwinpthread-1.dll"];
+    let mut rustc_dlls = vec!["libwinpthread-1.dll"];
     if target_triple.starts_with("i686-") {
         rustc_dlls.push("libgcc_s_dw2-1.dll");
     } else {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -159,7 +159,7 @@ impl Step for Llvm {
 
         // For distribution we want the LLVM tools to be *statically* linked to libstdc++
         if builder.config.llvm_tools_enabled || builder.config.lldb_enabled {
-            if !target.contains("windows") {
+            if !target.contains("msvc") {
                 if target.contains("apple") {
                     cfg.define("CMAKE_EXE_LINKER_FLAGS", "-static-libstdc++");
                 } else {
@@ -395,7 +395,7 @@ fn configure_cmake(builder: &Builder<'_>,
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");
     if builder.config.llvm_static_stdcpp &&
-        !target.contains("windows") &&
+        !target.contains("msvc") &&
         !target.contains("netbsd")
     {
         cxxflags.push_str(" -static-libstdc++");

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -279,7 +279,11 @@ fn main() {
             let path = PathBuf::from(s);
             println!("cargo:rustc-link-search=native={}",
                      path.parent().unwrap().display());
-            println!("cargo:rustc-link-lib=static={}", stdcppname);
+            if target.contains("windows") {
+                println!("cargo:rustc-link-lib=static-nobundle={}", stdcppname);
+            } else {
+                println!("cargo:rustc-link-lib=static={}", stdcppname);
+            }
         } else if cxxflags.contains("stdlib=libc++") {
             println!("cargo:rustc-link-lib=c++");
         } else {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/61561 by not shipping `libstdc++-6.dll` which can conflict with the GCC.