### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 
 [[package]]
 name = "backtrace"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
+checksum = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
+checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 dependencies = [
  "cc",
  "compiler_builtins",
@@ -391,9 +391,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
+checksum = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 
 [[package]]
 name = "cfg-if"
@@ -3113,6 +3113,7 @@ dependencies = [
  "backtrace",
  "bitflags",
  "byteorder",
+ "cc",
  "chalk-engine",
  "fmt_macros",
  "graphviz",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2-rfc"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [dependencies]
 arena = { path = "../libarena" }
-bitflags = "1.0"
+bitflags = "1.2.1"
 fmt_macros = { path = "../libfmt_macros" }
 graphviz = { path = "../libgraphviz" }
 jobserver = "0.1"

--- a/src/librustc/Cargo.toml
+++ b/src/librustc/Cargo.toml
@@ -10,6 +10,10 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
+# Prevent cc from upgrading all the way to 1.0.46,
+# which fails the build (see e.g. #65445.)
+cc = "=1.0.37"
+
 arena = { path = "../libarena" }
 bitflags = "1.0"
 fmt_macros = { path = "../libfmt_macros" }
@@ -30,7 +34,7 @@ errors = { path = "../librustc_errors", package = "rustc_errors" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-backtrace = "0.3.3"
+backtrace = "0.3.40"
 parking_lot = "0.9"
 byteorder = { version = "1.3" }
 chalk-engine = { version = "0.9.0", default-features=false }

--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -2219,7 +2219,7 @@ rejected in your own crates.
 "##,
 
 E0736: r##"
-#[track_caller] and #[naked] cannot be applied to the same function.
+`#[track_caller]` and `#[naked]` cannot both be applied to the same function.
 
 Erroneous code example:
 
@@ -2233,6 +2233,57 @@ fn foo() {}
 
 This is primarily due to ABI incompatibilities between the two attributes.
 See [RFC 2091] for details on this and other limitations.
+
+[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
+"##,
+
+E0738: r##"
+`#[track_caller]` cannot be used in traits yet. This is due to limitations in
+the compiler which are likely to be temporary. See [RFC 2091] for details on
+this and other restrictions.
+
+Erroneous example with a trait method implementation:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    fn bar(&self);
+}
+
+impl Foo for u64 {
+    #[track_caller]
+    fn bar(&self) {}
+}
+```
+
+Erroneous example with a blanket trait method implementation:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    #[track_caller]
+    fn bar(&self) {}
+    fn baz(&self);
+}
+```
+
+Erroneous example with a trait method declaration:
+
+```compile_fail,E0738
+#![feature(track_caller)]
+
+trait Foo {
+    fn bar(&self) {}
+
+    #[track_caller]
+    fn baz(&self);
+}
+```
+
+Note that while the compiler may be able to support the attribute in traits in
+the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/librustc/hir/check_attr.rs
+++ b/src/librustc/hir/check_attr.rs
@@ -278,7 +278,7 @@ impl CheckAttrVisitor<'tcx> {
     /// Checks if the `#[target_feature]` attribute on `item` is valid. Returns `true` if valid.
     fn check_target_feature(&self, attr: &Attribute, span: &Span, target: Target) -> bool {
         match target {
-            Target::Fn => true,
+            Target::Fn | Target::Method { body: true } => true,
             _ => {
                 self.tcx.sess
                     .struct_span_err(attr.span, "attribute should be applied to a function")

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -203,7 +203,7 @@ pub trait Visitor<'v>: Sized {
 
     /// Invoked to visit the body of a function, method or closure. Like
     /// visit_nested_item, does nothing by default unless you override
-    /// `nested_visit_map` to return other htan `None`, in which case it will walk
+    /// `nested_visit_map` to return other than `None`, in which case it will walk
     /// the body.
     fn visit_nested_body(&mut self, id: BodyId) {
         let opt_body = self.nested_visit_map().intra().map(|map| map.body(id));

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2756,10 +2756,10 @@ bitflags! {
         /// `#[used]`: indicates that LLVM can't eliminate this function (but the
         /// linker can!).
         const USED                      = 1 << 9;
-        /// #[ffi_returns_twice], indicates that an extern function can return
+        /// `#[ffi_returns_twice]`, indicates that an extern function can return
         /// multiple times
         const FFI_RETURNS_TWICE         = 1 << 10;
-        /// #[track_caller]: allow access to the caller location
+        /// `#[track_caller]`: allow access to the caller location
         const TRACK_CALLER              = 1 << 11;
     }
 }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2512,7 +2512,7 @@ pub enum ItemKind {
     Fn(P<FnDecl>, FnHeader, Generics, BodyId),
     /// A module.
     Mod(Mod),
-    /// An external module.
+    /// An external module, e.g. `extern { .. }`.
     ForeignMod(ForeignMod),
     /// Module-level inline assembly (from `global_asm!`).
     GlobalAsm(P<GlobalAsm>),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1523,7 +1523,17 @@ impl<'a> State<'a> {
                                         colons_before_params)
             }
             hir::QPath::TypeRelative(ref qself, ref item_segment) => {
-                self.print_type(qself);
+                // If we've got a compound-qualified-path, let's push an additional pair of angle
+                // brackets, so that we pretty-print `<<A::B>::C>` as `<A::B>::C`, instead of just
+                // `A::B::C` (since the latter could be ambiguous to the user)
+                if let hir::TyKind::Path(hir::QPath::Resolved(None, _)) = &qself.kind {
+                    self.print_type(qself);
+                } else {
+                    self.s.word("<");
+                    self.print_type(qself);
+                    self.s.word(">");
+                }
+
                 self.s.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -1523,9 +1523,7 @@ impl<'a> State<'a> {
                                         colons_before_params)
             }
             hir::QPath::TypeRelative(ref qself, ref item_segment) => {
-                self.s.word("<");
                 self.print_type(qself);
-                self.s.word(">");
                 self.s.word("::");
                 self.print_ident(item_segment.ident);
                 self.print_generic_args(item_segment.generic_args(),

--- a/src/librustc/ich/impls_syntax.rs
+++ b/src/librustc/ich/impls_syntax.rs
@@ -80,6 +80,7 @@ impl_stable_hash_for!(enum ::rustc_target::spec::abi::Abi {
     Msp430Interrupt,
     X86Interrupt,
     AmdGpuKernel,
+    EfiApi,
     Rust,
     C,
     System,

--- a/src/librustc/lint/builtin.rs
+++ b/src/librustc/lint/builtin.rs
@@ -69,6 +69,12 @@ declare_lint! {
 }
 
 declare_lint! {
+    pub UNUSED_ATTRIBUTES,
+    Warn,
+    "detects attributes that were not used by the compiler"
+}
+
+declare_lint! {
     pub UNREACHABLE_CODE,
     Warn,
     "detects unreachable code paths",

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -378,12 +378,12 @@ fn orphan_check_trait_ref<'tcx>(
         //      Let Ti be the first such type.
         //     - No uncovered type parameters P1..=Pn may appear in T0..Ti (excluding Ti)
         //
-        fn uncover_fundamental_ty<'a>(
-            tcx: TyCtxt<'_>,
-            ty: Ty<'a>,
+        fn uncover_fundamental_ty<'tcx>(
+            tcx: TyCtxt<'tcx>,
+            ty: Ty<'tcx>,
             in_crate: InCrate,
-        ) -> Vec<Ty<'a>> {
-            if fundamental_ty(ty) && !ty_is_local(tcx, ty, in_crate) {
+        ) -> Vec<Ty<'tcx>> {
+            if fundamental_ty(ty) && ty_is_non_local(tcx, ty, in_crate).is_some() {
                 ty.walk_shallow().flat_map(|ty| uncover_fundamental_ty(tcx, ty, in_crate)).collect()
             } else {
                 vec![ty]

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -237,7 +237,7 @@ pub fn trait_ref_is_local_or_fundamental<'tcx>(
 }
 
 pub enum OrphanCheckErr<'tcx> {
-    NonLocalInputType(Vec<(Ty<'tcx>, usize)>),
+    NonLocalInputType(Vec<(Ty<'tcx>, bool)>),
     UncoveredTy(Ty<'tcx>),
 }
 
@@ -355,7 +355,7 @@ pub fn orphan_check(
 /// Note that this function is never called for types that have both type
 /// parameters and inference variables.
 fn orphan_check_trait_ref<'tcx>(
-    tcx: TyCtxt<'_>,
+    tcx: TyCtxt<'tcx>,
     trait_ref: ty::TraitRef<'tcx>,
     in_crate: InCrate,
 ) -> Result<(), OrphanCheckErr<'tcx>> {
@@ -397,14 +397,19 @@ fn orphan_check_trait_ref<'tcx>(
             .enumerate()
         {
             debug!("orphan_check_trait_ref: check ty `{:?}`", input_ty);
-            if ty_is_local(tcx, input_ty, in_crate) {
+            let non_local_tys = ty_is_non_local(tcx, input_ty, in_crate);
+            if non_local_tys.is_none() {
                 debug!("orphan_check_trait_ref: ty_is_local `{:?}`", input_ty);
                 return Ok(());
             } else if let ty::Param(_) = input_ty.kind {
                 debug!("orphan_check_trait_ref: uncovered ty: `{:?}`", input_ty);
                 return Err(OrphanCheckErr::UncoveredTy(input_ty))
             }
-            non_local_spans.push((input_ty, i));
+            if let Some(non_local_tys) = non_local_tys {
+                for input_ty in non_local_tys {
+                    non_local_spans.push((input_ty, i == 0));
+                }
+            }
         }
         // If we exit above loop, never found a local type.
         debug!("orphan_check_trait_ref: no local type");
@@ -416,7 +421,8 @@ fn orphan_check_trait_ref<'tcx>(
         // first.  Find the first input type that either references a
         // type parameter OR some local type.
         for (i, input_ty) in trait_ref.input_types().enumerate() {
-            if ty_is_local(tcx, input_ty, in_crate) {
+            let non_local_tys = ty_is_non_local(tcx, input_ty, in_crate);
+            if non_local_tys.is_none() {
                 debug!("orphan_check_trait_ref: ty_is_local `{:?}`", input_ty);
 
                 // First local input type. Check that there are no
@@ -444,7 +450,11 @@ fn orphan_check_trait_ref<'tcx>(
                 return Err(OrphanCheckErr::UncoveredTy(param));
             }
 
-            non_local_spans.push((input_ty, i));
+            if let Some(non_local_tys) = non_local_tys {
+                for input_ty in non_local_tys {
+                    non_local_spans.push((input_ty, i == 0));
+                }
+            }
         }
         // If we exit above loop, never found a local type.
         debug!("orphan_check_trait_ref: no local type");
@@ -452,8 +462,8 @@ fn orphan_check_trait_ref<'tcx>(
     }
 }
 
-fn uncovered_tys<'tcx>(tcx: TyCtxt<'_>, ty: Ty<'tcx>, in_crate: InCrate) -> Vec<Ty<'tcx>> {
-    if ty_is_local_constructor(tcx, ty, in_crate) {
+fn uncovered_tys<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, in_crate: InCrate) -> Vec<Ty<'tcx>> {
+    if ty_is_non_local_constructor(tcx, ty, in_crate).is_none() {
         vec![]
     } else if fundamental_ty(ty) {
         ty.walk_shallow()
@@ -471,9 +481,23 @@ fn is_possibly_remote_type(ty: Ty<'_>, _in_crate: InCrate) -> bool {
     }
 }
 
-fn ty_is_local(tcx: TyCtxt<'_>, ty: Ty<'_>, in_crate: InCrate) -> bool {
-    ty_is_local_constructor(tcx, ty, in_crate) ||
-        fundamental_ty(ty) && ty.walk_shallow().any(|t| ty_is_local(tcx, t, in_crate))
+fn ty_is_non_local<'t>(tcx: TyCtxt<'t>, ty: Ty<'t>, in_crate: InCrate) -> Option<Vec<Ty<'t>>> {
+    match ty_is_non_local_constructor(tcx, ty, in_crate) {
+        Some(ty) => if !fundamental_ty(ty) {
+            Some(vec![ty])
+        } else {
+            let tys: Vec<_> = ty.walk_shallow()
+                .filter_map(|t| ty_is_non_local(tcx, t, in_crate))
+                .flat_map(|i| i)
+                .collect();
+            if tys.is_empty() {
+                None
+            } else {
+                Some(tys)
+            }
+        },
+        None => None,
+    }
 }
 
 fn fundamental_ty(ty: Ty<'_>) -> bool {
@@ -493,8 +517,12 @@ fn def_id_is_local(def_id: DefId, in_crate: InCrate) -> bool {
     }
 }
 
-fn ty_is_local_constructor(tcx: TyCtxt<'_>, ty: Ty<'_>, in_crate: InCrate) -> bool {
-    debug!("ty_is_local_constructor({:?})", ty);
+fn ty_is_non_local_constructor<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    in_crate: InCrate,
+) -> Option<Ty<'tcx>> {
+    debug!("ty_is_non_local_constructor({:?})", ty);
 
     match ty.kind {
         ty::Bool |
@@ -513,18 +541,26 @@ fn ty_is_local_constructor(tcx: TyCtxt<'_>, ty: Ty<'_>, in_crate: InCrate) -> bo
         ty::Tuple(..) |
         ty::Param(..) |
         ty::Projection(..) => {
-            false
+            Some(ty)
         }
 
         ty::Placeholder(..) | ty::Bound(..) | ty::Infer(..) => match in_crate {
-            InCrate::Local => false,
+            InCrate::Local => Some(ty),
             // The inference variable might be unified with a local
             // type in that remote crate.
-            InCrate::Remote => true,
+            InCrate::Remote => None,
         },
 
-        ty::Adt(def, _) => def_id_is_local(def.did, in_crate),
-        ty::Foreign(did) => def_id_is_local(did, in_crate),
+        ty::Adt(def, _) => if def_id_is_local(def.did, in_crate) {
+            None
+        } else {
+            Some(ty)
+        },
+        ty::Foreign(did) => if def_id_is_local(did, in_crate) {
+            None
+        } else {
+            Some(ty)
+        },
         ty::Opaque(did, _) => {
             // Check the underlying type that this opaque
             // type resolves to.
@@ -532,18 +568,22 @@ fn ty_is_local_constructor(tcx: TyCtxt<'_>, ty: Ty<'_>, in_crate: InCrate) -> bo
             // since we've already managed to successfully
             // resolve all opaque types by this point
             let real_ty = tcx.type_of(did);
-            ty_is_local_constructor(tcx, real_ty, in_crate)
+            ty_is_non_local_constructor(tcx, real_ty, in_crate)
         }
 
         ty::Dynamic(ref tt, ..) => {
             if let Some(principal) = tt.principal() {
-                def_id_is_local(principal.def_id(), in_crate)
+                if def_id_is_local(principal.def_id(), in_crate) {
+                    None
+                } else {
+                    Some(ty)
+                }
             } else {
-                false
+                Some(ty)
             }
         }
 
-        ty::Error => true,
+        ty::Error => None,
 
         ty::UnnormalizedProjection(..) |
         ty::Closure(..) |

--- a/src/librustc/traits/coherence.rs
+++ b/src/librustc/traits/coherence.rs
@@ -237,7 +237,7 @@ pub fn trait_ref_is_local_or_fundamental<'tcx>(
 }
 
 pub enum OrphanCheckErr<'tcx> {
-    NonLocalInputType(Vec<(Ty<'tcx>, bool)>),
+    NonLocalInputType(Vec<(Ty<'tcx>, bool /* Is this the first input type? */)>),
     UncoveredTy(Ty<'tcx>),
 }
 

--- a/src/librustc/ty/layout.rs
+++ b/src/librustc/ty/layout.rs
@@ -2596,6 +2596,7 @@ where
 
             // It's the ABI's job to select this, not ours.
             System => bug!("system abi should be selected elsewhere"),
+            EfiApi => bug!("eficall abi should be selected elsewhere"),
 
             Stdcall => Conv::X86Stdcall,
             Fastcall => Conv::X86Fastcall,

--- a/src/librustc_apfloat/Cargo.toml
+++ b/src/librustc_apfloat/Cargo.toml
@@ -9,5 +9,5 @@ name = "rustc_apfloat"
 path = "lib.rs"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 smallvec = { version = "0.6.7", features = ["union", "may_dangle"] }

--- a/src/librustc_codegen_ssa/Cargo.toml
+++ b/src/librustc_codegen_ssa/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 test = false
 
 [dependencies]
-bitflags = "1.0.4"
+bitflags = "1.2.1"
 cc = "1.0.1"
 num_cpus = "1.0"
 memmap = "0.6"

--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def::{Res, DefKind};
 use rustc::hir::def_id::DefId;
 use rustc::lint;
+use rustc::lint::builtin::UNUSED_ATTRIBUTES;
 use rustc::ty::{self, Ty};
 use rustc::ty::adjustment;
 use rustc_data_structures::fx::FxHashMap;
@@ -275,12 +276,6 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for PathStatements {
             }
         }
     }
-}
-
-declare_lint! {
-    pub UNUSED_ATTRIBUTES,
-    Warn,
-    "detects attributes that were not used by the compiler"
 }
 
 #[derive(Copy, Clone)]

--- a/src/librustc_resolve/Cargo.toml
+++ b/src/librustc_resolve/Cargo.toml
@@ -11,7 +11,7 @@ test = false
 doctest = false
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 log = "0.4"
 syntax = { path = "../libsyntax" }
 syntax_expand = { path = "../libsyntax_expand" }

--- a/src/librustc_target/Cargo.toml
+++ b/src/librustc_target/Cargo.toml
@@ -9,7 +9,7 @@ name = "rustc_target"
 path = "lib.rs"
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 log = "0.4"
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_serialize = { path = "../libserialize", package = "serialize" }

--- a/src/librustc_target/spec/abi.rs
+++ b/src/librustc_target/spec/abi.rs
@@ -21,6 +21,7 @@ pub enum Abi {
     Msp430Interrupt,
     X86Interrupt,
     AmdGpuKernel,
+    EfiApi,
 
     // Multiplatform / generic ABIs
     Rust,
@@ -58,6 +59,7 @@ const AbiDatas: &[AbiData] = &[
     AbiData {abi: Abi::Msp430Interrupt, name: "msp430-interrupt", generic: false },
     AbiData {abi: Abi::X86Interrupt, name: "x86-interrupt", generic: false },
     AbiData {abi: Abi::AmdGpuKernel, name: "amdgpu-kernel", generic: false },
+    AbiData {abi: Abi::EfiApi, name: "efiapi", generic: false },
 
     // Cross-platform ABIs
     AbiData {abi: Abi::Rust, name: "Rust", generic: true },

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -906,7 +906,7 @@ impl Target {
                 }
             },
             Abi::EfiApi => {
-                if self.arch != "x86_64" {
+                if self.arch == "x86_64" {
                     Abi::Win64
                 } else {
                     Abi::C

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -905,6 +905,13 @@ impl Target {
                     abi
                 }
             },
+            Abi::EfiApi => {
+                if self.arch != "x86_64" {
+                    Abi::Win64
+                } else {
+                    Abi::C
+                }
+            },
             abi => abi
         }
     }

--- a/src/librustc_typeck/check/demand.rs
+++ b/src/librustc_typeck/check/demand.rs
@@ -172,10 +172,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }).peekable();
 
             if compatible_variants.peek().is_some() {
-                let expr_text = print::to_string(print::NO_ANN, |s| s.print_expr(expr));
+                let expr_text = self.tcx.sess
+                    .source_map()
+                    .span_to_snippet(expr.span)
+                    .unwrap_or_else(|_| {
+                        print::to_string(print::NO_ANN, |s| s.print_expr(expr))
+                    });
                 let suggestions = compatible_variants
                     .map(|v| format!("{}({})", v, expr_text));
-                let msg = "try using a variant of the expected type";
+                let msg = "try using a variant of the expected enum";
                 err.span_suggestions(expr.span, msg, suggestions, Applicability::MaybeIncorrect);
             }
         }

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -172,18 +172,6 @@ pub fn check_trait_item(tcx: TyCtxt<'_>, def_id: DefId) {
         _ => None
     };
     check_associated_item(tcx, trait_item.hir_id, trait_item.span, method_sig);
-
-    // Prohibits applying `#[track_caller]` to trait decls
-    for attr in &trait_item.attrs {
-        if attr.check_name(sym::track_caller) {
-            struct_span_err!(
-                tcx.sess,
-                attr.span,
-                E0738,
-                "`#[track_caller]` is not supported in trait declarations."
-            ).emit();
-        }
-    }
 }
 
 pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {
@@ -194,29 +182,6 @@ pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: DefId) {
         hir::ImplItemKind::Method(ref sig, _) => Some(sig),
         _ => None
     };
-
-    // Prohibits applying `#[track_caller]` to trait impls
-    if method_sig.is_some() {
-        let track_caller_attr = impl_item.attrs.iter()
-            .find(|a| a.check_name(sym::track_caller));
-        if let Some(tc_attr) = track_caller_attr {
-            let parent_hir_id = tcx.hir().get_parent_item(hir_id);
-            let containing_item = tcx.hir().expect_item(parent_hir_id);
-            let containing_impl_is_for_trait = match &containing_item.kind {
-                hir::ItemKind::Impl(_, _, _, _, tr, _, _) => tr.is_some(),
-                _ => bug!("parent of an ImplItem must be an Impl"),
-            };
-
-            if containing_impl_is_for_trait {
-                struct_span_err!(
-                    tcx.sess,
-                    tc_attr.span,
-                    E0738,
-                    "`#[track_caller]` is not supported in traits yet."
-                ).emit();
-            }
-        }
-    }
 
     check_associated_item(tcx, impl_item.hir_id, impl_item.span, method_sig);
 }

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -54,8 +54,9 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                             "`{}` is not defined in the current crate{}",
                             ty,
                             match &ty.kind {
-                                ty::Slice(_) => " because slices are always considered foreign",
-                                ty::Array(..) => " because arrays are always considered foreign",
+                                ty::Slice(_) => " because slices are always foreign",
+                                ty::Array(..) => " because arrays are always foreign",
+                                ty::Tuple(..) => " because tuples are always foreign",
                                 _ => "",
                             },
                         );

--- a/src/librustc_typeck/coherence/orphan.rs
+++ b/src/librustc_typeck/coherence/orphan.rs
@@ -24,7 +24,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
     fn visit_item(&mut self, item: &hir::Item) {
         let def_id = self.tcx.hir().local_def_id(item.hir_id);
         // "Trait" impl
-        if let hir::ItemKind::Impl(.., generics, Some(_), impl_ty, _) = &item.kind {
+        if let hir::ItemKind::Impl(.., generics, Some(tr), impl_ty, _) = &item.kind {
             debug!("coherence2::orphan check: trait impl {}",
                    self.tcx.hir().node_to_string(item.hir_id));
             let trait_ref = self.tcx.impl_trait_ref(def_id).unwrap();
@@ -47,7 +47,7 @@ impl ItemLikeVisitor<'v> for OrphanChecker<'tcx> {
                         if *i == 0 {
                             err.span_label(impl_ty.span, &msg);
                         } else {
-                            err.note(&msg);
+                            err.span_label(tr.path.span, &msg);
                         }
                     }
                     err.note("define and implement a trait or new type instead");

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -2640,7 +2640,7 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
                     tcx.sess,
                     attr.span,
                     E0737,
-                    "rust ABI is required to use `#[track_caller]`"
+                    "Rust ABI is required to use `#[track_caller]`"
                 ).emit();
             }
             codegen_fn_attrs.flags |= CodegenFnAttrFlags::TRACK_CALLER;

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -4938,7 +4938,7 @@ and the pin is required to keep it in the same place in memory.
 "##,
 
 E0737: r##"
-#[track_caller] requires functions to have the "Rust" ABI for implicitly
+`#[track_caller]` requires functions to have the `"Rust"` ABI for implicitly
 receiving caller location. See [RFC 2091] for details on this and other
 restrictions.
 
@@ -4950,57 +4950,6 @@ Erroneous code example:
 #[track_caller]
 extern "C" fn foo() {}
 ```
-
-[RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
-"##,
-
-E0738: r##"
-#[track_caller] cannot be used in traits yet.  This is due to limitations in the
-compiler which are likely to be temporary. See [RFC 2091] for details on this
-and other restrictions.
-
-Erroneous example with a trait method implementation:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    fn bar(&self);
-}
-
-impl Foo for u64 {
-    #[track_caller]
-    fn bar(&self) {}
-}
-```
-
-Erroneous example with a blanket trait method implementation:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    #[track_caller]
-    fn bar(&self) {}
-    fn baz(&self);
-}
-```
-
-Erroneous example with a trait method declaration:
-
-```compile_fail,E0738
-#![feature(track_caller)]
-
-trait Foo {
-    fn bar(&self) {}
-
-    #[track_caller]
-    fn baz(&self);
-}
-```
-
-Note that while the compiler may be able to support the attribute in traits in
-the future, [RFC 2091] prohibits their implementation without a follow-up RFC.
 
 [RFC 2091]: https://github.com/rust-lang/rfcs/blob/master/text/2091-inline-semantic.md
 "##,

--- a/src/libsyntax/Cargo.toml
+++ b/src/libsyntax/Cargo.toml
@@ -10,7 +10,7 @@ path = "lib.rs"
 doctest = false
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "1.2.1"
 rustc_serialize = { path = "../libserialize", package = "serialize" }
 log = "0.4"
 scoped-tls = "1.0"

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -531,6 +531,9 @@ declare_features! (
     /// Non-object safe trait objects safe to use but cannot be created in safe rust
     (active, object_safe_for_dispatch, "1.40.0", Some(43561), None),
 
+    /// Allows using the `efiapi` ABI.
+    (active, abi_efiapi, "1.40.0", Some(1), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -532,7 +532,7 @@ declare_features! (
     (active, object_safe_for_dispatch, "1.40.0", Some(43561), None),
 
     /// Allows using the `efiapi` ABI.
-    (active, abi_efiapi, "1.40.0", Some(1), None),
+    (active, abi_efiapi, "1.40.0", Some(65815), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -234,6 +234,10 @@ impl<'a> PostExpansionVisitor<'a> {
                 gate_feature_post!(&self, abi_amdgpu_kernel, span,
                                    "amdgpu-kernel ABI is experimental and subject to change");
             },
+            Abi::EfiApi => {
+                gate_feature_post!(&self, abi_efiapi, span,
+                                   "efiapi ABI is experimental and subject to change");
+            },
             // Stable
             Abi::Cdecl |
             Abi::Stdcall |

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -110,6 +110,7 @@ symbols! {
         aarch64_target_feature,
         abi,
         abi_amdgpu_kernel,
+        abi_efiapi,
         abi_msp430_interrupt,
         abi_ptx,
         abi_sysv64,

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -1,20 +1,29 @@
 // Checks if the correct annotation for the efiapi ABI is passed to llvm.
 
+// revisions:x86_64 i686 aarch64 arm riscv
+
+//[x86_64] compile-flags: --target x86_64-unknown-uefi
+//[i686] compile-flags: --target i686-unknown-linux-musl
+//[aarch64] compile-flags: --target aarch64-unknown-none
+//[arm] compile-flags: --target armv7r-none-eabi
+//[riscv] compile-flags: --target riscv64gc-unknown-none-elf
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
-#![feature(abi_efiapi)]
+#![feature(no_core, lang_items, abi_efiapi)]
+#![no_core]
 
-// CHECK: define win64 i64 @has_efiapi
-#[no_mangle]
-#[cfg(target_arch = "x86_64")]
-pub extern "efiapi" fn has_efiapi(a: i64) -> i64 {
-    a * 2
-}
+#[lang="sized"]
+trait Sized { }
+#[lang="freeze"]
+trait Freeze { }
+#[lang="copy"]
+trait Copy { }
 
-// CHECK: define c i64 @has_efiapi
+//x86_64: define win64cc void @has_efiapi
+//i686: define void @has_efiapi
+//aarch64: define void @has_efiapi
+//arm: define void @has_efiapi
+//riscv: define void @has_efiapi
 #[no_mangle]
-#[cfg(not(target_arch = "x86_64"))]
-pub extern "efiapi" fn has_efiapi(a: i64) -> i64 {
-    a * 2
-}
+pub extern "efiapi" fn has_efiapi() {}

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -2,6 +2,8 @@
 
 // revisions:x86_64 i686 aarch64 arm riscv
 
+// min-llvm-version 9.0
+
 //[x86_64] compile-flags: --target x86_64-unknown-uefi
 //[i686] compile-flags: --target i686-unknown-linux-musl
 //[aarch64] compile-flags: --target aarch64-unknown-none

--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -1,0 +1,20 @@
+// Checks if the correct annotation for the efiapi ABI is passed to llvm.
+
+// compile-flags: -C no-prepopulate-passes
+
+#![crate_type = "lib"]
+#![feature(abi_efiapi)]
+
+// CHECK: define win64 i64 @has_efiapi
+#[no_mangle]
+#[cfg(target_arch = "x86_64")]
+pub extern "efiapi" fn has_efiapi(a: i64) -> i64 {
+    a * 2
+}
+
+// CHECK: define c i64 @has_efiapi
+#[no_mangle]
+#[cfg(not(target_arch = "x86_64"))]
+pub extern "efiapi" fn has_efiapi(a: i64) -> i64 {
+    a * 2
+}

--- a/src/test/pretty/issue-4264.pp
+++ b/src/test/pretty/issue-4264.pp
@@ -30,7 +30,7 @@ pub fn bar() ({
 
 
                   ((::alloc::fmt::format as
-                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((<::core::fmt::Arguments>::new_v1
+                       for<'r> fn(std::fmt::Arguments<'r>) -> std::string::String {std::fmt::format})(((::core::fmt::Arguments::new_v1
                                                                                                            as
                                                                                                            fn(&[&str], &[std::fmt::ArgumentV1<'_>]) -> std::fmt::Arguments<'_> {std::fmt::Arguments::<'_>::new_v1})((&([("test"
                                                                                                                                                                                                                             as

--- a/src/test/ui/codemap_tests/unicode.stderr
+++ b/src/test/ui/codemap_tests/unicode.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `路濫狼á́́`
 LL | extern "路濫狼á́́" fn foo() {}
    |        ^^^^^^^^^ invalid ABI
    |
-   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
+   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, efiapi, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/coherence-all-remote.old.stderr
+++ b/src/test/ui/coherence/coherence-all-remote.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-all-remote.rs:9:1
+  --> $DIR/coherence-all-remote.rs:9:6
    |
 LL | impl<T> Remote1<T> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-all-remote.re.stderr
+++ b/src/test/ui/coherence/coherence-all-remote.re.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-all-remote.rs:9:1
+  --> $DIR/coherence-all-remote.rs:9:6
    |
 LL | impl<T> Remote1<T> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-bigint-param.old.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-bigint-param.rs:11:1
+  --> $DIR/coherence-bigint-param.rs:11:6
    |
 LL | impl<T> Remote1<BigInt> for T { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-bigint-param.re.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.re.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-bigint-param.rs:11:1
+  --> $DIR/coherence-bigint-param.rs:11:6
    |
 LL | impl<T> Remote1<BigInt> for T { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-cow.a.stderr
+++ b/src/test/ui/coherence/coherence-cow.a.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-cow.rs:18:1
+  --> $DIR/coherence-cow.rs:18:6
    |
 LL | impl<T> Remote for Pair<T,Cover<T>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-cow.b.stderr
+++ b/src/test/ui/coherence/coherence-cow.b.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-cow.rs:23:1
+  --> $DIR/coherence-cow.rs:23:6
    |
 LL | impl<T> Remote for Pair<Cover<T>,T> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-cow.c.stderr
+++ b/src/test/ui/coherence/coherence-cow.c.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-cow.rs:28:1
+  --> $DIR/coherence-cow.rs:28:6
    |
 LL | impl<T,U> Remote for Pair<Cover<T>,U> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-cow.re_a.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_a.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<T,Cover<T>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Pair<T, Cover<T>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_a.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_a.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<T,Cover<T>> { }
    | ^^^^^^^^^^^^^^^^^^^----------------
    | |                  |
-   | |                  `lib::Pair<T, Cover<T>>` is not defined in the current crate
+   | |                  `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-cow.re_a.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_a.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-cow.rs:18:1
    |
 LL | impl<T> Remote for Pair<T,Cover<T>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^----------------
+   | |                  |
+   | |                  `lib::Pair<T, Cover<T>>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<T, Cover<T>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_b.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_b.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-cow.rs:23:1
    |
 LL | impl<T> Remote for Pair<Cover<T>,T> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^----------------
+   | |                  |
+   | |                  `lib::Pair<Cover<T>, T>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<Cover<T>, T>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_b.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_b.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<Cover<T>,T> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Pair<Cover<T>, T>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_b.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_b.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Pair<Cover<T>,T> { }
    | ^^^^^^^^^^^^^^^^^^^----------------
    | |                  |
-   | |                  `lib::Pair<Cover<T>, T>` is not defined in the current crate
+   | |                  `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-cow.re_c.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_c.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<Cover<T>,U> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Pair<Cover<T>, U>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cow.re_c.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_c.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<Cover<T>,U> { }
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `lib::Pair<Cover<T>, U>` is not defined in the current crate
+   | |                    `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-cow.re_c.stderr
+++ b/src/test/ui/coherence/coherence-cow.re_c.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-cow.rs:28:1
    |
 LL | impl<T,U> Remote for Pair<Cover<T>,U> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^----------------
+   | |                    |
+   | |                    `lib::Pair<Cover<T>, U>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<Cover<T>, U>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-cross-crate-conflict.old.stderr
+++ b/src/test/ui/coherence/coherence-cross-crate-conflict.old.stderr
@@ -8,10 +8,10 @@ LL | impl<A> Foo for A {
            - impl trait_impl_conflict::Foo for isize;
 
 error[E0210]: type parameter `A` must be used as the type parameter for some local type (e.g., `MyStruct<A>`)
-  --> $DIR/coherence-cross-crate-conflict.rs:12:1
+  --> $DIR/coherence-cross-crate-conflict.rs:12:6
    |
 LL | impl<A> Foo for A {
-   | ^^^^^^^^^^^^^^^^^ type parameter `A` must be used as the type parameter for some local type
+   |      ^ type parameter `A` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-cross-crate-conflict.re.stderr
+++ b/src/test/ui/coherence/coherence-cross-crate-conflict.re.stderr
@@ -8,10 +8,10 @@ LL | impl<A> Foo for A {
            - impl trait_impl_conflict::Foo for isize;
 
 error[E0210]: type parameter `A` must be used as the type parameter for some local type (e.g., `MyStruct<A>`)
-  --> $DIR/coherence-cross-crate-conflict.rs:12:1
+  --> $DIR/coherence-cross-crate-conflict.rs:12:6
    |
 LL | impl<A> Foo for A {
-   | ^^^^^^^^^^^^^^^^^ type parameter `A` must be used as the type parameter for some local type
+   |      ^ type parameter `A` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-fundamental-trait-objects.rs:15:1
    |
 LL | impl Misc for dyn Fundamental<Local> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^----------------------
+   | |             |
+   | |             `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^----------------------
    | |             |
-   | |             `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current crate
+   | |             `dyn coherence_fundamental_trait_lib::Fundamental<Local>` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-fundamental-trait-objects.rs:15:1
    |
 LL | impl Misc for dyn Fundamental<Local> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^----------------------
+   | |             |
+   | |             `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
+++ b/src/test/ui/coherence/coherence-fundamental-trait-objects.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Misc for dyn Fundamental<Local> {}
    | ^^^^^^^^^^^^^^----------------------
    | |             |
-   | |             `(dyn coherence_fundamental_trait_lib::Fundamental<Local> + 'static)` is not defined in the current crate
+   | |             `dyn coherence_fundamental_trait_lib::Fundamental<Local>` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for dyn Marker2 {}
    | ^^^^^^^^^^^^^^^-----------
    | |              |
-   | |              `(dyn Marker2 + 'static)` is not defined in the current crate
+   | |              `dyn Marker2` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for dyn Marker2 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(dyn Marker2 + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-negative.stderr
@@ -14,9 +14,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impl-trait-for-marker-trait-negative.rs:22:1
    |
 LL | impl !Send for dyn Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^-----------
+   | |              |
+   | |              `(dyn Marker2 + 'static)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(dyn Marker2 + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for dyn Marker2 {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(dyn Marker2 + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for dyn Marker2 {}
    | ^^^^^^^^^^^^^^^^^^^^^-----------
    | |                    |
-   | |                    `(dyn Marker2 + 'static)` is not defined in the current crate
+   | |                    `dyn Marker2` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
+++ b/src/test/ui/coherence/coherence-impl-trait-for-marker-trait-positive.stderr
@@ -14,9 +14,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impl-trait-for-marker-trait-positive.rs:22:1
    |
 LL | unsafe impl Send for dyn Marker2 {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^-----------
+   | |                    |
+   | |                    `(dyn Marker2 + 'static)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(dyn Marker2 + 'static)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `(dyn Object + 'static)`

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate
+   | |             `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `&'static [NotSync]` is not defined in the current crate
+   | |             `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -49,36 +49,44 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-copy.rs:8:1
    |
 LL | impl Copy for i32 {}
-   | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^---
+   | |             |
+   | |             `i32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `i32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:32:1
    |
 LL | impl Copy for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^----------------
+   | |             |
+   | |             `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:40:1
    |
 LL | impl Copy for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^--------
+   | |             |
+   | |             `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:45:1
    |
 LL | impl Copy for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^------------------
+   | |             |
+   | |             `&'static [NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for i32 {}
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `i32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -60,7 +60,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -69,7 +69,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -78,7 +78,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^----------------
    | |             |
-   | |             `(MyType, MyType)` is not defined in the current crate
+   | |             `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |             `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |             `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-copy.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.old.stderr
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^----------------
    | |             |
-   | |             `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |             this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate because slices are always foreign
+   | |             this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |             this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate
+   | |             `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `[NotSync]` is not defined in the current crate
+   | |             `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for i32 {}
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `i32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -60,7 +60,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -69,7 +69,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -78,7 +78,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^----------------
    | |             |
-   | |             `(MyType, MyType)` is not defined in the current crate
+   | |             `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |             `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |             `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -49,36 +49,44 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-copy.rs:8:1
    |
 LL | impl Copy for i32 {}
-   | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^---
+   | |             |
+   | |             `i32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `i32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:32:1
    |
 LL | impl Copy for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^----------------
+   | |             |
+   | |             `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:40:1
    |
 LL | impl Copy for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^--------
+   | |             |
+   | |             `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-copy.rs:45:1
    |
 LL | impl Copy for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^------------------
+   | |             |
+   | |             `[NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 10 previous errors

--- a/src/test/ui/coherence/coherence-impls-copy.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-copy.re.stderr
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^----------------
    | |             |
-   | |             `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |             this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -73,7 +73,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for [MyType] {}
    | ^^^^^^^^^^^^^^--------
    | |             |
-   | |             `[MyType]` is not defined in the current crate because slices are always foreign
+   | |             this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -84,7 +84,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^------------------
    | |             |
-   | |             `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |             this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate
+   | |                    `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `&'static [NotSync]` is not defined in the current crate
+   | |                    `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-send.rs:20:1
    |
 LL | unsafe impl Send for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^----------------
+   | |                    |
+   | |                    `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -17,18 +19,22 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-send.rs:28:1
    |
 LL | unsafe impl Send for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^--------
+   | |                    |
+   | |                    `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-send.rs:32:1
    |
 LL | unsafe impl Send for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^------------------
+   | |                    |
+   | |                    `&'static [NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |                    this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate because slices are always foreign
+   | |                    this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |                    this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `(MyType, MyType)` is not defined in the current crate
+   | |                    `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |                    `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |                    `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -19,7 +19,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -19,7 +19,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-send.rs:20:1
    |
 LL | unsafe impl Send for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^----------------
+   | |                    |
+   | |                    `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `std::marker::Send`, can only be implemented for a struct/enum type, not `&'static NotSync`
@@ -17,18 +19,22 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-send.rs:28:1
    |
 LL | unsafe impl Send for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^--------
+   | |                    |
+   | |                    `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-send.rs:32:1
    |
 LL | unsafe impl Send for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^------------------
+   | |                    |
+   | |                    `[NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate
+   | |                    `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `[NotSync]` is not defined in the current crate
+   | |                    `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |                    this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate because slices are always foreign
+   | |                    this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |                    this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-send.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-send.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `(MyType, MyType)` is not defined in the current crate
+   | |                    `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -21,7 +21,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^--------
    | |                    |
-   | |                    `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |                    `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | unsafe impl Send for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^------------------
    | |                    |
-   | |                    `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |                    `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -38,27 +38,33 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-sized.rs:27:1
    |
 LL | impl Sized for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^----------------
+   | |              |
+   | |              `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-sized.rs:39:1
    |
 LL | impl Sized for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^--------
+   | |              |
+   | |              `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-sized.rs:46:1
    |
 LL | impl Sized for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^------------------
+   | |              |
+   | |              `&'static [NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^----------------
    | |              |
-   | |              `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |              this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate because slices are always foreign
+   | |              this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |              this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate
+   | |              `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `&'static [NotSync]` is not defined in the current crate
+   | |              `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -49,7 +49,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -58,7 +58,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `&'static [NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.old.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.old.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^----------------
    | |              |
-   | |              `(MyType, MyType)` is not defined in the current crate
+   | |              `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |              `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |              `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -38,27 +38,33 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-impls-sized.rs:27:1
    |
 LL | impl Sized for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^----------------
+   | |              |
+   | |              `(MyType, MyType)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-sized.rs:39:1
    |
 LL | impl Sized for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^--------
+   | |              |
+   | |              `[MyType]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-impls-sized.rs:46:1
    |
 LL | impl Sized for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^------------------
+   | |              |
+   | |              `[NotSync]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^----------------
    | |              |
-   | |              `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
+   | |              this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate because slices are always foreign
+   | |              this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `[NotSync]` is not defined in the current crate because slices are always foreign
+   | |              this is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType, MyType)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -49,7 +49,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[MyType]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -58,7 +58,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[NotSync]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 9 previous errors

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate
+   | |              `[MyType]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `[NotSync]` is not defined in the current crate
+   | |              `[NotSync]` is not defined in the current crate because slices are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-impls-sized.re.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.re.stderr
@@ -40,7 +40,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for (MyType, MyType) {}
    | ^^^^^^^^^^^^^^^----------------
    | |              |
-   | |              `(MyType, MyType)` is not defined in the current crate
+   | |              `(MyType, MyType)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -51,7 +51,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for [MyType] {}
    | ^^^^^^^^^^^^^^^--------
    | |              |
-   | |              `[MyType]` is not defined in the current crate because slices are always considered foreign
+   | |              `[MyType]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -62,7 +62,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Sized for &'static [NotSync] {}
    | ^^^^^^^^^^^^^^^------------------
    | |              |
-   | |              `[NotSync]` is not defined in the current crate because slices are always considered foreign
+   | |              `[NotSync]` is not defined in the current crate because slices are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-lone-type-parameter.old.stderr
+++ b/src/test/ui/coherence/coherence-lone-type-parameter.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-lone-type-parameter.rs:9:1
+  --> $DIR/coherence-lone-type-parameter.rs:9:6
    |
 LL | impl<T> Remote for T { }
-   | ^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-lone-type-parameter.re.stderr
+++ b/src/test/ui/coherence/coherence-lone-type-parameter.re.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-lone-type-parameter.rs:9:1
+  --> $DIR/coherence-lone-type-parameter.rs:9:6
    |
 LL | impl<T> Remote for T { }
-   | ^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-orphan.old.stderr
+++ b/src/test/ui/coherence/coherence-orphan.old.stderr
@@ -2,19 +2,23 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-orphan.rs:13:1
    |
 LL | impl TheTrait<usize> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----
+   | |                        |
+   | |                        `isize` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `isize` is not defined in the current create
-   = note: `usize` is not defined in the current create
+   = note: `usize` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-orphan.rs:21:1
    |
 LL | impl !Send for Vec<isize> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^----------
+   | |              |
+   | |              `std::vec::Vec<isize>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `std::vec::Vec<isize>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-orphan.old.stderr
+++ b/src/test/ui/coherence/coherence-orphan.old.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^----------
    | |              |
-   | |              `std::vec::Vec<isize>` is not defined in the current crate
+   | |              `std::vec::Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-orphan.old.stderr
+++ b/src/test/ui/coherence/coherence-orphan.old.stderr
@@ -4,7 +4,8 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl TheTrait<usize> for isize { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `isize` is not defined in the current create
+   = note: `usize` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +14,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `std::vec::Vec<isize>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-orphan.old.stderr
+++ b/src/test/ui/coherence/coherence-orphan.old.stderr
@@ -2,12 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-orphan.rs:13:1
    |
 LL | impl TheTrait<usize> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----
-   | |                        |
-   | |                        `isize` is not defined in the current crate
+   | ^^^^^---------------^^^^^-----
+   | |    |                   |
+   | |    |                   `isize` is not defined in the current crate
+   | |    `usize` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
-   = note: `usize` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types

--- a/src/test/ui/coherence/coherence-orphan.re.stderr
+++ b/src/test/ui/coherence/coherence-orphan.re.stderr
@@ -2,19 +2,23 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-orphan.rs:13:1
    |
 LL | impl TheTrait<usize> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----
+   | |                        |
+   | |                        `isize` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `isize` is not defined in the current create
-   = note: `usize` is not defined in the current create
+   = note: `usize` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/coherence-orphan.rs:21:1
    |
 LL | impl !Send for Vec<isize> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^----------
+   | |              |
+   | |              `std::vec::Vec<isize>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `std::vec::Vec<isize>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-orphan.re.stderr
+++ b/src/test/ui/coherence/coherence-orphan.re.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^----------
    | |              |
-   | |              `std::vec::Vec<isize>` is not defined in the current crate
+   | |              `std::vec::Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-orphan.re.stderr
+++ b/src/test/ui/coherence/coherence-orphan.re.stderr
@@ -4,7 +4,8 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl TheTrait<usize> for isize { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `isize` is not defined in the current create
+   = note: `usize` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +14,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !Send for Vec<isize> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `std::vec::Vec<isize>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-orphan.re.stderr
+++ b/src/test/ui/coherence/coherence-orphan.re.stderr
@@ -2,12 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-orphan.rs:13:1
    |
 LL | impl TheTrait<usize> for isize { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^-----
-   | |                        |
-   | |                        `isize` is not defined in the current crate
+   | ^^^^^---------------^^^^^-----
+   | |    |                   |
+   | |    |                   `isize` is not defined in the current crate
+   | |    `usize` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
-   = note: `usize` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types

--- a/src/test/ui/coherence/coherence-overlapping-pairs.old.stderr
+++ b/src/test/ui/coherence/coherence-overlapping-pairs.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-overlapping-pairs.rs:11:1
+  --> $DIR/coherence-overlapping-pairs.rs:11:6
    |
 LL | impl<T> Remote for lib::Pair<T,Foo> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
+++ b/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for lib::Pair<T,Foo> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Pair<T, Foo>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
+++ b/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for lib::Pair<T,Foo> { }
    | ^^^^^^^^^^^^^^^^^^^----------------
    | |                  |
-   | |                  `lib::Pair<T, Foo>` is not defined in the current crate
+   | |                  `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
+++ b/src/test/ui/coherence/coherence-overlapping-pairs.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-overlapping-pairs.rs:11:1
    |
 LL | impl<T> Remote for lib::Pair<T,Foo> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^----------------
+   | |                  |
+   | |                  `lib::Pair<T, Foo>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<T, Foo>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.old.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-pair-covered-uncovered-1.rs:15:1
+  --> $DIR/coherence-pair-covered-uncovered-1.rs:15:6
    |
 LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
@@ -5,7 +5,7 @@ LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
    | ^^^^^^^^^^^--------------------------^^^^^---
    | |          |                              |
    | |          |                              `i32` is not defined in the current crate
-   | |          `lib::Pair<T, Local<U>>` is not defined in the current crate
+   | |          `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
@@ -2,12 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-pair-covered-uncovered-1.rs:15:1
    |
 LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   | |                                         |
-   | |                                         `i32` is not defined in the current crate
+   | ^^^^^^^^^^^--------------------------^^^^^---
+   | |          |                              |
+   | |          |                              `i32` is not defined in the current crate
+   | |          `lib::Pair<T, Local<U>>` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<T, Local<U>>` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
@@ -4,7 +4,8 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `i32` is not defined in the current create
+   = note: `lib::Pair<T, Local<U>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered-1.re.stderr
@@ -2,10 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-pair-covered-uncovered-1.rs:15:1
    |
 LL | impl<T, U> Remote1<Pair<T, Local<U>>> for i32 { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
+   | |                                         |
+   | |                                         `i32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `i32` is not defined in the current create
-   = note: `lib::Pair<T, Local<U>>` is not defined in the current create
+   = note: `lib::Pair<T, Local<U>>` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered.old.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-pair-covered-uncovered.rs:11:1
+  --> $DIR/coherence-pair-covered-uncovered.rs:11:6
    |
 LL | impl<T,U> Remote for Pair<T,Local<U>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<T,Local<U>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Pair<T, Local<U>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T,U> Remote for Pair<T,Local<U>> { }
    | ^^^^^^^^^^^^^^^^^^^^^----------------
    | |                    |
-   | |                    `lib::Pair<T, Local<U>>` is not defined in the current crate
+   | |                    `lib::Pair` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
+++ b/src/test/ui/coherence/coherence-pair-covered-uncovered.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-pair-covered-uncovered.rs:11:1
    |
 LL | impl<T,U> Remote for Pair<T,Local<U>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^----------------
+   | |                    |
+   | |                    `lib::Pair<T, Local<U>>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Pair<T, Local<U>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local-2.old.stderr
+++ b/src/test/ui/coherence/coherence-vec-local-2.old.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/coherence-vec-local-2.rs:14:1
+  --> $DIR/coherence-vec-local-2.rs:14:6
    |
 LL | impl<T> Remote for Vec<Local<T>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/coherence-vec-local-2.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local-2.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-vec-local-2.rs:14:1
    |
 LL | impl<T> Remote for Vec<Local<T>> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^-------------
+   | |                  |
+   | |                  `std::vec::Vec<Local<T>>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `std::vec::Vec<Local<T>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local-2.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local-2.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Vec<Local<T>> { }
    | ^^^^^^^^^^^^^^^^^^^-------------
    | |                  |
-   | |                  `std::vec::Vec<Local<T>>` is not defined in the current crate
+   | |                  `std::vec::Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-vec-local-2.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local-2.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<T> Remote for Vec<Local<T>> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `std::vec::Vec<Local<T>>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.old.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.old.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-vec-local.rs:14:1
    |
 LL | impl Remote for Vec<Local> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^----------
+   | |               |
+   | |               `std::vec::Vec<Local>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `std::vec::Vec<Local>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.old.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^----------
    | |               |
-   | |               `std::vec::Vec<Local>` is not defined in the current crate
+   | |               `std::vec::Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-vec-local.old.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `std::vec::Vec<Local>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence-vec-local.rs:14:1
    |
 LL | impl Remote for Vec<Local> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^----------
+   | |               |
+   | |               `std::vec::Vec<Local>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `std::vec::Vec<Local>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-vec-local.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^----------
    | |               |
-   | |               `std::vec::Vec<Local>` is not defined in the current crate
+   | |               `std::vec::Vec` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence-vec-local.re.stderr
+++ b/src/test/ui/coherence/coherence-vec-local.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote for Vec<Local> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `std::vec::Vec<Local>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^---------------------
    | |                    |
-   | |                    `lib::MyStruct<MyType>` is not defined in the current crate
+   | |                    `lib::MyStruct` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence_local_err_struct.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.old.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence_local_err_struct.rs:17:1
    |
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^---------------------
+   | |                    |
+   | |                    `lib::MyStruct<MyType>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::MyStruct<MyType>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::MyStruct<MyType>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^---------------------
    | |                    |
-   | |                    `lib::MyStruct<MyType>` is not defined in the current crate
+   | |                    `lib::MyStruct` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence_local_err_struct.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence_local_err_struct.rs:17:1
    |
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^---------------------
+   | |                    |
+   | |                    `lib::MyStruct<MyType>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::MyStruct<MyType>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_struct.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_struct.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for lib::MyStruct<MyType> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::MyStruct<MyType>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence_local_err_tuple.rs:17:1
    |
 LL | impl lib::MyCopy for (MyType,) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^---------
+   | |                    |
+   | |                    `(MyType,)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^---------
    | |                    |
-   | |                    `(MyType,)` is not defined in the current crate because tuples are always foreign
+   | |                    this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.old.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^---------
    | |                    |
-   | |                    `(MyType,)` is not defined in the current crate
+   | |                    `(MyType,)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/coherence_local_err_tuple.rs:17:1
    |
 LL | impl lib::MyCopy for (MyType,) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^---------
+   | |                    |
+   | |                    `(MyType,)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(MyType,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^---------
    | |                    |
-   | |                    `(MyType,)` is not defined in the current crate because tuples are always foreign
+   | |                    this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(MyType,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
+++ b/src/test/ui/coherence/coherence_local_err_tuple.re.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl lib::MyCopy for (MyType,) { }
    | ^^^^^^^^^^^^^^^^^^^^^---------
    | |                    |
-   | |                    `(MyType,)` is not defined in the current crate
+   | |                    `(MyType,)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/coherence/impl-foreign-for-foreign.stderr
+++ b/src/test/ui/coherence/impl-foreign-for-foreign.stderr
@@ -2,9 +2,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign-for-foreign.rs:12:1
    |
 LL | impl Remote for i32 {
-   | ^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^---
+   | |               |
+   | |               `i32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl-foreign-for-foreign[foreign].stderr
+++ b/src/test/ui/coherence/impl-foreign-for-foreign[foreign].stderr
@@ -2,27 +2,36 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign-for-foreign[foreign].rs:12:1
    |
 LL | impl Remote1<Rc<i32>> for i32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^----------------^^^^^---
+   | |    |                    |
+   | |    |                    `i32` is not defined in the current crate
+   | |    `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl-foreign-for-foreign[foreign].rs:16:1
    |
 LL | impl Remote1<Rc<Local>> for f64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^------------------^^^^^---
+   | |    |                      |
+   | |    |                      `f64` is not defined in the current crate
+   | |    `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl-foreign-for-foreign[foreign].rs:20:1
    |
 LL | impl<T> Remote1<Rc<T>> for f32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^--------------^^^^^---
+   | |       |                  |
+   | |       |                  `f32` is not defined in the current crate
+   | |       `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/coherence/impl-foreign-for-fundamental[foreign].stderr
+++ b/src/test/ui/coherence/impl-foreign-for-fundamental[foreign].stderr
@@ -2,18 +2,22 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign-for-fundamental[foreign].rs:12:1
    |
 LL | impl Remote for Box<i32> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^--------
+   | |               |
+   | |               `i32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl-foreign-for-fundamental[foreign].rs:16:1
    |
 LL | impl<T> Remote for Box<Rc<T>> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^----------
+   | |                  |
+   | |                  `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
@@ -4,7 +4,8 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Remote1<u32> for f64 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `f64` is not defined in the current create
+   = note: `u32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
@@ -2,10 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign[foreign]-for-foreign.rs:12:1
    |
 LL | impl Remote1<u32> for f64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^---
+   | |                     |
+   | |                     `f64` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `f64` is not defined in the current create
-   = note: `u32` is not defined in the current create
+   = note: `u32` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl-foreign[foreign]-for-foreign.stderr
@@ -2,12 +2,12 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign[foreign]-for-foreign.rs:12:1
    |
 LL | impl Remote1<u32> for f64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^---
-   | |                     |
-   | |                     `f64` is not defined in the current crate
+   | ^^^^^------------^^^^^---
+   | |    |                |
+   | |    |                `f64` is not defined in the current crate
+   | |    `u32` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
-   = note: `u32` is not defined in the current crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl-foreign[fundemental[foreign]]-for-foreign.stderr
@@ -2,27 +2,36 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl-foreign[fundemental[foreign]]-for-foreign.rs:13:1
    |
 LL | impl Remote1<Box<String>> for i32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^--------------------^^^^^---
+   | |    |                        |
+   | |    |                        `i32` is not defined in the current crate
+   | |    `std::string::String` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl-foreign[fundemental[foreign]]-for-foreign.rs:17:1
    |
 LL | impl Remote1<Box<Rc<i32>>> for f64 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^---------------------^^^^^---
+   | |    |                         |
+   | |    |                         `f64` is not defined in the current crate
+   | |    `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl-foreign[fundemental[foreign]]-for-foreign.rs:21:1
    |
 LL | impl<T> Remote1<Box<Rc<T>>> for f32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^-------------------^^^^^---
+   | |       |                       |
+   | |       |                       `f32` is not defined in the current crate
+   | |       `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign-for-foreign[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign-for-foreign[t].stderr
@@ -2,18 +2,22 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/impl[t]-foreign-for-foreign[t].rs:13:1
    |
 LL | impl Remote for Rc<Local> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^---------
+   | |               |
+   | |               `std::rc::Rc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/impl[t]-foreign-for-foreign[t].rs:18:1
    |
 LL | impl<T> Remote for Arc<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^------
+   | |                  |
+   | |                  `std::sync::Arc` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: the impl does not reference only types defined in this crate
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign-for-fundamental[t].rs:12:1
+  --> $DIR/impl[t]-foreign-for-fundamental[t].rs:12:6
    |
 LL | impl<T> Remote for Box<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:12:1
+  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:12:6
    |
 LL | impl<T> Remote1<u32> for Box<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:16:1
+  --> $DIR/impl[t]-foreign[foreign]-for-fundamental[t].rs:16:10
    |
 LL | impl<'a, T> Remote1<u32> for &'a T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[foreign]-for-t.rs:12:1
+  --> $DIR/impl[t]-foreign[foreign]-for-t.rs:12:6
    |
 LL | impl<T> Remote1<u32> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:12:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:12:6
    |
 LL | impl<T> Remote1<Box<T>> for u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:16:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-foreign.rs:16:10
    |
 LL | impl<'a, T> Remote1<&'a T> for u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:12:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:12:10
    |
 LL | impl<'a, T> Remote1<Box<T>> for &'a T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:15:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-fundamental[t].rs:15:10
    |
 LL | impl<'a, T> Remote1<&'a T> for Box<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:12:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:12:6
    |
 LL | impl<T> Remote1<Box<T>> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:15:1
+  --> $DIR/impl[t]-foreign[fundamental[t]]-for-t.rs:15:10
    |
 LL | impl<'a, T> Remote1<&'a T> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:12:1
+  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:12:6
    |
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:16:1
+  --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:16:10
    |
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:12:1
+  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:12:6
    |
 LL | impl<T> Remote1<Local> for Box<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:16:1
+  --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:16:6
    |
 LL | impl<T> Remote1<Local> for &T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[local]-for-t.rs:12:1
+  --> $DIR/impl[t]-foreign[local]-for-t.rs:12:6
    |
 LL | impl<T> Remote1<Local> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-foreign.rs:12:1
+  --> $DIR/impl[t]-foreign[t]-for-foreign.rs:12:6
    |
 LL | impl<T> Remote1<T> for u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
@@ -1,16 +1,16 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:12:1
+  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:12:6
    |
 LL | impl<T> Remote1<T> for Box<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `B` must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
-  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:16:1
+  --> $DIR/impl[t]-foreign[t]-for-fundamental.rs:16:13
    |
 LL | impl<'a, A, B> Remote1<A> for &'a B {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `B` must be used as the type parameter for some local type
+   |             ^ type parameter `B` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/impl[t]-foreign[t]-for-t.rs:12:1
+  --> $DIR/impl[t]-foreign[t]-for-t.rs:12:6
    |
 LL | impl<T> Remote1<T> for T {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/did_you_mean/issue-42764.rs
+++ b/src/test/ui/did_you_mean/issue-42764.rs
@@ -10,7 +10,7 @@ fn main() {
     let n: usize = 42;
     this_function_expects_a_double_option(n);
     //~^ ERROR mismatched types
-    //~| HELP try using a variant of the expected type
+    //~| HELP try using a variant of the expected enum
 }
 
 

--- a/src/test/ui/did_you_mean/issue-42764.stderr
+++ b/src/test/ui/did_you_mean/issue-42764.stderr
@@ -6,7 +6,7 @@ LL |     this_function_expects_a_double_option(n);
    |
    = note: expected type `DoubleOption<_>`
               found type `usize`
-help: try using a variant of the expected type
+help: try using a variant of the expected enum
    |
 LL |     this_function_expects_a_double_option(DoubleOption::FirstSome(n));
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/dropck/drop-on-non-struct.stderr
+++ b/src/test/ui/dropck/drop-on-non-struct.stderr
@@ -8,9 +8,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/drop-on-non-struct.rs:1:1
    |
 LL | impl<'a> Drop for &'a mut isize {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^-------------
+   | |                 |
+   | |                 `&'a mut isize` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `&'a mut isize` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/dropck/drop-on-non-struct.stderr
+++ b/src/test/ui/dropck/drop-on-non-struct.stderr
@@ -10,7 +10,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<'a> Drop for &'a mut isize {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `&'a mut isize` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/dropck/drop-on-non-struct.stderr
+++ b/src/test/ui/dropck/drop-on-non-struct.stderr
@@ -10,7 +10,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl<'a> Drop for &'a mut isize {
    | ^^^^^^^^^^^^^^^^^^-------------
    | |                 |
-   | |                 `&'a mut isize` is not defined in the current crate
+   | |                 `isize` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/error-codes/E0117.stderr
+++ b/src/test/ui/error-codes/E0117.stderr
@@ -10,7 +10,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Drop for u32 {}
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `u32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/error-codes/E0117.stderr
+++ b/src/test/ui/error-codes/E0117.stderr
@@ -8,9 +8,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/E0117.rs:1:1
    |
 LL | impl Drop for u32 {}
-   | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^---
+   | |             |
+   | |             `u32` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `u32` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/error-codes/E0164.stderr
+++ b/src/test/ui/error-codes/E0164.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found associated constant `<Foo>::B`
+error[E0164]: expected tuple struct or tuple variant, found associated constant `Foo::B`
   --> $DIR/E0164.rs:9:9
    |
 LL |         Foo::B(i) => i,

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for Foo { }
    | ^^^^^^^^^^^^^^---
    | |             |
-   | |             `[u8; _]` is not defined in the current crate
+   | |             `[u8; _]` is not defined in the current crate because arrays are always considered foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -14,9 +14,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/E0206.rs:3:1
    |
 LL | impl Copy for Foo { }
-   | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^---
+   | |             |
+   | |             `[u8; _]` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `[u8; _]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for Foo { }
    | ^^^^^^^^^^^^^^---
    | |             |
-   | |             `[u8; _]` is not defined in the current crate because arrays are always considered foreign
+   | |             `[u8; _]` is not defined in the current crate because arrays are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for Foo { }
    | ^^^^^^^^^^^^^^---
    | |             |
-   | |             `[u8; _]` is not defined in the current crate because arrays are always foreign
+   | |             this is not defined in the current crate because arrays are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/error-codes/E0206.stderr
+++ b/src/test/ui/error-codes/E0206.stderr
@@ -16,7 +16,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl Copy for Foo { }
    | ^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `[u8; _]` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/error-codes/e0119/complex-impl.stderr
+++ b/src/test/ui/error-codes/e0119/complex-impl.stderr
@@ -9,10 +9,10 @@ LL | impl<R> External for (Q, R) {}
              where <U as std::ops::FnOnce<(T,)>>::Output == V, <V as std::iter::Iterator>::Item == T, 'b : 'a, T : 'a, U: std::ops::FnOnce<(T,)>, U : 'static, V: std::iter::Iterator, V: std::clone::Clone, W: std::ops::Add, <W as std::ops::Add>::Output: std::marker::Copy;
 
 error[E0210]: type parameter `R` must be used as the type parameter for some local type (e.g., `MyStruct<R>`)
-  --> $DIR/complex-impl.rs:9:1
+  --> $DIR/complex-impl.rs:9:6
    |
 LL | impl<R> External for (Q, R) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `R` must be used as the type parameter for some local type
+   |      ^ type parameter `R` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/error-codes/e0119/issue-28981.stderr
+++ b/src/test/ui/error-codes/e0119/issue-28981.stderr
@@ -9,10 +9,10 @@ LL | impl<Foo> Deref for Foo { }
              where T: ?Sized;
 
 error[E0210]: type parameter `Foo` must be used as the type parameter for some local type (e.g., `MyStruct<Foo>`)
-  --> $DIR/issue-28981.rs:5:1
+  --> $DIR/issue-28981.rs:5:6
    |
 LL | impl<Foo> Deref for Foo { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^ type parameter `Foo` must be used as the type parameter for some local type
+   |      ^^^ type parameter `Foo` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/feature-gates/feature-gate-abi.rs
+++ b/src/test/ui/feature-gates/feature-gate-abi.rs
@@ -7,6 +7,7 @@
 // gate-test-abi_ptx
 // gate-test-abi_x86_interrupt
 // gate-test-abi_amdgpu_kernel
+// gate-test-abi_efiapi
 
 // Functions
 extern "rust-intrinsic" fn f1() {} //~ ERROR intrinsics are subject to change
@@ -20,6 +21,7 @@ extern "ptx-kernel" fn f6() {} //~ ERROR PTX ABIs are experimental and subject t
 extern "x86-interrupt" fn f7() {} //~ ERROR x86-interrupt ABI is experimental
 extern "thiscall" fn f8() {} //~ ERROR thiscall is experimental and subject to change
 extern "amdgpu-kernel" fn f9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+extern "efiapi" fn f10() {} //~ ERROR efiapi ABI is experimental and subject to change
 
 // Methods in trait definition
 trait Tr {
@@ -34,6 +36,7 @@ trait Tr {
     extern "x86-interrupt" fn m7(); //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn m8(); //~ ERROR thiscall is experimental and subject to change
     extern "amdgpu-kernel" fn m9(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+    extern "efiapi" fn m10(); //~ ERROR efiapi ABI is experimental and subject to change
 
     extern "vectorcall" fn dm3() {} //~ ERROR vectorcall is experimental and subject to change
     extern "rust-call" fn dm4() {} //~ ERROR rust-call ABI is subject to change
@@ -42,6 +45,7 @@ trait Tr {
     extern "x86-interrupt" fn dm7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn dm8() {} //~ ERROR thiscall is experimental and subject to change
     extern "amdgpu-kernel" fn dm9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+    extern "efiapi" fn dm10() {} //~ ERROR efiapi ABI is experimental and subject to change
 }
 
 struct S;
@@ -59,6 +63,7 @@ impl Tr for S {
     extern "x86-interrupt" fn m7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn m8() {} //~ ERROR thiscall is experimental and subject to change
     extern "amdgpu-kernel" fn m9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+    extern "efiapi" fn m10() {} //~ ERROR efiapi ABI is experimental and subject to change
 }
 
 // Methods in inherent impl
@@ -74,6 +79,7 @@ impl S {
     extern "x86-interrupt" fn im7() {} //~ ERROR x86-interrupt ABI is experimental
     extern "thiscall" fn im8() {} //~ ERROR thiscall is experimental and subject to change
     extern "amdgpu-kernel" fn im9() {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+    extern "efiapi" fn im10() {} //~ ERROR efiapi ABI is experimental and subject to change
 }
 
 // Function pointer types
@@ -86,6 +92,7 @@ type A6 = extern "ptx-kernel" fn (); //~ ERROR PTX ABIs are experimental and sub
 type A7 = extern "x86-interrupt" fn(); //~ ERROR x86-interrupt ABI is experimental
 type A8 = extern "thiscall" fn(); //~ ERROR thiscall is experimental and subject to change
 type A9 = extern "amdgpu-kernel" fn(); //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+type A10 = extern "efiapi" fn(); //~ ERROR efiapi ABI is experimental and subject to change
 
 // Foreign modules
 extern "rust-intrinsic" {} //~ ERROR intrinsics are subject to change
@@ -97,5 +104,6 @@ extern "ptx-kernel" {} //~ ERROR PTX ABIs are experimental and subject to change
 extern "x86-interrupt" {} //~ ERROR x86-interrupt ABI is experimental
 extern "thiscall" {} //~ ERROR thiscall is experimental and subject to change
 extern "amdgpu-kernel" {} //~ ERROR amdgpu-kernel ABI is experimental and subject to change
+extern "efiapi" {} //~ ERROR efiapi ABI is experimental and subject to change
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi.stderr
@@ -82,7 +82,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | extern "efiapi" fn f10() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -169,7 +169,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn m10();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
@@ -239,7 +239,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn dm10() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -326,7 +326,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn m10() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -413,7 +413,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL |     extern "efiapi" fn im10() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -500,7 +500,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | type A10 = extern "efiapi" fn();
    |            ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error[E0658]: intrinsics are subject to change
@@ -587,7 +587,7 @@ error[E0658]: efiapi ABI is experimental and subject to change
 LL | extern "efiapi" {}
    | ^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = note: for more information, see https://github.com/rust-lang/rust/issues/65815
    = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block

--- a/src/test/ui/feature-gates/feature-gate-abi.stderr
+++ b/src/test/ui/feature-gates/feature-gate-abi.stderr
@@ -1,5 +1,5 @@
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:12:1
+  --> $DIR/feature-gate-abi.rs:13:1
    |
 LL | extern "rust-intrinsic" fn f1() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | extern "rust-intrinsic" fn f1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:14:1
+  --> $DIR/feature-gate-abi.rs:15:1
    |
 LL | extern "platform-intrinsic" fn f2() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL | extern "platform-intrinsic" fn f2() {}
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:16:1
+  --> $DIR/feature-gate-abi.rs:17:1
    |
 LL | extern "vectorcall" fn f3() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL | extern "vectorcall" fn f3() {}
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:17:1
+  --> $DIR/feature-gate-abi.rs:18:1
    |
 LL | extern "rust-call" fn f4() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -33,7 +33,7 @@ LL | extern "rust-call" fn f4() {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:18:1
+  --> $DIR/feature-gate-abi.rs:19:1
    |
 LL | extern "msp430-interrupt" fn f5() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL | extern "msp430-interrupt" fn f5() {}
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:19:1
+  --> $DIR/feature-gate-abi.rs:20:1
    |
 LL | extern "ptx-kernel" fn f6() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL | extern "ptx-kernel" fn f6() {}
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:20:1
+  --> $DIR/feature-gate-abi.rs:21:1
    |
 LL | extern "x86-interrupt" fn f7() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL | extern "x86-interrupt" fn f7() {}
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:21:1
+  --> $DIR/feature-gate-abi.rs:22:1
    |
 LL | extern "thiscall" fn f8() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL | extern "thiscall" fn f8() {}
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:22:1
+  --> $DIR/feature-gate-abi.rs:23:1
    |
 LL | extern "amdgpu-kernel" fn f9() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -76,8 +76,17 @@ LL | extern "amdgpu-kernel" fn f9() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:24:1
+   |
+LL | extern "efiapi" fn f10() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:26:5
+  --> $DIR/feature-gate-abi.rs:28:5
    |
 LL |     extern "rust-intrinsic" fn m1();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -85,7 +94,7 @@ LL |     extern "rust-intrinsic" fn m1();
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:28:5
+  --> $DIR/feature-gate-abi.rs:30:5
    |
 LL |     extern "platform-intrinsic" fn m2();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,7 +103,7 @@ LL |     extern "platform-intrinsic" fn m2();
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:30:5
+  --> $DIR/feature-gate-abi.rs:32:5
    |
 LL |     extern "vectorcall" fn m3();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,7 +111,7 @@ LL |     extern "vectorcall" fn m3();
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:31:5
+  --> $DIR/feature-gate-abi.rs:33:5
    |
 LL |     extern "rust-call" fn m4();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +120,7 @@ LL |     extern "rust-call" fn m4();
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:32:5
+  --> $DIR/feature-gate-abi.rs:34:5
    |
 LL |     extern "msp430-interrupt" fn m5();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +129,7 @@ LL |     extern "msp430-interrupt" fn m5();
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:33:5
+  --> $DIR/feature-gate-abi.rs:35:5
    |
 LL |     extern "ptx-kernel" fn m6();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -129,7 +138,7 @@ LL |     extern "ptx-kernel" fn m6();
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:34:5
+  --> $DIR/feature-gate-abi.rs:36:5
    |
 LL |     extern "x86-interrupt" fn m7();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +147,7 @@ LL |     extern "x86-interrupt" fn m7();
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:35:5
+  --> $DIR/feature-gate-abi.rs:37:5
    |
 LL |     extern "thiscall" fn m8();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -146,7 +155,7 @@ LL |     extern "thiscall" fn m8();
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:36:5
+  --> $DIR/feature-gate-abi.rs:38:5
    |
 LL |     extern "amdgpu-kernel" fn m9();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,8 +163,17 @@ LL |     extern "amdgpu-kernel" fn m9();
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:39:5
+   |
+LL |     extern "efiapi" fn m10();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:38:5
+  --> $DIR/feature-gate-abi.rs:41:5
    |
 LL |     extern "vectorcall" fn dm3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -163,7 +181,7 @@ LL |     extern "vectorcall" fn dm3() {}
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:39:5
+  --> $DIR/feature-gate-abi.rs:42:5
    |
 LL |     extern "rust-call" fn dm4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -172,7 +190,7 @@ LL |     extern "rust-call" fn dm4() {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:40:5
+  --> $DIR/feature-gate-abi.rs:43:5
    |
 LL |     extern "msp430-interrupt" fn dm5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,7 +199,7 @@ LL |     extern "msp430-interrupt" fn dm5() {}
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:41:5
+  --> $DIR/feature-gate-abi.rs:44:5
    |
 LL |     extern "ptx-kernel" fn dm6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -190,7 +208,7 @@ LL |     extern "ptx-kernel" fn dm6() {}
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:42:5
+  --> $DIR/feature-gate-abi.rs:45:5
    |
 LL |     extern "x86-interrupt" fn dm7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -199,7 +217,7 @@ LL |     extern "x86-interrupt" fn dm7() {}
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:43:5
+  --> $DIR/feature-gate-abi.rs:46:5
    |
 LL |     extern "thiscall" fn dm8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -207,7 +225,7 @@ LL |     extern "thiscall" fn dm8() {}
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:44:5
+  --> $DIR/feature-gate-abi.rs:47:5
    |
 LL |     extern "amdgpu-kernel" fn dm9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -215,8 +233,17 @@ LL |     extern "amdgpu-kernel" fn dm9() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:48:5
+   |
+LL |     extern "efiapi" fn dm10() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:51:5
+  --> $DIR/feature-gate-abi.rs:55:5
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +251,7 @@ LL |     extern "rust-intrinsic" fn m1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:53:5
+  --> $DIR/feature-gate-abi.rs:57:5
    |
 LL |     extern "platform-intrinsic" fn m2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -233,7 +260,7 @@ LL |     extern "platform-intrinsic" fn m2() {}
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:55:5
+  --> $DIR/feature-gate-abi.rs:59:5
    |
 LL |     extern "vectorcall" fn m3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -241,7 +268,7 @@ LL |     extern "vectorcall" fn m3() {}
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:56:5
+  --> $DIR/feature-gate-abi.rs:60:5
    |
 LL |     extern "rust-call" fn m4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,7 +277,7 @@ LL |     extern "rust-call" fn m4() {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:57:5
+  --> $DIR/feature-gate-abi.rs:61:5
    |
 LL |     extern "msp430-interrupt" fn m5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -259,7 +286,7 @@ LL |     extern "msp430-interrupt" fn m5() {}
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:58:5
+  --> $DIR/feature-gate-abi.rs:62:5
    |
 LL |     extern "ptx-kernel" fn m6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -268,7 +295,7 @@ LL |     extern "ptx-kernel" fn m6() {}
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:59:5
+  --> $DIR/feature-gate-abi.rs:63:5
    |
 LL |     extern "x86-interrupt" fn m7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -277,7 +304,7 @@ LL |     extern "x86-interrupt" fn m7() {}
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:60:5
+  --> $DIR/feature-gate-abi.rs:64:5
    |
 LL |     extern "thiscall" fn m8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -285,7 +312,7 @@ LL |     extern "thiscall" fn m8() {}
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:61:5
+  --> $DIR/feature-gate-abi.rs:65:5
    |
 LL |     extern "amdgpu-kernel" fn m9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -293,8 +320,17 @@ LL |     extern "amdgpu-kernel" fn m9() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
-error[E0658]: intrinsics are subject to change
+error[E0658]: efiapi ABI is experimental and subject to change
   --> $DIR/feature-gate-abi.rs:66:5
+   |
+LL |     extern "efiapi" fn m10() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
+error[E0658]: intrinsics are subject to change
+  --> $DIR/feature-gate-abi.rs:71:5
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -302,7 +338,7 @@ LL |     extern "rust-intrinsic" fn im1() {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:68:5
+  --> $DIR/feature-gate-abi.rs:73:5
    |
 LL |     extern "platform-intrinsic" fn im2() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -311,7 +347,7 @@ LL |     extern "platform-intrinsic" fn im2() {}
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:70:5
+  --> $DIR/feature-gate-abi.rs:75:5
    |
 LL |     extern "vectorcall" fn im3() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -319,7 +355,7 @@ LL |     extern "vectorcall" fn im3() {}
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:71:5
+  --> $DIR/feature-gate-abi.rs:76:5
    |
 LL |     extern "rust-call" fn im4() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -328,7 +364,7 @@ LL |     extern "rust-call" fn im4() {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:72:5
+  --> $DIR/feature-gate-abi.rs:77:5
    |
 LL |     extern "msp430-interrupt" fn im5() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,7 +373,7 @@ LL |     extern "msp430-interrupt" fn im5() {}
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:73:5
+  --> $DIR/feature-gate-abi.rs:78:5
    |
 LL |     extern "ptx-kernel" fn im6() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -346,7 +382,7 @@ LL |     extern "ptx-kernel" fn im6() {}
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:74:5
+  --> $DIR/feature-gate-abi.rs:79:5
    |
 LL |     extern "x86-interrupt" fn im7() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -355,7 +391,7 @@ LL |     extern "x86-interrupt" fn im7() {}
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:75:5
+  --> $DIR/feature-gate-abi.rs:80:5
    |
 LL |     extern "thiscall" fn im8() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -363,7 +399,7 @@ LL |     extern "thiscall" fn im8() {}
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:76:5
+  --> $DIR/feature-gate-abi.rs:81:5
    |
 LL |     extern "amdgpu-kernel" fn im9() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -371,8 +407,17 @@ LL |     extern "amdgpu-kernel" fn im9() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:82:5
+   |
+LL |     extern "efiapi" fn im10() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:80:11
+  --> $DIR/feature-gate-abi.rs:86:11
    |
 LL | type A1 = extern "rust-intrinsic" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -380,7 +425,7 @@ LL | type A1 = extern "rust-intrinsic" fn();
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:81:11
+  --> $DIR/feature-gate-abi.rs:87:11
    |
 LL | type A2 = extern "platform-intrinsic" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -389,7 +434,7 @@ LL | type A2 = extern "platform-intrinsic" fn();
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:82:11
+  --> $DIR/feature-gate-abi.rs:88:11
    |
 LL | type A3 = extern "vectorcall" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -397,7 +442,7 @@ LL | type A3 = extern "vectorcall" fn();
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:83:11
+  --> $DIR/feature-gate-abi.rs:89:11
    |
 LL | type A4 = extern "rust-call" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^
@@ -406,7 +451,7 @@ LL | type A4 = extern "rust-call" fn();
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:84:11
+  --> $DIR/feature-gate-abi.rs:90:11
    |
 LL | type A5 = extern "msp430-interrupt" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -415,7 +460,7 @@ LL | type A5 = extern "msp430-interrupt" fn();
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:85:11
+  --> $DIR/feature-gate-abi.rs:91:11
    |
 LL | type A6 = extern "ptx-kernel" fn ();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -424,7 +469,7 @@ LL | type A6 = extern "ptx-kernel" fn ();
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:86:11
+  --> $DIR/feature-gate-abi.rs:92:11
    |
 LL | type A7 = extern "x86-interrupt" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -433,7 +478,7 @@ LL | type A7 = extern "x86-interrupt" fn();
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:87:11
+  --> $DIR/feature-gate-abi.rs:93:11
    |
 LL | type A8 = extern "thiscall" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^
@@ -441,7 +486,7 @@ LL | type A8 = extern "thiscall" fn();
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:88:11
+  --> $DIR/feature-gate-abi.rs:94:11
    |
 LL | type A9 = extern "amdgpu-kernel" fn();
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -449,8 +494,17 @@ LL | type A9 = extern "amdgpu-kernel" fn();
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:95:12
+   |
+LL | type A10 = extern "efiapi" fn();
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error[E0658]: intrinsics are subject to change
-  --> $DIR/feature-gate-abi.rs:91:1
+  --> $DIR/feature-gate-abi.rs:98:1
    |
 LL | extern "rust-intrinsic" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -458,7 +512,7 @@ LL | extern "rust-intrinsic" {}
    = help: add `#![feature(intrinsics)]` to the crate attributes to enable
 
 error[E0658]: platform intrinsics are experimental and possibly buggy
-  --> $DIR/feature-gate-abi.rs:92:1
+  --> $DIR/feature-gate-abi.rs:99:1
    |
 LL | extern "platform-intrinsic" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -467,7 +521,7 @@ LL | extern "platform-intrinsic" {}
    = help: add `#![feature(platform_intrinsics)]` to the crate attributes to enable
 
 error[E0658]: vectorcall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:93:1
+  --> $DIR/feature-gate-abi.rs:100:1
    |
 LL | extern "vectorcall" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -475,7 +529,7 @@ LL | extern "vectorcall" {}
    = help: add `#![feature(abi_vectorcall)]` to the crate attributes to enable
 
 error[E0658]: rust-call ABI is subject to change
-  --> $DIR/feature-gate-abi.rs:94:1
+  --> $DIR/feature-gate-abi.rs:101:1
    |
 LL | extern "rust-call" {}
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -484,7 +538,7 @@ LL | extern "rust-call" {}
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: msp430-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:95:1
+  --> $DIR/feature-gate-abi.rs:102:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -493,7 +547,7 @@ LL | extern "msp430-interrupt" {}
    = help: add `#![feature(abi_msp430_interrupt)]` to the crate attributes to enable
 
 error[E0658]: PTX ABIs are experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:96:1
+  --> $DIR/feature-gate-abi.rs:103:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -502,7 +556,7 @@ LL | extern "ptx-kernel" {}
    = help: add `#![feature(abi_ptx)]` to the crate attributes to enable
 
 error[E0658]: x86-interrupt ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:97:1
+  --> $DIR/feature-gate-abi.rs:104:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -511,7 +565,7 @@ LL | extern "x86-interrupt" {}
    = help: add `#![feature(abi_x86_interrupt)]` to the crate attributes to enable
 
 error[E0658]: thiscall is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:98:1
+  --> $DIR/feature-gate-abi.rs:105:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
@@ -519,7 +573,7 @@ LL | extern "thiscall" {}
    = help: add `#![feature(abi_thiscall)]` to the crate attributes to enable
 
 error[E0658]: amdgpu-kernel ABI is experimental and subject to change
-  --> $DIR/feature-gate-abi.rs:99:1
+  --> $DIR/feature-gate-abi.rs:106:1
    |
 LL | extern "amdgpu-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -527,54 +581,63 @@ LL | extern "amdgpu-kernel" {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/51575
    = help: add `#![feature(abi_amdgpu_kernel)]` to the crate attributes to enable
 
+error[E0658]: efiapi ABI is experimental and subject to change
+  --> $DIR/feature-gate-abi.rs:107:1
+   |
+LL | extern "efiapi" {}
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/1
+   = help: add `#![feature(abi_efiapi)]` to the crate attributes to enable
+
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:26:32
+  --> $DIR/feature-gate-abi.rs:28:32
    |
 LL |     extern "rust-intrinsic" fn m1();
    |                                ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:28:36
+  --> $DIR/feature-gate-abi.rs:30:36
    |
 LL |     extern "platform-intrinsic" fn m2();
    |                                    ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:12:33
+  --> $DIR/feature-gate-abi.rs:13:33
    |
 LL | extern "rust-intrinsic" fn f1() {}
    |                                 ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:14:37
+  --> $DIR/feature-gate-abi.rs:15:37
    |
 LL | extern "platform-intrinsic" fn f2() {}
    |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:51:37
+  --> $DIR/feature-gate-abi.rs:55:37
    |
 LL |     extern "rust-intrinsic" fn m1() {}
    |                                     ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:53:41
+  --> $DIR/feature-gate-abi.rs:57:41
    |
 LL |     extern "platform-intrinsic" fn m2() {}
    |                                         ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:66:38
+  --> $DIR/feature-gate-abi.rs:71:38
    |
 LL |     extern "rust-intrinsic" fn im1() {}
    |                                      ^^
 
 error: intrinsic must be in `extern "rust-intrinsic" { ... }` block
-  --> $DIR/feature-gate-abi.rs:68:42
+  --> $DIR/feature-gate-abi.rs:73:42
    |
 LL |     extern "platform-intrinsic" fn im2() {}
    |                                          ^^
 
-error: aborting due to 69 previous errors
+error: aborting due to 76 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-re-rebalance-coherence.stderr
+++ b/src/test/ui/feature-gates/feature-gate-re-rebalance-coherence.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/feature-gate-re-rebalance-coherence.rs:10:1
+  --> $DIR/feature-gate-re-rebalance-coherence.rs:10:10
    |
 LL | impl<'a, T:'a, Tab> QueryFragment<Oracle> for BatchInsert<'a, T, Tab> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/fn-in-pat.stderr
+++ b/src/test/ui/fn-in-pat.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `<A>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `A::new`
   --> $DIR/fn-in-pat.rs:11:9
    |
 LL |         A::new() => (),

--- a/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
+++ b/src/test/ui/fully-qualified-type/fully-qualified-type-name1.stderr
@@ -5,7 +5,7 @@ LL |     x = 5;
    |         ^
    |         |
    |         expected enum `std::option::Option`, found integer
-   |         help: try using a variant of the expected type: `Some(5)`
+   |         help: try using a variant of the expected enum: `Some(5)`
    |
    = note: expected type `std::option::Option<usize>`
               found type `{integer}`

--- a/src/test/ui/issues/issue-28992-empty.rs
+++ b/src/test/ui/issues/issue-28992-empty.rs
@@ -12,5 +12,5 @@ impl S {
 fn main() {
     if let C1(..) = 0 {} //~ ERROR expected tuple struct or tuple variant, found constant `C1`
     if let S::C2(..) = 0 {}
-    //~^ ERROR expected tuple struct or tuple variant, found associated constant `<S>::C2`
+    //~^ ERROR expected tuple struct or tuple variant, found associated constant `S::C2`
 }

--- a/src/test/ui/issues/issue-28992-empty.stderr
+++ b/src/test/ui/issues/issue-28992-empty.stderr
@@ -4,7 +4,7 @@ error[E0532]: expected tuple struct or tuple variant, found constant `C1`
 LL |     if let C1(..) = 0 {}
    |            ^^ not a tuple struct or tuple variant
 
-error[E0164]: expected tuple struct or tuple variant, found associated constant `<S>::C2`
+error[E0164]: expected tuple struct or tuple variant, found associated constant `S::C2`
   --> $DIR/issue-28992-empty.rs:14:12
    |
 LL |     if let S::C2(..) = 0 {}

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -16,10 +16,10 @@ LL | impl<T> Drop for T where T: A {
    |                  ^ implementing Drop requires a struct
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/issue-41974.rs:7:1
+  --> $DIR/issue-41974.rs:7:6
    |
 LL | impl<T> Drop for T where T: A {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/issues/issue-46112.stderr
+++ b/src/test/ui/issues/issue-46112.stderr
@@ -5,7 +5,7 @@ LL | fn main() { test(Ok(())); }
    |                     ^^
    |                     |
    |                     expected enum `std::option::Option`, found ()
-   |                     help: try using a variant of the expected type: `Some(())`
+   |                     help: try using a variant of the expected enum: `Some(())`
    |
    = note: expected type `std::option::Option<()>`
               found type `()`

--- a/src/test/ui/issues/issue-52057.stderr
+++ b/src/test/ui/issues/issue-52057.stderr
@@ -1,0 +1,8 @@
+warning: `#[inline]` is ignored on function prototypes
+  --> $DIR/issue-52057.rs:10:5
+   |
+LL |     #[inline(always)]
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unused_attributes)]` on by default
+

--- a/src/test/ui/issues/issue-55587.stderr
+++ b/src/test/ui/issues/issue-55587.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
   --> $DIR/issue-55587.rs:4:9
    |
 LL |     let Path::new();

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,8 +1,11 @@
 #![feature(extern_types)]
 #![feature(type_alias_impl_trait)]
 
+#![warn(unused_attributes)]
+
 trait Trait {
-    #[inline] //~ ERROR attribute should be applied to function or closure
+    #[inline] //~ WARN `#[inline]` is ignored on constants
+    //~^ WARN this was previously accepted
     const X: u32;
 
     #[inline] //~ ERROR attribute should be applied to function or closure
@@ -12,7 +15,8 @@ trait Trait {
 }
 
 impl Trait for () {
-    #[inline] //~ ERROR attribute should be applied to function or closure
+    #[inline] //~ WARN `#[inline]` is ignored on constants
+    //~^ WARN this was previously accepted
     const X: u32 = 0;
 
     #[inline] //~ ERROR attribute should be applied to function or closure

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,0 +1,19 @@
+#![feature(extern_types)]
+
+trait Trait {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    const X: u32;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T;
+}
+
+extern {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    static X: u32;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T;
+}
+
+fn main() {}

--- a/src/test/ui/lint/inline-trait-and-foreign-items.rs
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.rs
@@ -1,4 +1,5 @@
 #![feature(extern_types)]
+#![feature(type_alias_impl_trait)]
 
 trait Trait {
     #[inline] //~ ERROR attribute should be applied to function or closure
@@ -6,6 +7,19 @@ trait Trait {
 
     #[inline] //~ ERROR attribute should be applied to function or closure
     type T;
+
+    type U;
+}
+
+impl Trait for () {
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    const X: u32 = 0;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type T = Self;
+
+    #[inline] //~ ERROR attribute should be applied to function or closure
+    type U = impl Trait; //~ ERROR could not find defining uses
 }
 
 extern {

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,0 +1,35 @@
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:12:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     static X: u32;
+   |     -------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T;
+   |     ------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:4:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     const X: u32;
+   |     ------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:7:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T;
+   |     ------- not a function or closure
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,5 +1,5 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:12:5
+  --> $DIR/inline-trait-and-foreign-items.rs:26:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     static X: u32;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+  --> $DIR/inline-trait-and-foreign-items.rs:29:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:4:5
+  --> $DIR/inline-trait-and-foreign-items.rs:5:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -23,13 +23,43 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:7:5
+  --> $DIR/inline-trait-and-foreign-items.rs:8:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error: aborting due to 4 previous errors
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:15:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     const X: u32 = 0;
+   |     ----------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:18:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type T = Self;
+   |     -------------- not a function or closure
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:21:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+LL |     type U = impl Trait;
+   |     -------------------- not a function or closure
+
+error: could not find defining uses
+  --> $DIR/inline-trait-and-foreign-items.rs:22:5
+   |
+LL |     type U = impl Trait;
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/inline-trait-and-foreign-items.stderr
+++ b/src/test/ui/lint/inline-trait-and-foreign-items.stderr
@@ -1,5 +1,5 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:26:5
+  --> $DIR/inline-trait-and-foreign-items.rs:30:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -7,39 +7,46 @@ LL |     static X: u32;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:29:5
+  --> $DIR/inline-trait-and-foreign-items.rs:33:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:5:5
+warning: `#[inline]` is ignored on constants
+  --> $DIR/inline-trait-and-foreign-items.rs:7:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
-LL |     const X: u32;
-   |     ------------- not a function or closure
+   |
+note: lint level defined here
+  --> $DIR/inline-trait-and-foreign-items.rs:4:9
+   |
+LL | #![warn(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:8:5
+  --> $DIR/inline-trait-and-foreign-items.rs:11:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
 LL |     type T;
    |     ------- not a function or closure
 
-error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:15:5
-   |
-LL |     #[inline]
-   |     ^^^^^^^^^
-LL |     const X: u32 = 0;
-   |     ----------------- not a function or closure
-
-error[E0518]: attribute should be applied to function or closure
+warning: `#[inline]` is ignored on constants
   --> $DIR/inline-trait-and-foreign-items.rs:18:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #65833 <https://github.com/rust-lang/rust/issues/65833>
+
+error[E0518]: attribute should be applied to function or closure
+  --> $DIR/inline-trait-and-foreign-items.rs:22:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -47,7 +54,7 @@ LL |     type T = Self;
    |     -------------- not a function or closure
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/inline-trait-and-foreign-items.rs:21:5
+  --> $DIR/inline-trait-and-foreign-items.rs:25:5
    |
 LL |     #[inline]
    |     ^^^^^^^^^
@@ -55,11 +62,11 @@ LL |     type U = impl Trait;
    |     -------------------- not a function or closure
 
 error: could not find defining uses
-  --> $DIR/inline-trait-and-foreign-items.rs:22:5
+  --> $DIR/inline-trait-and-foreign-items.rs:26:5
    |
 LL |     type U = impl Trait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0518`.

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
@@ -1,0 +1,8 @@
+#![deny(unused_attributes)]
+
+trait Trait {
+    #[inline] //~ ERROR `#[inline]` is ignored on function prototypes
+    fn foo();
+}
+
+fn main() {}

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.rs
@@ -5,4 +5,9 @@ trait Trait {
     fn foo();
 }
 
+extern {
+    #[inline] //~ ERROR `#[inline]` is ignored on function prototypes
+    fn foo();
+}
+
 fn main() {}

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -1,0 +1,14 @@
+error: `#[inline]` is ignored on function prototypes
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:9:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:1:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
+++ b/src/test/ui/lint/warn-unused-inline-on-fn-prototypes.stderr
@@ -10,5 +10,11 @@ note: lint level defined here
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
+error: `#[inline]` is ignored on function prototypes
+  --> $DIR/warn-unused-inline-on-fn-prototypes.rs:4:5
+   |
+LL |     #[inline]
+   |     ^^^^^^^^^
+
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/match/match-fn-call.stderr
+++ b/src/test/ui/match/match-fn-call.stderr
@@ -1,4 +1,4 @@
-error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
   --> $DIR/match-fn-call.rs:6:9
    |
 LL |         Path::new("foo") => println!("foo"),
@@ -6,7 +6,7 @@ LL |         Path::new("foo") => println!("foo"),
    |
    = help: for more information, visit https://doc.rust-lang.org/book/ch18-00-patterns.html
 
-error[E0164]: expected tuple struct or tuple variant, found method `<Path>::new`
+error[E0164]: expected tuple struct or tuple variant, found method `Path::new`
   --> $DIR/match-fn-call.rs:8:9
    |
 LL |         Path::new("bar") => println!("bar"),

--- a/src/test/ui/methods/method-path-in-pattern.rs
+++ b/src/test/ui/methods/method-path-in-pattern.rs
@@ -13,20 +13,20 @@ impl MyTrait for Foo {}
 fn main() {
     match 0u32 {
         Foo::bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
     }
     match 0u32 {
         <Foo>::bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
     }
     match 0u32 {
         <Foo>::trait_bar => {}
-        //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
+        //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::trait_bar`
     }
     if let Foo::bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
     if let <Foo>::bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::bar`
     if let Foo::trait_bar = 0u32 {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `Foo::trait_bar`
 }

--- a/src/test/ui/methods/method-path-in-pattern.stderr
+++ b/src/test/ui/methods/method-path-in-pattern.stderr
@@ -1,34 +1,34 @@
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:15:9
    |
 LL |         Foo::bar => {}
    |         ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:19:9
    |
 LL |         <Foo>::bar => {}
    |         ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:23:9
    |
 LL |         <Foo>::trait_bar => {}
    |         ^^^^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:26:12
    |
 LL |     if let Foo::bar = 0u32 {}
    |            ^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::bar`
   --> $DIR/method-path-in-pattern.rs:28:12
    |
 LL |     if let <Foo>::bar = 0u32 {}
    |            ^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found method `<Foo>::trait_bar`
+error[E0533]: expected unit struct, unit variant or constant, found method `Foo::trait_bar`
   --> $DIR/method-path-in-pattern.rs:30:12
    |
 LL |     if let Foo::trait_bar = 0u32 {}

--- a/src/test/ui/orphan-check-diagnostics.stderr
+++ b/src/test/ui/orphan-check-diagnostics.stderr
@@ -1,8 +1,8 @@
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
-  --> $DIR/orphan-check-diagnostics.rs:11:1
+  --> $DIR/orphan-check-diagnostics.rs:11:6
    |
 LL | impl<T> RemoteTrait for T where T: LocalTrait {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be used as the type parameter for some local type
    |
    = note: only traits defined in the current crate can be implemented for a type parameter
 

--- a/src/test/ui/parser/issue-8537.stderr
+++ b/src/test/ui/parser/issue-8537.stderr
@@ -4,7 +4,7 @@ error[E0703]: invalid ABI: found `invalid-ab_isize`
 LL |   "invalid-ab_isize"
    |   ^^^^^^^^^^^^^^^^^^ invalid ABI
    |
-   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
+   = help: valid ABIs: cdecl, stdcall, fastcall, vectorcall, thiscall, aapcs, win64, sysv64, ptx-kernel, msp430-interrupt, x86-interrupt, amdgpu-kernel, efiapi, Rust, C, system, rust-intrinsic, rust-call, platform-intrinsic, unadjusted
 
 error: aborting due to previous error
 

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<S as Tr>::A::f<u8>`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.rs
+++ b/src/test/ui/qualified/qualified-path-params.rs
@@ -18,7 +18,7 @@ impl S {
 fn main() {
     match 10 {
         <S as Tr>::A::f::<u8> => {}
-    //~^ ERROR expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
+    //~^ ERROR expected unit struct, unit variant or constant, found method `<S as Tr>::A::f<u8>`
         0 ..= <S as Tr>::A::f::<u8> => {} //~ ERROR only char and numeric types are allowed in range
     }
 }

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found method `<S as Tr>::A::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/qualified/qualified-path-params.stderr
+++ b/src/test/ui/qualified/qualified-path-params.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found method `<S as Tr>::A::f<u8>`
+error[E0533]: expected unit struct, unit variant or constant, found method `<<S as Tr>::A>::f<u8>`
   --> $DIR/qualified-path-params.rs:20:9
    |
 LL |         <S as Tr>::A::f::<u8> => {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.rs
@@ -1,7 +1,6 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
-#[track_caller]
+#[track_caller] //~ ERROR Rust ABI is required to use `#[track_caller]`
 extern "C" fn f() {}
-//~^^ ERROR rust ABI is required to use `#[track_caller]`
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-invalid-abi.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0737]: rust ABI is required to use `#[track_caller]`
+error[E0737]: Rust ABI is required to use `#[track_caller]`
   --> $DIR/error-with-invalid-abi.rs:3:1
    |
 LL | #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.rs
@@ -1,9 +1,8 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self);
-    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 impl Trait for u64 {

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-decl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in trait declarations.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-decl.rs:4:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.rs
@@ -1,9 +1,8 @@
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
-    //~^^ ERROR: `#[track_caller]` is not supported in trait declarations.
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-default-impl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in trait declarations.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-default-impl.rs:4:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
@@ -5,9 +5,8 @@ trait Trait {
 }
 
 impl Trait for u64 {
-    #[track_caller]
+    #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
-    //~^^ ERROR: `#[track_caller]` is not supported in traits yet.
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.rs
@@ -1,3 +1,5 @@
+// check-fail
+
 #![feature(track_caller)] //~ WARN the feature `track_caller` is incomplete
 
 trait Trait {
@@ -7,6 +9,13 @@ trait Trait {
 impl Trait for u64 {
     #[track_caller] //~ ERROR: `#[track_caller]` may not be used on trait methods
     fn unwrap(&self) {}
+}
+
+struct S;
+
+impl S {
+    #[track_caller] // ok
+    fn foo() {}
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -6,7 +6,7 @@ LL | #![feature(track_caller)]
    |
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0738]: `#[track_caller]` is not supported in traits yet.
+error[E0738]: `#[track_caller]` may not be used on trait methods
   --> $DIR/error-with-trait-fn-impl.rs:8:5
    |
 LL |     #[track_caller]

--- a/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
+++ b/src/test/ui/rfc-2091-track-caller/error-with-trait-fn-impl.stderr
@@ -1,5 +1,5 @@
 warning: the feature `track_caller` is incomplete and may cause the compiler to crash
-  --> $DIR/error-with-trait-fn-impl.rs:1:12
+  --> $DIR/error-with-trait-fn-impl.rs:3:12
    |
 LL | #![feature(track_caller)]
    |            ^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | #![feature(track_caller)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error[E0738]: `#[track_caller]` may not be used on trait methods
-  --> $DIR/error-with-trait-fn-impl.rs:8:5
+  --> $DIR/error-with-trait-fn-impl.rs:10:5
    |
 LL |     #[track_caller]
    |     ^^^^^^^^^^^^^^^

--- a/src/test/ui/symbol-names/basic.legacy.stderr
+++ b/src/test/ui/symbol-names/basic.legacy.stderr
@@ -1,10 +1,10 @@
-error: symbol-name(_ZN5basic4main17hd72940ef9669d526E)
+error: symbol-name(_ZN5basic4main17h81759b0695851718E)
   --> $DIR/basic.rs:7:1
    |
 LL | #[rustc_symbol_name]
    | ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(basic::main::hd72940ef9669d526)
+error: demangling(basic::main::h81759b0695851718)
   --> $DIR/basic.rs:7:1
    |
 LL | #[rustc_symbol_name]

--- a/src/test/ui/symbol-names/impl1.legacy.stderr
+++ b/src/test/ui/symbol-names/impl1.legacy.stderr
@@ -1,10 +1,10 @@
-error: symbol-name(_ZN5impl13foo3Foo3bar17he53b9bee7600ed8dE)
+error: symbol-name(_ZN5impl13foo3Foo3bar17h92cf46db76791039E)
   --> $DIR/impl1.rs:13:9
    |
 LL |         #[rustc_symbol_name]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(impl1::foo::Foo::bar::he53b9bee7600ed8d)
+error: demangling(impl1::foo::Foo::bar::h92cf46db76791039)
   --> $DIR/impl1.rs:13:9
    |
 LL |         #[rustc_symbol_name]
@@ -22,13 +22,13 @@ error: def-path(foo::Foo::bar)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN5impl13bar33_$LT$impl$u20$impl1..foo..Foo$GT$3baz17h86c41f0462d901d4E)
+error: symbol-name(_ZN5impl13bar33_$LT$impl$u20$impl1..foo..Foo$GT$3baz17h90c4a800b1aa0df0E)
   --> $DIR/impl1.rs:31:9
    |
 LL |         #[rustc_symbol_name]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(impl1::bar::<impl impl1::foo::Foo>::baz::h86c41f0462d901d4)
+error: demangling(impl1::bar::<impl impl1::foo::Foo>::baz::h90c4a800b1aa0df0)
   --> $DIR/impl1.rs:31:9
    |
 LL |         #[rustc_symbol_name]
@@ -46,13 +46,13 @@ error: def-path(bar::<impl foo::Foo>::baz)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17h636bc933fc62ee2fE)
+error: symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17h61b0fcb05ebeeb79E)
   --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method::h636bc933fc62ee2f)
+error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method::h61b0fcb05ebeeb79)
   --> $DIR/impl1.rs:61:13
    |
 LL |             #[rustc_symbol_name]

--- a/src/test/ui/symbol-names/issue-60925.legacy.stderr
+++ b/src/test/ui/symbol-names/issue-60925.legacy.stderr
@@ -1,10 +1,10 @@
-error: symbol-name(_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$3foo17h059a991a004536adE)
+error: symbol-name(_ZN11issue_609253foo37Foo$LT$issue_60925..llv$u6d$..Foo$GT$3foo17hc86312d25b60f6eeE)
   --> $DIR/issue-60925.rs:21:9
    |
 LL |         #[rustc_symbol_name]
    |         ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo::h059a991a004536ad)
+error: demangling(issue_60925::foo::Foo<issue_60925::llvm::Foo>::foo::hc86312d25b60f6ee)
   --> $DIR/issue-60925.rs:21:9
    |
 LL |         #[rustc_symbol_name]

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-Self-issue-58006.stderr
@@ -1,4 +1,4 @@
-error[E0533]: expected unit struct, unit variant or constant, found tuple variant `<Self>::A`
+error[E0533]: expected unit struct, unit variant or constant, found tuple variant `Self::A`
   --> $DIR/incorrect-variant-form-through-Self-issue-58006.rs:8:13
    |
 LL |             Self::A => (),

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.rs
@@ -8,14 +8,14 @@ type Alias = Enum;
 
 fn main() {
     Alias::Braced;
-    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `Alias::Braced` [E0533]
     let Alias::Braced = panic!();
-    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced` [E0533]
+    //~^ ERROR expected unit struct, unit variant or constant, found struct variant `Alias::Braced` [E0533]
     let Alias::Braced(..) = panic!();
-    //~^ ERROR expected tuple struct or tuple variant, found struct variant `<Alias>::Braced` [E0164]
+    //~^ ERROR expected tuple struct or tuple variant, found struct variant `Alias::Braced` [E0164]
 
     Alias::Unit();
-    //~^ ERROR expected function, found enum variant `<Alias>::Unit`
+    //~^ ERROR expected function, found enum variant `Alias::Unit`
     let Alias::Unit() = panic!();
-    //~^ ERROR expected tuple struct or tuple variant, found unit variant `<Alias>::Unit` [E0164]
+    //~^ ERROR expected tuple struct or tuple variant, found unit variant `Alias::Unit` [E0164]
 }

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -1,38 +1,38 @@
-error[E0533]: expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:10:5
    |
 LL |     Alias::Braced;
    |     ^^^^^^^^^^^^^
 
-error[E0533]: expected unit struct, unit variant or constant, found struct variant `<Alias>::Braced`
+error[E0533]: expected unit struct, unit variant or constant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:12:9
    |
 LL |     let Alias::Braced = panic!();
    |         ^^^^^^^^^^^^^
 
-error[E0164]: expected tuple struct or tuple variant, found struct variant `<Alias>::Braced`
+error[E0164]: expected tuple struct or tuple variant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:14:9
    |
 LL |     let Alias::Braced(..) = panic!();
    |         ^^^^^^^^^^^^^^^^^ not a tuple variant or struct
 
-error[E0618]: expected function, found enum variant `<Alias>::Unit`
+error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:17:5
    |
 LL | enum Enum { Braced {}, Unit, Tuple() }
-   |                        ---- `<Alias>::Unit` defined here
+   |                        ---- `Alias::Unit` defined here
 ...
 LL |     Alias::Unit();
    |     ^^^^^^^^^^^--
    |     |
    |     call expression requires function
    |
-help: `<Alias>::Unit` is a unit variant, you need to write it without the parenthesis
+help: `Alias::Unit` is a unit variant, you need to write it without the parenthesis
    |
-LL |     <Alias>::Unit;
-   |     ^^^^^^^^^^^^^
+LL |     Alias::Unit;
+   |     ^^^^^^^^^^^
 
-error[E0164]: expected tuple struct or tuple variant, found unit variant `<Alias>::Unit`
+error[E0164]: expected tuple struct or tuple variant, found unit variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:19:9
    |
 LL |     let Alias::Unit() = panic!();

--- a/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for (A,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(A,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
@@ -13,7 +13,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !DefaultedTrait for (B,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `(B,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `lib::DefaultedTrait`, can only be implemented for a struct/enum type defined in the current crate
@@ -28,7 +28,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for lib::Something<C> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
    |
-   = note: the impl does not reference only types defined in this crate
+   = note: `lib::Something<C>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for (A,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^----
    | |                       |
-   | |                       `(A,)` is not defined in the current crate because tuples are always foreign
+   | |                       this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -15,7 +15,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !DefaultedTrait for (B,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^----
    | |                        |
-   | |                        `(B,)` is not defined in the current crate because tuples are always foreign
+   | |                        this is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -32,7 +32,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for lib::Something<C> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^-----------------
    | |                       |
-   | |                       `lib::Something<C>` is not defined in the current crate
+   | |                       `lib::Something` is not defined in the current crate
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
@@ -4,7 +4,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl DefaultedTrait for (A,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^----
    | |                       |
-   | |                       `(A,)` is not defined in the current crate
+   | |                       `(A,)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead
@@ -15,7 +15,7 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
 LL | impl !DefaultedTrait for (B,) { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^----
    | |                        |
-   | |                        `(B,)` is not defined in the current crate
+   | |                        `(B,)` is not defined in the current crate because tuples are always foreign
    | impl doesn't use only types from inside the current crate
    |
    = note: define and implement a trait or new type instead

--- a/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
+++ b/src/test/ui/typeck/typeck-default-trait-impl-cross-crate-coherence.stderr
@@ -2,18 +2,22 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/typeck-default-trait-impl-cross-crate-coherence.rs:13:1
    |
 LL | impl DefaultedTrait for (A,) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^----
+   | |                       |
+   | |                       `(A,)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(A,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
   --> $DIR/typeck-default-trait-impl-cross-crate-coherence.rs:16:1
    |
 LL | impl !DefaultedTrait for (B,) { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^----
+   | |                        |
+   | |                        `(B,)` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `(B,)` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error[E0321]: cross-crate traits with a default impl, like `lib::DefaultedTrait`, can only be implemented for a struct/enum type defined in the current crate
@@ -26,9 +30,11 @@ error[E0117]: only traits defined in the current crate can be implemented for ar
   --> $DIR/typeck-default-trait-impl-cross-crate-coherence.rs:21:1
    |
 LL | impl DefaultedTrait for lib::Something<C> { }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl doesn't use types inside crate
+   | ^^^^^^^^^^^^^^^^^^^^^^^^-----------------
+   | |                       |
+   | |                       `lib::Something<C>` is not defined in the current crate
+   | impl doesn't use only types from inside the current crate
    |
-   = note: `lib::Something<C>` is not defined in the current create
    = note: define and implement a trait or new type instead
 
 error: aborting due to 4 previous errors


### PR DESCRIPTION
Successful merges:

 - #65294 (Lint ignored `#[inline]` on function prototypes)
 - #65318 (Call out the types that are non local on E0117)
 - #65531 (Update backtrace to 0.3.40)
 - #65562 (Improve the "try using a variant of the expected type" hint.)
 - #65809 (Add new EFIAPI ABI)

Failed merges:


r? @ghost