### PR TITLE
Use rustc-workspace-hack for rustbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,6 +3103,7 @@ dependencies = [
  "failure",
  "mdbook",
  "mdbook-linkcheck",
+ "rustc-workspace-hack",
 ]
 
 [[package]]

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -244,6 +244,7 @@ pub fn prepare_tool_cargo(
             path.ends_with("rls") ||
             path.ends_with("clippy") ||
             path.ends_with("miri") ||
+            path.ends_with("rustbook") ||
             path.ends_with("rustfmt")
         {
             cargo.env("LIBZ_SYS_STATIC", "1");

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -13,6 +13,11 @@ clap = "2.25.0"
 failure = "0.1"
 mdbook-linkcheck = { version = "0.3.0", optional = true }
 
+# A noop dependency that changes in the Rust repository, it's a bit of a hack.
+# See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
+# for more information.
+rustc-workspace-hack = "1.0.0"
+
 [dependencies.mdbook]
 version = "0.3.0"
 default-features = false


### PR DESCRIPTION
As rustbook now depends transitively on openssl, it needs access to the
rustc-workspace-hack/all-static feature to pick up openssl-sys/vendored.
This fixes the rust build with `all-static = true` on systems where
openssl is not installed (e.g. when cross-compiling).