### PR TITLE
Don't use eval_always for miri queries used from codegen.

### DIFF
--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -462,13 +462,11 @@ rustc_queries! {
         query const_field(
             key: ty::ParamEnvAnd<'tcx, (&'tcx ty::Const<'tcx>, mir::Field)>
         ) -> &'tcx ty::Const<'tcx> {
-            eval_always
             no_force
             desc { "extract field of const" }
         }
 
         query const_caller_location(key: (syntax_pos::Symbol, u32, u32)) -> &'tcx ty::Const<'tcx> {
-            eval_always
             no_force
             desc { "get a &core::panic::Location referring to a span" }
         }


### PR DESCRIPTION
This should fix the [massive incremental perf regression](https://perf.rust-lang.org/compare.html?start=95f437b3cfb2fec966d7eaf69d7c2e36f9c274d1&end=9285d401a6070094747465962bc49969b93e14c5&stat=instructions:u) introduced in #65664.

It seems that `eval_always` was mistakenly(?) added to `const_field` and then it ended up on `const_caller_location` (which is used much more often than `const_field` is).

r? @michaelwoerister cc @oli-obk @nnethercote 