### PR TITLE
save-analysis: Account for async desugaring in async fn return types

### DIFF
--- a/src/test/ui/save-analysis/issue-65590.rs
+++ b/src/test/ui/save-analysis/issue-65590.rs
@@ -1,0 +1,21 @@
+// check-pass
+// compile-flags: -Zsave-analysis
+// edition:2018
+
+// Async desugaring for return types in (associated) functions introduces a
+// separate definition internally, which we need to take into account
+// (or else we ICE).
+trait Trait { type Assoc; }
+struct Struct;
+
+async fn foobar<T: Trait>() -> T::Assoc {
+    unimplemented!()
+}
+
+impl Struct {
+    async fn foo<T: Trait>(&self) -> T::Assoc {
+        unimplemented!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #65590 

When visiting the return type of an async function we need to take into account its desugaring, since it introduces a new definition under which the return type is redefined.

r? @nikomatsakis 