### PR TITLE
Add more context to `async fn` trait error. Suggest `async-trait`.

### DIFF
--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -244,7 +244,12 @@ impl<'a> AstValidator<'a> {
     fn check_trait_fn_not_async(&self, span: Span, asyncness: IsAsync) {
         if asyncness.is_async() {
             struct_span_err!(self.session, span, E0706,
-                             "trait fns cannot be declared `async`").emit()
+                             "trait fns cannot be declared `async`")
+                .note("Due to technical restrictions rust does not currently support `async` \
+                       trait fns.")
+                .note("Consider using the `async-trait` crate in the meantime until further \
+                       notice.")
+                .emit();
         }
     }
 


### PR DESCRIPTION
Addresses #65899 

I decided to keep the information a bit more generic and not provide a link to the technical blog post following @estebank suggestion. 

I can put the link to the blog post if you feel like it's worth it. I definitely learned quite a bit from it and it forced me to dig a bit further into other concepts that I wasn't entirely familiar with either.

The error output now looks like this for example:
```
error[E0706]: trait fns cannot be declared `async`
 --> src/main.rs:2:5
  |
2 |     async fn foo() {}
  |     ^^^^^^^^^^^^^^^^^
  |
  = note: Due to technical restrictions rust does not currently support `async` trait fns.
  = note: Consider using the `async-trait` crate in the meantime until further notice.
```