### PR TITLE
Use new promoter to emit errors when required promotion fails

### DIFF
--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -80,6 +80,17 @@ pub enum Candidate {
     Argument { bb: BasicBlock, index: usize },
 }
 
+impl Candidate {
+    /// Returns `true` if we should use the "explicit" rules for promotability for this `Candidate`.
+    fn is_explicit_context(&self) -> bool {
+        match self {
+            Candidate::Ref(_) |
+            Candidate::Repeat(_) => false,
+            Candidate::Argument { .. } => true,
+        }
+    }
+}
+
 fn args_required_const(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Vec<usize>> {
     let attrs = tcx.get_attrs(def_id);
     let attr = attrs.iter().find(|a| a.check_name(sym::rustc_args_required_const))?;
@@ -727,11 +738,7 @@ pub fn validate_candidates(
     };
 
     candidates.iter().copied().filter(|&candidate| {
-        validator.explicit = match candidate {
-            Candidate::Ref(_) |
-            Candidate::Repeat(_) => false,
-            Candidate::Argument { .. } => true,
-        };
+        validator.explicit = candidate.is_explicit_context();
 
         // FIXME(eddyb) also emit the errors for shuffle indices
         // and `#[rustc_args_required_const]` arguments here.


### PR DESCRIPTION
This PR adds error reporting to `promote_consts` for when a `#[rustc_args_required_const]` argument cannot be promoted. This required some minor refactoring, notably `TempState`s are now determined in a separate MIR `Visitor` from the one that collects `Candidate`s for promotion, and `Candidate`s are validated at the same time they are collected.

This is another step on the road to removing the existing `qualify_consts` entirely.

r? @eddyb