### PR TITLE
Point at method call when type annotations are needed

### DIFF
--- a/src/librustc/infer/error_reporting/mod.rs
+++ b/src/librustc/infer/error_reporting/mod.rs
@@ -70,6 +70,7 @@ use std::{cmp, fmt};
 mod note;
 
 mod need_type_info;
+pub use need_type_info::TypeAnnotationNeeded;
 
 pub mod nice_region_error;
 

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -22,7 +22,7 @@ use crate::hir;
 use crate::hir::Node;
 use crate::hir::def_id::DefId;
 use crate::infer::{self, InferCtxt};
-use crate::infer::error_reporting::TypeAnnotationNeeded::*;
+use crate::infer::error_reporting::TypeAnnotationNeeded as ErrorCode;
 use crate::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use crate::session::DiagnosticMessageId;
 use crate::ty::{self, AdtKind, DefIdTree, ToPredicate, ToPolyTraitRef, Ty, TyCtxt, TypeFoldable};
@@ -1989,10 +1989,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 if self.tcx.lang_items().sized_trait()
                     .map_or(false, |sized_id| sized_id == trait_ref.def_id())
                 {
-                    self.need_type_info_err(body_id, span, self_ty, E0282).emit();
+                    self.need_type_info_err(body_id, span, self_ty, ErrorCode::E0282).emit();
                     return;
                 }
-                let mut err = self.need_type_info_err(body_id, span, self_ty, E0283);
+                let mut err = self.need_type_info_err(body_id, span, self_ty, ErrorCode::E0283);
                 err.note(&format!("cannot resolve `{}`", predicate));
                 err
             }
@@ -2003,7 +2003,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 if ty.references_error() || self.tcx.sess.has_errors() {
                     return;
                 }
-                self.need_type_info_err(body_id, span, ty, E0282)
+                self.need_type_info_err(body_id, span, ty, ErrorCode::E0282)
             }
 
             ty::Predicate::Subtype(ref data) => {
@@ -2014,7 +2014,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 let &SubtypePredicate { a_is_expected: _, a, b } = data.skip_binder();
                 // both must be type variables, or the other would've been instantiated
                 assert!(a.is_ty_var() && b.is_ty_var());
-                self.need_type_info_err(body_id, span, a, E0282)
+                self.need_type_info_err(body_id, span, a, ErrorCode::E0282)
             }
             ty::Predicate::Projection(ref data) => {
                 let trait_ref = data.to_poly_trait_ref(self.tcx);
@@ -2022,7 +2022,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 if predicate.references_error() {
                     return;
                 }
-                let mut err = self.need_type_info_err(body_id, span, self_ty, E0284);
+                let mut err = self.need_type_info_err(body_id, span, self_ty, ErrorCode::E0284);
                 err.note(&format!("cannot resolve `{}`", predicate));
                 err
             }

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -338,6 +338,8 @@ pub struct TypeckTables<'tcx> {
     /// typeck::check::fn_ctxt for details.
     node_types: ItemLocalMap<Ty<'tcx>>,
 
+    node_method_sig: ItemLocalMap<ty::PolyFnSig<'tcx>>,
+
     /// Stores the type parameters which were substituted to obtain the type
     /// of this node. This only applies to nodes that refer to entities
     /// parameterized by type parameters, such as generic fns, types, or
@@ -442,6 +444,7 @@ impl<'tcx> TypeckTables<'tcx> {
             user_provided_types: Default::default(),
             user_provided_sigs: Default::default(),
             node_types: Default::default(),
+            node_method_sig: Default::default(),
             node_substs: Default::default(),
             adjustments: Default::default(),
             pat_binding_modes: Default::default(),
@@ -539,6 +542,20 @@ impl<'tcx> TypeckTables<'tcx> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.node_types
+        }
+    }
+
+    pub fn node_method_sig(&self) -> LocalTableInContext<'_, ty::PolyFnSig<'tcx>> {
+        LocalTableInContext {
+            local_id_root: self.local_id_root,
+            data: &self.node_method_sig
+        }
+    }
+
+    pub fn node_method_sig_mut(&mut self) -> LocalTableInContextMut<'_, ty::PolyFnSig<'tcx>> {
+        LocalTableInContextMut {
+            local_id_root: self.local_id_root,
+            data: &mut self.node_method_sig
         }
     }
 
@@ -748,6 +765,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             ref user_provided_types,
             ref user_provided_sigs,
             ref node_types,
+            ref node_method_sig,
             ref node_substs,
             ref adjustments,
             ref pat_binding_modes,
@@ -774,6 +792,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             user_provided_types.hash_stable(hcx, hasher);
             user_provided_sigs.hash_stable(hcx, hasher);
             node_types.hash_stable(hcx, hasher);
+            node_method_sig.hash_stable(hcx, hasher);
             node_substs.hash_stable(hcx, hasher);
             adjustments.hash_stable(hcx, hasher);
             pat_binding_modes.hash_stable(hcx, hasher);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -338,8 +338,6 @@ pub struct TypeckTables<'tcx> {
     /// typeck::check::fn_ctxt for details.
     node_types: ItemLocalMap<Ty<'tcx>>,
 
-    node_method_def_id: ItemLocalMap<DefId>,
-
     /// Stores the type parameters which were substituted to obtain the type
     /// of this node. This only applies to nodes that refer to entities
     /// parameterized by type parameters, such as generic fns, types, or
@@ -444,7 +442,6 @@ impl<'tcx> TypeckTables<'tcx> {
             user_provided_types: Default::default(),
             user_provided_sigs: Default::default(),
             node_types: Default::default(),
-            node_method_def_id: Default::default(),
             node_substs: Default::default(),
             adjustments: Default::default(),
             pat_binding_modes: Default::default(),
@@ -542,20 +539,6 @@ impl<'tcx> TypeckTables<'tcx> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
             data: &mut self.node_types
-        }
-    }
-
-    pub fn node_method_def_id(&self) -> LocalTableInContext<'_, DefId> {
-        LocalTableInContext {
-            local_id_root: self.local_id_root,
-            data: &self.node_method_def_id
-        }
-    }
-
-    pub fn node_method_def_id_mut(&mut self) -> LocalTableInContextMut<'_, DefId> {
-        LocalTableInContextMut {
-            local_id_root: self.local_id_root,
-            data: &mut self.node_method_def_id
         }
     }
 
@@ -765,7 +748,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             ref user_provided_types,
             ref user_provided_sigs,
             ref node_types,
-            ref node_method_def_id,
             ref node_substs,
             ref adjustments,
             ref pat_binding_modes,
@@ -792,7 +774,6 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             user_provided_types.hash_stable(hcx, hasher);
             user_provided_sigs.hash_stable(hcx, hasher);
             node_types.hash_stable(hcx, hasher);
-            node_method_def_id.hash_stable(hcx, hasher);
             node_substs.hash_stable(hcx, hasher);
             adjustments.hash_stable(hcx, hasher);
             pat_binding_modes.hash_stable(hcx, hasher);

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -338,7 +338,7 @@ pub struct TypeckTables<'tcx> {
     /// typeck::check::fn_ctxt for details.
     node_types: ItemLocalMap<Ty<'tcx>>,
 
-    node_method_sig: ItemLocalMap<ty::PolyFnSig<'tcx>>,
+    node_method_def_id: ItemLocalMap<DefId>,
 
     /// Stores the type parameters which were substituted to obtain the type
     /// of this node. This only applies to nodes that refer to entities
@@ -444,7 +444,7 @@ impl<'tcx> TypeckTables<'tcx> {
             user_provided_types: Default::default(),
             user_provided_sigs: Default::default(),
             node_types: Default::default(),
-            node_method_sig: Default::default(),
+            node_method_def_id: Default::default(),
             node_substs: Default::default(),
             adjustments: Default::default(),
             pat_binding_modes: Default::default(),
@@ -545,17 +545,17 @@ impl<'tcx> TypeckTables<'tcx> {
         }
     }
 
-    pub fn node_method_sig(&self) -> LocalTableInContext<'_, ty::PolyFnSig<'tcx>> {
+    pub fn node_method_def_id(&self) -> LocalTableInContext<'_, DefId> {
         LocalTableInContext {
             local_id_root: self.local_id_root,
-            data: &self.node_method_sig
+            data: &self.node_method_def_id
         }
     }
 
-    pub fn node_method_sig_mut(&mut self) -> LocalTableInContextMut<'_, ty::PolyFnSig<'tcx>> {
+    pub fn node_method_def_id_mut(&mut self) -> LocalTableInContextMut<'_, DefId> {
         LocalTableInContextMut {
             local_id_root: self.local_id_root,
-            data: &mut self.node_method_sig
+            data: &mut self.node_method_def_id
         }
     }
 
@@ -765,7 +765,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             ref user_provided_types,
             ref user_provided_sigs,
             ref node_types,
-            ref node_method_sig,
+            ref node_method_def_id,
             ref node_substs,
             ref adjustments,
             ref pat_binding_modes,
@@ -792,7 +792,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckTables<'tcx> {
             user_provided_types.hash_stable(hcx, hasher);
             user_provided_sigs.hash_stable(hcx, hasher);
             node_types.hash_stable(hcx, hasher);
-            node_method_sig.hash_stable(hcx, hasher);
+            node_method_def_id.hash_stable(hcx, hasher);
             node_substs.hash_stable(hcx, hasher);
             adjustments.hash_stable(hcx, hasher);
             pat_binding_modes.hash_stable(hcx, hasher);

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -871,7 +871,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let method = match self.lookup_method(rcvr_t, segment, span, expr, rcvr) {
             Ok(method) => {
-                let sig = self.tcx.fn_sig(method.def_id);
                 // We could add a "consider `foo::<params>`" suggestion here, but I wasn't able to
                 // trigger this codepath causing `structuraly_resolved_type` to emit an error.
 
@@ -890,7 +889,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 //    |
                 //    = note: type must be known at this point
                 // ```
-                self.tables.borrow_mut().node_method_sig_mut().insert(expr.hir_id, sig);
+                self.tables.borrow_mut().node_method_def_id_mut().insert(
+                    expr.hir_id,
+                    method.def_id,
+                );
 
                 self.write_method_call(expr.hir_id, method);
                 Ok(method)

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -874,26 +874,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // We could add a "consider `foo::<params>`" suggestion here, but I wasn't able to
                 // trigger this codepath causing `structuraly_resolved_type` to emit an error.
 
-                // We could do this only when type params are present in the method to reducte
-                // memory usage, but doing it unconditionally lets us also point at the method
-                // expression and state the resolved return value:
-                // ```
-                // error[E0282]: type annotations needed
-                //    --> $DIR/issue-65611.rs:59:20
-                //    |
-                // LL |     let x = buffer.last().unwrap().0.clone();
-                //    |             -------^^^^--
-                //    |             |      |
-                //    |             |      cannot infer type for `T`
-                //    |             this method call resolves to `std::option::Option<&T>`
-                //    |
-                //    = note: type must be known at this point
-                // ```
-                self.tables.borrow_mut().node_method_def_id_mut().insert(
-                    expr.hir_id,
-                    method.def_id,
-                );
-
                 self.write_method_call(expr.hir_id, method);
                 Ok(method)
             }

--- a/src/librustc_typeck/check/expr.rs
+++ b/src/librustc_typeck/check/expr.rs
@@ -871,6 +871,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let method = match self.lookup_method(rcvr_t, segment, span, expr, rcvr) {
             Ok(method) => {
+                let sig = self.tcx.fn_sig(method.def_id);
+                // We could add a "consider `foo::<params>`" suggestion here, but I wasn't able to
+                // trigger this codepath causing `structuraly_resolved_type` to emit an error.
+
+                // We could do this only when type params are present in the method to reducte
+                // memory usage, but doing it unconditionally lets us also point at the method
+                // expression and state the resolved return value:
+                // ```
+                // error[E0282]: type annotations needed
+                //    --> $DIR/issue-65611.rs:59:20
+                //    |
+                // LL |     let x = buffer.last().unwrap().0.clone();
+                //    |             -------^^^^--
+                //    |             |      |
+                //    |             |      cannot infer type for `T`
+                //    |             this method call resolves to `std::option::Option<&T>`
+                //    |
+                //    = note: type must be known at this point
+                // ```
+                self.tables.borrow_mut().node_method_sig_mut().insert(expr.hir_id, sig);
+
                 self.write_method_call(expr.hir_id, method);
                 Ok(method)
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -5359,7 +5359,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty
         } else {
             if !self.is_tainted_by_errors() {
-                self.need_type_info_err((**self).body_id, sp, ty)
+                self.need_type_info_err((**self).body_id, sp, ty, false)
                     .note("type must be known at this point")
                     .emit();
             }

--- a/src/librustc_typeck/check/mod.rs
+++ b/src/librustc_typeck/check/mod.rs
@@ -103,6 +103,7 @@ use rustc_index::vec::Idx;
 use rustc_target::spec::abi::Abi;
 use rustc::infer::opaque_types::OpaqueTypeDecl;
 use rustc::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
+use rustc::infer::error_reporting::TypeAnnotationNeeded::E0282;
 use rustc::infer::unify_key::{ConstVariableOrigin, ConstVariableOriginKind};
 use rustc::middle::region;
 use rustc::mir::interpret::{ConstValue, GlobalId};
@@ -5359,7 +5360,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty
         } else {
             if !self.is_tainted_by_errors() {
-                self.need_type_info_err((**self).body_id, sp, ty, false)
+                self.need_type_info_err((**self).body_id, sp, ty, E0282)
                     .note("type must be known at this point")
                     .emit();
             }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -717,7 +717,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
     fn report_error(&self, t: Ty<'tcx>) {
         if !self.tcx.sess.has_errors() {
             self.infcx
-                .need_type_info_err(Some(self.body.id()), self.span.to_span(self.tcx), t)
+                .need_type_info_err(Some(self.body.id()), self.span.to_span(self.tcx), t, false)
                 .emit();
         }
     }

--- a/src/librustc_typeck/check/writeback.rs
+++ b/src/librustc_typeck/check/writeback.rs
@@ -8,6 +8,7 @@ use rustc::hir;
 use rustc::hir::def_id::{DefId, DefIndex};
 use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::infer::InferCtxt;
+use rustc::infer::error_reporting::TypeAnnotationNeeded::E0282;
 use rustc::ty::adjustment::{Adjust, Adjustment, PointerCast};
 use rustc::ty::fold::{TypeFoldable, TypeFolder};
 use rustc::ty::{self, Ty, TyCtxt};
@@ -717,7 +718,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
     fn report_error(&self, t: Ty<'tcx>) {
         if !self.tcx.sess.has_errors() {
             self.infcx
-                .need_type_info_err(Some(self.body.id()), self.span.to_span(self.tcx), t, false)
+                .need_type_info_err(Some(self.body.id()), self.span.to_span(self.tcx), t, E0282)
                 .emit();
         }
     }

--- a/src/test/ui/associated-const/issue-63496.rs
+++ b/src/test/ui/associated-const/issue-63496.rs
@@ -2,8 +2,8 @@ trait A {
     const C: usize;
 
     fn f() -> ([u8; A::C], [u8; A::C]);
-    //~^ ERROR: type annotations needed: cannot resolve
-    //~| ERROR: type annotations needed: cannot resolve
+    //~^ ERROR: type annotations needed
+    //~| ERROR: type annotations needed
 }
 
 fn main() {}

--- a/src/test/ui/associated-const/issue-63496.stderr
+++ b/src/test/ui/associated-const/issue-63496.stderr
@@ -1,20 +1,24 @@
-error[E0283]: type annotations needed: cannot resolve `_: A`
+error[E0283]: type annotations needed
   --> $DIR/issue-63496.rs:4:21
    |
 LL |     const C: usize;
    |     --------------- required by `A::C`
 LL | 
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
-   |                     ^^^^
+   |                     ^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: A`
 
-error[E0283]: type annotations needed: cannot resolve `_: A`
+error[E0283]: type annotations needed
   --> $DIR/issue-63496.rs:4:33
    |
 LL |     const C: usize;
    |     --------------- required by `A::C`
 LL | 
 LL |     fn f() -> ([u8; A::C], [u8; A::C]);
-   |                                 ^^^^
+   |                                 ^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: A`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-item/issue-48027.stderr
+++ b/src/test/ui/associated-item/issue-48027.stderr
@@ -7,13 +7,15 @@ LL |     const X: usize;
 LL | impl dyn Bar {}
    |      ^^^^^^^ the trait `Bar` cannot be made into an object
 
-error[E0283]: type annotations needed: cannot resolve `_: Bar`
+error[E0283]: type annotations needed
   --> $DIR/issue-48027.rs:3:32
    |
 LL |     const X: usize;
    |     --------------- required by `Bar::X`
 LL |     fn return_n(&self) -> [u8; Bar::X];
-   |                                ^^^^^^
+   |                                ^^^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: Bar`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -1,18 +1,23 @@
-error[E0284]: type annotations needed: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
+error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:4:1
    |
 LL | trait Foo: Iterator<Item = i32> {}
    | ------------------------------- required by `Foo`
 LL | trait Bar: Foo<Item = u32> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `Self`
+   |
+   = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 
-error[E0282]: type annotations needed
+error[E0284]: type annotations needed
   --> $DIR/associated-types-overridden-binding.rs:7:1
    |
+LL | trait I32Iterator = Iterator<Item = i32>;
+   | ----------------------------------------- required by `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `Self`
+   |
+   = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 
 error: aborting due to 2 previous errors
 
-Some errors have detailed explanations: E0282, E0284.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -4,7 +4,7 @@ error[E0284]: type annotations needed
 LL | trait Foo: Iterator<Item = i32> {}
    | ------------------------------- required by `Foo`
 LL | trait Bar: Foo<Item = u32> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `Self`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
    = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 
@@ -14,7 +14,7 @@ error[E0284]: type annotations needed
 LL | trait I32Iterator = Iterator<Item = i32>;
    | ----------------------------------------- required by `I32Iterator`
 LL | trait U32Iterator = I32Iterator<Item = u32>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `Self`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `Self`
    |
    = note: cannot resolve `<Self as std::iter::Iterator>::Item == i32`
 

--- a/src/test/ui/associated-types/associated-types-unconstrained.stderr
+++ b/src/test/ui/associated-types/associated-types-unconstrained.stderr
@@ -1,8 +1,10 @@
-error[E0284]: type annotations needed: cannot resolve `<_ as Foo>::A == _`
+error[E0284]: type annotations needed
   --> $DIR/associated-types-unconstrained.rs:14:20
    |
 LL |     let x: isize = Foo::bar();
-   |                    ^^^^^^^^
+   |                    ^^^^^^^^ cannot infer type
+   |
+   = note: cannot resolve `<_ as Foo>::A == _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/unresolved_type_param.rs
+++ b/src/test/ui/async-await/unresolved_type_param.rs
@@ -8,7 +8,7 @@ async fn bar<T>() -> () {}
 async fn foo() {
     bar().await;
     //~^ ERROR type inside `async fn` body must be known in this context
-    //~| NOTE cannot infer type for `T`
+    //~| NOTE cannot infer type for type parameter `T`
     //~| NOTE the type is part of the `async fn` body because of this `await`
     //~| NOTE in this expansion of desugaring of `await`
 }

--- a/src/test/ui/async-await/unresolved_type_param.stderr
+++ b/src/test/ui/async-await/unresolved_type_param.stderr
@@ -2,7 +2,7 @@ error[E0698]: type inside `async fn` body must be known in this context
   --> $DIR/unresolved_type_param.rs:9:5
    |
 LL |     bar().await;
-   |     ^^^ cannot infer type for `T`
+   |     ^^^ cannot infer type for type parameter `T`
    |
 note: the type is part of the `async fn` body because of this `await`
   --> $DIR/unresolved_type_param.rs:9:5

--- a/src/test/ui/const-generics/cannot-infer-const-args.stderr
+++ b/src/test/ui/const-generics/cannot-infer-const-args.stderr
@@ -10,7 +10,7 @@ error[E0282]: type annotations needed
   --> $DIR/cannot-infer-const-args.rs:9:5
    |
 LL |     foo();
-   |     ^^^ cannot infer type for `fn() -> usize {foo::<_: usize>}`
+   |     ^^^ cannot infer type for fn item `fn() -> usize {foo::<_: usize>}`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/fn-const-param-infer.stderr
+++ b/src/test/ui/const-generics/fn-const-param-infer.stderr
@@ -30,7 +30,7 @@ error[E0282]: type annotations needed
   --> $DIR/fn-const-param-infer.rs:22:23
    |
 LL |     let _ = Checked::<generic>;
-   |                       ^^^^^^^ cannot infer type for `T`
+   |                       ^^^^^^^ cannot infer type for type parameter `T`
 
 error[E0308]: mismatched types
   --> $DIR/fn-const-param-infer.rs:25:40

--- a/src/test/ui/consts/issue-64662.stderr
+++ b/src/test/ui/consts/issue-64662.stderr
@@ -2,13 +2,13 @@ error[E0282]: type annotations needed
   --> $DIR/issue-64662.rs:2:9
    |
 LL |     A = foo(),
-   |         ^^^ cannot infer type for `T`
+   |         ^^^ cannot infer type for type parameter `T`
 
 error[E0282]: type annotations needed
   --> $DIR/issue-64662.rs:3:9
    |
 LL |     B = foo(),
-   |         ^^^ cannot infer type for `T`
+   |         ^^^ cannot infer type for type parameter `T`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0283.stderr
+++ b/src/test/ui/error-codes/E0283.stderr
@@ -1,11 +1,13 @@
-error[E0283]: type annotations needed: cannot resolve `_: Generator`
+error[E0283]: type annotations needed
   --> $DIR/E0283.rs:18:21
    |
 LL |     fn create() -> u32;
    |     ------------------- required by `Generator::create`
 ...
 LL |     let cont: u32 = Generator::create();
-   |                     ^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: Generator`
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0401.stderr
+++ b/src/test/ui/error-codes/E0401.stderr
@@ -36,7 +36,7 @@ error[E0282]: type annotations needed
   --> $DIR/E0401.rs:11:5
    |
 LL |     bfnr(x);
-   |     ^^^^ cannot infer type for `U`
+   |     ^^^^ cannot infer type for type parameter `U`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/issues/issue-12028.stderr
+++ b/src/test/ui/issues/issue-12028.stderr
@@ -1,8 +1,10 @@
-error[E0284]: type annotations needed: cannot resolve `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+error[E0284]: type annotations needed
   --> $DIR/issue-12028.rs:27:14
    |
 LL |         self.input_stream(&mut stream);
-   |              ^^^^^^^^^^^^
+   |              ^^^^^^^^^^^^ cannot infer type for `H`
+   |
+   = note: cannot resolve `<_ as StreamHasher>::S == <H as StreamHasher>::S`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-12028.stderr
+++ b/src/test/ui/issues/issue-12028.stderr
@@ -2,7 +2,7 @@ error[E0284]: type annotations needed
   --> $DIR/issue-12028.rs:27:14
    |
 LL |         self.input_stream(&mut stream);
-   |              ^^^^^^^^^^^^ cannot infer type for `H`
+   |              ^^^^^^^^^^^^ cannot infer type for type parameter `H`
    |
    = note: cannot resolve `<_ as StreamHasher>::S == <H as StreamHasher>::S`
 

--- a/src/test/ui/issues/issue-16966.stderr
+++ b/src/test/ui/issues/issue-16966.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-16966.rs:2:5
    |
 LL |     panic!(std::default::Default::default());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `M`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `M`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 

--- a/src/test/ui/issues/issue-17551.stderr
+++ b/src/test/ui/issues/issue-17551.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `B<T>`
   --> $DIR/issue-17551.rs:6:15
    |
 LL |     let foo = B(marker::PhantomData);
-   |         ---   ^ cannot infer type for `T`
+   |         ---   ^ cannot infer type for type parameter `T`
    |         |
    |         consider giving `foo` the explicit type `B<T>`, where the type parameter `T` is specified
 

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -11,7 +11,7 @@ LL | | {
 LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
-   | |_^ cannot infer type for `&'a T`
+   | |_^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,4 +1,4 @@
-error[E0283]: type annotations needed: cannot resolve `&'a T: Foo`
+error[E0283]: type annotations needed
   --> $DIR/issue-21974.rs:10:1
    |
 LL |   trait Foo {
@@ -11,7 +11,9 @@ LL | | {
 LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
-   | |_^
+   | |_^ cannot infer type for `&'a T`
+   |
+   = note: cannot resolve `&'a T: Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24424.rs
+++ b/src/test/ui/issues/issue-24424.rs
@@ -2,6 +2,6 @@ trait Trait1<'l0, T0> {}
 trait Trait0<'l0>  {}
 
 impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-//~^ ERROR type annotations needed: cannot resolve `T0: Trait0<'l0>`
+//~^ ERROR type annotations needed
 
 fn main() {}

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -5,7 +5,7 @@ LL | trait Trait0<'l0>  {}
    | ----------------- required by `Trait0`
 LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `T0`
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T0`
    |
    = note: cannot resolve `T0: Trait0<'l0>`
 

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,11 +1,13 @@
-error[E0283]: type annotations needed: cannot resolve `T0: Trait0<'l0>`
+error[E0283]: type annotations needed
   --> $DIR/issue-24424.rs:4:1
    |
 LL | trait Trait0<'l0>  {}
    | ----------------- required by `Trait0`
 LL | 
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for `T0`
+   |
+   = note: cannot resolve `T0: Trait0<'l0>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-25368.stderr
+++ b/src/test/ui/issues/issue-25368.stderr
@@ -5,7 +5,7 @@ LL |     let (tx, rx) = channel();
    |         -------- consider giving this pattern the explicit type `(std::sync::mpsc::Sender<Foo<T>>, std::sync::mpsc::Receiver<Foo<T>>)`, where the type parameter `T` is specified
 ...
 LL |         tx.send(Foo{ foo: PhantomData });
-   |                 ^^^ cannot infer type for `T`
+   |                 ^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-29147.rs
+++ b/src/test/ui/issues/issue-29147.rs
@@ -18,5 +18,5 @@ impl Foo for S5<u32> { fn xxx(&self) {} }
 impl Foo for S5<u64> { fn xxx(&self) {} }
 
 fn main() {
-    let _ = <S5<_>>::xxx; //~ ERROR cannot resolve `S5<_>: Foo`
+    let _ = <S5<_>>::xxx; //~ ERROR type annotations needed
 }

--- a/src/test/ui/issues/issue-29147.stderr
+++ b/src/test/ui/issues/issue-29147.stderr
@@ -5,7 +5,7 @@ LL | trait Foo { fn xxx(&self); }
    |             -------------- required by `Foo::xxx`
 ...
 LL |     let _ = <S5<_>>::xxx;
-   |             ^^^^^^^^^^^^ cannot infer type for `S5<_>`
+   |             ^^^^^^^^^^^^ cannot infer type for struct `S5<_>`
    |
    = note: cannot resolve `S5<_>: Foo`
 

--- a/src/test/ui/issues/issue-29147.stderr
+++ b/src/test/ui/issues/issue-29147.stderr
@@ -1,11 +1,13 @@
-error[E0283]: type annotations needed: cannot resolve `S5<_>: Foo`
+error[E0283]: type annotations needed
   --> $DIR/issue-29147.rs:21:13
    |
 LL | trait Foo { fn xxx(&self); }
    |             -------------- required by `Foo::xxx`
 ...
 LL |     let _ = <S5<_>>::xxx;
-   |             ^^^^^^^^^^^^
+   |             ^^^^^^^^^^^^ cannot infer type for `S5<_>`
+   |
+   = note: cannot resolve `S5<_>: Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-5062.stderr
+++ b/src/test/ui/issues/issue-5062.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-5062.rs:1:29
    |
 LL | fn main() { format!("{:?}", None); }
-   |                             ^^^^ cannot infer type for `T`
+   |                             ^^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -4,14 +4,16 @@ error[E0379]: trait fns cannot be declared const
 LL |     const fn const_val<T: Sized>() -> usize {
    |     ^^^^^ trait fns cannot be const
 
-error[E0283]: type annotations needed: cannot resolve `_: Tt`
+error[E0283]: type annotations needed
   --> $DIR/issue-54954.rs:3:24
    |
 LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 ...
 LL |     const fn const_val<T: Sized>() -> usize {
    |              --------- - required by this bound in `Tt::const_val`
+   |
+   = note: cannot resolve `_: Tt`
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-54954.rs:13:15

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -8,7 +8,10 @@ error[E0283]: type annotations needed
   --> $DIR/issue-54954.rs:3:24
    |
 LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                        |
+   |                        cannot infer type
+   |                        help: consider specifying the type argument in the function call: `Tt::const_val::<[i8; 123]>::<T>`
 ...
 LL |     const fn const_val<T: Sized>() -> usize {
    |              --------- - required by this bound in `Tt::const_val`

--- a/src/test/ui/issues/issue-54954.stderr
+++ b/src/test/ui/issues/issue-54954.stderr
@@ -8,10 +8,7 @@ error[E0283]: type annotations needed
   --> $DIR/issue-54954.rs:3:24
    |
 LL | const ARR_LEN: usize = Tt::const_val::<[i8; 123]>();
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                        |
-   |                        cannot infer type
-   |                        help: consider specifying the type argument in the function call: `Tt::const_val::<[i8; 123]>::<T>`
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 ...
 LL |     const fn const_val<T: Sized>() -> usize {
    |              --------- - required by this bound in `Tt::const_val`

--- a/src/test/ui/issues/issue-58022.rs
+++ b/src/test/ui/issues/issue-58022.rs
@@ -2,7 +2,7 @@ pub trait Foo: Sized {
     const SIZE: usize;
 
     fn new(slice: &[u8; Foo::SIZE]) -> Self;
-    //~^ ERROR: type annotations needed: cannot resolve `_: Foo`
+    //~^ ERROR: type annotations needed
 }
 
 pub struct Bar<T: ?Sized>(T);

--- a/src/test/ui/issues/issue-58022.stderr
+++ b/src/test/ui/issues/issue-58022.stderr
@@ -4,14 +4,16 @@ error[E0423]: expected function, tuple struct or tuple variant, found trait `Foo
 LL |         Foo(Box::new(*slice))
    |         ^^^ not a function, tuple struct or tuple variant
 
-error[E0283]: type annotations needed: cannot resolve `_: Foo`
+error[E0283]: type annotations needed
   --> $DIR/issue-58022.rs:4:25
    |
 LL |     const SIZE: usize;
    |     ------------------ required by `Foo::SIZE`
 LL | 
 LL |     fn new(slice: &[u8; Foo::SIZE]) -> Self;
-   |                         ^^^^^^^^^
+   |                         ^^^^^^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: Foo`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-6458-2.stderr
+++ b/src/test/ui/issues/issue-6458-2.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-6458-2.rs:3:21
    |
 LL |     format!("{:?}", None);
-   |                     ^^^^ cannot infer type for `T`
+   |                     ^^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-6458.stderr
+++ b/src/test/ui/issues/issue-6458.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-6458.rs:9:4
    |
 LL |    foo(TypeWithState(marker::PhantomData));
-   |    ^^^ cannot infer type for `State`
+   |    ^^^ cannot infer type for type parameter `State`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-65611.stderr
+++ b/src/test/ui/issues/issue-65611.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     let x = buffer.last().unwrap().0.clone();
    |             -------^^^^--
    |             |      |
-   |             |      cannot infer type for `T`
+   |             |      cannot infer type for type parameter `T`
    |             this method call resolves to `std::option::Option<&T>`
    |
    = note: type must be known at this point

--- a/src/test/ui/issues/issue-65611.stderr
+++ b/src/test/ui/issues/issue-65611.stderr
@@ -2,7 +2,10 @@ error[E0282]: type annotations needed
   --> $DIR/issue-65611.rs:59:20
    |
 LL |     let x = buffer.last().unwrap().0.clone();
-   |                    ^^^^ cannot infer type for `T`
+   |                    ^^^^
+   |                    |
+   |                    cannot infer type for `T`
+   |                    help: consider specifying the type argument in the method call: `last::<_>`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/issues/issue-65611.stderr
+++ b/src/test/ui/issues/issue-65611.stderr
@@ -2,10 +2,10 @@ error[E0282]: type annotations needed
   --> $DIR/issue-65611.rs:59:20
    |
 LL |     let x = buffer.last().unwrap().0.clone();
-   |                    ^^^^
-   |                    |
-   |                    cannot infer type for `T`
-   |                    help: consider specifying the type argument in the method call: `last::<_>`
+   |             -------^^^^--
+   |             |      |
+   |             |      cannot infer type for `T`
+   |             this method call resolves to `std::option::Option<&T>`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
+++ b/src/test/ui/methods/method-ambig-one-trait-unknown-int-type.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/method-ambig-one-trait-unknown-int-type.rs:24:17
    |
 LL |     let mut x = Vec::new();
-   |         -----   ^^^^^^^^ cannot infer type for `T`
+   |         -----   ^^^^^^^^ cannot infer type for type parameter `T`
    |         |
    |         consider giving `x` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/missing-type-parameter.rs:4:5
    |
 LL |     foo();
-   |     ^^^ cannot infer type for `X`
+   |     ^^^ cannot infer type for type parameter `X`
 
 error: aborting due to previous error
 

--- a/src/test/ui/question-mark-type-infer.rs
+++ b/src/test/ui/question-mark-type-infer.rs
@@ -9,7 +9,7 @@ fn f(x: &i32) -> Result<i32, ()> {
 
 fn g() -> Result<Vec<i32>, ()> {
     let l = [1, 2, 3, 4];
-    l.iter().map(f).collect()? //~ ERROR type annotations needed: cannot resolve
+    l.iter().map(f).collect()? //~ ERROR type annotations needed
 }
 
 fn main() {

--- a/src/test/ui/question-mark-type-infer.stderr
+++ b/src/test/ui/question-mark-type-infer.stderr
@@ -5,7 +5,7 @@ LL |     l.iter().map(f).collect()?
    |                     ^^^^^^^
    |                     |
    |                     cannot infer type
-   |                     help: consider specifying the type argument in the method call: `collect::<_>`
+   |                     help: consider specifying the type argument in the method call: `collect::<B>`
    |
    = note: cannot resolve `<_ as std::ops::Try>::Ok == _`
 

--- a/src/test/ui/question-mark-type-infer.stderr
+++ b/src/test/ui/question-mark-type-infer.stderr
@@ -1,8 +1,13 @@
-error[E0284]: type annotations needed: cannot resolve `<_ as std::ops::Try>::Ok == _`
-  --> $DIR/question-mark-type-infer.rs:12:5
+error[E0284]: type annotations needed
+  --> $DIR/question-mark-type-infer.rs:12:21
    |
 LL |     l.iter().map(f).collect()?
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^^
+   |                     |
+   |                     cannot infer type
+   |                     help: consider specifying the type argument in the method call: `collect::<_>`
+   |
+   = note: cannot resolve `<_ as std::ops::Try>::Ok == _`
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.rs
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.rs
@@ -9,8 +9,8 @@ fn shines_a_beacon_through_the_darkness() {
 }
 
 fn courier_to_des_moines_and_points_west(data: &[u32]) -> String {
-    data.iter() //~ ERROR type annotations needed
-        .sum::<_>()
+    data.iter()
+        .sum::<_>() //~ ERROR type annotations needed
         .to_string()
 }
 

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -9,11 +9,10 @@ LL |     x.unwrap().method_that_could_exist_on_some_type();
    = note: type must be known at this point
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-42234-unknown-receiver-type.rs:12:5
+  --> $DIR/issue-42234-unknown-receiver-type.rs:13:10
    |
-LL | /     data.iter()
-LL | |         .sum::<_>()
-   | |___________________^ cannot infer type
+LL |         .sum::<_>()
+   |          ^^^ cannot infer type
    |
    = note: type must be known at this point
 

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed for `std::option::Option<_>`
 LL |     let x: Option<_> = None;
    |         - consider giving `x` the explicit type `std::option::Option<_>`, where the type parameter `T` is specified
 LL |     x.unwrap().method_that_could_exist_on_some_type();
-   |       ^^^^^^ cannot infer type for `T`
+   |       ^^^^^^ cannot infer type for type parameter `T`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -2,7 +2,10 @@ error[E0282]: type annotations needed
   --> $DIR/type-annotations-needed-expr.rs:2:39
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
-   |                                       ^^^ cannot infer type for `S`
+   |                                       ^^^
+   |                                       |
+   |                                       cannot infer type for `S`
+   |                                       help: consider specifying the type argument in the method call: `sum::<_>`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^
    |                                       |
-   |                                       cannot infer type for `S`
+   |                                       cannot infer type for type parameter `S`
    |                                       help: consider specifying the type argument in the method call: `sum::<S>`
    |
    = note: type must be known at this point

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -5,7 +5,7 @@ LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^
    |                                       |
    |                                       cannot infer type for `S`
-   |                                       help: consider specifying the type argument in the method call: `sum::<_>`
+   |                                       help: consider specifying the type argument in the method call: `sum::<S>`
    |
    = note: type must be known at this point
 

--- a/src/test/ui/traits/trait-static-method-generic-inference.stderr
+++ b/src/test/ui/traits/trait-static-method-generic-inference.stderr
@@ -1,11 +1,13 @@
-error[E0283]: type annotations needed: cannot resolve `_: base::HasNew<base::Foo>`
+error[E0283]: type annotations needed
   --> $DIR/trait-static-method-generic-inference.rs:24:25
    |
 LL |         fn new() -> T;
    |         -------------- required by `base::HasNew::new`
 ...
 LL |     let _f: base::Foo = base::HasNew::new();
-   |                         ^^^^^^^^^^^^^^^^^
+   |                         ^^^^^^^^^^^^^^^^^ cannot infer type
+   |
+   = note: cannot resolve `_: base::HasNew<base::Foo>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/traits-multidispatch-convert-ambig-dest.stderr
+++ b/src/test/ui/traits/traits-multidispatch-convert-ambig-dest.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/traits-multidispatch-convert-ambig-dest.rs:26:5
    |
 LL |     test(22, std::default::Default::default());
-   |     ^^^^ cannot infer type for `U`
+   |     ^^^^ cannot infer type for type parameter `U`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-inference/or_else-multiple-type-params.rs
+++ b/src/test/ui/type-inference/or_else-multiple-type-params.rs
@@ -1,0 +1,10 @@
+use std::process::{Command, Stdio};
+
+fn main() {
+    let process = Command::new("wc")
+        .stdout(Stdio::piped())
+        .spawn()
+        .or_else(|err| { //~ ERROR type annotations needed
+            panic!("oh no: {:?}", err);
+        }).unwrap();
+}

--- a/src/test/ui/type-inference/or_else-multiple-type-params.stderr
+++ b/src/test/ui/type-inference/or_else-multiple-type-params.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |         .or_else(|err| {
    |          ^^^^^^^
    |          |
-   |          cannot infer type for `F`
+   |          cannot infer type for type parameter `F`
    |          help: consider specifying the type arguments in the method call: `or_else::<F, O>`
 
 error: aborting due to previous error

--- a/src/test/ui/type-inference/or_else-multiple-type-params.stderr
+++ b/src/test/ui/type-inference/or_else-multiple-type-params.stderr
@@ -1,0 +1,12 @@
+error[E0282]: type annotations needed
+  --> $DIR/or_else-multiple-type-params.rs:7:10
+   |
+LL |         .or_else(|err| {
+   |          ^^^^^^^
+   |          |
+   |          cannot infer type for `F`
+   |          help: consider specifying the type arguments in the method call: `or_else::<F, O>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/type-inference/sort_by_key.rs
+++ b/src/test/ui/type-inference/sort_by_key.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let mut lst: [([i32; 10], bool); 10] = [([0; 10], false); 10];
+    lst.sort_by_key(|&(v, _)| v.iter().sum()); //~ ERROR type annotations needed
+    println!("{:?}", lst);
+}

--- a/src/test/ui/type-inference/sort_by_key.stderr
+++ b/src/test/ui/type-inference/sort_by_key.stderr
@@ -4,7 +4,7 @@ error[E0282]: type annotations needed
 LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
    |         ^^^^^^^^^^^                    --- help: consider specifying the type argument in the method call: `sum::<S>`
    |         |
-   |         cannot infer type for `K`
+   |         cannot infer type for type parameter `K`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-inference/sort_by_key.stderr
+++ b/src/test/ui/type-inference/sort_by_key.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/sort_by_key.rs:3:9
+   |
+LL |     lst.sort_by_key(|&(v, _)| v.iter().sum());
+   |         ^^^^^^^^^^^                    --- help: consider specifying the type argument in the method call: `sum::<S>`
+   |         |
+   |         cannot infer type for `K`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/type-inference/unbounded-associated-type.rs
+++ b/src/test/ui/type-inference/unbounded-associated-type.rs
@@ -1,0 +1,16 @@
+trait T {
+    type A;
+    fn foo(&self) -> Self::A {
+        panic!()
+    }
+}
+
+struct S<X>(std::marker::PhantomData<X>);
+
+impl<X> T for S<X> {
+   type A = X;
+}
+
+fn main() {
+    S(std::marker::PhantomData).foo(); //~ ERROR type annotations needed
+}

--- a/src/test/ui/type-inference/unbounded-associated-type.stderr
+++ b/src/test/ui/type-inference/unbounded-associated-type.stderr
@@ -1,0 +1,15 @@
+error[E0282]: type annotations needed
+  --> $DIR/unbounded-associated-type.rs:15:5
+   |
+LL |     type A;
+   |     ------- `<Self as T>::A` defined here
+...
+LL |     S(std::marker::PhantomData).foo();
+   |     ^--------------------------------
+   |     |
+   |     this method call resolves to `<Self as T>::A`
+   |     cannot infer type for type parameter `X`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.rs
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.rs
@@ -1,0 +1,9 @@
+#[allow(invalid_type_param_default)]
+
+fn foo<T, U = u64>() -> (T, U) {
+    panic!()
+}
+
+fn main() {
+    foo(); //~ ERROR type annotations needed
+}

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-6458-3.rs:4:5
+  --> $DIR/unbounded-type-param-in-fn-with-assoc-type.rs:8:5
    |
-LL |     mem::transmute(0);
-   |     ^^^^^^^^^^^^^^ cannot infer type for type parameter `U`
+LL |     foo();
+   |     ^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn.rs
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn.rs
@@ -1,0 +1,7 @@
+fn foo<T>() -> T {
+    panic!()
+}
+
+fn main() {
+    foo(); //~ ERROR type annotations needed
+}

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn.stderr
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn.stderr
@@ -1,8 +1,8 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-6458-3.rs:4:5
+  --> $DIR/unbounded-type-param-in-fn.rs:6:5
    |
-LL |     mem::transmute(0);
-   |     ^^^^^^^^^^^^^^ cannot infer type for type parameter `U`
+LL |     foo();
+   |     ^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-annotation-needed.rs
+++ b/src/test/ui/type/type-annotation-needed.rs
@@ -5,4 +5,6 @@ fn foo<T: Into<String>>(x: i32) {}
 fn main() {
     foo(42);
     //~^ ERROR type annotations needed
+    //~| NOTE cannot infer type
+    //~| NOTE cannot resolve
 }

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -5,7 +5,10 @@ LL | fn foo<T: Into<String>>(x: i32) {}
    |    ---    ------------ required by this bound in `foo`
 ...
 LL |     foo(42);
-   |     ^^^ cannot infer type for `T`
+   |     ^^^
+   |     |
+   |     cannot infer type for `T`
+   |     help: consider specifying the type argument in the function call: `foo::<T>`
    |
    = note: cannot resolve `_: std::convert::Into<std::string::String>`
 

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -7,7 +7,7 @@ LL | fn foo<T: Into<String>>(x: i32) {}
 LL |     foo(42);
    |     ^^^
    |     |
-   |     cannot infer type for `T`
+   |     cannot infer type for type parameter `T`
    |     help: consider specifying the type argument in the function call: `foo::<T>`
    |
    = note: cannot resolve `_: std::convert::Into<std::string::String>`

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,11 +1,13 @@
-error[E0283]: type annotations needed: cannot resolve `_: std::convert::Into<std::string::String>`
+error[E0283]: type annotations needed
   --> $DIR/type-annotation-needed.rs:6:5
    |
 LL | fn foo<T: Into<String>>(x: i32) {}
    |    ---    ------------ required by this bound in `foo`
 ...
 LL |     foo(42);
-   |     ^^^
+   |     ^^^ cannot infer type for `T`
+   |
+   = note: cannot resolve `_: std::convert::Into<std::string::String>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/cannot_infer_local_or_vec.rs:2:13
    |
 LL |     let x = vec![];
-   |         -   ^^^^^^ cannot infer type for `T`
+   |         -   ^^^^^^ cannot infer type for type parameter `T`
    |         |
    |         consider giving `x` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_vec_in_tuples.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `(std::vec::Vec<T>,)`
   --> $DIR/cannot_infer_local_or_vec_in_tuples.rs:2:18
    |
 LL |     let (x, ) = (vec![], );
-   |         -----    ^^^^^^ cannot infer type for `T`
+   |         -----    ^^^^^^ cannot infer type for type parameter `T`
    |         |
    |         consider giving this pattern the explicit type `(std::vec::Vec<T>,)`, where the type parameter `T` is specified
    |

--- a/src/test/ui/type/type-check/issue-22897.stderr
+++ b/src/test/ui/type/type-check/issue-22897.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/issue-22897.rs:4:5
    |
 LL |     [];
-   |     ^^ cannot infer type for `[_; 0]`
+   |     ^^ cannot infer type for array `[_; 0]`
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -11,7 +11,7 @@ LL | | {
 LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
-   | |_^ cannot infer type for `&'a T`
+   | |_^ cannot infer type for reference `&'a T`
    |
    = note: cannot resolve `&'a T: Foo`
 

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,4 +1,4 @@
-error[E0283]: type annotations needed: cannot resolve `&'a T: Foo`
+error[E0283]: type annotations needed
   --> $DIR/issue-40294.rs:5:1
    |
 LL |   trait Foo: Sized {
@@ -11,7 +11,9 @@ LL | | {
 LL | |     x.foo();
 LL | |     y.foo();
 LL | | }
-   | |_^
+   | |_^ cannot infer type for `&'a T`
+   |
+   = note: cannot resolve `&'a T: Foo`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unconstrained-none.stderr
+++ b/src/test/ui/unconstrained-none.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/unconstrained-none.rs:4:5
    |
 LL |     None;
-   |     ^^^^ cannot infer type for `T`
+   |     ^^^^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/unconstrained-ref.stderr
+++ b/src/test/ui/unconstrained-ref.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed
   --> $DIR/unconstrained-ref.rs:6:5
    |
 LL |     S { o: &None };
-   |     ^ cannot infer type for `T`
+   |     ^ cannot infer type for type parameter `T`
 
 error: aborting due to previous error
 

--- a/src/test/ui/vector-no-ann.stderr
+++ b/src/test/ui/vector-no-ann.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `std::vec::Vec<T>`
   --> $DIR/vector-no-ann.rs:2:16
    |
 LL |     let _foo = Vec::new();
-   |         ----   ^^^^^^^^ cannot infer type for `T`
+   |         ----   ^^^^^^^^ cannot infer type for type parameter `T`
    |         |
    |         consider giving `_foo` the explicit type `std::vec::Vec<T>`, where the type parameter `T` is specified
 


### PR DESCRIPTION
- Point at method call instead of whole expression when type annotations are needed.
- Suggest use of turbofish on function and methods.

Fix #49391, fix #46333, fix #48089. CC #58517, #63502, #63082.

Fixes https://github.com/rust-lang/rust/issues/40015

r? @nikomatsakis 