### PR TITLE
ci: revert msys2 ca-certificates hack

### DIFF
--- a/src/ci/scripts/install-msys2-packages.sh
+++ b/src/ci/scripts/install-msys2-packages.sh
@@ -8,14 +8,6 @@ source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 if isWindows; then
     pacman -S --noconfirm --needed base-devel ca-certificates make diffutils tar
 
-    # FIXME(#65767): workaround msys bug, step 2
-    arch=i686
-    if [ "$MSYS_BITS" = "64" ]; then
-      arch=x86_64
-    fi
-    pacman -U --noconfirm --noprogressbar mingw-w64-$arch-ca-certificates-20180409-1-any.pkg.tar.xz
-    rm mingw-w64-$arch-ca-certificates-20180409-1-any.pkg.tar.xz
-
     # Make sure we use the native python interpreter instead of some msys equivalent
     # one way or another. The msys interpreters seem to have weird path conversions
     # baked in which break LLVM's build system one way or another, so let's use the

--- a/src/ci/scripts/install-msys2.sh
+++ b/src/ci/scripts/install-msys2.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# ignore-tidy-linelength
 # Download and install MSYS2, needed primarily for the test suite (run-make) but
 # also used by the MinGW toolchain for assembling things.
 #
@@ -13,13 +12,6 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isWindows; then
-    # FIXME(#65767): workaround msys bug, step 1
-    arch=i686
-    if [ "$MSYS_BITS" = "64" ]; then
-      arch=x86_64
-    fi
-    curl -O "${MIRRORS_BASE}/msys2-repo/mingw/$arch/mingw-w64-$arch-ca-certificates-20180409-1-any.pkg.tar.xz"
-
     choco install msys2 --params="/InstallDir:${SYSTEM_WORKFOLDER}/msys2 /NoPath" -y --no-progress
     mkdir -p "${SYSTEM_WORKFOLDER}/msys2/home/${USERNAME}"
 


### PR DESCRIPTION
The hack was added because upstream msys2 broke the ca-certificates package, but since then it has been fixed. This reverts CI to use the upstream package.

Part of #65767