### PR TITLE
Adjust close delim span

### DIFF
--- a/src/libsyntax/parse/tests.rs
+++ b/src/libsyntax/parse/tests.rs
@@ -135,6 +135,28 @@ fn string_to_tts_1() {
     })
 }
 
+#[test]
+fn string_to_tts_2() {
+    with_default_globals(|| {
+        let tts = string_to_stream("fn main(\u{063c}".to_string());
+
+        let expected = TokenStream::new(vec![
+            TokenTree::token(token::Ident(kw::Fn, false), sp(0, 2)).into(),
+            TokenTree::token(token::Ident(Name::intern("main"), false), sp(3, 7)).into(),
+            TokenTree::Delimited(
+                DelimSpan::from_pair(sp(7, 8), sp(10, 10)),
+                token::DelimToken::Paren,
+                TokenStream::new(vec![
+                    TokenTree::token(token::Ident(Name::intern("\u{063c}"), false),
+                    sp(8, 10)).into(),
+                ]).into(),
+            ).into()
+        ]);
+
+        assert_eq!(tts, expected);
+    })
+}
+
 #[test] fn parse_use() {
     with_default_globals(|| {
         let use_s = "use foo::bar::baz;";

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -115,6 +115,7 @@ impl TokenTree {
         let open_span = if span.is_dummy() {
             span
         } else {
+            assert!(span.lo() != span.hi());
             span.with_hi(span.lo() + BytePos(delim.len() as u32))
         };
         TokenTree::token(token::OpenDelim(delim), open_span)
@@ -122,7 +123,7 @@ impl TokenTree {
 
     /// Returns the closing delimiter as a token tree.
     pub fn close_tt(span: Span, delim: DelimToken) -> TokenTree {
-        let close_span = if span.is_dummy() {
+        let close_span = if span.is_dummy() || span.lo() == span.hi() {
             span
         } else {
             span.with_lo(span.hi() - BytePos(delim.len() as u32))

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -33,7 +33,7 @@ LL | )
    |
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
-  --> $DIR/issue-62973.rs:8:1
+  --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
    |          ----- while parsing this match expression

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -39,7 +39,7 @@ LL | fn p() { match s { v, E { [) {) }
    |          ----- while parsing this match expression
 LL | 
 LL | 
-   | ^ expected one of `.`, `?`, `{`, or an operator here
+   |  ^ expected one of `.`, `?`, `{`, or an operator here
 
 error: incorrect close delimiter: `)`
   --> $DIR/issue-62973.rs:6:28

--- a/src/test/ui/parser/issue-63135.stderr
+++ b/src/test/ui/parser/issue-63135.stderr
@@ -23,13 +23,13 @@ LL | fn i(n{...,f #
    |        `..` must be at the end and cannot have a trailing comma
 
 error: expected `[`, found `}`
-  --> $DIR/issue-63135.rs:3:15
+  --> $DIR/issue-63135.rs:3:16
    |
 LL | fn i(n{...,f #
    |                ^ expected `[`
 
 error: expected one of `:` or `|`, found `)`
-  --> $DIR/issue-63135.rs:3:15
+  --> $DIR/issue-63135.rs:3:16
    |
 LL | fn i(n{...,f #
    |                ^ expected one of `:` or `|` here

--- a/src/test/ui/parser/issue-63135.stderr
+++ b/src/test/ui/parser/issue-63135.stderr
@@ -26,13 +26,13 @@ error: expected `[`, found `}`
   --> $DIR/issue-63135.rs:3:15
    |
 LL | fn i(n{...,f #
-   |               ^ expected `[`
+   |                ^ expected `[`
 
 error: expected one of `:` or `|`, found `)`
   --> $DIR/issue-63135.rs:3:15
    |
 LL | fn i(n{...,f #
-   |               ^ expected one of `:` or `|` here
+   |                ^ expected one of `:` or `|` here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/missing_right_paren.rs
+++ b/src/test/ui/parser/missing_right_paren.rs
@@ -1,0 +1,3 @@
+// ignore-tidy-trailing-newlines
+// error-pattern: aborting due to 2 previous errors
+fn main((ؼ

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -1,0 +1,17 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/missing_right_paren.rs:3:11
+   |
+LL | fn main((ؼ
+   |        -- ^
+   |        ||
+   |        |un-closed delimiter
+   |        un-closed delimiter
+
+error: expected one of `:` or `|`, found `)`
+  --> $DIR/missing_right_paren.rs:3:11
+   |
+LL | fn main((ؼ
+   |           ^ expected one of `:` or `|` here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/62524

The only thing that's not quite perfect is that I need to update two existing unit tests... If I remove the newline in these two files, then the "^" position looks reasonable. Any hints how to adjust that? Or do you think this fix is a good start? (at least it fixes the ICE).
