### PR TITLE
Fix incorrect diagnostics for expected type in E0271 with an associated type

### DIFF
--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -5,10 +5,10 @@ LL | fn blue_car<C:Car<Color=Blue>>(c: C) {
    |    --------       ---------- required by this bound in `blue_car`
 ...
 LL | fn b() { blue_car(ModelT); }
-   |          ^^^^^^^^ expected struct `Black`, found struct `Blue`
+   |          ^^^^^^^^ expected struct `Blue`, found struct `Black`
    |
-   = note: expected type `Black`
-              found type `Blue`
+   = note: expected type `Blue`
+              found type `Black`
 
 error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
@@ -17,10 +17,10 @@ LL | fn black_car<C:Car<Color=Black>>(c: C) {
    |    ---------       ----------- required by this bound in `black_car`
 ...
 LL | fn c() { black_car(ModelU); }
-   |          ^^^^^^^^^ expected struct `Blue`, found struct `Black`
+   |          ^^^^^^^^^ expected struct `Black`, found struct `Blue`
    |
-   = note: expected type `Blue`
-              found type `Black`
+   = note: expected type `Black`
+              found type `Blue`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/associated-types-eq-3.rs
+++ b/src/test/ui/associated-types/associated-types-eq-3.rs
@@ -37,8 +37,8 @@ pub fn main() {
     let a = 42;
     foo1(a);
     //~^ ERROR type mismatch resolving
-    //~| expected usize, found struct `Bar`
+    //~| expected struct `Bar`, found usize
     baz(&a);
     //~^ ERROR type mismatch resolving
-    //~| expected usize, found struct `Bar`
+    //~| expected struct `Bar`, found usize
 }

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -16,19 +16,19 @@ LL | fn foo1<I: Foo<A=Bar>>(x: I) {
    |    ----        ----- required by this bound in `foo1`
 ...
 LL |     foo1(a);
-   |     ^^^^ expected usize, found struct `Bar`
+   |     ^^^^ expected struct `Bar`, found usize
    |
-   = note: expected type `usize`
-              found type `Bar`
+   = note: expected type `Bar`
+              found type `usize`
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:41:9
    |
 LL |     baz(&a);
-   |         ^^ expected usize, found struct `Bar`
+   |         ^^ expected struct `Bar`, found usize
    |
-   = note: expected type `usize`
-              found type `Bar`
+   = note: expected type `Bar`
+              found type `usize`
    = note: required for the cast to the object type `dyn Foo<A = Bar>`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -7,10 +7,10 @@ LL |     where T : for<'x> TheTrait<&'x isize, A = &'x isize>
    |                                           ------------- required by this bound in `foo`
 ...
 LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ expected usize, found isize
+   |     ^^^^^^^^^^^^^^^^^ expected isize, found usize
    |
-   = note: expected type `&usize`
-              found type `&isize`
+   = note: expected type `&isize`
+              found type `&usize`
 
 error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
   --> $DIR/associated-types-eq-hr.rs:86:5
@@ -21,10 +21,10 @@ LL |     where T : for<'x> TheTrait<&'x isize, A = &'x usize>
    |                                           ------------- required by this bound in `bar`
 ...
 LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ expected isize, found usize
+   |     ^^^^^^^^^^^^^^^^ expected usize, found isize
    |
-   = note: expected type `&isize`
-              found type `&usize`
+   = note: expected type `&usize`
+              found type `&isize`
 
 error[E0277]: the trait bound `for<'x, 'y> Tuple: TheTrait<(&'x isize, &'y isize)>` is not satisfied
   --> $DIR/associated-types-eq-hr.rs:91:17

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -5,10 +5,10 @@ LL | fn is_iterator_of<A, I: Iterator<Item=A>>(_: &I) {}
    |    --------------                ------ required by this bound in `is_iterator_of`
 ...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found enum `std::option::Option`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `std::option::Option`, found type parameter
    |
-   = note: expected type `T`
-              found type `std::option::Option<T>`
+   = note: expected type `std::option::Option<T>`
+              found type `T`
    = help: type parameters must be constrained to match other types
    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 

--- a/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
+++ b/src/test/ui/associated-types/associated-types-multiple-types-one-trait.stderr
@@ -2,28 +2,28 @@ error[E0271]: type mismatch resolving `<T as Foo>::Y == i32`
   --> $DIR/associated-types-multiple-types-one-trait.rs:13:5
    |
 LL |     want_y(t);
-   |     ^^^^^^ expected associated type, found i32
+   |     ^^^^^^ expected i32, found associated type
 ...
 LL | fn want_y<T:Foo<Y=i32>>(t: &T) { }
    |    ------       ----- required by this bound in `want_y`
    |
-   = note: expected type `<T as Foo>::Y`
-              found type `i32`
-   = note: consider constraining the associated type `<T as Foo>::Y` to `i32` or calling a method that returns `<T as Foo>::Y`
+   = note: expected type `i32`
+              found type `<T as Foo>::Y`
+   = note: consider constraining the associated type `<T as Foo>::Y` to `i32`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error[E0271]: type mismatch resolving `<T as Foo>::X == u32`
   --> $DIR/associated-types-multiple-types-one-trait.rs:18:5
    |
 LL |     want_x(t);
-   |     ^^^^^^ expected associated type, found u32
+   |     ^^^^^^ expected u32, found associated type
 ...
 LL | fn want_x<T:Foo<X=u32>>(t: &T) { }
    |    ------       ----- required by this bound in `want_x`
    |
-   = note: expected type `<T as Foo>::X`
-              found type `u32`
-   = note: consider constraining the associated type `<T as Foo>::X` to `u32` or calling a method that returns `<T as Foo>::X`
+   = note: expected type `u32`
+              found type `<T as Foo>::X`
+   = note: consider constraining the associated type `<T as Foo>::X` to `u32`
    = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/associated-types/associated-types-overridden-binding-2.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding-2.stderr
@@ -2,10 +2,10 @@ error[E0271]: type mismatch resolving `<std::vec::IntoIter<u32> as std::iter::It
   --> $DIR/associated-types-overridden-binding-2.rs:6:43
    |
 LL |     let _: &dyn I32Iterator<Item = u32> = &vec![42].into_iter();
-   |                                           ^^^^^^^^^^^^^^^^^^^^^ expected u32, found i32
+   |                                           ^^^^^^^^^^^^^^^^^^^^^ expected i32, found u32
    |
-   = note: expected type `u32`
-              found type `i32`
+   = note: expected type `i32`
+              found type `u32`
    = note: required for the cast to the object type `dyn std::iter::Iterator<Item = u32, Item = i32>`
 
 error: aborting due to previous error

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -33,10 +33,10 @@ error[E0271]: type mismatch resolving `<impl std::future::Future as std::future:
   --> $DIR/async-block-control-flow-static-semantics.rs:18:39
    |
 LL |     let _: &dyn Future<Output = ()> = &block;
-   |                                       ^^^^^^ expected u8, found ()
+   |                                       ^^^^^^ expected (), found u8
    |
-   = note: expected type `u8`
-              found type `()`
+   = note: expected type `()`
+              found type `u8`
    = note: required for the cast to the object type `dyn std::future::Future<Output = ()>`
 
 error[E0308]: mismatched types
@@ -59,10 +59,10 @@ error[E0271]: type mismatch resolving `<impl std::future::Future as std::future:
   --> $DIR/async-block-control-flow-static-semantics.rs:27:39
    |
 LL |     let _: &dyn Future<Output = ()> = &block;
-   |                                       ^^^^^^ expected u8, found ()
+   |                                       ^^^^^^ expected (), found u8
    |
-   = note: expected type `u8`
-              found type `()`
+   = note: expected type `()`
+              found type `u8`
    = note: required for the cast to the object type `dyn std::future::Future<Output = ()>`
 
 error[E0308]: mismatched types

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -5,10 +5,10 @@ LL | fn foo<T>(t: T) where T: Trait<AssociatedType=u32> {
    |    ---                         ------------------ required by this bound in `foo`
 ...
 LL |     foo(3_i8);
-   |     ^^^ expected reference, found u32
+   |     ^^^ expected u32, found reference
    |
-   = note: expected type `&'static str`
-              found type `u32`
+   = note: expected type `u32`
+              found type `&'static str`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24204.stderr
+++ b/src/test/ui/issues/issue-24204.stderr
@@ -5,10 +5,10 @@ LL | trait Trait: Sized {
    | ------------------ required by `Trait`
 ...
 LL | fn test<T: Trait<B=i32>>(b: i32) -> T where T::A: MultiDispatch<i32> { T::new(b) }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found type parameter
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found associated type
    |
-   = note: expected type `<<T as Trait>::A as MultiDispatch<i32>>::O`
-              found type `T`
+   = note: expected type `T`
+              found type `<<T as Trait>::A as MultiDispatch<i32>>::O`
    = note: you might be missing a type parameter or trait bound
 
 error: aborting due to previous error


### PR DESCRIPTION
With code like the following code:

```rust
#[derive(Debug)]
struct Data {}

fn do_stuff<'a>(iterator: impl Iterator<Item = &'a Data>) {
    for item in iterator {
        println!("{:?}", item)
    }
}

fn main() {
    let v = vec![Data {}];
    
    do_stuff(v.into_iter());
}
```

the diagnostic (in nightly & stable) wrongly complains about the expected type:

```
error[E0271]: type mismatch resolving `<std::vec::IntoIter<Data> as std::iter::Iterator>::Item == &Data`
  --> src/main.rs:15:5
   |
5  | fn do_stuff<'a>(iterator: impl Iterator<Item = &'a Data>) {
   |    --------                             --------------- required by this bound in `do_stuff`
...
15 |     do_stuff(v.into_iter());
   |     ^^^^^^^^ expected struct `Data`, found &Data
   |
   = note: expected type `Data`
              found type `&Data`
```

This PR fixes this issue by flipping the expected/actual values where appropriate, so it looks like this:

```
error[E0271]: type mismatch resolving `<std::vec::IntoIter<Data> as std::iter::Iterator>::Item == &Data`
  --> main.rs:15:5
   |
5  | fn do_stuff<'a>(iterator: impl Iterator<Item = &'a Data>) {
   |    --------                             --------------- required by this bound in `do_stuff`
...
15 |     do_stuff(v.into_iter());
   |     ^^^^^^^^ expected &Data, found struct `Data`
   |
   = note: expected type `&Data`
              found type `Data`
```

This improves the output of a lot of existing tests (check out `associated-types-binding-to-type-defined-in-supertrait`!).

The only change which I wasn't too sure about is in the test `associated-types-overridden-binding-2`, but I think it's an improvement and the underlying problem is with handling of `trait_alias`.

Fix #57226, fix #64760, fix #58092.