### PR TITLE
work around aggressive syntax feature gating

### DIFF
--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -133,6 +133,7 @@
 #[allow(unused)]
 use prelude::v1::*;
 
+#[cfg(not(test))] // See #65860
 #[macro_use]
 mod macros;
 
@@ -180,10 +181,14 @@ pub mod hint;
 
 /* Core language traits */
 
+#[cfg(not(test))] // See #65860
 pub mod marker;
 pub mod ops;
+#[cfg(not(test))] // See #65860
 pub mod cmp;
+#[cfg(not(test))] // See #65860
 pub mod clone;
+#[cfg(not(test))] // See #65860
 pub mod default;
 pub mod convert;
 pub mod borrow;
@@ -191,6 +196,7 @@ pub mod borrow;
 /* Core types and methods on primitives */
 
 pub mod any;
+#[cfg(not(test))] // See #65860
 pub mod array;
 pub mod ascii;
 pub mod sync;
@@ -198,7 +204,9 @@ pub mod cell;
 pub mod char;
 pub mod panic;
 pub mod panicking;
+#[cfg(not(test))] // See #65860
 pub mod pin;
+#[cfg(not(test))] // See #65860
 pub mod iter;
 pub mod option;
 pub mod raw;
@@ -206,14 +214,18 @@ pub mod result;
 pub mod ffi;
 
 pub mod slice;
+#[cfg(not(test))] // See #65860
 pub mod str;
+#[cfg(not(test))] // See #65860
 pub mod hash;
+#[cfg(not(test))] // See #65860
 pub mod fmt;
 pub mod time;
 
 pub mod unicode;
 
 /* Async */
+#[cfg(not(test))] // See #65860
 pub mod future;
 pub mod task;
 


### PR DESCRIPTION
This works around https://github.com/rust-lang/rust/issues/65860; fixing `rustc +nightly lib.rs --test --edition 2018` for libcore and thus unblocking https://github.com/RalfJung/miri-test-libstd.