### PR TITLE
Add error code E0743 for "C-variadic has been used on a non-foreign function"

### DIFF
--- a/src/libsyntax/error_codes.rs
+++ b/src/libsyntax/error_codes.rs
@@ -487,7 +487,6 @@ Erroneous code example:
                                // `test_2018_feature` is
                                // included in the Rust 2018 edition
 ```
-
 "##,
 
 E0725: r##"
@@ -503,6 +502,20 @@ Erroneous code example:
 
 Delete the offending feature attribute, or add it to the list of allowed
 features in the `-Z allow_features` flag.
+"##,
+
+E0743: r##"
+C-variadic has been used on a non-foreign function.
+
+Erroneous code example:
+
+```compile_fail,E0743
+fn foo2(x: u8, ...) {} // error!
+```
+
+Only foreign functions can use C-variadic (`...`). It is used to give an
+undefined number of parameters to a given function (like `printf` in C). The
+equivalent in Rust would be to use macros directly.
 "##,
 
 ;

--- a/src/libsyntax/parse/parser/ty.rs
+++ b/src/libsyntax/parse/parser/ty.rs
@@ -197,8 +197,11 @@ impl<'a> Parser<'a> {
                 self.eat(&token::DotDotDot);
                 TyKind::CVarArgs
             } else {
-                return Err(self.fatal(
-                    "only foreign functions are allowed to be C-variadic"
+                return Err(struct_span_fatal!(
+                    self.sess.span_diagnostic,
+                    self.token.span,
+                    E0743,
+                    "only foreign functions are allowed to be C-variadic",
                 ));
             }
         } else {

--- a/src/test/ui/invalid/invalid-variadic-function.stderr
+++ b/src/test/ui/invalid/invalid-variadic-function.stderr
@@ -1,4 +1,4 @@
-error: only foreign functions are allowed to be C-variadic
+error[E0743]: only foreign functions are allowed to be C-variadic
   --> $DIR/invalid-variadic-function.rs:1:26
    |
 LL | extern "C" fn foo(x: u8, ...);
@@ -12,3 +12,4 @@ LL | extern "C" fn foo(x: u8, ...);
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0743`.

--- a/src/test/ui/parser/variadic-ffi-3.stderr
+++ b/src/test/ui/parser/variadic-ffi-3.stderr
@@ -1,4 +1,4 @@
-error: only foreign functions are allowed to be C-variadic
+error[E0743]: only foreign functions are allowed to be C-variadic
   --> $DIR/variadic-ffi-3.rs:1:18
    |
 LL | fn foo(x: isize, ...) {
@@ -6,3 +6,4 @@ LL | fn foo(x: isize, ...) {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0743`.

--- a/src/test/ui/parser/variadic-ffi-4.stderr
+++ b/src/test/ui/parser/variadic-ffi-4.stderr
@@ -1,4 +1,4 @@
-error: only foreign functions are allowed to be C-variadic
+error[E0743]: only foreign functions are allowed to be C-variadic
   --> $DIR/variadic-ffi-4.rs:1:29
    |
 LL | extern "C" fn foo(x: isize, ...) {
@@ -6,3 +6,4 @@ LL | extern "C" fn foo(x: isize, ...) {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0743`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/65967