### PR TITLE
Fix outdated rustdoc of Once::init_locking function

### DIFF
--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -492,10 +492,10 @@ impl<T> Once<T> {
         assert!(self.try_set(value).is_none());
     }
 
-    /// Tries to initialize the inner value by calling the closure while ensuring that no-one else
-    /// can access the value in the mean time by holding a lock for the duration of the closure.
-    /// If the value was already initialized the closure is not called and `false` is returned,
-    /// otherwise if the value from the closure initializes the inner value, `true` is returned
+    /// Initializes the inner value if it wasn't already done by calling the provided closure. It
+    /// ensures that no-one else can access the value in the mean time by holding a lock for the
+    /// duration of the closure.
+    /// A reference to the inner value is returned.
     #[inline]
     pub fn init_locking<F: FnOnce() -> T>(&self, f: F) -> &T {
         {


### PR DESCRIPTION
r? @Mark-Simulacrum 

related to https://github.com/rust-lang/rust/pull/65979