### PR TITLE
Partially revert the early feature-gatings added in #65742.

### DIFF
--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -443,6 +443,11 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                    "auto traits are experimental and possibly buggy");
             }
 
+            ast::ItemKind::MacroDef(ast::MacroDef { legacy: false, .. }) => {
+                let msg = "`macro` is experimental";
+                gate_feature_post!(&self, decl_macro, i.span, msg);
+            }
+
             ast::ItemKind::OpaqueTy(..) => {
                 gate_feature_post!(
                     &self,

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -876,6 +876,21 @@ pub fn check_crate(krate: &ast::Crate,
     gate_all!(yields, generators, "yield syntax is experimental");
     gate_all!(or_patterns, "or-patterns syntax is experimental");
     gate_all!(const_extern_fn, "`const extern fn` definitions are unstable");
+
+    // All uses of `gate_all!` below this point were added in #65742,
+    // and subsequently disabled (with the non-early gating readded).
+    macro_rules! gate_all {
+        ($gate:ident, $msg:literal) => {
+            // FIXME(eddyb) do something more useful than always
+            // disabling these uses of early feature-gatings.
+            if false {
+                for span in &*parse_sess.gated_spans.$gate.borrow() {
+                    gate_feature!(&visitor, $gate, *span, $msg);
+                }
+            }
+        }
+    }
+
     gate_all!(trait_alias, "trait aliases are experimental");
     gate_all!(associated_type_bounds, "associated type bounds are unstable");
     gate_all!(crate_visibility_modifier, "`crate` visibility modifier is experimental");

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -518,6 +518,12 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                        "type ascription is experimental");
                 }
             }
+            ast::ExprKind::Block(_, opt_label) => {
+                if let Some(label) = opt_label {
+                    gate_feature_post!(&self, label_break_value, label.ident.span,
+                                    "labels on blocks are unstable");
+                }
+            }
             _ => {}
         }
         visit::walk_expr(self, e)

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -3,7 +3,10 @@ use super::accepted::ACCEPTED_FEATURES;
 use super::removed::{REMOVED_FEATURES, STABLE_REMOVED_FEATURES};
 use super::builtin_attrs::{AttributeGate, BUILTIN_ATTRIBUTE_MAP};
 
-use crate::ast::{self, NodeId, GenericParam, GenericParamKind, PatKind, RangeEnd, VariantData};
+use crate::ast::{
+    self, AssocTyConstraint, AssocTyConstraintKind, NodeId, GenericParam, GenericParamKind,
+    PatKind, RangeEnd, VariantData,
+};
 use crate::attr::{self, check_builtin_attribute};
 use crate::source_map::Spanned;
 use crate::edition::{ALL_EDITIONS, Edition};
@@ -602,6 +605,16 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             _ => {}
         }
         visit::walk_generic_param(self, param)
+    }
+
+    fn visit_assoc_ty_constraint(&mut self, constraint: &'a AssocTyConstraint) {
+        match constraint.kind {
+            AssocTyConstraintKind::Bound { .. } =>
+                gate_feature_post!(&self, associated_type_bounds, constraint.span,
+                    "associated type bounds are unstable"),
+            _ => {}
+        }
+        visit::walk_assoc_ty_constraint(self, constraint)
     }
 
     fn visit_trait_item(&mut self, ti: &'a ast::TraitItem) {

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -502,6 +502,21 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
     }
 
+    fn visit_expr(&mut self, e: &'a ast::Expr) {
+        match e.kind {
+            ast::ExprKind::Type(..) => {
+                // To avoid noise about type ascription in common syntax errors, only emit if it
+                // is the *only* error.
+                if self.parse_sess.span_diagnostic.err_count() == 0 {
+                    gate_feature_post!(&self, type_ascription, e.span,
+                                       "type ascription is experimental");
+                }
+            }
+            _ => {}
+        }
+        visit::walk_expr(self, e)
+    }
+
     fn visit_pat(&mut self, pattern: &'a ast::Pat) {
         match &pattern.kind {
             PatKind::Slice(pats) => {

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -446,6 +446,15 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                    "auto traits are experimental and possibly buggy");
             }
 
+            ast::ItemKind::TraitAlias(..) => {
+                gate_feature_post!(
+                    &self,
+                    trait_alias,
+                    i.span,
+                    "trait aliases are experimental"
+                );
+            }
+
             ast::ItemKind::MacroDef(ast::MacroDef { legacy: false, .. }) => {
                 let msg = "`macro` is experimental";
                 gate_feature_post!(&self, decl_macro, i.span, msg);

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -153,6 +153,9 @@ fn leveled_feature_err<'a, S: Into<MultiSpan>>(
 
 }
 
+const EXPLAIN_BOX_SYNTAX: &str =
+    "box expression syntax is experimental; you can call `Box::new` instead";
+
 pub const EXPLAIN_STMT_ATTR_SYNTAX: &str =
     "attributes on expressions are experimental";
 
@@ -504,6 +507,9 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
 
     fn visit_expr(&mut self, e: &'a ast::Expr) {
         match e.kind {
+            ast::ExprKind::Box(_) => {
+                gate_feature_post!(&self, box_syntax, e.span, EXPLAIN_BOX_SYNTAX);
+            }
             ast::ExprKind::Type(..) => {
                 // To avoid noise about type ascription in common syntax errors, only emit if it
                 // is the *only* error.

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -661,6 +661,14 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
         visit::walk_impl_item(self, ii)
     }
+
+    fn visit_vis(&mut self, vis: &'a ast::Visibility) {
+        if let ast::VisibilityKind::Crate(ast::CrateSugar::JustCrate) = vis.node {
+            gate_feature_post!(&self, crate_visibility_modifier, vis.span,
+                               "`crate` visibility modifier is experimental");
+        }
+        visit::walk_vis(self, vis)
+    }
 }
 
 pub fn get_features(span_handler: &Handler, krate_attrs: &[ast::Attribute],

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -3,8 +3,9 @@ use super::accepted::ACCEPTED_FEATURES;
 use super::removed::{REMOVED_FEATURES, STABLE_REMOVED_FEATURES};
 use super::builtin_attrs::{AttributeGate, BUILTIN_ATTRIBUTE_MAP};
 
-use crate::ast::{self, NodeId, PatKind, VariantData};
+use crate::ast::{self, NodeId, PatKind, RangeEnd, VariantData};
 use crate::attr::{self, check_builtin_attribute};
+use crate::source_map::Spanned;
 use crate::edition::{ALL_EDITIONS, Edition};
 use crate::visit::{self, FnKind, Visitor};
 use crate::parse::token;
@@ -550,6 +551,10 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                         );
                     }
                 }
+            }
+            PatKind::Range(_, _, Spanned { node: RangeEnd::Excluded, .. }) => {
+                gate_feature_post!(&self, exclusive_range_pattern, pattern.span,
+                                   "exclusive range pattern syntax is experimental");
             }
             _ => {}
         }

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -3,7 +3,7 @@ use super::accepted::ACCEPTED_FEATURES;
 use super::removed::{REMOVED_FEATURES, STABLE_REMOVED_FEATURES};
 use super::builtin_attrs::{AttributeGate, BUILTIN_ATTRIBUTE_MAP};
 
-use crate::ast::{self, NodeId, PatKind, RangeEnd, VariantData};
+use crate::ast::{self, NodeId, GenericParam, GenericParamKind, PatKind, RangeEnd, VariantData};
 use crate::attr::{self, check_builtin_attribute};
 use crate::source_map::Spanned;
 use crate::edition::{ALL_EDITIONS, Edition};
@@ -592,6 +592,16 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         }
 
         visit::walk_fn(self, fn_kind, fn_decl, span)
+    }
+
+    fn visit_generic_param(&mut self, param: &'a GenericParam) {
+        match param.kind {
+            GenericParamKind::Const { .. } =>
+                gate_feature_post!(&self, const_generics, param.ident.span,
+                    "const generics are unstable"),
+            _ => {}
+        }
+        visit::walk_generic_param(self, param)
     }
 
     fn visit_trait_item(&mut self, ti: &'a ast::TraitItem) {

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -518,6 +518,9 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                                        "type ascription is experimental");
                 }
             }
+            ast::ExprKind::TryBlock(_) => {
+                gate_feature_post!(&self, try_blocks, e.span, "`try` expression is experimental");
+            }
             ast::ExprKind::Block(_, opt_label) => {
                 if let Some(label) = opt_label {
                     gate_feature_post!(&self, label_break_value, label.ident.span,

--- a/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-in-trait-ungated.stderr
@@ -1,8 +1,8 @@
 error[E0658]: const generics are unstable
-  --> $DIR/const-param-in-trait-ungated.rs:1:13
+  --> $DIR/const-param-in-trait-ungated.rs:1:19
    |
 LL | trait Trait<const T: ()> {}
-   |             ^^^^^^^^^^^
+   |                   ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable

--- a/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
+++ b/src/test/ui/const-generics/const-param-type-depends-on-type-param-ungated.stderr
@@ -1,8 +1,8 @@
 error[E0658]: const generics are unstable
-  --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:13
+  --> $DIR/const-param-type-depends-on-type-param-ungated.rs:3:19
    |
 LL | struct B<T, const N: T>(PhantomData<[T; N]>);
-   |             ^^^^^^^^^^
+   |                   ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable

--- a/src/test/ui/const-generics/issues/issue-60263.stderr
+++ b/src/test/ui/const-generics/issues/issue-60263.stderr
@@ -1,8 +1,8 @@
 error[E0658]: const generics are unstable
-  --> $DIR/issue-60263.rs:1:10
+  --> $DIR/issue-60263.rs:1:16
    |
 LL | struct B<const I: u8>;
-   |          ^^^^^^^^^^^
+   |                ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.rs
@@ -70,7 +70,3 @@ fn main() {
     // FIXME: uncomment when `impl_trait_in_bindings` feature is fixed.
     // let _: &dyn Tr1<As1: Copy> = &S1;
 }
-
-macro_rules! accept_path { ($p:path) => {} }
-accept_path!(Iterator<Item: Ord>);
-//~^ ERROR associated type bounds are unstable

--- a/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-associated_type_bounds.stderr
@@ -115,15 +115,6 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    = note: for more information, see https://github.com/rust-lang/rust/issues/52662
    = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
 
-error[E0658]: associated type bounds are unstable
-  --> $DIR/feature-gate-associated_type_bounds.rs:75:23
-   |
-LL | accept_path!(Iterator<Item: Ord>);
-   |                       ^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/52662
-   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
-
 error[E0562]: `impl Trait` not allowed outside of function and inherent method return types
   --> $DIR/feature-gate-associated_type_bounds.rs:54:14
    |
@@ -148,7 +139,7 @@ LL |     let _: impl Tr1<As1: Copy> = S1;
    |
    = help: add `#![feature(impl_trait_in_bindings)]` to the crate attributes to enable
 
-error: aborting due to 17 previous errors
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0562, E0658.
 For more information about an error, try `rustc --explain E0562`.

--- a/src/test/ui/feature-gates/feature-gate-box_patterns.rs
+++ b/src/test/ui/feature-gates/feature-gate-box_patterns.rs
@@ -2,6 +2,3 @@ fn main() {
     let box x = Box::new('c'); //~ ERROR box pattern syntax is experimental
     println!("x: {}", x);
 }
-
-macro_rules! accept_pat { ($p:pat) => {} }
-accept_pat!(box 0); //~ ERROR box pattern syntax is experimental

--- a/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_patterns.stderr
@@ -7,15 +7,6 @@ LL |     let box x = Box::new('c');
    = note: for more information, see https://github.com/rust-lang/rust/issues/29641
    = help: add `#![feature(box_patterns)]` to the crate attributes to enable
 
-error[E0658]: box pattern syntax is experimental
-  --> $DIR/feature-gate-box_patterns.rs:7:13
-   |
-LL | accept_pat!(box 0);
-   |             ^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29641
-   = help: add `#![feature(box_patterns)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-box_syntax.rs
+++ b/src/test/ui/feature-gates/feature-gate-box_syntax.rs
@@ -1,9 +1,6 @@
 // Test that the use of the box syntax is gated by `box_syntax` feature gate.
 
-#[cfg(FALSE)]
-fn foo() {
+fn main() {
     let x = box 3;
     //~^ ERROR box expression syntax is experimental; you can call `Box::new` instead
 }
-
-fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
+++ b/src/test/ui/feature-gates/feature-gate-box_syntax.stderr
@@ -1,5 +1,5 @@
 error[E0658]: box expression syntax is experimental; you can call `Box::new` instead
-  --> $DIR/feature-gate-box_syntax.rs:5:13
+  --> $DIR/feature-gate-box_syntax.rs:4:13
    |
 LL |     let x = box 3;
    |             ^^^^^

--- a/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics-ptr.stderr
@@ -1,17 +1,17 @@
 error[E0658]: const generics are unstable
-  --> $DIR/feature-gate-const_generics-ptr.rs:1:16
+  --> $DIR/feature-gate-const_generics-ptr.rs:1:22
    |
 LL | struct ConstFn<const F: fn()>;
-   |                ^^^^^^^^^^^^^
+   |                      ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: const generics are unstable
-  --> $DIR/feature-gate-const_generics-ptr.rs:5:17
+  --> $DIR/feature-gate-const_generics-ptr.rs:5:23
    |
 LL | struct ConstPtr<const P: *const u32>;
-   |                 ^^^^^^^^^^^^^^^^^^^
+   |                       ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable

--- a/src/test/ui/feature-gates/feature-gate-const_generics.rs
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.rs
@@ -2,9 +2,4 @@ fn foo<const X: ()>() {} //~ ERROR const generics are unstable
 
 struct Foo<const X: usize>([(); X]); //~ ERROR const generics are unstable
 
-macro_rules! accept_item { ($i:item) => {} }
-accept_item! {
-    impl<const X: ()> A {} //~ ERROR const generics are unstable
-}
-
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-const_generics.stderr
+++ b/src/test/ui/feature-gates/feature-gate-const_generics.stderr
@@ -1,30 +1,21 @@
 error[E0658]: const generics are unstable
-  --> $DIR/feature-gate-const_generics.rs:1:8
+  --> $DIR/feature-gate-const_generics.rs:1:14
    |
 LL | fn foo<const X: ()>() {}
-   |        ^^^^^^^^^^^
+   |              ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
 error[E0658]: const generics are unstable
-  --> $DIR/feature-gate-const_generics.rs:3:12
+  --> $DIR/feature-gate-const_generics.rs:3:18
    |
 LL | struct Foo<const X: usize>([(); X]);
-   |            ^^^^^^^^^^^^^^
+   |                  ^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/44580
    = help: add `#![feature(const_generics)]` to the crate attributes to enable
 
-error[E0658]: const generics are unstable
-  --> $DIR/feature-gate-const_generics.rs:7:10
-   |
-LL |     impl<const X: ()> A {}
-   |          ^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44580
-   = help: add `#![feature(const_generics)]` to the crate attributes to enable
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.rs
+++ b/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.rs
@@ -5,7 +5,4 @@ crate struct Bender { //~ ERROR `crate` visibility modifier is experimental
     water: bool,
 }
 
-macro_rules! accept_vis { ($v:vis) => {} }
-accept_vis!(crate);  //~ ERROR `crate` visibility modifier is experimental
-
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
+++ b/src/test/ui/feature-gates/feature-gate-crate_visibility_modifier.stderr
@@ -7,15 +7,6 @@ LL | crate struct Bender {
    = note: for more information, see https://github.com/rust-lang/rust/issues/53120
    = help: add `#![feature(crate_visibility_modifier)]` to the crate attributes to enable
 
-error[E0658]: `crate` visibility modifier is experimental
-  --> $DIR/feature-gate-crate_visibility_modifier.rs:9:13
-   |
-LL | accept_vis!(crate);
-   |             ^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/53120
-   = help: add `#![feature(crate_visibility_modifier)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-decl_macro.rs
+++ b/src/test/ui/feature-gates/feature-gate-decl_macro.rs
@@ -2,8 +2,4 @@
 
 macro m() {} //~ ERROR `macro` is experimental
 
-macro_rules! accept_item { ($i:item) => {} }
-accept_item! {
-    macro m() {} //~ ERROR `macro` is experimental
-}
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
+++ b/src/test/ui/feature-gates/feature-gate-decl_macro.stderr
@@ -7,15 +7,6 @@ LL | macro m() {}
    = note: for more information, see https://github.com/rust-lang/rust/issues/39412
    = help: add `#![feature(decl_macro)]` to the crate attributes to enable
 
-error[E0658]: `macro` is experimental
-  --> $DIR/feature-gate-decl_macro.rs:7:5
-   |
-LL |     macro m() {}
-   |     ^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/39412
-   = help: add `#![feature(decl_macro)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.rs
+++ b/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.rs
@@ -1,10 +1,6 @@
-#[cfg(FALSE)]
-fn foo() {
+pub fn main() {
     match 22 {
         0 .. 3 => {} //~ ERROR exclusive range pattern syntax is experimental
-        PATH .. 3 => {} //~ ERROR exclusive range pattern syntax is experimental
         _ => {}
     }
 }
-
-fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
+++ b/src/test/ui/feature-gates/feature-gate-exclusive-range-pattern.stderr
@@ -1,21 +1,12 @@
 error[E0658]: exclusive range pattern syntax is experimental
-  --> $DIR/feature-gate-exclusive-range-pattern.rs:4:11
+  --> $DIR/feature-gate-exclusive-range-pattern.rs:3:9
    |
 LL |         0 .. 3 => {}
-   |           ^^
+   |         ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37854
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
 
-error[E0658]: exclusive range pattern syntax is experimental
-  --> $DIR/feature-gate-exclusive-range-pattern.rs:5:14
-   |
-LL |         PATH .. 3 => {}
-   |              ^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/37854
-   = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-label_break_value.rs
+++ b/src/test/ui/feature-gates/feature-gate-label_break_value.rs
@@ -1,8 +1,5 @@
-#[cfg(FALSE)]
-pub fn foo() {
+pub fn main() {
     'a: { //~ ERROR labels on blocks are unstable
         break 'a;
     }
 }
-
-fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
+++ b/src/test/ui/feature-gates/feature-gate-label_break_value.stderr
@@ -1,5 +1,5 @@
 error[E0658]: labels on blocks are unstable
-  --> $DIR/feature-gate-label_break_value.rs:3:5
+  --> $DIR/feature-gate-label_break_value.rs:2:5
    |
 LL |     'a: {
    |     ^^

--- a/src/test/ui/feature-gates/feature-gate-trait-alias.rs
+++ b/src/test/ui/feature-gates/feature-gate-trait-alias.rs
@@ -1,13 +1,4 @@
 trait Foo = Default;
 //~^ ERROR trait aliases are experimental
 
-macro_rules! accept_item {
-    ($i:item) => {}
-}
-
-accept_item! {
-    trait Foo = Ord + Eq;
-    //~^ ERROR trait aliases are experimental
-}
-
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trait-alias.stderr
@@ -7,15 +7,6 @@ LL | trait Foo = Default;
    = note: for more information, see https://github.com/rust-lang/rust/issues/41517
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
 
-error[E0658]: trait aliases are experimental
-  --> $DIR/feature-gate-trait-alias.rs:9:5
-   |
-LL |     trait Foo = Ord + Eq;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/41517
-   = help: add `#![feature(trait_alias)]` to the crate attributes to enable
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-try_blocks.rs
+++ b/src/test/ui/feature-gates/feature-gate-try_blocks.rs
@@ -1,12 +1,9 @@
 // compile-flags: --edition 2018
 
-#[cfg(FALSE)]
-fn foo() {
-    let try_result: Option<_> = try { //~ ERROR `try` blocks are unstable
+pub fn main() {
+    let try_result: Option<_> = try { //~ ERROR `try` expression is experimental
         let x = 5;
         x
     };
     assert_eq!(try_result, Some(5));
 }
-
-fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
+++ b/src/test/ui/feature-gates/feature-gate-try_blocks.stderr
@@ -1,5 +1,5 @@
-error[E0658]: `try` blocks are unstable
-  --> $DIR/feature-gate-try_blocks.rs:5:33
+error[E0658]: `try` expression is experimental
+  --> $DIR/feature-gate-try_blocks.rs:4:33
    |
 LL |       let try_result: Option<_> = try {
    |  _________________________________^

--- a/src/test/ui/feature-gates/feature-gate-type_ascription.rs
+++ b/src/test/ui/feature-gates/feature-gate-type_ascription.rs
@@ -1,8 +1,5 @@
 // Type ascription is unstable
 
-#[cfg(FALSE)]
-fn foo() {
+fn main() {
     let a = 10: u8; //~ ERROR type ascription is experimental
 }
-
-fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
+++ b/src/test/ui/feature-gates/feature-gate-type_ascription.stderr
@@ -1,5 +1,5 @@
 error[E0658]: type ascription is experimental
-  --> $DIR/feature-gate-type_ascription.rs:5:13
+  --> $DIR/feature-gate-type_ascription.rs:4:13
    |
 LL |     let a = 10: u8;
    |             ^^^^^^

--- a/src/test/ui/or-patterns/or-patterns-syntactic-pass.rs
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-pass.rs
@@ -4,7 +4,6 @@
 // check-pass
 
 #![feature(or_patterns)]
-#![feature(box_patterns)]
 
 fn main() {}
 

--- a/src/test/ui/parser/pat-tuple-4.rs
+++ b/src/test/ui/parser/pat-tuple-4.rs
@@ -4,6 +4,7 @@ fn main() {
     match 0 {
         (.. PAT) => {}
         //~^ ERROR `..X` range patterns are not supported
+        //~| ERROR exclusive range pattern syntax is experimental
     }
 }
 

--- a/src/test/ui/parser/pat-tuple-4.stderr
+++ b/src/test/ui/parser/pat-tuple-4.stderr
@@ -4,8 +4,17 @@ error: `..X` range patterns are not supported
 LL |         (.. PAT) => {}
    |          ^^^^^^ help: try using the minimum value for the type: `MIN..PAT`
 
+error[E0658]: exclusive range pattern syntax is experimental
+  --> $DIR/pat-tuple-4.rs:5:10
+   |
+LL |         (.. PAT) => {}
+   |          ^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/37854
+   = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable
+
 error[E0308]: mismatched types
-  --> $DIR/pat-tuple-4.rs:10:30
+  --> $DIR/pat-tuple-4.rs:11:30
    |
 LL | const RECOVERY_WITNESS: () = 0;
    |                              ^ expected (), found integer
@@ -13,6 +22,7 @@ LL | const RECOVERY_WITNESS: () = 0;
    = note: expected type `()`
               found type `{integer}`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0308`.
+Some errors have detailed explanations: E0308, E0658.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/pat-tuple-5.stderr
+++ b/src/test/ui/parser/pat-tuple-5.stderr
@@ -5,10 +5,10 @@ LL |         (PAT ..) => {}
    |          ^^^^^^ help: try using the maximum value for the type: `PAT..MAX`
 
 error[E0658]: exclusive range pattern syntax is experimental
-  --> $DIR/pat-tuple-5.rs:5:14
+  --> $DIR/pat-tuple-5.rs:5:10
    |
 LL |         (PAT ..) => {}
-   |              ^^
+   |          ^^^^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/37854
    = help: add `#![feature(exclusive_range_pattern)]` to the crate attributes to enable

--- a/src/test/ui/pattern/rest-pat-syntactic.rs
+++ b/src/test/ui/pattern/rest-pat-syntactic.rs
@@ -3,8 +3,6 @@
 
 // check-pass
 
-#![feature(box_patterns)]
-
 fn main() {}
 
 macro_rules! accept_pat {


### PR DESCRIPTION
The intent here is to address #65860 ASAP (in time for beta, ideally), while leaving as much of #65742 around as possible, to make it easier to re-enable later.

Therefore, I've only kept the parts of the revert that re-add the old (i.e. non-early) feature-gating checks that were removed in #65742, and the test reverts.

I've disabled the new early feature-gating checks from #65742 entirely for now, but it would be easy to put them behind a `-Z` flag, or turn them into warnings, which would allow us to keep tests for both the early and late versions of the checks - assuming that's desirable.

cc @nikomatsakis @Mark-Simulacrum @Centril