### PR TITLE
Upgrade openssl and openssl-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.16"
+version = "0.10.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"
+checksum = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2280,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.43"
+version = "0.9.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c86834957dd5b915623e94f2f4ab2c70dd8f6b70679824155d5ae21dbd495d"
+checksum = "c977d08e1312e2f7e4b86f9ebaa0ed3b19d1daff75fae88bbb88108afbd801fc"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Fixes #65808 

This PR updates `openssl` and `openssl-sys` to support newer versions of `libressl` in `rust` builds. I can confirm (*at least on my machine*) that `rust` builds and works successfully with the newer versions of `libressl`.

This is my first contribution to `rust`, apologies if I have done this incorrectly. For reference, I have based this PR on a previous PR which updates these two dependencies to fix a similar issue. https://github.com/rust-lang/rust/pull/57263

Thanks / Ευχαριστώ :+1: