### PR TITLE
De-querify `trivial_dropck_outlives`.

### DIFF
--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -228,12 +228,6 @@ rustc_queries! {
             cycle_delay_bug
         }
 
-        query trivial_dropck_outlives(ty: Ty<'tcx>) -> bool {
-            anon
-            no_force
-            desc { "checking if `{:?}` has trivial dropck", ty }
-        }
-
         query adt_dtorck_constraint(
             _: DefId
         ) -> Result<DtorckConstraint<'tcx>, NoSolution> {}

--- a/src/librustc/traits/query/dropck_outlives.rs
+++ b/src/librustc/traits/query/dropck_outlives.rs
@@ -5,7 +5,6 @@ use std::iter::FromIterator;
 use syntax::source_map::Span;
 use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
-use crate::ty::query::Providers;
 
 impl<'cx, 'tcx> At<'cx, 'tcx> {
     /// Given a type `ty` of some value being dropped, computes a set
@@ -34,7 +33,7 @@ impl<'cx, 'tcx> At<'cx, 'tcx> {
         // Quick check: there are a number of cases that we know do not require
         // any destructor.
         let tcx = self.infcx.tcx;
-        if tcx.trivial_dropck_outlives(ty) {
+        if trivial_dropck_outlives(tcx, ty) {
             return InferOk {
                 value: vec![],
                 obligations: vec![],
@@ -208,15 +207,15 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Error => true,
 
         // [T; N] and [T] have same properties as T.
-        ty::Array(ty, _) | ty::Slice(ty) => tcx.trivial_dropck_outlives(ty),
+        ty::Array(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, ty),
 
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *any* of those are trivial.
-        ty::Tuple(ref tys) => tys.iter().all(|t| tcx.trivial_dropck_outlives(t.expect_ty())),
+        ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t.expect_ty())),
         ty::Closure(def_id, ref substs) => substs
             .as_closure()
             .upvar_tys(def_id, tcx)
-            .all(|t| tcx.trivial_dropck_outlives(t)),
+            .all(|t| trivial_dropck_outlives(tcx, t)),
 
         ty::Adt(def, _) => {
             if Some(def.did) == tcx.lang_items().manually_drop() {
@@ -243,11 +242,4 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
 
         ty::UnnormalizedProjection(..) => bug!("only used with chalk-engine"),
     }
-}
-
-crate fn provide(p: &mut Providers<'_>) {
-    *p = Providers {
-        trivial_dropck_outlives,
-        ..*p
-    };
 }

--- a/src/librustc/traits/query/type_op/outlives.rs
+++ b/src/librustc/traits/query/type_op/outlives.rs
@@ -1,5 +1,5 @@
 use crate::infer::canonical::{Canonicalized, CanonicalizedQueryResponse};
-use crate::traits::query::dropck_outlives::DropckOutlivesResult;
+use crate::traits::query::dropck_outlives::{DropckOutlivesResult, trivial_dropck_outlives};
 use crate::traits::query::Fallible;
 use crate::ty::{ParamEnvAnd, Ty, TyCtxt};
 
@@ -21,7 +21,7 @@ impl super::QueryTypeOp<'tcx> for DropckOutlives<'tcx> {
         tcx: TyCtxt<'tcx>,
         key: &ParamEnvAnd<'tcx, Self>,
     ) -> Option<Self::QueryResponse> {
-        if tcx.trivial_dropck_outlives(key.value.dropped_ty) {
+        if trivial_dropck_outlives(tcx, key.value.dropped_ty) {
             Some(DropckOutlivesResult::default())
         } else {
             None

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -3407,7 +3407,6 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
     layout::provide(providers);
     util::provide(providers);
     constness::provide(providers);
-    crate::traits::query::dropck_outlives::provide(providers);
     *providers = ty::query::Providers {
         asyncness,
         associated_item,

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::traits::query::dropck_outlives::{DropckOutlivesResult, DtorckConstraint};
+use rustc::traits::query::dropck_outlives::trivial_dropck_outlives;
 use rustc::traits::query::{CanonicalTyGoal, NoSolution};
 use rustc::traits::{TraitEngine, Normalized, ObligationCause, TraitEngineExt};
 use rustc::ty::query::Providers;
@@ -172,7 +173,7 @@ fn dtorck_constraint_for_ty<'tcx>(
         return Ok(());
     }
 
-    if tcx.trivial_dropck_outlives(ty) {
+    if trivial_dropck_outlives(tcx, ty) {
         return Ok(());
     }
 


### PR DESCRIPTION
It's sufficiently simple and fast that memoizing it is a slight
pessimization.

r? @michaelwoerister 