### PR TITLE
Improved std::iter::Chain documentation

### DIFF
--- a/src/libcore/iter/adapters/chain.rs
+++ b/src/libcore/iter/adapters/chain.rs
@@ -3,7 +3,7 @@ use crate::usize;
 
 use super::super::{Iterator, DoubleEndedIterator, FusedIterator, TrustedLen};
 
-/// An iterator that strings two iterators together.
+/// An iterator that links two iterators together, in a chain.
 ///
 /// This `struct` is created by the [`chain`] method on [`Iterator`]. See its
 /// documentation for more.


### PR DESCRIPTION
Replaces `strings two iterators` by `links two iterators` in `std::iter::Chain` documentation. 

I didn't find any meaning of `strings` which can be evaluated as `links` or `joins`. 

I don't think that `std::iter:Chain` works as a stringer or plays billiards. (https://www.lexico.com/en/definition/string).