### PR TITLE
[WIP] rustc: avoid checking Trait's predicates for WF(<T as Trait>::X).

### DIFF
--- a/src/test/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding.stderr
@@ -6,13 +6,6 @@ LL | trait Foo: Iterator<Item = i32> {}
 LL | trait Bar: Foo<Item = u32> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0282]: type annotations needed
-  --> $DIR/associated-types-overridden-binding.rs:7:1
-   |
-LL | trait U32Iterator = I32Iterator<Item = u32>;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0282, E0284.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0284`.

--- a/src/test/ui/issues/issue-20831-debruijn.stderr
+++ b/src/test/ui/issues/issue-20831-debruijn.stderr
@@ -1,65 +1,3 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-20831-debruijn.rs:28:5
-   |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^ lifetime mismatch
-   |
-   = note: expected type `'a`
-              found type `'_`
-note: the anonymous lifetime #2 defined on the method body at 28:5...
-  --> $DIR/issue-20831-debruijn.rs:28:5
-   |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
-note: ...does not necessarily outlive the lifetime `'a` as defined on the impl at 26:6
-  --> $DIR/issue-20831-debruijn.rs:26:6
-   |
-LL | impl<'a> Publisher<'a> for MyStruct<'a> {
-   |      ^^
-
-error[E0308]: mismatched types
-  --> $DIR/issue-20831-debruijn.rs:28:5
-   |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^ lifetime mismatch
-   |
-   = note: expected type `'a`
-              found type `'_`
-note: the lifetime `'a` as defined on the impl at 26:6...
-  --> $DIR/issue-20831-debruijn.rs:26:6
-   |
-LL | impl<'a> Publisher<'a> for MyStruct<'a> {
-   |      ^^
-note: ...does not necessarily outlive the anonymous lifetime #2 defined on the method body at 28:5
-  --> $DIR/issue-20831-debruijn.rs:28:5
-   |
-LL | /     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-LL | |         // Not obvious, but there is an implicit lifetime here -------^
-LL | |
-LL | |
-...  |
-LL | |         self.sub = t;
-LL | |     }
-   | |_____^
-
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
   --> $DIR/issue-20831-debruijn.rs:28:5
    |
@@ -92,7 +30,6 @@ LL | impl<'a> Publisher<'a> for MyStruct<'a> {
            expected Publisher<'_>
               found Publisher<'_>
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0308, E0495.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0495`.


### PR DESCRIPTION
Fixes #65510 - specifically, this is the WF disabling patch mentioned in https://github.com/rust-lang/rust/issues/65510#issuecomment-544269964.

This is marked WIP to avoid merging it without serious scrutiny, since there's a chance this is unsound.

In case this doesn't work out, we can probably try caching proving WF obligations (perhaps when no type/const inference variables are involved? in general we could try to use queries more).

r? @nikomatsakis 