### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -657,11 +657,11 @@ pub fn build_codegen_backend(builder: &Builder<'_>,
             if let Some(ref s) = builder.config.llvm_ldflags {
                 cargo.env("LLVM_LINKER_FLAGS", s);
             }
-            // Building with a static libstdc++ is only supported on linux right now,
+            // Building with a static libstdc++ is only supported on linux and mingw right now,
             // not for MSVC or macOS
             if builder.config.llvm_static_stdcpp &&
                !target.contains("freebsd") &&
-               !target.contains("windows") &&
+               !target.contains("msvc") &&
                !target.contains("apple") {
                 let file = compiler_file(builder,
                                          builder.cxx(target).unwrap(),

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -236,7 +236,7 @@ fn make_win_dist(
     }
 
     let target_tools = ["gcc.exe", "ld.exe", "dlltool.exe", "libwinpthread-1.dll"];
-    let mut rustc_dlls = vec!["libstdc++-6.dll", "libwinpthread-1.dll"];
+    let mut rustc_dlls = vec!["libwinpthread-1.dll"];
     if target_triple.starts_with("i686-") {
         rustc_dlls.push("libgcc_s_dw2-1.dll");
     } else {

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -159,7 +159,7 @@ impl Step for Llvm {
 
         // For distribution we want the LLVM tools to be *statically* linked to libstdc++
         if builder.config.llvm_tools_enabled || builder.config.lldb_enabled {
-            if !target.contains("windows") {
+            if !target.contains("msvc") {
                 if target.contains("apple") {
                     cfg.define("CMAKE_EXE_LINKER_FLAGS", "-static-libstdc++");
                 } else {
@@ -395,7 +395,7 @@ fn configure_cmake(builder: &Builder<'_>,
     cfg.define("CMAKE_C_FLAGS", cflags);
     let mut cxxflags = builder.cflags(target, GitRepo::Llvm).join(" ");
     if builder.config.llvm_static_stdcpp &&
-        !target.contains("windows") &&
+        !target.contains("msvc") &&
         !target.contains("netbsd")
     {
         cxxflags.push_str(" -static-libstdc++");

--- a/src/librustc/query/mod.rs
+++ b/src/librustc/query/mod.rs
@@ -228,12 +228,6 @@ rustc_queries! {
             cycle_delay_bug
         }
 
-        query trivial_dropck_outlives(ty: Ty<'tcx>) -> bool {
-            anon
-            no_force
-            desc { "checking if `{:?}` has trivial dropck", ty }
-        }
-
         query adt_dtorck_constraint(
             _: DefId
         ) -> Result<DtorckConstraint<'tcx>, NoSolution> {}

--- a/src/librustc/traits/query/dropck_outlives.rs
+++ b/src/librustc/traits/query/dropck_outlives.rs
@@ -5,7 +5,6 @@ use std::iter::FromIterator;
 use syntax::source_map::Span;
 use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
-use crate::ty::query::Providers;
 
 impl<'cx, 'tcx> At<'cx, 'tcx> {
     /// Given a type `ty` of some value being dropped, computes a set
@@ -34,7 +33,7 @@ impl<'cx, 'tcx> At<'cx, 'tcx> {
         // Quick check: there are a number of cases that we know do not require
         // any destructor.
         let tcx = self.infcx.tcx;
-        if tcx.trivial_dropck_outlives(ty) {
+        if trivial_dropck_outlives(tcx, ty) {
             return InferOk {
                 value: vec![],
                 obligations: vec![],
@@ -208,15 +207,15 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         | ty::Error => true,
 
         // [T; N] and [T] have same properties as T.
-        ty::Array(ty, _) | ty::Slice(ty) => tcx.trivial_dropck_outlives(ty),
+        ty::Array(ty, _) | ty::Slice(ty) => trivial_dropck_outlives(tcx, ty),
 
         // (T1..Tn) and closures have same properties as T1..Tn --
         // check if *any* of those are trivial.
-        ty::Tuple(ref tys) => tys.iter().all(|t| tcx.trivial_dropck_outlives(t.expect_ty())),
+        ty::Tuple(ref tys) => tys.iter().all(|t| trivial_dropck_outlives(tcx, t.expect_ty())),
         ty::Closure(def_id, ref substs) => substs
             .as_closure()
             .upvar_tys(def_id, tcx)
-            .all(|t| tcx.trivial_dropck_outlives(t)),
+            .all(|t| trivial_dropck_outlives(tcx, t)),
 
         ty::Adt(def, _) => {
             if Some(def.did) == tcx.lang_items().manually_drop() {
@@ -243,11 +242,4 @@ pub fn trivial_dropck_outlives<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
 
         ty::UnnormalizedProjection(..) => bug!("only used with chalk-engine"),
     }
-}
-
-crate fn provide(p: &mut Providers<'_>) {
-    *p = Providers {
-        trivial_dropck_outlives,
-        ..*p
-    };
 }

--- a/src/librustc/traits/query/type_op/outlives.rs
+++ b/src/librustc/traits/query/type_op/outlives.rs
@@ -1,5 +1,5 @@
 use crate::infer::canonical::{Canonicalized, CanonicalizedQueryResponse};
-use crate::traits::query::dropck_outlives::DropckOutlivesResult;
+use crate::traits::query::dropck_outlives::{DropckOutlivesResult, trivial_dropck_outlives};
 use crate::traits::query::Fallible;
 use crate::ty::{ParamEnvAnd, Ty, TyCtxt};
 
@@ -21,7 +21,7 @@ impl super::QueryTypeOp<'tcx> for DropckOutlives<'tcx> {
         tcx: TyCtxt<'tcx>,
         key: &ParamEnvAnd<'tcx, Self>,
     ) -> Option<Self::QueryResponse> {
-        if tcx.trivial_dropck_outlives(key.value.dropped_ty) {
+        if trivial_dropck_outlives(tcx, key.value.dropped_ty) {
             Some(DropckOutlivesResult::default())
         } else {
             None

--- a/src/librustc/ty/mod.rs
+++ b/src/librustc/ty/mod.rs
@@ -3407,7 +3407,6 @@ pub fn provide(providers: &mut ty::query::Providers<'_>) {
     layout::provide(providers);
     util::provide(providers);
     constness::provide(providers);
-    crate::traits::query::dropck_outlives::provide(providers);
     *providers = ty::query::Providers {
         asyncness,
         associated_item,

--- a/src/librustc_codegen_llvm/back/write.rs
+++ b/src/librustc_codegen_llvm/back/write.rs
@@ -161,6 +161,7 @@ pub fn target_machine_factory(sess: &Session, optlvl: config::OptLevel, find_fea
     let cpu = SmallCStr::new(llvm_util::target_cpu(sess));
     let features = features.join(",");
     let features = CString::new(features).unwrap();
+    let abi = SmallCStr::new(&sess.target.target.options.llvm_abiname);
     let is_pie_binary = !find_features && is_pie_binary(sess);
     let trap_unreachable = sess.target.target.options.trap_unreachable;
     let emit_stack_size_section = sess.opts.debugging_opts.emit_stack_sizes;
@@ -170,7 +171,7 @@ pub fn target_machine_factory(sess: &Session, optlvl: config::OptLevel, find_fea
     Arc::new(move || {
         let tm = unsafe {
             llvm::LLVMRustCreateTargetMachine(
-                triple.as_ptr(), cpu.as_ptr(), features.as_ptr(),
+                triple.as_ptr(), cpu.as_ptr(), features.as_ptr(), abi.as_ptr(),
                 code_model,
                 reloc_model,
                 opt_level,

--- a/src/librustc_codegen_llvm/llvm/ffi.rs
+++ b/src/librustc_codegen_llvm/llvm/ffi.rs
@@ -1684,6 +1684,7 @@ extern "C" {
     pub fn LLVMRustCreateTargetMachine(Triple: *const c_char,
                                        CPU: *const c_char,
                                        Features: *const c_char,
+                                       Abi: *const c_char,
                                        Model: CodeModel,
                                        Reloc: RelocMode,
                                        Level: CodeGenOptLevel,

--- a/src/librustc_llvm/build.rs
+++ b/src/librustc_llvm/build.rs
@@ -279,7 +279,11 @@ fn main() {
             let path = PathBuf::from(s);
             println!("cargo:rustc-link-search=native={}",
                      path.parent().unwrap().display());
-            println!("cargo:rustc-link-lib=static={}", stdcppname);
+            if target.contains("windows") {
+                println!("cargo:rustc-link-lib=static-nobundle={}", stdcppname);
+            } else {
+                println!("cargo:rustc-link-lib=static={}", stdcppname);
+            }
         } else if cxxflags.contains("stdlib=libc++") {
             println!("cargo:rustc-link-lib=c++");
         } else {

--- a/src/librustc_metadata/cstore_impl.rs
+++ b/src/librustc_metadata/cstore_impl.rs
@@ -440,7 +440,7 @@ impl cstore::CStore {
         let source_file = sess.parse_sess.source_map().new_source_file(source_name, def.body);
         let local_span = Span::with_root_ctxt(source_file.start_pos, source_file.end_pos);
         let (body, mut errors) = source_file_to_stream(&sess.parse_sess, source_file, None);
-        emit_unclosed_delims(&mut errors, &sess.diagnostic());
+        emit_unclosed_delims(&mut errors, &sess.parse_sess);
 
         // Mark the attrs as used
         let attrs = data.get_item_attrs(id.index, sess);

--- a/src/librustc_target/spec/mod.rs
+++ b/src/librustc_target/spec/mod.rs
@@ -793,7 +793,10 @@ pub struct TargetOptions {
     pub merge_functions: MergeFunctions,
 
     /// Use platform dependent mcount function
-    pub target_mcount: String
+    pub target_mcount: String,
+
+    /// LLVM ABI name, corresponds to the '-mabi' parameter available in multilib C compilers
+    pub llvm_abiname: String,
 }
 
 impl Default for TargetOptions {
@@ -880,6 +883,7 @@ impl Default for TargetOptions {
             override_export_symbols: None,
             merge_functions: MergeFunctions::Aliases,
             target_mcount: "mcount".to_string(),
+            llvm_abiname: "".to_string(),
         }
     }
 }
@@ -1196,6 +1200,7 @@ impl Target {
         key!(override_export_symbols, opt_list);
         key!(merge_functions, MergeFunctions)?;
         key!(target_mcount);
+        key!(llvm_abiname);
 
         if let Some(array) = obj.find("abi-blacklist").and_then(Json::as_array) {
             for name in array.iter().filter_map(|abi| abi.as_string()) {
@@ -1414,6 +1419,7 @@ impl ToJson for Target {
         target_option_val!(override_export_symbols);
         target_option_val!(merge_functions);
         target_option_val!(target_mcount);
+        target_option_val!(llvm_abiname);
 
         if default.abi_blacklist != self.options.abi_blacklist {
             d.insert("abi-blacklist".to_string(), self.options.abi_blacklist.iter()

--- a/src/librustc_traits/dropck_outlives.rs
+++ b/src/librustc_traits/dropck_outlives.rs
@@ -1,6 +1,7 @@
 use rustc::hir::def_id::DefId;
 use rustc::infer::canonical::{Canonical, QueryResponse};
 use rustc::traits::query::dropck_outlives::{DropckOutlivesResult, DtorckConstraint};
+use rustc::traits::query::dropck_outlives::trivial_dropck_outlives;
 use rustc::traits::query::{CanonicalTyGoal, NoSolution};
 use rustc::traits::{TraitEngine, Normalized, ObligationCause, TraitEngineExt};
 use rustc::ty::query::Providers;
@@ -172,7 +173,7 @@ fn dtorck_constraint_for_ty<'tcx>(
         return Ok(());
     }
 
-    if tcx.trivial_dropck_outlives(ty) {
+    if trivial_dropck_outlives(tcx, ty) {
         return Ok(());
     }
 

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -2,7 +2,7 @@ use crate::check::{Inherited, FnCtxt};
 use crate::constrained_generic_params::{identify_constrained_generic_params, Parameter};
 
 use crate::hir::def_id::DefId;
-use rustc::traits::{self, ObligationCauseCode};
+use rustc::traits::{self, ObligationCause, ObligationCauseCode};
 use rustc::ty::{self, Ty, TyCtxt, GenericParamDefKind, TypeFoldable, ToPredicate};
 use rustc::ty::subst::{Subst, InternalSubsts};
 use rustc::util::nodemap::{FxHashSet, FxHashMap};
@@ -893,6 +893,11 @@ fn receiver_is_valid<'fcx, 'tcx>(
     // The first type is `receiver_ty`, which we know its not equal to `self_ty`; skip it.
     autoderef.next();
 
+    let receiver_trait_def_id = fcx.tcx.require_lang_item(
+        lang_items::ReceiverTraitLangItem,
+        None,
+    );
+
     // Keep dereferencing `receiver_ty` until we get to `self_ty`.
     loop {
         if let Some((potential_self_ty, _)) = autoderef.next() {
@@ -909,6 +914,19 @@ fn receiver_is_valid<'fcx, 'tcx>(
                 }
 
                 break
+            } else {
+                // Without `feature(arbitrary_self_types)`, we require that each step in the
+                // deref chain implement `receiver`
+                if !arbitrary_self_types_enabled
+                    && !receiver_is_implemented(
+                        fcx,
+                        receiver_trait_def_id,
+                        cause.clone(),
+                        potential_self_ty,
+                    )
+                {
+                    return false
+                }
             }
         } else {
             debug!("receiver_is_valid: type `{:?}` does not deref to `{:?}`",
@@ -917,43 +935,42 @@ fn receiver_is_valid<'fcx, 'tcx>(
             // unecessary errors (#58712).
             return receiver_ty.references_error();
         }
-
-        // Without the `arbitrary_self_types` feature, `receiver_ty` must directly deref to
-        // `self_ty`. Enforce this by only doing one iteration of the loop.
-        if !arbitrary_self_types_enabled {
-            return false
-        }
     }
 
     // Without `feature(arbitrary_self_types)`, we require that `receiver_ty` implements `Receiver`.
-    if !arbitrary_self_types_enabled {
-        let trait_def_id = match fcx.tcx.lang_items().receiver_trait() {
-            Some(did) => did,
-            None => {
-                debug!("receiver_is_valid: missing Receiver trait");
-                return false
-            }
-        };
-
-        let trait_ref = ty::TraitRef{
-            def_id: trait_def_id,
-            substs: fcx.tcx.mk_substs_trait(receiver_ty, &[]),
-        };
-
-        let obligation = traits::Obligation::new(
-            cause,
-            fcx.param_env,
-            trait_ref.to_predicate()
-        );
-
-        if !fcx.predicate_must_hold_modulo_regions(&obligation) {
-            debug!("receiver_is_valid: type `{:?}` does not implement `Receiver` trait",
-                receiver_ty);
-            return false
-        }
+    if !arbitrary_self_types_enabled
+        && !receiver_is_implemented(fcx, receiver_trait_def_id, cause.clone(), receiver_ty)
+    {
+        return false
     }
 
     true
+}
+
+fn receiver_is_implemented(
+    fcx: &FnCtxt<'_, 'tcx>,
+    receiver_trait_def_id: DefId,
+    cause: ObligationCause<'tcx>,
+    receiver_ty: Ty<'tcx>,
+) -> bool {
+    let trait_ref = ty::TraitRef{
+        def_id: receiver_trait_def_id,
+        substs: fcx.tcx.mk_substs_trait(receiver_ty, &[]),
+    };
+
+    let obligation = traits::Obligation::new(
+        cause,
+        fcx.param_env,
+        trait_ref.to_predicate()
+    );
+
+    if fcx.predicate_must_hold_modulo_regions(&obligation) {
+        true
+    } else {
+        debug!("receiver_is_implemented: type `{:?}` does not implement `Receiver` trait",
+            receiver_ty);
+        false
+    }
 }
 
 fn check_variances_for_type_defn<'tcx>(

--- a/src/libsyntax/parse/lexer/mod.rs
+++ b/src/libsyntax/parse/lexer/mod.rs
@@ -23,7 +23,7 @@ mod unicode_chars;
 #[derive(Clone, Debug)]
 pub struct UnmatchedBrace {
     pub expected_delim: token::DelimToken,
-    pub found_delim: token::DelimToken,
+    pub found_delim: Option<token::DelimToken>,
     pub found_span: Span,
     pub unclosed_span: Option<Span>,
     pub candidate_span: Option<Span>,

--- a/src/libsyntax/parse/lexer/tokentrees.rs
+++ b/src/libsyntax/parse/lexer/tokentrees.rs
@@ -80,6 +80,13 @@ impl<'a> TokenTreesReader<'a> {
                     .struct_span_err(self.token.span, msg);
                 for &(_, sp) in &self.open_braces {
                     err.span_label(sp, "un-closed delimiter");
+                    self.unmatched_braces.push(UnmatchedBrace {
+                        expected_delim: token::DelimToken::Brace,
+                        found_delim: None,
+                        found_span: self.token.span,
+                        unclosed_span: Some(sp),
+                        candidate_span: None,
+                    });
                 }
 
                 if let Some((delim, _)) = self.open_braces.last() {
@@ -170,7 +177,7 @@ impl<'a> TokenTreesReader<'a> {
                             let (tok, _) = self.open_braces.pop().unwrap();
                             self.unmatched_braces.push(UnmatchedBrace {
                                 expected_delim: tok,
-                                found_delim: other,
+                                found_delim: Some(other),
                                 found_span: self.token.span,
                                 unclosed_span: unclosed_delimiter,
                                 candidate_span: candidate,

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -1,7 +1,7 @@
 //! The main parser interface.
 
 use crate::ast;
-use crate::parse::parser::{Parser, emit_unclosed_delims};
+use crate::parse::parser::{Parser, emit_unclosed_delims, make_unclosed_delims_error};
 use crate::parse::token::Nonterminal;
 use crate::tokenstream::{self, TokenStream, TokenTree};
 use crate::print::pprust;
@@ -242,18 +242,9 @@ pub fn maybe_file_to_stream(
             err.buffer(&mut buffer);
             // Not using `emit_unclosed_delims` to use `db.buffer`
             for unmatched in unmatched_braces {
-                let mut db = sess.span_diagnostic.struct_span_err(unmatched.found_span, &format!(
-                    "incorrect close delimiter: `{}`",
-                    pprust::token_kind_to_string(&token::CloseDelim(unmatched.found_delim)),
-                ));
-                db.span_label(unmatched.found_span, "incorrect close delimiter");
-                if let Some(sp) = unmatched.candidate_span {
-                    db.span_label(sp, "close delimiter possibly meant for this");
+                if let Some(err) = make_unclosed_delims_error(unmatched, &sess.span_diagnostic) {
+                    err.buffer(&mut buffer);
                 }
-                if let Some(sp) = unmatched.unclosed_span {
-                    db.span_label(sp, "un-closed delimiter");
-                }
-                db.buffer(&mut buffer);
             }
             Err(buffer)
         }

--- a/src/libsyntax/parse/mod.rs
+++ b/src/libsyntax/parse/mod.rs
@@ -108,7 +108,7 @@ pub fn parse_stream_from_source_str(
         sess.source_map().new_source_file(name, source),
         override_span,
     );
-    emit_unclosed_delims(&mut errors, &sess.span_diagnostic);
+    emit_unclosed_delims(&mut errors, &sess);
     stream
 }
 
@@ -242,7 +242,7 @@ pub fn maybe_file_to_stream(
             err.buffer(&mut buffer);
             // Not using `emit_unclosed_delims` to use `db.buffer`
             for unmatched in unmatched_braces {
-                if let Some(err) = make_unclosed_delims_error(unmatched, &sess.span_diagnostic) {
+                if let Some(err) = make_unclosed_delims_error(unmatched, &sess) {
                     err.buffer(&mut buffer);
                 }
             }

--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -27,7 +27,7 @@ use crate::symbol::{kw, sym, Symbol};
 use crate::tokenstream::{self, DelimSpan, TokenTree, TokenStream, TreeAndJoint};
 use crate::ThinVec;
 
-use errors::{Applicability, DiagnosticId, FatalError};
+use errors::{Applicability, DiagnosticBuilder, DiagnosticId, FatalError};
 use rustc_target::spec::abi::{self, Abi};
 use syntax_pos::{Span, BytePos, DUMMY_SP, FileName};
 use log::debug;
@@ -1370,20 +1370,29 @@ impl<'a> Parser<'a> {
     }
 }
 
-pub fn emit_unclosed_delims(unclosed_delims: &mut Vec<UnmatchedBrace>, handler: &errors::Handler) {
-    for unmatched in unclosed_delims.iter() {
-        let mut err = handler.struct_span_err(unmatched.found_span, &format!(
-            "incorrect close delimiter: `{}`",
-            pprust::token_kind_to_string(&token::CloseDelim(unmatched.found_delim)),
-        ));
-        err.span_label(unmatched.found_span, "incorrect close delimiter");
-        if let Some(sp) = unmatched.candidate_span {
-            err.span_label(sp, "close delimiter possibly meant for this");
-        }
-        if let Some(sp) = unmatched.unclosed_span {
-            err.span_label(sp, "un-closed delimiter");
-        }
-        err.emit();
+crate fn make_unclosed_delims_error(
+    unmatched: UnmatchedBrace,
+    handler: &errors::Handler,
+) -> Option<DiagnosticBuilder<'_>> {
+    // `None` here means an `Eof` was found. We already emit those errors elsewhere, we add them to
+    // `unmatched_braces` only for error recovery in the `Parser`.
+    let found_delim = unmatched.found_delim?;
+    let mut err = handler.struct_span_err(unmatched.found_span, &format!(
+        "incorrect close delimiter: `{}`",
+        pprust::token_kind_to_string(&token::CloseDelim(found_delim)),
+    ));
+    err.span_label(unmatched.found_span, "incorrect close delimiter");
+    if let Some(sp) = unmatched.candidate_span {
+        err.span_label(sp, "close delimiter possibly meant for this");
     }
-    unclosed_delims.clear();
+    if let Some(sp) = unmatched.unclosed_span {
+        err.span_label(sp, "un-closed delimiter");
+    }
+    Some(err)
+}
+
+pub fn emit_unclosed_delims(unclosed_delims: &mut Vec<UnmatchedBrace>, handler: &errors::Handler) {
+    for unmatched in unclosed_delims.drain(..) {
+        make_unclosed_delims_error(unmatched, handler).map(|mut e| e.emit());
+    }
 }

--- a/src/libsyntax/parse/parser/diagnostics.rs
+++ b/src/libsyntax/parse/parser/diagnostics.rs
@@ -171,6 +171,12 @@ impl RecoverQPath for Expr {
     }
 }
 
+/// Control whether the closing delimiter should be consumed when calling `Parser::consume_block`.
+crate enum ConsumeClosingDelim {
+    Yes,
+    No,
+}
+
 impl<'a> Parser<'a> {
     pub fn fatal(&self, m: &str) -> DiagnosticBuilder<'a> {
         self.span_fatal(self.token.span, m)
@@ -1105,8 +1111,8 @@ impl<'a> Parser<'a> {
             Ok(x) => x,
             Err(mut err) => {
                 err.emit();
-                // Recover from parse error.
-                self.consume_block(delim);
+                // Recover from parse error, callers expect the closing delim to be consumed.
+                self.consume_block(delim, ConsumeClosingDelim::Yes);
                 self.mk_expr(lo.to(self.prev_span), ExprKind::Err, ThinVec::new())
             }
         }
@@ -1154,9 +1160,16 @@ impl<'a> Parser<'a> {
                     delim.to_string(),
                     Applicability::MaybeIncorrect,
                 );
-                err.emit();
-                self.expected_tokens.clear();  // reduce errors
-                Ok(true)
+                if unmatched.found_delim.is_none() {
+                    // Encountered `Eof` when lexing blocks. Do not recover here to avoid knockdown
+                    // errors which would be emitted elsewhere in the parser and let other error
+                    // recovery consume the rest of the file.
+                    Err(err)
+                } else {
+                    err.emit();
+                    self.expected_tokens.clear();  // Reduce the number of errors.
+                    Ok(true)
+                }
             }
             _ => Err(err),
         }
@@ -1164,7 +1177,12 @@ impl<'a> Parser<'a> {
 
     /// Recovers from `pub` keyword in places where it seems _reasonable_ but isn't valid.
     pub(super) fn eat_bad_pub(&mut self) {
-        if self.token.is_keyword(kw::Pub) {
+        // When `unclosed_delims` is populated, it means that the code being parsed is already
+        // quite malformed, which might mean that, for example, a pub struct definition could be
+        // parsed as being a trait item, which is invalid and this error would trigger
+        // unconditionally, resulting in misleading diagnostics. Because of this, we only attempt
+        // this nice to have recovery for code that is otherwise well formed.
+        if self.token.is_keyword(kw::Pub) && self.unclosed_delims.is_empty() {
             match self.parse_visibility(false) {
                 Ok(vis) => {
                     self.diagnostic()
@@ -1422,15 +1440,26 @@ impl<'a> Parser<'a> {
         Ok(param)
     }
 
-    pub(super) fn consume_block(&mut self, delim: token::DelimToken) {
+    pub(super) fn consume_block(
+        &mut self,
+        delim: token::DelimToken,
+        consume_close: ConsumeClosingDelim,
+    ) {
         let mut brace_depth = 0;
         loop {
             if self.eat(&token::OpenDelim(delim)) {
                 brace_depth += 1;
-            } else if self.eat(&token::CloseDelim(delim)) {
+            } else if self.check(&token::CloseDelim(delim)) {
                 if brace_depth == 0 {
+                    if let ConsumeClosingDelim::Yes = consume_close {
+                        // Some of the callers of this method expect to be able to parse the
+                        // closing delimiter themselves, so we leave it alone. Otherwise we advance
+                        // the parser.
+                        self.bump();
+                    }
                     return;
                 } else {
+                    self.bump();
                     brace_depth -= 1;
                     continue;
                 }

--- a/src/libsyntax/parse/parser/diagnostics.rs
+++ b/src/libsyntax/parse/parser/diagnostics.rs
@@ -1141,6 +1141,11 @@ impl<'a> Parser<'a> {
                  // Don't attempt to recover from this unclosed delimiter more than once.
                 let unmatched = self.unclosed_delims.remove(pos);
                 let delim = TokenType::Token(token::CloseDelim(unmatched.expected_delim));
+                if unmatched.found_delim.is_none() {
+                    // We encountered `Eof`, set this fact here to avoid complaining about missing
+                    // `fn main()` when we found place to suggest the closing brace.
+                    *self.sess.reached_eof.borrow_mut() = true;
+                }
 
                 // We want to suggest the inclusion of the closing delimiter where it makes
                 // the most sense, which is immediately after the last token:

--- a/src/libsyntax/sess.rs
+++ b/src/libsyntax/sess.rs
@@ -73,6 +73,8 @@ pub struct ParseSess {
     pub ambiguous_block_expr_parse: Lock<FxHashMap<Span, Span>>,
     pub injected_crate_name: Once<Symbol>,
     crate gated_spans: GatedSpans,
+    /// The parser has reached `Eof` due to an unclosed brace. Used to silence unnecessary errors.
+    pub reached_eof: Lock<bool>,
 }
 
 impl ParseSess {
@@ -101,6 +103,7 @@ impl ParseSess {
             ambiguous_block_expr_parse: Lock::new(FxHashMap::default()),
             injected_crate_name: Once::new(),
             gated_spans: GatedSpans::default(),
+            reached_eof: Lock::new(false),
         }
     }
 

--- a/src/rustllvm/PassWrapper.cpp
+++ b/src/rustllvm/PassWrapper.cpp
@@ -343,7 +343,7 @@ extern "C" const char* LLVMRustGetHostCPUName(size_t *len) {
 
 extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     const char *TripleStr, const char *CPU, const char *Feature,
-    LLVMRustCodeModel RustCM, LLVMRustRelocMode RustReloc,
+    const char *ABIStr, LLVMRustCodeModel RustCM, LLVMRustRelocMode RustReloc,
     LLVMRustCodeGenOptLevel RustOptLevel, bool UseSoftFloat,
     bool PositionIndependentExecutable, bool FunctionSections,
     bool DataSections,
@@ -374,6 +374,7 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   Options.FunctionSections = FunctionSections;
   Options.MCOptions.AsmVerbose = AsmComments;
   Options.MCOptions.PreserveAsmComments = AsmComments;
+  Options.MCOptions.ABIName = ABIStr;
 
   if (TrapUnreachable) {
     // Tell LLVM to codegen `unreachable` into an explicit trap instruction.

--- a/src/test/ui-fulldeps/lint-group-plugin.rs
+++ b/src/test/ui-fulldeps/lint-group-plugin.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(lint_group_plugin_test)]
+#![plugin(lint_group_plugin_test)] //~ WARNING use of deprecated attribute
 #![allow(dead_code)]
 
 fn lintme() { } //~ WARNING item is named 'lintme'

--- a/src/test/ui-fulldeps/lint-plugin.rs
+++ b/src/test/ui-fulldeps/lint-plugin.rs
@@ -2,7 +2,7 @@
 // aux-build:lint-plugin-test.rs
 // ignore-stage1
 #![feature(plugin)]
-#![plugin(lint_plugin_test)]
+#![plugin(lint_plugin_test)] //~ WARNING use of deprecated attribute
 #![allow(dead_code)]
 
 fn lintme() { } //~ WARNING item is named 'lintme'

--- a/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
+++ b/src/test/ui/conditional-compilation/cfg-attr-multi-true.rs
@@ -17,5 +17,5 @@ impl MustUseDeprecated { //~ warning: use of deprecated item
 
 fn main() {
     MustUseDeprecated::new(); //~ warning: use of deprecated item
-    //| warning: unused `MustUseDeprecated` that must be used
+    //~| warning: unused `MustUseDeprecated` that must be used
 }

--- a/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
+++ b/src/test/ui/const-generics/cannot-infer-type-for-const-param.rs
@@ -8,6 +8,5 @@
 struct Foo<const NUM_BYTES: usize>(pub [u8; NUM_BYTES]);
 
 fn main() {
-    let _ = Foo::<3>([1, 2, 3]); //~ ERROR type annotations needed
-    //~^ ERROR mismatched types
+    let _ = Foo::<3>([1, 2, 3]);
 }

--- a/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.rs
+++ b/src/test/ui/const-generics/issues/issue-62187-encountered-polymorphic-const.rs
@@ -12,5 +12,5 @@ impl<const L: usize> BitLen for [u8; L] {
 }
 
 fn main() {
-    let foo = <[u8; 2]>::BIT_LEN;
+    let foo = <[u8; 2]>::BIT_LEN; //~ WARN unused variable
 }

--- a/src/test/ui/continue-after-missing-main.rs
+++ b/src/test/ui/continue-after-missing-main.rs
@@ -1,6 +1,4 @@
-#![allow(dead_code)]
-
-// error-pattern:`main` function not found in crate
+#![allow(dead_code)] //~ ERROR `main` function not found in crate
 
 struct Tableau<'a, MP> {
     provider: &'a MP,

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -3,15 +3,15 @@ error[E0601]: `main` function not found in crate `continue_after_missing_main`
    |
 LL | / #![allow(dead_code)]
 LL | |
-LL | | // error-pattern:`main` function not found in crate
-LL | |
+LL | | struct Tableau<'a, MP> {
+LL | |     provider: &'a MP,
 ...  |
 LL | |
 LL | | }
    | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
 error[E0623]: lifetime mismatch
-  --> $DIR/continue-after-missing-main.rs:30:56
+  --> $DIR/continue-after-missing-main.rs:28:56
    |
 LL |     tableau: Tableau<'data_provider, AdaptedMatrixProvider<'original_data, MP>>,
    |              ------------------------------------------------------------------ these two types are declared with different lifetimes...

--- a/src/test/ui/derive-uninhabited-enum-38885.rs
+++ b/src/test/ui/derive-uninhabited-enum-38885.rs
@@ -10,7 +10,7 @@ enum Void {}
 #[derive(Debug)]
 enum Foo {
     Bar(u8),
-    Void(Void), //~ WARN never used
+    Void(Void), //~ WARN never constructed
 }
 
 fn main() {

--- a/src/test/ui/did_you_mean/issue-40006.rs
+++ b/src/test/ui/did_you_mean/issue-40006.rs
@@ -1,5 +1,4 @@
-impl dyn X { //~ ERROR cannot be made into an object
-//~^ ERROR missing
+impl dyn A { //~ ERROR missing
     Y
 }
 
@@ -7,10 +6,25 @@ struct S;
 
 trait X { //~ ERROR missing
     X() {}
-    fn xxx() { ### } //~ ERROR missing
-    //~^ ERROR expected
-    L = M; //~ ERROR missing
-    Z = { 2 + 3 }; //~ ERROR expected one of
+    fn xxx() { ### }
+    L = M;
+    Z = { 2 + 3 };
+    ::Y ();
+}
+
+trait A { //~ ERROR missing
+    X() {}
+}
+trait B {
+    fn xxx() { ### } //~ ERROR expected
+}
+trait C { //~ ERROR missing `fn`, `type`, or `const` for trait-item declaration
+    L = M;
+}
+trait D { //~ ERROR missing `fn`, `type`, or `const` for trait-item declaration
+    Z = { 2 + 3 };
+}
+trait E {
     ::Y (); //~ ERROR expected one of
 }
 
@@ -21,5 +35,5 @@ impl S {
 }
 
 fn main() {
-    S.hello_method();
+    S.hello_method(); //~ no method named `hello_method` found for type `S` in the current scope
 }

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -1,70 +1,70 @@
 error: missing `fn`, `type`, or `const` for impl-item declaration
   --> $DIR/issue-40006.rs:1:13
    |
-LL |   impl dyn X {
+LL |   impl dyn A {
    |  _____________^
-LL | |
 LL | |     Y
    | |____^ missing `fn`, `type`, or `const`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
-  --> $DIR/issue-40006.rs:8:10
+  --> $DIR/issue-40006.rs:7:10
    |
 LL |   trait X {
    |  __________^
 LL | |     X() {}
    | |____^ missing `fn`, `type`, or `const`
 
+error: missing `fn`, `type`, or `const` for trait-item declaration
+  --> $DIR/issue-40006.rs:15:10
+   |
+LL |   trait A {
+   |  __________^
+LL | |     X() {}
+   | |____^ missing `fn`, `type`, or `const`
+
 error: expected `[`, found `#`
-  --> $DIR/issue-40006.rs:10:17
+  --> $DIR/issue-40006.rs:19:17
    |
 LL |     fn xxx() { ### }
    |                 ^ expected `[`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
-  --> $DIR/issue-40006.rs:10:21
+  --> $DIR/issue-40006.rs:21:10
    |
-LL |       fn xxx() { ### }
-   |  _____________________^
-LL | |
+LL |   trait C {
+   |  __________^
 LL | |     L = M;
    | |____^ missing `fn`, `type`, or `const`
 
 error: missing `fn`, `type`, or `const` for trait-item declaration
-  --> $DIR/issue-40006.rs:12:11
+  --> $DIR/issue-40006.rs:24:10
    |
-LL |       L = M;
-   |  ___________^
+LL |   trait D {
+   |  __________^
 LL | |     Z = { 2 + 3 };
    | |____^ missing `fn`, `type`, or `const`
 
-error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
-  --> $DIR/issue-40006.rs:13:18
-   |
-LL |     Z = { 2 + 3 };
-   |                  ^ expected one of 7 possible tokens here
-
 error: expected one of `!` or `::`, found `(`
-  --> $DIR/issue-40006.rs:14:9
+  --> $DIR/issue-40006.rs:28:9
    |
 LL |     ::Y ();
    |         ^ expected one of `!` or `::` here
 
 error: missing `fn`, `type`, or `const` for impl-item declaration
-  --> $DIR/issue-40006.rs:18:8
+  --> $DIR/issue-40006.rs:32:8
    |
 LL |     pub hello_method(&self) {
    |        ^ missing `fn`, `type`, or `const`
 
-error[E0038]: the trait `X` cannot be made into an object
-  --> $DIR/issue-40006.rs:1:6
+error[E0599]: no method named `hello_method` found for type `S` in the current scope
+  --> $DIR/issue-40006.rs:38:7
    |
-LL | impl dyn X {
-   |      ^^^^^ the trait `X` cannot be made into an object
+LL | struct S;
+   | --------- method `hello_method` not found for this
 ...
-LL |     fn xxx() { ### }
-   |        --- associated function `xxx` has no `self` parameter
+LL |     S.hello_method();
+   |       ^^^^^^^^^^^^ method not found in `S`
 
 error: aborting due to 9 previous errors
 
-For more information about this error, try `rustc --explain E0038`.
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.rs
@@ -38,6 +38,7 @@
 // Exception, a gated and deprecated attribute.
 
 #![plugin_registrar] //~ WARN unused attribute
+//~| WARN use of deprecated attribute
 
 // UNGATED WHITE-LISTED BUILT-IN ATTRIBUTES
 
@@ -90,7 +91,7 @@
 #![crate_id = "10"] //~ WARN use of deprecated attribute
 
 // FIXME(#44232) we should warn that this isn't used.
-#![feature(rust1)]
+#![feature(rust1)] //~ WARN no longer requires an attribute to enable
 
 #![no_start] //~ WARN use of deprecated attribute
 
@@ -215,20 +216,25 @@ mod macro_export {
 
 #[plugin_registrar]
 //~^ WARN unused attribute
+//~| WARN use of deprecated attribute
 mod plugin_registrar {
     mod inner { #![plugin_registrar] }
     //~^ WARN unused attribute
+    //~| WARN use of deprecated attribute
 
     // for `fn f()` case, see gated-plugin_registrar.rs
 
     #[plugin_registrar] struct S;
     //~^ WARN unused attribute
+    //~| WARN use of deprecated attribute
 
     #[plugin_registrar] type T = S;
     //~^ WARN unused attribute
+    //~| WARN use of deprecated attribute
 
     #[plugin_registrar] impl S { }
     //~^ WARN unused attribute
+    //~| WARN use of deprecated attribute
 }
 
 #[main]

--- a/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gate/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,5 +1,5 @@
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:44:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:9
    |
 LL | #![warn(x5400)]
    |         ^^^^^
@@ -11,175 +11,175 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |                            ^^^^^^^^^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:45:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:46:10
    |
 LL | #![allow(x5300)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:46:11
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:47:11
    |
 LL | #![forbid(x5200)]
    |           ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:47:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:48:9
    |
 LL | #![deny(x5100)]
    |         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:104:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:105:8
    |
 LL | #[warn(x5400)]
    |        ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:107:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:108:25
    |
 LL |     mod inner { #![warn(x5400)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:110:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:111:12
    |
 LL |     #[warn(x5400)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:113:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:114:12
    |
 LL |     #[warn(x5400)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:116:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:117:12
    |
 LL |     #[warn(x5400)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5400`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:119:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:120:12
    |
 LL |     #[warn(x5400)] impl S { }
    |            ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:123:9
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:124:9
    |
 LL | #[allow(x5300)]
    |         ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:126:26
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:127:26
    |
 LL |     mod inner { #![allow(x5300)] }
    |                          ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:129:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:130:13
    |
 LL |     #[allow(x5300)] fn f() { }
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:132:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:133:13
    |
 LL |     #[allow(x5300)] struct S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:135:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:136:13
    |
 LL |     #[allow(x5300)] type T = S;
    |             ^^^^^
 
 warning: unknown lint: `x5300`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:138:13
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:139:13
    |
 LL |     #[allow(x5300)] impl S { }
    |             ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:142:10
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:143:10
    |
 LL | #[forbid(x5200)]
    |          ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:145:27
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:146:27
    |
 LL |     mod inner { #![forbid(x5200)] }
    |                           ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:148:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:149:14
    |
 LL |     #[forbid(x5200)] fn f() { }
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:151:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:152:14
    |
 LL |     #[forbid(x5200)] struct S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:154:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:155:14
    |
 LL |     #[forbid(x5200)] type T = S;
    |              ^^^^^
 
 warning: unknown lint: `x5200`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:157:14
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:158:14
    |
 LL |     #[forbid(x5200)] impl S { }
    |              ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:161:8
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:162:8
    |
 LL | #[deny(x5100)]
    |        ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:164:25
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:165:25
    |
 LL |     mod inner { #![deny(x5100)] }
    |                         ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:167:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:168:12
    |
 LL |     #[deny(x5100)] fn f() { }
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:170:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:171:12
    |
 LL |     #[deny(x5100)] struct S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:173:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:174:12
    |
 LL |     #[deny(x5100)] type T = S;
    |            ^^^^^
 
 warning: unknown lint: `x5100`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:176:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:177:12
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
 
 warning: macro_escape is a deprecated synonym for macro_use
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:460:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:1
    |
 LL | #[macro_escape]
    | ^^^^^^^^^^^^^^^
 
 warning: macro_escape is a deprecated synonym for macro_use
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:463:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:17
    |
 LL |     mod inner { #![macro_escape] }
    |                 ^^^^^^^^^^^^^^^^
@@ -187,7 +187,7 @@ LL |     mod inner { #![macro_escape] }
    = help: consider an outer attribute, `#[macro_use]` mod ...
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:17
    |
 LL |     mod inner { #![plugin_registrar] }
    |                 ^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
@@ -195,25 +195,25 @@ LL |     mod inner { #![plugin_registrar] }
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
    |
 LL |     #[plugin_registrar] struct S;
    |     ^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:231:5
    |
 LL |     #[plugin_registrar] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:230:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:235:5
    |
 LL |     #[plugin_registrar] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
 
 warning: use of deprecated attribute `plugin_registrar`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:217:1
    |
 LL | #[plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
@@ -225,19 +225,19 @@ LL | #![plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
 
 warning: use of deprecated attribute `crate_id`: no longer used.
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:90:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:91:1
    |
 LL | #![crate_id = "10"]
    | ^^^^^^^^^^^^^^^^^^^ help: remove this attribute
 
 warning: use of deprecated attribute `no_start`: no longer used.
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:95:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:96:1
    |
 LL | #![no_start]
    | ^^^^^^^^^^^^ help: remove this attribute
 
 warning: the feature `rust1` has been stable since 1.0.0 and no longer requires an attribute to enable
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:93:12
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:94:12
    |
 LL | #![feature(rust1)]
    |            ^^^^^
@@ -245,7 +245,7 @@ LL | #![feature(rust1)]
    = note: `#[warn(stable_features)]` on by default
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:184:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:185:5
    |
 LL |     #[macro_use] fn f() { }
    |     ^^^^^^^^^^^^
@@ -257,913 +257,913 @@ LL | #![warn(unused_attributes, unknown_lints)]
    |         ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:187:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:188:5
    |
 LL |     #[macro_use] struct S;
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:190:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:191:5
    |
 LL |     #[macro_use] type T = S;
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:193:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:194:5
    |
 LL |     #[macro_use] impl S { }
    |     ^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:200:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:201:17
    |
 LL |     mod inner { #![macro_export] }
    |                 ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:203:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:204:5
    |
 LL |     #[macro_export] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:206:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:207:5
    |
 LL |     #[macro_export] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:209:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:210:5
    |
 LL |     #[macro_export] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:212:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:213:5
    |
 LL |     #[macro_export] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:197:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:198:1
    |
 LL | #[macro_export]
    | ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:219:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:221:17
    |
 LL |     mod inner { #![plugin_registrar] }
    |                 ^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:224:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
    |
 LL |     #[plugin_registrar] struct S;
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:227:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:231:5
    |
 LL |     #[plugin_registrar] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:230:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:235:5
    |
 LL |     #[plugin_registrar] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:216:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:217:1
    |
 LL | #[plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:237:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:243:17
    |
 LL |     mod inner { #![main] }
    |                 ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:242:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:248:5
    |
 LL |     #[main] struct S;
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:245:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:251:5
    |
 LL |     #[main] type T = S;
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:248:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:254:5
    |
 LL |     #[main] impl S { }
    |     ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:234:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:240:1
    |
 LL | #[main]
    | ^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:255:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:261:17
    |
 LL |     mod inner { #![start] }
    |                 ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:260:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:266:5
    |
 LL |     #[start] struct S;
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:263:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:269:5
    |
 LL |     #[start] type T = S;
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:266:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:272:5
    |
 LL |     #[start] impl S { }
    |     ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:252:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:258:1
    |
 LL | #[start]
    | ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:319:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:325:5
    |
 LL |     #[path = "3800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:322:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:328:5
    |
 LL |     #[path = "3800"]  struct S;
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:325:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:331:5
    |
 LL |     #[path = "3800"] type T = S;
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:328:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:334:5
    |
 LL |     #[path = "3800"] impl S { }
    |     ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:335:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:17
    |
 LL |     mod inner { #![automatically_derived] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:338:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:344:5
    |
 LL |     #[automatically_derived] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:341:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:347:5
    |
 LL |     #[automatically_derived] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:344:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:350:5
    |
 LL |     #[automatically_derived] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:347:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:353:5
    |
 LL |     #[automatically_derived] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:332:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:338:1
    |
 LL | #[automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:367:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:17
    |
 LL |     mod inner { #![no_link] }
    |                 ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:370:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:376:5
    |
 LL |     #[no_link] fn f() { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:373:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:5
    |
 LL |     #[no_link] struct S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:376:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:382:5
    |
 LL |     #[no_link]type T = S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:379:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:385:5
    |
 LL |     #[no_link] impl S { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:364:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:370:1
    |
 LL | #[no_link]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:386:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:17
    |
 LL |     mod inner { #![should_panic] }
    |                 ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:5
    |
 LL |     #[should_panic] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:392:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:5
    |
 LL |     #[should_panic] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:395:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:401:5
    |
 LL |     #[should_panic] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:404:5
    |
 LL |     #[should_panic] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:383:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:389:1
    |
 LL | #[should_panic]
    | ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:405:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:411:17
    |
 LL |     mod inner { #![ignore] }
    |                 ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
    |
 LL |     #[ignore] fn f() { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:411:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:417:5
    |
 LL |     #[ignore] struct S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:414:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:420:5
    |
 LL |     #[ignore] type T = S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:417:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:423:5
    |
 LL |     #[ignore] impl S { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:402:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:408:1
    |
 LL | #[ignore]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:424:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:430:17
    |
 LL |     mod inner { #![no_implicit_prelude] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:433:5
    |
 LL |     #[no_implicit_prelude] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:430:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:436:5
    |
 LL |     #[no_implicit_prelude] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:433:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:439:5
    |
 LL |     #[no_implicit_prelude] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:436:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:442:5
    |
 LL |     #[no_implicit_prelude] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:421:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:427:1
    |
 LL | #[no_implicit_prelude]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:443:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:17
    |
 LL |     mod inner { #![reexport_test_harness_main="2900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:446:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:452:5
    |
 LL |     #[reexport_test_harness_main = "2900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:449:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:455:5
    |
 LL |     #[reexport_test_harness_main = "2900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:452:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:458:5
    |
 LL |     #[reexport_test_harness_main = "2900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:455:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:461:5
    |
 LL |     #[reexport_test_harness_main = "2900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:440:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:446:1
    |
 LL | #[reexport_test_harness_main = "2900"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:466:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:5
    |
 LL |     #[macro_escape] fn f() { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:469:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:5
    |
 LL |     #[macro_escape] struct S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:472:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:478:5
    |
 LL |     #[macro_escape] type T = S;
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:475:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:481:5
    |
 LL |     #[macro_escape] impl S { }
    |     ^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:489:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:483:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:489:17
    |
 LL |     mod inner { #![no_std] }
    |                 ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:493:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:487:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:493:5
    |
 LL |     #[no_std] fn f() { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:497:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:491:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:497:5
    |
 LL |     #[no_std] struct S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:501:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:495:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:501:5
    |
 LL |     #[no_std] type T = S;
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:499:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:505:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:499:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:505:5
    |
 LL |     #[no_std] impl S { }
    |     ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:485:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:479:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:485:1
    |
 LL | #[no_std]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:638:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:644:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:638:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:644:17
    |
 LL |     mod inner { #![crate_name="0900"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:648:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:642:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:648:5
    |
 LL |     #[crate_name = "0900"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:652:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:646:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:652:5
    |
 LL |     #[crate_name = "0900"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:656:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:650:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:656:5
    |
 LL |     #[crate_name = "0900"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:654:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:660:5
    |
 LL |     #[crate_name = "0900"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:640:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:634:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:640:1
    |
 LL | #[crate_name = "0900"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:669:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:663:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:669:17
    |
 LL |     mod inner { #![crate_type="0800"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:667:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:673:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:667:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:673:5
    |
 LL |     #[crate_type = "0800"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:677:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:671:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:677:5
    |
 LL |     #[crate_type = "0800"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:681:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:675:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:681:5
    |
 LL |     #[crate_type = "0800"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:679:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:679:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:685:5
    |
 LL |     #[crate_type = "0800"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:659:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:665:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:659:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:665:1
    |
 LL | #[crate_type = "0800"]
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:694:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:688:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:694:17
    |
 LL |     mod inner { #![feature(x0600)] }
    |                 ^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:698:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:692:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:698:5
    |
 LL |     #[feature(x0600)] fn f() { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:702:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:696:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:702:5
    |
 LL |     #[feature(x0600)] struct S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:700:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:706:5
    |
 LL |     #[feature(x0600)] type T = S;
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:704:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:704:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:5
    |
 LL |     #[feature(x0600)] impl S { }
    |     ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:684:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:690:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:684:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:690:1
    |
 LL | #[feature(x0600)]
    | ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:714:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:720:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:714:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:720:17
    |
 LL |     mod inner { #![no_main] }
    |                 ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:724:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:718:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:724:5
    |
 LL |     #[no_main] fn f() { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:728:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:722:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:728:5
    |
 LL |     #[no_main] struct S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:732:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:726:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:732:5
    |
 LL |     #[no_main] type T = S;
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:730:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:736:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:730:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:736:5
    |
 LL |     #[no_main] impl S { }
    |     ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:710:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:716:1
    |
 LL | #[no_main]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:752:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:758:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:752:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:758:17
    |
 LL |     mod inner { #![recursion_limit="0200"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:762:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:756:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:762:5
    |
 LL |     #[recursion_limit="0200"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:766:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:760:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:766:5
    |
 LL |     #[recursion_limit="0200"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:764:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:770:5
    |
 LL |     #[recursion_limit="0200"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:768:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:774:5
    |
 LL |     #[recursion_limit="0200"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:748:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:754:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:748:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:754:1
    |
 LL | #[recursion_limit="0200"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:783:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be in the root module
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:777:17
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:783:17
    |
 LL |     mod inner { #![type_length_limit="0100"] }
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:787:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:781:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:787:5
    |
 LL |     #[type_length_limit="0100"] fn f() { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:791:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:785:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:791:5
    |
 LL |     #[type_length_limit="0100"] struct S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:789:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:795:5
    |
 LL |     #[type_length_limit="0100"] type T = S;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:799:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:793:5
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:799:5
    |
 LL |     #[type_length_limit="0100"] impl S { }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:779:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:773:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:779:1
    |
 LL | #[type_length_limit="0100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1175,61 +1175,61 @@ LL | #![plugin_registrar]
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:49:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:50:1
    |
 LL | #![macro_export]
    | ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:52:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:53:1
    |
 LL | #![main]
    | ^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:53:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:54:1
    |
 LL | #![start]
    | ^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:56:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:57:1
    |
 LL | #![repr()]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:58:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:59:1
    |
 LL | #![path = "3800"]
    | ^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:59:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:60:1
    |
 LL | #![automatically_derived]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:61:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:62:1
    |
 LL | #![no_link]
    | ^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:63:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:64:1
    |
 LL | #![should_panic]
    | ^^^^^^^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:64:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:65:1
    |
 LL | #![ignore]
    | ^^^^^^^^^^
 
 warning: unused attribute
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:70:1
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:71:1
    |
 LL | #![proc_macro_derive()]
    | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/huge-struct.rs
+++ b/src/test/ui/huge-struct.rs
@@ -47,6 +47,6 @@ struct S1M<T> { val: S1k<S1k<T>> }
 
 fn main() {
     let fat: Option<S1M<S1M<S1M<u32>>>> = None;
-    //~^ ERROR the type `S32<S1M<S1M<u32>>>` is too big for the current architecture
+    //~^ ERROR is too big for the current architecture
 
 }

--- a/src/test/ui/if/if-let.rs
+++ b/src/test/ui/if/if-let.rs
@@ -4,6 +4,8 @@ fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             if let $p = $e $b
+            //~^ WARN irrefutable if-let
+            //~| WARN irrefutable if-let
         }}
     }
     macro_rules! bar{
@@ -12,10 +14,10 @@ fn macros() {
         }}
     }
 
-    foo!(a, 1, { //~ WARN irrefutable if-let
+    foo!(a, 1, {
         println!("irrefutable pattern");
     });
-    bar!(a, 1, { //~ WARN irrefutable if-let
+    bar!(a, 1, {
         println!("irrefutable pattern");
     });
 }

--- a/src/test/ui/if/if-let.stderr
+++ b/src/test/ui/if/if-let.stderr
@@ -23,7 +23,7 @@ LL | |     });
    | |_______- in this macro invocation
 
 warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:24:5
+  --> $DIR/if-let.rs:26:5
    |
 LL | /     if let a = 1 {
 LL | |         println!("irrefutable pattern");
@@ -31,7 +31,7 @@ LL | |     }
    | |_____^
 
 warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:28:5
+  --> $DIR/if-let.rs:30:5
    |
 LL | /     if let a = 1 {
 LL | |         println!("irrefutable pattern");
@@ -43,7 +43,7 @@ LL | |     }
    | |_____^
 
 warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:38:12
+  --> $DIR/if-let.rs:40:12
    |
 LL |       } else if let a = 1 {
    |  ____________^
@@ -52,7 +52,7 @@ LL | |     }
    | |_____^
 
 warning: irrefutable if-let pattern
-  --> $DIR/if-let.rs:44:12
+  --> $DIR/if-let.rs:46:12
    |
 LL |       } else if let a = 1 {
    |  ____________^

--- a/src/test/ui/issues/issue-54943-3.rs
+++ b/src/test/ui/issues/issue-54943-3.rs
@@ -15,7 +15,6 @@ fn bar<'a>() {
     return;
 
     let _x = foo::<Vec<_>>(Vec::<&'a u32>::new());
-    //~^ ERROR the type `&'a u32` does not fulfill the required lifetime [E0477]
 }
 
 fn main() {}

--- a/src/test/ui/issues/issue-60075.rs
+++ b/src/test/ui/issues/issue-60075.rs
@@ -5,8 +5,7 @@ trait T {
         let _ = if true {
         });
 //~^ ERROR expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `;`
-//~^^ ERROR expected one of `.`, `;`, `?`, `else`, or an operator, found `}`
-//~^^^ ERROR 6:11: 6:12: expected identifier, found `;`
-//~^^^^ ERROR missing `fn`, `type`, or `const` for trait-item declaration
+//~| ERROR expected one of `.`, `;`, `?`, `else`, or an operator, found `}`
+//~| ERROR expected identifier, found `;`
         Some(4)
     }

--- a/src/test/ui/issues/issue-60075.stderr
+++ b/src/test/ui/issues/issue-60075.stderr
@@ -19,17 +19,5 @@ error: expected identifier, found `;`
 LL |         });
    |           ^ expected identifier
 
-error: missing `fn`, `type`, or `const` for trait-item declaration
-  --> $DIR/issue-60075.rs:6:12
-   |
-LL |           });
-   |  ____________^
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |         Some(4)
-   | |________^ missing `fn`, `type`, or `const`
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/lint/reasons.rs
+++ b/src/test/ui/lint/reasons.rs
@@ -28,6 +28,8 @@ impl fmt::Debug for CheaterDetectionMechanism {
 
 fn main() {
     let Social_exchange_psychology = CheaterDetectionMechanism {};
-    //~^ WARN should have a snake case name such as
+    //~^ WARN should have a snake case name
+    //~| NOTE #[warn(non_snake_case)]` implied by `#[warn(nonstandard_style)]
     //~| NOTE people shouldn't have to change their usual style habits
+    //~| HELP convert the identifier to snake case
 }

--- a/src/test/ui/lint/type-overflow.rs
+++ b/src/test/ui/lint/type-overflow.rs
@@ -2,7 +2,7 @@
 #![warn(overflowing_literals)]
 
 fn main() {
-    let error = 255i8; //~WARNING literal out of range for i8
+    let error = 255i8; //~WARNING literal out of range for `i8`
 
     let ok = 0b1000_0001; // should be ok -> i32
     let ok = 0b0111_1111i8; // should be ok -> 127i8

--- a/src/test/ui/lint/use-redundant.rs
+++ b/src/test/ui/lint/use-redundant.rs
@@ -1,7 +1,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 #![warn(unused_imports)]
 
-use crate::foo::Bar; //~ WARNING first import
+use crate::foo::Bar;
 
 mod foo {
     pub type Bar = i32;
@@ -14,14 +14,14 @@ fn baz() -> Bar {
 mod m1 { pub struct S {} }
 mod m2 { pub struct S {} }
 
-use m1::*;
-use m2::*;
+use m1::*; //~ WARNING unused import
+use m2::*; //~ WARNING unused import
 
 fn main() {
-    use crate::foo::Bar; //~ WARNING redundant import
+    use crate::foo::Bar; //~ WARNING imported redundantly
     let _a: Bar = 3;
     baz();
 
-    use m1::S; //~ WARNING redundant import
+    use m1::S;
     let _s = S {};
 }

--- a/src/test/ui/malformed/malformed-regressions.rs
+++ b/src/test/ui/malformed/malformed-regressions.rs
@@ -1,8 +1,18 @@
 // build-pass (FIXME(62277): could be check-pass?)
 
-#[doc] //~ WARN attribute must be of the form
-#[ignore()] //~ WARN attribute must be of the form
-#[inline = ""] //~ WARN attribute must be of the form
-#[link] //~ WARN attribute must be of the form
-#[link = ""] //~ WARN attribute must be of the form
+#[doc]
+//~^ WARN attribute must be of the form
+//~| WARN this was previously accepted
+#[ignore()]
+//~^ WARN attribute must be of the form
+//~| WARN this was previously accepted
+#[inline = ""]
+//~^ WARN attribute must be of the form
+//~| WARN this was previously accepted
+#[link]
+//~^WARN attribute must be of the form
+//~| WARN this was previously accepted
+#[link = ""]
+//~^ WARN attribute must be of the form
+//~| WARN this was previously accepted
 fn main() {}

--- a/src/test/ui/malformed/malformed-regressions.stderr
+++ b/src/test/ui/malformed/malformed-regressions.stderr
@@ -9,7 +9,7 @@ LL | #[doc]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[ignore]` or `#[ignore = "reason"]`
-  --> $DIR/malformed-regressions.rs:4:1
+  --> $DIR/malformed-regressions.rs:6:1
    |
 LL | #[ignore()]
    | ^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL | #[ignore()]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[inline]` or `#[inline(always|never)]`
-  --> $DIR/malformed-regressions.rs:5:1
+  --> $DIR/malformed-regressions.rs:9:1
    |
 LL | #[inline = ""]
    | ^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL | #[inline = ""]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dylib|static|...", /*opt*/ cfg = "...")]`
-  --> $DIR/malformed-regressions.rs:6:1
+  --> $DIR/malformed-regressions.rs:12:1
    |
 LL | #[link]
    | ^^^^^^^
@@ -36,7 +36,7 @@ LL | #[link]
    = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>
 
 warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dylib|static|...", /*opt*/ cfg = "...")]`
-  --> $DIR/malformed-regressions.rs:7:1
+  --> $DIR/malformed-regressions.rs:15:1
    |
 LL | #[link = ""]
    | ^^^^^^^^^^^^

--- a/src/test/ui/parser-recovery-1.rs
+++ b/src/test/ui/parser-recovery-1.rs
@@ -3,7 +3,6 @@
 // Test that we can recover from missing braces in the parser.
 
 trait Foo {
-//~^ ERROR `main` function not found
     fn bar() {
         let x = foo();
         //~^ ERROR cannot find function `foo` in this scope

--- a/src/test/ui/parser-recovery-1.stderr
+++ b/src/test/ui/parser-recovery-1.stderr
@@ -1,9 +1,8 @@
 error: this file contains an un-closed delimiter
-  --> $DIR/parser-recovery-1.rs:16:55
+  --> $DIR/parser-recovery-1.rs:15:55
    |
 LL | trait Foo {
    |           - un-closed delimiter
-LL |
 LL |     fn bar() {
    |              - this delimiter might not be properly closed...
 ...
@@ -14,36 +13,23 @@ LL | }
    |                                                       ^
 
 error: unexpected token: `;`
-  --> $DIR/parser-recovery-1.rs:13:15
+  --> $DIR/parser-recovery-1.rs:12:15
    |
 LL |     let x = y.;
    |               ^
 
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/parser-recovery-1.rs:8:17
+  --> $DIR/parser-recovery-1.rs:7:17
    |
 LL |         let x = foo();
    |                 ^^^ not found in this scope
 
 error[E0425]: cannot find value `y` in this scope
-  --> $DIR/parser-recovery-1.rs:13:13
+  --> $DIR/parser-recovery-1.rs:12:13
    |
 LL |     let x = y.;
    |             ^ not found in this scope
 
-error[E0601]: `main` function not found in crate `parser_recovery_1`
-  --> $DIR/parser-recovery-1.rs:5:1
-   |
-LL | / trait Foo {
-LL | |
-LL | |     fn bar() {
-LL | |         let x = foo();
-...  |
-LL | |
-LL | | }
-   | |______________________________________________________^ consider adding a `main` function to `$DIR/parser-recovery-1.rs`
+error: aborting due to 4 previous errors
 
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0425, E0601.
-For more information about an error, try `rustc --explain E0425`.
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/parser/issue-2354.rs
+++ b/src/test/ui/parser/issue-2354.rs
@@ -1,7 +1,4 @@
 fn foo() { //~ NOTE un-closed delimiter
-//~^ ERROR `main` function not found
-//~^^ NOTE main function must be defined
-//~^^^ NOTE you have one or more functions
   match Some(10) {
   //~^ NOTE this delimiter might not be properly closed...
       Some(y) => { panic!(); }
@@ -14,5 +11,5 @@ fn bar() {
     while (i < 1000) {}
 }
 
-fn main() {} //~ NOTE here is a function named `main`
-             //~ ERROR this file contains an un-closed delimiter
+fn main() {}
+//~ ERROR this file contains an un-closed delimiter

--- a/src/test/ui/parser/issue-2354.stderr
+++ b/src/test/ui/parser/issue-2354.stderr
@@ -1,9 +1,8 @@
 error: this file contains an un-closed delimiter
-  --> $DIR/issue-2354.rs:18:66
+  --> $DIR/issue-2354.rs:15:53
    |
 LL | fn foo() {
    |          - un-closed delimiter
-...
 LL |   match Some(10) {
    |                  - this delimiter might not be properly closed...
 ...
@@ -11,28 +10,7 @@ LL | }
    | - ...as it matches this but it has different indentation
 ...
 LL |
-   |                                                                  ^
+   |                                                     ^
 
-error[E0601]: `main` function not found in crate `issue_2354`
-  --> $DIR/issue-2354.rs:1:1
-   |
-LL | / fn foo() {
-LL | |
-LL | |
-LL | |
-...  |
-LL | | fn main() {}
-LL | |
-   | |_________________________________________________________________^ the main function must be defined at the crate level (in `$DIR/issue-2354.rs`)
-   |
-note: here is a function named `main`
-  --> $DIR/issue-2354.rs:17:1
-   |
-LL | fn main() {}
-   | ^^^^^^^^^^^^
-   = note: you have one or more functions named `main` not defined at the crate level
-   = help: either move the `main` function definitions or attach the `#[main]` attribute to one of them
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -13,9 +13,11 @@ error: expected one of `,` or `}`, found `{`
   --> $DIR/issue-62973.rs:6:25
    |
 LL | fn p() { match s { v, E { [) {) }
-   |                -        ^ expected one of `,` or `}` here
-   |                |
-   |                while parsing this struct
+   |        -       -       -^ expected one of `,` or `}` here
+   |        |       |       |
+   |        |       |       help: `}` may belong here
+   |        |       while parsing this struct
+   |        unclosed delimiter
 
 error: struct literals are not allowed here
   --> $DIR/issue-62973.rs:6:16

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
@@ -1,0 +1,13 @@
+impl T for () { //~ ERROR `main` function not found
+//~^ ERROR cannot find trait `T` in this scope
+
+fn foo(&self) {}
+
+trait T { //~ ERROR expected one of
+    fn foo(&self);
+}
+
+pub(crate) struct Bar<T>();
+
+fn main() {}
+//~ ERROR this file contains an un-closed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.rs
@@ -1,5 +1,4 @@
-impl T for () { //~ ERROR `main` function not found
-//~^ ERROR cannot find trait `T` in this scope
+impl T for () { //~ ERROR cannot find trait `T` in this scope
 
 fn foo(&self) {}
 

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
@@ -1,5 +1,5 @@
 error: this file contains an un-closed delimiter
-  --> $DIR/missing-close-brace-in-impl-trait.rs:13:53
+  --> $DIR/missing-close-brace-in-impl-trait.rs:12:53
    |
 LL | impl T for () {
    |               - un-closed delimiter
@@ -7,12 +7,12 @@ LL | impl T for () {
 LL |
    |                                                     ^
 
-error: expected one of `async`, `const`, `crate`, `default`, `extern`, `fn`, `pub`, `type`, `unsafe`, or `}`, found `trait`
-  --> $DIR/missing-close-brace-in-impl-trait.rs:6:1
+error: expected one of `async`, `const`, `crate`, `default`, `extern`, `fn`, `pub`, `type`, `unsafe`, or `}`, found keyword `trait`
+  --> $DIR/missing-close-brace-in-impl-trait.rs:5:1
    |
 LL | impl T for () {
    |               - unclosed delimiter
-...
+LL | 
 LL | fn foo(&self) {}
    |                 -
    |                 |
@@ -28,19 +28,6 @@ error[E0405]: cannot find trait `T` in this scope
 LL | impl T for () {
    |      ^ not found in this scope
 
-error[E0601]: `main` function not found in crate `missing_close_brace_in_impl_trait`
-  --> $DIR/missing-close-brace-in-impl-trait.rs:1:1
-   |
-LL | / impl T for () {
-LL | |
-LL | |
-LL | | fn foo(&self) {}
-...  |
-LL | | fn main() {}
-LL | |
-   | |____________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-impl-trait.rs`
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0405, E0601.
-For more information about an error, try `rustc --explain E0405`.
+For more information about this error, try `rustc --explain E0405`.

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-impl-trait.stderr
@@ -1,0 +1,46 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/missing-close-brace-in-impl-trait.rs:13:53
+   |
+LL | impl T for () {
+   |               - un-closed delimiter
+...
+LL |
+   |                                                     ^
+
+error: expected one of `async`, `const`, `crate`, `default`, `extern`, `fn`, `pub`, `type`, `unsafe`, or `}`, found `trait`
+  --> $DIR/missing-close-brace-in-impl-trait.rs:6:1
+   |
+LL | impl T for () {
+   |               - unclosed delimiter
+...
+LL | fn foo(&self) {}
+   |                 -
+   |                 |
+   |                 expected one of 10 possible tokens here
+   |                 help: `}` may belong here
+LL | 
+LL | trait T {
+   | ^^^^^ unexpected token
+
+error[E0405]: cannot find trait `T` in this scope
+  --> $DIR/missing-close-brace-in-impl-trait.rs:1:6
+   |
+LL | impl T for () {
+   |      ^ not found in this scope
+
+error[E0601]: `main` function not found in crate `missing_close_brace_in_impl_trait`
+  --> $DIR/missing-close-brace-in-impl-trait.rs:1:1
+   |
+LL | / impl T for () {
+LL | |
+LL | |
+LL | | fn foo(&self) {}
+...  |
+LL | | fn main() {}
+LL | |
+   | |____________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-impl-trait.rs`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0405, E0601.
+For more information about an error, try `rustc --explain E0405`.

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
@@ -1,0 +1,14 @@
+pub(crate) struct Bar<T> { //~ ERROR `main` function not found
+  foo: T,
+
+trait T { //~ ERROR expected identifier, found keyword `trait`
+//~^ ERROR expected `:`, found `T`
+    fn foo(&self);
+}
+
+
+impl T for Bar<usize> {
+fn foo(&self) {}
+}
+
+fn main() {} //~ ERROR this file contains an un-closed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.rs
@@ -1,4 +1,4 @@
-pub(crate) struct Bar<T> { //~ ERROR `main` function not found
+pub(crate) struct Bar<T> {
   foo: T,
 
 trait T { //~ ERROR expected identifier, found keyword `trait`

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
@@ -24,18 +24,5 @@ error: expected `:`, found `T`
 LL | trait T {
    |       ^ expected `:`
 
-error[E0601]: `main` function not found in crate `missing_close_brace_in_struct`
-  --> $DIR/missing-close-brace-in-struct.rs:1:1
-   |
-LL | / pub(crate) struct Bar<T> {
-LL | |   foo: T,
-LL | |
-LL | | trait T {
-...  |
-LL | |
-LL | | fn main() {}
-   | |_________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-struct.rs`
+error: aborting due to 3 previous errors
 
-error: aborting due to 4 previous errors
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-struct.stderr
@@ -1,0 +1,41 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/missing-close-brace-in-struct.rs:14:66
+   |
+LL | pub(crate) struct Bar<T> {
+   |                          - un-closed delimiter
+...
+LL | fn main() {}
+   |                                                                  ^
+
+error: expected identifier, found keyword `trait`
+  --> $DIR/missing-close-brace-in-struct.rs:4:1
+   |
+LL | trait T {
+   | ^^^^^ expected identifier, found keyword
+   |
+help: you can escape reserved keywords to use them as identifiers
+   |
+LL | r#trait T {
+   | ^^^^^^^
+
+error: expected `:`, found `T`
+  --> $DIR/missing-close-brace-in-struct.rs:4:7
+   |
+LL | trait T {
+   |       ^ expected `:`
+
+error[E0601]: `main` function not found in crate `missing_close_brace_in_struct`
+  --> $DIR/missing-close-brace-in-struct.rs:1:1
+   |
+LL | / pub(crate) struct Bar<T> {
+LL | |   foo: T,
+LL | |
+LL | | trait T {
+...  |
+LL | |
+LL | | fn main() {}
+   | |_________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-struct.rs`
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
@@ -1,0 +1,11 @@
+trait T {
+//~^ ERROR `main` function not found in crate `missing_close_brace_in_trait`
+    fn foo(&self);
+
+pub(crate) struct Bar<T>(); //~ ERROR expected one of
+
+impl T for Bar<usize> {
+fn foo(&self) {}
+}
+
+fn main() {} //~ ERROR this file contains an un-closed delimiter

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.rs
@@ -1,5 +1,4 @@
 trait T {
-//~^ ERROR `main` function not found in crate `missing_close_brace_in_trait`
     fn foo(&self);
 
 pub(crate) struct Bar<T>(); //~ ERROR expected one of

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
@@ -1,0 +1,39 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/missing-close-brace-in-trait.rs:11:66
+   |
+LL | trait T {
+   |         - un-closed delimiter
+...
+LL | fn main() {}
+   |                                                                  ^
+
+error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
+  --> $DIR/missing-close-brace-in-trait.rs:5:1
+   |
+LL | trait T {
+   |         - unclosed delimiter
+LL |
+LL |     fn foo(&self);
+   |                   -
+   |                   |
+   |                   expected one of 7 possible tokens here
+   |                   help: `}` may belong here
+LL | 
+LL | pub(crate) struct Bar<T>();
+   | ^^^ unexpected token
+
+error[E0601]: `main` function not found in crate `missing_close_brace_in_trait`
+  --> $DIR/missing-close-brace-in-trait.rs:1:1
+   |
+LL | / trait T {
+LL | |
+LL | |     fn foo(&self);
+LL | |
+...  |
+LL | |
+LL | | fn main() {}
+   | |_________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-trait.rs`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
+++ b/src/test/ui/parser/mismatched-braces/missing-close-brace-in-trait.stderr
@@ -1,5 +1,5 @@
 error: this file contains an un-closed delimiter
-  --> $DIR/missing-close-brace-in-trait.rs:11:66
+  --> $DIR/missing-close-brace-in-trait.rs:10:66
    |
 LL | trait T {
    |         - un-closed delimiter
@@ -7,12 +7,11 @@ LL | trait T {
 LL | fn main() {}
    |                                                                  ^
 
-error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found `pub`
-  --> $DIR/missing-close-brace-in-trait.rs:5:1
+error: expected one of `async`, `const`, `extern`, `fn`, `type`, `unsafe`, or `}`, found keyword `pub`
+  --> $DIR/missing-close-brace-in-trait.rs:4:1
    |
 LL | trait T {
    |         - unclosed delimiter
-LL |
 LL |     fn foo(&self);
    |                   -
    |                   |
@@ -22,18 +21,5 @@ LL |
 LL | pub(crate) struct Bar<T>();
    | ^^^ unexpected token
 
-error[E0601]: `main` function not found in crate `missing_close_brace_in_trait`
-  --> $DIR/missing-close-brace-in-trait.rs:1:1
-   |
-LL | / trait T {
-LL | |
-LL | |     fn foo(&self);
-LL | |
-...  |
-LL | |
-LL | | fn main() {}
-   | |_________________________________________________________________^ consider adding a `main` function to `$DIR/missing-close-brace-in-trait.rs`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0601`.

--- a/src/test/ui/pattern/usefulness/issue-43253.rs
+++ b/src/test/ui/pattern/usefulness/issue-43253.rs
@@ -32,14 +32,14 @@ fn main() {
 
     match 10 {
         1..10 => {},
-        8..=9 => {}, //~ WARNING multiple patterns covering the same range
+        8..=9 => {}, //~ WARNING unreachable pattern
         _ => {},
     }
 
     match 10 {
         5..7 => {},
         6 => {}, //~ WARNING unreachable pattern
-        1..10 => {}, //~ WARNING multiple patterns covering the same range
+        1..10 => {},
         9..=9 => {}, //~ WARNING unreachable pattern
         6 => {}, //~ WARNING unreachable pattern
         _ => {},

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-region.rs
@@ -13,7 +13,7 @@ mod variant_struct_region {
         x: &'a i32,
     }
     struct Bar<'a,'b> {
-        f: &'a Foo<'b> //~ ERROR reference has a longer lifetime
+        f: &'a Foo<'b>
     }
 }
 

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type-rev.rs
@@ -13,7 +13,7 @@ mod rev_variant_struct_type {
         x: fn(T)
     }
     struct Bar<'a,'b> {
-        f: &'a Foo<&'b i32> //~ ERROR reference has a longer lifetime
+        f: &'a Foo<&'b i32>
     }
 }
 

--- a/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
+++ b/src/test/ui/regions/regions-outlives-nominal-type-struct-type.rs
@@ -13,7 +13,7 @@ mod variant_struct_type {
         x: T
     }
     struct Bar<'a,'b> {
-        f: &'a Foo<&'b i32> //~ ERROR reference has a longer lifetime
+        f: &'a Foo<&'b i32>
     }
 }
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/arbitrary-self-types-not-object-safe.rs:34:32
+  --> $DIR/arbitrary-self-types-not-object-safe.rs:33:32
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |        --- method `foo`'s `self` parameter cannot be dispatched on
@@ -8,7 +8,7 @@ LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |                                ^^^^^^^^^^^ the trait `Foo` cannot be made into an object
 
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/arbitrary-self-types-not-object-safe.rs:34:13
+  --> $DIR/arbitrary-self-types-not-object-safe.rs:33:13
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |        --- method `foo`'s `self` parameter cannot be dispatched on

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/arbitrary-self-types-not-object-safe.rs:34:13
+  --> $DIR/arbitrary-self-types-not-object-safe.rs:33:13
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |        --- method `foo`'s `self` parameter cannot be dispatched on

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.rs
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.rs
@@ -1,7 +1,6 @@
 // revisions: curr object_safe_for_dispatch
 
 #![cfg_attr(object_safe_for_dispatch, feature(object_safe_for_dispatch))]
-#![feature(arbitrary_self_types)]
 
 use std::rc::Rc;
 

--- a/src/test/ui/self/arbitrary-self-types-not-object-safe.stderr
+++ b/src/test/ui/self/arbitrary-self-types-not-object-safe.stderr
@@ -1,5 +1,5 @@
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/arbitrary-self-types-not-object-safe.rs:31:32
+  --> $DIR/arbitrary-self-types-not-object-safe.rs:29:32
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |        --- method `foo`'s `self` parameter cannot be dispatched on
@@ -8,7 +8,7 @@ LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |                                ^^^^^^^^^^^ the trait `Foo` cannot be made into an object
 
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/arbitrary-self-types-not-object-safe.rs:31:13
+  --> $DIR/arbitrary-self-types-not-object-safe.rs:29:13
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |        --- method `foo`'s `self` parameter cannot be dispatched on

--- a/src/test/ui/self/arbitrary_self_types_nested.rs
+++ b/src/test/ui/self/arbitrary_self_types_nested.rs
@@ -1,0 +1,36 @@
+// run-pass
+
+use {
+    std::{
+        rc::Rc,
+        sync::Arc,
+    },
+};
+
+#[derive(Default)]
+struct Ty;
+
+trait Trait {
+    fn receive_trait(self: &Arc<Rc<Box<Self>>>) -> u32;
+}
+
+const TRAIT_MAGIC: u32 = 42;
+const INHERENT_MAGIC: u32 = 1995;
+
+impl Trait for Ty {
+    fn receive_trait(self: &Arc<Rc<Box<Self>>>) -> u32 {
+        TRAIT_MAGIC
+    }
+}
+
+impl Ty {
+    fn receive_inherent(self: &Arc<Rc<Box<Self>>>) -> u32 {
+        INHERENT_MAGIC
+    }
+}
+
+fn main() {
+    let ty = <Arc<Rc<Box<Ty>>>>::default();
+    assert_eq!(TRAIT_MAGIC, ty.receive_trait());
+    assert_eq!(INHERENT_MAGIC, ty.receive_inherent());
+}

--- a/src/test/ui/self/arbitrary_self_types_struct.rs
+++ b/src/test/ui/self/arbitrary_self_types_struct.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(arbitrary_self_types)]
 
 use std::rc::Rc;
 

--- a/src/test/ui/self/arbitrary_self_types_trait.rs
+++ b/src/test/ui/self/arbitrary_self_types_trait.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(arbitrary_self_types)]
 
 use std::rc::Rc;
 

--- a/src/test/ui/self/arbitrary_self_types_unsized_struct.rs
+++ b/src/test/ui/self/arbitrary_self_types_unsized_struct.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(arbitrary_self_types)]
 
 use std::rc::Rc;
 

--- a/src/test/ui/self/elision/alias-async.rs
+++ b/src/test/ui/self/elision/alias-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/alias.rs
+++ b/src/test/ui/self/elision/alias.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/assoc-async.rs
+++ b/src/test/ui/self/elision/assoc-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/assoc.rs
+++ b/src/test/ui/self/elision/assoc.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-alias-async.rs
+++ b/src/test/ui/self/elision/lt-alias-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-alias.rs
+++ b/src/test/ui/self/elision/lt-alias.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-assoc-async.rs
+++ b/src/test/ui/self/elision/lt-assoc-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-assoc.rs
+++ b/src/test/ui/self/elision/lt-assoc.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-ref-self-async.rs
+++ b/src/test/ui/self/elision/lt-ref-self-async.rs
@@ -1,6 +1,5 @@
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/lt-ref-self-async.stderr
+++ b/src/test/ui/self/elision/lt-ref-self-async.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:14:9
+  --> $DIR/lt-ref-self-async.rs:13:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:20:9
+  --> $DIR/lt-ref-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:24:9
+  --> $DIR/lt-ref-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:28:9
+  --> $DIR/lt-ref-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:32:9
+  --> $DIR/lt-ref-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
@@ -49,7 +49,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self-async.rs:36:9
+  --> $DIR/lt-ref-self-async.rs:35:9
    |
 LL |     async fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                         -----                ----

--- a/src/test/ui/self/elision/lt-ref-self.rs
+++ b/src/test/ui/self/elision/lt-ref-self.rs
@@ -1,4 +1,3 @@
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/lt-ref-self.stderr
+++ b/src/test/ui/self/elision/lt-ref-self.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:12:9
+  --> $DIR/lt-ref-self.rs:11:9
    |
 LL |     fn ref_self(&self, f: &u32) -> &u32 {
    |                           ----     ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:18:9
+  --> $DIR/lt-ref-self.rs:17:9
    |
 LL |     fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                                 ----     ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:22:9
+  --> $DIR/lt-ref-self.rs:21:9
    |
 LL |     fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                          ----     ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:26:9
+  --> $DIR/lt-ref-self.rs:25:9
    |
 LL |     fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                          ----     ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:30:9
+  --> $DIR/lt-ref-self.rs:29:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                                   ----     ----
@@ -49,7 +49,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/lt-ref-self.rs:34:9
+  --> $DIR/lt-ref-self.rs:33:9
    |
 LL |     fn box_pin_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                               ----     ----

--- a/src/test/ui/self/elision/lt-self-async.rs
+++ b/src/test/ui/self/elision/lt-self-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/lt-self.rs
+++ b/src/test/ui/self/elision/lt-self.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/lt-struct-async.rs
+++ b/src/test/ui/self/elision/lt-struct-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/lt-struct.rs
+++ b/src/test/ui/self/elision/lt-struct.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/ref-alias-async.rs
+++ b/src/test/ui/self/elision/ref-alias-async.rs
@@ -1,7 +1,6 @@
 // edition:2018
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-alias.rs
+++ b/src/test/ui/self/elision/ref-alias.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-assoc-async.rs
+++ b/src/test/ui/self/elision/ref-assoc-async.rs
@@ -1,7 +1,6 @@
 // edition:2018
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-assoc.rs
+++ b/src/test/ui/self/elision/ref-assoc.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-alias-async.rs
+++ b/src/test/ui/self/elision/ref-mut-alias-async.rs
@@ -1,7 +1,6 @@
 // edition:2018
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-alias.rs
+++ b/src/test/ui/self/elision/ref-mut-alias.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-self-async.rs
+++ b/src/test/ui/self/elision/ref-mut-self-async.rs
@@ -1,6 +1,5 @@
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-self-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-self-async.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:14:9
+  --> $DIR/ref-mut-self-async.rs:13:9
    |
 LL |     async fn ref_self(&mut self, f: &u32) -> &u32 {
    |                       ---------              ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:20:9
+  --> $DIR/ref-mut-self-async.rs:19:9
    |
 LL |     async fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                             ---------              ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:24:9
+  --> $DIR/ref-mut-self-async.rs:23:9
    |
 LL |     async fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:28:9
+  --> $DIR/ref-mut-self-async.rs:27:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                     ---------               ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:32:9
+  --> $DIR/ref-mut-self-async.rs:31:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----
@@ -49,7 +49,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self-async.rs:36:9
+  --> $DIR/ref-mut-self-async.rs:35:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                             ---------                ----

--- a/src/test/ui/self/elision/ref-mut-self.rs
+++ b/src/test/ui/self/elision/ref-mut-self.rs
@@ -1,4 +1,3 @@
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-self.stderr
+++ b/src/test/ui/self/elision/ref-mut-self.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:12:9
+  --> $DIR/ref-mut-self.rs:11:9
    |
 LL |     fn ref_self(&mut self, f: &u32) -> &u32 {
    |                               ----     ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:18:9
+  --> $DIR/ref-mut-self.rs:17:9
    |
 LL |     fn ref_Self(self: &mut Self, f: &u32) -> &u32 {
    |                                     ----     ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:22:9
+  --> $DIR/ref-mut-self.rs:21:9
    |
 LL |     fn box_ref_Self(self: Box<&mut Self>, f: &u32) -> &u32 {
    |                                              ----     ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:26:9
+  --> $DIR/ref-mut-self.rs:25:9
    |
 LL |     fn pin_ref_Self(self: Pin<&mut Self>, f: &u32) -> &u32 {
    |                                              ----     ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:30:9
+  --> $DIR/ref-mut-self.rs:29:9
    |
 LL |     fn box_box_ref_Self(self: Box<Box<&mut Self>>, f: &u32) -> &u32 {
    |                                                       ----     ----
@@ -49,7 +49,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-self.rs:34:9
+  --> $DIR/ref-mut-self.rs:33:9
    |
 LL |     fn box_pin_ref_Self(self: Box<Pin<&mut Self>>, f: &u32) -> &u32 {
    |                                                       ----     ----

--- a/src/test/ui/self/elision/ref-mut-struct-async.rs
+++ b/src/test/ui/self/elision/ref-mut-struct-async.rs
@@ -1,6 +1,5 @@
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct-async.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:14:9
+  --> $DIR/ref-mut-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                               -----------              ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:18:9
+  --> $DIR/ref-mut-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:22:9
+  --> $DIR/ref-mut-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                       -----------               ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:26:9
+  --> $DIR/ref-mut-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct-async.rs:30:9
+  --> $DIR/ref-mut-struct-async.rs:29:9
    |
 LL |     async fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                               -----------                ----

--- a/src/test/ui/self/elision/ref-mut-struct.rs
+++ b/src/test/ui/self/elision/ref-mut-struct.rs
@@ -1,4 +1,3 @@
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-mut-struct.stderr
+++ b/src/test/ui/self/elision/ref-mut-struct.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct.rs:12:9
+  --> $DIR/ref-mut-struct.rs:11:9
    |
 LL |     fn ref_Struct(self: &mut Struct, f: &u32) -> &u32 {
    |                                         ----     ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct.rs:16:9
+  --> $DIR/ref-mut-struct.rs:15:9
    |
 LL |     fn box_ref_Struct(self: Box<&mut Struct>, f: &u32) -> &u32 {
    |                                                  ----     ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct.rs:20:9
+  --> $DIR/ref-mut-struct.rs:19:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&mut Struct>, f: &u32) -> &u32 {
    |                                                  ----     ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct.rs:24:9
+  --> $DIR/ref-mut-struct.rs:23:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&mut Struct>>, f: &u32) -> &u32 {
    |                                                           ----     ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-mut-struct.rs:28:9
+  --> $DIR/ref-mut-struct.rs:27:9
    |
 LL |     fn box_pin_ref_Struct(self: Box<Pin<&mut Struct>>, f: &u32) -> &u32 {
    |                                                           ----     ----

--- a/src/test/ui/self/elision/ref-self-async.rs
+++ b/src/test/ui/self/elision/ref-self-async.rs
@@ -1,6 +1,5 @@
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::marker::PhantomData;

--- a/src/test/ui/self/elision/ref-self-async.stderr
+++ b/src/test/ui/self/elision/ref-self-async.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:23:9
+  --> $DIR/ref-self-async.rs:22:9
    |
 LL |     async fn ref_self(&self, f: &u32) -> &u32 {
    |                       -----              ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:29:9
+  --> $DIR/ref-self-async.rs:28:9
    |
 LL |     async fn ref_Self(self: &Self, f: &u32) -> &u32 {
    |                             -----              ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:33:9
+  --> $DIR/ref-self-async.rs:32:9
    |
 LL |     async fn box_ref_Self(self: Box<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:37:9
+  --> $DIR/ref-self-async.rs:36:9
    |
 LL |     async fn pin_ref_Self(self: Pin<&Self>, f: &u32) -> &u32 {
    |                                     -----               ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:41:9
+  --> $DIR/ref-self-async.rs:40:9
    |
 LL |     async fn box_box_ref_Self(self: Box<Box<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
@@ -49,7 +49,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:45:9
+  --> $DIR/ref-self-async.rs:44:9
    |
 LL |     async fn box_pin_ref_Self(self: Box<Pin<&Self>>, f: &u32) -> &u32 {
    |                                             -----                ----
@@ -59,7 +59,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-self-async.rs:49:9
+  --> $DIR/ref-self-async.rs:48:9
    |
 LL |     async fn wrap_ref_Self_Self(self: Wrap<&Self, Self>, f: &u8) -> &u8 {
    |                                            -----                    ---

--- a/src/test/ui/self/elision/ref-struct-async.rs
+++ b/src/test/ui/self/elision/ref-struct-async.rs
@@ -1,6 +1,5 @@
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-struct-async.stderr
+++ b/src/test/ui/self/elision/ref-struct-async.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:14:9
+  --> $DIR/ref-struct-async.rs:13:9
    |
 LL |     async fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                               -------              ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:18:9
+  --> $DIR/ref-struct-async.rs:17:9
    |
 LL |     async fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:22:9
+  --> $DIR/ref-struct-async.rs:21:9
    |
 LL |     async fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                       -------               ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:26:9
+  --> $DIR/ref-struct-async.rs:25:9
    |
 LL |     async fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                               -------                ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct-async.rs:30:9
+  --> $DIR/ref-struct-async.rs:29:9
    |
 LL |     async fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                           -------                ----

--- a/src/test/ui/self/elision/ref-struct.rs
+++ b/src/test/ui/self/elision/ref-struct.rs
@@ -1,4 +1,3 @@
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::pin::Pin;

--- a/src/test/ui/self/elision/ref-struct.stderr
+++ b/src/test/ui/self/elision/ref-struct.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct.rs:12:9
+  --> $DIR/ref-struct.rs:11:9
    |
 LL |     fn ref_Struct(self: &Struct, f: &u32) -> &u32 {
    |                                     ----     ----
@@ -9,7 +9,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct.rs:16:9
+  --> $DIR/ref-struct.rs:15:9
    |
 LL |     fn box_ref_Struct(self: Box<&Struct>, f: &u32) -> &u32 {
    |                                              ----     ----
@@ -19,7 +19,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct.rs:20:9
+  --> $DIR/ref-struct.rs:19:9
    |
 LL |     fn pin_ref_Struct(self: Pin<&Struct>, f: &u32) -> &u32 {
    |                                              ----     ----
@@ -29,7 +29,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct.rs:24:9
+  --> $DIR/ref-struct.rs:23:9
    |
 LL |     fn box_box_ref_Struct(self: Box<Box<&Struct>>, f: &u32) -> &u32 {
    |                                                       ----     ----
@@ -39,7 +39,7 @@ LL |         f
    |         ^ ...but data from `f` is returned here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/ref-struct.rs:28:9
+  --> $DIR/ref-struct.rs:27:9
    |
 LL |     fn box_pin_Struct(self: Box<Pin<&Struct>>, f: &u32) -> &u32 {
    |                                                   ----     ----

--- a/src/test/ui/self/elision/self-async.rs
+++ b/src/test/ui/self/elision/self-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/self.rs
+++ b/src/test/ui/self/elision/self.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/struct-async.rs
+++ b/src/test/ui/self/elision/struct-async.rs
@@ -1,7 +1,6 @@
 // check-pass
 // edition:2018
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/self/elision/struct.rs
+++ b/src/test/ui/self/elision/struct.rs
@@ -1,6 +1,5 @@
 // check-pass
 
-#![feature(arbitrary_self_types)]
 #![allow(non_snake_case)]
 
 use std::rc::Rc;

--- a/src/test/ui/simd/simd-intrinsic-float-minmax.rs
+++ b/src/test/ui/simd/simd-intrinsic-float-minmax.rs
@@ -1,7 +1,6 @@
 // run-pass
 // ignore-emscripten
 // min-llvm-version 7.0
-// error-pattern: panicked
 
 // Test that the simd_f{min,max} intrinsics produce the correct results.
 

--- a/src/test/ui/while-let.rs
+++ b/src/test/ui/while-let.rs
@@ -5,6 +5,8 @@ fn macros() {
     macro_rules! foo{
         ($p:pat, $e:expr, $b:block) => {{
             while let $p = $e $b
+            //~^ WARN irrefutable while-let
+            //~| WARN irrefutable while-let
         }}
     }
     macro_rules! bar{
@@ -13,10 +15,10 @@ fn macros() {
         }}
     }
 
-    foo!(_a, 1, { //~ WARN irrefutable while-let
+    foo!(_a, 1, {
         println!("irrefutable pattern");
     });
-    bar!(_a, 1, { //~ WARN irrefutable while-let
+    bar!(_a, 1, {
         println!("irrefutable pattern");
     });
 }

--- a/src/test/ui/while-let.stderr
+++ b/src/test/ui/while-let.stderr
@@ -23,7 +23,7 @@ LL | |     });
    | |_______- in this macro invocation
 
 warning: irrefutable while-let pattern
-  --> $DIR/while-let.rs:25:5
+  --> $DIR/while-let.rs:27:5
    |
 LL | /     while let _a = 1 {
 LL | |         println!("irrefutable pattern");

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3137,6 +3137,10 @@ impl<'test> TestCx<'test> {
                     self.fatal_proc_rec("test run succeeded!", &proc_res);
                 }
             }
+            if !self.props.error_patterns.is_empty() {
+                // "// error-pattern" comments
+                self.check_error_patterns(&proc_res.stderr, &proc_res);
+            }
         }
 
         debug!("run_ui_test: explicit={:?} config.compare_mode={:?} expected_errors={:?} \
@@ -3144,14 +3148,13 @@ impl<'test> TestCx<'test> {
                explicit, self.config.compare_mode, expected_errors, proc_res.status,
                self.props.error_patterns);
         if !explicit && self.config.compare_mode.is_none() {
-            if !proc_res.status.success() {
-                if !self.props.error_patterns.is_empty() {
-                    // "// error-pattern" comments
-                    self.check_error_patterns(&proc_res.stderr, &proc_res);
-                } else {
-                    // "//~ERROR comments"
-                    self.check_expected_errors(expected_errors, &proc_res);
-                }
+            if !self.should_run() && !self.props.error_patterns.is_empty() {
+                // "// error-pattern" comments
+                self.check_error_patterns(&proc_res.stderr, &proc_res);
+            }
+            if !expected_errors.is_empty() {
+                // "//~ERROR comments"
+                self.check_expected_errors(expected_errors, &proc_res);
             }
         }
 


### PR DESCRIPTION
Successful merges:

 - #64325 (Stabilize nested self receivers in 1.40.0)
 - #65759 (Validate error patterns and error annotation in ui tests when present)
 - #65838 (Reduce amount of errors given unclosed delimiter)
 - #65911 (Statically link libstdc++ on windows-gnu)
 - #65953 (Allow specifying LLVM's MCTargetOptions::ABIName in target specification files)
 - #66012 (De-querify `trivial_dropck_outlives`.)

Failed merges:


r? @ghost