### PR TITLE
[wip] degenerate object safety check for crater

### DIFF
--- a/src/librustc/traits/error_reporting/mod.rs
+++ b/src/librustc/traits/error_reporting/mod.rs
@@ -704,11 +704,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             if self.predicate_may_hold(&unit_obligation) {
                                 err.note(
                                     "the trait is implemented for `()`. \
-                                         Possibly this error has been caused by changes to \
-                                         Rust's type-inference algorithm \
-                                         (see: https://github.com/rust-lang/rust/issues/48950 \
-                                         for more info). Consider whether you meant to use the \
-                                         type `()` here instead.",
+                                     Possibly this error has been caused by changes to \
+                                     Rust's type-inference algorithm \
+                                     (see: https://github.com/rust-lang/rust/issues/48950 \
+                                     for more info). Consider whether you meant to use the \
+                                     type `()` here instead.",
                                 );
                             }
                         }
@@ -792,7 +792,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         *span,
                                         format!(
                                             "closure is `FnOnce` because it moves the \
-                                         variable `{}` out of its environment",
+                                             variable `{}` out of its environment",
                                             name
                                         ),
                                     );
@@ -802,7 +802,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                         *span,
                                         format!(
                                             "closure is `FnMut` because it mutates the \
-                                         variable `{}` here",
+                                             variable `{}` here",
                                             name
                                         ),
                                     );
@@ -1012,7 +1012,7 @@ pub fn recursive_type_with_infinite_size_error(
     err.span_label(span, "recursive type has infinite size");
     err.help(&format!(
         "insert indirection (e.g., a `Box`, `Rc`, or `&`) \
-                           at some point to make `{}` representable",
+         at some point to make `{}` representable",
         tcx.def_path_str(type_def_id)
     ));
     err
@@ -1038,10 +1038,7 @@ pub fn report_object_safety_error(
     let mut reported_violations = FxHashSet::default();
     for violation in violations {
         if reported_violations.insert(violation.clone()) {
-            match violation.span() {
-                Some(span) => err.span_label(span, violation.error_msg()),
-                None => err.note(&violation.error_msg()),
-            };
+            violation.annotate_diagnostic(tcx, &mut err);
         }
     }
 

--- a/src/librustc_data_structures/lib.rs
+++ b/src/librustc_data_structures/lib.rs
@@ -23,6 +23,7 @@
 #![feature(integer_atomics)]
 #![feature(test)]
 #![feature(associated_type_bounds)]
+#![feature(rustc_attrs)]
 #![cfg_attr(unix, feature(libc))]
 #![allow(rustc::default_hash_types)]
 

--- a/src/librustc_data_structures/sync.rs
+++ b/src/librustc_data_structures/sync.rs
@@ -29,6 +29,7 @@ pub use std::sync::atomic::Ordering::SeqCst;
 cfg_if! {
     if #[cfg(not(parallel_compiler))] {
         pub auto trait Send {}
+
         pub auto trait Sync {}
 
         impl<T: ?Sized> Send for T {}

--- a/src/librustc_feature/builtin_attrs.rs
+++ b/src/librustc_feature/builtin_attrs.rs
@@ -143,7 +143,7 @@ macro_rules! rustc_attr {
                 "the `#[",
                 stringify!($attr),
                 "]` attribute is just used for rustc unit tests \
-                and will never be stable",
+                 and will never be stable",
             ),
         )
     };

--- a/src/test/ui/issue-59387.rs
+++ b/src/test/ui/issue-59387.rs
@@ -1,0 +1,19 @@
+trait Object<U> {
+    type Output;
+}
+
+impl<T: ?Sized, U> Object<U> for T {
+    // ^-- Here is the blanket impl; relies on `?Sized`.
+    type Output = U;
+}
+
+fn foo<T: ?Sized, U>(x: <T as Object<U>>::Output) -> U {
+    x
+}
+
+fn transmute<T, U>(x: T) -> U {
+    foo::<dyn Object<U, Output = T>, U>(x)
+    //~^ ERROR the trait `Object` cannot be made into an object
+}
+
+fn main() {}

--- a/src/test/ui/issue-59387.stderr
+++ b/src/test/ui/issue-59387.stderr
@@ -1,0 +1,15 @@
+error[E0038]: the trait `Object` cannot be made into an object
+  --> $DIR/issue-59387.rs:15:11
+   |
+LL | / impl<T: ?Sized, U> Object<U> for T {
+LL | |     // ^-- Here is the blanket impl; relies on `?Sized`.
+LL | |     type Output = U;
+LL | | }
+   | |_- traits with non-method items cannot have an impl with an unsized `Self` type
+...
+LL |       foo::<dyn Object<U, Output = T>, U>(x)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Object` cannot be made into an object
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/src/test/ui/issues/issue-50781.stderr
+++ b/src/test/ui/issues/issue-50781.stderr
@@ -2,7 +2,7 @@ error: the trait `X` cannot be made into an object
   --> $DIR/issue-50781.rs:6:8
    |
 LL |     fn foo(&self) where Self: Trait;
-   |        ^^^
+   |        ^^^ method `foo` references the `Self` type in where clauses
    |
 note: lint level defined here
   --> $DIR/issue-50781.rs:1:9
@@ -11,7 +11,6 @@ LL | #![deny(where_clauses_object_safety)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
-   = note: method `foo` references the `Self` type in where clauses
 
 error: aborting due to previous error
 


### PR DESCRIPTION
The purpose of this PR is just to be able to do a crater run to assess the impact of the proposed fix for #57893.

With this fix:

* traits that are implemented for unsized types are not dyn safe
* unless they are marked `#[rustc_dyn]` (this would eventually be `dyn trait`)

r? @nikomatsakis  -- this doesn't need review, won't land in this form