### PR TITLE
Don't double-count `simd_shuffle` promotion candidates

### DIFF
--- a/src/librustc_mir/transform/promote_consts.rs
+++ b/src/librustc_mir/transform/promote_consts.rs
@@ -199,6 +199,8 @@ impl<'tcx> Visitor<'tcx> for Collector<'_, 'tcx> {
                             bb: location.block,
                             index: 2,
                         });
+
+                        return; // Don't double count `simd_shuffle` candidates
                     }
                 }
 


### PR DESCRIPTION
Resolves #66016.

The `#[rustc_args_required_const]` attribute was added to `simd_shuffle*` in rust-lang/stdarch#825. This caused `promote_consts` to double-count its second argument when recording promotion candidates, which caused the promotion candidate compatibility check to fail.

Once `stdarch` is updated in-tree to include rust-lang/stdarch#825, all special logic around `simd_shuffle` can and should be removed.