### PR TITLE
when Miri tests are not passing, do not add Miri component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ name = "build-manifest"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "toml",
 ]
 

--- a/src/tools/build-manifest/Cargo.toml
+++ b/src/tools/build-manifest/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 toml = "0.5"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -11,10 +11,11 @@ use serde::Serialize;
 
 use std::collections::BTreeMap;
 use std::env;
-use std::fs;
+use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{PathBuf, Path};
 use std::process::{Command, Stdio};
+use std::collections::HashMap;
 
 static HOSTS: &[&str] = &[
     "aarch64-unknown-linux-gnu",
@@ -366,12 +367,29 @@ impl Builder {
         self.lldb_git_commit_hash = self.git_commit_hash("lldb", "x86_64-unknown-linux-gnu");
         self.miri_git_commit_hash = self.git_commit_hash("miri", "x86_64-unknown-linux-gnu");
 
+        self.check_toolstate();
         self.digest_and_sign();
         let manifest = self.build_manifest();
         self.write_channel_files(&self.rust_release, &manifest);
 
         if self.rust_release != "beta" && self.rust_release != "nightly" {
             self.write_channel_files("stable", &manifest);
+        }
+    }
+
+    /// If a tool does not pass its tests, don't ship it.
+    /// Right now, we do this only for Miri.
+    fn check_toolstate(&mut self) {
+        // Get the toolstate for this rust revision.
+        let toolstates = File::open(self.input.join("toolstates-linux.json"))
+            .expect("failed to open toolstates file");
+        let toolstates: HashMap<String, String> = serde_json::from_reader(&toolstates)
+            .expect("toolstates file contains malformed JSON");
+        // Mark some tools as missing based on toolstate.
+        if toolstates.get("miri").map(|s| &*s as &str) != Some("test-pass") {
+            println!("Miri tests are not passing, removing component");
+            self.miri_version = None;
+            self.miri_git_commit_hash = None;
         }
     }
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -384,7 +384,8 @@ impl Builder {
             File::open(self.input.join("toolstates-linux.json")).ok()
                 .and_then(|f| serde_json::from_reader(&f).ok());
         let toolstates = toolstates.unwrap_or_else(|| {
-            println!("WARNING: `toolstates-linux.json` missing; assuming all tools failed");
+            println!("WARNING: `toolstates-linux.json` missing/malformed; \
+                assuming all tools failed");
             HashMap::default() // Use empty map if anything went wrong.
         });
         // Mark some tools as missing based on toolstate.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -4,7 +4,6 @@
 //! via `x.py dist hash-and-sign`; the cmdline arguments are set up
 //! by rustbuild (in `src/bootstrap/dist.rs`).
 
-#![feature(try_blocks)]
 #![deny(warnings)]
 
 use toml;
@@ -381,10 +380,9 @@ impl Builder {
     /// If a tool does not pass its tests, don't ship it.
     /// Right now, we do this only for Miri.
     fn check_toolstate(&mut self) {
-        let toolstates: Option<HashMap<String, String>> = try {
-            let toolstates = File::open(self.input.join("toolstates-linux.json")).ok()?;
-            serde_json::from_reader(&toolstates).ok()?
-        };
+        let toolstates: Option<HashMap<String, String>> =
+            File::open(self.input.join("toolstates-linux.json")).ok()
+                .and_then(|f| serde_json::from_reader(&f).ok());
         let toolstates = toolstates.unwrap_or_else(|| {
             println!("WARNING: `toolstates-linux.json` missing; assuming all tools failed");
             HashMap::default() // Use empty map if anything went wrong.


### PR DESCRIPTION
Second attempt, this time based on the JSON files that exist since https://github.com/rust-lang/rust/pull/65274.

Fixes https://github.com/rust-lang/rust/issues/60301
r? @pietroalbini @alexcrichton 