### PR TITLE
syntax: Avoid span arithmetic for delimiter tokens

### DIFF
--- a/src/libsyntax/parse/parser.rs
+++ b/src/libsyntax/parse/parser.rs
@@ -210,12 +210,12 @@ impl TokenCursor {
         loop {
             let tree = if !self.frame.open_delim {
                 self.frame.open_delim = true;
-                TokenTree::open_tt(self.frame.span.open, self.frame.delim)
+                TokenTree::open_tt(self.frame.span, self.frame.delim)
             } else if let Some(tree) = self.frame.tree_cursor.next() {
                 tree
             } else if !self.frame.close_delim {
                 self.frame.close_delim = true;
-                TokenTree::close_tt(self.frame.span.close, self.frame.delim)
+                TokenTree::close_tt(self.frame.span, self.frame.delim)
             } else if let Some(frame) = self.stack.pop() {
                 self.frame = frame;
                 continue

--- a/src/libsyntax/tokenstream.rs
+++ b/src/libsyntax/tokenstream.rs
@@ -15,7 +15,7 @@
 
 use crate::parse::token::{self, DelimToken, Token, TokenKind};
 
-use syntax_pos::{BytePos, Span, DUMMY_SP};
+use syntax_pos::{Span, DUMMY_SP};
 #[cfg(target_arch = "x86_64")]
 use rustc_data_structures::static_assert_size;
 use rustc_data_structures::sync::Lrc;
@@ -110,23 +110,13 @@ impl TokenTree {
     }
 
     /// Returns the opening delimiter as a token tree.
-    pub fn open_tt(span: Span, delim: DelimToken) -> TokenTree {
-        let open_span = if span.is_dummy() {
-            span
-        } else {
-            span.with_hi(span.lo() + BytePos(delim.len() as u32))
-        };
-        TokenTree::token(token::OpenDelim(delim), open_span)
+    pub fn open_tt(span: DelimSpan, delim: DelimToken) -> TokenTree {
+        TokenTree::token(token::OpenDelim(delim), span.open)
     }
 
     /// Returns the closing delimiter as a token tree.
-    pub fn close_tt(span: Span, delim: DelimToken) -> TokenTree {
-        let close_span = if span.is_dummy() {
-            span
-        } else {
-            span.with_lo(span.hi() - BytePos(delim.len() as u32))
-        };
-        TokenTree::token(token::CloseDelim(delim), close_span)
+    pub fn close_tt(span: DelimSpan, delim: DelimToken) -> TokenTree {
+        TokenTree::token(token::CloseDelim(delim), span.close)
     }
 }
 

--- a/src/libsyntax_expand/mbe.rs
+++ b/src/libsyntax_expand/mbe.rs
@@ -13,7 +13,7 @@ use syntax::ast;
 use syntax::parse::token::{self, Token, TokenKind};
 use syntax::tokenstream::{DelimSpan};
 
-use syntax_pos::{BytePos, Span};
+use syntax_pos::Span;
 
 use rustc_data_structures::sync::Lrc;
 
@@ -27,23 +27,13 @@ struct Delimited {
 
 impl Delimited {
     /// Returns a `self::TokenTree` with a `Span` corresponding to the opening delimiter.
-    fn open_tt(&self, span: Span) -> TokenTree {
-        let open_span = if span.is_dummy() {
-            span
-        } else {
-            span.with_hi(span.lo() + BytePos(self.delim.len() as u32))
-        };
-        TokenTree::token(token::OpenDelim(self.delim), open_span)
+    fn open_tt(&self, span: DelimSpan) -> TokenTree {
+        TokenTree::token(token::OpenDelim(self.delim), span.open)
     }
 
     /// Returns a `self::TokenTree` with a `Span` corresponding to the closing delimiter.
-    fn close_tt(&self, span: Span) -> TokenTree {
-        let close_span = if span.is_dummy() {
-            span
-        } else {
-            span.with_lo(span.hi() - BytePos(self.delim.len() as u32))
-        };
-        TokenTree::token(token::CloseDelim(self.delim), close_span)
+    fn close_tt(&self, span: DelimSpan) -> TokenTree {
+        TokenTree::token(token::CloseDelim(self.delim), span.close)
     }
 }
 
@@ -138,10 +128,10 @@ impl TokenTree {
             }
             (&TokenTree::Delimited(span, ref delimed), _) => {
                 if index == 0 {
-                    return delimed.open_tt(span.open);
+                    return delimed.open_tt(span);
                 }
                 if index == delimed.tts.len() + 1 {
-                    return delimed.close_tt(span.close);
+                    return delimed.close_tt(span);
                 }
                 delimed.tts[index - 1].clone()
             }

--- a/src/libsyntax_expand/mbe/macro_rules.rs
+++ b/src/libsyntax_expand/mbe/macro_rules.rs
@@ -566,7 +566,7 @@ impl FirstSets {
                     }
                     TokenTree::Delimited(span, ref delimited) => {
                         build_recur(sets, &delimited.tts[..]);
-                        first.replace_with(delimited.open_tt(span.open));
+                        first.replace_with(delimited.open_tt(span));
                     }
                     TokenTree::Sequence(sp, ref seq_rep) => {
                         let subfirst = build_recur(sets, &seq_rep.tts[..]);
@@ -628,7 +628,7 @@ impl FirstSets {
                     return first;
                 }
                 TokenTree::Delimited(span, ref delimited) => {
-                    first.add_one(delimited.open_tt(span.open));
+                    first.add_one(delimited.open_tt(span));
                     return first;
                 }
                 TokenTree::Sequence(sp, ref seq_rep) => {
@@ -826,7 +826,7 @@ fn check_matcher_core(
                 }
             }
             TokenTree::Delimited(span, ref d) => {
-                let my_suffix = TokenSet::singleton(d.close_tt(span.close));
+                let my_suffix = TokenSet::singleton(d.close_tt(span));
                 check_matcher_core(sess, features, attrs, first_sets, &d.tts, &my_suffix);
                 // don't track non NT tokens
                 last.replace_with_irrelevant();

--- a/src/test/ui/imports/import-prefix-macro-1.stderr
+++ b/src/test/ui/imports/import-prefix-macro-1.stderr
@@ -2,7 +2,7 @@ error: expected one of `::`, `;`, or `as`, found `{`
   --> $DIR/import-prefix-macro-1.rs:11:27
    |
 LL |     ($p: path) => (use $p {S, Z});
-   |                           ^ expected one of `::`, `;`, or `as` here
+   |                           ^^^^^^ expected one of `::`, `;`, or `as` here
 ...
 LL | import! { a::b::c }
    | ------------------- in this macro invocation

--- a/src/test/ui/issues/issue-39848.stderr
+++ b/src/test/ui/issues/issue-39848.stderr
@@ -2,7 +2,7 @@ error: expected `{`, found `foo`
   --> $DIR/issue-39848.rs:8:19
    |
 LL |         if $tgt.has_$field() {}
-   |         --                 - help: try placing this code inside a block: `{ ) }`
+   |         --                -- help: try placing this code inside a block: `{ () }`
    |         |
    |         this `if` statement has a condition, but no block
 ...

--- a/src/test/ui/parser/issue-62973.stderr
+++ b/src/test/ui/parser/issue-62973.stderr
@@ -34,13 +34,13 @@ LL | )
    |
 
 error: expected one of `.`, `?`, `{`, or an operator, found `}`
-  --> $DIR/issue-62973.rs:8:1
+  --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
    |          ----- while parsing this match expression
 LL | 
 LL | 
-   | ^ expected one of `.`, `?`, `{`, or an operator here
+   |  ^ expected one of `.`, `?`, `{`, or an operator here
 
 error: incorrect close delimiter: `)`
   --> $DIR/issue-62973.rs:6:28

--- a/src/test/ui/parser/issue-63135.stderr
+++ b/src/test/ui/parser/issue-63135.stderr
@@ -23,16 +23,16 @@ LL | fn i(n{...,f #
    |        `..` must be at the end and cannot have a trailing comma
 
 error: expected `[`, found `}`
-  --> $DIR/issue-63135.rs:3:15
+  --> $DIR/issue-63135.rs:3:16
    |
 LL | fn i(n{...,f #
-   |               ^ expected `[`
+   |                ^ expected `[`
 
 error: expected one of `:` or `|`, found `)`
-  --> $DIR/issue-63135.rs:3:15
+  --> $DIR/issue-63135.rs:3:16
    |
 LL | fn i(n{...,f #
-   |               ^ expected one of `:` or `|` here
+   |                ^ expected one of `:` or `|` here
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/parser/macro/macro-doc-comments-2.stderr
+++ b/src/test/ui/parser/macro/macro-doc-comments-2.stderr
@@ -5,7 +5,7 @@ LL | macro_rules! inner {
    | ------------------ when calling this macro
 ...
 LL |     /// Outer
-   |     ^ no rules expected this token in macro call
+   |     ^^^^^^^^^ no rules expected this token in macro call
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/missing_right_paren.rs
+++ b/src/test/ui/parser/missing_right_paren.rs
@@ -1,0 +1,3 @@
+// ignore-tidy-trailing-newlines
+// error-pattern: aborting due to 2 previous errors
+fn main((ؼ

--- a/src/test/ui/parser/missing_right_paren.stderr
+++ b/src/test/ui/parser/missing_right_paren.stderr
@@ -1,0 +1,17 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/missing_right_paren.rs:3:11
+   |
+LL | fn main((ؼ
+   |        -- ^
+   |        ||
+   |        |un-closed delimiter
+   |        un-closed delimiter
+
+error: expected one of `:` or `|`, found `)`
+  --> $DIR/missing_right_paren.rs:3:11
+   |
+LL | fn main((ؼ
+   |           ^ expected one of `:` or `|` here
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The +/-1 logic is from the time where the whole group had a single span and the delimiter spans had to be calculated from it.
Now the delimiters have their own spans which are constructed by lexer or proc macro API and can be used directly.
If those spans are not perfect, then it should be fixed by tweaking the corresponding lexer logic rather than by trying to add or substract `1` from the span boundaries.

Fixes https://github.com/rust-lang/rust/issues/62524
r? @estebank 