### PR TITLE
Remove promotion candidate gathering and checking from `qualify_consts.rs`

### DIFF
--- a/src/test/ui/consts/const_let_promote.rs
+++ b/src/test/ui/consts/const_let_promote.rs
@@ -1,0 +1,17 @@
+// run-pass
+
+use std::cell::Cell;
+
+const X: Option<Cell<i32>> = None;
+
+const Y: Option<Cell<i32>> = {
+    let x = None;
+    x
+};
+
+// Ensure that binding the final value of a `const` to a variable does not affect promotion.
+#[allow(unused)]
+fn main() {
+    let x: &'static _ = &X;
+    let y: &'static _ = &Y;
+}


### PR DESCRIPTION
This makes promotion candidate gathering and checking the exclusive domain of `promote_consts`, but the `QualifyAndPromoteConsts` pass is still responsible for both const-checking and creating promoted MIR fragments.

This should not be merged until the beta branches on Nov. 5.

r? @eddyb 