### PR TITLE
Vec::recycle (experimental API implementation)

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(recycle_vec)]
 
 // Allow testing this library
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -10,6 +10,7 @@
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
+#![feature(recycle_vec)]
 
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1281,8 +1281,8 @@ fn test_recycle_lifetime() {
 
         assert_eq!(buf2.len(), 1);
         assert_eq!(buf2.capacity(), 100);
-        val_size = core::mem::size_of_val(&buf[0]);
-        val_align = core::mem::align_of_val(&buf[0]);
+        val_size = core::mem::size_of_val(&buf2[0]);
+        val_align = core::mem::align_of_val(&buf2[0]);
 
         buf = buf2.recycle();
     }
@@ -1312,8 +1312,8 @@ fn test_recycle_type() {
 
         assert_eq!(buf2.len(), 1);
         assert_eq!(buf2.capacity(), 100);
-        val_size = core::mem::size_of_val(&buf[0]);
-        val_align = core::mem::align_of_val(&buf[0]);
+        val_size = core::mem::size_of_val(&buf2[0]);
+        val_align = core::mem::align_of_val(&buf2[0]);
 
         buf = buf2.recycle();
     }

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1295,6 +1295,10 @@ fn test_recycle_lifetime() {
 #[test]
 fn test_recycle_type() {
     let s = "foo".to_string();
+
+    let val_size;
+    let val_align;
+
     let mut buf = Vec::with_capacity(100);
     {
         let mut buf2 = buf.recycle();

--- a/src/liballoc/tests/vec.rs
+++ b/src/liballoc/tests/vec.rs
@@ -1264,22 +1264,31 @@ fn test_try_reserve_exact() {
 
 }
 
-/// Tests that `recycle` successfully re-interprets the type to have different lifetime from the original
+/// Tests that `recycle` successfully re-interprets the type
+/// to have a different lifetime from the original
 #[test]
 fn test_recycle_lifetime() {
     let s_1 = "foo".to_string();
+
+    let val_size;
+    let val_align;
+
     let mut buf = Vec::with_capacity(100);
     {
         let mut buf2 = buf;
-        let s_2 = "foo".to_string();
+        let s_2 = "bar".to_string();
         buf2.push(s_2.as_str());
 
         assert_eq!(buf2.len(), 1);
         assert_eq!(buf2.capacity(), 100);
+        val_size = core::mem::size_of_val(&buf[0]);
+        val_align = core::mem::align_of_val(&buf[0]);
 
         buf = buf2.recycle();
     }
     buf.push(s_1.as_str());
+    assert_eq!(val_size, core::mem::size_of_val(&buf[0]));
+    assert_eq!(val_align, core::mem::align_of_val(&buf[0]));
 }
 
 /// Tests that `recycle` successfully re-interprets the type itself
@@ -1299,10 +1308,14 @@ fn test_recycle_type() {
 
         assert_eq!(buf2.len(), 1);
         assert_eq!(buf2.capacity(), 100);
+        val_size = core::mem::size_of_val(&buf[0]);
+        val_align = core::mem::align_of_val(&buf[0]);
 
         buf = buf2.recycle();
     }
     buf.push(s.as_str());
+    assert_eq!(val_size, core::mem::size_of_val(&buf[0]));
+    assert_eq!(val_align, core::mem::align_of_val(&buf[0]));
 }
 
 /// Tests that `recycle` successfully panics with incompatible sizes

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 //! A contiguous growable array type with heap-allocated contents, written
 //! `Vec<T>`.
 //!

--- a/src/liballoc/vec.rs
+++ b/src/liballoc/vec.rs
@@ -684,7 +684,7 @@ impl<T> Vec<T> {
         assert_eq!(core::mem::size_of::<T>(), core::mem::size_of::<U>());
         assert_eq!(core::mem::align_of::<T>(), core::mem::align_of::<U>());
         self.clear();
-        let (ptr, len, capacity) = self.into_raw_parts();
+        let (ptr, _, capacity) = self.into_raw_parts();
         let ptr = ptr as *mut U;
         unsafe { Vec::from_raw_parts(ptr, 0, capacity) }
     }


### PR DESCRIPTION
Implements the API described here https://github.com/rust-lang/rfcs/pull/2802 behind a feature flag `recycle_vec`.