### PR TITLE
Support registering inert attributes and attribute tools using crate-level attributes

### DIFF
--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -40,6 +40,8 @@ pub enum NonMacroAttrKind {
     Tool,
     /// Single-segment custom attribute registered by a derive macro (`#[serde(default)]`).
     DeriveHelper,
+    /// Single-segment custom attribute registered with `#[register_attr]`.
+    Registered,
     /// Single-segment custom attribute registered by a legacy plugin (`register_attribute`).
     LegacyPluginHelper,
     /// Single-segment custom attribute not registered in any way (`#[my_attr]`).
@@ -329,6 +331,7 @@ impl NonMacroAttrKind {
             NonMacroAttrKind::Builtin => "built-in attribute",
             NonMacroAttrKind::Tool => "tool attribute",
             NonMacroAttrKind::DeriveHelper => "derive helper attribute",
+            NonMacroAttrKind::Registered => "explicitly registered attribute",
             NonMacroAttrKind::LegacyPluginHelper => "legacy plugin helper attribute",
             NonMacroAttrKind::Custom => "custom attribute",
         }

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -333,6 +333,22 @@ impl NonMacroAttrKind {
             NonMacroAttrKind::LegacyPluginHelper => "legacy plugin helper attribute",
         }
     }
+
+    pub fn article(self) -> &'static str {
+        match self {
+            NonMacroAttrKind::Registered => "an",
+            _ => "a",
+        }
+    }
+
+    /// Users of some attributes cannot mark them as used, so they are considered always used.
+    pub fn is_used(self) -> bool {
+        match self {
+            NonMacroAttrKind::Tool | NonMacroAttrKind::DeriveHelper => true,
+            NonMacroAttrKind::Builtin | NonMacroAttrKind::Registered |
+            NonMacroAttrKind::LegacyPluginHelper => false,
+        }
+    }
 }
 
 impl<Id> Res<Id> {
@@ -389,6 +405,7 @@ impl<Id> Res<Id> {
     pub fn article(&self) -> &'static str {
         match *self {
             Res::Def(kind, _) => kind.article(),
+            Res::NonMacroAttr(kind) => kind.article(),
             Res::Err => "an",
             _ => "a",
         }

--- a/src/librustc/hir/def.rs
+++ b/src/librustc/hir/def.rs
@@ -44,8 +44,6 @@ pub enum NonMacroAttrKind {
     Registered,
     /// Single-segment custom attribute registered by a legacy plugin (`register_attribute`).
     LegacyPluginHelper,
-    /// Single-segment custom attribute not registered in any way (`#[my_attr]`).
-    Custom,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, RustcEncodable, RustcDecodable, Hash, Debug, HashStable)]
@@ -333,7 +331,6 @@ impl NonMacroAttrKind {
             NonMacroAttrKind::DeriveHelper => "derive helper attribute",
             NonMacroAttrKind::Registered => "explicitly registered attribute",
             NonMacroAttrKind::LegacyPluginHelper => "legacy plugin helper attribute",
-            NonMacroAttrKind::Custom => "custom attribute",
         }
     }
 }

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -101,7 +101,6 @@ impl<'a> Registry<'a> {
 
     /// Register an attribute with an attribute type.
     ///
-    /// Registered attributes will bypass the `custom_attribute` feature gate.
     /// `Whitelisted` attributes will additionally not trigger the `unused_attribute`
     /// lint. `CrateLevel` attributes will not be allowed on anything other than a crate.
     pub fn register_attribute(&mut self, name: Symbol, ty: AttributeType) {

--- a/src/librustc_resolve/build_reduced_graph.rs
+++ b/src/librustc_resolve/build_reduced_graph.rs
@@ -141,8 +141,7 @@ impl<'a> Resolver<'a> {
     crate fn get_macro(&mut self, res: Res) -> Option<Lrc<SyntaxExtension>> {
         match res {
             Res::Def(DefKind::Macro(..), def_id) => self.get_macro_by_def_id(def_id),
-            Res::NonMacroAttr(attr_kind) =>
-                Some(self.non_macro_attr(attr_kind == NonMacroAttrKind::Tool)),
+            Res::NonMacroAttr(attr_kind) => Some(self.non_macro_attr(attr_kind.is_used())),
             _ => None,
         }
     }

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -1472,7 +1472,7 @@ impl<'a> Resolver<'a> {
                 Scope::MacroRules(..) => true,
                 Scope::CrateRoot => true,
                 Scope::Module(..) => true,
-                Scope::RegisteredAttrs => true,
+                Scope::RegisteredAttrs => use_prelude,
                 Scope::MacroUsePrelude => use_prelude || rust_2015,
                 Scope::BuiltinAttrs => true,
                 Scope::LegacyPluginHelpers => use_prelude || rust_2015,

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -620,7 +620,6 @@ enum AmbiguityKind {
     Import,
     BuiltinAttr,
     DeriveHelper,
-    LegacyHelperVsPrelude,
     LegacyVsModern,
     GlobVsOuter,
     GlobVsGlob,
@@ -637,8 +636,6 @@ impl AmbiguityKind {
                 "built-in attribute vs any other name",
             AmbiguityKind::DeriveHelper =>
                 "derive helper attribute vs any other name",
-            AmbiguityKind::LegacyHelperVsPrelude =>
-                "legacy plugin helper attribute vs name from prelude",
             AmbiguityKind::LegacyVsModern =>
                 "`macro_rules` vs non-`macro_rules` from other module",
             AmbiguityKind::GlobVsOuter =>

--- a/src/librustc_resolve/lib.rs
+++ b/src/librustc_resolve/lib.rs
@@ -74,8 +74,6 @@ mod check_unused;
 mod build_reduced_graph;
 mod resolve_imports;
 
-const KNOWN_TOOLS: &[Name] = &[sym::clippy, sym::rustfmt];
-
 enum Weak {
     Yes,
     No,
@@ -102,6 +100,7 @@ enum Scope<'a> {
     MacroRules(LegacyScope<'a>),
     CrateRoot,
     Module(Module<'a>),
+    RegisteredAttrs,
     MacroUsePrelude,
     BuiltinAttrs,
     LegacyPluginHelpers,
@@ -916,6 +915,8 @@ pub struct Resolver<'a> {
     crate_loader: CrateLoader<'a>,
     macro_names: FxHashSet<Ident>,
     builtin_macros: FxHashMap<Name, SyntaxExtension>,
+    registered_attrs: FxHashSet<Ident>,
+    registered_tools: FxHashSet<Ident>,
     macro_use_prelude: FxHashMap<Name, &'a NameBinding<'a>>,
     all_macros: FxHashMap<Name, Res>,
     macro_map: FxHashMap<DefId, Lrc<SyntaxExtension>>,
@@ -1132,6 +1133,9 @@ impl<'a> Resolver<'a> {
             }
         }
 
+        let (registered_attrs, registered_tools) =
+            macros::registered_attrs_and_tools(session, &krate.attrs);
+
         let mut invocation_parent_scopes = FxHashMap::default();
         invocation_parent_scopes.insert(ExpnId::root(), ParentScope::module(graph_root));
 
@@ -1201,6 +1205,8 @@ impl<'a> Resolver<'a> {
             crate_loader: CrateLoader::new(session, metadata_loader, crate_name),
             macro_names: FxHashSet::default(),
             builtin_macros: Default::default(),
+            registered_attrs,
+            registered_tools,
             macro_use_prelude: FxHashMap::default(),
             all_macros: FxHashMap::default(),
             macro_map: FxHashMap::default(),
@@ -1469,6 +1475,7 @@ impl<'a> Resolver<'a> {
                 Scope::MacroRules(..) => true,
                 Scope::CrateRoot => true,
                 Scope::Module(..) => true,
+                Scope::RegisteredAttrs => true,
                 Scope::MacroUsePrelude => use_prelude || rust_2015,
                 Scope::BuiltinAttrs => true,
                 Scope::LegacyPluginHelpers => use_prelude || rust_2015,
@@ -1513,11 +1520,12 @@ impl<'a> Resolver<'a> {
                             match ns {
                                 TypeNS => Scope::ExternPrelude,
                                 ValueNS => Scope::StdLibPrelude,
-                                MacroNS => Scope::MacroUsePrelude,
+                                MacroNS => Scope::RegisteredAttrs,
                             }
                         }
                     }
                 }
+                Scope::RegisteredAttrs => Scope::MacroUsePrelude,
                 Scope::MacroUsePrelude => Scope::StdLibPrelude,
                 Scope::BuiltinAttrs => Scope::LegacyPluginHelpers,
                 Scope::LegacyPluginHelpers => break, // nowhere else to search
@@ -1673,11 +1681,11 @@ impl<'a> Resolver<'a> {
                 if let Some(binding) = self.extern_prelude_get(ident, !record_used) {
                     return Some(LexicalScopeBinding::Item(binding));
                 }
-            }
-            if ns == TypeNS && KNOWN_TOOLS.contains(&ident.name) {
-                let binding = (Res::ToolMod, ty::Visibility::Public,
-                               DUMMY_SP, ExpnId::root()).to_name_binding(self.arenas);
-                return Some(LexicalScopeBinding::Item(binding));
+                if let Some(ident) = self.registered_tools.get(&ident) {
+                    let binding = (Res::ToolMod, ty::Visibility::Public,
+                                   ident.span, ExpnId::root()).to_name_binding(self.arenas);
+                    return Some(LexicalScopeBinding::Item(binding));
+                }
             }
             if let Some(prelude) = self.prelude {
                 if let Ok(binding) = self.resolve_ident_in_module_unadjusted(

--- a/src/librustc_resolve/macros.rs
+++ b/src/librustc_resolve/macros.rs
@@ -94,6 +94,7 @@ fn fast_print_path(path: &ast::Path) -> Symbol {
     }
 }
 
+/// The code common between processing `#![register_tool]` and `#![register_attr]`.
 fn registered_idents(
     sess: &Session,
     attrs: &[ast::Attribute],
@@ -832,7 +833,8 @@ impl<'a> Resolver<'a> {
                                          res: Option<Res>, span: Span) {
         if let Some(Res::NonMacroAttr(kind)) = res {
             if kind != NonMacroAttrKind::Tool && binding.map_or(true, |b| b.is_import()) {
-                let msg = format!("cannot use a {} through an import", kind.descr());
+                let msg =
+                    format!("cannot use {} {} through an import", kind.article(), kind.descr());
                 let mut err = self.session.struct_span_err(span, &msg);
                 if let Some(binding) = binding {
                     err.span_note(binding.span, &format!("the {} imported here", kind.descr()));

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -265,9 +265,6 @@ declare_features! (
     /// Allows the use of SIMD types in functions declared in `extern` blocks.
     (active, simd_ffi, "1.0.0", Some(27731), None),
 
-    /// Allows using custom attributes (RFC 572).
-    (active, custom_attribute, "1.0.0", Some(29642), None),
-
     /// Allows using non lexical lifetimes (RFC 2094).
     (active, nll, "1.0.0", Some(43234), None),
 

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -526,6 +526,12 @@ declare_features! (
     /// Allows using the `efiapi` ABI.
     (active, abi_efiapi, "1.40.0", Some(65815), None),
 
+    /// Allows using the `#[register_attr]` attribute.
+    (active, register_attr, "1.41.0", Some(29642), None),
+
+    /// Allows using the `#[register_attr]` attribute.
+    (active, register_tool, "1.41.0", Some(44690), None),
+
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates
     // -------------------------------------------------------------------------

--- a/src/libsyntax/feature_gate/active.rs
+++ b/src/libsyntax/feature_gate/active.rs
@@ -524,10 +524,10 @@ declare_features! (
     (active, abi_efiapi, "1.40.0", Some(65815), None),
 
     /// Allows using the `#[register_attr]` attribute.
-    (active, register_attr, "1.41.0", Some(29642), None),
+    (active, register_attr, "1.41.0", Some(66080), None),
 
     /// Allows using the `#[register_attr]` attribute.
-    (active, register_tool, "1.41.0", Some(44690), None),
+    (active, register_tool, "1.41.0", Some(66079), None),
 
     // -------------------------------------------------------------------------
     // feature-group-end: actual feature gates

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -330,11 +330,11 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     gated!(ffi_returns_twice, Whitelisted, template!(Word), experimental!(ffi_returns_twice)),
     gated!(track_caller, Whitelisted, template!(Word), experimental!(track_caller)),
     gated!(
-        register_attr, Whitelisted, template!(List: "attr1, attr2, ..."),
+        register_attr, CrateLevel, template!(List: "attr1, attr2, ..."),
         experimental!(register_attr),
     ),
     gated!(
-        register_tool, Whitelisted, template!(List: "tool1, tool2, ..."),
+        register_tool, CrateLevel, template!(List: "tool1, tool2, ..."),
         experimental!(register_tool),
     ),
 

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -329,6 +329,14 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
 
     gated!(ffi_returns_twice, Whitelisted, template!(Word), experimental!(ffi_returns_twice)),
     gated!(track_caller, Whitelisted, template!(Word), experimental!(track_caller)),
+    gated!(
+        register_attr, Whitelisted, template!(List: "attr1, attr2, ..."),
+        experimental!(register_attr),
+    ),
+    gated!(
+        register_tool, Whitelisted, template!(List: "tool1, tool2, ..."),
+        experimental!(register_tool),
+    ),
 
     // ==========================================================================
     // Internal attributes: Stability, deprecation, and unsafe:

--- a/src/libsyntax/feature_gate/removed.rs
+++ b/src/libsyntax/feature_gate/removed.rs
@@ -67,6 +67,9 @@ declare_features! (
      Some("merged into `#![feature(slice_patterns)]`")),
     (removed, macro_reexport, "1.0.0", Some(29638), None,
      Some("subsumed by `pub use`")),
+    /// Allows using custom attributes (RFC 572).
+    (removed, custom_attribute, "1.0.0", Some(29642), None,
+     Some("removed in favor of `#![register_tool]` and `#![register_attr]`")),
     (removed, pushpop_unsafe, "1.2.0", None, None, None),
     (removed, needs_allocator, "1.4.0", Some(27389), None,
      Some("subsumed by `#![feature(allocator_internals)]`")),

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -545,6 +545,8 @@ symbols! {
         recursion_limit,
         reexport_test_harness_main,
         reflect,
+        register_attr,
+        register_tool,
         relaxed_adts,
         repr,
         repr128,

--- a/src/test/ui-fulldeps/issue-15778-pass.rs
+++ b/src/test/ui-fulldeps/issue-15778-pass.rs
@@ -3,7 +3,15 @@
 // ignore-stage1
 // compile-flags: -D crate-not-okay
 
-#![feature(plugin, custom_attribute, custom_inner_attributes, rustc_attrs)]
+#![feature(plugin, register_attr, custom_inner_attributes, rustc_attrs)]
+
+#![register_attr(
+    rustc_crate_okay,
+    rustc_crate_blue,
+    rustc_crate_red,
+    rustc_crate_grey,
+    rustc_crate_green,
+)]
 
 #![plugin(lint_for_crate_rpass)]
 #![rustc_crate_okay]

--- a/src/test/ui-fulldeps/issue-15778-pass.stderr
+++ b/src/test/ui-fulldeps/issue-15778-pass.stderr
@@ -1,5 +1,5 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/issue-15778-pass.rs:8:1
+  --> $DIR/issue-15778-pass.rs:16:1
    |
 LL | #![plugin(lint_for_crate_rpass)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version

--- a/src/test/ui/attributes/register-attr-tool-fail.rs
+++ b/src/test/ui/attributes/register-attr-tool-fail.rs
@@ -1,0 +1,13 @@
+#![feature(register_attr)]
+#![feature(register_tool)]
+
+#![register_attr] //~ ERROR malformed `register_attr` attribute input
+#![register_tool] //~ ERROR malformed `register_tool` attribute input
+
+#![register_attr(a::b)] //~ ERROR `register_attr` only accepts identifiers
+#![register_tool(a::b)] //~ ERROR `register_tool` only accepts identifiers
+
+#![register_attr(attr, attr)] //~ ERROR attribute `attr` was already registered
+#![register_tool(tool, tool)] //~ ERROR tool `tool` was already registered
+
+fn main() {}

--- a/src/test/ui/attributes/register-attr-tool-fail.stderr
+++ b/src/test/ui/attributes/register-attr-tool-fail.stderr
@@ -1,0 +1,42 @@
+error: `register_attr` only accepts identifiers
+  --> $DIR/register-attr-tool-fail.rs:7:18
+   |
+LL | #![register_attr(a::b)]
+   |                  ^^^^ not an identifier
+
+error: attribute `attr` was already registered
+  --> $DIR/register-attr-tool-fail.rs:10:24
+   |
+LL | #![register_attr(attr, attr)]
+   |                  ----  ^^^^
+   |                  |
+   |                  already registered here
+
+error: `register_tool` only accepts identifiers
+  --> $DIR/register-attr-tool-fail.rs:8:18
+   |
+LL | #![register_tool(a::b)]
+   |                  ^^^^ not an identifier
+
+error: tool `tool` was already registered
+  --> $DIR/register-attr-tool-fail.rs:11:24
+   |
+LL | #![register_tool(tool, tool)]
+   |                  ----  ^^^^
+   |                  |
+   |                  already registered here
+
+error: malformed `register_attr` attribute input
+  --> $DIR/register-attr-tool-fail.rs:4:1
+   |
+LL | #![register_attr]
+   | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[register_attr(attr1, attr2, ...)]`
+
+error: malformed `register_tool` attribute input
+  --> $DIR/register-attr-tool-fail.rs:5:1
+   |
+LL | #![register_tool]
+   | ^^^^^^^^^^^^^^^^^ help: must be of the form: `#[register_tool(tool1, tool2, ...)]`
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/attributes/register-attr-tool-import.rs
+++ b/src/test/ui/attributes/register-attr-tool-import.rs
@@ -1,0 +1,14 @@
+// edition:2018
+
+#![feature(register_attr)]
+#![feature(register_tool)]
+
+#![register_attr(attr)]
+#![register_tool(tool)]
+
+use attr as renamed_attr; // OK
+use tool as renamed_tool; // OK
+
+#[renamed_attr] //~ ERROR cannot use an explicitly registered attribute through an import
+#[renamed_tool::attr] //~ ERROR cannot use a tool module through an import
+fn main() {}

--- a/src/test/ui/attributes/register-attr-tool-import.stderr
+++ b/src/test/ui/attributes/register-attr-tool-import.stderr
@@ -1,0 +1,26 @@
+error: cannot use an explicitly registered attribute through an import
+  --> $DIR/register-attr-tool-import.rs:12:3
+   |
+LL | #[renamed_attr]
+   |   ^^^^^^^^^^^^
+   |
+note: the explicitly registered attribute imported here
+  --> $DIR/register-attr-tool-import.rs:9:5
+   |
+LL | use attr as renamed_attr; // OK
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use a tool module through an import
+  --> $DIR/register-attr-tool-import.rs:13:3
+   |
+LL | #[renamed_tool::attr]
+   |   ^^^^^^^^^^^^
+   |
+note: the tool module imported here
+  --> $DIR/register-attr-tool-import.rs:10:5
+   |
+LL | use tool as renamed_tool; // OK
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/attributes/register-attr-tool-prelude.rs
+++ b/src/test/ui/attributes/register-attr-tool-prelude.rs
@@ -1,0 +1,14 @@
+#![feature(register_attr)]
+#![feature(register_tool)]
+
+#![register_attr(attr)]
+#![register_tool(tool)]
+
+#[no_implicit_prelude]
+mod m {
+    #[attr] //~ ERROR cannot find attribute `attr` in this scope
+    #[tool::attr] //~ ERROR failed to resolve: use of undeclared type or module `tool`
+    fn check() {}
+}
+
+fn main() {}

--- a/src/test/ui/attributes/register-attr-tool-prelude.stderr
+++ b/src/test/ui/attributes/register-attr-tool-prelude.stderr
@@ -1,0 +1,15 @@
+error[E0433]: failed to resolve: use of undeclared type or module `tool`
+  --> $DIR/register-attr-tool-prelude.rs:10:7
+   |
+LL |     #[tool::attr]
+   |       ^^^^ use of undeclared type or module `tool`
+
+error: cannot find attribute `attr` in this scope
+  --> $DIR/register-attr-tool-prelude.rs:9:7
+   |
+LL |     #[attr]
+   |       ^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0433`.

--- a/src/test/ui/attributes/register-attr-tool-unused.rs
+++ b/src/test/ui/attributes/register-attr-tool-unused.rs
@@ -1,0 +1,10 @@
+#![deny(unused)]
+
+#![feature(register_attr)]
+#![feature(register_tool)]
+
+#[register_attr(attr)] //~ ERROR crate-level attribute should be an inner attribute
+                       //~| ERROR unused attribute
+#[register_tool(tool)] //~ ERROR crate-level attribute should be an inner attribute
+                       //~| ERROR unused attribute
+fn main() {}

--- a/src/test/ui/attributes/register-attr-tool-unused.stderr
+++ b/src/test/ui/attributes/register-attr-tool-unused.stderr
@@ -1,0 +1,33 @@
+error: unused attribute
+  --> $DIR/register-attr-tool-unused.rs:6:1
+   |
+LL | #[register_attr(attr)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: lint level defined here
+  --> $DIR/register-attr-tool-unused.rs:1:9
+   |
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(unused_attributes)]` implied by `#[deny(unused)]`
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
+  --> $DIR/register-attr-tool-unused.rs:6:1
+   |
+LL | #[register_attr(attr)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: unused attribute
+  --> $DIR/register-attr-tool-unused.rs:8:1
+   |
+LL | #[register_tool(tool)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
+  --> $DIR/register-attr-tool-unused.rs:8:1
+   |
+LL | #[register_tool(tool)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/attributes/register-attr-tool.rs
+++ b/src/test/ui/attributes/register-attr-tool.rs
@@ -1,0 +1,19 @@
+// check-pass
+// compile-flags: --cfg foo
+
+#![feature(register_attr)]
+#![feature(register_tool)]
+
+#![register_attr(attr)]
+#![register_tool(tool)]
+#![register_tool(rustfmt, clippy)] // OK
+#![cfg_attr(foo, register_attr(conditional_attr))]
+#![cfg_attr(foo, register_tool(conditional_tool))]
+
+#[attr]
+#[tool::attr]
+#[rustfmt::attr]
+#[clippy::attr]
+#[conditional_attr]
+#[conditional_tool::attr]
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute2.rs
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute2.rs
@@ -1,8 +1,6 @@
 // This test ensures that attributes on formals in generic parameter
 // lists are included when we are checking for unstable attributes.
 
-// gate-test-custom_attribute
-
 struct StLt<#[lt_struct] 'a>(&'a u32);
 //~^ ERROR cannot find attribute `lt_struct` in this scope
 struct StTy<#[ty_struct] I>(I);

--- a/src/test/ui/feature-gates/feature-gate-custom_attribute2.stderr
+++ b/src/test/ui/feature-gates/feature-gate-custom_attribute2.stderr
@@ -1,101 +1,101 @@
 error: cannot find attribute `lt_hof` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:53:21
+  --> $DIR/feature-gate-custom_attribute2.rs:51:21
    |
 LL |     where Q: for <#[lt_hof] 'i> Fn(&'i [u32]) -> &'i u32
    |                     ^^^^^^
 
 error: cannot find attribute `ty_meth` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:48:15
+  --> $DIR/feature-gate-custom_attribute2.rs:46:15
    |
 LL |     fn m_ty<#[ty_meth] P>(_: P) { }
    |               ^^^^^^^
 
 error: cannot find attribute `lt_meth` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:46:15
+  --> $DIR/feature-gate-custom_attribute2.rs:44:15
    |
 LL |     fn m_lt<#[lt_meth] 'h>(_: &'h [u32]) -> &'h u32 { loop { } }
    |               ^^^^^^^
 
 error: cannot find attribute `ty_fn` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:42:11
+  --> $DIR/feature-gate-custom_attribute2.rs:40:11
    |
 LL | fn f_ty<#[ty_fn] O>(_: O) { }
    |           ^^^^^
 
 error: cannot find attribute `lt_fn` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:40:11
+  --> $DIR/feature-gate-custom_attribute2.rs:38:11
    |
 LL | fn f_lt<#[lt_fn] 'g>(_: &'g [u32]) -> &'g u32 { loop { } }
    |           ^^^^^
 
 error: cannot find attribute `ty_impl_for` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:35:8
+  --> $DIR/feature-gate-custom_attribute2.rs:33:8
    |
 LL | impl<#[ty_impl_for] N> TrTy<N> for StTy<N> {
    |        ^^^^^^^^^^^
 
 error: cannot find attribute `lt_impl_for` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:31:8
+  --> $DIR/feature-gate-custom_attribute2.rs:29:8
    |
 LL | impl<#[lt_impl_for] 'f> TrLt<'f> for StLt<'f> {
    |        ^^^^^^^^^^^
 
 error: cannot find attribute `ty_inherent` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:28:8
+  --> $DIR/feature-gate-custom_attribute2.rs:26:8
    |
 LL | impl<#[ty_inherent] M> StTy<M> { }
    |        ^^^^^^^^^^^
 
 error: cannot find attribute `lt_inherent` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:26:8
+  --> $DIR/feature-gate-custom_attribute2.rs:24:8
    |
 LL | impl<#[lt_inherent] 'e> StLt<'e> { }
    |        ^^^^^^^^^^^
 
 error: cannot find attribute `ty_type` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:23:13
+  --> $DIR/feature-gate-custom_attribute2.rs:21:13
    |
 LL | type TyTy<#[ty_type] L> = (L, );
    |             ^^^^^^^
 
 error: cannot find attribute `lt_type` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:21:13
+  --> $DIR/feature-gate-custom_attribute2.rs:19:13
    |
 LL | type TyLt<#[lt_type] 'd> = &'d u32;
    |             ^^^^^^^
 
 error: cannot find attribute `ty_trait` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:18:14
+  --> $DIR/feature-gate-custom_attribute2.rs:16:14
    |
 LL | trait TrTy<#[ty_trait] K> { fn foo(&self, _: K); }
    |              ^^^^^^^^
 
 error: cannot find attribute `lt_trait` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:16:14
+  --> $DIR/feature-gate-custom_attribute2.rs:14:14
    |
 LL | trait TrLt<#[lt_trait] 'c> { fn foo(&self, _: &'c [u32]) -> &'c u32; }
    |              ^^^^^^^^
 
 error: cannot find attribute `ty_enum` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:13:13
+  --> $DIR/feature-gate-custom_attribute2.rs:11:13
    |
 LL | enum EnTy<#[ty_enum] J> { A(J), B }
    |             ^^^^^^^
 
 error: cannot find attribute `lt_enum` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:11:13
+  --> $DIR/feature-gate-custom_attribute2.rs:9:13
    |
 LL | enum EnLt<#[lt_enum] 'b> { A(&'b u32), B }
    |             ^^^^^^^
 
 error: cannot find attribute `ty_struct` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:8:15
+  --> $DIR/feature-gate-custom_attribute2.rs:6:15
    |
 LL | struct StTy<#[ty_struct] I>(I);
    |               ^^^^^^^^^
 
 error: cannot find attribute `lt_struct` in this scope
-  --> $DIR/feature-gate-custom_attribute2.rs:6:15
+  --> $DIR/feature-gate-custom_attribute2.rs:4:15
    |
 LL | struct StLt<#[lt_struct] 'a>(&'a u32);
    |               ^^^^^^^^^

--- a/src/test/ui/feature-gates/feature-gate-register_attr.rs
+++ b/src/test/ui/feature-gates/feature-gate-register_attr.rs
@@ -1,0 +1,3 @@
+#![register_attr(attr)] //~ ERROR the `#[register_attr]` attribute is an experimental feature
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-register_attr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_attr.stderr
@@ -1,0 +1,12 @@
+error[E0658]: the `#[register_attr]` attribute is an experimental feature
+  --> $DIR/feature-gate-register_attr.rs:1:1
+   |
+LL | #![register_attr(attr)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = help: add `#![feature(register_attr)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-register_attr.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_attr.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[register_attr]` attribute is an experimental feature
 LL | #![register_attr(attr)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/29642
+   = note: for more information, see https://github.com/rust-lang/rust/issues/66080
    = help: add `#![feature(register_attr)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-register_tool.rs
+++ b/src/test/ui/feature-gates/feature-gate-register_tool.rs
@@ -1,0 +1,3 @@
+#![register_tool(tool)] //~ ERROR the `#[register_tool]` attribute is an experimental feature
+
+fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-register_tool.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_tool.stderr
@@ -1,0 +1,12 @@
+error[E0658]: the `#[register_tool]` attribute is an experimental feature
+  --> $DIR/feature-gate-register_tool.rs:1:1
+   |
+LL | #![register_tool(tool)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/44690
+   = help: add `#![feature(register_tool)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/feature-gates/feature-gate-register_tool.stderr
+++ b/src/test/ui/feature-gates/feature-gate-register_tool.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `#[register_tool]` attribute is an experimental feature
 LL | #![register_tool(tool)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: for more information, see https://github.com/rust-lang/rust/issues/44690
+   = note: for more information, see https://github.com/rust-lang/rust/issues/66079
    = help: add `#![feature(register_tool)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/proc-macro/expand-to-unstable-2.rs
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.rs
@@ -1,6 +1,8 @@
 // aux-build:derive-unstable-2.rs
 
-#![feature(custom_attribute)]
+#![feature(register_attr)]
+
+#![register_attr(rustc_foo)]
 
 #[macro_use]
 extern crate derive_unstable_2;

--- a/src/test/ui/proc-macro/expand-to-unstable-2.stderr
+++ b/src/test/ui/proc-macro/expand-to-unstable-2.stderr
@@ -1,5 +1,5 @@
 error[E0658]: attributes starting with `rustc` are reserved for use by the `rustc` compiler
-  --> $DIR/expand-to-unstable-2.rs:8:10
+  --> $DIR/expand-to-unstable-2.rs:10:10
    |
 LL | #[derive(Unstable)]
    |          ^^^^^^^^

--- a/src/test/ui/proc-macro/issue-41211.rs
+++ b/src/test/ui/proc-macro/issue-41211.rs
@@ -3,11 +3,13 @@
 // FIXME: https://github.com/rust-lang/rust/issues/41430
 // This is a temporary regression test for the ICE reported in #41211
 
-#![feature(custom_attribute)]
 #![feature(custom_inner_attributes)]
+#![feature(register_attr)]
+
+#![register_attr(identity_attr)]
 
 #![identity_attr]
-//~^ ERROR inconsistent resolution for a macro: first custom attribute, then attribute macro
+//~^ ERROR `identity_attr` is ambiguous
 extern crate test_macros;
 use test_macros::identity_attr;
 

--- a/src/test/ui/proc-macro/issue-41211.stderr
+++ b/src/test/ui/proc-macro/issue-41211.stderr
@@ -1,8 +1,21 @@
-error: inconsistent resolution for a macro: first custom attribute, then attribute macro
-  --> $DIR/issue-41211.rs:9:4
+error[E0659]: `identity_attr` is ambiguous (macro-expanded name vs less macro-expanded name from outer scope during import/macro resolution)
+  --> $DIR/issue-41211.rs:11:4
    |
 LL | #![identity_attr]
-   |    ^^^^^^^^^^^^^
+   |    ^^^^^^^^^^^^^ ambiguous name
+   |
+note: `identity_attr` could refer to the attribute macro imported here
+  --> $DIR/issue-41211.rs:14:5
+   |
+LL | use test_macros::identity_attr;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: use `crate::identity_attr` to refer to this attribute macro unambiguously
+note: `identity_attr` could also refer to the explicitly registered attribute defined here
+  --> $DIR/issue-41211.rs:9:18
+   |
+LL | #![register_attr(identity_attr)]
+   |                  ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0659`.

--- a/src/test/ui/span/issue-36530.rs
+++ b/src/test/ui/span/issue-36530.rs
@@ -1,6 +1,8 @@
 // gate-test-custom_inner_attributes
 
-#![feature(custom_attribute)]
+#![feature(register_attr)]
+
+#![register_attr(foo)]
 
 #[foo]
 mod foo {

--- a/src/test/ui/span/issue-36530.stderr
+++ b/src/test/ui/span/issue-36530.stderr
@@ -1,5 +1,5 @@
 error[E0658]: non-builtin inner attributes are unstable
-  --> $DIR/issue-36530.rs:7:5
+  --> $DIR/issue-36530.rs:9:5
    |
 LL |     #![foo]
    |     ^^^^^^^


### PR DESCRIPTION
And remove `#[feature(custom_attribute)]`.
(`rustc_plugin::Registry::register_attribute` is not removed yet, I'll do it in a follow up PR.)

```rust
#![register_attr(my_attr)]
#![register_tool(my_tool)]

#[my_attr] // OK
#[my_tool::anything] // OK
fn main() {}
```

---
Some tools (`rustfmt` and `clippy`) used in tool attributes are hardcoded in the compiler.
We need some way to introduce them without hardcoding as well.

This PR introduces a way to do it with a crate level attribute.
The previous attempt to introduce them through command line (https://github.com/rust-lang/rust/pull/57921) met some resistance.

This probably needs to go through an RFC before stabilization.
However, I'd prefer to land *this* PR without an RFC to able to remove `#[feature(custom_attribute)]` and `Registry::register_attribute` while also providing a replacement.

---
`register_attr` is a direct replacement for `#![feature(custom_attribute)]` (https://github.com/rust-lang/rust/issues/29642), except it doesn't rely on implicit fallback from unresolved attributes to custom attributes (which was always hacky and is the primary reason for the removal of `custom_attribute`) and requires registering the attribute explicitly.
It's not clear whether it should go through stabilization or not.
It's quite possible that all the uses should migrate to `#![register_tool]` (https://github.com/rust-lang/rust/issues/66079) instead.

---

Details:
- The naming is `register_attr`/`register_tool` rather than some `register_attributes` (plural, no abbreviation) for consistency with already existing attributes like `cfg_attr`, or `feature`, etc.
---
Previous attempt: https://github.com/rust-lang/rust/pull/57921
cc https://github.com/rust-lang/rust/issues/44690
Tracking issues: #66079 (`register_tool`), #66080 (`register_attr`)
Closes https://github.com/rust-lang/rust/issues/29642