### PR TITLE
Do not needlessly write-lock

### DIFF
--- a/src/librustc_lint/unused.rs
+++ b/src/librustc_lint/unused.rs
@@ -309,7 +309,7 @@ impl<'a, 'tcx> LateLintPass<'a, 'tcx> for UnusedAttributes {
             }
         }
 
-        let plugin_attributes = cx.sess().plugin_attributes.borrow_mut();
+        let plugin_attributes = cx.sess().plugin_attributes.borrow();
         for &(name, ty) in plugin_attributes.iter() {
             if ty == AttributeType::Whitelisted && attr.check_name(name) {
                 debug!("{:?} (plugin attr) is whitelisted with ty {:?}", name, ty);


### PR DESCRIPTION
Just removes a needless `borrow_mut()` by using `borrow()` instead.