### PR TITLE
expand: Feature gate out-of-line modules in proc macro input

### DIFF
--- a/src/test/ui/proc-macro/attributes-on-modules-fail.rs
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.rs
@@ -1,0 +1,29 @@
+// aux-build:test-macros.rs
+
+#[macro_use]
+extern crate test_macros;
+
+#[identity_attr] //~ ERROR custom attributes cannot be applied to modules
+mod m {
+    pub struct X;
+
+    type A = Y; //~ ERROR cannot find type `Y` in this scope
+}
+
+struct Y;
+type A = X; //~ ERROR cannot find type `X` in this scope
+
+#[derive(Copy)] //~ ERROR `derive` may only be applied to structs, enums and unions
+mod n {}
+
+#[empty_attr]
+mod module; //~ ERROR non-inline modules in proc macro input are unstable
+
+#[empty_attr] //~ ERROR custom attributes cannot be applied to modules
+mod outer {
+    mod inner; //~ ERROR non-inline modules in proc macro input are unstable
+
+    mod inner_inline {} // OK
+}
+
+fn main() {}

--- a/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
+++ b/src/test/ui/proc-macro/attributes-on-modules-fail.stderr
@@ -1,0 +1,76 @@
+error[E0658]: custom attributes cannot be applied to modules
+  --> $DIR/attributes-on-modules-fail.rs:6:1
+   |
+LL | #[identity_attr]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error: `derive` may only be applied to structs, enums and unions
+  --> $DIR/attributes-on-modules-fail.rs:16:1
+   |
+LL | #[derive(Copy)]
+   | ^^^^^^^^^^^^^^^
+
+error[E0658]: non-inline modules in proc macro input are unstable
+  --> $DIR/attributes-on-modules-fail.rs:20:1
+   |
+LL | mod module;
+   | ^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error[E0658]: non-inline modules in proc macro input are unstable
+  --> $DIR/attributes-on-modules-fail.rs:24:5
+   |
+LL |     mod inner;
+   |     ^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error[E0658]: custom attributes cannot be applied to modules
+  --> $DIR/attributes-on-modules-fail.rs:22:1
+   |
+LL | #[empty_attr]
+   | ^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error[E0412]: cannot find type `Y` in this scope
+  --> $DIR/attributes-on-modules-fail.rs:10:14
+   |
+LL |     type A = Y;
+   |     ---------^- similarly named type alias `A` defined here
+   |
+help: a type alias with a similar name exists
+   |
+LL |     type A = A;
+   |              ^
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL |     use Y;
+   |
+
+error[E0412]: cannot find type `X` in this scope
+  --> $DIR/attributes-on-modules-fail.rs:14:10
+   |
+LL | type A = X;
+   | ---------^- similarly named type alias `A` defined here
+   |
+help: a type alias with a similar name exists
+   |
+LL | type A = A;
+   |          ^
+help: possible candidate is found in another module, you can import it into scope
+   |
+LL | use m::X;
+   |
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0412, E0658.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/proc-macro/attributes-on-modules.rs
+++ b/src/test/ui/proc-macro/attributes-on-modules.rs
@@ -1,0 +1,13 @@
+// aux-build:test-macros.rs
+
+#[macro_use]
+extern crate test_macros;
+
+#[identity_attr] //~ ERROR custom attributes cannot be applied to modules
+mod m {
+    pub struct S;
+}
+
+fn main() {
+    let s = m::S;
+}

--- a/src/test/ui/proc-macro/attributes-on-modules.stderr
+++ b/src/test/ui/proc-macro/attributes-on-modules.stderr
@@ -1,0 +1,12 @@
+error[E0658]: custom attributes cannot be applied to modules
+  --> $DIR/attributes-on-modules.rs:6:1
+   |
+LL | #[identity_attr]
+   | ^^^^^^^^^^^^^^^^
+   |
+   = note: for more information, see https://github.com/rust-lang/rust/issues/54727
+   = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/proc-macro/module.rs
+++ b/src/test/ui/proc-macro/module.rs
@@ -1,0 +1,1 @@
+// ignore-test

--- a/src/test/ui/proc-macro/outer/inner.rs
+++ b/src/test/ui/proc-macro/outer/inner.rs
@@ -1,0 +1,1 @@
+// ignore-test


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust/pull/64273.

We are currently gating attributes applied directly to `mod` items because there are unresolved questions about out-of-line modules and their behavior is very likely to change.

However, you can sneak an out-of-line module into an attribute macro input using modules nested into other items like
```rust
#[my_attr]
fn m() {
    #[path = "zzz.rs"]
    mod n; // what tokens does the `my_attr` macro see?
}
```
This PR prevents that and emits a feature gate error for this case as well.

r? @Centril 
It would be great to land this before beta.