### PR TITLE
Do not require extra LLVM backends for `x.py test` to pass

### DIFF
--- a/src/test/codegen/abi-efiapi.rs
+++ b/src/test/codegen/abi-efiapi.rs
@@ -1,14 +1,12 @@
 // Checks if the correct annotation for the efiapi ABI is passed to llvm.
 
-// revisions:x86_64 i686 aarch64 arm riscv
+// revisions:x86_64 i686 arm
 
 // min-llvm-version 9.0
 
 //[x86_64] compile-flags: --target x86_64-unknown-uefi
 //[i686] compile-flags: --target i686-unknown-linux-musl
-//[aarch64] compile-flags: --target aarch64-unknown-none
 //[arm] compile-flags: --target armv7r-none-eabi
-//[riscv] compile-flags: --target riscv64gc-unknown-none-elf
 // compile-flags: -C no-prepopulate-passes
 
 #![crate_type = "lib"]
@@ -24,8 +22,6 @@ trait Copy { }
 
 //x86_64: define win64cc void @has_efiapi
 //i686: define void @has_efiapi
-//aarch64: define void @has_efiapi
 //arm: define void @has_efiapi
-//riscv: define void @has_efiapi
 #[no_mangle]
 pub extern "efiapi" fn has_efiapi() {}


### PR DESCRIPTION
For long time our testing passed with a partially built LLVM
```
[llvm]
targets = "X86;ARM"
```
, a [recent PR](https://github.com/rust-lang/rust/pull/65809) changed that.