### PR TITLE
[T]::rejoin (experimental API implementation)

### DIFF
--- a/src/liballoc/lib.rs
+++ b/src/liballoc/lib.rs
@@ -123,6 +123,7 @@
 #![feature(alloc_layout_extra)]
 #![feature(try_trait)]
 #![feature(associated_type_bounds)]
+#![feature(rejoin_slice)]
 
 // Allow testing this library
 

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -567,6 +567,21 @@ impl str {
         // make_ascii_lowercase() preserves the UTF-8 invariant.
         unsafe { String::from_utf8_unchecked(bytes) }
     }
+
+    /// Joins two string slices that are adjacent in memory into one string slice.
+    /// # Panics
+    /// Panics in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn rejoin<'r>(&'r self, other: &'r str) -> &'r str {
+        self.try_rejoin(other).expect("the input string slices must be adjacent in memory")
+    }
+
+    /// Joins two string slices that are adjacent in memory into one string slice.
+    /// Returns None in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn try_rejoin<'r>(&'r self, other: &'r str) -> Option<&'r str> {
+        self.as_bytes().try_rejoin(other.as_bytes()).map(|s| unsafe { core::str::from_utf8_unchecked(s) })
+    }
 }
 
 /// Converts a boxed slice of bytes to a boxed string slice without checking

--- a/src/liballoc/str.rs
+++ b/src/liballoc/str.rs
@@ -580,7 +580,9 @@ impl str {
     /// Returns None in the case the slices aren't adjacent.
     #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
     pub fn try_rejoin<'r>(&'r self, other: &'r str) -> Option<&'r str> {
-        self.as_bytes().try_rejoin(other.as_bytes()).map(|s| unsafe { core::str::from_utf8_unchecked(s) })
+        self.as_bytes().try_rejoin(other.as_bytes()).map(|s|
+            unsafe { core::str::from_utf8_unchecked(s) }
+        )
     }
 }
 

--- a/src/liballoc/tests/lib.rs
+++ b/src/liballoc/tests/lib.rs
@@ -10,6 +10,7 @@
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
 #![feature(binary_heap_drain_sorted)]
+#![feature(rejoin_slice)]
 
 use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;

--- a/src/liballoc/tests/str.rs
+++ b/src/liballoc/tests/str.rs
@@ -1859,3 +1859,46 @@ fn different_str_pattern_forwarding_lifetimes() {
 
     foo::<&str>("x");
 }
+
+#[test]
+fn test_rejoin() {
+    let slice = &"abcdefg"[..];
+
+    assert_eq!(slice[..3].rejoin(&slice[3..]), slice);
+    assert_eq!(slice[..4].rejoin(&slice[4..]), slice);
+    assert_eq!(slice[..0].rejoin(&slice[0..]), slice);
+    assert_eq!(slice[..1].rejoin(&slice[1..]), slice);
+    assert_eq!(slice[..6].rejoin(&slice[6..]), slice);
+    assert_eq!(slice[..7].rejoin(&slice[7..]), slice);
+}
+
+#[test]
+#[should_panic]
+fn test_rejoin_nogaps() {
+    let slice = &"abcdefg"[..];
+
+    // Don't allow gaps between slices
+    slice[..3].rejoin(&slice[4..]);
+}
+#[test]
+#[should_panic]
+fn test_rejoin_leftright() {
+    let slice = &"abcdefg"[..];
+
+    // Don't allow joining in wrong order
+    slice[3..].rejoin(&slice[..3]);
+}
+
+#[test]
+fn test_try_rejoin() {
+    let slice = &"abcdefg"[..];
+
+    assert_eq!(slice[..3].try_rejoin(&slice[3..]), Some(slice));
+    assert_eq!(slice[..0].try_rejoin(&slice[0..]), Some(slice));
+    assert_eq!(slice[..1].try_rejoin(&slice[1..]), Some(slice));
+    assert_eq!(slice[..6].try_rejoin(&slice[6..]), Some(slice));
+    assert_eq!(slice[..7].try_rejoin(&slice[7..]), Some(slice));
+
+    assert_eq!(slice[..3].try_rejoin(&slice[4..]), None);
+    assert_eq!(slice[3..].try_rejoin(&slice[3..]), None);
+}

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -128,6 +128,7 @@
 #![feature(maybe_uninit_slice)]
 #![feature(external_doc)]
 #![feature(associated_type_bounds)]
+#![feature(rejoin_slice)]
 
 #[prelude_import]
 #[allow(unused)]

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1340,6 +1340,47 @@ impl<T> [T] {
             }
         }
     }
+    /// Joins two slices that are adjacent in memory into one slice.
+    /// # Panics
+    /// Panics in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn rejoin<'r>(&'r self, other: &'r [T]) -> &'r [T] {
+        self.try_rejoin(other).expect("the input slices must be adjacent in memory")
+    }
+
+    /// Joins two mutable slices that are adjacent in memory into one slice.
+    /// # Panics
+    /// Panics in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn rejoin_mut<'r>(&'r mut self, other: &'r mut [T]) -> &'r mut [T] {
+        self.try_rejoin_mut(other).expect("the input slices must be adjacent in memory")
+    }
+
+    /// Joins two slices that are adjacent in memory into one slice.
+    /// Returns None in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn try_rejoin<'r>(&'r self, other: &'r [T]) -> Option<&'r [T]> {
+        let self_len = self.len();
+        let self_end = self[self_len..].as_ptr();
+        if crate::ptr::eq(self_end, other.as_ptr()) {
+            Some(unsafe { crate::slice::from_raw_parts(self.as_ptr(), self.len() + other.len()) })
+        } else {
+            None
+        }
+    }
+
+    /// Joins two mutable slices that are adjacent in memory into one slice.
+    /// Returns None in the case the slices aren't adjacent.
+    #[unstable(feature = "rejoin_slice", reason = "new API", issue = "0")]
+    pub fn try_rejoin_mut<'r>(&'r mut self, other: &'r mut [T]) -> Option<&'r mut [T]> {
+        let self_len = self.len();
+        let self_end = self[self_len..].as_mut_ptr();
+        if crate::ptr::eq(self_end, other.as_mut_ptr()) {
+            Some(unsafe { crate::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len() + other.len()) })
+        } else {
+            None
+        }
+    }
 
     /// Returns `true` if the slice contains an element with the given value.
     ///

--- a/src/libcore/slice/mod.rs
+++ b/src/libcore/slice/mod.rs
@@ -1376,7 +1376,9 @@ impl<T> [T] {
         let self_len = self.len();
         let self_end = self[self_len..].as_mut_ptr();
         if crate::ptr::eq(self_end, other.as_mut_ptr()) {
-            Some(unsafe { crate::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len() + other.len()) })
+            Some(unsafe {
+                crate::slice::from_raw_parts_mut(self.as_mut_ptr(), self.len() + other.len())
+            })
         } else {
             None
         }

--- a/src/libcore/tests/lib.rs
+++ b/src/libcore/tests/lib.rs
@@ -36,6 +36,7 @@
 #![feature(iter_is_partitioned)]
 #![feature(iter_order_by)]
 #![feature(cmp_min_max_by)]
+#![feature(rejoin_slice)]
 
 extern crate test;
 

--- a/src/libcore/tests/slice.rs
+++ b/src/libcore/tests/slice.rs
@@ -1676,3 +1676,129 @@ fn test_is_sorted() {
     assert!(!["c", "bb", "aaa"].is_sorted());
     assert!(["c", "bb", "aaa"].is_sorted_by_key(|s| s.len()));
 }
+
+#[test]
+fn test_rejoin() {
+    let slice = &[0, 1, 2, 3, 4, 5, 6][..];
+
+    assert_eq!(slice[..3].rejoin(&slice[3..]), slice);
+    assert_eq!(slice[..4].rejoin(&slice[4..]), slice);
+    assert_eq!(slice[..0].rejoin(&slice[0..]), slice);
+    assert_eq!(slice[..1].rejoin(&slice[1..]), slice);
+    assert_eq!(slice[..6].rejoin(&slice[6..]), slice);
+    assert_eq!(slice[..7].rejoin(&slice[7..]), slice);
+}
+
+#[test]
+#[should_panic]
+fn test_rejoin_nogaps() {
+    let slice = &[0, 1, 2, 3, 4, 5, 6][..];
+
+    // Don't allow gaps between slices
+    slice[..3].rejoin(&slice[4..]);
+}
+#[test]
+#[should_panic]
+fn test_rejoin_leftright() {
+    let slice = &[0, 1, 2, 3, 4, 5, 6][..];
+
+    // Don't allow joining in wrong order
+    slice[3..].rejoin(&slice[..3]);
+}
+
+#[test]
+fn test_rejoin_mut() {
+    let slice = &mut [0, 1, 2, 3, 4, 5, 6][..];
+
+    let (a, b) = slice.split_at_mut(3);
+    a.rejoin_mut(b).copy_from_slice(&[14, 15, 16, 17, 18, 19, 20][..]);
+    assert_eq!(slice, &[14, 15, 16, 17, 18, 19, 20][..]);
+
+    let (a, b) = slice.split_at_mut(4);
+    a.rejoin_mut(b).copy_from_slice(&[21, 22, 23, 24, 25, 26, 27][..]);
+    assert_eq!(slice, &[21, 22, 23, 24, 25, 26, 27][..]);
+
+    let (a, b) = slice.split_at_mut(0);
+    a.rejoin_mut(b).copy_from_slice(&[28, 29, 30, 31, 32, 33, 34][..]);
+    assert_eq!(slice, &[28, 29, 30, 31, 32, 33, 34][..]);
+
+    let (a, b) = slice.split_at_mut(1);
+    a.rejoin_mut(b).copy_from_slice(&[35, 36, 37, 38, 39, 40, 41][..]);
+    assert_eq!(slice, &[35, 36, 37, 38, 39, 40, 41][..]);
+
+    let (a, b) = slice.split_at_mut(6);
+    a.rejoin_mut(b).copy_from_slice(&[42, 43, 44, 45, 46, 47, 48][..]);
+    assert_eq!(slice, &[42, 43, 44, 45, 46, 47, 48][..]);
+
+    let (a, b) = slice.split_at_mut(7);
+    a.rejoin_mut(b).copy_from_slice(&[49, 50, 51, 52, 53, 54, 55][..]);
+    assert_eq!(slice, &[49, 50, 51, 52, 53, 54, 55][..]);
+}
+
+#[test]
+#[should_panic]
+fn test_rejoin_mut_nogaps() {
+    let slice = &mut [0, 1, 2, 3, 4, 5, 6][..];
+
+    // Don't allow gaps between slices
+    let (a, b) = slice.split_at_mut(3);
+    a.rejoin_mut(&mut b[1..]);
+}
+#[test]
+#[should_panic]
+fn test_rejoin_mut_leftright() {
+    let slice = &mut [0, 1, 2, 3, 4, 5, 6][..];
+
+    // Don't allow joining in wrong order
+    let (a, b) = slice.split_at_mut(3);
+    b.rejoin_mut(a);
+}
+
+#[test]
+fn test_try_rejoin() {
+    let slice = &[0, 1, 2, 3, 4, 5, 6][..];
+
+    assert_eq!(slice[..3].try_rejoin(&slice[3..]), Some(slice));
+    assert_eq!(slice[..0].try_rejoin(&slice[0..]), Some(slice));
+    assert_eq!(slice[..1].try_rejoin(&slice[1..]), Some(slice));
+    assert_eq!(slice[..6].try_rejoin(&slice[6..]), Some(slice));
+    assert_eq!(slice[..7].try_rejoin(&slice[7..]), Some(slice));
+
+    assert_eq!(slice[..3].try_rejoin(&slice[4..]), None);
+    assert_eq!(slice[3..].try_rejoin(&slice[3..]), None);
+}
+
+#[test]
+fn test_try_rejoin_mut() {
+    let slice = &mut [0, 1, 2, 3, 4, 5, 6][..];
+
+    let (a, b) = slice.split_at_mut(3);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[14, 15, 16, 17, 18, 19, 20][..]));
+    assert_eq!(slice, &[14, 15, 16, 17, 18, 19, 20][..]);
+
+    let (a, b) = slice.split_at_mut(4);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[21, 22, 23, 24, 25, 26, 27][..]));
+    assert_eq!(slice, &[21, 22, 23, 24, 25, 26, 27][..]);
+
+    let (a, b) = slice.split_at_mut(0);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[28, 29, 30, 31, 32, 33, 34][..]));
+    assert_eq!(slice, &[28, 29, 30, 31, 32, 33, 34][..]);
+
+    let (a, b) = slice.split_at_mut(1);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[35, 36, 37, 38, 39, 40, 41][..]));
+    assert_eq!(slice, &[35, 36, 37, 38, 39, 40, 41][..]);
+
+    let (a, b) = slice.split_at_mut(6);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[42, 43, 44, 45, 46, 47, 48][..]));
+    assert_eq!(slice, &[42, 43, 44, 45, 46, 47, 48][..]);
+
+    let (a, b) = slice.split_at_mut(7);
+    a.try_rejoin_mut(b).as_mut().map(|s| s.copy_from_slice(&[49, 50, 51, 52, 53, 54, 55][..]));
+    assert_eq!(slice, &[49, 50, 51, 52, 53, 54, 55][..]);
+
+    let (a, b) = slice.split_at_mut(3);
+    assert_eq!(a.try_rejoin_mut(&mut b[1..]), None);
+
+    let (a, b) = slice.split_at_mut(4);
+    assert_eq!(b.try_rejoin_mut(a), None);
+}


### PR DESCRIPTION
Implements the APIs described here: https://github.com/rust-lang/rfcs/pull/2806 behind a feature flag `rejoin_slice`.