### PR TITLE
Use KERN_ARND syscall for random numbers on NetBSD, same as FreeBSD.

### DIFF
--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -143,7 +143,7 @@ mod imp {
     }
 }
 
-#[cfg(target_os = "freebsd", target_os = "netbsd")]
+#[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
 mod imp {
     use crate::ptr;
 

--- a/src/libstd/sys/unix/rand.rs
+++ b/src/libstd/sys/unix/rand.rs
@@ -15,6 +15,7 @@ pub fn hashmap_random_keys() -> (u64, u64) {
           not(target_os = "ios"),
           not(target_os = "openbsd"),
           not(target_os = "freebsd"),
+          not(target_os = "netbsd"),
           not(target_os = "fuchsia"),
           not(target_os = "redox")))]
 mod imp {
@@ -142,7 +143,7 @@ mod imp {
     }
 }
 
-#[cfg(target_os = "freebsd")]
+#[cfg(target_os = "freebsd", target_os = "netbsd")]
 mod imp {
     use crate::ptr;
 


### PR DESCRIPTION
This system call is present on all supported NetBSD versions and provides an endless stream of non-blocking random data from the kernel's ChaCha20-based CSPRNG. It doesn't require a file like `/dev/urandom` to be opened.

The system call is documented here (under kern.arandom):
https://netbsd.gw.com/cgi-bin/man-cgi?sysctl+7+NetBSD-7.0

And defined here:
https://nxr.netbsd.org/xref/src/sys/sys/sysctl.h#273

The semantics are the same as FreeBSD so reading 256 bytes per call is fine.

Similar change for getrandom crate: rust-random/getrandom#115