### PR TITLE
Do not ICE with a precision flag in formatting str and no format arguments

### DIFF
--- a/src/libsyntax_ext/format.rs
+++ b/src/libsyntax_ext/format.rs
@@ -374,10 +374,12 @@ impl<'a, 'b> Context<'a, 'b> {
                                 format!("are {} arguments", count)
                             },
                         ));
-                        e.span_label(
-                            self.args[pos].span,
-                            "this parameter corresponds to the precision flag",
-                        );
+                        if let Some(arg) = self.args.get(pos) {
+                            e.span_label(
+                                arg.span,
+                                "this parameter corresponds to the precision flag",
+                            );
+                        }
                         zero_based_note = true;
                     }
                     _ => {}

--- a/src/test/ui/if/ifmt-bad-arg.rs
+++ b/src/test/ui/if/ifmt-bad-arg.rs
@@ -86,4 +86,9 @@ tenth number: {}",
     println!("{:foo}", 1); //~ ERROR unknown format trait `foo`
     println!("{5} {:4$} {6:7$}", 1);
     //~^ ERROR invalid reference to positional arguments 4, 5, 6 and 7 (there is 1 argument)
+
+    // We used to ICE here because we tried to unconditionally access the first argument, which
+    // doesn't exist.
+    println!("{:.*}");
+    //~^ ERROR 2 positional arguments in format string, but no arguments were given
 }

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -285,6 +285,17 @@ LL |     println!("{5} {:4$} {6:7$}", 1);
    = note: positional arguments are zero-based
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
 
+error: 2 positional arguments in format string, but no arguments were given
+  --> $DIR/ifmt-bad-arg.rs:92:15
+   |
+LL |     println!("{:.*}");
+   |               ^^--^
+   |                 |
+   |                 this precision flag adds an extra required argument at position 0, which is why there are 2 arguments expected
+   |
+   = note: positional arguments are zero-based
+   = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
+
 error[E0308]: mismatched types
   --> $DIR/ifmt-bad-arg.rs:78:32
    |
@@ -303,6 +314,6 @@ LL |     println!("{} {:07$.*} {}", 1, 3.2, 4);
    = note: expected type `&usize`
               found type `&{float}`
 
-error: aborting due to 35 previous errors
+error: aborting due to 36 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fix #66065.