### PR TITLE
Fix documentation for `Iterator::count()`.

### DIFF
--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -201,13 +201,13 @@ pub trait Iterator {
 
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
-    /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the
-    /// number of times it called [`next`]. Note that [`next`] has to be called at
-    /// least once even if the iterator does not have any elements.
+    /// This method will call [`next`] repeatedly until [`None`] is encountered,
+    /// returning the number of times it saw [`Some`]. Note that [`next`] has to be
+    /// called at least once even if the iterator does not have any elements.
     ///
     /// [`next`]: #tymethod.next
     /// [`None`]: ../../std/option/enum.Option.html#variant.None
+    /// [`Some`]: ../../std/option/enum.Option.html#variant.Some
     ///
     /// # Overflow Behavior
     ///

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -202,8 +202,9 @@ pub trait Iterator {
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns the number of
-    /// times it called [`next`].
+    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the 
+    /// number of times it called [`next`]. Note that [`next`] has to be called at
+    /// least once even if the iterator does not have any elements.
     ///
     /// [`next`]: #tymethod.next
     /// [`None`]: ../../std/option/enum.Option.html#variant.None

--- a/src/libcore/iter/traits/iterator.rs
+++ b/src/libcore/iter/traits/iterator.rs
@@ -202,7 +202,7 @@ pub trait Iterator {
     /// Consumes the iterator, counting the number of iterations and returning it.
     ///
     /// This method will evaluate the iterator until its [`next`] returns
-    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the 
+    /// [`None`]. Once [`None`] is encountered, `count()` returns one less than the
     /// number of times it called [`next`]. Note that [`next`] has to be called at
     /// least once even if the iterator does not have any elements.
     ///


### PR DESCRIPTION
The documentation of std::core::Iterator::count() stated that the number returned is the number of times `next` is called on the iterator. However this is not true as the number of times `next` is called is exactly one plus the number returned by `count()`.