### PR TITLE
Add a failing UI test for multiple loops of all kinds in a `const`

### DIFF
--- a/src/test/ui/consts/const-loop.rs
+++ b/src/test/ui/consts/const-loop.rs
@@ -1,0 +1,58 @@
+const _: i32 = {
+    let mut x = 0;
+
+    while x < 4 {
+        //~^ ERROR constant contains unimplemented expression type
+        //~| ERROR constant contains unimplemented expression type
+        x += 1;
+    }
+
+    while x < 8 {
+        x += 1;
+    }
+
+    x
+};
+
+const _: i32 = {
+    let mut x = 0;
+
+    for i in 0..4 {
+        //~^ ERROR constant contains unimplemented expression type
+        //~| ERROR constant contains unimplemented expression type
+        //~| ERROR references in constants may only refer to immutable values
+        //~| ERROR calls in constants are limited to constant functions, tuple
+        //         structs and tuple variants
+        x += i;
+    }
+
+    for i in 0..4 {
+        x += i;
+    }
+
+    x
+};
+
+const _: i32 = {
+    let mut x = 0;
+
+    loop {
+        x += 1;
+        if x == 4 {
+            //~^ ERROR constant contains unimplemented expression type
+            //~| ERROR constant contains unimplemented expression type
+            break;
+        }
+    }
+
+    loop {
+        x += 1;
+        if x == 8 {
+            break;
+        }
+    }
+
+    x
+};
+
+fn main() {}

--- a/src/test/ui/consts/const-loop.stderr
+++ b/src/test/ui/consts/const-loop.stderr
@@ -1,0 +1,60 @@
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:4:11
+   |
+LL |     while x < 4 {
+   |           ^^^^^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:4:5
+   |
+LL | /     while x < 4 {
+LL | |
+LL | |
+LL | |         x += 1;
+LL | |     }
+   | |_____^
+
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/const-loop.rs:20:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:20:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^
+
+error[E0017]: references in constants may only refer to immutable values
+  --> $DIR/const-loop.rs:20:14
+   |
+LL |     for i in 0..4 {
+   |              ^^^^ constants require immutable values
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:20:9
+   |
+LL |     for i in 0..4 {
+   |         ^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:41:12
+   |
+LL |         if x == 4 {
+   |            ^^^^^^
+
+error[E0019]: constant contains unimplemented expression type
+  --> $DIR/const-loop.rs:41:9
+   |
+LL | /         if x == 4 {
+LL | |
+LL | |
+LL | |             break;
+LL | |         }
+   | |_________^
+
+error: aborting due to 8 previous errors
+
+Some errors have detailed explanations: E0015, E0017, E0019.
+For more information about an error, try `rustc --explain E0015`.


### PR DESCRIPTION
This simply demonstrates the current behavior and ensures we don't allow anything by accident.

The new const checker will be able to improve the diagnostics here. While working on it, I didn't see very many tests with non-`while` loops in a `const`, and there were no tests with multiple loops.