### PR TITLE
Detect `::` -> `:` typo when involving turbofish

### DIFF
--- a/src/libsyntax/parse/parser/diagnostics.rs
+++ b/src/libsyntax/parse/parser/diagnostics.rs
@@ -354,7 +354,7 @@ impl<'a> Parser<'a> {
     }
 
     pub fn maybe_annotate_with_ascription(
-        &self,
+        &mut self,
         err: &mut DiagnosticBuilder<'_>,
         maybe_expected_semicolon: bool,
     ) {
@@ -395,6 +395,7 @@ impl<'a> Parser<'a> {
                 err.note("for more information, see \
                           https://github.com/rust-lang/rust/issues/23416");
             }
+            self.last_type_ascription = None;
         }
     }
 

--- a/src/libsyntax/parse/parser/stmt.rs
+++ b/src/libsyntax/parse/parser/stmt.rs
@@ -397,6 +397,7 @@ impl<'a> Parser<'a> {
             }
             let stmt = match self.parse_full_stmt(false) {
                 Err(mut err) => {
+                    self.maybe_annotate_with_ascription(&mut err, false);
                     err.emit();
                     self.recover_stmt_(SemiColonMode::Ignore, BlockMode::Ignore);
                     Some(Stmt {

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-2.rs
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-2.rs
@@ -1,0 +1,5 @@
+fn main() -> Result<(), ()> {
+    vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
+    //~^ ERROR expected `::`, found `(`
+    Ok(())
+}

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -4,7 +4,7 @@ error: expected `::`, found `(`
 LL |     vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
    |                                    -                  ^ expected `::`
    |                                    |
-   |                                    tried to parse a type due to this type ascription
+   |                                    help: maybe write a path separator here: `::`
    |
    = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
    = note: for more information, see https://github.com/rust-lang/rust/issues/23416

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-2.stderr
@@ -1,0 +1,13 @@
+error: expected `::`, found `(`
+  --> $DIR/type-ascription-instead-of-path-2.rs:2:55
+   |
+LL |     vec![Ok(2)].into_iter().collect:<Result<Vec<_>,_>>()?;
+   |                                    -                  ^ expected `::`
+   |                                    |
+   |                                    tried to parse a type due to this type ascription
+   |
+   = note: `#![feature(type_ascription)]` lets you annotate an expression with a type: `<expr>: <type>`
+   = note: for more information, see https://github.com/rust-lang/rust/issues/23416
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fix #65569.