### PR TITLE
Fix typo in explanation of `E0080`

### DIFF
--- a/src/librustc/error_codes.rs
+++ b/src/librustc/error_codes.rs
@@ -335,7 +335,7 @@ This works because `Box` is a pointer, so its size is well-known.
 "##,
 
 E0080: r##"
-This error indicates that the compiler was unable to sensibly evaluate an
+This error indicates that the compiler was unable to sensibly evaluate a
 constant expression that had to be evaluated. Attempting to divide by 0
 or causing integer overflow are two ways to induce this error. For example:
 


### PR DESCRIPTION
Handling issue #66105 in Rust repo.
`evaluate an constant expression` to `evaluate a constant expression`