### PR TITLE
[WIP] Make a table of trait object type_ids and vtable pointers available to programs

### DIFF
--- a/src/librustc_codegen_llvm/base.rs
+++ b/src/librustc_codegen_llvm/base.rs
@@ -162,10 +162,13 @@ pub fn compile_codegen_unit(
                 }
             }
 
-            // Create the llvm.used variable
-            // This variable has type [N x i8*] and is stored in the llvm.metadata section
+            // Create the llvm.used and llvm.compiler.used variables
+            // These have type [N x i8*] and are stored in the llvm.metadata section
             if !cx.used_statics().borrow().is_empty() {
                 cx.create_used_variable()
+            }
+            if !cx.compiler_used_statics().borrow().is_empty() {
+                cx.create_compiler_used_variable()
             }
 
             // Finalize debuginfo

--- a/src/librustc_codegen_llvm/consts.rs
+++ b/src/librustc_codegen_llvm/consts.rs
@@ -356,9 +356,9 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
         gv
     }
 
-    fn append_vtable_pointer(
+    fn append_vtable_lookup(
         &self,
-        vtable: &'ll Value,
+        vtable_lookup: &'ll Value,
         align: Align,
     ) {
         // Add a pointer to the vtable to a special section. The linker can provide pointers to the
@@ -393,11 +393,11 @@ impl StaticMethods for CodegenCx<'ll, 'tcx> {
         unsafe {
             // members of llvm.compiler.used must be named
             let name = self.generate_local_symbol_name("vtable_ptr");
-            let gv = self.define_global(&name[..], self.val_ty(vtable)).unwrap_or_else(|| {
+            let gv = self.define_global(&name[..], self.val_ty(vtable_lookup)).unwrap_or_else(|| {
                 bug!("symbol `{}` is already defined", name);
             });
             llvm::LLVMRustSetLinkage(gv, llvm::Linkage::PrivateLinkage);
-            llvm::LLVMSetInitializer(gv, vtable);
+            llvm::LLVMSetInitializer(gv, vtable_lookup);
             set_global_alignment(&self, gv, align);
             SetUnnamedAddr(gv, true);
             llvm::LLVMSetGlobalConstant(gv, True);

--- a/src/librustc_codegen_ssa/base.rs
+++ b/src/librustc_codegen_ssa/base.rs
@@ -140,7 +140,7 @@ pub fn unsized_info<'tcx, Cx: CodegenMethods<'tcx>>(
         (_, &ty::Dynamic(ref data, ..)) => {
             let vtable_ptr = cx.layout_of(cx.tcx().mk_mut_ptr(target))
                 .field(cx, FAT_PTR_EXTRA);
-            cx.const_ptrcast(meth::get_vtable(cx, source, data.principal()),
+            cx.const_ptrcast(meth::get_vtable(cx, source, target, data.principal()),
                             cx.backend_type(vtable_ptr))
         }
         _ => bug!("unsized_info: invalid unsizing {:?} -> {:?}",

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -117,7 +117,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));
 
-    cx.create_vtable_symbol(vtable, align);
+    cx.append_vtable_pointer(vtable, align);
 
     cx.create_vtable_metadata(ty, vtable);
 

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -117,6 +117,8 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
     let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));
 
+    cx.create_vtable_symbol(vtable, align);
+
     cx.create_vtable_metadata(ty, vtable);
 
     cx.vtables().borrow_mut().insert((ty, trait_ref), vtable);

--- a/src/librustc_codegen_ssa/meth.rs
+++ b/src/librustc_codegen_ssa/meth.rs
@@ -120,8 +120,8 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
 
     let type_id = tcx.type_id_hash(trait_ty);
     let type_id = cx.const_u64(type_id);
-    let vtable_lookup_const = cx.const_struct(&[type_id, vtable], true);
-    cx.append_vtable_lookup(vtable_lookup_const, align);
+    let vtable_record = cx.const_struct(&[type_id, vtable], true);
+    cx.append_vtable_lookup(vtable_record, align);
 
     cx.create_vtable_metadata(ty, vtable);
 

--- a/src/librustc_codegen_ssa/traits/misc.rs
+++ b/src/librustc_codegen_ssa/traits/misc.rs
@@ -18,7 +18,9 @@ pub trait MiscMethods<'tcx>: BackendTypes {
     fn sess(&self) -> &Session;
     fn codegen_unit(&self) -> &Arc<CodegenUnit<'tcx>>;
     fn used_statics(&self) -> &RefCell<Vec<Self::Value>>;
+    fn compiler_used_statics(&self) -> &RefCell<Vec<Self::Value>>;
     fn set_frame_pointer_elimination(&self, llfn: Self::Function);
     fn apply_target_cpu_attr(&self, llfn: Self::Function);
     fn create_used_variable(&self);
+    fn create_compiler_used_variable(&self);
 }

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -4,7 +4,7 @@ use rustc::ty::layout::Align;
 
 pub trait StaticMethods: BackendTypes {
     fn static_addr_of(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
-    fn create_vtable_symbol(&self, cv: Self::Value, align: Align);
+    fn append_vtable_pointer(&self, cv: Self::Value, align: Align);
     fn codegen_static(&self, def_id: DefId, is_mutable: bool);
 }
 

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -4,6 +4,7 @@ use rustc::ty::layout::Align;
 
 pub trait StaticMethods: BackendTypes {
     fn static_addr_of(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
+    fn create_vtable_symbol(&self, cv: Self::Value, align: Align);
     fn codegen_static(&self, def_id: DefId, is_mutable: bool);
 }
 

--- a/src/librustc_codegen_ssa/traits/statics.rs
+++ b/src/librustc_codegen_ssa/traits/statics.rs
@@ -4,7 +4,7 @@ use rustc::ty::layout::Align;
 
 pub trait StaticMethods: BackendTypes {
     fn static_addr_of(&self, cv: Self::Value, align: Align, kind: Option<&str>) -> Self::Value;
-    fn append_vtable_pointer(&self, cv: Self::Value, align: Align);
+    fn append_vtable_lookup(&self, cv: Self::Value, align: Align);
     fn codegen_static(&self, def_id: DefId, is_mutable: bool);
 }
 

--- a/src/librustc_mir/interpret/cast.rs
+++ b/src/librustc_mir/interpret/cast.rs
@@ -278,7 +278,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             (_, &ty::Dynamic(ref data, _)) => {
                 // Initial cast from sized to dyn trait
-                let vtable = self.get_vtable(src_pointee_ty, data.principal())?;
+                let vtable = self.get_vtable(src_pointee_ty, dest_pointee_ty, data.principal())?;
                 let ptr = self.read_immediate(src)?.to_scalar_ptr()?;
                 let val = Immediate::new_dyn_trait(ptr, vtable);
                 self.write_immediate(val, dest)

--- a/src/librustc_mir/interpret/traits.rs
+++ b/src/librustc_mir/interpret/traits.rs
@@ -14,6 +14,7 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     pub fn get_vtable(
         &mut self,
         ty: Ty<'tcx>,
+        _poly_trait_ty: Ty<'tcx>,
         poly_trait_ref: Option<ty::PolyExistentialTraitRef<'tcx>>,
     ) -> InterpResult<'tcx, Pointer<M::PointerTag>> {
         trace!("get_vtable(trait_ref={:?})", poly_trait_ref);

--- a/src/test/ui/vtables/vtable-list.rs
+++ b/src/test/ui/vtables/vtable-list.rs
@@ -1,4 +1,4 @@
-// For windows, linux, android, macos and ios only
+// Only Windows, Linux, Android, macOS and iOS have this implemented for now.
 
 // run-pass
 

--- a/src/test/ui/vtables/vtable-list.rs
+++ b/src/test/ui/vtables/vtable-list.rs
@@ -12,14 +12,26 @@
 // ignore-solaris
 // ignore-sgx
 
+#![feature(core_intrinsics)]
 #![feature(ptr_offset_from)]
 #![feature(raw)]
+#![feature(test)]
 
-use std::{mem::transmute, raw::TraitObject, slice};
+use std::intrinsics::type_id;
+use std::mem::transmute;
+use std::raw::TraitObject;
+use std::slice;
 
-#[allow(improper_ctypes)]
-fn vtables() -> &'static [&'static ()] {
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+struct Record {
+    type_id: u64,
+    vtable: &'static (),
+}
+
+fn vtables() -> &'static [Record] {
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))]
+    #[allow(improper_ctypes)]
     extern "C" {
         #[cfg_attr(
             any(target_os = "linux", target_os = "android"),
@@ -29,7 +41,7 @@ fn vtables() -> &'static [&'static ()] {
             any(target_os = "macos", target_os = "ios"),
             link_name = "\u{1}section$start$__DATA$__rust_vtables"
         )]
-        static START: [&'static (); 0];
+        static START: [Record; 0];
         #[cfg_attr(
             any(target_os = "linux", target_os = "android"),
             link_name = "__stop___rust_vtables"
@@ -38,28 +50,44 @@ fn vtables() -> &'static [&'static ()] {
             any(target_os = "macos", target_os = "ios"),
             link_name = "\u{1}section$end$__DATA$__rust_vtables"
         )]
-        static END: [&'static (); 0];
+        static END: [Record; 0];
     }
 
     #[cfg(target_os = "windows")]
     {
         #[link_section = ".rdata.__rust_vtables$A"]
-        static START: [&'static (); 0] = [];
+        static START: [Record; 0] = [];
         #[link_section = ".rdata.__rust_vtables$C"]
-        static END: [&'static (); 0] = [];
+        static END: [Record; 0] = [];
     }
 
     unsafe {
-        let (start_ptr, end_ptr) = (&START as *const &'static (), &END as *const &'static ());
+        let (start_ptr, end_ptr) = (&START as *const Record, &END as *const Record);
         slice::from_raw_parts(start_ptr, end_ptr.offset_from(start_ptr) as usize)
     }
 }
 
 trait Trait {}
-struct Foo;
-impl Trait for Foo {}
+struct Struct;
+impl Trait for Struct {}
+
+#[inline(never)]
+fn foo() {
+    let a: &dyn Trait = &Struct;
+    let b: &(dyn Trait + Send) = &Struct;
+    std::hint::black_box((a, b));
+}
 
 fn main() {
-    let vtable: &'static () = unsafe { &*transmute::<&dyn Trait, TraitObject>(&Foo).vtable };
-    vtables().iter().find(|&&x| x as *const () == vtable as *const ()).unwrap();
+    let vtable: &'static () = unsafe { &*transmute::<&dyn Trait, TraitObject>(&Struct).vtable };
+    let type_id = unsafe { type_id::<dyn Trait>() };
+    let count = vtables().iter().filter(|&&record| record.type_id == type_id).count();
+    assert_ne!(count, 0, "The vtable record for dyn Trait is missing");
+    assert_eq!(count, 1, "Duplicate vtable records found for dyn Trait");
+    let record = vtables().iter().find(|&&record| record.vtable as *const () == vtable).unwrap();
+    assert_eq!(
+        record.vtable as *const (), vtable,
+        "The vtable for Struct as dyn Trait is incorrect"
+    );
+    foo();
 }

--- a/src/test/ui/vtables/vtable-list.rs
+++ b/src/test/ui/vtables/vtable-list.rs
@@ -1,0 +1,65 @@
+// For windows, linux, android, macos and ios only
+
+// run-pass
+
+// ignore-cloudabi
+// ignore-dragonfly
+// ignore-emscripten
+// ignore-freebsd
+// ignore-haiku
+// ignore-netbsd
+// ignore-openbsd
+// ignore-solaris
+// ignore-sgx
+
+#![feature(ptr_offset_from)]
+#![feature(raw)]
+
+use std::{mem::transmute, raw::TraitObject, slice};
+
+#[allow(improper_ctypes)]
+fn vtables() -> &'static [&'static ()] {
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))]
+    extern "C" {
+        #[cfg_attr(
+            any(target_os = "linux", target_os = "android"),
+            link_name = "__start___rust_vtables"
+        )]
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios"),
+            link_name = "\u{1}section$start$__DATA$__rust_vtables"
+        )]
+        static START: [&'static (); 0];
+        #[cfg_attr(
+            any(target_os = "linux", target_os = "android"),
+            link_name = "__stop___rust_vtables"
+        )]
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios"),
+            link_name = "\u{1}section$end$__DATA$__rust_vtables"
+        )]
+        static END: [&'static (); 0];
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        #[link_section = ".rdata.__rust_vtables$A"]
+        static START: [&'static (); 0] = [];
+        #[link_section = ".rdata.__rust_vtables$C"]
+        static END: [&'static (); 0] = [];
+    }
+
+    unsafe {
+        let (start_ptr, end_ptr) = (&START as *const &'static (), &END as *const &'static ());
+        slice::from_raw_parts(start_ptr, end_ptr.offset_from(start_ptr) as usize)
+    }
+}
+
+trait Trait {}
+struct Foo;
+impl Trait for Foo {}
+
+fn main() {
+    let vtable: &'static () = unsafe { &*transmute::<&dyn Trait, TraitObject>(&Foo).vtable };
+    vtables().iter().find(|&&x| x as *const () == vtable as *const ()).unwrap();
+}


### PR DESCRIPTION
This PR aims to enable safe and sound serialization and deserialization of trait objects on tier 1 platforms.

Some context: The ability to serialize and deserialize trait objects, or similarly closures, has been requested by various members of the community for some time: https://github.com/rust-lang/rfcs/issues/668 https://github.com/rust-lang/rfcs/issues/1022. The two main use cases are IPC – for example sending trait objects between forks of a process; and distributed computing – for example sending trait objects to processes distributed across a cluster. While some message kinds can be wrapped in an enum instead of a trait object, this can be inconvenient, and isn't viable for un-nameable types like closures. The goal of this PR is to lay the groundwork for safe and sound serialization and deserialization of trait objects in a low-impact manner that allows user crates to safely experiment and iterate on this functionality.

Deserializing trait objects is possible today, but only in a rather hairy manner. The crate [`serde_traitobject`](https://github.com/alecmocatta/serde_traitobject) for example works and sees usage, but it has two unsoundness vectors:

* a malicious MITM (who could forge ostensibly-valid but unsound data); and
* multiple vtable segments in a single binary that are loaded at inconsistent relative addresses.

The latter requires a very odd linker script and is unlikely to occur in practise; the former is concerning and rules out many use cases. It is however sufficient for other use cases – in fact a really cool one using it was published recently: [`native_spark`](https://github.com/rajasekarv/native_spark).

The approach I've taken in this PR is to create essentially a global array with [appending linkage](https://llvm.org/docs/LangRef.html#linkage-appending) that stores structs comprising the [`type_id`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/ty/struct.TyCtxt.html#method.type_id_hash) of the trait object and a pointer to the vtable, for all materialized vtables. Unfortunately appending linkage isn't really implemented by LLVM yet besides for a couple of special variables, so I've used the old-school approach of emitting static variables into an [orphan section](https://sourceware.org/binutils/docs/ld/Orphan-Sections.html). The start and end of this section can be reliably retreived by user programs with help from the linker.

This array increases the size of libraries by a small amount; for example build/x86_64-apple-darwin/stage2 by ~1.3MiB i.e. ~0.2%. Thanks to `--gc-sections` on Linux and `/OPT:REF` on Windows, it's removed entirely from binaries that don't use it on those platforms. macOS's `-dead_strip` works a little differently, and the best solution I've found adds 16 bytes per used vtable to the resulting binary. This increases the size of binaries by a small amount: hello world grows by 76 bytes i.e. ~0.03%. With a bit more work I think this could probably be made zero-cost similar to Linux and Windows. Android and iOS behave the same as Linux and macOS, and on other platforms this PR is a no-op.

This array allows programs to retrieve a list of all materializable vtable pointers for a given `dyn Trait`. From this, a candidate concrete type for serialization can be selected and safely invoked. Here's a rough sketch of how serialization and deserialization can work:

```rust
use std::raw::TraitObject;
fn vtables() { /* see src/test/ui/vtables/vtable-list.rs */ }

// Process A
let send: Box<T> = send;
let send: Box<dyn Trait> = send;
let type_tag = send.type_tag();
type_tag.serialize();
trait_object.serialize();

// Process B
let trait_type_id = type_id::<dyn Trait>();
let type_tag = deserialize();
let trait_object = vtables().iter().find_map(|record| {
    if record.type_id != trait_type_id {
        return None;
    }
    let trait_object = TraitObject { data: ptr::dangling(), vtable: record.vtable };
    let trait_object = transmute::<TraitObject, *const dyn Trait>();
    (trait_object.type_tag() == type_tag).then(trait_object)
}).unwrap();
let send: Box<dyn Trait> = trait_object.deserialize_erased();
```

`fn type_tag()` here could be `type_id()`, which would work for unnameable types like closures but doesn't work across different builds where the `type_id` has changed due to potentially unrelated changes. It could be provided explicitly by the program (i.e. like [`typetag`](https://github.com/dtolnay/typetag)), which would not work for unnameable types but would work across different builds. It could also be a combination of both – explicit tags where provided, falling back to `type_id`.

I believe this is a step in the right direction to enabling sound trait object serialization and deserialization. It resolves the aforementioned security issue that exists in applications being used today, it enables user crates to safely iterate on the user interface for trait object deserialization, and it can hopefully co-evolve with the unsafe code guidelines and other RFCs like https://github.com/rust-lang/rfcs/pull/2580 to increase the strength of its guarantees. 

An upside of this PR is safe and sound serialization and deserialization of closures in conjunction with [`serde_closure`](https://github.com/alecmocatta/serde_closure) - which is a proc macro that extracts captured variables from the AST and puts them in a struct that implements Serialize, Deserialize, Debug and other convenient traits. This is the major use case for distributed computing frameworks like [`constellation`](https://github.com/constellation-rs/constellation) and [`native_spark`](https://github.com/rajasekarv/native_spark).

---

I'd like to add a test that checks the array is removed by the linker on Linux and Windows if it's not used, but I'm not familiar with how to do this?

Let me know how best to feature gate it. Or if it perhaps doesn't need it – doing anything useful with the array is already unstable (i.e. transmuting `dyn Trait` <-> `std::raw::TraitObject` to get/set the vtable). Per the RFC guidelines as this should be "invisible to users-of-rust" I've gone ahead with this PR – let me know if it does indeed need an RFC. And lastly it's probably worth confirming it is indeed "invisible to users-of-rust" with a crater and/or perf run?