### PR TITLE
Improve std::thread::Result documentation

### DIFF
--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1275,7 +1275,7 @@ impl fmt::Debug for Thread {
 /// is the value the thread panicked with;
 /// that is, the argument the `panic!` macro was called with.
 /// Unlike with normal errors, this value doesn't implement
-/// the [`Error`](std::error::Error) trait.
+/// the [`Error`](crate::error::Error) trait.
 ///
 /// Thus, a sensible way to handle a thread panic is to either:
 /// 1. `unwrap` the `Result<T>`, propagating the panic

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1273,15 +1273,15 @@ impl fmt::Debug for Thread {
 ///
 /// The value contained in the `Result::Err` variant
 /// is the value the thread panicked with;
-/// that is, the parameter the `panic!` macro was called with.
+/// that is, the argument the `panic!` macro was called with.
 /// Unlike with normal errors, this value doesn't implement
-/// the `std::error::Error` trait.
+/// the [`Error`] trait.
 ///
-/// Thus, a sensible way to handle a thread panic is to either
-/// `unwrap` the `Result`, propagating the panic,
-/// or in case the thread is intended to be a subsystem boundary
+/// Thus, a sensible way to handle a thread panic is to either:
+/// 1. `unwrap` the `Result<T>`, propagating the panic
+/// 2. or in case the thread is intended to be a subsystem boundary
 /// that is supposed to isolate system-level failures,
-/// match for the `Err` variant and handle the panic in an appropriate way.
+/// match on the `Err` variant and handle the panic in an appropriate way.
 ///
 /// A thread that completes without panicking is considered to exit successfully.
 ///

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1275,7 +1275,7 @@ impl fmt::Debug for Thread {
 /// is the value the thread panicked with;
 /// that is, the argument the `panic!` macro was called with.
 /// Unlike with normal errors, this value doesn't implement
-/// the [`Error`] trait.
+/// the [`Error`](std::error::Error) trait.
 ///
 /// Thus, a sensible way to handle a thread panic is to either:
 /// 1. `unwrap` the `Result<T>`, propagating the panic

--- a/src/libstd/thread/mod.rs
+++ b/src/libstd/thread/mod.rs
@@ -1271,6 +1271,18 @@ impl fmt::Debug for Thread {
 ///
 /// Indicates the manner in which a thread exited.
 ///
+/// The value contained in the `Result::Err` variant
+/// is the value the thread panicked with;
+/// that is, the parameter the `panic!` macro was called with.
+/// Unlike with normal errors, this value doesn't implement
+/// the `std::error::Error` trait.
+///
+/// Thus, a sensible way to handle a thread panic is to either
+/// `unwrap` the `Result`, propagating the panic,
+/// or in case the thread is intended to be a subsystem boundary
+/// that is supposed to isolate system-level failures,
+/// match for the `Err` variant and handle the panic in an appropriate way.
+///
 /// A thread that completes without panicking is considered to exit successfully.
 ///
 /// # Examples


### PR DESCRIPTION
Thanks to @dtolnay for pointing out the different premise of the contents of the `Err` variant in `std::thread::Result` WRT normal error handling.