### PR TITLE
Tweak where_clauses_object_safety lint to allow auto traits

### DIFF
--- a/src/test/ui/issues/issue-50781-1.rs
+++ b/src/test/ui/issues/issue-50781-1.rs
@@ -1,0 +1,15 @@
+// run-pass
+
+#![deny(where_clauses_object_safety)]
+
+trait Y {
+    fn foo(&self) where Self: Send {}
+    fn bar(&self) where Self: Send + Sync {}
+}
+
+impl Y for () {}
+
+fn main() {
+    <dyn Y + Send as Y>::foo(&());
+    <dyn Y + Send + Sync as Y>::bar(&());
+}


### PR DESCRIPTION
This tweaks the lint of https://github.com/rust-lang/rust/issues/51443 to not fire when all the bounds are auto traits.

Auto traits do not impact vtables, and as discussed in that issue, the lint firing in cases like this is a false positive.

This example currently errors, but succeeds with this commit:
```rust
#[deny(where_clauses_object_safety)]

trait Y {
    fn foo(&self) where Self: Send {}
}
impl Y for () {}

fn main() {
    <dyn Y + Send as Y>::foo(&());
}
```
([Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=e6e3af3eb253dba803cdce245f8d8f6c))

Errors:

```
   Compiling playground v0.0.1 (/playground)
warning: the trait `Y` cannot be made into an object
 --> src/main.rs:4:5
  |
4 |     fn foo(&self) where Self: Send {}
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(where_clauses_object_safety)]` on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
  = note: method `foo` references the `Self` type in where clauses

    Finished dev [unoptimized + debuginfo] target(s) in 1.06s
     Running `target/debug/playground`

```