### PR TITLE
Update the bundled `wasi-libc` repository

### DIFF
--- a/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
+++ b/src/ci/docker/dist-various-2/build-wasi-toolchain.sh
@@ -4,17 +4,17 @@
 
 set -ex
 
-# Originally from https://releases.llvm.org/8.0.0/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
-curl https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/clang%2Bllvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | \
+# Originally from https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz
+curl https://rust-lang-ci-mirrors.s3-us-west-1.amazonaws.com/rustc/clang%2Bllvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz | \
   tar xJf -
-export PATH=`pwd`/clang+llvm-8.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
+export PATH=`pwd`/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04/bin:$PATH
 
-git clone https://github.com/CraneStation/wasi-sysroot
+git clone https://github.com/CraneStation/wasi-libc
 
-cd wasi-sysroot
-git reset --hard e5f14be38362f1ab83302895a6e74b2ffd0e2302
+cd wasi-libc
+git reset --hard a94d2d04e7722b323573da2bd04e909a5763d35b
 make -j$(nproc) INSTALL_DIR=/wasm32-wasi install
 
 cd ..
-rm -rf reference-sysroot-wasi
+rm -rf wasi-libc
 rm -rf clang+llvm*


### PR DESCRIPTION
This updates the libc that the `wasm32-wasi` target links against to the
latest revision, mostly just bringing in minor bug fixes and minor wasm
size improvements.