### PR TITLE
Point at formatting descriptor string when it is invalid

### DIFF
--- a/src/libfmt_macros/lib.rs
+++ b/src/libfmt_macros/lib.rs
@@ -35,7 +35,7 @@ impl InnerOffset {
 
 /// A piece is a portion of the format string which represents the next part
 /// to emit. These are emitted as a stream by the `Parser` class.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Piece<'a> {
     /// A literal string which should directly be emitted
     String(&'a str),
@@ -45,7 +45,7 @@ pub enum Piece<'a> {
 }
 
 /// Representation of an argument specification.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Argument<'a> {
     /// Where to find this argument
     pub position: Position,
@@ -54,7 +54,7 @@ pub struct Argument<'a> {
 }
 
 /// Specification for the formatting of an argument in the format string.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct FormatSpec<'a> {
     /// Optionally specified character to fill alignment with.
     pub fill: Option<char>,
@@ -79,7 +79,7 @@ pub struct FormatSpec<'a> {
 }
 
 /// Enum describing where an argument for a format can be located.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Position {
     /// The argument is implied to be located at an index
     ArgumentImplicitlyIs(usize),
@@ -99,7 +99,7 @@ impl Position {
 }
 
 /// Enum of alignments which are supported.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Alignment {
     /// The value will be aligned to the left.
     AlignLeft,
@@ -113,7 +113,7 @@ pub enum Alignment {
 
 /// Various flags which can be applied to format strings. The meaning of these
 /// flags is defined by the formatters themselves.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Flag {
     /// A `+` will be used to denote positive numbers.
     FlagSignPlus,
@@ -133,7 +133,7 @@ pub enum Flag {
 
 /// A count is used for the precision and width parameters of an integer, and
 /// can reference either an argument or a literal integer.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Count {
     /// The count is specified explicitly.
     CountIs(usize),
@@ -572,10 +572,11 @@ impl<'a> Parser<'a> {
         } else {
             spec.ty = self.word();
             let ty_span_end = self.cur.peek().map(|(pos, _)| *pos);
-            let this = self;
-            spec.ty_span = ty_span_start
-                .and_then(|s| ty_span_end.map(|e| (s, e)))
-                .map(|(start, end)| this.to_span_index(start).to(this.to_span_index(end)));
+            if !spec.ty.is_empty() {
+                spec.ty_span = ty_span_start
+                    .and_then(|s| ty_span_end.map(|e| (s, e)))
+                    .map(|(start, end)| self.to_span_index(start).to(self.to_span_index(end)));
+            }
         }
         spec
     }

--- a/src/libfmt_macros/tests.rs
+++ b/src/libfmt_macros/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 fn same(fmt: &'static str, p: &[Piece<'static>]) {
     let parser = Parser::new(fmt, None, vec![], false);
-    assert!(parser.collect::<Vec<Piece<'static>>>() == p);
+    assert_eq!(parser.collect::<Vec<Piece<'static>>>(), p);
 }
 
 fn fmtdflt() -> FormatSpec<'static> {
@@ -15,6 +15,7 @@ fn fmtdflt() -> FormatSpec<'static> {
         precision_span: None,
         width_span: None,
         ty: "",
+        ty_span: None,
     };
 }
 
@@ -82,7 +83,7 @@ fn format_position_nothing_else() {
 #[test]
 fn format_type() {
     same(
-        "{3:a}",
+        "{3:x}",
         &[NextArgument(Argument {
             position: ArgumentIs(3),
             format: FormatSpec {
@@ -93,7 +94,8 @@ fn format_type() {
                 width: CountImplied,
                 precision_span: None,
                 width_span: None,
-                ty: "a",
+                ty: "x",
+                ty_span: None,
             },
         })]);
 }
@@ -112,6 +114,7 @@ fn format_align_fill() {
                 precision_span: None,
                 width_span: None,
                 ty: "",
+                ty_span: None,
             },
         })]);
     same(
@@ -127,6 +130,7 @@ fn format_align_fill() {
                 precision_span: None,
                 width_span: None,
                 ty: "",
+                ty_span: None,
             },
         })]);
     same(
@@ -142,6 +146,7 @@ fn format_align_fill() {
                 precision_span: None,
                 width_span: None,
                 ty: "abcd",
+                ty_span: Some(InnerSpan::new(6, 10)),
             },
         })]);
 }
@@ -150,7 +155,7 @@ fn format_counts() {
     use syntax_pos::{GLOBALS, Globals, edition};
     GLOBALS.set(&Globals::new(edition::DEFAULT_EDITION), || {
     same(
-        "{:10s}",
+        "{:10x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
             format: FormatSpec {
@@ -161,11 +166,12 @@ fn format_counts() {
                 width: CountIs(10),
                 precision_span: None,
                 width_span: None,
-                ty: "s",
+                ty: "x",
+                ty_span: None,
             },
         })]);
     same(
-        "{:10$.10s}",
+        "{:10$.10x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
             format: FormatSpec {
@@ -176,11 +182,12 @@ fn format_counts() {
                 width: CountIsParam(10),
                 precision_span: None,
                 width_span: Some(InnerSpan::new(3, 6)),
-                ty: "s",
+                ty: "x",
+                ty_span: None,
             },
         })]);
     same(
-        "{:.*s}",
+        "{:.*x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(1),
             format: FormatSpec {
@@ -191,11 +198,12 @@ fn format_counts() {
                 width: CountImplied,
                 precision_span: Some(InnerSpan::new(3, 5)),
                 width_span: None,
-                ty: "s",
+                ty: "x",
+                ty_span: None,
             },
         })]);
     same(
-        "{:.10$s}",
+        "{:.10$x}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
             format: FormatSpec {
@@ -206,11 +214,12 @@ fn format_counts() {
                 width: CountImplied,
                 precision_span: Some(InnerSpan::new(3, 7)),
                 width_span: None,
-                ty: "s",
+                ty: "x",
+                ty_span: None,
             },
         })]);
     same(
-        "{:a$.b$s}",
+        "{:a$.b$?}",
         &[NextArgument(Argument {
             position: ArgumentImplicitlyIs(0),
             format: FormatSpec {
@@ -221,7 +230,8 @@ fn format_counts() {
                 width: CountIsName(Symbol::intern("a")),
                 precision_span: None,
                 width_span: None,
-                ty: "s",
+                ty: "?",
+                ty_span: None,
             },
         })]);
     });
@@ -241,6 +251,7 @@ fn format_flags() {
                 precision_span: None,
                 width_span: None,
                 ty: "",
+                ty_span: None,
             },
         })]);
     same(
@@ -256,13 +267,14 @@ fn format_flags() {
                 precision_span: None,
                 width_span: None,
                 ty: "",
+                ty_span: None,
             },
         })]);
 }
 #[test]
 fn format_mixture() {
     same(
-        "abcd {3:a} efg",
+        "abcd {3:x} efg",
         &[
             String("abcd "),
             NextArgument(Argument {
@@ -275,7 +287,8 @@ fn format_mixture() {
                     width: CountImplied,
                     precision_span: None,
                     width_span: None,
-                    ty: "a",
+                    ty: "x",
+                    ty_span: None,
                 },
             }),
             String(" efg"),

--- a/src/test/ui/if/ifmt-bad-arg.stderr
+++ b/src/test/ui/if/ifmt-bad-arg.stderr
@@ -257,10 +257,10 @@ LL |     println!("{} {:07$} {}", 1, 3.2, 4);
    = note: for information about formatting flags, visit https://doc.rust-lang.org/std/fmt/index.html
 
 error: unknown format trait `foo`
-  --> $DIR/ifmt-bad-arg.rs:86:24
+  --> $DIR/ifmt-bad-arg.rs:86:17
    |
 LL |     println!("{:foo}", 1);
-   |                        ^
+   |                 ^^^
    |
    = note: the only appropriate formatting traits are:
            - ``, which uses the `Display` trait

--- a/src/test/ui/if/ifmt-unknown-trait.stderr
+++ b/src/test/ui/if/ifmt-unknown-trait.stderr
@@ -1,8 +1,8 @@
 error: unknown format trait `notimplemented`
-  --> $DIR/ifmt-unknown-trait.rs:2:34
+  --> $DIR/ifmt-unknown-trait.rs:2:16
    |
 LL |     format!("{:notimplemented}", "3");
-   |                                  ^^^
+   |                ^^^^^^^^^^^^^^
    |
    = note: the only appropriate formatting traits are:
            - ``, which uses the `Display` trait


### PR DESCRIPTION
When a formatting string contains an invalid descriptor, point at it
instead of the argument:

```
error: unknown format trait `foo`
  --> $DIR/ifmt-bad-arg.rs:86:17
   |
LL |     println!("{:foo}", 1);
   |                 ^^^
   |
   = note: the only appropriate formatting traits are:
           - ``, which uses the `Display` trait
           - `?`, which uses the `Debug` trait
           - `e`, which uses the `LowerExp` trait
           - `E`, which uses the `UpperExp` trait
           - `o`, which uses the `Octal` trait
           - `p`, which uses the `Pointer` trait
           - `b`, which uses the `Binary` trait
           - `x`, which uses the `LowerHex` trait
           - `X`, which uses the `UpperHex` trait
```