### PR TITLE
rename cfg(rustdoc) into cfg(doc)

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -25,7 +25,7 @@ fn main() {
     let mut dylib_path = bootstrap::util::dylib_path();
     dylib_path.insert(0, PathBuf::from(libdir.clone()));
 
-    //FIXME(misdreavus): once stdsimd uses cfg(rustdoc) instead of cfg(dox), remove the `--cfg dox`
+    //FIXME(misdreavus): once stdsimd uses cfg(doc) instead of cfg(dox), remove the `--cfg dox`
     //arguments here
     let mut cmd = Command::new(rustdoc);
     cmd.args(&args)

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -106,11 +106,11 @@ item, it will be accompanied by a banner explaining that the item is only availa
 platforms.
 
 For Rustdoc to document an item, it needs to see it, regardless of what platform it's currently
-running on. To aid this, Rustdoc sets the flag `#[cfg(rustdoc)]` when running on your crate.
+running on. To aid this, Rustdoc sets the flag `#[cfg(doc)]` when running on your crate.
 Combining this with the target platform of a given item allows it to appear when building your crate
 normally on that platform, as well as when building documentation anywhere.
 
-For example, `#[cfg(any(windows, rustdoc))]` will preserve the item either on Windows or during the
+For example, `#[cfg(any(windows, doc))]` will preserve the item either on Windows or during the
 documentation process. Then, adding a new attribute `#[doc(cfg(windows))]` will tell Rustdoc that
 the item is supposed to be used on Windows. For example:
 
@@ -118,12 +118,12 @@ the item is supposed to be used on Windows. For example:
 #![feature(doc_cfg)]
 
 /// Token struct that can only be used on Windows.
-#[cfg(any(windows, rustdoc))]
+#[cfg(any(windows, doc))]
 #[doc(cfg(windows))]
 pub struct WindowsToken;
 
 /// Token struct that can only be used on Unix.
-#[cfg(any(unix, rustdoc))]
+#[cfg(any(unix, doc))]
 #[doc(cfg(unix))]
 pub struct UnixToken;
 ```

--- a/src/doc/unstable-book/src/language-features/doc-cfg.md
+++ b/src/doc/unstable-book/src/language-features/doc-cfg.md
@@ -13,7 +13,7 @@ This attribute has two effects:
 2. The item's doc-tests will only run on the specific platform.
 
 In addition to allowing the use of the `#[doc(cfg)]` attribute, this feature enables the use of a
-special conditional compilation flag, `#[cfg(rustdoc)]`, set whenever building documentation on your
+special conditional compilation flag, `#[cfg(doc)]`, set whenever building documentation on your
 crate.
 
 This feature was introduced as part of PR [#43348] to allow the platform-specific parts of the
@@ -22,7 +22,7 @@ standard library be documented.
 ```rust
 #![feature(doc_cfg)]
 
-#[cfg(any(windows, rustdoc))]
+#[cfg(any(windows, doc))]
 #[doc(cfg(windows))]
 /// The application's icon in the notification area (a.k.a. system tray).
 ///

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -247,7 +247,7 @@ pub fn run_core(options: RustdocOptions) -> (clean::Crate, RenderInfo, RenderOpt
     } = options;
 
     // Add the rustdoc cfg into the doc build.
-    cfgs.push("rustdoc".to_string());
+    cfgs.push("doc".to_string());
 
     let cpath = Some(input.clone());
     let input = Input::File(input);

--- a/src/librustdoc/test.rs
+++ b/src/librustdoc/test.rs
@@ -63,7 +63,7 @@ pub fn run(options: Options) -> i32 {
     };
 
     let mut cfgs = options.cfgs.clone();
-    cfgs.push("rustdoc".to_owned());
+    cfgs.push("doc".to_owned());
     cfgs.push("doctest".to_owned());
     let config = interface::Config {
         opts: sessopts,

--- a/src/libstd/os/mod.rs
+++ b/src/libstd/os/mod.rs
@@ -4,7 +4,7 @@
 #![allow(missing_docs, nonstandard_style, missing_debug_implementations)]
 
 cfg_if::cfg_if! {
-    if #[cfg(rustdoc)] {
+    if #[cfg(doc)] {
 
         // When documenting libstd we want to show unix/windows/linux modules as
         // these are the "main modules" that are used across platforms. This

--- a/src/libstd/sys/mod.rs
+++ b/src/libstd/sys/mod.rs
@@ -56,7 +56,7 @@ cfg_if::cfg_if! {
 // then later used in the `std::os` module when documenting, for example,
 // Windows when we're compiling for Linux.
 
-#[cfg(rustdoc)]
+#[cfg(doc)]
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
         // On unix we'll document what's already available
@@ -80,7 +80,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(rustdoc)]
+#[cfg(doc)]
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         // On windows we'll just be documenting what's already available

--- a/src/libstd/sys/unix/mod.rs
+++ b/src/libstd/sys/unix/mod.rs
@@ -2,21 +2,21 @@
 
 use crate::io::ErrorKind;
 
-#[cfg(any(rustdoc, target_os = "linux"))] pub use crate::os::linux as platform;
+#[cfg(any(doc, target_os = "linux"))] pub use crate::os::linux as platform;
 
-#[cfg(all(not(rustdoc), target_os = "android"))]   pub use crate::os::android as platform;
-#[cfg(all(not(rustdoc), target_os = "dragonfly"))] pub use crate::os::dragonfly as platform;
-#[cfg(all(not(rustdoc), target_os = "freebsd"))]   pub use crate::os::freebsd as platform;
-#[cfg(all(not(rustdoc), target_os = "haiku"))]     pub use crate::os::haiku as platform;
-#[cfg(all(not(rustdoc), target_os = "ios"))]       pub use crate::os::ios as platform;
-#[cfg(all(not(rustdoc), target_os = "macos"))]     pub use crate::os::macos as platform;
-#[cfg(all(not(rustdoc), target_os = "netbsd"))]    pub use crate::os::netbsd as platform;
-#[cfg(all(not(rustdoc), target_os = "openbsd"))]   pub use crate::os::openbsd as platform;
-#[cfg(all(not(rustdoc), target_os = "solaris"))]   pub use crate::os::solaris as platform;
-#[cfg(all(not(rustdoc), target_os = "emscripten"))] pub use crate::os::emscripten as platform;
-#[cfg(all(not(rustdoc), target_os = "fuchsia"))]   pub use crate::os::fuchsia as platform;
-#[cfg(all(not(rustdoc), target_os = "l4re"))]      pub use crate::os::linux as platform;
-#[cfg(all(not(rustdoc), target_os = "redox"))]      pub use crate::os::redox as platform;
+#[cfg(all(not(doc), target_os = "android"))]   pub use crate::os::android as platform;
+#[cfg(all(not(doc), target_os = "dragonfly"))] pub use crate::os::dragonfly as platform;
+#[cfg(all(not(doc), target_os = "freebsd"))]   pub use crate::os::freebsd as platform;
+#[cfg(all(not(doc), target_os = "haiku"))]     pub use crate::os::haiku as platform;
+#[cfg(all(not(doc), target_os = "ios"))]       pub use crate::os::ios as platform;
+#[cfg(all(not(doc), target_os = "macos"))]     pub use crate::os::macos as platform;
+#[cfg(all(not(doc), target_os = "netbsd"))]    pub use crate::os::netbsd as platform;
+#[cfg(all(not(doc), target_os = "openbsd"))]   pub use crate::os::openbsd as platform;
+#[cfg(all(not(doc), target_os = "solaris"))]   pub use crate::os::solaris as platform;
+#[cfg(all(not(doc), target_os = "emscripten"))] pub use crate::os::emscripten as platform;
+#[cfg(all(not(doc), target_os = "fuchsia"))]   pub use crate::os::fuchsia as platform;
+#[cfg(all(not(doc), target_os = "l4re"))]      pub use crate::os::linux as platform;
+#[cfg(all(not(doc), target_os = "redox"))]      pub use crate::os::redox as platform;
 
 pub use self::rand::hashmap_random_keys;
 pub use libc::strlen;

--- a/src/libstd/sys_common/mod.rs
+++ b/src/libstd/sys_common/mod.rs
@@ -45,7 +45,7 @@ pub mod backtrace;
 pub mod condvar;
 pub mod io;
 pub mod mutex;
-#[cfg(any(rustdoc, // see `mod os`, docs are generated for multiple platforms
+#[cfg(any(doc, // see `mod os`, docs are generated for multiple platforms
           unix,
           target_os = "redox",
           target_os = "cloudabi",

--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -30,7 +30,7 @@ const GATED_CFGS: &[(Symbol, Symbol, GateFn)] = &[
     (sym::target_thread_local, sym::cfg_target_thread_local, cfg_fn!(cfg_target_thread_local)),
     (sym::target_has_atomic, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
     (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
-    (sym::rustdoc, sym::doc_cfg, cfg_fn!(doc_cfg)),
+    (sym::doc, sym::doc_cfg, cfg_fn!(doc_cfg)),
 ];
 
 #[derive(Debug)]

--- a/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
+++ b/src/test/rustdoc-ui/doc-test-rustdoc-feature.rs
@@ -4,11 +4,11 @@
 
 #![feature(doc_cfg)]
 
-// Make sure `cfg(rustdoc)` is set when finding doctests but not inside the doctests.
+// Make sure `cfg(doc)` is set when finding doctests but not inside the doctests.
 
 /// ```
 /// #![feature(doc_cfg)]
-/// assert!(!cfg!(rustdoc));
+/// assert!(!cfg!(doc));
 /// ```
-#[cfg(rustdoc)]
+#[cfg(doc)]
 pub struct Foo;

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.rs
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.rs
@@ -1,4 +1,4 @@
-#[cfg(rustdoc)] //~ ERROR: `cfg(rustdoc)` is experimental and subject to change
+#[cfg(doc)] //~ ERROR: `cfg(doc)` is experimental and subject to change
 pub struct SomeStruct;
 
 fn main() {}

--- a/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
+++ b/src/test/ui/feature-gates/feature-gate-doc_cfg-cfg-rustdoc.stderr
@@ -1,8 +1,8 @@
-error[E0658]: `cfg(rustdoc)` is experimental and subject to change
+error[E0658]: `cfg(doc)` is experimental and subject to change
   --> $DIR/feature-gate-doc_cfg-cfg-rustdoc.rs:1:7
    |
-LL | #[cfg(rustdoc)]
-   |       ^^^^^^^
+LL | #[cfg(doc)]
+   |       ^^^
    |
    = note: for more information, see https://github.com/rust-lang/rust/issues/43781
    = help: add `#![feature(doc_cfg)]` to the crate attributes to enable


### PR DESCRIPTION
Needed by https://github.com/rust-lang/rust/pull/61351

r? @QuietMisdreavus 