### PR TITLE
[WIP] Rename MaybeUninit::get_{ref,mut} to MaybeUninit::assume_init_{ref,mut}

### DIFF
--- a/src/libcore/mem/maybe_uninit.rs
+++ b/src/libcore/mem/maybe_uninit.rs
@@ -317,7 +317,7 @@ impl<T> MaybeUninit<T> {
     pub fn write(&mut self, val: T) -> &mut T {
         unsafe {
             self.value = ManuallyDrop::new(val);
-            self.get_mut()
+            self.assume_init_mut()
         }
     }
 
@@ -536,7 +536,7 @@ impl<T> MaybeUninit<T> {
     /// // create a shared reference to it:
     /// let x: &Vec<u32> = unsafe {
     ///     // Safety: `x` has been initialized.
-    ///     x.get_ref()
+    ///     x.assume_init_ref()
     /// };
     /// assert_eq!(x, &vec![1, 2, 3]);
     /// ```
@@ -548,7 +548,7 @@ impl<T> MaybeUninit<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let x = MaybeUninit::<Vec<u32>>::uninit();
-    /// let x_vec: &Vec<u32> = unsafe { x.get_ref() };
+    /// let x_vec: &Vec<u32> = unsafe { x.assume_init_ref() };
     /// // We have created a reference to an uninitialized vector! This is undefined behavior.
     /// ```
     ///
@@ -559,14 +559,14 @@ impl<T> MaybeUninit<T> {
     /// let b = MaybeUninit::<Cell<bool>>::uninit();
     /// // Initialize the `MaybeUninit` using `Cell::set`:
     /// unsafe {
-    ///     b.get_ref().set(true);
-    ///  // ^^^^^^^^^^^
+    ///     b.assume_init_ref().set(true);
+    ///  // ^^^^^^^^^^^^^^^^^^^
     ///  // Reference to an uninitialized `Cell<bool>`: UB!
     /// }
     /// ```
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
-    pub unsafe fn get_ref(&self) -> &T {
+    pub unsafe fn assume_init_ref(&self) -> &T {
         intrinsics::panic_if_uninhabited::<T>();
         &*self.value
     }
@@ -581,7 +581,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// Calling this when the content is not yet fully initialized causes undefined
     /// behavior: it is up to the caller to guarantee that the `MaybeUninit<T>` really
-    /// is in an initialized state. For instance, `.get_mut()` cannot be used to
+    /// is in an initialized state. For instance, `.assume_init_mut()` cannot be used to
     /// initialize a `MaybeUninit`.
     ///
     /// # Examples
@@ -609,7 +609,7 @@ impl<T> MaybeUninit<T> {
     /// // the `&mut MaybeUninit<[u8; 2048]>` to a `&mut [u8; 2048]`:
     /// let buf: &mut [u8; 2048] = unsafe {
     ///     // Safety: `buf` has been initialized.
-    ///     buf.get_mut()
+    ///     buf.assume_init_mut()
     /// };
     ///
     /// // Now we can use `buf` as a normal slice:
@@ -622,7 +622,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// ### *Incorrect* usages of this method:
     ///
-    /// You cannot use `.get_mut()` to initialize a value:
+    /// You cannot use `.assume_init_mut()` to initialize a value:
     ///
     /// ```rust,no_run
     /// #![feature(maybe_uninit_ref)]
@@ -630,7 +630,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// let mut b = MaybeUninit::<bool>::uninit();
     /// unsafe {
-    ///     *b.get_mut() = true;
+    ///     *b.assume_init_mut() = true;
     ///     // We have created a (mutable) reference to an uninitialized `bool`!
     ///     // This is undefined behavior.
     /// }
@@ -647,8 +647,8 @@ impl<T> MaybeUninit<T> {
     /// fn read_chunk (reader: &'_ mut dyn io::Read) -> io::Result<[u8; 64]>
     /// {
     ///     let mut buffer = MaybeUninit::<[u8; 64]>::uninit();
-    ///     reader.read_exact(unsafe { buffer.get_mut() })?;
-    ///                             // ^^^^^^^^^^^^^^^^
+    ///     reader.read_exact(unsafe { buffer.assume_init_mut() })?;
+    ///                             // ^^^^^^^^^^^^^^^^^^^^^^^^
     ///                             // (mutable) reference to uninitialized memory!
     ///                             // This is undefined behavior.
     ///     Ok(unsafe { buffer.assume_init() })
@@ -668,12 +668,12 @@ impl<T> MaybeUninit<T> {
     ///
     /// let foo: Foo = unsafe {
     ///     let mut foo = MaybeUninit::<Foo>::uninit();
-    ///     ptr::write(&mut foo.get_mut().a as *mut u32, 1337);
-    ///                  // ^^^^^^^^^^^^^
+    ///     ptr::write(&mut foo.assume_init_mut().a as *mut u32, 1337);
+    ///                  // ^^^^^^^^^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
-    ///     ptr::write(&mut foo.get_mut().b as *mut u8, 42);
-    ///                  // ^^^^^^^^^^^^^
+    ///     ptr::write(&mut foo.assume_init_mut().b as *mut u8, 42);
+    ///                  // ^^^^^^^^^^^^^^^^^^^^^
     ///                  // (mutable) reference to uninitialized memory!
     ///                  // This is undefined behavior.
     ///     foo.assume_init()
@@ -684,7 +684,7 @@ impl<T> MaybeUninit<T> {
     // a final decision about the rules before stabilization.
     #[unstable(feature = "maybe_uninit_ref", issue = "63568")]
     #[inline(always)]
-    pub unsafe fn get_mut(&mut self) -> &mut T {
+    pub unsafe fn assume_init_mut(&mut self) -> &mut T {
         intrinsics::panic_if_uninhabited::<T>();
         &mut *self.value
     }


### PR DESCRIPTION
This is the last remaining concern blocking the stabilization of the by-ref accessors of `MaybeUninit` (#63568).
This change of name not only does align with `.into_inner()` being called `.assume_init()`,
it also conveys the dangerous semantics of the method in a much clearer and more direct way,
reducing the change of misuse and thus of unsoundness.

r? @RalfJung cc @SimonSapin @Centril