### PR TITLE
`MethodSig` -> `FnSig` & Use it in `ItemKind::Fn`

### DIFF
--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -45,7 +45,7 @@ pub enum FnKind<'a> {
     ItemFn(Ident, &'a Generics, FnHeader, &'a Visibility, &'a [Attribute]),
 
     /// `fn foo(&self)`
-    Method(Ident, &'a MethodSig, Option<&'a Visibility>, &'a [Attribute]),
+    Method(Ident, &'a FnSig, Option<&'a Visibility>, &'a [Attribute]),
 
     /// `|x, y| {}`
     Closure(&'a [Attribute]),

--- a/src/librustc/hir/intravisit.rs
+++ b/src/librustc/hir/intravisit.rs
@@ -481,13 +481,13 @@ pub fn walk_item<'v, V: Visitor<'v>>(visitor: &mut V, item: &'v Item) {
             visitor.visit_ty(typ);
             visitor.visit_nested_body(body);
         }
-        ItemKind::Fn(ref declaration, header, ref generics, body_id) => {
+        ItemKind::Fn(ref sig, ref generics, body_id) => {
             visitor.visit_fn(FnKind::ItemFn(item.ident,
                                             generics,
-                                            header,
+                                            sig.header,
                                             &item.vis,
                                             &item.attrs),
-                             declaration,
+                             &sig.decl,
                              body_id,
                              item.span,
                              item.hir_id)

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -328,7 +328,7 @@ impl LoweringContext<'_> {
                             header.asyncness.node.opt_return_id()
                         ),
                     );
-                    let sig = hir::MethodSig { decl, header: this.lower_fn_header(header) };
+                    let sig = hir::FnSig { decl, header: this.lower_fn_header(header) };
                     hir::ItemKind::Fn(sig, generics, body_id)
                 })
             }
@@ -1259,7 +1259,7 @@ impl LoweringContext<'_> {
         fn_def_id: DefId,
         impl_trait_return_allow: bool,
         is_async: Option<NodeId>,
-    ) -> (hir::Generics, hir::MethodSig) {
+    ) -> (hir::Generics, hir::FnSig) {
         let header = self.lower_fn_header(sig.header);
         let (generics, decl) = self.add_in_band_defs(
             generics,
@@ -1272,7 +1272,7 @@ impl LoweringContext<'_> {
                 is_async,
             ),
         );
-        (generics, hir::MethodSig { header, decl })
+        (generics, hir::FnSig { header, decl })
     }
 
     fn lower_is_auto(&mut self, a: IsAuto) -> hir::IsAuto {

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -317,7 +317,7 @@ impl LoweringContext<'_> {
                     // declaration (decl), not the return types.
                     let body_id = this.lower_maybe_async_body(&decl, header.asyncness.node, body);
 
-                    let (generics, fn_decl) = this.add_in_band_defs(
+                    let (generics, decl) = this.add_in_band_defs(
                         generics,
                         fn_def_id,
                         AnonymousLifetimeMode::PassThrough,
@@ -328,13 +328,8 @@ impl LoweringContext<'_> {
                             header.asyncness.node.opt_return_id()
                         ),
                     );
-
-                    hir::ItemKind::Fn(
-                        fn_decl,
-                        this.lower_fn_header(header),
-                        generics,
-                        body_id,
-                    )
+                    let sig = hir::MethodSig { decl, header: this.lower_fn_header(header) };
+                    hir::ItemKind::Fn(sig, generics, body_id)
                 })
             }
             ItemKind::Mod(ref m) => hir::ItemKind::Mod(self.lower_mod(m)),

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -1255,7 +1255,7 @@ impl LoweringContext<'_> {
     fn lower_method_sig(
         &mut self,
         generics: &Generics,
-        sig: &MethodSig,
+        sig: &FnSig,
         fn_def_id: DefId,
         impl_trait_return_allow: bool,
         is_async: Option<NodeId>,

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -306,7 +306,7 @@ impl LoweringContext<'_> {
                     self.lower_const_body(e)
                 )
             }
-            ItemKind::Fn(ref decl, header, ref generics, ref body) => {
+            ItemKind::Fn(FnSig { ref decl, header }, ref generics, ref body) => {
                 let fn_def_id = self.resolver.definitions().local_def_id(id);
                 self.with_new_scopes(|this| {
                     this.current_item = Some(ident.span);

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -158,25 +158,25 @@ impl<'a> FnLikeNode<'a> {
 
     pub fn body(self) -> ast::BodyId {
         self.handle(|i: ItemFnParts<'a>| i.body,
-                    |_, _, _: &'a ast::MethodSig, _, body: ast::BodyId, _, _| body,
+                    |_, _, _: &'a ast::FnSig, _, body: ast::BodyId, _, _| body,
                     |c: ClosureParts<'a>| c.body)
     }
 
     pub fn decl(self) -> &'a FnDecl {
         self.handle(|i: ItemFnParts<'a>| &*i.decl,
-                    |_, _, sig: &'a ast::MethodSig, _, _, _, _| &sig.decl,
+                    |_, _, sig: &'a ast::FnSig, _, _, _, _| &sig.decl,
                     |c: ClosureParts<'a>| c.decl)
     }
 
     pub fn span(self) -> Span {
         self.handle(|i: ItemFnParts<'_>| i.span,
-                    |_, _, _: &'a ast::MethodSig, _, _, span, _| span,
+                    |_, _, _: &'a ast::FnSig, _, _, span, _| span,
                     |c: ClosureParts<'_>| c.span)
     }
 
     pub fn id(self) -> ast::HirId {
         self.handle(|i: ItemFnParts<'_>| i.id,
-                    |id, _, _: &'a ast::MethodSig, _, _, _, _| id,
+                    |id, _, _: &'a ast::FnSig, _, _, _, _| id,
                     |c: ClosureParts<'_>| c.id)
     }
 
@@ -199,7 +199,7 @@ impl<'a> FnLikeNode<'a> {
         let closure = |c: ClosureParts<'a>| {
             FnKind::Closure(c.attrs)
         };
-        let method = |_, ident: Ident, sig: &'a ast::MethodSig, vis, _, _, attrs| {
+        let method = |_, ident: Ident, sig: &'a ast::FnSig, vis, _, _, attrs| {
             FnKind::Method(ident, sig, vis, attrs)
         };
         self.handle(item, method, closure)
@@ -209,7 +209,7 @@ impl<'a> FnLikeNode<'a> {
         I: FnOnce(ItemFnParts<'a>) -> A,
         M: FnOnce(ast::HirId,
                   Ident,
-                  &'a ast::MethodSig,
+                  &'a ast::FnSig,
                   Option<&'a ast::Visibility>,
                   ast::BodyId,
                   Span,

--- a/src/librustc/hir/map/blocks.rs
+++ b/src/librustc/hir/map/blocks.rs
@@ -219,16 +219,16 @@ impl<'a> FnLikeNode<'a> {
     {
         match self.node {
             map::Node::Item(i) => match i.kind {
-                ast::ItemKind::Fn(ref decl, header, ref generics, block) =>
+                ast::ItemKind::Fn(ref sig, ref generics, block) =>
                     item_fn(ItemFnParts {
                         id: i.hir_id,
                         ident: i.ident,
-                        decl: &decl,
+                        decl: &sig.decl,
                         body: block,
                         vis: &i.vis,
                         span: i.span,
                         attrs: &i.attrs,
-                        header,
+                        header: sig.header,
                         generics,
                     }),
                 _ => bug!("item FnLikeNode that is not fn-like"),

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -228,7 +228,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
 
     fn visit_impl_item(&mut self, ii: &'a ImplItem) {
         let def_data = match ii.kind {
-            ImplItemKind::Method(MethodSig {
+            ImplItemKind::Method(FnSig {
                 ref header,
                 ref decl,
             }, ref body) if header.asyncness.node.is_async() => {

--- a/src/librustc/hir/map/def_collector.rs
+++ b/src/librustc/hir/map/def_collector.rs
@@ -100,7 +100,7 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
 
         // Pick the def data. This need not be unique, but the more
         // information we encapsulate into, the better
-        let def_data = match i.kind {
+        let def_data = match &i.kind {
             ItemKind::Impl(..) => DefPathData::Impl,
             ItemKind::Mod(..) if i.ident.name == kw::Invalid => {
                 return visit::walk_item(self, i);
@@ -109,19 +109,14 @@ impl<'a> visit::Visitor<'a> for DefCollector<'a> {
             ItemKind::Enum(..) | ItemKind::Struct(..) | ItemKind::Union(..) |
             ItemKind::OpaqueTy(..) | ItemKind::ExternCrate(..) | ItemKind::ForeignMod(..) |
             ItemKind::TyAlias(..) => DefPathData::TypeNs(i.ident.name),
-            ItemKind::Fn(
-                ref decl,
-                ref header,
-                ref generics,
-                ref body,
-            ) if header.asyncness.node.is_async() => {
+            ItemKind::Fn(sig, generics, body) if sig.header.asyncness.node.is_async() => {
                 return self.visit_async_fn(
                     i.id,
                     i.ident.name,
                     i.span,
-                    header,
+                    &sig.header,
                     generics,
-                    decl,
+                    &sig.decl,
                     body,
                 )
             }

--- a/src/librustc/hir/map/mod.rs
+++ b/src/librustc/hir/map/mod.rs
@@ -49,21 +49,21 @@ impl<'hir> Entry<'hir> {
         match self.node {
             Node::Item(ref item) => {
                 match item.kind {
-                    ItemKind::Fn(ref fn_decl, _, _, _) => Some(fn_decl),
+                    ItemKind::Fn(ref sig, _, _) => Some(&sig.decl),
                     _ => None,
                 }
             }
 
             Node::TraitItem(ref item) => {
                 match item.kind {
-                    TraitItemKind::Method(ref method_sig, _) => Some(&method_sig.decl),
+                    TraitItemKind::Method(ref sig, _) => Some(&sig.decl),
                     _ => None
                 }
             }
 
             Node::ImplItem(ref item) => {
                 match item.kind {
-                    ImplItemKind::Method(ref method_sig, _) => Some(&method_sig.decl),
+                    ImplItemKind::Method(ref sig, _) => Some(&sig.decl),
                     _ => None,
                 }
             }
@@ -85,7 +85,7 @@ impl<'hir> Entry<'hir> {
                 match item.kind {
                     ItemKind::Const(_, body) |
                     ItemKind::Static(.., body) |
-                    ItemKind::Fn(_, _, _, body) => Some(body),
+                    ItemKind::Fn(.., body) => Some(body),
                     _ => None,
                 }
             }
@@ -605,7 +605,7 @@ impl<'hir> Map<'hir> {
                 Node::TraitItem(ref trait_item) => Some(&trait_item.generics),
                 Node::Item(ref item) => {
                     match item.kind {
-                        ItemKind::Fn(_, _, ref generics, _) |
+                        ItemKind::Fn(_, ref generics, _) |
                         ItemKind::TyAlias(_, ref generics) |
                         ItemKind::Enum(_, ref generics) |
                         ItemKind::Struct(_, ref generics) |
@@ -702,9 +702,9 @@ impl<'hir> Map<'hir> {
                 ..
             }) => true,
             Node::Item(&Item {
-                kind: ItemKind::Fn(_, header, ..),
+                kind: ItemKind::Fn(ref sig, ..),
                 ..
-            }) => header.constness == Constness::Const,
+            }) => sig.header.constness == Constness::Const,
             _ => false,
         }
     }

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -1876,9 +1876,10 @@ pub struct MutTy {
     pub mutbl: Mutability,
 }
 
-/// Represents a method's signature in a trait declaration or implementation.
+/// Represents a function's signature in a trait declaration,
+/// trait implementation, or a free function.
 #[derive(RustcEncodable, RustcDecodable, Debug, HashStable)]
-pub struct MethodSig {
+pub struct FnSig {
     pub header: FnHeader,
     pub decl: P<FnDecl>,
 }
@@ -1921,7 +1922,7 @@ pub enum TraitItemKind {
     /// An associated constant with an optional value (otherwise `impl`s must contain a value).
     Const(P<Ty>, Option<BodyId>),
     /// A method with an optional body.
-    Method(MethodSig, TraitMethod),
+    Method(FnSig, TraitMethod),
     /// An associated type with (possibly empty) bounds and optional concrete
     /// type.
     Type(GenericBounds, Option<P<Ty>>),
@@ -1955,7 +1956,7 @@ pub enum ImplItemKind {
     /// of the expression.
     Const(P<Ty>, BodyId),
     /// A method implementation with the given signature and body.
-    Method(MethodSig, BodyId),
+    Method(FnSig, BodyId),
     /// An associated type.
     TyAlias(P<Ty>),
     /// An associated `type = impl Trait`.
@@ -2534,7 +2535,7 @@ pub enum ItemKind {
     /// A `const` item.
     Const(P<Ty>, BodyId),
     /// A function declaration.
-    Fn(MethodSig, Generics, BodyId),
+    Fn(FnSig, Generics, BodyId),
     /// A module.
     Mod(Mod),
     /// An external module, e.g. `extern { .. }`.

--- a/src/librustc/hir/mod.rs
+++ b/src/librustc/hir/mod.rs
@@ -2534,7 +2534,7 @@ pub enum ItemKind {
     /// A `const` item.
     Const(P<Ty>, BodyId),
     /// A function declaration.
-    Fn(P<FnDecl>, FnHeader, Generics, BodyId),
+    Fn(MethodSig, Generics, BodyId),
     /// A module.
     Mod(Mod),
     /// An external module, e.g. `extern { .. }`.
@@ -2599,7 +2599,7 @@ impl ItemKind {
 
     pub fn generics(&self) -> Option<&Generics> {
         Some(match *self {
-            ItemKind::Fn(_, _, ref generics, _) |
+            ItemKind::Fn(_, ref generics, _) |
             ItemKind::TyAlias(_, ref generics) |
             ItemKind::OpaqueTy(OpaqueTy { ref generics, impl_trait_fn: None, .. }) |
             ItemKind::Enum(_, ref generics) |

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -835,7 +835,7 @@ impl<'a> State<'a> {
     }
     pub fn print_method_sig(&mut self,
                             ident: ast::Ident,
-                            m: &hir::MethodSig,
+                            m: &hir::FnSig,
                             generics: &hir::Generics,
                             vis: &hir::Visibility,
                             arg_names: &[ast::Ident],

--- a/src/librustc/hir/print.rs
+++ b/src/librustc/hir/print.rs
@@ -533,10 +533,10 @@ impl<'a> State<'a> {
                 self.s.word(";");
                 self.end(); // end the outer cbox
             }
-            hir::ItemKind::Fn(ref decl, header, ref param_names, body) => {
+            hir::ItemKind::Fn(ref sig, ref param_names, body) => {
                 self.head("");
-                self.print_fn(decl,
-                              header,
+                self.print_fn(&sig.decl,
+                              sig.header,
                               Some(item.ident.name),
                               param_names,
                               &item.vis,

--- a/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/src/librustc/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -31,10 +31,10 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             if let Some(hir_id) = self.tcx().hir().as_local_hir_id(def_id) {
                 let fndecl = match self.tcx().hir().get(hir_id) {
                     Node::Item(&hir::Item {
-                        kind: hir::ItemKind::Fn(ref fndecl, ..),
+                        kind: hir::ItemKind::Fn(ref m, ..),
                         ..
-                    }) => &fndecl,
-                    Node::TraitItem(&hir::TraitItem {
+                    })
+                    | Node::TraitItem(&hir::TraitItem {
                         kind: hir::TraitItemKind::Method(ref m, ..),
                         ..
                     })

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -33,7 +33,7 @@ fn item_might_be_inlined(tcx: TyCtxt<'tcx>, item: &hir::Item, attrs: CodegenFnAt
     }
 
     match item.kind {
-        hir::ItemKind::Fn(_, header, ..) if header.is_const() => {
+        hir::ItemKind::Fn(ref sig, ..) if sig.header.is_const() => {
             return true;
         }
         hir::ItemKind::Impl(..) |
@@ -225,8 +225,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
             // If we are building an executable, only explicitly extern
             // types need to be exported.
             if let Node::Item(item) = *node {
-                let reachable = if let hir::ItemKind::Fn(_, header, ..) = item.kind {
-                    header.abi != Abi::Rust
+                let reachable = if let hir::ItemKind::Fn(ref sig, ..) = item.kind {
+                    sig.header.abi != Abi::Rust
                 } else {
                     false
                 };

--- a/src/librustc/middle/resolve_lifetime.rs
+++ b/src/librustc/middle/resolve_lifetime.rs
@@ -460,8 +460,8 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
     fn visit_item(&mut self, item: &'tcx hir::Item) {
         match item.kind {
-            hir::ItemKind::Fn(ref decl, _, ref generics, _) => {
-                self.visit_early_late(None, decl, generics, |this| {
+            hir::ItemKind::Fn(ref sig, ref generics, _) => {
+                self.visit_early_late(None, &sig.decl, generics, |this| {
                     intravisit::walk_item(this, item);
                 });
             }
@@ -1524,8 +1524,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             {
                 match parent {
                     Node::Item(item) => {
-                        if let hir::ItemKind::Fn(decl, _, _, _) = &item.kind {
-                            find_arg_use_span(&decl.inputs);
+                        if let hir::ItemKind::Fn(sig, _, _) = &item.kind {
+                            find_arg_use_span(&sig.decl.inputs);
                         }
                     },
                     Node::ImplItem(impl_item) => {

--- a/src/librustc/traits/error_reporting.rs
+++ b/src/librustc/traits/error_reporting.rs
@@ -383,9 +383,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let hir = &self.tcx.hir();
         let node = hir.find(hir_id)?;
         if let hir::Node::Item(
-            hir::Item{kind: hir::ItemKind::Fn(_ ,fn_header ,_ , body_id), .. }) = &node {
+            hir::Item{kind: hir::ItemKind::Fn(sig, _, body_id), .. }) = &node {
             self.describe_generator(*body_id).or_else(||
-                Some(if let hir::FnHeader{ asyncness: hir::IsAsync::Async, .. } = fn_header {
+                Some(if let hir::FnHeader{ asyncness: hir::IsAsync::Async, .. } = sig.header {
                     "an async function"
                 } else {
                     "a function"
@@ -1081,7 +1081,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 }
 
                 hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Fn(_, _, generics, _), ..
+                    kind: hir::ItemKind::Fn(_, generics, _), ..
                 }) |
                 hir::Node::TraitItem(hir::TraitItem {
                     generics,
@@ -1112,7 +1112,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                     kind: hir::ItemKind::Impl(_, _, _, generics, ..), span, ..
                 }) |
                 hir::Node::Item(hir::Item {
-                    kind: hir::ItemKind::Fn(_, _, generics, _), span, ..
+                    kind: hir::ItemKind::Fn(_, generics, _), span, ..
                 }) |
                 hir::Node::Item(hir::Item {
                     kind: hir::ItemKind::TyAlias(_, generics), span, ..
@@ -1436,12 +1436,12 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let parent_node = hir.get_parent_node(obligation.cause.body_id);
         let node = hir.find(parent_node);
         if let Some(hir::Node::Item(hir::Item {
-            kind: hir::ItemKind::Fn(decl, _, _, body_id),
+            kind: hir::ItemKind::Fn(sig, _, body_id),
             ..
         })) = node {
             let body = hir.body(*body_id);
             if let hir::ExprKind::Block(blk, _) = &body.value.kind {
-                if decl.output.span().overlaps(span) && blk.expr.is_none() &&
+                if sig.decl.output.span().overlaps(span) && blk.expr.is_none() &&
                     "()" == &trait_ref.self_ty().to_string()
                 {
                     // FIXME(estebank): When encountering a method with a trait
@@ -1493,20 +1493,20 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             Node::Item(&hir::Item {
                 span,
-                kind: hir::ItemKind::Fn(ref decl, ..),
+                kind: hir::ItemKind::Fn(ref sig, ..),
                 ..
             }) |
             Node::ImplItem(&hir::ImplItem {
                 span,
-                kind: hir::ImplItemKind::Method(hir::MethodSig { ref decl, .. }, _),
+                kind: hir::ImplItemKind::Method(ref sig, _),
                 ..
             }) |
             Node::TraitItem(&hir::TraitItem {
                 span,
-                kind: hir::TraitItemKind::Method(hir::MethodSig { ref decl, .. }, _),
+                kind: hir::TraitItemKind::Method(ref sig, _),
                 ..
             }) => {
-                (self.tcx.sess.source_map().def_span(span), decl.inputs.iter()
+                (self.tcx.sess.source_map().def_span(span), sig.decl.inputs.iter()
                         .map(|arg| match arg.clone().kind {
                     hir::TyKind::Tup(ref tys) => ArgKind::Tuple(
                         Some(arg.span),
@@ -2040,11 +2040,11 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .and_then(|parent_did| self.tcx.hir().get_if_local(parent_did));
         debug!("note_obligation_cause_for_async_await: parent_node={:?}", parent_node);
         if let Some(hir::Node::Item(hir::Item {
-            kind: hir::ItemKind::Fn(_, header, _, _),
+            kind: hir::ItemKind::Fn(sig, _, _),
             ..
         })) = parent_node {
-            debug!("note_obligation_cause_for_async_await: header={:?}", header);
-            if header.asyncness != hir::IsAsync::Async {
+            debug!("note_obligation_cause_for_async_await: header={:?}", sig.header);
+            if sig.header.asyncness != hir::IsAsync::Async {
                 return false;
             }
         }

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -802,7 +802,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn flat_map_trait_item(&mut self, i: ast::TraitItem) -> SmallVec<[ast::TraitItem; 1]> {
         let is_const = match i.kind {
             ast::TraitItemKind::Const(..) => true,
-            ast::TraitItemKind::Method(ast::MethodSig { ref decl, ref header, .. }, _) =>
+            ast::TraitItemKind::Method(ast::FnSig { ref decl, ref header, .. }, _) =>
                 header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
             _ => false,
         };
@@ -812,7 +812,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn flat_map_impl_item(&mut self, i: ast::ImplItem) -> SmallVec<[ast::ImplItem; 1]> {
         let is_const = match i.kind {
             ast::ImplItemKind::Const(..) => true,
-            ast::ImplItemKind::Method(ast::MethodSig { ref decl, ref header, .. }, _) =>
+            ast::ImplItemKind::Method(ast::FnSig { ref decl, ref header, .. }, _) =>
                 header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
             _ => false,
         };

--- a/src/librustc_interface/util.rs
+++ b/src/librustc_interface/util.rs
@@ -786,14 +786,17 @@ impl<'a> ReplaceBodyWithLoop<'a> {
             false
         }
     }
+
+    fn is_sig_const(sig: &ast::FnSig) -> bool {
+        sig.header.constness.node == ast::Constness::Const || Self::should_ignore_fn(&sig.decl)
+    }
 }
 
 impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn visit_item_kind(&mut self, i: &mut ast::ItemKind) {
         let is_const = match i {
             ast::ItemKind::Static(..) | ast::ItemKind::Const(..) => true,
-            ast::ItemKind::Fn(ref decl, ref header, _, _) =>
-                header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
+            ast::ItemKind::Fn(ref sig, _, _) => Self::is_sig_const(sig),
             _ => false,
         };
         self.run(is_const, |s| noop_visit_item_kind(i, s))
@@ -802,8 +805,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn flat_map_trait_item(&mut self, i: ast::TraitItem) -> SmallVec<[ast::TraitItem; 1]> {
         let is_const = match i.kind {
             ast::TraitItemKind::Const(..) => true,
-            ast::TraitItemKind::Method(ast::FnSig { ref decl, ref header, .. }, _) =>
-                header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
+            ast::TraitItemKind::Method(ref sig, _) => Self::is_sig_const(sig),
             _ => false,
         };
         self.run(is_const, |s| noop_flat_map_trait_item(i, s))
@@ -812,8 +814,7 @@ impl<'a> MutVisitor for ReplaceBodyWithLoop<'a> {
     fn flat_map_impl_item(&mut self, i: ast::ImplItem) -> SmallVec<[ast::ImplItem; 1]> {
         let is_const = match i.kind {
             ast::ImplItemKind::Const(..) => true,
-            ast::ImplItemKind::Method(ast::FnSig { ref decl, ref header, .. }, _) =>
-                header.constness.node == ast::Constness::Const || Self::should_ignore_fn(decl),
+            ast::ImplItemKind::Method(ref sig, _) => Self::is_sig_const(sig),
             _ => false,
         };
         self.run(is_const, |s| noop_flat_map_impl_item(i, s))

--- a/src/librustc_metadata/rmeta/encoder.rs
+++ b/src/librustc_metadata/rmeta/encoder.rs
@@ -1095,10 +1095,10 @@ impl EncodeContext<'tcx> {
                     self.encode_rendered_const_for_body(body_id)
                 )
             }
-            hir::ItemKind::Fn(_, header, .., body) => {
+            hir::ItemKind::Fn(ref sig, .., body) => {
                 let data = FnData {
-                    asyncness: header.asyncness,
-                    constness: header.constness,
+                    asyncness: sig.header.asyncness,
+                    constness: sig.header.constness,
                     param_names: self.encode_fn_param_names_for_body(body),
                 };
 
@@ -1284,14 +1284,14 @@ impl EncodeContext<'tcx> {
 
         let mir = match item.kind {
             hir::ItemKind::Static(..) | hir::ItemKind::Const(..) => true,
-            hir::ItemKind::Fn(_, header, ..) => {
+            hir::ItemKind::Fn(ref sig, ..) => {
                 let generics = tcx.generics_of(def_id);
                 let needs_inline =
                     (generics.requires_monomorphization(tcx) ||
                         tcx.codegen_fn_attrs(def_id).requests_inline()) &&
                         !self.metadata_output_only();
                 let always_encode_mir = self.tcx.sess.opts.debugging_opts.always_encode_mir;
-                needs_inline || header.constness == hir::Constness::Const || always_encode_mir
+                needs_inline || sig.header.constness == hir::Constness::Const || always_encode_mir
             }
             _ => false,
         };

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -30,7 +30,12 @@ pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> Body<'_> {
     // Figure out what primary body this item has.
     let (body_id, return_ty_span) = match tcx.hir().get(id) {
         Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(_, decl, body_id, _, _), .. })
-        | Node::Item(hir::Item { kind: hir::ItemKind::Fn(decl, _, _, body_id), .. })
+        | Node::Item(
+            hir::Item {
+                kind: hir::ItemKind::Fn(hir::MethodSig { decl, .. }, _, body_id),
+                ..
+            }
+        )
         | Node::ImplItem(
             hir::ImplItem {
                 kind: hir::ImplItemKind::Method(hir::MethodSig { decl, .. }, body_id),

--- a/src/librustc_mir/build/mod.rs
+++ b/src/librustc_mir/build/mod.rs
@@ -32,20 +32,20 @@ pub fn mir_build(tcx: TyCtxt<'_>, def_id: DefId) -> Body<'_> {
         Node::Expr(hir::Expr { kind: hir::ExprKind::Closure(_, decl, body_id, _, _), .. })
         | Node::Item(
             hir::Item {
-                kind: hir::ItemKind::Fn(hir::MethodSig { decl, .. }, _, body_id),
+                kind: hir::ItemKind::Fn(hir::FnSig { decl, .. }, _, body_id),
                 ..
             }
         )
         | Node::ImplItem(
             hir::ImplItem {
-                kind: hir::ImplItemKind::Method(hir::MethodSig { decl, .. }, body_id),
+                kind: hir::ImplItemKind::Method(hir::FnSig { decl, .. }, body_id),
                 ..
             }
         )
         | Node::TraitItem(
             hir::TraitItem {
                 kind: hir::TraitItemKind::Method(
-                    hir::MethodSig { decl, .. },
+                    hir::FnSig { decl, .. },
                     hir::TraitMethod::Provided(body_id),
                 ),
                 ..

--- a/src/librustc_mir/monomorphize/collector.rs
+++ b/src/librustc_mir/monomorphize/collector.rs
@@ -1071,7 +1071,7 @@ impl ItemLikeVisitor<'v> for RootCollector<'_, 'v> {
 
     fn visit_impl_item(&mut self, ii: &'v hir::ImplItem) {
         match ii.kind {
-            hir::ImplItemKind::Method(hir::MethodSig { .. }, _) => {
+            hir::ImplItemKind::Method(hir::FnSig { .. }, _) => {
                 let def_id = self.tcx.hir().local_def_id(ii.hir_id);
                 self.push_if_root(def_id);
             }

--- a/src/librustc_mir/transform/check_unsafety.rs
+++ b/src/librustc_mir/transform/check_unsafety.rs
@@ -576,10 +576,10 @@ fn is_enclosed(
         if used_unsafe.contains(&parent_id) {
             Some(("block".to_string(), parent_id))
         } else if let Some(Node::Item(&hir::Item {
-            kind: hir::ItemKind::Fn(_, header, _, _),
+            kind: hir::ItemKind::Fn(ref sig, _, _),
             ..
         })) = tcx.hir().find(parent_id) {
-            match header.unsafety {
+            match sig.header.unsafety {
                 hir::Unsafety::Unsafe => Some(("fn".to_string(), parent_id)),
                 hir::Unsafety::Normal => None,
             }

--- a/src/librustc_passes/ast_validation.rs
+++ b/src/librustc_passes/ast_validation.rs
@@ -575,12 +575,12 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                         .note("only trait implementations may be annotated with default").emit();
                 }
             }
-            ItemKind::Fn(ref decl, ref header, ref generics, _) => {
-                self.visit_fn_header(header);
-                self.check_fn_decl(decl);
+            ItemKind::Fn(ref sig, ref generics, _) => {
+                self.visit_fn_header(&sig.header);
+                self.check_fn_decl(&sig.decl);
                 // We currently do not permit const generics in `const fn`, as
                 // this is tantamount to allowing compile-time dependent typing.
-                if header.constness.node == Constness::Const {
+                if sig.header.constness.node == Constness::Const {
                     // Look for const generics and error if we find any.
                     for param in &generics.params {
                         match param.kind {

--- a/src/librustc_resolve/late.rs
+++ b/src/librustc_resolve/late.rs
@@ -731,7 +731,7 @@ impl<'a, 'b> LateResolutionVisitor<'a, '_> {
         match item.kind {
             ItemKind::TyAlias(_, ref generics) |
             ItemKind::OpaqueTy(_, ref generics) |
-            ItemKind::Fn(_, _, ref generics, _) => {
+            ItemKind::Fn(_, ref generics, _) => {
                 self.with_generic_param_rib(generics, ItemRibKind(HasGenericParams::Yes),
                                             |this| visit::walk_item(this, item));
             }

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -272,7 +272,7 @@ impl<'l, 'tcx> DumpVisitor<'l, 'tcx> {
 
     fn process_method(
         &mut self,
-        sig: &'l ast::MethodSig,
+        sig: &'l ast::FnSig,
         body: Option<&'l ast::Block>,
         id: ast::NodeId,
         ident: ast::Ident,

--- a/src/librustc_save_analysis/dump_visitor.rs
+++ b/src/librustc_save_analysis/dump_visitor.rs
@@ -1334,8 +1334,8 @@ impl<'l, 'tcx> Visitor<'l> for DumpVisitor<'l, 'tcx> {
                     );
                 }
             }
-            Fn(ref decl, ref header, ref ty_params, ref body) => {
-                self.process_fn(item, &decl, &header, ty_params, &body)
+            Fn(ref sig, ref ty_params, ref body) => {
+                self.process_fn(item, &sig.decl, &sig.header, ty_params, &body)
             }
             Static(ref typ, _, ref expr) => self.process_static_or_const_item(item, typ, expr),
             Const(ref typ, ref expr) => self.process_static_or_const_item(item, &typ, &expr),

--- a/src/librustc_save_analysis/lib.rs
+++ b/src/librustc_save_analysis/lib.rs
@@ -180,7 +180,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
 
     pub fn get_item_data(&self, item: &ast::Item) -> Option<Data> {
         match item.kind {
-            ast::ItemKind::Fn(ref decl, .., ref generics, _) => {
+            ast::ItemKind::Fn(ref sig, .., ref generics, _) => {
                 let qualname = format!("::{}",
                     self.tcx.def_path_str(self.tcx.hir().local_def_id_from_node_id(item.id)));
                 filter!(self.span_utils, item.ident.span);
@@ -190,7 +190,7 @@ impl<'l, 'tcx> SaveContext<'l, 'tcx> {
                     span: self.span_from_span(item.ident.span),
                     name: item.ident.to_string(),
                     qualname,
-                    value: make_signature(decl, generics),
+                    value: make_signature(&sig.decl, generics),
                     parent: None,
                     children: vec![],
                     decl_id: None,

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -72,7 +72,7 @@ pub fn method_signature(
     id: NodeId,
     ident: ast::Ident,
     generics: &ast::Generics,
-    m: &ast::MethodSig,
+    m: &ast::FnSig,
     scx: &SaveContext<'_, '_>,
 ) -> Option<Signature> {
     if !scx.config.signatures {
@@ -932,7 +932,7 @@ fn make_method_signature(
     id: NodeId,
     ident: ast::Ident,
     generics: &ast::Generics,
-    m: &ast::MethodSig,
+    m: &ast::FnSig,
     scx: &SaveContext<'_, '_>,
 ) -> Result {
     // FIXME code dup with function signature

--- a/src/librustc_save_analysis/sig.rs
+++ b/src/librustc_save_analysis/sig.rs
@@ -376,7 +376,7 @@ impl Sig for ast::Item {
 
                 Ok(extend_sig(ty, text, defs, vec![]))
             }
-            ast::ItemKind::Fn(ref decl, header, ref generics, _) => {
+            ast::ItemKind::Fn(ast::FnSig { ref decl, header }, ref generics, _) => {
                 let mut text = String::new();
                 if header.constness.node == ast::Constness::Const {
                     text.push_str("const ");

--- a/src/librustc_typeck/check/wfcheck.rs
+++ b/src/librustc_typeck/check/wfcheck.rs
@@ -190,7 +190,7 @@ fn check_associated_item(
     tcx: TyCtxt<'_>,
     item_id: hir::HirId,
     span: Span,
-    sig_if_method: Option<&hir::MethodSig>,
+    sig_if_method: Option<&hir::FnSig>,
 ) {
     debug!("check_associated_item: {:?}", item_id);
 
@@ -783,7 +783,7 @@ const HELP_FOR_SELF_TYPE: &str =
 
 fn check_method_receiver<'fcx, 'tcx>(
     fcx: &FnCtxt<'fcx, 'tcx>,
-    method_sig: &hir::MethodSig,
+    fn_sig: &hir::FnSig,
     method: &ty::AssocItem,
     self_ty: Ty<'tcx>,
 ) {
@@ -794,7 +794,7 @@ fn check_method_receiver<'fcx, 'tcx>(
         return;
     }
 
-    let span = method_sig.decl.inputs[0].span;
+    let span = fn_sig.decl.inputs[0].span;
 
     let sig = fcx.tcx.fn_sig(method.def_id);
     let sig = fcx.normalize_associated_types_in(span, &sig);

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -1809,7 +1809,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
         },
 
         TraitItem(hir::TraitItem {
-            kind: TraitItemKind::Method(MethodSig { header, decl }, _),
+            kind: TraitItemKind::Method(FnSig { header, decl }, _),
             ..
         }) => {
             AstConv::ty_of_fn(&icx, header.unsafety, header.abi, decl)

--- a/src/librustc_typeck/collect.rs
+++ b/src/librustc_typeck/collect.rs
@@ -885,8 +885,8 @@ fn has_late_bound_regions<'tcx>(tcx: TyCtxt<'tcx>, node: Node<'tcx>) -> Option<S
             _ => None,
         },
         Node::Item(item) => match item.kind {
-            hir::ItemKind::Fn(ref fn_decl, .., ref generics, _) => {
-                has_late_bound_regions(tcx, generics, fn_decl)
+            hir::ItemKind::Fn(ref sig, .., ref generics, _) => {
+                has_late_bound_regions(tcx, generics, &sig.decl)
             }
             _ => None,
         },
@@ -1779,17 +1779,17 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
 
     match tcx.hir().get(hir_id) {
         TraitItem(hir::TraitItem {
-            kind: TraitItemKind::Method(MethodSig { header, decl }, TraitMethod::Provided(_)),
+            kind: TraitItemKind::Method(sig, TraitMethod::Provided(_)),
             ..
         })
         | ImplItem(hir::ImplItem {
-            kind: ImplItemKind::Method(MethodSig { header, decl }, _),
+            kind: ImplItemKind::Method(sig, _),
             ..
         })
         | Item(hir::Item {
-            kind: ItemKind::Fn(decl, header, _, _),
+            kind: ItemKind::Fn(sig, _, _),
             ..
-        }) => match get_infer_ret_ty(&decl.output) {
+        }) => match get_infer_ret_ty(&sig.decl.output) {
             Some(ty) => {
                 let fn_sig = tcx.typeck_tables_of(def_id).liberated_fn_sigs()[hir_id];
                 let mut diag = bad_placeholder_type(tcx, ty.span);
@@ -1805,7 +1805,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: DefId) -> ty::PolyFnSig<'_> {
                 diag.emit();
                 ty::Binder::bind(fn_sig)
             },
-            None => AstConv::ty_of_fn(&icx, header.unsafety, header.abi, decl)
+            None => AstConv::ty_of_fn(&icx, sig.header.unsafety, sig.header.abi, &sig.decl)
         },
 
         TraitItem(hir::TraitItem {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1984,7 +1984,7 @@ pub struct Method {
     pub ret_types: Vec<Type>,
 }
 
-impl<'a> Clean<Method> for (&'a hir::MethodSig, &'a hir::Generics, hir::BodyId,
+impl<'a> Clean<Method> for (&'a hir::FnSig, &'a hir::Generics, hir::BodyId,
                             Option<hir::Defaultness>) {
     fn clean(&self, cx: &DocContext<'_>) -> Method {
         let (generics, decl) = enter_impl_trait(cx, || {

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -438,8 +438,8 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 om.structs.push(self.visit_variant_data(item, ident.name, sd, gen)),
             hir::ItemKind::Union(ref sd, ref gen) =>
                 om.unions.push(self.visit_union_data(item, ident.name, sd, gen)),
-            hir::ItemKind::Fn(ref fd, header, ref gen, body) =>
-                self.visit_fn(om, item, ident.name, &**fd, header, gen, body),
+            hir::ItemKind::Fn(ref sig, ref gen, body) =>
+                self.visit_fn(om, item, ident.name, &sig.decl, sig.header, gen, body),
             hir::ItemKind::TyAlias(ref ty, ref gen) => {
                 let t = Typedef {
                     ty,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1501,10 +1501,10 @@ pub struct MutTy {
     pub mutbl: Mutability,
 }
 
-/// Represents a method's signature in a trait declaration,
-/// or in an implementation.
+/// Represents a function's signature in a trait declaration,
+/// trait implementation, or free function.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
-pub struct MethodSig {
+pub struct FnSig {
     pub header: FnHeader,
     pub decl: P<FnDecl>,
 }
@@ -1528,7 +1528,7 @@ pub struct TraitItem {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum TraitItemKind {
     Const(P<Ty>, Option<P<Expr>>),
-    Method(MethodSig, Option<P<Block>>),
+    Method(FnSig, Option<P<Block>>),
     Type(GenericBounds, Option<P<Ty>>),
     Macro(Mac),
 }
@@ -1552,7 +1552,7 @@ pub struct ImplItem {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub enum ImplItemKind {
     Const(P<Ty>, P<Expr>),
-    Method(MethodSig, P<Block>),
+    Method(FnSig, P<Block>),
     TyAlias(P<Ty>),
     OpaqueTy(GenericBounds),
     Macro(Mac),

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2433,7 +2433,7 @@ pub enum ItemKind {
     /// A function declaration (`fn`).
     ///
     /// E.g., `fn foo(bar: usize) -> usize { .. }`.
-    Fn(P<FnDecl>, FnHeader, Generics, P<Block>),
+    Fn(FnSig, Generics, P<Block>),
     /// A module declaration (`mod`).
     ///
     /// E.g., `mod foo;` or `mod foo { .. }`.

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -357,7 +357,7 @@ pub fn visit_bounds<T: MutVisitor>(bounds: &mut GenericBounds, vis: &mut T) {
 }
 
 // No `noop_` prefix because there isn't a corresponding method in `MutVisitor`.
-pub fn visit_method_sig<T: MutVisitor>(FnSig { header, decl }: &mut FnSig, vis: &mut T) {
+pub fn visit_fn_sig<T: MutVisitor>(FnSig { header, decl }: &mut FnSig, vis: &mut T) {
     vis.visit_fn_header(header);
     vis.visit_fn_decl(decl);
 }
@@ -878,9 +878,8 @@ pub fn noop_visit_item_kind<T: MutVisitor>(kind: &mut ItemKind, vis: &mut T) {
             vis.visit_ty(ty);
             vis.visit_expr(expr);
         }
-        ItemKind::Fn(decl, header, generics, body) => {
-            vis.visit_fn_decl(decl);
-            vis.visit_fn_header(header);
+        ItemKind::Fn(sig, generics, body) => {
+            visit_fn_sig(sig, vis);
             vis.visit_generics(generics);
             vis.visit_block(body);
         }
@@ -938,7 +937,7 @@ pub fn noop_flat_map_trait_item<T: MutVisitor>(mut item: TraitItem, vis: &mut T)
             visit_opt(default, |default| vis.visit_expr(default));
         }
         TraitItemKind::Method(sig, body) => {
-            visit_method_sig(sig, vis);
+            visit_fn_sig(sig, vis);
             visit_opt(body, |body| vis.visit_block(body));
         }
         TraitItemKind::Type(bounds, default) => {
@@ -970,7 +969,7 @@ pub fn noop_flat_map_impl_item<T: MutVisitor>(mut item: ImplItem, visitor: &mut 
             visitor.visit_expr(expr);
         }
         ImplItemKind::Method(sig, body) => {
-            visit_method_sig(sig, visitor);
+            visit_fn_sig(sig, visitor);
             visitor.visit_block(body);
         }
         ImplItemKind::TyAlias(ty) => visitor.visit_ty(ty),

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -357,7 +357,7 @@ pub fn visit_bounds<T: MutVisitor>(bounds: &mut GenericBounds, vis: &mut T) {
 }
 
 // No `noop_` prefix because there isn't a corresponding method in `MutVisitor`.
-pub fn visit_method_sig<T: MutVisitor>(MethodSig { header, decl }: &mut MethodSig, vis: &mut T) {
+pub fn visit_method_sig<T: MutVisitor>(FnSig { header, decl }: &mut FnSig, vis: &mut T) {
     vis.visit_fn_header(header);
     vis.visit_fn_decl(decl);
 }

--- a/src/libsyntax/parse/parser/item.rs
+++ b/src/libsyntax/parse/parser/item.rs
@@ -1800,7 +1800,7 @@ impl<'a> Parser<'a> {
             is_name_required: |_| true,
         })?;
         let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
-        let kind = ItemKind::Fn(decl, header, generics, body);
+        let kind = ItemKind::Fn(FnSig { decl, header }, generics, body);
         self.mk_item_with_info(attrs, lo, vis, (ident, kind, Some(inner_attrs)))
     }
 

--- a/src/libsyntax/parse/parser/item.rs
+++ b/src/libsyntax/parse/parser/item.rs
@@ -8,7 +8,7 @@ use crate::ast::{ItemKind, ImplItem, ImplItemKind, TraitItem, TraitItemKind, Use
 use crate::ast::{PathSegment, IsAuto, Constness, IsAsync, Unsafety, Defaultness};
 use crate::ast::{Visibility, VisibilityKind, Mutability, FnHeader, ForeignItem, ForeignItemKind};
 use crate::ast::{Ty, TyKind, Generics, GenericBounds, TraitRef, EnumDef, VariantData, StructField};
-use crate::ast::{Mac, MacDelimiter, Block, BindingMode, FnDecl, MethodSig, SelfKind, Param};
+use crate::ast::{Mac, MacDelimiter, Block, BindingMode, FnDecl, FnSig, SelfKind, Param};
 use crate::parse::token;
 use crate::tokenstream::{TokenTree, TokenStream};
 use crate::symbol::{kw, sym};
@@ -1897,14 +1897,14 @@ impl<'a> Parser<'a> {
     fn parse_method_sig(
         &mut self,
         is_name_required: fn(&token::Token) -> bool,
-    ) -> PResult<'a, (Ident, MethodSig, Generics)> {
+    ) -> PResult<'a, (Ident, FnSig, Generics)> {
         let header = self.parse_fn_front_matter()?;
         let (ident, decl, generics) = self.parse_fn_sig(ParamCfg {
             is_self_allowed: true,
             allow_c_variadic: false,
             is_name_required,
         })?;
-        Ok((ident, MethodSig { header, decl }, generics))
+        Ok((ident, FnSig { header, decl }, generics))
     }
 
     /// Parses all the "front matter" for a `fn` declaration, up to

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1199,11 +1199,11 @@ impl<'a> State<'a> {
                 self.s.word(";");
                 self.end(); // end the outer cbox
             }
-            ast::ItemKind::Fn(ref decl, header, ref param_names, ref body) => {
+            ast::ItemKind::Fn(ref sig, ref param_names, ref body) => {
                 self.head("");
                 self.print_fn(
-                    decl,
-                    header,
+                    &sig.decl,
+                    sig.header,
                     Some(item.ident),
                     param_names,
                     &item.vis

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1541,7 +1541,7 @@ impl<'a> State<'a> {
     crate fn print_method_sig(&mut self,
                             ident: ast::Ident,
                             generics: &ast::Generics,
-                            m: &ast::MethodSig,
+                            m: &ast::FnSig,
                             vis: &ast::Visibility)
                             {
         self.print_fn(&m.decl,

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -25,7 +25,7 @@ pub enum FnKind<'a> {
     ItemFn(Ident, &'a FnHeader, &'a Visibility, &'a Block),
 
     /// E.g., `fn foo(&self)`.
-    Method(Ident, &'a MethodSig, Option<&'a Visibility>, &'a Block),
+    Method(Ident, &'a FnSig, Option<&'a Visibility>, &'a Block),
 
     /// E.g., `|x, y| body`.
     Closure(&'a Expr),

--- a/src/libsyntax/visit.rs
+++ b/src/libsyntax/visit.rs
@@ -244,12 +244,11 @@ pub fn walk_item<'a, V: Visitor<'a>>(visitor: &mut V, item: &'a Item) {
             visitor.visit_ty(typ);
             visitor.visit_expr(expr);
         }
-        ItemKind::Fn(ref declaration, ref header, ref generics, ref body) => {
+        ItemKind::Fn(ref sig, ref generics, ref body) => {
             visitor.visit_generics(generics);
-            visitor.visit_fn_header(header);
-            visitor.visit_fn(FnKind::ItemFn(item.ident, header,
-                                            &item.vis, body),
-                             declaration,
+            visitor.visit_fn_header(&sig.header);
+            visitor.visit_fn(FnKind::ItemFn(item.ident, &sig.header, &item.vis, body),
+                             &sig.decl,
                              item.span,
                              item.id)
         }

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -950,7 +950,7 @@ impl<'a> MethodDef<'a> {
 
         let trait_lo_sp = trait_.span.shrink_to_lo();
 
-        let sig = ast::MethodSig {
+        let sig = ast::FnSig {
             header: ast::FnHeader {
                 unsafety,
                 abi: Abi::new(abi, trait_lo_sp),

--- a/src/libsyntax_ext/test_harness.rs
+++ b/src/libsyntax_ext/test_harness.rs
@@ -306,10 +306,9 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
         ecx.block(sp, vec![call_test_main])
     };
 
-    let main = ast::ItemKind::Fn(ecx.fn_decl(vec![], ast::FunctionRetTy::Ty(main_ret_ty)),
-                           ast::FnHeader::default(),
-                           ast::Generics::default(),
-                           main_body);
+    let decl = ecx.fn_decl(vec![], ast::FunctionRetTy::Ty(main_ret_ty));
+    let sig = ast::FnSig { decl, header: ast::FnHeader::default() };
+    let main = ast::ItemKind::Fn(sig, ast::Generics::default(), main_body);
 
     // Honor the reexport_test_harness_main attribute
     let main_id = match cx.reexport_test_harness_main {


### PR DESCRIPTION
In both AST & HIR, rename `MethodSig` to `FnSig` and then proceed to use it in `ItemKind::Fn` so that the overall structure is more regular.

r? @davidtwco 