### PR TITLE
Update Clang & build MSVC LLVM with it

### DIFF
--- a/src/ci/azure-pipelines/auto.yml
+++ b/src/ci/azure-pipelines/auto.yml
@@ -318,7 +318,7 @@ jobs:
       # 32/64 bit MSVC and GNU deployment
       dist-x86_64-msvc:
         MSYS_BITS: 64
-        RUST_CONFIGURE_ARGS: >
+        RUST_CONFIGURE_ARGS: >-
           --build=x86_64-pc-windows-msvc
           --target=x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
           --enable-full-tools
@@ -328,7 +328,7 @@ jobs:
         DEPLOY: 1
       dist-i686-msvc:
         MSYS_BITS: 32
-        RUST_CONFIGURE_ARGS: >
+        RUST_CONFIGURE_ARGS: >-
           --build=i686-pc-windows-msvc
           --target=i586-pc-windows-msvc
           --enable-full-tools

--- a/src/ci/docker/dist-i686-linux/Dockerfile
+++ b/src/ci/docker/dist-i686-linux/Dockerfile
@@ -69,7 +69,7 @@ RUN ./build-python.sh
 
 # Now build LLVM+Clang 7, afterwards configuring further compilations to use the
 # clang/clang++ compilers.
-COPY dist-x86_64-linux/build-clang.sh /tmp/
+COPY dist-x86_64-linux/build-clang.sh dist-x86_64-linux/llvm-project-centos.patch /tmp/
 RUN ./build-clang.sh
 ENV CC=clang CXX=clang++
 

--- a/src/ci/docker/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/dist-x86_64-linux/Dockerfile
@@ -69,7 +69,7 @@ RUN ./build-python.sh
 
 # Now build LLVM+Clang 7, afterwards configuring further compilations to use the
 # clang/clang++ compilers.
-COPY dist-x86_64-linux/build-clang.sh /tmp/
+COPY dist-x86_64-linux/build-clang.sh dist-x86_64-linux/llvm-project-centos.patch /tmp/
 RUN ./build-clang.sh
 ENV CC=clang CXX=clang++
 

--- a/src/ci/docker/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/dist-x86_64-linux/build-clang.sh
@@ -4,13 +4,16 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-8.0.0-rc2
+LLVM=llvmorg-9.0.0
 
 mkdir llvm-project
 cd llvm-project
 
 curl -L https://github.com/llvm/llvm-project/archive/$LLVM.tar.gz | \
   tar xzf - --strip-components=1
+
+yum install -y patch
+patch -Np1 < ../llvm-project-centos.patch
 
 mkdir clang-build
 cd clang-build

--- a/src/ci/docker/dist-x86_64-linux/llvm-project-centos.patch
+++ b/src/ci/docker/dist-x86_64-linux/llvm-project-centos.patch
@@ -1,0 +1,18 @@
+diff --git a/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp b/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp
+index 176d6d6abf3..a6d63bf24b8 100644
+--- a/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp
++++ b/clang/lib/DirectoryWatcher/linux/DirectoryWatcher-linux.cpp
+@@ -33,6 +33,13 @@ namespace {
+ using namespace llvm;
+ using namespace clang;
+ 
++#define EPOLL_CLOEXEC -1
++#define IN_CLOEXEC -1
++#define O_CLOEXEC -1
++static int epoll_create1(int flags) { return -1; }
++static int inotify_init1(int flags) { return -1; }
++static int pipe2(int *fds, int flags) { return -1; }
++
+ /// Pipe for inter-thread synchronization - for epoll-ing on multiple
+ /// conditions. It is meant for uni-directional 1:1 signalling - specifically:
+ /// no multiple consumers, no data passing. Thread waiting for signal should

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -9,10 +9,10 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 if isMacOS; then
-    curl -f "${MIRRORS_BASE}/clang%2Bllvm-7.0.0-x86_64-apple-darwin.tar.xz" | tar xJf -
+    curl -f "${MIRRORS_BASE}/clang%2Bllvm-9.0.0-x86_64-darwin-apple.tar.xz" | tar xJf -
 
-    ciCommandSetEnv CC "$(pwd)/clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang"
-    ciCommandSetEnv CXX "$(pwd)/clang+llvm-7.0.0-x86_64-apple-darwin/bin/clang++"
+    ciCommandSetEnv CC "$(pwd)/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang"
+    ciCommandSetEnv CXX "$(pwd)/clang+llvm-9.0.0-x86_64-darwin-apple/bin/clang++"
 
     # Configure `AR` specifically so rustbuild doesn't try to infer it as
     # `clang-ar` by accident.
@@ -27,17 +27,18 @@ elif isWindows && [[ -z ${MINGW_URL+x} ]]; then
     # Note that the LLVM installer is an NSIS installer
     #
     # Original downloaded here came from
-    # http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe
-    # That installer was run through `wine` on Linux and then the resulting
-    # installation directory (found in `$HOME/.wine/drive_c/Program Files/LLVM`) was
-    # packaged up into a tarball. We've had issues otherwise that the installer will
-    # randomly hang, provide not a lot of useful information, pollute global state,
-    # etc. In general the tarball is just more confined and easier to deal with when
-    # working with various CI environments.
+    # http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe
+    # That installer was run through `wine ./installer.exe /S /NCRC` on Linux
+    # and then the resulting installation directory (found in
+    # `$HOME/.wine/drive_c/Program Files/LLVM`) was packaged up into a tarball.
+    # We've had issues otherwise that the installer will randomly hang, provide
+    # not a lot of useful information, pollute global state, etc. In general the
+    # tarball is just more confined and easier to deal with when working with
+    # various CI environments.
 
     mkdir -p citools
     cd citools
-    curl -f "${MIRRORS_BASE}/LLVM-7.0.0-win64.tar.gz" | tar xzf -
+    curl -f "${MIRRORS_BASE}/LLVM-9.0.0-win64.tar.gz" | tar xzf -
     ciCommandSetEnv RUST_CONFIGURE_ARGS \
         "${RUST_CONFIGURE_ARGS} --set llvm.clang-cl=$(pwd)/clang-rust/bin/clang-cl.exe"
 fi


### PR DESCRIPTION
This is a general update of our builders to Clang 9, and then it also attempts to tackle a bit of #66192 by building LLVM for rustc with Clang, not with the system `cl.exe` on MSVC.