### PR TITLE
Fix generating CTFE backtrace on optimized MIR

### DIFF
--- a/src/librustc/mir/mod.rs
+++ b/src/librustc/mir/mod.rs
@@ -105,6 +105,14 @@ pub struct Body<'tcx> {
 
     /// Crate-local information for each source scope, that can't (and
     /// needn't) be tracked across crates.
+    ///
+    /// Before optimizations run, every scope in `source_scopes` is guarnateed
+    /// to have an entry in `source_scope_local_data` (assuming it is `ClearCrossCrate::Set`).
+    ///
+    /// However, after optimizations are run, there may be some scopes with no entry
+    /// in `source_scope_local_data:`. This is due to the fact that MIR inlining can
+    /// cause scopes from a different crate to be inlined into this `Body`, which
+    /// cannot have crate-local data.
     pub source_scope_local_data: ClearCrossCrate<IndexVec<SourceScope, SourceScopeLocalData>>,
 
     /// The yield type of the function, if it is a generator.

--- a/src/librustc_mir/interpret/eval_context.rs
+++ b/src/librustc_mir/interpret/eval_context.rs
@@ -816,7 +816,12 @@ impl<'mir, 'tcx, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                     block.terminator().source_info
                 };
                 match body.source_scope_local_data {
-                    mir::ClearCrossCrate::Set(ref ivs) => Some(ivs[source_info.scope].lint_root),
+                    // The scope may have been inlined from a different crate, in which
+                    // case we will not have crate-local data for it. If that is the case,
+                    // we just use our root lint level.
+                    mir::ClearCrossCrate::Set(ref ivs) => {
+                        ivs.get(source_info.scope).map(|d| d.lint_root)
+                    }
                     mir::ClearCrossCrate::Clear => None,
                 }
             });


### PR DESCRIPTION
During MIR optimization, we may inline function calls acrross crates.
While we can inline the corresponding scopes into `Body.source_scopes`,
we cannot inline the corresponding data from `source_scope_local_data`,
since it references crate-local data.

This commit makes us fall back to the root lint level when generating a
CTFE backtrace, if it was not possible to find crate-local data for a
scope in `source_scope_local_data`.

Fixes #66137