### PR TITLE
MacOS: add linker flag "-undefined dynamic_lookup" for shared libs.

### DIFF
--- a/src/librustc_codegen_ssa/back/linker.rs
+++ b/src/librustc_codegen_ssa/back/linker.rs
@@ -361,6 +361,9 @@ impl<'a> Linker for GccLinker<'a> {
             self.cmd.arg("-dynamiclib");
             self.linker_arg("-dylib");
 
+            // some symbols may be defined in the program loading the library
+            self.linker_arg("-undefined,dynamic_lookup");
+
             // Note that the `osx_rpath_install_name` option here is a hack
             // purely to support rustbuild right now, we should get a more
             // principled solution at some point to force the compiler to pass


### PR DESCRIPTION
Necessary for shared libraries where not all symbols are resolved
until the library is loaded at runtime.

Fixes #62874