### PR TITLE
Suggest `#[repr(C)]` instead of `#[repr(C, packed, ...)]`

### DIFF
--- a/src/libsyntax/feature_gate/builtin_attrs.rs
+++ b/src/libsyntax/feature_gate/builtin_attrs.rs
@@ -231,7 +231,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(link_name, Whitelisted, template!(NameValueStr: "name")),
     ungated!(no_link, Normal, template!(Word)),
-    ungated!(repr, Normal, template!(List: "C, packed, ...")),
+    ungated!(repr, Normal, template!(List: "C")),
     ungated!(export_name, Whitelisted, template!(NameValueStr: "name")),
     ungated!(link_section, Whitelisted, template!(NameValueStr: "name")),
     ungated!(no_mangle, Whitelisted, template!(Word)),

--- a/src/test/ui/issues/issue-43988.stderr
+++ b/src/test/ui/issues/issue-43988.stderr
@@ -2,13 +2,13 @@ error: malformed `repr` attribute input
   --> $DIR/issue-43988.rs:24:5
    |
 LL |     #[repr]
-   |     ^^^^^^^ help: must be of the form: `#[repr(C, packed, ...)]`
+   |     ^^^^^^^ help: must be of the form: `#[repr(C)]`
 
 error: malformed `repr` attribute input
   --> $DIR/issue-43988.rs:35:14
    |
 LL |     let _z = #[repr] 1;
-   |              ^^^^^^^ help: must be of the form: `#[repr(C, packed, ...)]`
+   |              ^^^^^^^ help: must be of the form: `#[repr(C)]`
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-43988.rs:5:5

--- a/src/test/ui/repr.stderr
+++ b/src/test/ui/repr.stderr
@@ -2,19 +2,19 @@ error: malformed `repr` attribute input
   --> $DIR/repr.rs:1:1
    |
 LL | #[repr]
-   | ^^^^^^^ help: must be of the form: `#[repr(C, packed, ...)]`
+   | ^^^^^^^ help: must be of the form: `#[repr(C)]`
 
 error: malformed `repr` attribute input
   --> $DIR/repr.rs:4:1
    |
 LL | #[repr = "B"]
-   | ^^^^^^^^^^^^^ help: must be of the form: `#[repr(C, packed, ...)]`
+   | ^^^^^^^^^^^^^ help: must be of the form: `#[repr(C)]`
 
 error: malformed `repr` attribute input
   --> $DIR/repr.rs:7:1
    |
 LL | #[repr = "C"]
-   | ^^^^^^^^^^^^^ help: must be of the form: `#[repr(C, packed, ...)]`
+   | ^^^^^^^^^^^^^ help: must be of the form: `#[repr(C)]`
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
The code was previously suggesting `#[repr(C, packed, ...)]` for incorrect uses of `repr` (e.g. `#[repr = "C"]`). This change suggests the usage of `#[repr(C)]` instead.

r? @estebank

Ref: #61286.