### PR TITLE
Make error and warning annotations mandatory in UI tests

### DIFF
--- a/src/test/rustdoc-ui/intra-links-warning-crlf.rs
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.rs
@@ -1,19 +1,21 @@
 // ignore-tidy-cr
-
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 // This file checks the spans of intra-link warnings in a file with CRLF line endings. The
 // .gitattributes file in this directory should enforce it.
 
 /// [error]
 pub struct A;
+//~^^ WARNING `[error]` cannot be resolved
 
 ///
 /// docs [error1]
+//~^ WARNING `[error1]` cannot be resolved
 
 /// docs [error2]
 ///
 pub struct B;
+//~^^^ WARNING `[error2]` cannot be resolved
 
 /**
  * This is a multi-line comment.
@@ -21,3 +23,4 @@ pub struct B;
  * It also has an [error].
  */
 pub struct C;
+//~^^^ WARNING `[error]` cannot be resolved

--- a/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning-crlf.stderr
@@ -1,5 +1,5 @@
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning-crlf.rs:8:6
+  --> $DIR/intra-links-warning-crlf.rs:7:6
    |
 LL | /// [error]
    |      ^^^^^ cannot be resolved, ignoring
@@ -16,7 +16,7 @@ LL | /// docs [error1]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error2]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning-crlf.rs:14:11
+  --> $DIR/intra-links-warning-crlf.rs:15:11
    |
 LL | /// docs [error2]
    |           ^^^^^^ cannot be resolved, ignoring
@@ -24,7 +24,7 @@ LL | /// docs [error2]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning-crlf.rs:21:20
+  --> $DIR/intra-links-warning-crlf.rs:23:20
    |
 LL |  * It also has an [error].
    |                    ^^^^^ cannot be resolved, ignoring

--- a/src/test/rustdoc-ui/intra-links-warning.rs
+++ b/src/test/rustdoc-ui/intra-links-warning.rs
@@ -1,30 +1,37 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
        //! Test with [Foo::baz], [Bar::foo], ...
+//~^ WARNING `[Foo::baz]` cannot be resolved
+//~| WARNING `[Bar::foo]` cannot be resolved
      //! , [Uniooon::X] and [Qux::Z].
+//~^ WARNING `[Uniooon::X]` cannot be resolved
+//~| WARNING `[Qux::Z]` cannot be resolved
        //!
       //! , [Uniooon::X] and [Qux::Z].
+//~^ WARNING `[Uniooon::X]` cannot be resolved
+//~| WARNING `[Qux::Z]` cannot be resolved
 
        /// [Qux:Y]
+//~^ WARNING `[Qux:Y]` cannot be resolved
 pub struct Foo {
     pub bar: usize,
 }
 
 /// Foo
-/// bar [BarA] bar
+/// bar [BarA] bar //~ WARNING `[BarA]` cannot be resolved
 /// baz
 pub fn a() {}
 
 /**
  * Foo
- * bar [BarB] bar
+ * bar [BarB] bar //~ WARNING `[BarB]` cannot be resolved
  * baz
  */
 pub fn b() {}
 
 /** Foo
 
-bar [BarC] bar
+bar [BarC] bar //~ WARNING `[BarC]` cannot be resolved
 baz
 
     let bar_c_1 = 0;
@@ -35,12 +42,12 @@ baz
 */
 pub fn c() {}
 
-#[doc = "Foo\nbar [BarD] bar\nbaz"]
+#[doc = "Foo\nbar [BarD] bar\nbaz"] //~ WARNING `[BarD]` cannot be resolved
 pub fn d() {}
 
 macro_rules! f {
     ($f:expr) => {
-        #[doc = $f]
+        #[doc = $f] //~ WARNING `[BarF]` cannot be resolved
         pub fn f() {}
     }
 }
@@ -48,30 +55,30 @@ f!("Foo\nbar [BarF] bar\nbaz");
 
 /** # for example,
  *
- * time to introduce a link [error]*/
+ * time to introduce a link [error]*/ //~ WARNING `[error]` cannot be resolved
 pub struct A;
 
 /**
  * # for example,
  *
- * time to introduce a link [error]
+ * time to introduce a link [error] //~ WARNING `[error]` cannot be resolved
  */
 pub struct B;
 
-#[doc = "single line [error]"]
+#[doc = "single line [error]"] //~ WARNING `[error]` cannot be resolved
 pub struct C;
 
-#[doc = "single line with \"escaping\" [error]"]
+#[doc = "single line with \"escaping\" [error]"] //~ WARNING `[error]` cannot be resolved
 pub struct D;
 
-/// Item docs.
+/// Item docs. //~ WARNING `[error]` cannot be resolved
 #[doc="Hello there!"]
 /// [error]
 pub struct E;
 
 ///
-/// docs [error1]
+/// docs [error1] //~ WARNING `[error1]` cannot be resolved
 
-/// docs [error2]
+/// docs [error2] //~ WARNING `[error2]` cannot be resolved
 ///
 pub struct F;

--- a/src/test/rustdoc-ui/intra-links-warning.stderr
+++ b/src/test/rustdoc-ui/intra-links-warning.stderr
@@ -16,7 +16,7 @@ LL |        //! Test with [Foo::baz], [Bar::foo], ...
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[Uniooon::X]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:4:13
+  --> $DIR/intra-links-warning.rs:6:13
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
    |             ^^^^^^^^^^ cannot be resolved, ignoring
@@ -24,7 +24,7 @@ LL |      //! , [Uniooon::X] and [Qux::Z].
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[Qux::Z]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:4:30
+  --> $DIR/intra-links-warning.rs:6:30
    |
 LL |      //! , [Uniooon::X] and [Qux::Z].
    |                              ^^^^^^ cannot be resolved, ignoring
@@ -32,7 +32,7 @@ LL |      //! , [Uniooon::X] and [Qux::Z].
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[Uniooon::X]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:6:14
+  --> $DIR/intra-links-warning.rs:10:14
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
    |              ^^^^^^^^^^ cannot be resolved, ignoring
@@ -40,7 +40,7 @@ LL |       //! , [Uniooon::X] and [Qux::Z].
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[Qux::Z]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:6:31
+  --> $DIR/intra-links-warning.rs:10:31
    |
 LL |       //! , [Uniooon::X] and [Qux::Z].
    |                               ^^^^^^ cannot be resolved, ignoring
@@ -48,7 +48,7 @@ LL |       //! , [Uniooon::X] and [Qux::Z].
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[Qux:Y]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:8:13
+  --> $DIR/intra-links-warning.rs:14:13
    |
 LL |        /// [Qux:Y]
    |             ^^^^^ cannot be resolved, ignoring
@@ -56,7 +56,7 @@ LL |        /// [Qux:Y]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:51:30
+  --> $DIR/intra-links-warning.rs:58:30
    |
 LL |  * time to introduce a link [error]*/
    |                              ^^^^^ cannot be resolved, ignoring
@@ -64,7 +64,7 @@ LL |  * time to introduce a link [error]*/
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:57:30
+  --> $DIR/intra-links-warning.rs:64:30
    |
 LL |  * time to introduce a link [error]
    |                              ^^^^^ cannot be resolved, ignoring
@@ -72,7 +72,7 @@ LL |  * time to introduce a link [error]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:61:1
+  --> $DIR/intra-links-warning.rs:68:1
    |
 LL | #[doc = "single line [error]"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL | #[doc = "single line [error]"]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:64:1
+  --> $DIR/intra-links-warning.rs:71:1
    |
 LL | #[doc = "single line with \"escaping\" [error]"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -96,7 +96,7 @@ LL | #[doc = "single line with \"escaping\" [error]"]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:67:1
+  --> $DIR/intra-links-warning.rs:74:1
    |
 LL | / /// Item docs.
 LL | | #[doc="Hello there!"]
@@ -110,7 +110,7 @@ LL | | /// [error]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error1]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:73:11
+  --> $DIR/intra-links-warning.rs:80:11
    |
 LL | /// docs [error1]
    |           ^^^^^^ cannot be resolved, ignoring
@@ -118,7 +118,7 @@ LL | /// docs [error1]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[error2]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:75:11
+  --> $DIR/intra-links-warning.rs:82:11
    |
 LL | /// docs [error2]
    |           ^^^^^^ cannot be resolved, ignoring
@@ -126,7 +126,7 @@ LL | /// docs [error2]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[BarA]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:14:10
+  --> $DIR/intra-links-warning.rs:21:10
    |
 LL | /// bar [BarA] bar
    |          ^^^^ cannot be resolved, ignoring
@@ -134,7 +134,7 @@ LL | /// bar [BarA] bar
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[BarB]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:20:9
+  --> $DIR/intra-links-warning.rs:27:9
    |
 LL |  * bar [BarB] bar
    |         ^^^^ cannot be resolved, ignoring
@@ -142,7 +142,7 @@ LL |  * bar [BarB] bar
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[BarC]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:27:6
+  --> $DIR/intra-links-warning.rs:34:6
    |
 LL | bar [BarC] bar
    |      ^^^^ cannot be resolved, ignoring
@@ -150,7 +150,7 @@ LL | bar [BarC] bar
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[BarD]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:38:1
+  --> $DIR/intra-links-warning.rs:45:1
    |
 LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,7 +162,7 @@ LL | #[doc = "Foo\nbar [BarD] bar\nbaz"]
    = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
 
 warning: `[BarF]` cannot be resolved, ignoring it...
-  --> $DIR/intra-links-warning.rs:43:9
+  --> $DIR/intra-links-warning.rs:50:9
    |
 LL |         #[doc = $f]
    |         ^^^^^^^^^^^

--- a/src/test/rustdoc-ui/invalid-syntax.rs
+++ b/src/test/rustdoc-ui/invalid-syntax.rs
@@ -1,9 +1,10 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// build-pass
 
 /// ```
 /// \__________pkt->size___________/          \_result->size_/ \__pkt->size__/
 /// ```
 pub fn foo() {}
+//~^^^^ WARNING could not parse code block as Rust code
 
 /// ```
 ///    |
@@ -11,6 +12,7 @@ pub fn foo() {}
 ///    |     ^^^^^^ did you mean `baz::foobar`?
 /// ```
 pub fn bar() {}
+//~^^^^^^ WARNING could not parse code block as Rust code
 
 /// ```
 /// valid
@@ -24,6 +26,7 @@ pub fn bar() {}
 /// "invalid
 /// ```
 pub fn valid_and_invalid() {}
+//~^^^^^^^^ WARNING could not parse code block as Rust code
 
 /// This is a normal doc comment, but...
 ///
@@ -35,6 +38,7 @@ pub fn valid_and_invalid() {}
 ///
 /// Good thing we tested it!
 pub fn baz() {}
+//~^^^^^^ WARNING could not parse code block as Rust code
 
 /// Indented block start
 ///
@@ -43,6 +47,7 @@ pub fn baz() {}
 ///
 /// Indented block end
 pub fn quux() {}
+//~^^^^^ could not parse code block as Rust code
 
 /// Unclosed fence
 ///
@@ -54,26 +59,31 @@ pub fn xyzzy() {}
 ///
 ///     ```
 pub fn blah() {}
+//~^^ WARNING could not parse code block as Rust code
 
 /// ```edition2018
 /// \_
 /// ```
 pub fn blargh() {}
+//~^^^^ WARNING could not parse code block as Rust code
 
 #[doc = "```"]
 /// \_
 #[doc = "```"]
 pub fn crazy_attrs() {}
+//~^^^^ WARNING doc comment contains an invalid Rust code block
 
 /// ```rust
 /// ```
 pub fn empty_rust() {}
+//~^^^ WARNING Rust code block is empty
 
 /// ```
 ///
 ///
 /// ```
 pub fn empty_rust_with_whitespace() {}
+//~^^^^^ WARNING Rust code block is empty
 
 /// ```
 /// let x = 1;
@@ -82,3 +92,4 @@ pub fn empty_rust_with_whitespace() {}
 ///     \____/
 ///
 pub fn indent_after_fenced() {}
+//~^^^ WARNING could not parse code block as Rust code

--- a/src/test/rustdoc-ui/invalid-syntax.stderr
+++ b/src/test/rustdoc-ui/invalid-syntax.stderr
@@ -53,7 +53,7 @@ help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it
   |                                          ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:8:5
+  --> $DIR/invalid-syntax.rs:9:5
    |
 LL |   /// ```
    |  _____^
@@ -75,7 +75,7 @@ error: unknown start of token: \
   | ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:19:5
+  --> $DIR/invalid-syntax.rs:21:5
    |
 LL |   /// ```
    |  _____^
@@ -95,7 +95,7 @@ error: unknown start of token: \
   | ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:32:5
+  --> $DIR/invalid-syntax.rs:35:5
    |
 LL |   /// ```rust
    |  _____^
@@ -110,7 +110,7 @@ error: unknown start of token: \
   |     ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:41:9
+  --> $DIR/invalid-syntax.rs:45:9
    |
 LL |   ///     code with bad syntax
    |  _________^
@@ -151,7 +151,7 @@ help: Unicode character '`' (Grave Accent) looks like ''' (Single Quote), but it
   |   ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:55:9
+  --> $DIR/invalid-syntax.rs:60:9
    |
 LL | ///     ```
    |         ^^^
@@ -163,7 +163,7 @@ error: unknown start of token: \
   | ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:58:5
+  --> $DIR/invalid-syntax.rs:64:5
    |
 LL |   /// ```edition2018
    |  _____^
@@ -178,7 +178,7 @@ error: unknown start of token: \
   | ^
 
 warning: doc comment contains an invalid Rust code block
-  --> $DIR/invalid-syntax.rs:63:1
+  --> $DIR/invalid-syntax.rs:70:1
    |
 LL | / #[doc = "```"]
 LL | | /// \_
@@ -188,7 +188,7 @@ LL | | #[doc = "```"]
    = help: mark blocks that do not contain Rust code as text: ```text
 
 warning: Rust code block is empty
-  --> $DIR/invalid-syntax.rs:68:5
+  --> $DIR/invalid-syntax.rs:76:5
    |
 LL |   /// ```rust
    |  _____^
@@ -196,7 +196,7 @@ LL | | /// ```
    | |_______^
 
 warning: Rust code block is empty
-  --> $DIR/invalid-syntax.rs:72:5
+  --> $DIR/invalid-syntax.rs:81:5
    |
 LL |   /// ```
    |  _____^
@@ -217,7 +217,7 @@ error: unknown start of token: \
   | ^
 
 warning: could not parse code block as Rust code
-  --> $DIR/invalid-syntax.rs:82:9
+  --> $DIR/invalid-syntax.rs:92:9
    |
 LL | ///     \____/
    |         ^^^^^^

--- a/src/test/ui-fulldeps/issue-15778-pass.rs
+++ b/src/test/ui-fulldeps/issue-15778-pass.rs
@@ -13,7 +13,7 @@
     rustc_crate_green,
 )]
 
-#![plugin(lint_for_crate_rpass)]
+#![plugin(lint_for_crate_rpass)] //~ WARNING compiler plugins are deprecated
 #![rustc_crate_okay]
 #![rustc_crate_blue]
 #![rustc_crate_red]

--- a/src/test/ui-fulldeps/issue-40001.rs
+++ b/src/test/ui-fulldeps/issue-40001.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(issue_40001_plugin)]
+#![plugin(issue_40001_plugin)] //~ WARNING compiler plugins are deprecated
 
 #[whitelisted_attr]
 fn main() {}

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.rs
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.rs
@@ -1,11 +1,10 @@
-// run-pass
+// check-pass
 // aux-build:lint-plugin-test.rs
 // ignore-stage1
 // compile-flags: -A test-lint
 
 #![feature(plugin)]
-#![warn(unused)]
-#![plugin(lint_plugin_test)]
+#![plugin(lint_plugin_test)] //~ WARNING compiler plugins are deprecated
 
 fn lintme() { }
 

--- a/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-plugin-cmdline-allow.stderr
@@ -1,21 +1,8 @@
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/lint-plugin-cmdline-allow.rs:8:1
+  --> $DIR/lint-plugin-cmdline-allow.rs:7:1
    |
 LL | #![plugin(lint_plugin_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
    |
    = note: `#[warn(deprecated)]` on by default
-
-warning: function is never used: `lintme`
-  --> $DIR/lint-plugin-cmdline-allow.rs:10:4
-   |
-LL | fn lintme() { }
-   |    ^^^^^^
-   |
-note: lint level defined here
-  --> $DIR/lint-plugin-cmdline-allow.rs:7:9
-   |
-LL | #![warn(unused)]
-   |         ^^^^^^
-   = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
 

--- a/src/test/ui-fulldeps/lint-tool-cmdline-allow.rs
+++ b/src/test/ui-fulldeps/lint-tool-cmdline-allow.rs
@@ -1,12 +1,12 @@
-// run-pass
+// check-pass
 // aux-build:lint-tool-test.rs
 // ignore-stage1
 // compile-flags: -A test-lint
 
 #![feature(plugin)]
-#![warn(unused)]
-#![plugin(lint_tool_test)]
+#![plugin(lint_tool_test)] //~ WARNING compiler plugins are deprecated
 
 fn lintme() {}
+//~^ WARNING item is named 'lintme' [clippy::test_lint]
 
 pub fn main() {}

--- a/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
+++ b/src/test/ui-fulldeps/lint-tool-cmdline-allow.stderr
@@ -3,7 +3,7 @@ warning: lint name `test_lint` is deprecated and does not have an effect anymore
    = note: requested on the command line with `-A test_lint`
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
-  --> $DIR/lint-tool-cmdline-allow.rs:8:1
+  --> $DIR/lint-tool-cmdline-allow.rs:7:1
    |
 LL | #![plugin(lint_tool_test)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: may be removed in a future compiler version
@@ -11,23 +11,10 @@ LL | #![plugin(lint_tool_test)]
    = note: `#[warn(deprecated)]` on by default
 
 warning: item is named 'lintme'
-  --> $DIR/lint-tool-cmdline-allow.rs:10:1
+  --> $DIR/lint-tool-cmdline-allow.rs:9:1
    |
 LL | fn lintme() {}
    | ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::test_lint)]` on by default
-
-warning: function is never used: `lintme`
-  --> $DIR/lint-tool-cmdline-allow.rs:10:4
-   |
-LL | fn lintme() {}
-   |    ^^^^^^
-   |
-note: lint level defined here
-  --> $DIR/lint-tool-cmdline-allow.rs:7:9
-   |
-LL | #![warn(unused)]
-   |         ^^^^^^
-   = note: `#[warn(dead_code)]` implied by `#[warn(unused)]`
 

--- a/src/test/ui-fulldeps/llvm-pass-plugin.rs
+++ b/src/test/ui-fulldeps/llvm-pass-plugin.rs
@@ -3,6 +3,6 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(llvm_pass_plugin)]
+#![plugin(llvm_pass_plugin)] //~ WARNING compiler plugins are deprecated
 
 pub fn main() { }

--- a/src/test/ui-fulldeps/lto-syntax-extension.rs
+++ b/src/test/ui-fulldeps/lto-syntax-extension.rs
@@ -6,7 +6,7 @@
 // no-prefer-dynamic
 
 #![feature(plugin)]
-#![plugin(lto_syntax_extension_plugin)]
+#![plugin(lto_syntax_extension_plugin)] //~ WARNING compiler plugins are deprecated
 
 extern crate lto_syntax_extension_lib;
 

--- a/src/test/ui-fulldeps/outlive-expansion-phase.rs
+++ b/src/test/ui-fulldeps/outlive-expansion-phase.rs
@@ -3,6 +3,6 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(outlive_expansion_phase)]
+#![plugin(outlive_expansion_phase)] //~ WARNING compiler plugins are deprecated
 
 pub fn main() {}

--- a/src/test/ui-fulldeps/plugin-args-1.rs
+++ b/src/test/ui-fulldeps/plugin-args-1.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(plugin_args)]
+#![plugin(plugin_args)] //~ WARNING compiler plugins are deprecated
 
 fn main() {
     assert_eq!(plugin_args!(), "");

--- a/src/test/ui-fulldeps/plugin-args-2.rs
+++ b/src/test/ui-fulldeps/plugin-args-2.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(plugin_args())]
+#![plugin(plugin_args())] //~ WARNING compiler plugins are deprecated
 
 fn main() {
     assert_eq!(plugin_args!(), "");

--- a/src/test/ui-fulldeps/plugin-args-3.rs
+++ b/src/test/ui-fulldeps/plugin-args-3.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(plugin_args(hello(there), how(are="you")))]
+#![plugin(plugin_args(hello(there), how(are="you")))] //~ WARNING compiler plugins are deprecated
 
 fn main() {
     assert_eq!(plugin_args!(), "hello(there), how(are = \"you\")");

--- a/src/test/ui-fulldeps/roman-numerals-macro.rs
+++ b/src/test/ui-fulldeps/roman-numerals-macro.rs
@@ -3,7 +3,7 @@
 // ignore-stage1
 
 #![feature(plugin)]
-#![plugin(roman_numerals)]
+#![plugin(roman_numerals)] //~ WARNING compiler plugins are deprecated
 
 pub fn main() {
     assert_eq!(rn!(MMXV), 2015);

--- a/src/test/ui/associated-type-bounds/dyn-lcsit.rs
+++ b/src/test/ui/associated-type-bounds/dyn-lcsit.rs
@@ -2,7 +2,7 @@
 
 #![feature(associated_type_bounds)]
 #![feature(impl_trait_in_bindings)]
-
+//~^ WARNING `impl_trait_in_bindings` is incomplete
 #![allow(non_upper_case_globals)]
 
 use std::ops::Add;

--- a/src/test/ui/associated-type-bounds/lcsit.rs
+++ b/src/test/ui/associated-type-bounds/lcsit.rs
@@ -2,7 +2,7 @@
 
 #![feature(associated_type_bounds)]
 #![feature(impl_trait_in_bindings)]
-
+//~^ WARNING `impl_trait_in_bindings` is incomplete
 #![allow(non_upper_case_globals)]
 
 use std::ops::Add;

--- a/src/test/ui/associated-type-bounds/type-alias.rs
+++ b/src/test/ui/associated-type-bounds/type-alias.rs
@@ -1,19 +1,19 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(associated_type_bounds)]
 
-type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
-type _TaWhere2<T> where T: Iterator<Item: 'static> = T;
-type _TaWhere3<T> where T: Iterator<Item: 'static> = T;
-type _TaWhere4<T> where T: Iterator<Item: 'static + Copy + Send> = T;
-type _TaWhere5<T> where T: Iterator<Item: for<'a> Into<&'a u8>> = T;
-type _TaWhere6<T> where T: Iterator<Item: Iterator<Item: Copy>> = T;
+type _TaWhere1<T> where T: Iterator<Item: Copy> = T; //~ WARNING type_alias_bounds
+type _TaWhere2<T> where T: Iterator<Item: 'static> = T; //~ WARNING type_alias_bounds
+type _TaWhere3<T> where T: Iterator<Item: 'static> = T; //~ WARNING type_alias_bounds
+type _TaWhere4<T> where T: Iterator<Item: 'static + Copy + Send> = T; //~ WARNING type_alias_bounds
+type _TaWhere5<T> where T: Iterator<Item: for<'a> Into<&'a u8>> = T; //~ WARNING type_alias_bounds
+type _TaWhere6<T> where T: Iterator<Item: Iterator<Item: Copy>> = T; //~ WARNING type_alias_bounds
 
-type _TaInline1<T: Iterator<Item: Copy>> = T;
-type _TaInline2<T: Iterator<Item: 'static>> = T;
-type _TaInline3<T: Iterator<Item: 'static>> = T;
-type _TaInline4<T: Iterator<Item: 'static + Copy + Send>> = T;
-type _TaInline5<T: Iterator<Item: for<'a> Into<&'a u8>>> = T;
-type _TaInline6<T: Iterator<Item: Iterator<Item: Copy>>> = T;
+type _TaInline1<T: Iterator<Item: Copy>> = T; //~ WARNING type_alias_bounds
+type _TaInline2<T: Iterator<Item: 'static>> = T; //~ WARNING type_alias_bounds
+type _TaInline3<T: Iterator<Item: 'static>> = T; //~ WARNING type_alias_bounds
+type _TaInline4<T: Iterator<Item: 'static + Copy + Send>> = T; //~ WARNING type_alias_bounds
+type _TaInline5<T: Iterator<Item: for<'a> Into<&'a u8>>> = T; //~ WARNING type_alias_bounds
+type _TaInline6<T: Iterator<Item: Iterator<Item: Copy>>> = T; //~ WARNING type_alias_bounds
 
 fn main() {}

--- a/src/test/ui/async-await/issues/issue-54752-async-block.rs
+++ b/src/test/ui/async-await/issues/issue-54752-async-block.rs
@@ -4,3 +4,4 @@
 // pp-exact
 
 fn main() { let _a = (async  { }); }
+//~^ WARNING unnecessary parentheses around assigned value

--- a/src/test/ui/block-expr-precedence.rs
+++ b/src/test/ui/block-expr-precedence.rs
@@ -58,4 +58,5 @@ pub fn main() {
   if (true) { 12; } {-num};
   if (true) { 12; }; {-num};
   if (true) { 12; };;; -num;
+  //~^ WARNING unnecessary trailing semicolons
 }

--- a/src/test/ui/codemap_tests/unicode_3.rs
+++ b/src/test/ui/codemap_tests/unicode_3.rs
@@ -1,6 +1,6 @@
 // build-pass (FIXME(62277): could be check-pass?)
 
 fn main() {
-    let s = "ZͨA͑ͦ͒͋ͤ͑̚L̄͑͋Ĝͨͥ̿͒̽̈́Oͥ͛ͭ!̏"; while true { break; }
+    let s = "ZͨA͑ͦ͒͋ͤ͑̚L̄͑͋Ĝͨͥ̿͒̽̈́Oͥ͛ͭ!̏"; while true { break; } //~ WARNING while_true
     println!("{}", s);
 }

--- a/src/test/ui/consts/const-eval/const_fn_ptr.rs
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.rs
@@ -6,18 +6,18 @@ fn double(x: usize) -> usize { x * 2 }
 const fn double_const(x: usize) -> usize { x * 2 }
 
 const X: fn(usize) -> usize = double;
-const X_const: fn(usize) -> usize = double_const;
+const X_CONST: fn(usize) -> usize = double_const;
 
 const fn bar(x: usize) -> usize {
-    X(x)
+    X(x) //~ WARNING skipping const checks
 }
 
 const fn bar_const(x: usize) -> usize {
-    X_const(x)
+    X_CONST(x) //~ WARNING skipping const checks
 }
 
 const fn foo(x: fn(usize) -> usize, y: usize)  -> usize {
-    x(y)
+    x(y) //~ WARNING skipping const checks
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/const_fn_ptr.stderr
+++ b/src/test/ui/consts/const-eval/const_fn_ptr.stderr
@@ -7,7 +7,7 @@ LL |     X(x)
 warning: skipping const checks
   --> $DIR/const_fn_ptr.rs:16:5
    |
-LL |     X_const(x)
+LL |     X_CONST(x)
    |     ^^^^^^^^^^
 
 warning: skipping const checks
@@ -15,12 +15,4 @@ warning: skipping const checks
    |
 LL |     x(y)
    |     ^^^^
-
-warning: constant `X_const` should have an upper case name
-  --> $DIR/const_fn_ptr.rs:9:7
-   |
-LL | const X_const: fn(usize) -> usize = double_const;
-   |       ^^^^^^^ help: convert the identifier to upper case: `X_CONST`
-   |
-   = note: `#[warn(non_upper_case_globals)]` on by default
 

--- a/src/test/ui/consts/const-eval/issue-64970.rs
+++ b/src/test/ui/consts/const-eval/issue-64970.rs
@@ -10,6 +10,6 @@ fn foo(mut n: i32) {
     }
 
     if n > 0i32 {
-        1i32 / n;
+        let _ = 1i32 / n;
     }
 }

--- a/src/test/ui/consts/const-eval/issue-64970.stderr
+++ b/src/test/ui/consts/const-eval/issue-64970.stderr
@@ -1,8 +1,0 @@
-warning: unused arithmetic operation that must be used
-  --> $DIR/issue-64970.rs:13:9
-   |
-LL |         1i32 / n;
-   |         ^^^^^^^^
-   |
-   = note: `#[warn(unused_must_use)]` on by default
-

--- a/src/test/ui/consts/miri_unleashed/enum_discriminants.rs
+++ b/src/test/ui/consts/miri_unleashed/enum_discriminants.rs
@@ -20,9 +20,9 @@ const OVERFLOW: usize = {
         C(WithWraparoundInvalidValues),
     }
 
-    let x = Foo::B;
+    let x = Foo::B; //~ WARNING skipping const checks
     match x {
-        Foo::B => 0,
+        Foo::B => 0, //~ WARNING skipping const checks
         _ => panic!(),
     }
 };
@@ -86,6 +86,8 @@ const MORE_OVERFLOW: usize = {
     }
 
     if let E1::V2 { .. } = (E1::V1 { f: true }) {
+        //~^ WARNING skipping const checks
+        //~| WARNING skipping const checks
         unreachable!()
     }
     if let E1::V1 { .. } = (E1::V1 { f: true }) {

--- a/src/test/ui/consts/packed_pattern.rs
+++ b/src/test/ui/consts/packed_pattern.rs
@@ -13,7 +13,7 @@ const FOO: Foo = Foo {
 fn main() {
     match FOO {
         Foo { field: (5, 6, 7, 8) } => {},
-        FOO => unreachable!(),
+        FOO => unreachable!(), //~ WARNING unreachable pattern
         _ => unreachable!(),
     }
 }

--- a/src/test/ui/consts/packed_pattern2.rs
+++ b/src/test/ui/consts/packed_pattern2.rs
@@ -21,7 +21,7 @@ const FOO: Bar = Bar {
 fn main() {
     match FOO {
         Bar { a: Foo { field: (5, 6) } } => {},
-        FOO => unreachable!(),
+        FOO => unreachable!(), //~ WARNING unreachable pattern
         _ => unreachable!(),
     }
 }

--- a/src/test/ui/deprecation/deprecation-in-future.rs
+++ b/src/test/ui/deprecation/deprecation-in-future.rs
@@ -7,6 +7,7 @@ pub fn deprecated_future() {}
 
 fn test() {
     deprecated_future(); // ok; deprecated_in_future only applies to rustc_deprecated
+    //~^ WARNING use of deprecated item 'deprecated_future': text [deprecated]
 }
 
 fn main() {}

--- a/src/test/ui/extern/extern-prelude-core.rs
+++ b/src/test/ui/extern/extern-prelude-core.rs
@@ -1,5 +1,5 @@
 // run-pass
-#![feature(extern_prelude, lang_items, start)]
+#![feature(lang_items, start)]
 #![no_std]
 
 extern crate std as other;

--- a/src/test/ui/extern/extern-prelude-core.stderr
+++ b/src/test/ui/extern/extern-prelude-core.stderr
@@ -1,8 +1,0 @@
-warning: the feature `extern_prelude` has been stable since 1.30.0 and no longer requires an attribute to enable
-  --> $DIR/extern-prelude-core.rs:2:12
-   |
-LL | #![feature(extern_prelude, lang_items, start)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(stable_features)]` on by default
-

--- a/src/test/ui/extern/extern-prelude-std.rs
+++ b/src/test/ui/extern/extern-prelude-std.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(extern_prelude)]
 
 mod foo {
     pub fn test() {

--- a/src/test/ui/extern/extern-prelude-std.stderr
+++ b/src/test/ui/extern/extern-prelude-std.stderr
@@ -1,8 +1,0 @@
-warning: the feature `extern_prelude` has been stable since 1.30.0 and no longer requires an attribute to enable
-  --> $DIR/extern-prelude-std.rs:2:12
-   |
-LL | #![feature(extern_prelude)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(stable_features)]` on by default
-

--- a/src/test/ui/hygiene/dollar-crate-modern.rs
+++ b/src/test/ui/hygiene/dollar-crate-modern.rs
@@ -3,7 +3,7 @@
 // check-pass
 // aux-build:intercrate.rs
 
-#![feature(decl_macro, crate_in_paths)]
+#![feature(decl_macro)]
 
 extern crate intercrate;
 

--- a/src/test/ui/hygiene/dollar-crate-modern.stderr
+++ b/src/test/ui/hygiene/dollar-crate-modern.stderr
@@ -1,8 +1,0 @@
-warning: the feature `crate_in_paths` has been stable since 1.30.0 and no longer requires an attribute to enable
-  --> $DIR/dollar-crate-modern.rs:6:24
-   |
-LL | #![feature(decl_macro, crate_in_paths)]
-   |                        ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(stable_features)]` on by default
-

--- a/src/test/ui/hygiene/generic_params.rs
+++ b/src/test/ui/hygiene/generic_params.rs
@@ -4,6 +4,7 @@
 // ignore-pretty pretty-printing is unhygienic
 
 #![feature(decl_macro, rustc_attrs, const_generics)]
+//~^ WARNING the feature `const_generics` is incomplete
 
 mod type_params {
     macro m($T:ident) {

--- a/src/test/ui/hygiene/hygienic-labels-in-let.rs
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.rs
@@ -13,6 +13,10 @@ macro_rules! loop_x {
     ($e: expr) => {
         // $e shouldn't be able to interact with this 'x
         'x: loop { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -20,6 +24,11 @@ macro_rules! while_true {
     ($e: expr) => {
         // $e shouldn't be able to interact with this 'x
         'x: while 1 + 1 == 2 { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -27,6 +36,13 @@ macro_rules! run_once {
     ($e: expr) => {
         // ditto
         'x: for _ in 0..1 { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -45,6 +61,8 @@ pub fn main() {
 
     let k: isize = {
         'x: for _ in 0..1 {
+            //~^ WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
             // ditto
             loop_x!(break 'x);
             i += 1;
@@ -55,6 +73,10 @@ pub fn main() {
 
     let l: isize = {
         'x: for _ in 0..1 {
+            //~^ WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
             // ditto
             while_true!(break 'x);
             i += 1;
@@ -65,6 +87,12 @@ pub fn main() {
 
     let n: isize = {
         'x: for _ in 0..1 {
+            //~^ WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
+            //~| WARNING shadows a label name that is already in scope
             // ditto
             run_once!(continue 'x);
             i += 1;

--- a/src/test/ui/hygiene/hygienic-labels-in-let.stderr
+++ b/src/test/ui/hygiene/hygienic-labels-in-let.stderr
@@ -11,7 +11,7 @@ LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:47:9
+  --> $DIR/hygienic-labels-in-let.rs:63:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -20,7 +20,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:47:9
+  --> $DIR/hygienic-labels-in-let.rs:63:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -60,12 +60,12 @@ LL |         'x: loop { $e }
 ...
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
-LL |             // ditto
+...
 LL |             loop_x!(break 'x);
    |             ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:57:9
+  --> $DIR/hygienic-labels-in-let.rs:75:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -74,7 +74,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:57:9
+  --> $DIR/hygienic-labels-in-let.rs:75:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:57:9
+  --> $DIR/hygienic-labels-in-let.rs:75:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -92,7 +92,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:57:9
+  --> $DIR/hygienic-labels-in-let.rs:75:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:22:9
+  --> $DIR/hygienic-labels-in-let.rs:26:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:22:9
+  --> $DIR/hygienic-labels-in-let.rs:26:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:22:9
+  --> $DIR/hygienic-labels-in-let.rs:26:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:22:9
+  --> $DIR/hygienic-labels-in-let.rs:26:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,19 +149,19 @@ LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:22:9
+  --> $DIR/hygienic-labels-in-let.rs:26:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
 ...
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
-LL |             // ditto
+...
 LL |             while_true!(break 'x);
    |             ---------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: loop {
    |         -- first declared here
@@ -170,7 +170,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -179,7 +179,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -188,7 +188,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -197,7 +197,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
@@ -206,7 +206,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:67:9
+  --> $DIR/hygienic-labels-in-let.rs:89:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -215,7 +215,7 @@ LL |         'x: for _ in 0..1 {
    |         ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -227,7 +227,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -239,7 +239,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -251,7 +251,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -263,7 +263,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -275,7 +275,7 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -287,14 +287,14 @@ LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels-in-let.rs:29:9
+  --> $DIR/hygienic-labels-in-let.rs:38:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
 ...
 LL |         'x: for _ in 0..1 {
    |         -- first declared here
-LL |             // ditto
+...
 LL |             run_once!(continue 'x);
    |             ----------------------- in this macro invocation
 

--- a/src/test/ui/hygiene/hygienic-labels.rs
+++ b/src/test/ui/hygiene/hygienic-labels.rs
@@ -10,6 +10,10 @@ macro_rules! loop_x {
     ($e: expr) => {
         // $e shouldn't be able to interact with this 'x
         'x: loop { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -17,6 +21,13 @@ macro_rules! run_once {
     ($e: expr) => {
         // ditto
         'x: for _ in 0..1 { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -24,6 +35,11 @@ macro_rules! while_x {
     ($e: expr) => {
         // ditto
         'x: while 1 + 1 == 2 { $e }
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
     }
 }
 
@@ -35,17 +51,32 @@ pub fn main() {
     }
 
     'x: loop {
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+
         // ditto
         loop_x!(break 'x);
         panic!("break doesn't act hygienically inside infinite loop");
     }
 
     'x: while 1 + 1 == 2 {
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+
         while_x!(break 'x);
         panic!("break doesn't act hygienically inside infinite while loop");
     }
 
     'x: for _ in 0..1 {
+        //~^ WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+        //~| WARNING shadows a label name that is already in scope
+
         // ditto
         run_once!(continue 'x);
         panic!("continue doesn't act hygienically inside for loop");

--- a/src/test/ui/hygiene/hygienic-labels.stderr
+++ b/src/test/ui/hygiene/hygienic-labels.stderr
@@ -11,7 +11,7 @@ LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:5
+  --> $DIR/hygienic-labels.rs:53:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -20,7 +20,7 @@ LL |     'x: loop {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:37:5
+  --> $DIR/hygienic-labels.rs:53:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -60,12 +60,12 @@ LL |         'x: loop { $e }
 ...
 LL |     'x: loop {
    |     -- first declared here
-LL |         // ditto
+...
 LL |         loop_x!(break 'x);
    |         ------------------ in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:43:5
+  --> $DIR/hygienic-labels.rs:62:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -74,7 +74,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:43:5
+  --> $DIR/hygienic-labels.rs:62:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -83,7 +83,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:43:5
+  --> $DIR/hygienic-labels.rs:62:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -92,7 +92,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:43:5
+  --> $DIR/hygienic-labels.rs:62:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -101,7 +101,7 @@ LL |     'x: while 1 + 1 == 2 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:26:9
+  --> $DIR/hygienic-labels.rs:37:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -113,7 +113,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:26:9
+  --> $DIR/hygienic-labels.rs:37:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -125,7 +125,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:26:9
+  --> $DIR/hygienic-labels.rs:37:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
@@ -137,7 +137,7 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:26:9
+  --> $DIR/hygienic-labels.rs:37:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -149,18 +149,19 @@ LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:26:9
+  --> $DIR/hygienic-labels.rs:37:9
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         ^^ lifetime 'x already in scope
 ...
 LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
+...
 LL |         while_x!(break 'x);
    |         ------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
@@ -169,7 +170,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -178,7 +179,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |     'x: loop {
    |     -- first declared here
@@ -187,7 +188,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -196,7 +197,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |     'x: while 1 + 1 == 2 {
    |     -- first declared here
@@ -205,7 +206,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:48:5
+  --> $DIR/hygienic-labels.rs:72:5
    |
 LL |         'x: while 1 + 1 == 2 { $e }
    |         -- first declared here
@@ -214,7 +215,7 @@ LL |     'x: for _ in 0..1 {
    |     ^^ lifetime 'x already in scope
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -226,7 +227,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -238,7 +239,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -250,7 +251,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: loop { $e }
    |         -- first declared here
@@ -262,7 +263,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -274,7 +275,7 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
@@ -286,14 +287,14 @@ LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 
 warning: label name `'x` shadows a label name that is already in scope
-  --> $DIR/hygienic-labels.rs:19:9
+  --> $DIR/hygienic-labels.rs:23:9
    |
 LL |         'x: for _ in 0..1 { $e }
    |         ^^ lifetime 'x already in scope
 ...
 LL |     'x: for _ in 0..1 {
    |     -- first declared here
-LL |         // ditto
+...
 LL |         run_once!(continue 'x);
    |         ----------------------- in this macro invocation
 

--- a/src/test/ui/hygiene/issue-61574-const-parameters.rs
+++ b/src/test/ui/hygiene/issue-61574-const-parameters.rs
@@ -3,7 +3,7 @@
 
 // check-pass
 
-#![feature(const_generics)]
+#![feature(const_generics)] //~ WARNING `const_generics` is incomplete
 
 use std::ops::Add;
 

--- a/src/test/ui/if-ret.rs
+++ b/src/test/ui/if-ret.rs
@@ -3,6 +3,6 @@
 #![allow(unused_parens)]
 // pretty-expanded FIXME #23616
 
-fn foo() { if (return) { } }
+fn foo() { if (return) { } } //~ WARNING unreachable block in `if` expression
 
 pub fn main() { foo(); }

--- a/src/test/ui/inference/inference-variable-behind-raw-pointer.rs
+++ b/src/test/ui/inference/inference-variable-behind-raw-pointer.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // tests that the following code compiles, but produces a future-compatibility warning
 
@@ -6,4 +6,6 @@ fn main() {
     let data = std::ptr::null();
     let _ = &data as *const *const ();
     if data.is_null() {}
+    //~^ WARNING type annotations needed
+    //~| WARNING this was previously accepted by the compiler but is being phased out
 }

--- a/src/test/ui/issues/issue-33140-traitobject-crate.rs
+++ b/src/test/ui/issues/issue-33140-traitobject-crate.rs
@@ -83,9 +83,15 @@ unsafe impl<T> Trait for dyn (::std::iter::Iterator<Item=T>) + Send + Sync { }
 unsafe impl Trait for dyn (::std::marker::Send) + Send { }
 unsafe impl Trait for dyn (::std::marker::Send) + Sync { }
 unsafe impl Trait for dyn (::std::marker::Send) + Send + Sync { }
+//~^ WARNING conflicting implementations of trait `Trait` for type
+//~| WARNING this was previously accepted by the compiler but is being phased out
 unsafe impl Trait for dyn (::std::marker::Sync) + Send { }
+//~^ WARNING conflicting implementations of trait `Trait` for type
+//~| WARNING this was previously accepted by the compiler but is being phased out
 unsafe impl Trait for dyn (::std::marker::Sync) + Sync { }
 unsafe impl Trait for dyn (::std::marker::Sync) + Send + Sync { }
+//~^ WARNING conflicting implementations of trait `Trait` for type
+//~| WARNING this was previously accepted by the compiler but is being phased out
 unsafe impl Trait for dyn (::std::ops::Drop) + Send { }
 unsafe impl Trait for dyn (::std::ops::Drop) + Sync { }
 unsafe impl Trait for dyn (::std::ops::Drop) + Send + Sync { }

--- a/src/test/ui/issues/issue-33140-traitobject-crate.stderr
+++ b/src/test/ui/issues/issue-33140-traitobject-crate.stderr
@@ -15,10 +15,11 @@ LL | #![warn(order_dependent_trait_objects)]
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 warning: conflicting implementations of trait `Trait` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
-  --> $DIR/issue-33140-traitobject-crate.rs:86:1
+  --> $DIR/issue-33140-traitobject-crate.rs:88:1
    |
 LL | unsafe impl Trait for dyn (::std::marker::Send) + Send + Sync { }
    | ------------------------------------------------------------- first implementation here
+...
 LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |
@@ -26,11 +27,11 @@ LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send { }
    = note: for more information, see issue #56484 <https://github.com/rust-lang/rust/issues/56484>
 
 warning: conflicting implementations of trait `Trait` for type `(dyn std::marker::Send + std::marker::Sync + 'static)`: (E0119)
-  --> $DIR/issue-33140-traitobject-crate.rs:88:1
+  --> $DIR/issue-33140-traitobject-crate.rs:92:1
    |
 LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send { }
    | ------------------------------------------------------ first implementation here
-LL | unsafe impl Trait for dyn (::std::marker::Sync) + Sync { }
+...
 LL | unsafe impl Trait for dyn (::std::marker::Sync) + Send + Sync { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |

--- a/src/test/ui/issues/issue-39720.rs
+++ b/src/test/ui/issues/issue-39720.rs
@@ -5,12 +5,12 @@
 
 #![feature(repr_simd, platform_intrinsics)]
 
-#[repr(C)]
+#[repr(C)] //~ WARNING conflicting representation hints
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
 pub struct char3(pub i8, pub i8, pub i8);
 
-#[repr(C)]
+#[repr(C)]  //~ WARNING conflicting representation hints
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
 pub struct short3(pub i16, pub i16, pub i16);

--- a/src/test/ui/issues/issue-52057.rs
+++ b/src/test/ui/issues/issue-52057.rs
@@ -7,7 +7,6 @@
 pub trait Parser {
     type Input;
 
-    #[inline(always)]
     fn parse_first(input: &mut Self::Input);
 }
 

--- a/src/test/ui/issues/issue-52057.stderr
+++ b/src/test/ui/issues/issue-52057.stderr
@@ -1,8 +1,0 @@
-warning: `#[inline]` is ignored on function prototypes
-  --> $DIR/issue-52057.rs:10:5
-   |
-LL |     #[inline(always)]
-   |     ^^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(unused_attributes)]` on by default
-

--- a/src/test/ui/issues/issue-57399-self-return-impl-trait.rs
+++ b/src/test/ui/issues/issue-57399-self-return-impl-trait.rs
@@ -1,4 +1,4 @@
-// run-pass
+// check-pass
 
 trait T {
     type T;

--- a/src/test/ui/issues/issue-57399-self-return-impl-trait.stderr
+++ b/src/test/ui/issues/issue-57399-self-return-impl-trait.stderr
@@ -1,8 +1,0 @@
-warning: field is never used: `a`
-  --> $DIR/issue-57399-self-return-impl-trait.rs:12:5
-   |
-LL |     a: A,
-   |     ^^^^
-   |
-   = note: `#[warn(dead_code)]` on by default
-

--- a/src/test/ui/lint/command-line-lint-group-warn.rs
+++ b/src/test/ui/lint/command-line-lint-group-warn.rs
@@ -1,6 +1,7 @@
 // compile-flags: -W bad-style
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 fn main() {
     let _InappropriateCamelCasing = true;
+    //~^ WARNING should have a snake case name
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.rs
@@ -23,7 +23,7 @@ enum Large {
 struct Tuple(Large, ());
 
 fn main() {
-    let i_think_continually = 2;
+    let i_think_continually = 2; //~ WARNING unused variable: `i_think_continually`
     let who_from_the_womb_remembered = SoulHistory {
         corridors_of_light: 5,
         hours_are_suns: true,
@@ -31,20 +31,25 @@ fn main() {
     };
 
     let mut mut_unused_var = 1;
+    //~^ WARNING unused variable: `mut_unused_var`
+    //~| WARNING variable does not need to be mutable
 
     let (mut var, unused_var) = (1, 2);
+    //~^ WARNING unused variable: `var`
+    //~| WARNING unused variable: `unused_var`
+    //~| WARNING variable does not need to be mutable
     // NOTE: `var` comes after `unused_var` lexicographically yet the warning
     // for `var` will be emitted before the one for `unused_var`. We use an
     // `IndexMap` to ensure this is the case instead of a `BTreeMap`.
 
-    if let SoulHistory { corridors_of_light,
-                         mut hours_are_suns,
+    if let SoulHistory { corridors_of_light, //~ WARNING unused variable: `corridors_of_light`
+                         mut hours_are_suns, //~ WARNING `hours_are_suns` is assigned to, but
                          endless_and_singing: true } = who_from_the_womb_remembered {
-        hours_are_suns = false;
+        hours_are_suns = false; //~ WARNING unused_assignments
     }
 
     let the_spirit = LovelyAmbition { lips: 1, fire: 2 };
-    let LovelyAmbition { lips, fire } = the_spirit;
+    let LovelyAmbition { lips, fire } = the_spirit; //~ WARNING unused variable: `fire`
     println!("{}", lips);
 
     let bag = Large::Suit {
@@ -53,31 +58,31 @@ fn main() {
 
     // Plain struct
     match bag {
-        Large::Suit { case } => {}
+        Large::Suit { case } => {} //~ WARNING unused variable: `case`
     };
 
     // Referenced struct
     match &bag {
-        &Large::Suit { case } => {}
+        &Large::Suit { case } => {} //~ WARNING unused variable: `case`
     };
 
     // Boxed struct
     match box bag {
-        box Large::Suit { case } => {}
+        box Large::Suit { case } => {} //~ WARNING unused variable: `case`
     };
 
     // Tuple with struct
     match (bag,) {
-        (Large::Suit { case },) => {}
+        (Large::Suit { case },) => {} //~ WARNING unused variable: `case`
     };
 
     // Slice with struct
     match [bag] {
-        [Large::Suit { case }] => {}
+        [Large::Suit { case }] => {} //~ WARNING unused variable: `case`
     };
 
     // Tuple struct with struct
     match Tuple(bag, ()) {
-        Tuple(Large::Suit { case }, ()) => {}
+        Tuple(Large::Suit { case }, ()) => {} //~ WARNING unused variable: `case`
     };
 }

--- a/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
+++ b/src/test/ui/lint/issue-47390-unused-variable-in-struct-pattern.stderr
@@ -18,25 +18,25 @@ LL |     let mut mut_unused_var = 1;
    |             ^^^^^^^^^^^^^^ help: consider prefixing with an underscore: `_mut_unused_var`
 
 warning: unused variable: `var`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:14
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:14
    |
 LL |     let (mut var, unused_var) = (1, 2);
    |              ^^^ help: consider prefixing with an underscore: `_var`
 
 warning: unused variable: `unused_var`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:19
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:19
    |
 LL |     let (mut var, unused_var) = (1, 2);
    |                   ^^^^^^^^^^ help: consider prefixing with an underscore: `_unused_var`
 
 warning: unused variable: `corridors_of_light`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:40:26
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:45:26
    |
 LL |     if let SoulHistory { corridors_of_light,
    |                          ^^^^^^^^^^^^^^^^^^ help: try ignoring the field: `corridors_of_light: _`
 
 warning: variable `hours_are_suns` is assigned to, but never used
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:41:30
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:46:30
    |
 LL |                          mut hours_are_suns,
    |                              ^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |                          mut hours_are_suns,
    = note: consider using `_hours_are_suns` instead
 
 warning: value assigned to `hours_are_suns` is never read
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:43:9
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:48:9
    |
 LL |         hours_are_suns = false;
    |         ^^^^^^^^^^^^^^
@@ -58,43 +58,43 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = help: maybe it is overwritten before being read?
 
 warning: unused variable: `fire`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:47:32
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:52:32
    |
 LL |     let LovelyAmbition { lips, fire } = the_spirit;
    |                                ^^^^ help: try ignoring the field: `fire: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:56:23
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:61:23
    |
 LL |         Large::Suit { case } => {}
    |                       ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:61:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:66:24
    |
 LL |         &Large::Suit { case } => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:66:27
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:71:27
    |
 LL |         box Large::Suit { case } => {}
    |                           ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:71:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:76:24
    |
 LL |         (Large::Suit { case },) => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:76:24
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:81:24
    |
 LL |         [Large::Suit { case }] => {}
    |                        ^^^^ help: try ignoring the field: `case: _`
 
 warning: unused variable: `case`
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:81:29
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:86:29
    |
 LL |         Tuple(Large::Suit { case }, ()) => {}
    |                             ^^^^ help: try ignoring the field: `case: _`
@@ -115,7 +115,7 @@ LL | #![warn(unused)] // UI tests pass `-A unused` (#43896)
    = note: `#[warn(unused_mut)]` implied by `#[warn(unused)]`
 
 warning: variable does not need to be mutable
-  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:35:10
+  --> $DIR/issue-47390-unused-variable-in-struct-pattern.rs:37:10
    |
 LL |     let (mut var, unused_var) = (1, 2);
    |          ----^^^

--- a/src/test/ui/lint/must-use-ops.rs
+++ b/src/test/ui/lint/must-use-ops.rs
@@ -1,6 +1,6 @@
 // Issue #50124 - Test warning for unused operator expressions
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(unused_must_use)]
 
@@ -9,33 +9,33 @@ fn main() {
     let val_pointer = &val;
 
 // Comparison Operators
-    val == 1;
-    val < 1;
-    val <= 1;
-    val != 1;
-    val >= 1;
-    val > 1;
+    val == 1; //~ WARNING unused comparison
+    val < 1; //~ WARNING unused comparison
+    val <= 1; //~ WARNING unused comparison
+    val != 1; //~ WARNING unused comparison
+    val >= 1; //~ WARNING unused comparison
+    val > 1; //~ WARNING unused comparison
 
 // Arithmetic Operators
-    val + 2;
-    val - 2;
-    val / 2;
-    val * 2;
-    val % 2;
+    val + 2; //~ WARNING unused arithmetic operation
+    val - 2; //~ WARNING unused arithmetic operation
+    val / 2; //~ WARNING unused arithmetic operation
+    val * 2; //~ WARNING unused arithmetic operation
+    val % 2; //~ WARNING unused arithmetic operation
 
 // Logical Operators
-    true && true;
-    false || true;
+    true && true; //~ WARNING unused logical operation
+    false || true; //~ WARNING unused logical operation
 
 // Bitwise Operators
-    5 ^ val;
-    5 & val;
-    5 | val;
-    5 << val;
-    5 >> val;
+    5 ^ val; //~ WARNING unused bitwise operation
+    5 & val; //~ WARNING unused bitwise operation
+    5 | val; //~ WARNING unused bitwise operation
+    5 << val; //~ WARNING unused bitwise operation
+    5 >> val; //~ WARNING unused bitwise operation
 
 // Unary Operators
-    !val;
-    -val;
-    *val_pointer;
+    !val; //~ WARNING unused unary operation
+    -val; //~ WARNING unused unary operation
+    *val_pointer; //~ WARNING unused unary operation
 }

--- a/src/test/ui/lint/not_found.rs
+++ b/src/test/ui/lint/not_found.rs
@@ -1,13 +1,21 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 // this tests the `unknown_lint` lint, especially the suggestions
 
 // the suggestion only appears if a lint with the lowercase name exists
 #[allow(FOO_BAR)]
+//~^ WARNING unknown lint
+
 // the suggestion appears on all-uppercase names
 #[warn(DEAD_CODE)]
+//~^ WARNING unknown lint
+//~| HELP did you mean
+
 // the suggestion appears also on mixed-case names
 #[deny(Warnings)]
+//~^ WARNING unknown lint
+//~| HELP did you mean
+
 fn main() {
     unimplemented!();
 }

--- a/src/test/ui/lint/not_found.stderr
+++ b/src/test/ui/lint/not_found.stderr
@@ -7,13 +7,13 @@ LL | #[allow(FOO_BAR)]
    = note: `#[warn(unknown_lints)]` on by default
 
 warning: unknown lint: `DEAD_CODE`
-  --> $DIR/not_found.rs:8:8
+  --> $DIR/not_found.rs:10:8
    |
 LL | #[warn(DEAD_CODE)]
    |        ^^^^^^^^^ help: did you mean: `dead_code`
 
 warning: unknown lint: `Warnings`
-  --> $DIR/not_found.rs:10:8
+  --> $DIR/not_found.rs:15:8
    |
 LL | #[deny(Warnings)]
    |        ^^^^^^^^ help: did you mean (notice the capitalization): `warnings`

--- a/src/test/ui/lint/unreachable_pub-pub_crate.rs
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.rs
@@ -4,44 +4,45 @@
 // suggestions to use `crate` given when it is on). When that feature becomes
 // stable, this test can be deleted.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 
-#![allow(unused)]
 #![warn(unreachable_pub)]
 
 mod private_mod {
     // non-leaked `pub` items in private module should be linted
-    pub use std::fmt;
+    pub use std::fmt; //~ WARNING unreachable_pub
     pub use std::env::{Args}; // braced-use has different item spans than unbraced
+    //~^ WARNING unreachable_pub
 
-    pub struct Hydrogen {
+    pub struct Hydrogen { //~ WARNING unreachable_pub
         // `pub` struct fields, too
-        pub neutrons: usize,
+        pub neutrons: usize, //~ WARNING unreachable_pub
         // (... but not more-restricted fields)
         pub(crate) electrons: usize
     }
     impl Hydrogen {
         // impls, too
-        pub fn count_neutrons(&self) -> usize { self.neutrons }
+        pub fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
         pub(crate) fn count_electrons(&self) -> usize { self.electrons }
     }
 
-    pub enum Helium {}
-    pub union Lithium { c1: usize, c2: u8 }
-    pub fn beryllium() {}
-    pub trait Boron {}
-    pub const CARBON: usize = 1;
-    pub static NITROGEN: usize = 2;
-    pub type Oxygen = bool;
+    pub enum Helium {} //~ WARNING unreachable_pub
+    pub union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
+    pub fn beryllium() {} //~ WARNING unreachable_pub
+    pub trait Boron {} //~ WARNING unreachable_pub
+    pub const CARBON: usize = 1; //~ WARNING unreachable_pub
+    pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub type Oxygen = bool; //~ WARNING unreachable_pub
 
     macro_rules! define_empty_struct_with_visibility {
         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
+        //~^ WARNING unreachable_pub
     }
     define_empty_struct_with_visibility!(pub, Fluorine);
 
     extern {
-        pub fn catalyze() -> bool;
+        pub fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 
     // items leaked through signatures (see `get_neon` below) are OK

--- a/src/test/ui/lint/unreachable_pub-pub_crate.stderr
+++ b/src/test/ui/lint/unreachable_pub-pub_crate.stderr
@@ -1,5 +1,5 @@
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub-pub_crate.rs:15:5
+  --> $DIR/unreachable_pub-pub_crate.rs:14:5
    |
 LL |     pub use std::fmt;
    |     ---^^^^^^^^^^^^^^
@@ -7,14 +7,14 @@ LL |     pub use std::fmt;
    |     help: consider restricting its visibility: `pub(crate)`
    |
 note: lint level defined here
-  --> $DIR/unreachable_pub-pub_crate.rs:11:9
+  --> $DIR/unreachable_pub-pub_crate.rs:10:9
    |
 LL | #![warn(unreachable_pub)]
    |         ^^^^^^^^^^^^^^^
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub-pub_crate.rs:16:24
+  --> $DIR/unreachable_pub-pub_crate.rs:15:24
    |
 LL |     pub use std::env::{Args}; // braced-use has different item spans than unbraced
    |     ---                ^^^^
@@ -124,7 +124,7 @@ warning: unreachable `pub` item
    |
 LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     }
+...
 LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    |     ----------------------------------------------------
    |     |                                    |
@@ -134,7 +134,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub-pub_crate.rs:44:9
+  --> $DIR/unreachable_pub-pub_crate.rs:45:9
    |
 LL |         pub fn catalyze() -> bool;
    |         ---^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/lint/unreachable_pub.rs
+++ b/src/test/ui/lint/unreachable_pub.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![feature(crate_visibility_modifier)]
 
@@ -7,36 +7,38 @@
 
 mod private_mod {
     // non-leaked `pub` items in private module should be linted
-    pub use std::fmt;
+    pub use std::fmt; //~ WARNING unreachable_pub
     pub use std::env::{Args}; // braced-use has different item spans than unbraced
+    //~^ WARNING unreachable_pub
 
-    pub struct Hydrogen {
+    pub struct Hydrogen { //~ WARNING unreachable_pub
         // `pub` struct fields, too
-        pub neutrons: usize,
+        pub neutrons: usize, //~ WARNING unreachable_pub
         // (... but not more-restricted fields)
         crate electrons: usize
     }
     impl Hydrogen {
         // impls, too
-        pub fn count_neutrons(&self) -> usize { self.neutrons }
+        pub fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
         crate fn count_electrons(&self) -> usize { self.electrons }
     }
 
-    pub enum Helium {}
-    pub union Lithium { c1: usize, c2: u8 }
-    pub fn beryllium() {}
-    pub trait Boron {}
-    pub const CARBON: usize = 1;
-    pub static NITROGEN: usize = 2;
-    pub type Oxygen = bool;
+    pub enum Helium {} //~ WARNING unreachable_pub
+    pub union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
+    pub fn beryllium() {} //~ WARNING unreachable_pub
+    pub trait Boron {} //~ WARNING unreachable_pub
+    pub const CARBON: usize = 1; //~ WARNING unreachable_pub
+    pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub type Oxygen = bool; //~ WARNING unreachable_pub
 
     macro_rules! define_empty_struct_with_visibility {
         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
+        //~^ WARNING unreachable_pub
     }
     define_empty_struct_with_visibility!(pub, Fluorine);
 
     extern {
-        pub fn catalyze() -> bool;
+        pub fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 
     // items leaked through signatures (see `get_neon` below) are OK

--- a/src/test/ui/lint/unreachable_pub.stderr
+++ b/src/test/ui/lint/unreachable_pub.stderr
@@ -24,7 +24,7 @@ LL |     pub use std::env::{Args}; // braced-use has different item spans than u
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:13:5
+  --> $DIR/unreachable_pub.rs:14:5
    |
 LL |     pub struct Hydrogen {
    |     ---^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL |     pub struct Hydrogen {
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` field
-  --> $DIR/unreachable_pub.rs:15:9
+  --> $DIR/unreachable_pub.rs:16:9
    |
 LL |         pub neutrons: usize,
    |         ---^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL |         pub neutrons: usize,
    |         help: consider restricting its visibility: `crate`
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:21:9
+  --> $DIR/unreachable_pub.rs:22:9
    |
 LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         help: consider restricting its visibility: `crate`
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:25:5
+  --> $DIR/unreachable_pub.rs:26:5
    |
 LL |     pub enum Helium {}
    |     ---^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     pub enum Helium {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:26:5
+  --> $DIR/unreachable_pub.rs:27:5
    |
 LL |     pub union Lithium { c1: usize, c2: u8 }
    |     ---^^^^^^^^^^^^^^
@@ -70,7 +70,7 @@ LL |     pub union Lithium { c1: usize, c2: u8 }
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:27:5
+  --> $DIR/unreachable_pub.rs:28:5
    |
 LL |     pub fn beryllium() {}
    |     ---^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     pub fn beryllium() {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:28:5
+  --> $DIR/unreachable_pub.rs:29:5
    |
 LL |     pub trait Boron {}
    |     ---^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     pub trait Boron {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:29:5
+  --> $DIR/unreachable_pub.rs:30:5
    |
 LL |     pub const CARBON: usize = 1;
    |     ---^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -100,7 +100,7 @@ LL |     pub const CARBON: usize = 1;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:30:5
+  --> $DIR/unreachable_pub.rs:31:5
    |
 LL |     pub static NITROGEN: usize = 2;
    |     ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ LL |     pub static NITROGEN: usize = 2;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:31:5
+  --> $DIR/unreachable_pub.rs:32:5
    |
 LL |     pub type Oxygen = bool;
    |     ---^^^^^^^^^^^^^^^^^^^^
@@ -120,11 +120,11 @@ LL |     pub type Oxygen = bool;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:34:47
+  --> $DIR/unreachable_pub.rs:35:47
    |
 LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     }
+...
 LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    |     ----------------------------------------------------
    |     |                                    |
@@ -134,7 +134,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:39:9
+  --> $DIR/unreachable_pub.rs:41:9
    |
 LL |         pub fn catalyze() -> bool;
    |         ---^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/lint/unused_import_warning_issue_45268.rs
+++ b/src/test/ui/lint/unused_import_warning_issue_45268.rs
@@ -24,6 +24,7 @@ mod test {
 }
 
 use test::Unused;   // This is really unused, so warning is OK
+                    //~^ WARNING unused import
 use test::A;        // This is used by the test2::func() through import of super::*
 use test::B;        // This is used by the test2::func() through import of super::*
 

--- a/src/test/ui/macros/macro-lifetime-used-with-labels.rs
+++ b/src/test/ui/macros/macro-lifetime-used-with-labels.rs
@@ -18,7 +18,7 @@ macro_rules! br {
 }
 macro_rules! br2 {
     ($b:lifetime) => {
-        'b: loop {
+        'b: loop { //~ WARNING `'b` shadows a label name that is already in scope
             break $b; // this $b should refer to the outer loop.
         }
     }

--- a/src/test/ui/macros/macro-path-prelude-pass.rs
+++ b/src/test/ui/macros/macro-path-prelude-pass.rs
@@ -1,6 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
-
-#![feature(extern_prelude)]
+// check-pass
 
 mod m {
     fn check() {

--- a/src/test/ui/macros/macro-path-prelude-pass.stderr
+++ b/src/test/ui/macros/macro-path-prelude-pass.stderr
@@ -1,8 +1,0 @@
-warning: the feature `extern_prelude` has been stable since 1.30.0 and no longer requires an attribute to enable
-  --> $DIR/macro-path-prelude-pass.rs:3:12
-   |
-LL | #![feature(extern_prelude)]
-   |            ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(stable_features)]` on by default
-

--- a/src/test/ui/macros/macro-use-all-and-none.rs
+++ b/src/test/ui/macros/macro-use-all-and-none.rs
@@ -4,7 +4,7 @@
 #![warn(unused_attributes)]
 
 #[macro_use]
-#[macro_use()]
+#[macro_use()] //~ WARNING unused attribute
 extern crate two_macros_rpass;
 
 pub fn main() {

--- a/src/test/ui/or-patterns/or-patterns-syntactic-pass.rs
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-pass.rs
@@ -3,7 +3,7 @@
 
 // check-pass
 
-#![feature(or_patterns)]
+#![feature(or_patterns)] //~ WARNING the feature `or_patterns` is incomplete
 
 fn main() {}
 

--- a/src/test/ui/removing-extern-crate.fixed
+++ b/src/test/ui/removing-extern-crate.fixed
@@ -1,17 +1,16 @@
 // edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_idioms)]
-#![allow(unused_imports)]
 
-
-
+ //~ WARNING unused extern crate
+ //~ WARNING unused extern crate
 
 mod another {
-    
-    
+     //~ WARNING unused extern crate
+     //~ WARNING unused extern crate
 }
 
 fn main() {}

--- a/src/test/ui/removing-extern-crate.rs
+++ b/src/test/ui/removing-extern-crate.rs
@@ -1,17 +1,16 @@
 // edition:2018
 // aux-build:removing-extern-crate.rs
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_idioms)]
-#![allow(unused_imports)]
 
-extern crate removing_extern_crate as foo;
-extern crate core;
+extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+extern crate core; //~ WARNING unused extern crate
 
 mod another {
-    extern crate removing_extern_crate as foo;
-    extern crate core;
+    extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+    extern crate core; //~ WARNING unused extern crate
 }
 
 fn main() {}

--- a/src/test/ui/removing-extern-crate.stderr
+++ b/src/test/ui/removing-extern-crate.stderr
@@ -1,5 +1,5 @@
 warning: unused extern crate
-  --> $DIR/removing-extern-crate.rs:9:1
+  --> $DIR/removing-extern-crate.rs:8:1
    |
 LL | extern crate removing_extern_crate as foo;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
@@ -12,19 +12,19 @@ LL | #![warn(rust_2018_idioms)]
    = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
 
 warning: unused extern crate
-  --> $DIR/removing-extern-crate.rs:10:1
+  --> $DIR/removing-extern-crate.rs:9:1
    |
 LL | extern crate core;
    | ^^^^^^^^^^^^^^^^^^ help: remove it
 
 warning: unused extern crate
-  --> $DIR/removing-extern-crate.rs:13:5
+  --> $DIR/removing-extern-crate.rs:12:5
    |
 LL |     extern crate removing_extern_crate as foo;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
 
 warning: unused extern crate
-  --> $DIR/removing-extern-crate.rs:14:5
+  --> $DIR/removing-extern-crate.rs:13:5
    |
 LL |     extern crate core;
    |     ^^^^^^^^^^^^^^^^^^ help: remove it

--- a/src/test/ui/rfc-2497-if-let-chains/protect-precedences.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/protect-precedences.rs
@@ -10,7 +10,7 @@ fn main() {
 
     fn _f1() -> bool {
         // Should associate as `(let _ = (return (true && false)))`.
-        if let _ = return true && false {};
+        if let _ = return true && false {}; //~ WARNING unreachable_code
     }
     assert!(!_f1());
 }

--- a/src/test/ui/rust-2018/remove-extern-crate.fixed
+++ b/src/test/ui/rust-2018/remove-extern-crate.fixed
@@ -6,7 +6,7 @@
 
 #![warn(rust_2018_idioms)]
 
-
+ //~ WARNING unused extern crate
 // Shouldn't suggest changing to `use`, as `another_name`
 // would no longer be added to the prelude which could cause
 // compilation errors for imports that use `another_name` in other
@@ -29,7 +29,7 @@ fn main() {
 }
 
 mod another {
-    use core;
+    use core; //~ WARNING `extern crate` is not idiomatic
     use remove_extern_crate;
 
     pub fn foo() {

--- a/src/test/ui/rust-2018/remove-extern-crate.rs
+++ b/src/test/ui/rust-2018/remove-extern-crate.rs
@@ -6,7 +6,7 @@
 
 #![warn(rust_2018_idioms)]
 
-extern crate core;
+extern crate core; //~ WARNING unused extern crate
 // Shouldn't suggest changing to `use`, as `another_name`
 // would no longer be added to the prelude which could cause
 // compilation errors for imports that use `another_name` in other
@@ -29,7 +29,7 @@ fn main() {
 }
 
 mod another {
-    extern crate core;
+    extern crate core; //~ WARNING `extern crate` is not idiomatic
     use remove_extern_crate;
 
     pub fn foo() {

--- a/src/test/ui/rust-2018/try-ident.fixed
+++ b/src/test/ui/rust-2018/try-ident.fixed
@@ -5,7 +5,11 @@
 
 fn main() {
     r#try();
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING it will become a hard error in the 2018 edition!
 }
 
 fn r#try() {
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING it will become a hard error in the 2018 edition!
 }

--- a/src/test/ui/rust-2018/try-ident.rs
+++ b/src/test/ui/rust-2018/try-ident.rs
@@ -5,7 +5,11 @@
 
 fn main() {
     try();
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING it will become a hard error in the 2018 edition!
 }
 
 fn try() {
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING it will become a hard error in the 2018 edition!
 }

--- a/src/test/ui/rust-2018/try-ident.stderr
+++ b/src/test/ui/rust-2018/try-ident.stderr
@@ -14,7 +14,7 @@ LL | #![warn(rust_2018_compatibility)]
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 warning: `try` is a keyword in the 2018 edition
-  --> $DIR/try-ident.rs:10:4
+  --> $DIR/try-ident.rs:12:4
    |
 LL | fn try() {
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#try`

--- a/src/test/ui/rust-2018/try-macro.fixed
+++ b/src/test/ui/rust-2018/try-macro.fixed
@@ -1,16 +1,17 @@
 // Test that `try!` macros are rewritten.
 
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_compatibility)]
-#![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(deprecated)]
 
 fn foo() -> Result<usize, ()> {
     let x: Result<usize, ()> = Ok(22);
     r#try!(x);
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING this was previously accepted
     Ok(44)
 }
 

--- a/src/test/ui/rust-2018/try-macro.rs
+++ b/src/test/ui/rust-2018/try-macro.rs
@@ -1,16 +1,17 @@
 // Test that `try!` macros are rewritten.
 
 // run-rustfix
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![warn(rust_2018_compatibility)]
-#![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(deprecated)]
 
 fn foo() -> Result<usize, ()> {
     let x: Result<usize, ()> = Ok(22);
     try!(x);
+    //~^ WARNING `try` is a keyword in the 2018 edition
+    //~| WARNING this was previously accepted
     Ok(44)
 }
 

--- a/src/test/ui/rust-2018/try-macro.stderr
+++ b/src/test/ui/rust-2018/try-macro.stderr
@@ -1,5 +1,5 @@
 warning: `try` is a keyword in the 2018 edition
-  --> $DIR/try-macro.rs:13:5
+  --> $DIR/try-macro.rs:12:5
    |
 LL |     try!(x);
    |     ^^^ help: you can use a raw identifier to stay compatible: `r#try`

--- a/src/test/ui/test-attrs/test-on-macro.rs
+++ b/src/test/ui/test-attrs/test-on-macro.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags:--test
 
 #![deny(warnings)]
@@ -8,6 +8,6 @@ macro_rules! foo {
 }
 
 #[test]
-foo!();
+foo!(); //~ WARNING `#[test]` attribute should not be used on macros
 
 fn main(){}

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.rs
@@ -1,26 +1,26 @@
-// run-pass
+// check-pass
 // Check tautalogically false `Copy` bounds
 #![feature(trivial_bounds)]
-#![allow(unused)]
 
-fn copy_string(t: String) -> String where String: Copy {
+fn copy_string(t: String) -> String where String: Copy { //~ WARNING trivial_bounds
     is_copy(&t);
     let x = t;
     drop(t);
     t
 }
 
-fn copy_out_string(t: &String) -> String where String: Copy {
+fn copy_out_string(t: &String) -> String where String: Copy { //~ WARNING trivial_bounds
     *t
 }
 
-fn copy_string_with_param<T>(x: String) where String: Copy {
+fn copy_string_with_param<T>(x: String) where String: Copy { //~ WARNING trivial_bounds
     let y = x;
     let z = x;
 }
 
 // Check that no reborrowing occurs
 fn copy_mut<'a>(t: &&'a mut i32) -> &'a mut i32 where for<'b> &'b mut i32: Copy {
+    //~^ WARNING trivial_bounds
     is_copy(t);
     let x = *t;
     drop(x);

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-copy.stderr
@@ -1,5 +1,5 @@
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:6:51
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:5:51
    |
 LL | fn copy_string(t: String) -> String where String: Copy {
    |                                                   ^^^^
@@ -7,19 +7,19 @@ LL | fn copy_string(t: String) -> String where String: Copy {
    = note: `#[warn(trivial_bounds)]` on by default
 
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:13:56
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:12:56
    |
 LL | fn copy_out_string(t: &String) -> String where String: Copy {
    |                                                        ^^^^
 
 warning: Trait bound std::string::String: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:17:55
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:16:55
    |
 LL | fn copy_string_with_param<T>(x: String) where String: Copy {
    |                                                       ^^^^
 
 warning: Trait bound for<'b> &'b mut i32: std::marker::Copy does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-copy.rs:23:76
+  --> $DIR/trivial-bounds-inconsistent-copy.rs:22:76
    |
 LL | fn copy_mut<'a>(t: &&'a mut i32) -> &'a mut i32 where for<'b> &'b mut i32: Copy {
    |                                                                            ^^^^

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.rs
@@ -18,21 +18,21 @@ impl A for B {
 
 fn underspecified_bound() -> u8
 where
-    B: A
+    B: A //~ WARNING trivial_bounds
 {
     B::get_x()
 }
 
 fn inconsistent_bound() -> i32
 where
-    B: A<X = i32>
+    B: A<X = i32> //~ WARNING trivial_bounds
 {
     B::get_x()
 }
 
 fn redundant_bound() -> u8
 where
-    B: A<X = u8>
+    B: A<X = u8> //~ WARNING trivial_bounds
 {
     B::get_x()
 }
@@ -40,6 +40,8 @@ where
 fn inconsistent_dup_bound() -> i32
 where
     B: A<X = i32> + A
+    //~^ WARNING trivial_bounds
+    //~| WARNING trivial_bounds
 {
     B::get_x()
 }
@@ -47,6 +49,8 @@ where
 fn redundant_dup_bound() -> u8
 where
     B: A<X = u8> + A
+    //~^ WARNING trivial_bounds
+    //~| WARNING trivial_bounds
 {
     B::get_x()
 }

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-projection.stderr
@@ -31,13 +31,13 @@ LL |     B: A<X = i32> + A
    |                     ^
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:49:8
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:51:8
    |
 LL |     B: A<X = u8> + A
    |        ^^^^^^^^^
 
 warning: Trait bound B: A does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-projection.rs:49:20
+  --> $DIR/trivial-bounds-inconsistent-projection.rs:51:20
    |
 LL |     B: A<X = u8> + A
    |                    ^

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.rs
@@ -12,12 +12,15 @@ struct T<X: ?Sized> {
 }
 
 struct S(str, str) where str: Sized;
+//~^ WARNING Sized does not depend on any type or lifetime
 
 fn unsized_local() where for<'a> T<dyn A + 'a>: Sized {
+    //~^ WARNING Sized does not depend on any type or lifetime
     let x: T<dyn A> = *(Box::new(T { x: 1 }) as Box<T<dyn A>>);
 }
 
 fn return_str() -> str where str: Sized {
+    //~^ WARNING Sized does not depend on any type or lifetime
     *"Sized".to_string().into_boxed_str()
 }
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-sized.stderr
@@ -7,13 +7,13 @@ LL | struct S(str, str) where str: Sized;
    = note: `#[warn(trivial_bounds)]` on by default
 
 warning: Trait bound for<'a> T<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-sized.rs:16:49
+  --> $DIR/trivial-bounds-inconsistent-sized.rs:17:49
    |
 LL | fn unsized_local() where for<'a> T<dyn A + 'a>: Sized {
    |                                                 ^^^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent-sized.rs:20:35
+  --> $DIR/trivial-bounds-inconsistent-sized.rs:22:35
    |
 LL | fn return_str() -> str where str: Sized {
    |                                   ^^^^^

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent-well-formed.rs
@@ -5,6 +5,8 @@
 use std::fmt::Debug;
 
 pub fn foo() where Vec<str>: Debug, str: Copy {
+    //~^ WARNING Debug does not depend on any type or lifetime
+    //~| WARNING Copy does not depend on any type or lifetime
     let x = vec![*"1"];
     println!("{:?}", x);
 }

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.rs
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.rs
@@ -11,17 +11,19 @@ pub trait Foo {
 
 fn generic_function<X: Foo>(x: X) {}
 
-enum E where i32: Foo { V }
+enum E where i32: Foo { V } //~ WARNING trivial_bounds
 
-struct S where i32: Foo;
+struct S where i32: Foo; //~ WARNING trivial_bounds
 
-trait T where i32: Foo {}
+trait T where i32: Foo {} //~ WARNING trivial_bounds
 
-union U where i32: Foo { f: i32 }
+union U where i32: Foo { f: i32 } //~ WARNING trivial_bounds
 
 type Y where i32: Foo = ();
+//~^ WARNING type_alias_bounds
+//~| WARNING trivial_bounds
 
-impl Foo for () where i32: Foo {
+impl Foo for () where i32: Foo { //~ WARNING trivial_bounds
     fn test(&self) {
         3i32.test();
         Foo::test(&4i32);
@@ -29,14 +31,14 @@ impl Foo for () where i32: Foo {
     }
 }
 
-fn f() where i32: Foo {
+fn f() where i32: Foo { //~ WARNING trivial_bounds
     let s = S;
     3i32.test();
     Foo::test(&4i32);
     generic_function(5i32);
 }
 
-fn g() where &'static str: Foo {
+fn g() where &'static str: Foo { //~ WARNING trivial_bounds
     "Foo".test();
     Foo::test(&"Foo");
     generic_function("Foo");
@@ -50,21 +52,22 @@ struct Dst<X: ?Sized> {
     x: X,
 }
 
-struct TwoStrs(str, str) where str: Sized;
+struct TwoStrs(str, str) where str: Sized; //~ WARNING trivial_bounds
 
-fn unsized_local() where for<'a> Dst<dyn A + 'a>: Sized {
+fn unsized_local() where for<'a> Dst<dyn A + 'a>: Sized { //~ WARNING trivial_bounds
     let x: Dst<dyn A> = *(Box::new(Dst { x: 1 }) as Box<Dst<dyn A>>);
 }
 
-fn return_str() -> str where str: Sized {
+fn return_str() -> str where str: Sized { //~ WARNING trivial_bounds
     *"Sized".to_string().into_boxed_str()
 }
 
 fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
+    //~^ WARNING trivial_bounds
     -s
 }
 
-fn use_for() where i32: Iterator {
+fn use_for() where i32: Iterator { //~ WARNING trivial_bounds
     for _ in 2i32 {}
 }
 

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -43,49 +43,49 @@ LL | type Y where i32: Foo = ();
    |                   ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:24:28
+  --> $DIR/trivial-bounds-inconsistent.rs:26:28
    |
 LL | impl Foo for () where i32: Foo {
    |                            ^^^
 
 warning: Trait bound i32: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:32:19
+  --> $DIR/trivial-bounds-inconsistent.rs:34:19
    |
 LL | fn f() where i32: Foo {
    |                   ^^^
 
 warning: Trait bound &'static str: Foo does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:39:28
+  --> $DIR/trivial-bounds-inconsistent.rs:41:28
    |
 LL | fn g() where &'static str: Foo {
    |                            ^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:53:37
+  --> $DIR/trivial-bounds-inconsistent.rs:55:37
    |
 LL | struct TwoStrs(str, str) where str: Sized;
    |                                     ^^^^^
 
 warning: Trait bound for<'a> Dst<(dyn A + 'a)>: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:55:51
+  --> $DIR/trivial-bounds-inconsistent.rs:57:51
    |
 LL | fn unsized_local() where for<'a> Dst<dyn A + 'a>: Sized {
    |                                                   ^^^^^
 
 warning: Trait bound str: std::marker::Sized does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:59:35
+  --> $DIR/trivial-bounds-inconsistent.rs:61:35
    |
 LL | fn return_str() -> str where str: Sized {
    |                                   ^^^^^
 
 warning: Trait bound std::string::String: std::ops::Neg does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:63:46
+  --> $DIR/trivial-bounds-inconsistent.rs:65:46
    |
 LL | fn use_op(s: String) -> String where String: ::std::ops::Neg<Output=String> {
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Trait bound i32: std::iter::Iterator does not depend on any type or lifetime parameters
-  --> $DIR/trivial-bounds-inconsistent.rs:67:25
+  --> $DIR/trivial-bounds-inconsistent.rs:70:25
    |
 LL | fn use_for() where i32: Iterator {
    |                         ^^^^^^^^

--- a/src/test/ui/try-block/try-block-unreachable-code-lint.rs
+++ b/src/test/ui/try-block/try-block-unreachable-code-lint.rs
@@ -43,14 +43,14 @@ fn test_try_block_after_divergent_stmt() {
                 err()?;
             }
         }
-        // ~^^^^^ WARNING unreachable expression
+        //~^^^^^ WARNING unreachable expression
     };
 }
 
 fn test_wrapped_divergent_expr() {
     let _: Result<u32, ()> = {
         Err(return)
-        // ~^ WARNING unreachable call
+        //~^ WARNING unreachable call
     };
 }
 
@@ -61,7 +61,7 @@ fn test_expr_after_divergent_stmt_in_try_block() {
         }
 
         42
-        // ~^ WARNING unreachable expression
+        //~^ WARNING unreachable expression
     };
     println!("res: {:?}", res);
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3148,11 +3148,20 @@ impl<'test> TestCx<'test> {
                explicit, self.config.compare_mode, expected_errors, proc_res.status,
                self.props.error_patterns);
         if !explicit && self.config.compare_mode.is_none() {
-            if !self.should_run() && !self.props.error_patterns.is_empty() {
+            let check_patterns =
+                !self.should_run() &&
+                !self.props.error_patterns.is_empty();
+
+            let check_annotations =
+                !check_patterns ||
+                !expected_errors.is_empty();
+
+            if check_patterns {
                 // "// error-pattern" comments
                 self.check_error_patterns(&proc_res.stderr, &proc_res);
             }
-            if !expected_errors.is_empty() {
+
+            if check_annotations {
                 // "//~ERROR comments"
                 self.check_expected_errors(expected_errors, &proc_res);
             }


### PR DESCRIPTION
This change makes error and warning annotations mandatory in UI tests.
The only exception are tests that use error patterns to match compiler
output and don't have any annotations.

Fixes #55596.