### PR TITLE
Use `eq_opaque_type_and_type` when type-checking closure signatures

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-63263-closure-return.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63263-closure-return.rs
@@ -2,7 +2,7 @@
 // Tests that we properly handle closures with an explicit return type
 // that return an opaque type.
 
-// run-pass
+// check-pass
 
 #![feature(type_alias_impl_trait)]
 

--- a/src/test/ui/type-alias-impl-trait/issue-63263-closure-return.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63263-closure-return.rs
@@ -1,0 +1,13 @@
+// Regression test for issue #63263.
+// Tests that we properly handle closures with an explicit return type
+// that return an opaque type.
+
+// run-pass
+
+#![feature(type_alias_impl_trait)]
+
+pub type Closure = impl FnOnce();
+
+fn main() {
+    || -> Closure { || () };
+}


### PR DESCRIPTION
This handles the case where a user explicitly annotations a closure
signature with a opaque return type.

Fixes #63263