### PR TITLE
docs: Fix link to BufWriter::flush

### DIFF
--- a/src/libstd/io/buffered.rs
+++ b/src/libstd/io/buffered.rs
@@ -369,7 +369,7 @@ impl<R: Seek> Seek for BufReader<R> {
 ///
 /// It is critical to call [`flush`] before `BufWriter<W>` is dropped. Though
 /// dropping will attempt to flush the the contents of the buffer, any errors
-/// that happen in the process of dropping will be ignored. Calling ['flush']
+/// that happen in the process of dropping will be ignored. Calling [`flush`]
 /// ensures that the buffer is empty and thus dropping will not even attempt
 /// file operations.
 ///


### PR DESCRIPTION
One of the links in the docs was being rendered as a literal
open-bracket followed by a single quote, instead of being transformed
into a link. Fix it to match the link earlier in the same paragraph.