### PR TITLE
rustc_metadata: don't let LLVM confuse rmeta blobs for COFF object files.

### DIFF
--- a/src/librustc_codegen_ssa/lib.rs
+++ b/src/librustc_codegen_ssa/lib.rs
@@ -59,7 +59,8 @@ pub struct ModuleCodegen<M> {
     pub kind: ModuleKind,
 }
 
-pub const METADATA_FILENAME: &str = "rust.metadata.bin";
+// FIXME(eddyb) maybe include the crate name in this?
+pub const METADATA_FILENAME: &str = "lib.rmeta";
 pub const RLIB_BYTECODE_EXTENSION: &str = "bc.z";
 
 

--- a/src/librustc_metadata/rmeta/mod.rs
+++ b/src/librustc_metadata/rmeta/mod.rs
@@ -37,18 +37,15 @@ crate fn rustc_version() -> String {
 /// Metadata encoding version.
 /// N.B., increment this if you change the format of metadata such that
 /// the rustc version can't be found to compare with `rustc_version()`.
-const METADATA_VERSION: u8 = 4;
+const METADATA_VERSION: u8 = 5;
 
 /// Metadata header which includes `METADATA_VERSION`.
-/// To get older versions of rustc to ignore this metadata,
-/// there are 4 zero bytes at the start, which are treated
-/// as a length of 0 by old compilers.
 ///
 /// This header is followed by the position of the `CrateRoot`,
 /// which is encoded as a 32-bit big-endian unsigned integer,
 /// and further followed by the rustc version string.
-crate const METADATA_HEADER: &[u8; 12] =
-    &[0, 0, 0, 0, b'r', b'u', b's', b't', 0, 0, 0, METADATA_VERSION];
+crate const METADATA_HEADER: &[u8; 8] =
+    &[b'r', b'u', b's', b't', 0, 0, 0, METADATA_VERSION];
 
 /// Additional metadata for a `Lazy<T>` where `T` may not be `Sized`,
 /// e.g. for `Lazy<[T]>`, this is the length (count of `T` values).

--- a/src/test/run-make-fulldeps/invalid-library/Makefile
+++ b/src/test/run-make-fulldeps/invalid-library/Makefile
@@ -1,6 +1,6 @@
 -include ../tools.mk
 
 all:
-	touch $(TMPDIR)/rust.metadata.bin
-	$(AR) crus $(TMPDIR)/libfoo-ffffffff-1.0.rlib $(TMPDIR)/rust.metadata.bin
+	touch $(TMPDIR)/lib.rmeta
+	$(AR) crus $(TMPDIR)/libfoo-ffffffff-1.0.rlib $(TMPDIR)/lib.rmeta
 	$(RUSTC) foo.rs 2>&1 | $(CGREP) "can't find crate for"


### PR DESCRIPTION
This has likely been a silent issue since 1.10 but only caused trouble recently (see https://github.com/rust-lang/rust/issues/65536#issuecomment-552018224), when recent changes to the `rmeta` schema introduced more opportunities for COFF parse errors.

To prevent any undesired interactions with old compilers, I've renamed the file inside `rlib`s from `rust.metadata.bin` to `lib.rmeta` (not strongly attached to it, suggestions welcome).

Fixes #65536.

<hr/>

Before:
```
$ llvm-objdump -all-headers build/*/stage1-std/*/release/deps/libcore-*.rmeta

build/x86_64-unknown-linux-gnu/stage1-std/x86_64-unknown-linux-gnu/release/deps/libcore-6b9e8b5a59b79a1d.rmeta: file format COFF-<unknown arch>

architecture: unknown
start address: 0x00000000

Sections:
Idx Name          Size     VMA          Type

SYMBOL TABLE:
```

After:
```
$ llvm-objdump -all-headers build/*/stage1-std/*/release/deps/libcore-*.rmeta

llvm-objdump: error: 'build/x86_64-unknown-linux-gnu/stage1-std/x86_64-unknown-linux-gnu/release/deps/libcore-6b9e8b5a59b79a1d.rmeta':
    The file was not recognized as a valid object file
```