### PR TITLE
rustdoc: Stabilize `edition` annotation.

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -680,9 +680,7 @@ impl LangString {
                     seen_rust_tags = !seen_other_tags || seen_rust_tags;
                     data.no_run = true;
                 }
-                x if allow_error_code_check && x.starts_with("edition") => {
-                    // allow_error_code_check is true if we're on nightly, which
-                    // is needed for edition support
+                x if x.starts_with("edition") => {
                     data.edition = x[7..].parse::<Edition>().ok();
                 }
                 x if allow_error_code_check && x.starts_with("E") && x.len() == 5 => {

--- a/src/test/rustdoc/edition-flag.rs
+++ b/src/test/rustdoc/edition-flag.rs
@@ -1,4 +1,4 @@
-// compile-flags:--test -Z unstable-options
+// compile-flags:--test
 // edition:2018
 
 /// ```rust


### PR DESCRIPTION
The rustdoc `edition` annotation is currently ignored on stable. This means that the tests will be ignored, unless there is a `rust` annotation, then it will use the global edition. I suspect this was just an oversight during the edition stabilization, but I don't know. Example:

```rust
/// ```edition2018
/// // This code block was ignored on stable.
/// ```

/// ```rust,edition2018
/// // This code block would use whatever edition is passed on the command line.
/// ```
```

AFAIK, it is not possible to write a test that verifies stable behavior, as all tests appear to set RUSTC_BOOTSTRAP which forces all tests to run as "nightly", even on a stable release.

Closes #65980
