### PR TITLE
Simplify memory categorization

### DIFF
--- a/src/librustc/lib.rs
+++ b/src/librustc/lib.rs
@@ -96,7 +96,6 @@ pub mod infer;
 pub mod lint;
 
 pub mod middle {
-    pub mod expr_use_visitor;
     pub mod cstore;
     pub mod dependency_format;
     pub mod diagnostic_items;
@@ -104,7 +103,6 @@ pub mod middle {
     pub mod free_region;
     pub mod lib_features;
     pub mod lang_items;
-    pub mod mem_categorization;
     pub mod privacy;
     pub mod reachable;
     pub mod region;

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -75,7 +75,6 @@
 use crate::check::dropck;
 use crate::check::FnCtxt;
 use crate::middle::mem_categorization as mc;
-use crate::middle::mem_categorization::Categorization;
 use crate::middle::region;
 use rustc::hir::def_id::DefId;
 use rustc::infer::outlives::env::OutlivesEnvironment;
@@ -88,7 +87,6 @@ use rustc::hir::intravisit::{self, NestedVisitorMap, Visitor};
 use rustc::hir::{self, PatKind};
 use std::mem;
 use std::ops::Deref;
-use std::rc::Rc;
 use syntax_pos::Span;
 
 // a variation on try that just returns unit
@@ -898,10 +896,6 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
             }
 
             cmt = self.with_mc(|mc| mc.cat_expr_adjusted(expr, cmt, &adjustment))?;
-
-            if let Categorization::Deref(_, mc::BorrowedPtr(_, r_ptr)) = cmt.cat {
-                self.mk_subregion_due_to_dereference(expr.span, expr_region, r_ptr);
-            }
         }
 
         Ok(cmt)
@@ -920,16 +914,22 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         )
     }
 
-    fn check_safety_of_rvalue_destructor_if_necessary(&mut self, cmt: &mc::Place<'tcx>, span: Span) {
-        if let Categorization::Rvalue = cmt.cat {
-            let typ = self.resolve_type(cmt.ty);
-            let body_id = self.body_id;
-            let _ = dropck::check_drop_obligations(
-                self,
-                typ,
-                span,
-                body_id,
-            );
+    fn check_safety_of_rvalue_destructor_if_necessary(
+        &mut self,
+        place: &mc::Place<'tcx>,
+        span: Span,
+    ) {
+        if let mc::PlaceBase::Rvalue = place.base {
+            if place.projections.is_empty() {
+                let typ = self.resolve_type(place.ty);
+                let body_id = self.body_id;
+                let _ = dropck::check_drop_obligations(
+                    self,
+                    typ,
+                    span,
+                    body_id,
+                );
+            }
         }
     }
 
@@ -1034,7 +1034,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
             }
             Some(ref expr) => &**expr,
         };
-        let discr_cmt = Rc::new(ignore_err!(self.with_mc(|mc| mc.cat_expr(init_expr))));
+        let discr_cmt = ignore_err!(self.with_mc(|mc| mc.cat_expr(init_expr)));
         self.link_pattern(discr_cmt, &local.pat);
     }
 
@@ -1043,7 +1043,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     /// linked to the lifetime of its guarantor (if any).
     fn link_match(&self, discr: &hir::Expr, arms: &[hir::Arm]) {
         debug!("regionck::for_match()");
-        let discr_cmt = Rc::new(ignore_err!(self.with_mc(|mc| mc.cat_expr(discr))));
+        let discr_cmt = ignore_err!(self.with_mc(|mc| mc.cat_expr(discr)));
         debug!("discr_cmt={:?}", discr_cmt);
         for arm in arms {
             self.link_pattern(discr_cmt.clone(), &arm.pat);
@@ -1057,7 +1057,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         for param in params {
             let param_ty = self.node_ty(param.hir_id);
             let param_cmt = self.with_mc(|mc| {
-                Rc::new(mc.cat_rvalue(param.hir_id, param.pat.span, param_ty))
+                mc.cat_rvalue(param.hir_id, param.pat.span, param_ty)
             });
             debug!("param_ty={:?} param_cmt={:?} param={:?}", param_ty, param_cmt, param);
             self.link_pattern(param_cmt, &param.pat);
@@ -1066,7 +1066,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
 
     /// Link lifetimes of any ref bindings in `root_pat` to the pointers found
     /// in the discriminant, if needed.
-    fn link_pattern(&self, discr_cmt: mc::cmt<'tcx>, root_pat: &hir::Pat) {
+    fn link_pattern(&self, discr_cmt: mc::Place<'tcx>, root_pat: &hir::Pat) {
         debug!(
             "link_pattern(discr_cmt={:?}, root_pat={:?})",
             discr_cmt, root_pat
@@ -1152,60 +1152,34 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         span: Span,
         borrow_region: ty::Region<'tcx>,
         borrow_kind: ty::BorrowKind,
-        borrow_cmt: &mc::Place<'tcx>,
+        borrow_place: &mc::Place<'tcx>,
     ) {
-        let origin = infer::DataBorrowed(borrow_cmt.ty, span);
-        self.type_must_outlive(origin, borrow_cmt.ty, borrow_region);
+        let origin = infer::DataBorrowed(borrow_place.ty, span);
+        self.type_must_outlive(origin, borrow_place.ty, borrow_region);
 
-        let mut borrow_kind = borrow_kind;
-        let mut borrow_cmt_cat = borrow_cmt.cat.clone();
-
-        loop {
+        for pointer_ty in borrow_place.deref_tys() {
             debug!(
-                "link_region(borrow_region={:?}, borrow_kind={:?}, borrow_cmt={:?})",
-                borrow_region, borrow_kind, borrow_cmt
+                "link_region(borrow_region={:?}, borrow_kind={:?}, pointer_ty={:?})",
+                borrow_region, borrow_kind, borrow_place
             );
-            match borrow_cmt_cat {
-                Categorization::Deref(ref_cmt, mc::BorrowedPtr(ref_kind, ref_region)) => {
-                    match self.link_reborrowed_region(
+            match pointer_ty.kind {
+                ty::RawPtr(_) => return,
+                ty::Ref(ref_region, _, ref_mutability) => {
+                    if self.link_reborrowed_region(
                         span,
                         borrow_region,
-                        borrow_kind,
-                        ref_cmt,
                         ref_region,
-                        ref_kind,
-                        borrow_cmt.note,
+                        ref_mutability,
                     ) {
-                        Some((c, k)) => {
-                            borrow_cmt_cat = c.cat.clone();
-                            borrow_kind = k;
-                        }
-                        None => {
-                            return;
-                        }
+                        return;
                     }
-                }
 
-                Categorization::Downcast(cmt_base, _)
-                | Categorization::Deref(cmt_base, mc::Unique)
-                | Categorization::Interior(cmt_base, _) => {
-                    // Borrowing interior or owned data requires the base
-                    // to be valid and borrowable in the same fashion.
-                    borrow_cmt_cat = cmt_base.cat.clone();
-                    borrow_kind = borrow_kind;
                 }
-
-                Categorization::Deref(_, mc::UnsafePtr(..))
-                | Categorization::StaticItem
-                | Categorization::Upvar(..)
-                | Categorization::Local(..)
-                | Categorization::ThreadLocal
-                | Categorization::Rvalue => {
-                    // These are all "base cases" with independent lifetimes
-                    // that are not subject to inference
-                    return;
-                }
+                _ => assert!(pointer_ty.is_box(), "unexpected built-in deref type {}", pointer_ty)
             }
+        }
+        if let mc::PlaceBase::Upvar(upvar_id) = borrow_place.base {
+            self.link_upvar_region(span, borrow_region, upvar_id);
         }
     }
 
@@ -1230,83 +1204,28 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     ///
     /// Here `bk` stands for some borrow-kind (e.g., `mut`, `uniq`, etc).
     ///
-    /// Unfortunately, there are some complications beyond the simple
-    /// scenario I just painted:
+    /// There is a complication beyond the simple scenario I just painted: there
+    /// may in fact be more levels of reborrowing. In the example, I said the
+    /// borrow was like `&'z *r`, but it might in fact be a borrow like
+    /// `&'z **q` where `q` has type `&'a &'b mut T`. In that case, we want to
+    /// ensure that `'z <= 'a` and `'z <= 'b`.
     ///
-    /// 1. The reference `r` might in fact be a "by-ref" upvar. In that
-    ///    case, we have two jobs. First, we are inferring whether this reference
-    ///    should be an `&T`, `&mut T`, or `&uniq T` reference, and we must
-    ///    adjust that based on this borrow (e.g., if this is an `&mut` borrow,
-    ///    then `r` must be an `&mut` reference). Second, whenever we link
-    ///    two regions (here, `'z <= 'a`), we supply a *cause*, and in this
-    ///    case we adjust the cause to indicate that the reference being
-    ///    "reborrowed" is itself an upvar. This provides a nicer error message
-    ///    should something go wrong.
+    /// The return value of this function indicates whether we *don't* need to
+    /// the recurse to the next reference up.
     ///
-    /// 2. There may in fact be more levels of reborrowing. In the
-    ///    example, I said the borrow was like `&'z *r`, but it might
-    ///    in fact be a borrow like `&'z **q` where `q` has type `&'a
-    ///    &'b mut T`. In that case, we want to ensure that `'z <= 'a`
-    ///    and `'z <= 'b`. This is explained more below.
-    ///
-    /// The return value of this function indicates whether we need to
-    /// recurse and process `ref_cmt` (see case 2 above).
+    /// This is explained more below.
     fn link_reborrowed_region(
         &self,
         span: Span,
         borrow_region: ty::Region<'tcx>,
-        borrow_kind: ty::BorrowKind,
-        ref_cmt: mc::cmt<'tcx>,
         ref_region: ty::Region<'tcx>,
-        mut ref_kind: ty::BorrowKind,
-        note: mc::Note,
-    ) -> Option<(mc::cmt<'tcx>, ty::BorrowKind)> {
-        // Possible upvar ID we may need later to create an entry in the
-        // maybe link map.
-
-        // Detect by-ref upvar `x`:
-        let cause = match note {
-            mc::NoteUpvarRef(ref upvar_id) => {
-                match self.tables.borrow().upvar_capture_map.get(upvar_id) {
-                    Some(&ty::UpvarCapture::ByRef(ref upvar_borrow)) => {
-                        // The mutability of the upvar may have been modified
-                        // by the above adjustment, so update our local variable.
-                        ref_kind = upvar_borrow.kind;
-
-                        infer::ReborrowUpvar(span, *upvar_id)
-                    }
-                    _ => {
-                        span_bug!(span, "Illegal upvar id: {:?}", upvar_id);
-                    }
-                }
-            }
-            mc::NoteClosureEnv(ref upvar_id) => {
-                // We don't have any mutability changes to propagate, but
-                // we do want to note that an upvar reborrow caused this
-                // link
-                infer::ReborrowUpvar(span, *upvar_id)
-            }
-            _ => infer::Reborrow(span),
-        };
-
+        ref_mutability: hir::Mutability,
+    ) -> bool {
         debug!(
             "link_reborrowed_region: {:?} <= {:?}",
             borrow_region, ref_region
         );
-        self.sub_regions(cause, borrow_region, ref_region);
-
-        // If we end up needing to recurse and establish a region link
-        // with `ref_cmt`, calculate what borrow kind we will end up
-        // needing. This will be used below.
-        //
-        // One interesting twist is that we can weaken the borrow kind
-        // when we recurse: to reborrow an `&mut` referent as mutable,
-        // borrowck requires a unique path to the `&mut` reference but not
-        // necessarily a *mutable* path.
-        let new_borrow_kind = match borrow_kind {
-            ty::ImmBorrow => ty::ImmBorrow,
-            ty::MutBorrow | ty::UniqueImmBorrow => ty::UniqueImmBorrow,
-        };
+        self.sub_regions(infer::Reborrow(span), borrow_region, ref_region);
 
         // Decide whether we need to recurse and link any regions within
         // the `ref_cmt`. This is concerned for the case where the value
@@ -1335,24 +1254,83 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         // (Note that since we have not examined `ref_cmt.cat`, we don't
         // know whether this scenario has occurred; but I wanted to show
         // how all the types get adjusted.)
-        match ref_kind {
-            ty::ImmBorrow => {
+        match ref_mutability {
+            hir::Mutability::Immutable => {
                 // The reference being reborrowed is a shareable ref of
                 // type `&'a T`. In this case, it doesn't matter where we
                 // *found* the `&T` pointer, the memory it references will
                 // be valid and immutable for `'a`. So we can stop here.
-                //
-                // (Note that the `borrow_kind` must also be ImmBorrow or
-                // else the user is borrowed imm memory as mut memory,
-                // which means they'll get an error downstream in borrowck
-                // anyhow.)
-                return None;
+                true
             }
 
-            ty::MutBorrow | ty::UniqueImmBorrow => {
-                // The reference being reborrowed is either an `&mut T` or
-                // `&uniq T`. This is the case where recursion is needed.
-                return Some((ref_cmt, new_borrow_kind));
+            hir::Mutability::Mutable => {
+                // The reference being reborrowed is either an `&mut T`. This is
+                // the case where recursion is needed.
+                false
+            }
+        }
+    }
+
+    /// An upvar may be behind up to 2 references:
+    ///
+    /// * One can come from the reference to a "by-reference" upvar.
+    /// * Another one can come from the reference to the closure itself if it's
+    ///   a `FnMut` or `Fn` closure.
+    ///
+    /// This function links the lifetimes of those references to the lifetime
+    /// of the borrow that's provided. See [link_reborrowed_region] for some
+    /// more explanation of this in the general case.
+    ///
+    /// We also supply a *cause*, and in this case we set the cause to
+    /// indicate that the reference being "reborrowed" is itself an upvar. This
+    /// provides a nicer error message should something go wrong.
+    fn link_upvar_region(
+        &self,
+        span: Span,
+        borrow_region: ty::Region<'tcx>,
+        upvar_id: ty::UpvarId,
+    ) {
+        debug!("link_upvar_region(borrorw_region={:?}, upvar_id={:?}", borrow_region, upvar_id);
+        // A by-reference upvar can't be borrowed for longer than the
+        // upvar is borrowed from the environment.
+        match self.tables.borrow().upvar_capture(upvar_id) {
+            ty::UpvarCapture::ByRef(upvar_borrow) => {
+                self.sub_regions(
+                    infer::ReborrowUpvar(span, upvar_id),
+                    borrow_region,
+                    upvar_borrow.region,
+                );
+                if let ty::ImmBorrow = upvar_borrow.kind {
+                    debug!("link_upvar_region: capture by shared ref");
+                    return;
+                }
+            }
+            ty::UpvarCapture::ByValue => {}
+        }
+        let fn_hir_id = self.tcx.hir().local_def_id_to_hir_id(upvar_id.closure_expr_id);
+        let ty = self.resolve_node_type(fn_hir_id);
+        debug!("link_upvar_region: ty={:?}", ty);
+
+        // A closure capture can't be borrowed for longer than the
+        // reference to the closure.
+        if let ty::Closure(closure_def_id, substs) = ty.kind {
+            match self.infcx.closure_kind(closure_def_id, substs) {
+                Some(ty::ClosureKind::Fn) | Some(ty::ClosureKind::FnMut) => {
+                    // Region of environment pointer
+                    let env_region = self.tcx.mk_region(ty::ReFree(ty::FreeRegion {
+                        scope: upvar_id.closure_expr_id.to_def_id(),
+                        bound_region: ty::BrEnv
+                    }));
+                    self.sub_regions(
+                        infer::ReborrowUpvar(span, upvar_id),
+                        borrow_region,
+                        env_region,
+                    );
+                }
+                Some(ty::ClosureKind::FnOnce) => {}
+                None => {
+                    span_bug!(span, "Have not inferred closure kind before regionck");
+                }
             }
         }
     }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -825,7 +825,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
 
     /// Invoked on any adjustments that occur. Checks that if this is a region pointer being
     /// dereferenced, the lifetime of the pointer includes the deref expr.
-    fn constrain_adjustments(&mut self, expr: &hir::Expr) -> mc::McResult<mc::cmt_<'tcx>> {
+    fn constrain_adjustments(&mut self, expr: &hir::Expr) -> mc::McResult<mc::Place<'tcx>> {
         debug!("constrain_adjustments(expr={:?})", expr);
 
         let mut cmt = self.with_mc(|mc| mc.cat_expr_unadjusted(expr))?;
@@ -921,7 +921,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         )
     }
 
-    fn check_safety_of_rvalue_destructor_if_necessary(&mut self, cmt: &mc::cmt_<'tcx>, span: Span) {
+    fn check_safety_of_rvalue_destructor_if_necessary(&mut self, cmt: &mc::Place<'tcx>, span: Span) {
         if let Categorization::Rvalue = cmt.cat {
             let typ = self.resolve_type(cmt.ty);
             let body_id = self.body_id;
@@ -1100,7 +1100,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     fn link_autoref(
         &self,
         expr: &hir::Expr,
-        expr_cmt: &mc::cmt_<'tcx>,
+        expr_cmt: &mc::Place<'tcx>,
         autoref: &adjustment::AutoBorrow<'tcx>,
     ) {
         debug!(
@@ -1130,7 +1130,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         span: Span,
         id: hir::HirId,
         mutbl: hir::Mutability,
-        cmt_borrowed: &mc::cmt_<'tcx>,
+        cmt_borrowed: &mc::Place<'tcx>,
     ) {
         debug!(
             "link_region_from_node_type(id={:?}, mutbl={:?}, cmt_borrowed={:?})",
@@ -1153,7 +1153,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         span: Span,
         borrow_region: ty::Region<'tcx>,
         borrow_kind: ty::BorrowKind,
-        borrow_cmt: &mc::cmt_<'tcx>,
+        borrow_cmt: &mc::Place<'tcx>,
     ) {
         let origin = infer::DataBorrowed(borrow_cmt.ty, span);
         self.type_must_outlive(origin, borrow_cmt.ty, borrow_region);

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -814,11 +814,10 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
     where
         F: for<'b> FnOnce(mc::MemCategorizationContext<'b, 'tcx>) -> R,
     {
-        f(mc::MemCategorizationContext::with_infer(
+        f(mc::MemCategorizationContext::new(
             &self.infcx,
             self.outlives_environment.param_env,
             self.body_owner,
-            &self.region_scope_tree,
             &self.tables.borrow(),
         ))
     }

--- a/src/librustc_typeck/check/regionck.rs
+++ b/src/librustc_typeck/check/regionck.rs
@@ -74,7 +74,7 @@
 
 use crate::check::dropck;
 use crate::check::FnCtxt;
-use crate::middle::mem_categorization as mc;
+use crate::mem_categorization as mc;
 use crate::middle::region;
 use rustc::hir::def_id::DefId;
 use rustc::infer::outlives::env::OutlivesEnvironment;

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -171,20 +171,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let body_owner_def_id = self.tcx.hir().body_owner_def_id(body.id());
         assert_eq!(body_owner_def_id, closure_def_id);
-        let region_scope_tree = &self.tcx.region_scope_tree(body_owner_def_id);
         let mut delegate = InferBorrowKind {
             fcx: self,
-            closure_def_id: closure_def_id,
+            closure_def_id,
             current_closure_kind: ty::ClosureKind::LATTICE_BOTTOM,
             current_origin: None,
             adjust_upvar_captures: ty::UpvarCaptureMap::default(),
         };
-        euv::ExprUseVisitor::with_infer(
+        euv::ExprUseVisitor::new(
             &mut delegate,
             &self.infcx,
             body_owner_def_id,
             self.param_env,
-            region_scope_tree,
             &self.tables.borrow(),
         )
         .consume_body(body);

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -341,7 +341,7 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
         self.adjust_upvar_captures.insert(upvar_id, ty::UpvarCapture::ByValue);
     }
 
-    /// Indicates that `cmt` is being directly mutated (e.g., assigned
+    /// Indicates that `place` is being directly mutated (e.g., assigned
     /// to). If the place is based on a by-ref upvar, this implies that
     /// the upvar must be borrowed using an `&mut` borrow.
     fn adjust_upvar_borrow_kind_for_mut(&mut self, place: &mc::Place<'tcx>) {

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -34,7 +34,7 @@ use super::FnCtxt;
 
 use crate::middle::expr_use_visitor as euv;
 use crate::middle::mem_categorization as mc;
-use crate::middle::mem_categorization::Categorization;
+use crate::middle::mem_categorization::PlaceBase;
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::hir::def_id::LocalDefId;
@@ -76,6 +76,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InferBorrowKindVisitor<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
+    /// Analysis starting point.
     fn analyze_closure(
         &self,
         closure_hir_id: hir::HirId,
@@ -83,9 +84,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         body: &hir::Body,
         capture_clause: hir::CaptureBy,
     ) {
-        /*!
-         * Analysis starting point.
-         */
 
         debug!(
             "analyze_closure(id={:?}, body.id={:?})",
@@ -310,13 +308,10 @@ struct InferBorrowKind<'a, 'tcx> {
 impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
     fn adjust_upvar_borrow_kind_for_consume(
         &mut self,
-        cmt: &mc::Place<'tcx>,
+        place: &mc::Place<'tcx>,
         mode: euv::ConsumeMode,
     ) {
-        debug!(
-            "adjust_upvar_borrow_kind_for_consume(cmt={:?}, mode={:?})",
-            cmt, mode
-        );
+        debug!("adjust_upvar_borrow_kind_for_consume(place={:?}, mode={:?})", place, mode);
 
         // we only care about moves
         match mode {
@@ -327,132 +322,68 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
         }
 
         let tcx = self.fcx.tcx;
+        let upvar_id = if let PlaceBase::Upvar(upvar_id) = place.base {
+            upvar_id
+        } else {
+            return;
+        };
 
-        // watch out for a move of the deref of a borrowed pointer;
-        // for that to be legal, the upvar would have to be borrowed
-        // by value instead
-        let guarantor = cmt.guarantor();
-        debug!(
-            "adjust_upvar_borrow_kind_for_consume: guarantor={:?}",
-            guarantor
+        debug!("adjust_upvar_borrow_kind_for_consume: upvar={:?}", upvar_id);
+
+        // To move out of an upvar, this must be a FnOnce closure
+        self.adjust_closure_kind(
+            upvar_id.closure_expr_id,
+            ty::ClosureKind::FnOnce,
+            place.span,
+            var_name(tcx, upvar_id.var_path.hir_id),
         );
-        debug!(
-            "adjust_upvar_borrow_kind_for_consume: guarantor.cat={:?}",
-            guarantor.cat
-        );
-        if let Categorization::Deref(_, mc::BorrowedPtr(..)) = guarantor.cat {
-            debug!(
-                "adjust_upvar_borrow_kind_for_consume: found deref with note {:?}",
-                cmt.note
-            );
-            match guarantor.note {
-                mc::NoteUpvarRef(upvar_id) => {
-                    debug!(
-                        "adjust_upvar_borrow_kind_for_consume: \
-                         setting upvar_id={:?} to by value",
-                        upvar_id
-                    );
 
-                    // to move out of an upvar, this must be a FnOnce closure
-                    self.adjust_closure_kind(
-                        upvar_id.closure_expr_id,
-                        ty::ClosureKind::FnOnce,
-                        guarantor.span,
-                        var_name(tcx, upvar_id.var_path.hir_id),
-                    );
-
-                    self.adjust_upvar_captures
-                        .insert(upvar_id, ty::UpvarCapture::ByValue);
-                }
-                mc::NoteClosureEnv(upvar_id) => {
-                    // we get just a closureenv ref if this is a
-                    // `move` closure, or if the upvar has already
-                    // been inferred to by-value. In any case, we
-                    // must still adjust the kind of the closure
-                    // to be a FnOnce closure to permit moves out
-                    // of the environment.
-                    self.adjust_closure_kind(
-                        upvar_id.closure_expr_id,
-                        ty::ClosureKind::FnOnce,
-                        guarantor.span,
-                        var_name(tcx, upvar_id.var_path.hir_id),
-                    );
-                }
-                mc::NoteIndex | mc::NoteNone => {}
-            }
-        }
+        self.adjust_upvar_captures.insert(upvar_id, ty::UpvarCapture::ByValue);
     }
 
     /// Indicates that `cmt` is being directly mutated (e.g., assigned
-    /// to). If cmt contains any by-ref upvars, this implies that
-    /// those upvars must be borrowed using an `&mut` borrow.
-    fn adjust_upvar_borrow_kind_for_mut(&mut self, cmt: &mc::Place<'tcx>) {
-        debug!("adjust_upvar_borrow_kind_for_mut(cmt={:?})", cmt);
+    /// to). If the place is based on a by-ref upvar, this implies that
+    /// the upvar must be borrowed using an `&mut` borrow.
+    fn adjust_upvar_borrow_kind_for_mut(&mut self, place: &mc::Place<'tcx>) {
+        debug!("adjust_upvar_borrow_kind_for_mut(place={:?})", place);
 
-        match cmt.cat.clone() {
-            Categorization::Deref(base, mc::Unique)
-            | Categorization::Interior(base, _)
-            | Categorization::Downcast(base, _) => {
-                // Interior or owned data is mutable if base is
-                // mutable, so iterate to the base.
-                self.adjust_upvar_borrow_kind_for_mut(&base);
-            }
-
-            Categorization::Deref(base, mc::BorrowedPtr(..)) => {
-                if !self.try_adjust_upvar_deref(cmt, ty::MutBorrow) {
+        if let PlaceBase::Upvar(upvar_id) = place.base {
+            let mut borrow_kind = ty::MutBorrow;
+            for pointer_ty in place.deref_tys() {
+                match pointer_ty.kind {
+                    // Raw pointers don't inherit mutability.
+                    ty::RawPtr(_) => return,
                     // assignment to deref of an `&mut`
                     // borrowed pointer implies that the
                     // pointer itself must be unique, but not
                     // necessarily *mutable*
-                    self.adjust_upvar_borrow_kind_for_unique(&base);
+                    ty::Ref(.., hir::Mutability::Mutable) => borrow_kind = ty::UniqueImmBorrow,
+                    _ => (),
                 }
             }
+            self.adjust_upvar_deref(upvar_id, place.span, borrow_kind);
+        }
+    }
 
-            Categorization::Deref(_, mc::UnsafePtr(..))
-            | Categorization::StaticItem
-            | Categorization::ThreadLocal
-            | Categorization::Rvalue
-            | Categorization::Local(_)
-            | Categorization::Upvar(..) => {
+    fn adjust_upvar_borrow_kind_for_unique(&mut self, place: &mc::Place<'tcx>) {
+        debug!("adjust_upvar_borrow_kind_for_unique(place={:?})", place);
+
+        if let PlaceBase::Upvar(upvar_id) = place.base {
+            if place.deref_tys().any(ty::TyS::is_unsafe_ptr) {
+                // Raw pointers don't inherit mutability.
                 return;
             }
+            // for a borrowed pointer to be unique, its base must be unique
+            self.adjust_upvar_deref(upvar_id, place.span, ty::UniqueImmBorrow);
         }
     }
 
-    fn adjust_upvar_borrow_kind_for_unique(&mut self, cmt: &mc::Place<'tcx>) {
-        debug!("adjust_upvar_borrow_kind_for_unique(cmt={:?})", cmt);
-
-        match cmt.cat.clone() {
-            Categorization::Deref(base, mc::Unique)
-            | Categorization::Interior(base, _)
-            | Categorization::Downcast(base, _) => {
-                // Interior or owned data is unique if base is
-                // unique.
-                self.adjust_upvar_borrow_kind_for_unique(&base);
-            }
-
-            Categorization::Deref(base, mc::BorrowedPtr(..)) => {
-                if !self.try_adjust_upvar_deref(cmt, ty::UniqueImmBorrow) {
-                    // for a borrowed pointer to be unique, its
-                    // base must be unique
-                    self.adjust_upvar_borrow_kind_for_unique(&base);
-                }
-            }
-
-            Categorization::Deref(_, mc::UnsafePtr(..))
-            | Categorization::StaticItem
-            | Categorization::ThreadLocal
-            | Categorization::Rvalue
-            | Categorization::Local(_)
-            | Categorization::Upvar(..) => {}
-        }
-    }
-
-    fn try_adjust_upvar_deref(
+    fn adjust_upvar_deref(
         &mut self,
-        cmt: &mc::Place<'tcx>,
+        upvar_id: ty::UpvarId,
+        place_span: Span,
         borrow_kind: ty::BorrowKind,
-    ) -> bool {
+    ) {
         assert!(match borrow_kind {
             ty::MutBorrow => true,
             ty::UniqueImmBorrow => true,
@@ -463,39 +394,19 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
 
         let tcx = self.fcx.tcx;
 
-        match cmt.note {
-            mc::NoteUpvarRef(upvar_id) => {
-                // if this is an implicit deref of an
-                // upvar, then we need to modify the
-                // borrow_kind of the upvar to make sure it
-                // is inferred to mutable if necessary
-                self.adjust_upvar_borrow_kind(upvar_id, borrow_kind);
+        // if this is an implicit deref of an
+        // upvar, then we need to modify the
+        // borrow_kind of the upvar to make sure it
+        // is inferred to mutable if necessary
+        self.adjust_upvar_borrow_kind(upvar_id, borrow_kind);
 
-                // also need to be in an FnMut closure since this is not an ImmBorrow
-                self.adjust_closure_kind(
-                    upvar_id.closure_expr_id,
-                    ty::ClosureKind::FnMut,
-                    cmt.span,
-                    var_name(tcx, upvar_id.var_path.hir_id),
-                );
-
-                true
-            }
-            mc::NoteClosureEnv(upvar_id) => {
-                // this kind of deref occurs in a `move` closure, or
-                // for a by-value upvar; in either case, to mutate an
-                // upvar, we need to be an FnMut closure
-                self.adjust_closure_kind(
-                    upvar_id.closure_expr_id,
-                    ty::ClosureKind::FnMut,
-                    cmt.span,
-                    var_name(tcx, upvar_id.var_path.hir_id),
-                );
-
-                true
-            }
-            mc::NoteIndex | mc::NoteNone => false,
-        }
+        // also need to be in an FnMut closure since this is not an ImmBorrow
+        self.adjust_closure_kind(
+            upvar_id.closure_expr_id,
+            ty::ClosureKind::FnMut,
+            place_span,
+            var_name(tcx, upvar_id.var_path.hir_id),
+        );
     }
 
     /// We infer the borrow_kind with which to borrow upvars in a stack closure.
@@ -507,7 +418,7 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
         let upvar_capture = self
             .adjust_upvar_captures
             .get(&upvar_id)
-            .cloned()
+            .copied()
             .unwrap_or_else(|| self.fcx.tables.borrow().upvar_capture(upvar_id));
         debug!(
             "adjust_upvar_borrow_kind(upvar_id={:?}, upvar_capture={:?}, kind={:?})",
@@ -584,29 +495,29 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'tcx> {
-    fn consume(&mut self, cmt: &mc::Place<'tcx>,mode: euv::ConsumeMode) {
-        debug!("consume(cmt={:?},mode={:?})", cmt, mode);
-        self.adjust_upvar_borrow_kind_for_consume(cmt, mode);
+    fn consume(&mut self, place: &mc::Place<'tcx>,mode: euv::ConsumeMode) {
+        debug!("consume(place={:?},mode={:?})", place, mode);
+        self.adjust_upvar_borrow_kind_for_consume(place, mode);
     }
 
-    fn borrow(&mut self, cmt: &mc::Place<'tcx>, bk: ty::BorrowKind) {
-        debug!("borrow(cmt={:?}, bk={:?})", cmt, bk);
+    fn borrow(&mut self, place: &mc::Place<'tcx>, bk: ty::BorrowKind) {
+        debug!("borrow(place={:?}, bk={:?})", place, bk);
 
         match bk {
             ty::ImmBorrow => {}
             ty::UniqueImmBorrow => {
-                self.adjust_upvar_borrow_kind_for_unique(cmt);
+                self.adjust_upvar_borrow_kind_for_unique(place);
             }
             ty::MutBorrow => {
-                self.adjust_upvar_borrow_kind_for_mut(cmt);
+                self.adjust_upvar_borrow_kind_for_mut(place);
             }
         }
     }
 
-    fn mutate(&mut self, assignee_cmt: &mc::Place<'tcx>) {
-        debug!("mutate(assignee_cmt={:?})", assignee_cmt);
+    fn mutate(&mut self, assignee_place: &mc::Place<'tcx>) {
+        debug!("mutate(assignee_place={:?})", assignee_place);
 
-        self.adjust_upvar_borrow_kind_for_mut(assignee_cmt);
+        self.adjust_upvar_borrow_kind_for_mut(assignee_place);
     }
 }
 

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -312,7 +312,7 @@ struct InferBorrowKind<'a, 'tcx> {
 impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
     fn adjust_upvar_borrow_kind_for_consume(
         &mut self,
-        cmt: &mc::cmt_<'tcx>,
+        cmt: &mc::Place<'tcx>,
         mode: euv::ConsumeMode,
     ) {
         debug!(
@@ -388,7 +388,7 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
     /// Indicates that `cmt` is being directly mutated (e.g., assigned
     /// to). If cmt contains any by-ref upvars, this implies that
     /// those upvars must be borrowed using an `&mut` borrow.
-    fn adjust_upvar_borrow_kind_for_mut(&mut self, cmt: &mc::cmt_<'tcx>) {
+    fn adjust_upvar_borrow_kind_for_mut(&mut self, cmt: &mc::Place<'tcx>) {
         debug!("adjust_upvar_borrow_kind_for_mut(cmt={:?})", cmt);
 
         match cmt.cat.clone() {
@@ -421,7 +421,7 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
         }
     }
 
-    fn adjust_upvar_borrow_kind_for_unique(&mut self, cmt: &mc::cmt_<'tcx>) {
+    fn adjust_upvar_borrow_kind_for_unique(&mut self, cmt: &mc::Place<'tcx>) {
         debug!("adjust_upvar_borrow_kind_for_unique(cmt={:?})", cmt);
 
         match cmt.cat.clone() {
@@ -452,7 +452,7 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
 
     fn try_adjust_upvar_deref(
         &mut self,
-        cmt: &mc::cmt_<'tcx>,
+        cmt: &mc::Place<'tcx>,
         borrow_kind: ty::BorrowKind,
     ) -> bool {
         assert!(match borrow_kind {
@@ -586,12 +586,12 @@ impl<'a, 'tcx> InferBorrowKind<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'tcx> {
-    fn consume(&mut self, cmt: &mc::cmt_<'tcx>,mode: euv::ConsumeMode) {
+    fn consume(&mut self, cmt: &mc::Place<'tcx>,mode: euv::ConsumeMode) {
         debug!("consume(cmt={:?},mode={:?})", cmt, mode);
         self.adjust_upvar_borrow_kind_for_consume(cmt, mode);
     }
 
-    fn borrow(&mut self, cmt: &mc::cmt_<'tcx>, bk: ty::BorrowKind) {
+    fn borrow(&mut self, cmt: &mc::Place<'tcx>, bk: ty::BorrowKind) {
         debug!("borrow(cmt={:?}, bk={:?})", cmt, bk);
 
         match bk {
@@ -605,7 +605,7 @@ impl<'a, 'tcx> euv::Delegate<'tcx> for InferBorrowKind<'a, 'tcx> {
         }
     }
 
-    fn mutate(&mut self, assignee_cmt: &mc::cmt_<'tcx>) {
+    fn mutate(&mut self, assignee_cmt: &mc::Place<'tcx>) {
         debug!("mutate(assignee_cmt={:?})", assignee_cmt);
 
         self.adjust_upvar_borrow_kind_for_mut(assignee_cmt);

--- a/src/librustc_typeck/check/upvar.rs
+++ b/src/librustc_typeck/check/upvar.rs
@@ -32,9 +32,9 @@
 
 use super::FnCtxt;
 
-use crate::middle::expr_use_visitor as euv;
-use crate::middle::mem_categorization as mc;
-use crate::middle::mem_categorization::PlaceBase;
+use crate::expr_use_visitor as euv;
+use crate::mem_categorization as mc;
+use crate::mem_categorization::PlaceBase;
 use rustc::hir;
 use rustc::hir::def_id::DefId;
 use rustc::hir::def_id::LocalDefId;

--- a/src/librustc_typeck/lib.rs
+++ b/src/librustc_typeck/lib.rs
@@ -75,6 +75,9 @@ This API is completely unstable and subject to change.
 
 #[macro_use] extern crate rustc;
 
+// This is used by Clippy.
+pub mod expr_use_visitor;
+
 mod astconv;
 mod check;
 mod check_unused;
@@ -83,6 +86,7 @@ mod collect;
 mod constrained_generic_params;
 mod structured_errors;
 mod impl_wf_check;
+mod mem_categorization;
 mod namespace;
 mod outlives;
 mod variance;

--- a/src/test/ui/issues/issue-4335.rs
+++ b/src/test/ui/issues/issue-4335.rs
@@ -4,8 +4,7 @@ fn id<T>(t: T) -> T { t }
 
 fn f<'r, T>(v: &'r T) -> Box<dyn FnMut() -> T + 'r> {
     id(Box::new(|| *v))
-        //~^ ERROR E0373
-        //~| ERROR E0507
+        //~^ ERROR E0507
 }
 
 fn main() {

--- a/src/test/ui/issues/issue-4335.stderr
+++ b/src/test/ui/issues/issue-4335.stderr
@@ -6,25 +6,6 @@ LL | fn f<'r, T>(v: &'r T) -> Box<dyn FnMut() -> T + 'r> {
 LL |     id(Box::new(|| *v))
    |                    ^^ move occurs because `*v` has type `T`, which does not implement the `Copy` trait
 
-error[E0373]: closure may outlive the current function, but it borrows `v`, which is owned by the current function
-  --> $DIR/issue-4335.rs:6:17
-   |
-LL |     id(Box::new(|| *v))
-   |                 ^^  - `v` is borrowed here
-   |                 |
-   |                 may outlive borrowed value `v`
-   |
-note: closure is returned here
-  --> $DIR/issue-4335.rs:6:5
-   |
-LL |     id(Box::new(|| *v))
-   |     ^^^^^^^^^^^^^^^^^^^
-help: to force the closure to take ownership of `v` (and any other referenced variables), use the `move` keyword
-   |
-LL |     id(Box::new(move || *v))
-   |                 ^^^^^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0373, E0507.
-For more information about an error, try `rustc --explain E0373`.
+For more information about this error, try `rustc --explain E0507`.

--- a/src/test/ui/regions/regions-addr-of-upvar-self.stderr
+++ b/src/test/ui/regions/regions-addr-of-upvar-self.stderr
@@ -9,7 +9,7 @@ note: first, the lifetime cannot outlive the lifetime `'_` as defined on the bod
    |
 LL |         let _f = || {
    |                  ^^
-note: ...so that reference does not outlive borrowed content
+note: ...so that closure can access `self`
   --> $DIR/regions-addr-of-upvar-self.rs:10:41
    |
 LL |             let p: &'static mut usize = &mut self.food;

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-fn-once-move-from-projection.stderr
@@ -2,7 +2,7 @@ error[E0525]: expected a closure that implements the `Fn` trait, but this closur
   --> $DIR/unboxed-closures-infer-fn-once-move-from-projection.rs:14:13
    |
 LL |     let c = || drop(y.0);
-   |             ^^^^^^^^-^^^
+   |             ^^^^^^^^---^
    |             |       |
    |             |       closure is `FnOnce` because it moves the variable `y` out of its environment
    |             this closure implements `FnOnce`, not `Fn`


### PR DESCRIPTION
With AST borrowck gone, mem_categorization can be simplified, a lot.

* `cmt_` is now called `Place`. Most local variable names have been updated to reflect this, but the `cat_*` methods retain their names.
* `MemCategorizationContext` no longer needs a `ScopeTree` and always needs an `InferCtxt`.
* `Place` now uses a similar representation to `mir::Place` with a `Vec` of projections.
* `Upvar` places don't include the implicit environment and capture derefs. These are now handled by `regionck` when needed.
* Various types, methods and variants only used by AST borrowck have been removed.
* `ExprUseVisitor` now lives in `rustc_typeck::expr_use_visitor`.
* `MemCategorizationContext` and `Place` live in `rustc_typeck::mem_categorization`.
* `Place` is re-exported in `rustc_typeck::expr_use_visitor` so that Clippy can access it.

The loss of an error in `issue-4335.rs` is due to a change in capture inference in ill-formed programs. If any projection from a variable is moved from then we capture that variable by move, whether or not the place being moved from allows this.

Closes #66270