### PR TITLE
add raw ptr variant of UnsafeCell::get

### DIFF
--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1572,18 +1572,18 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// use std::mem::MaybeUninit;
     ///
     /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
-    /// unsafe { m.as_ptr().raw_get().write(5); }
+    /// unsafe { UnsafeCell::raw_get(m.as_ptr()).write(5); }
     /// let uc = unsafe { m.assume_init() };
     ///
     /// assert_eq!(uc.into_inner(), 5);
     /// ```
     #[inline]
     #[unstable(feature = "unsafe_cell_raw_get", issue = "66358")]
-    pub const fn raw_get(self: *const Self) -> *mut T {
+    pub const fn raw_get(this: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
         // #[repr(transparent)]. This exploits libstd's special status, there is
         // no guarantee for user code that this will work in future versions of the compiler!
-        self as *const T as *mut T
+        this as *const T as *mut T
     }
 }
 

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1551,15 +1551,20 @@ impl<T: ?Sized> UnsafeCell<T> {
     }
 
     /// Gets a mutable pointer to the wrapped value.
+    /// The difference to [`get`] is that this function accepts a raw pointer,
+    /// which is useful to avoid the creation of temporary references.
     ///
-    /// This can be cast to a pointer of any kind.
+    /// The result can be cast to a pointer of any kind.
     /// Ensure that the access is unique (no active references, mutable or not)
     /// when casting to `&mut T`, and ensure that there are no mutations
     /// or mutable aliases going on when casting to `&T`.
     ///
+    /// [`get`]: #method.get
+    ///
     /// # Examples
     ///
-    /// Gradual initialization of an `UnsafeCell`:
+    /// Gradual initialization of an `UnsafeCell` requires `raw_get`, as
+    /// calling `get` would require creating a reference to uninitialized data:
     ///
     /// ```
     /// #![feature(unsafe_cell_raw_get)]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1548,6 +1548,36 @@ impl<T: ?Sized> UnsafeCell<T> {
         // #[repr(transparent)]
         self as *const UnsafeCell<T> as *const T as *mut T
     }
+
+    /// Gets a mutable pointer to the wrapped value.
+    ///
+    /// This can be cast to a pointer of any kind.
+    /// Ensure that the access is unique (no active references, mutable or not)
+    /// when casting to `&mut T`, and ensure that there are no mutations
+    /// or mutable aliases going on when casting to `&T`
+    ///
+    /// # Examples
+    ///
+    /// Gradual initialization of an `UnsafeCell`:
+    ///
+    /// ```
+    /// #![feature(unsafe_cell_raw_get)]
+    /// use std::cell::UnsafeCell;
+    /// use std::mem::MaybeUninit;
+    ///
+    /// let m = MaybeUninit::<UnsafeCell<i32>>::uninit();
+    /// unsafe { m.as_ptr().raw_get().write(5); }
+    /// let uc = unsafe { m.assume_init() };
+    ///
+    /// assert_eq!(uc.into_inner(), 5);
+    /// ```
+    #[inline]
+    #[unstable(feature = "unsafe_cell_raw_get", issue = "0")]
+    pub const fn raw_get(self: *const Self) -> *mut T {
+        // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
+        // #[repr(transparent)]
+        self as *const T as *mut T
+    }
 }
 
 #[stable(feature = "unsafe_cell_default", since = "1.10.0")]

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1545,7 +1545,8 @@ impl<T: ?Sized> UnsafeCell<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub const fn get(&self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-        // #[repr(transparent)]
+        // #[repr(transparent)]. This exploits libstd's special status, there is
+        // no guarantee for user code that this will work in future versions of the compiler!
         self as *const UnsafeCell<T> as *const T as *mut T
     }
 
@@ -1572,10 +1573,11 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// assert_eq!(uc.into_inner(), 5);
     /// ```
     #[inline]
-    #[unstable(feature = "unsafe_cell_raw_get", issue = "0")]
+    #[unstable(feature = "unsafe_cell_raw_get", issue = "66358")]
     pub const fn raw_get(self: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
-        // #[repr(transparent)]
+        // #[repr(transparent)]. This exploits libstd's special status, there is
+        // no guarantee for user code that this will work in future versions of the compiler!
         self as *const T as *mut T
     }
 }

--- a/src/libcore/cell.rs
+++ b/src/libcore/cell.rs
@@ -1554,7 +1554,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// This can be cast to a pointer of any kind.
     /// Ensure that the access is unique (no active references, mutable or not)
     /// when casting to `&mut T`, and ensure that there are no mutations
-    /// or mutable aliases going on when casting to `&T`
+    /// or mutable aliases going on when casting to `&T`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This has come up recently in https://github.com/rust-lang/rust/pull/66051 (Cc @Centril @pitdicker) as well as in discussion with @nikomatsakis and in unrelated discussion with @withoutboats.