### PR TITLE
Improve errors after re rebalance coherence

### DIFF
--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -2124,10 +2124,11 @@ where `P1, ..., Pm` are the type parameters of the `impl` and `T0, ..., Tn`
 are types. One of the types `T0, ..., Tn` must be a local type (this is another
 orphan rule, see the explanation for E0117).
 
-Both of the folowing must be true:
-1. At least one of the types T0..=Tn must be a local type.
-Let Ti be the first such type.
-2. No uncovered type parameters P1..=Pm may appear in T0..Ti (excluding Ti).
+Both of the following must be true:
+1. At least one of the types `T0..=Tn` must be a local type.
+Let `Ti` be the first such type.
+2. No uncovered type parameters `P1..=Pm` may appear in `T0..Ti`
+(excluding `Ti`).
 
 For information on the design of the orphan rules,
 see [RFC 2451] and [RFC 1023].

--- a/src/librustc_typeck/error_codes.rs
+++ b/src/librustc_typeck/error_codes.rs
@@ -2058,8 +2058,13 @@ E0210: r##"
 This error indicates a violation of one of Rust's orphan rules for trait
 implementations. The rule concerns the use of type parameters in an
 implementation of a foreign trait (a trait defined in another crate), and
-states that type parameters must be "covered" by a local type. To understand
-what this means, it is perhaps easiest to consider a few examples.
+states that type parameters must be "covered" by a local type.
+
+When implementing a foreign trait for a foreign type,
+the trait must have one or more type parameters.
+A type local to your crate must appear before any use of any type parameters.
+
+To understand what this means, it is perhaps easier to consider a few examples.
 
 If `ForeignTrait` is a trait defined in some external crate `foo`, then the
 following trait `impl` is an error:
@@ -2117,12 +2122,17 @@ impl<P1, ..., Pm> ForeignTrait<T1, ..., Tn> for T0 { ... }
 
 where `P1, ..., Pm` are the type parameters of the `impl` and `T0, ..., Tn`
 are types. One of the types `T0, ..., Tn` must be a local type (this is another
-orphan rule, see the explanation for E0117). Let `i` be the smallest integer
-such that `Ti` is a local type. Then no type parameter can appear in any of the
-`Tj` for `j < i`.
+orphan rule, see the explanation for E0117).
 
-For information on the design of the orphan rules, see [RFC 1023].
+Both of the folowing must be true:
+1. At least one of the types T0..=Tn must be a local type.
+Let Ti be the first such type.
+2. No uncovered type parameters P1..=Pm may appear in T0..Ti (excluding Ti).
 
+For information on the design of the orphan rules,
+see [RFC 2451] and [RFC 1023].
+
+[RFC 2451]: https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html
 [RFC 1023]: https://github.com/rust-lang/rfcs/blob/master/text/1023-rebalancing-coherence.md
 "##,
 

--- a/src/test/ui/coherence/coherence-all-remote.stderr
+++ b/src/test/ui/coherence/coherence-all-remote.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for isize { }
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/coherence-bigint-param.stderr
+++ b/src/test/ui/coherence/coherence-bigint-param.stderr
@@ -1,10 +1,11 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
   --> $DIR/coherence-bigint-param.rs:8:6
    |
 LL | impl<T> Remote1<BigInt> for T { }
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`BigInt`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
+++ b/src/test/ui/coherence/coherence-cross-crate-conflict.stderr
@@ -13,6 +13,7 @@ error[E0210]: type parameter `A` must be used as the type parameter for some loc
 LL | impl<A> Foo for A {
    |      ^ type parameter `A` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/coherence-lone-type-parameter.stderr
+++ b/src/test/ui/coherence/coherence-lone-type-parameter.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote for T { }
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign-for-fundamental[t].stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-fundamental[t].stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<u32> for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -12,6 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<u32> for &'a T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[foreign]-for-t.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<u32> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-foreign.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<Box<T>> for u32 {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -12,6 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for u32 {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-fundamental[t].stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<Box<T>> for &'a T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -12,6 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for Box<T> {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]]-for-t.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<Box<T>> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
@@ -12,6 +13,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<'a, T> Remote1<&'a T> for T {
    |          ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs
@@ -8,11 +8,11 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote2<Box<T>, Local> for u32 {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be covered by another type
 }
 
 impl<'a, T> Remote2<&'a T, Local> for u32 {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be covered by another type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[fundamental[t]_local]-for-foreign.stderr
@@ -1,18 +1,20 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:10:6
    |
 LL | impl<T> Remote2<Box<T>, Local> for u32 {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[fundamental[t]_local]-for-foreign.rs:14:10
    |
 LL | impl<'a, T> Remote2<&'a T, Local> for u32 {
-   |          ^ type parameter `T` must be used as the type parameter for some local type
+   |          ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].rs
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].rs
@@ -8,11 +8,11 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<Local> for Box<T> {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be covered by another type
 }
 
 impl<T> Remote1<Local> for &T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be covered by another type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-fundamental[t].stderr
@@ -1,18 +1,20 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:10:6
    |
 LL | impl<T> Remote1<Local> for Box<T> {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[local]-for-fundamental[t].rs:14:6
    |
 LL | impl<T> Remote1<Local> for &T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.rs
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.rs
@@ -8,7 +8,7 @@ use std::rc::Rc;
 struct Local;
 
 impl<T> Remote1<Local> for T {
-    //~^ ERROR type parameter `T` must be used as the type parameter for some local type
+    //~^ ERROR type parameter `T` must be covered by another type
 }
 
 fn main() {}

--- a/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[local]-for-t.stderr
@@ -1,10 +1,11 @@
-error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
+error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
   --> $DIR/impl[t]-foreign[local]-for-t.rs:10:6
    |
 LL | impl<T> Remote1<Local> for T {
-   |      ^ type parameter `T` must be used as the type parameter for some local type
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Local`)
    |
-   = note: only traits defined in the current crate can be implemented for a type parameter
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-foreign.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for u32 {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-fundamental.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for Box<T> {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error[E0210]: type parameter `B` must be used as the type parameter for some local type (e.g., `MyStruct<B>`)
@@ -12,6 +13,7 @@ error[E0210]: type parameter `B` must be used as the type parameter for some loc
 LL | impl<'a, A, B> Remote1<A> for &'a B {
    |             ^ type parameter `B` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
+++ b/src/test/ui/coherence/impl[t]-foreign[t]-for-t.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Remote1<T> for T {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/e0119/issue-28981.stderr
+++ b/src/test/ui/error-codes/e0119/issue-28981.stderr
@@ -14,6 +14,7 @@ error[E0210]: type parameter `Foo` must be used as the type parameter for some l
 LL | impl<Foo> Deref for Foo { }
    |      ^^^ type parameter `Foo` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-41974.stderr
+++ b/src/test/ui/issues/issue-41974.stderr
@@ -21,6 +21,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> Drop for T where T: A {
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/orphan-check-diagnostics.stderr
+++ b/src/test/ui/orphan-check-diagnostics.stderr
@@ -4,6 +4,7 @@ error[E0210]: type parameter `T` must be used as the type parameter for some loc
 LL | impl<T> RemoteTrait for T where T: LocalTrait {}
    |      ^ type parameter `T` must be used as the type parameter for some local type
    |
+   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local
    = note: only traits defined in the current crate can be implemented for a type parameter
 
 error: aborting due to previous error


### PR DESCRIPTION
Following #65247, I noticed that some error messages should be updated to reflect the changes of `re_rebalance_coherence` (also there was a [note](https://rust-lang.github.io/rfcs/2451-re-rebalancing-coherence.html#teaching-users) in the RFC about it).

First, error message `E0210` was updated to match the RFC, and I also tried to improve a little the error when the "order" of types is problematic.

For code like this:
```
#![feature(re_rebalance_coherence)] // Now stable

struct Wrap<T>(T);

impl<T> From<Wrap<T>> for T {
    fn from(x: Wrap<T>) -> T {
        x.0
    }
}
```

The old error was:
```
error[E0210]: type parameter `T` must be used as the type parameter for some local type (e.g., `MyStruct<T>`)
 --> src/lib.rs:5:6
  |
5 | impl<T> From<Wrap<T>> for T {
  |      ^ type parameter `T` must be used as the type parameter for some local type
  |
  = note: only traits defined in the current crate can be implemented for a type parameter

```

and the new error is:
```
error[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`Wrap<T>`)
  --> main.rs:66:6
   |
66 | impl<T> From<Wrap<T>> for T {
   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`Wrap<T>`)
   |
   = note: implementing a foreign trait is only possible if at least one of the types for which is it implemented is local, and no uncovered type parameters appear before that first local type
   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
```

I tried to point at the uncovered `T`, but couldn't get something which was reliable (but I'll be happy to try if someone points me in the right direction). 


r? @estebank 
cc @nikomatsakis 

Fixes #65247