### PR TITLE
Layout::pad_to_align is infallible

### DIFF
--- a/src/liballoc/rc.rs
+++ b/src/liballoc/rc.rs
@@ -897,7 +897,7 @@ impl<T: ?Sized> Rc<T> {
         // reference (see #54908).
         let layout = Layout::new::<RcBox<()>>()
             .extend(value_layout).unwrap().0
-            .pad_to_align().unwrap();
+            .pad_to_align();
 
         // Allocate for the layout.
         let mem = Global.alloc(layout)

--- a/src/liballoc/sync.rs
+++ b/src/liballoc/sync.rs
@@ -751,7 +751,7 @@ impl<T: ?Sized> Arc<T> {
         // reference (see #54908).
         let layout = Layout::new::<ArcInner<()>>()
             .extend(value_layout).unwrap().0
-            .pad_to_align().unwrap();
+            .pad_to_align();
 
         let mem = Global.alloc(layout)
             .unwrap_or_else(|_| handle_alloc_error(layout));

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -225,7 +225,7 @@ impl Layout {
         // > `usize::MAX`)
         let new_size = self.size() + pad;
 
-        // SAFETY: This necessarily respectes the from_size_align
+        // SAFETY: This necessarily respects the from_size_align
         // prerequisites per the above.
         unsafe { Layout::from_size_align_unchecked(new_size, self.align()) }
     }

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -224,9 +224,10 @@ impl Layout {
         // > must not overflow (i.e., the rounded value must be less than
         // > `usize::MAX`)
         let new_size = self.size() + pad;
-        debug_assert!(new_size > self.size());
 
-        Layout::from_size_align(new_size, self.align())
+        // SAFETY: This necessarily respectes the from_size_align
+        // prerequisites per the above.
+        unsafe { Layout::from_size_align_unchecked(new_size, self.align()) }
     }
 
     /// Creates a layout describing the record for `n` instances of

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -219,7 +219,7 @@ impl Layout {
     #[inline]
     pub fn pad_to_align(&self) -> Layout {
         let pad = self.padding_needed_for(self.align());
-        // This cannot overflow: it is an invariant of Layout that
+        // This cannot overflow. Quoting from the invariant of Layout:
         // > `size`, when rounded up to the nearest multiple of `align`,
         // > must not overflow (i.e., the rounded value must be less than
         // > `usize::MAX`)

--- a/src/libcore/alloc.rs
+++ b/src/libcore/alloc.rs
@@ -225,9 +225,7 @@ impl Layout {
         // > `usize::MAX`)
         let new_size = self.size() + pad;
 
-        // SAFETY: This necessarily respects the from_size_align
-        // prerequisites per the above.
-        unsafe { Layout::from_size_align_unchecked(new_size, self.align()) }
+        Layout::from_size_align(new_size, self.align()).unwrap()
     }
 
     /// Creates a layout describing the record for `n` instances of


### PR DESCRIPTION
As per [this comment](https://github.com/rust-lang/rust/issues/55724#issuecomment-441421651) (cc @glandium).

> Per https://github.com/rust-lang/rust/blob/eb981a1/src/libcore/alloc.rs#L63-L65, `layout.size()` is always <= `usize::MAX - (layout.align() - 1)`.
> 
> Which means:
> 
> * The maximum value `layout.size()` can have is already aligned for `layout.align()` (`layout.align()` being a power of two, `usize::MAX - (layout.align() - 1)` is a multiple of `layout.align()`)
> * Incidentally, any value smaller than that maximum value will align at most to that maximum value.
> 
> IOW, `pad_to_align` can not return `Err(LayoutErr)`, except for the layout not respecting its invariants, but we shouldn't care about that.

This PR makes `pad_to_align` return `Layout` directly, representing the fact that it cannot fail.