### PR TITLE
Addition operation for two `char`s to produce a `String`

### DIFF
--- a/src/liballoc/char.rs
+++ b/src/liballoc/char.rs
@@ -1,12 +1,12 @@
 /// Implements the `+` operator for concatenating two `char`s together.
 ///
-/// This operation results into a new string being allocated with copies of the two `char`s in
+/// This operation results into a new `String` being allocated with copies of the two `char`s in
 /// the respective order.
 ///
 /// # Examples
 ///
 /// ```
-/// let a = char::from("🎈");
+/// let a = char::from('🎈');
 /// let b = char::from('🎉');
 /// let c = a + b;
 /// // `c` is a newly allocated `String`

--- a/src/liballoc/char.rs
+++ b/src/liballoc/char.rs
@@ -6,8 +6,8 @@
 /// # Examples
 ///
 /// ```
-/// let a = char::from('🎈');
-/// let b = char::from('🎉');
+/// let a = '🎈';
+/// let b = '🎉';
 /// let c = a + b;
 /// // `c` is a newly allocated `String`
 /// ```

--- a/src/liballoc/char.rs
+++ b/src/liballoc/char.rs
@@ -1,0 +1,26 @@
+/// Implements the `+` operator for concatenating two `char`s together.
+///
+/// This operation results into a new string being allocated with copies of the two `char`s in
+/// the respective order.
+///
+/// # Examples
+///
+/// ```
+/// let a = char::from("🎈");
+/// let b = char::from('🎉');
+/// let c = a + b;
+/// // `c` is a newly allocated `String`
+/// ```
+#[stable(feature = "add_chars", since = "1.41.0")]
+impl Add<char> for char {
+    type Output = String;
+
+    #[inline]
+    fn add(self, other: char) -> String {
+        let mut r = String::new();
+        r.push(self);
+        r.push(other);
+        
+        r
+    }
+}

--- a/src/liballoc/tests/char.rs
+++ b/src/liballoc/tests/char.rs
@@ -1,7 +1,7 @@
 #[test]
 fn test_char_add() {
-    let a = char::from('🎈');
-    let b = char::from('🎉');
+    let a = '🎈';
+    let b = '🎉';
     let c = a + b;
 
     assert_eq!(c, "🎈🎉");

--- a/src/liballoc/tests/char.rs
+++ b/src/liballoc/tests/char.rs
@@ -1,0 +1,8 @@
+#[test]
+fn test_char_add() {
+    let a = char::from("🎈");
+    let b = char::from('🎉');
+    let c = a + b;
+
+    assert_eq!(c, "🎈🎉");
+}

--- a/src/liballoc/tests/char.rs
+++ b/src/liballoc/tests/char.rs
@@ -1,6 +1,6 @@
 #[test]
 fn test_char_add() {
-    let a = char::from("🎈");
+    let a = char::from('🎈');
     let b = char::from('🎉');
     let c = a + b;
 


### PR DESCRIPTION
This is a proposal to support the addition operation to be possible between two `char` variables ultimately producing a newly allocated `String`.

```rust
let a = '🎈';
let b = '🎉';
let c = a + b;

assert_eq!(c, "🎈🎉");
```

# Motivation
Ease of `char` manipulation to achieve `String` results.