### PR TITLE
fix an ICE in macro's diagnostic message

### DIFF
--- a/src/test/ui/parser/macros-no-semicolon-items.stderr
+++ b/src/test/ui/parser/macros-no-semicolon-items.stderr
@@ -6,8 +6,8 @@ LL | macro_rules! foo()
    |
 help: change the delimiters to curly braces
    |
-LL | macro_rules! foo {}
-   |                  ^^
+LL | macro_rules! foo{}
+   |                 ^^
 help: add a semicolon
    |
 LL | macro_rules! foo();
@@ -26,7 +26,7 @@ LL | | )
    |
 help: change the delimiters to curly braces
    |
-LL | bar! {
+LL | bar!{
 LL |     blah
 LL |     blah
 LL |     blah

--- a/src/test/ui/parser/mbe_missing_right_paren.rs
+++ b/src/test/ui/parser/mbe_missing_right_paren.rs
@@ -1,0 +1,3 @@
+// ignore-tidy-trailing-newlines
+// error-pattern: aborting due to 3 previous errors
+macro_rules! abc(ؼ

--- a/src/test/ui/parser/mbe_missing_right_paren.stderr
+++ b/src/test/ui/parser/mbe_missing_right_paren.stderr
@@ -1,0 +1,31 @@
+error: this file contains an un-closed delimiter
+  --> $DIR/mbe_missing_right_paren.rs:3:19
+   |
+LL | macro_rules! abc(ؼ
+   |                 - ^
+   |                 |
+   |                 un-closed delimiter
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/mbe_missing_right_paren.rs:3:17
+   |
+LL | macro_rules! abc(ؼ
+   |                 ^^
+   |
+help: change the delimiters to curly braces
+   |
+LL | macro_rules! abc{ؼ}
+   |                 ^ ^
+help: add a semicolon
+   |
+LL | macro_rules! abc(ؼ;
+   |                   ^
+
+error: unexpected end of macro invocation
+  --> $DIR/mbe_missing_right_paren.rs:3:1
+   |
+LL | macro_rules! abc(ؼ
+   | ^^^^^^^^^^^^^^^^^^ missing tokens in macro arguments
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
This has two small fixes:
1. for the left brace, we don't need `<space>{`, simply `{` is enough.
2. for the right brace, it tries to peel off one character even when the close delim is missing. Without this fix, it would crash in some cases. (as shown in the new test case)

r? @estebank
