### PR TITLE
syntax: Keep string literals in ABIs and `asm!` more precisely

### DIFF
--- a/src/librustc/hir/lowering.rs
+++ b/src/librustc/hir/lowering.rs
@@ -1219,7 +1219,7 @@ impl<'a> LoweringContext<'a> {
                                     ImplTraitContext::disallowed(),
                                 ),
                                 unsafety: f.unsafety,
-                                abi: this.lower_abi(f.abi),
+                                abi: this.lower_extern(f.ext),
                                 decl: this.lower_fn_decl(&f.decl, None, false, None),
                                 param_names: this.lower_fn_params_to_names(&f.decl),
                             }))

--- a/src/librustc/hir/lowering/item.rs
+++ b/src/librustc/hir/lowering/item.rs
@@ -1287,8 +1287,8 @@ impl LoweringContext<'_> {
         }
     }
 
-    pub(super) fn lower_abi(&mut self, abi: Abi) -> abi::Abi {
-        abi::lookup(&abi.symbol.as_str()).unwrap_or_else(|| {
+    pub(super) fn lower_abi(&mut self, abi: StrLit) -> abi::Abi {
+        abi::lookup(&abi.symbol_unescaped.as_str()).unwrap_or_else(|| {
             self.error_on_invalid_abi(abi);
             abi::Abi::Rust
         })
@@ -1302,7 +1302,7 @@ impl LoweringContext<'_> {
         }
     }
 
-    fn error_on_invalid_abi(&self, abi: Abi) {
+    fn error_on_invalid_abi(&self, abi: StrLit) {
         struct_span_err!(
             self.sess,
             abi.span,

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1073,6 +1073,22 @@ impl<'a> Parser<'a> {
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
+    pub fn parse_str_lit(&mut self) -> Result<ast::StrLit, Option<Lit>> {
+        match self.parse_opt_lit() {
+            Some(lit) => match lit.kind {
+                ast::LitKind::Str(symbol_unescaped, style) => Ok(ast::StrLit {
+                    style,
+                    symbol: lit.token.symbol,
+                    suffix: lit.token.suffix,
+                    span: lit.span,
+                    symbol_unescaped,
+                }),
+                _ => Err(Some(lit)),
+            }
+            None => Err(None),
+        }
+    }
+
     pub(super) fn parse_lit(&mut self) -> PResult<'a, Lit> {
         self.parse_opt_lit().ok_or_else(|| {
             let msg = format!("unexpected token: {}", self.this_token_descr());

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -1073,6 +1073,9 @@ impl<'a> Parser<'a> {
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
+    /// Returns a string literal if the next token is a string literal.
+    /// In case of error returns `Some(lit)` if the next token is a literal with a wrong kind,
+    /// and returns `None` if the next token is not literal at all.
     pub fn parse_str_lit(&mut self) -> Result<ast::StrLit, Option<Lit>> {
         match self.parse_opt_lit() {
             Some(lit) => match lit.kind {

--- a/src/librustc_parse/parser/expr.rs
+++ b/src/librustc_parse/parser/expr.rs
@@ -778,13 +778,12 @@ impl<'a> Parser<'a> {
 
         macro_rules! parse_lit {
             () => {
-                match self.parse_lit() {
-                    Ok(literal) => {
+                match self.parse_opt_lit() {
+                    Some(literal) => {
                         hi = self.prev_span;
                         ex = ExprKind::Lit(literal);
                     }
-                    Err(mut err) => {
-                        err.cancel();
+                    None => {
                         return Err(self.expected_expression_found());
                     }
                 }
@@ -1074,11 +1073,20 @@ impl<'a> Parser<'a> {
         self.maybe_recover_from_bad_qpath(expr, true)
     }
 
-    /// Matches `lit = true | false | token_lit`.
     pub(super) fn parse_lit(&mut self) -> PResult<'a, Lit> {
+        self.parse_opt_lit().ok_or_else(|| {
+            let msg = format!("unexpected token: {}", self.this_token_descr());
+            self.span_fatal(self.token.span, &msg)
+        })
+    }
+
+    /// Matches `lit = true | false | token_lit`.
+    /// Returns `None` if the next token is not a literal.
+    pub(super) fn parse_opt_lit(&mut self) -> Option<Lit> {
         let mut recovered = None;
         if self.token == token::Dot {
-            // Attempt to recover `.4` as `0.4`.
+            // Attempt to recover `.4` as `0.4`. We don't currently have any syntax where
+            // dot would follow an optional literal, so we do this unconditionally.
             recovered = self.look_ahead(1, |next_token| {
                 if let token::Literal(token::Lit { kind: token::Integer, symbol, suffix })
                         = next_token.kind {
@@ -1107,11 +1115,10 @@ impl<'a> Parser<'a> {
         match Lit::from_token(token) {
             Ok(lit) => {
                 self.bump();
-                Ok(lit)
+                Some(lit)
             }
             Err(LitError::NotLiteral) => {
-                let msg = format!("unexpected token: {}", self.this_token_descr());
-                Err(self.span_fatal(token.span, &msg))
+                None
             }
             Err(err) => {
                 let span = token.span;
@@ -1120,18 +1127,18 @@ impl<'a> Parser<'a> {
                     _ => unreachable!(),
                 };
                 self.bump();
-                self.error_literal_from_token(err, lit, span);
+                self.report_lit_error(err, lit, span);
                 // Pack possible quotes and prefixes from the original literal into
                 // the error literal's symbol so they can be pretty-printed faithfully.
                 let suffixless_lit = token::Lit::new(lit.kind, lit.symbol, None);
                 let symbol = Symbol::intern(&suffixless_lit.to_string());
                 let lit = token::Lit::new(token::Err, symbol, lit.suffix);
-                Lit::from_lit_token(lit, span).map_err(|_| unreachable!())
+                Some(Lit::from_lit_token(lit, span).unwrap_or_else(|_| unreachable!()))
             }
         }
     }
 
-    fn error_literal_from_token(&self, err: LitError, lit: token::Lit, span: Span) {
+    fn report_lit_error(&self, err: LitError, lit: token::Lit, span: Span) {
         // Checks if `s` looks like i32 or u1234 etc.
         fn looks_like_width_suffix(first_chars: &[char], s: &str) -> bool {
             s.len() > 1

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -114,7 +114,7 @@ impl<'a> Parser<'a> {
                     unsafety: Unsafety::Normal,
                     asyncness: respan(fn_span, IsAsync::NotAsync),
                     constness: respan(fn_span, Constness::NotConst),
-                    abi,
+                    ext: Extern::from_abi(abi),
                 };
                 return self.parse_item_fn(lo, vis, attrs, header);
             } else if self.check(&token::OpenDelim(token::Brace)) {
@@ -143,14 +143,14 @@ impl<'a> Parser<'a> {
                 if self.check_keyword(kw::Extern) {
                     self.sess.gated_spans.gate(sym::const_extern_fn, lo.to(self.token.span));
                 }
-                let abi = self.parse_extern_abi()?;
+                let ext = self.parse_extern()?;
                 self.bump(); // `fn`
 
                 let header = FnHeader {
                     unsafety,
                     asyncness: respan(const_span, IsAsync::NotAsync),
                     constness: respan(const_span, Constness::Const),
-                    abi,
+                    ext,
                 };
                 return self.parse_item_fn(lo, vis, attrs, header);
             }
@@ -193,7 +193,7 @@ impl<'a> Parser<'a> {
                     unsafety,
                     asyncness,
                     constness: respan(fn_span, Constness::NotConst),
-                    abi: Abi::new(sym::Rust, fn_span),
+                    ext: Extern::None,
                 };
                 return self.parse_item_fn(lo, vis, attrs, header);
             }
@@ -230,7 +230,7 @@ impl<'a> Parser<'a> {
                 unsafety: Unsafety::Normal,
                 asyncness: respan(fn_span, IsAsync::NotAsync),
                 constness: respan(fn_span, Constness::NotConst),
-                abi: Abi::new(sym::Rust, fn_span),
+                ext: Extern::None,
             };
             return self.parse_item_fn(lo, vis, attrs, header);
         }
@@ -242,14 +242,14 @@ impl<'a> Parser<'a> {
             self.bump(); // `unsafe`
             // `{` is also expected after `unsafe`; in case of error, include it in the diagnostic.
             self.check(&token::OpenDelim(token::Brace));
-            let abi = self.parse_extern_abi()?;
+            let ext = self.parse_extern()?;
             self.expect_keyword(kw::Fn)?;
             let fn_span = self.prev_span;
             let header = FnHeader {
                 unsafety: Unsafety::Unsafe,
                 asyncness: respan(fn_span, IsAsync::NotAsync),
                 constness: respan(fn_span, Constness::NotConst),
-                abi,
+                ext,
             };
             return self.parse_item_fn(lo, vis, attrs, header);
         }
@@ -1100,7 +1100,7 @@ impl<'a> Parser<'a> {
     fn parse_item_foreign_mod(
         &mut self,
         lo: Span,
-        abi: Abi,
+        abi: Option<Abi>,
         visibility: Visibility,
         mut attrs: Vec<Attribute>,
         extern_sp: Span,
@@ -1775,9 +1775,16 @@ impl<'a> Parser<'a> {
         attrs: Vec<Attribute>,
         header: FnHeader,
     ) -> PResult<'a, Option<P<Item>>> {
+        let is_c_abi = match header.ext {
+            ast::Extern::None => false,
+            ast::Extern::Implicit => true,
+            ast::Extern::Explicit(abi) => abi.symbol == sym::C,
+        };
         let (ident, decl, generics) = self.parse_fn_sig(ParamCfg {
             is_self_allowed: false,
-            allow_c_variadic: header.abi.symbol == sym::C && header.unsafety == Unsafety::Unsafe,
+            // FIXME: Parsing should not depend on ABI or unsafety and
+            // the variadic parameter should always be parsed.
+            allow_c_variadic: is_c_abi && header.unsafety == Unsafety::Unsafe,
             is_name_required: |_| true,
         })?;
         let (inner_attrs, body) = self.parse_inner_attrs_and_block()?;
@@ -1905,11 +1912,11 @@ impl<'a> Parser<'a> {
         }
         let asyncness = respan(self.prev_span, asyncness);
         let unsafety = self.parse_unsafety();
-        let (constness, unsafety, abi) = if is_const_fn {
-            (respan(const_span, Constness::Const), unsafety, Abi::default())
+        let (constness, unsafety, ext) = if is_const_fn {
+            (respan(const_span, Constness::Const), unsafety, Extern::None)
         } else {
-            let abi = self.parse_extern_abi()?;
-            (respan(self.prev_span, Constness::NotConst), unsafety, abi)
+            let ext = self.parse_extern()?;
+            (respan(self.prev_span, Constness::NotConst), unsafety, ext)
         };
         if !self.eat_keyword(kw::Fn) {
             // It is possible for `expect_one_of` to recover given the contents of
@@ -1917,7 +1924,7 @@ impl<'a> Parser<'a> {
             // account for this.
             if !self.expect_one_of(&[], &[])? { unreachable!() }
         }
-        Ok(FnHeader { constness, unsafety, asyncness, abi })
+        Ok(FnHeader { constness, unsafety, asyncness, ext })
     }
 
     /// Parse the "signature", including the identifier, parameters, and generics of a function.

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -1100,7 +1100,7 @@ impl<'a> Parser<'a> {
     fn parse_item_foreign_mod(
         &mut self,
         lo: Span,
-        abi: Option<Abi>,
+        abi: Option<StrLit>,
         visibility: Visibility,
         mut attrs: Vec<Attribute>,
         extern_sp: Span,
@@ -1778,7 +1778,7 @@ impl<'a> Parser<'a> {
         let is_c_abi = match header.ext {
             ast::Extern::None => false,
             ast::Extern::Implicit => true,
-            ast::Extern::Explicit(abi) => abi.symbol == sym::C,
+            ast::Extern::Explicit(abi) => abi.symbol_unescaped == sym::C,
         };
         let (ident, decl, generics) = self.parse_fn_sig(ParamCfg {
             is_self_allowed: false,

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -3,9 +3,9 @@ use super::diagnostics::{Error, dummy_arg, ConsumeClosingDelim};
 
 use crate::maybe_whole;
 
-use syntax::ast::{self, Abi, DUMMY_NODE_ID, Ident, Attribute, AttrKind, AttrStyle, AnonConst, Item};
+use syntax::ast::{self, DUMMY_NODE_ID, Ident, Attribute, AttrKind, AttrStyle, AnonConst, Item};
 use syntax::ast::{ItemKind, ImplItem, ImplItemKind, TraitItem, TraitItemKind, UseTree, UseTreeKind};
-use syntax::ast::{PathSegment, IsAuto, Constness, IsAsync, Unsafety, Defaultness};
+use syntax::ast::{PathSegment, IsAuto, Constness, IsAsync, Unsafety, Defaultness, Extern, StrLit};
 use syntax::ast::{Visibility, VisibilityKind, Mutability, FnHeader, ForeignItem, ForeignItemKind};
 use syntax::ast::{Ty, TyKind, Generics, TraitRef, EnumDef, VariantData, StructField};
 use syntax::ast::{Mac, MacDelimiter, Block, BindingMode, FnDecl, FnSig, SelfKind, Param};
@@ -105,7 +105,7 @@ impl<'a> Parser<'a> {
                 return Ok(Some(self.parse_item_extern_crate(lo, vis, attrs)?));
             }
 
-            let abi = self.parse_opt_abi();
+            let abi = self.parse_abi();
 
             if self.eat_keyword(kw::Fn) {
                 // EXTERN FUNCTION ITEM

--- a/src/librustc_parse/parser/item.rs
+++ b/src/librustc_parse/parser/item.rs
@@ -105,7 +105,7 @@ impl<'a> Parser<'a> {
                 return Ok(Some(self.parse_item_extern_crate(lo, vis, attrs)?));
             }
 
-            let abi = self.parse_opt_abi()?;
+            let abi = self.parse_opt_abi();
 
             if self.eat_keyword(kw::Fn) {
                 // EXTERN FUNCTION ITEM

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -1214,21 +1214,20 @@ impl<'a> Parser<'a> {
     /// Parses `extern string_literal?`.
     fn parse_extern(&mut self) -> PResult<'a, Extern> {
         Ok(if self.eat_keyword(kw::Extern) {
-            Extern::from_abi(self.parse_opt_abi()?)
+            Extern::from_abi(self.parse_opt_abi())
         } else {
             Extern::None
         })
     }
 
     /// Parses a string literal as an ABI spec.
-    fn parse_opt_abi(&mut self) -> PResult<'a, Option<StrLit>> {
-        if self.token.can_begin_literal_or_bool() {
-            let ast::Lit { token: token::Lit { symbol, suffix, .. }, span, kind }
-                = self.parse_lit()?;
+    fn parse_opt_abi(&mut self) -> Option<StrLit> {
+        if let Some(ast::Lit { token: token::Lit { symbol, suffix, .. }, span, kind })
+                = self.parse_opt_lit() {
             match kind {
-                ast::LitKind::Str(symbol_unescaped, style) => return Ok(Some(StrLit {
+                ast::LitKind::Str(symbol_unescaped, style) => return Some(StrLit {
                     style, symbol, suffix, span, symbol_unescaped,
-                })),
+                }),
                 ast::LitKind::Err(_) => {}
                 _ => {
                     self.struct_span_err(span, "non-string ABI literal")
@@ -1242,7 +1241,7 @@ impl<'a> Parser<'a> {
                 }
             }
         }
-        Ok(None)
+        None
     }
 
     /// We are parsing `async fn`. If we are on Rust 2015, emit an error.

--- a/src/librustc_parse/parser/mod.rs
+++ b/src/librustc_parse/parser/mod.rs
@@ -15,7 +15,7 @@ use crate::{Directory, DirectoryOwnership};
 use crate::lexer::UnmatchedBrace;
 
 use syntax::ast::{
-    self, Abi, DUMMY_NODE_ID, AttrStyle, Attribute, CrateSugar, Extern, Ident,
+    self, DUMMY_NODE_ID, AttrStyle, Attribute, CrateSugar, Extern, Ident,
     IsAsync, MacDelimiter, Mutability, StrStyle, Visibility, VisibilityKind, Unsafety,
 };
 
@@ -1221,11 +1221,14 @@ impl<'a> Parser<'a> {
     }
 
     /// Parses a string literal as an ABI spec.
-    fn parse_opt_abi(&mut self) -> PResult<'a, Option<Abi>> {
+    fn parse_opt_abi(&mut self) -> PResult<'a, Option<StrLit>> {
         if self.token.can_begin_literal_or_bool() {
-            let ast::Lit { span, kind, .. } = self.parse_lit()?;
+            let ast::Lit { token: token::Lit { symbol, suffix, .. }, span, kind }
+                = self.parse_lit()?;
             match kind {
-                ast::LitKind::Str(symbol, _) => return Ok(Some(Abi { symbol, span })),
+                ast::LitKind::Str(symbol_unescaped, style) => return Ok(Some(StrLit {
+                    style, symbol, suffix, span, symbol_unescaped,
+                })),
                 ast::LitKind::Err(_) => {}
                 _ => {
                     self.struct_span_err(span, "non-string ABI literal")

--- a/src/librustc_parse/parser/ty.rs
+++ b/src/librustc_parse/parser/ty.rs
@@ -287,7 +287,7 @@ impl<'a> Parser<'a> {
         */
 
         let unsafety = self.parse_unsafety();
-        let abi = self.parse_extern_abi()?;
+        let ext = self.parse_extern()?;
         self.expect_keyword(kw::Fn)?;
         let cfg = ParamCfg {
             is_self_allowed: false,
@@ -296,7 +296,7 @@ impl<'a> Parser<'a> {
         };
         let decl = self.parse_fn_decl(cfg, false)?;
         Ok(TyKind::BareFn(P(BareFnTy {
-            abi,
+            ext,
             unsafety,
             generic_params,
             decl,

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -2448,10 +2448,7 @@ pub enum Extern {
 
 impl Extern {
     pub fn from_abi(abi: Option<StrLit>) -> Extern {
-        match abi {
-            Some(abi) => Extern::Explicit(abi),
-            None => Extern::Implicit,
-        }
+        abi.map_or(Extern::Implicit, Extern::Explicit)
     }
 }
 

--- a/src/libsyntax/ast.rs
+++ b/src/libsyntax/ast.rs
@@ -1745,7 +1745,7 @@ pub struct Ty {
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct BareFnTy {
     pub unsafety: Unsafety,
-    pub abi: Abi,
+    pub ext: Extern,
     pub generic_params: Vec<GenericParam>,
     pub decl: P<FnDecl>,
 }
@@ -2128,7 +2128,7 @@ pub struct Mod {
 /// E.g., `extern { .. }` or `extern C { .. }`.
 #[derive(Clone, RustcEncodable, RustcDecodable, Debug)]
 pub struct ForeignMod {
-    pub abi: Abi,
+    pub abi: Option<Abi>,
     pub items: Vec<ForeignItem>,
 }
 
@@ -2420,15 +2420,20 @@ pub struct Abi {
     pub span: Span,
 }
 
-impl Abi {
-    pub fn new(symbol: Symbol, span: Span) -> Self {
-        Self { symbol, span }
-    }
+/// `extern` qualifier on a function item or function type.
+#[derive(Clone, Copy, RustcEncodable, RustcDecodable, Debug)]
+pub enum Extern {
+    None,
+    Implicit,
+    Explicit(Abi),
 }
 
-impl Default for Abi {
-    fn default() -> Self {
-        Self::new(sym::Rust, DUMMY_SP)
+impl Extern {
+    pub fn from_abi(abi: Option<Abi>) -> Extern {
+        match abi {
+            Some(abi) => Extern::Explicit(abi),
+            None => Extern::Implicit,
+        }
     }
 }
 
@@ -2441,7 +2446,7 @@ pub struct FnHeader {
     pub unsafety: Unsafety,
     pub asyncness: Spanned<IsAsync>,
     pub constness: Spanned<Constness>,
-    pub abi: Abi,
+    pub ext: Extern,
 }
 
 impl Default for FnHeader {
@@ -2450,7 +2455,7 @@ impl Default for FnHeader {
             unsafety: Unsafety::Normal,
             asyncness: dummy_spanned(IsAsync::NotAsync),
             constness: dummy_spanned(Constness::NotConst),
-            abi: Abi::default(),
+            ext: Extern::None,
         }
     }
 }

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -191,10 +191,10 @@ macro_rules! gate_feature_post {
 }
 
 impl<'a> PostExpansionVisitor<'a> {
-    fn check_abi(&self, abi: ast::Abi) {
-        let ast::Abi { symbol, span } = abi;
+    fn check_abi(&self, abi: ast::StrLit) {
+        let ast::StrLit { symbol_unescaped, span, .. } = abi;
 
-        match &*symbol.as_str() {
+        match &*symbol_unescaped.as_str() {
             // Stable
             "Rust" |
             "C" |

--- a/src/libsyntax/feature_gate/check.rs
+++ b/src/libsyntax/feature_gate/check.rs
@@ -258,6 +258,12 @@ impl<'a> PostExpansionVisitor<'a> {
         }
     }
 
+    fn check_extern(&self, ext: ast::Extern) {
+        if let ast::Extern::Explicit(abi) = ext {
+            self.check_abi(abi);
+        }
+    }
+
     fn maybe_report_invalid_custom_discriminants(&self, variants: &[ast::Variant]) {
         let has_fields = variants.iter().any(|variant| match variant.data {
             VariantData::Tuple(..) | VariantData::Struct(..) => true,
@@ -388,7 +394,9 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_item(&mut self, i: &'a ast::Item) {
         match i.kind {
             ast::ItemKind::ForeignMod(ref foreign_module) => {
-                self.check_abi(foreign_module.abi);
+                if let Some(abi) = foreign_module.abi {
+                    self.check_abi(abi);
+                }
             }
 
             ast::ItemKind::Fn(..) => {
@@ -511,7 +519,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
     fn visit_ty(&mut self, ty: &'a ast::Ty) {
         match ty.kind {
             ast::TyKind::BareFn(ref bare_fn_ty) => {
-                self.check_abi(bare_fn_ty.abi);
+                self.check_extern(bare_fn_ty.ext);
             }
             ast::TyKind::Never => {
                 gate_feature_post!(&self, never_type, ty.span,
@@ -605,7 +613,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
             // Stability of const fn methods are covered in
             // `visit_trait_item` and `visit_impl_item` below; this is
             // because default methods don't pass through this point.
-            self.check_abi(header.abi);
+            self.check_extern(header.ext);
         }
 
         if fn_decl.c_variadic() {
@@ -639,7 +647,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
         match ti.kind {
             ast::TraitItemKind::Method(ref sig, ref block) => {
                 if block.is_none() {
-                    self.check_abi(sig.header.abi);
+                    self.check_extern(sig.header.ext);
                 }
                 if sig.decl.c_variadic() {
                     gate_feature_post!(&self, c_variadic, ti.span,

--- a/src/libsyntax/mut_visit.rs
+++ b/src/libsyntax/mut_visit.rs
@@ -441,7 +441,7 @@ pub fn noop_visit_ty<T: MutVisitor>(ty: &mut P<Ty>, vis: &mut T) {
             vis.visit_mt(mt);
         }
         TyKind::BareFn(bft) => {
-            let BareFnTy { unsafety: _, abi: _, generic_params, decl } = bft.deref_mut();
+            let BareFnTy { unsafety: _, ext: _, generic_params, decl } = bft.deref_mut();
             generic_params.flat_map_in_place(|param| vis.flat_map_generic_param(param));
             vis.visit_fn_decl(decl);
         }
@@ -974,7 +974,7 @@ pub fn noop_flat_map_impl_item<T: MutVisitor>(mut item: ImplItem, visitor: &mut 
 }
 
 pub fn noop_visit_fn_header<T: MutVisitor>(header: &mut FnHeader, vis: &mut T) {
-    let FnHeader { unsafety: _, asyncness, constness: _, abi: _ } = header;
+    let FnHeader { unsafety: _, asyncness, constness: _, ext: _ } = header;
     vis.visit_asyncness(&mut asyncness.node);
 }
 

--- a/src/libsyntax/print/pprust.rs
+++ b/src/libsyntax/print/pprust.rs
@@ -1233,7 +1233,8 @@ impl<'a> State<'a> {
             ast::ItemKind::ForeignMod(ref nmod) => {
                 self.head("extern");
                 if let Some(abi) = nmod.abi {
-                    self.print_abi(abi);
+                    self.print_literal(&abi.as_lit());
+                    self.nbsp();
                 }
                 self.bopen();
                 self.print_foreign_mod(nmod, &item.attrs);
@@ -2875,15 +2876,12 @@ impl<'a> State<'a> {
             }
             ast::Extern::Explicit(abi) => {
                 self.word_nbsp("extern");
-                self.print_abi(abi);
+                self.print_literal(&abi.as_lit());
+                self.nbsp();
             }
         }
 
         self.s.word("fn")
-    }
-
-    fn print_abi(&mut self, abi: ast::Abi) {
-        self.word_nbsp(format!("\"{}\"", abi.symbol));
     }
 
     crate fn print_unsafety(&mut self, s: ast::Unsafety) {

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -72,9 +72,8 @@ fn parse_asm_str<'a>(p: &mut Parser<'a>) -> PResult<'a, Symbol> {
         Ok(str_lit) => Ok(str_lit.symbol_unescaped),
         Err(opt_lit) => {
             let span = opt_lit.map_or(p.token.span, |lit| lit.span);
-            let msg = "expected string literal";
-            let mut err = p.sess.span_diagnostic.struct_span_fatal(span, msg);
-            err.span_label(span, msg);
+            let mut err = p.sess.span_diagnostic.struct_span_err(span, "expected string literal");
+            err.span_label(span, "not a string literal");
             Err(err)
         }
     }

--- a/src/libsyntax_ext/asm.rs
+++ b/src/libsyntax_ext/asm.rs
@@ -2,19 +2,17 @@
 //
 use State::*;
 
+use errors::{DiagnosticBuilder, PResult};
 use rustc_data_structures::thin_vec::ThinVec;
-
-use errors::DiagnosticBuilder;
-
-use syntax::ast;
-use syntax_expand::base::{self, *};
-use syntax::token::{self, Token};
+use rustc_parse::parser::Parser;
+use syntax_expand::base::*;
+use syntax_pos::Span;
+use syntax::{span_err, struct_span_err};
+use syntax::ast::{self, AsmDialect};
 use syntax::ptr::P;
 use syntax::symbol::{kw, sym, Symbol};
-use syntax::ast::AsmDialect;
-use syntax_pos::Span;
+use syntax::token::{self, Token};
 use syntax::tokenstream::{self, TokenStream};
-use syntax::{span_err, struct_span_err};
 
 use rustc_error_codes::*;
 
@@ -45,7 +43,7 @@ const OPTIONS: &[Symbol] = &[sym::volatile, sym::alignstack, sym::intel];
 pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt<'_>,
                        sp: Span,
                        tts: TokenStream)
-                       -> Box<dyn base::MacResult + 'cx> {
+                       -> Box<dyn MacResult + 'cx> {
     let mut inline_asm = match parse_inline_asm(cx, sp, tts) {
         Ok(Some(inline_asm)) => inline_asm,
         Ok(None) => return DummyResult::any(sp),
@@ -67,6 +65,19 @@ pub fn expand_asm<'cx>(cx: &'cx mut ExtCtxt<'_>,
         span: cx.with_def_site_ctxt(sp),
         attrs: ThinVec::new(),
     }))
+}
+
+fn parse_asm_str<'a>(p: &mut Parser<'a>) -> PResult<'a, Symbol> {
+    match p.parse_str_lit() {
+        Ok(str_lit) => Ok(str_lit.symbol_unescaped),
+        Err(opt_lit) => {
+            let span = opt_lit.map_or(p.token.span, |lit| lit.span);
+            let msg = "expected string literal";
+            let mut err = p.sess.span_diagnostic.struct_span_fatal(span, msg);
+            err.span_label(span, msg);
+            Err(err)
+        }
+    }
 }
 
 fn parse_inline_asm<'a>(
@@ -144,7 +155,7 @@ fn parse_inline_asm<'a>(
                         p.eat(&token::Comma);
                     }
 
-                    let (constraint, _) = p.parse_str()?;
+                    let constraint = parse_asm_str(&mut p)?;
 
                     let span = p.prev_span;
 
@@ -189,7 +200,7 @@ fn parse_inline_asm<'a>(
                         p.eat(&token::Comma);
                     }
 
-                    let (constraint, _) = p.parse_str()?;
+                    let constraint = parse_asm_str(&mut p)?;
 
                     if constraint.as_str().starts_with("=") {
                         span_err!(cx, p.prev_span, E0662,
@@ -212,7 +223,7 @@ fn parse_inline_asm<'a>(
                         p.eat(&token::Comma);
                     }
 
-                    let (s, _) = p.parse_str()?;
+                    let s = parse_asm_str(&mut p)?;
 
                     if OPTIONS.iter().any(|&opt| s == opt) {
                         cx.span_warn(p.prev_span, "expected a clobber, found an option");
@@ -225,7 +236,7 @@ fn parse_inline_asm<'a>(
                 }
             }
             Options => {
-                let (option, _) = p.parse_str()?;
+                let option = parse_asm_str(&mut p)?;
 
                 if option == sym::volatile {
                     // Indicates that the inline assembly has side effects

--- a/src/libsyntax_ext/deriving/generic/mod.rs
+++ b/src/libsyntax_ext/deriving/generic/mod.rs
@@ -182,7 +182,7 @@ use std::iter;
 use std::vec;
 
 use rustc_data_structures::thin_vec::ThinVec;
-use syntax::ast::{self, Abi, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
+use syntax::ast::{self, BinOpKind, EnumDef, Expr, Generics, Ident, PatKind};
 use syntax::ast::{VariantData, GenericParamKind, GenericArg};
 use syntax::attr;
 use syntax::source_map::respan;
@@ -737,7 +737,6 @@ impl<'a> TraitDef<'a> {
                                          self,
                                          type_ident,
                                          generics,
-                                         sym::Rust,
                                          explicit_self,
                                          tys,
                                          body)
@@ -792,7 +791,6 @@ impl<'a> TraitDef<'a> {
                                          self,
                                          type_ident,
                                          generics,
-                                         sym::Rust,
                                          explicit_self,
                                          tys,
                                          body)
@@ -918,7 +916,6 @@ impl<'a> MethodDef<'a> {
                      trait_: &TraitDef<'_>,
                      type_ident: Ident,
                      generics: &Generics,
-                     abi: Symbol,
                      explicit_self: Option<ast::ExplicitSelf>,
                      arg_types: Vec<(Ident, P<ast::Ty>)>,
                      body: P<Expr>)
@@ -953,7 +950,7 @@ impl<'a> MethodDef<'a> {
         let sig = ast::FnSig {
             header: ast::FnHeader {
                 unsafety,
-                abi: Abi::new(abi, trait_lo_sp),
+                ext: ast::Extern::None,
                 ..ast::FnHeader::default()
             },
             decl: fn_decl,

--- a/src/libsyntax_pos/symbol.rs
+++ b/src/libsyntax_pos/symbol.rs
@@ -570,7 +570,6 @@ symbols! {
         rust_2018_preview,
         rust_begin_unwind,
         rustc,
-        Rust,
         RustcDecodable,
         RustcEncodable,
         rustc_allocator,

--- a/src/test/ui/asm/asm-literal-escaping.rs
+++ b/src/test/ui/asm/asm-literal-escaping.rs
@@ -1,0 +1,12 @@
+// build-pass
+// only-x86_64
+
+#![feature(asm)]
+
+fn main() {
+    unsafe {
+        // "nop" :: "r"(x) : "eax" : "volatile"
+        let x = 10;
+        asm!("\x6Eop" :: "\x72"(x) : "\x65ax" : "\x76olatile");
+    }
+}

--- a/src/test/ui/asm/asm-parse-errors.stderr
+++ b/src/test/ui/asm/asm-parse-errors.stderr
@@ -8,13 +8,13 @@ error: expected string literal
   --> $DIR/asm-parse-errors.rs:5:18
    |
 LL |     asm!("nop" : struct);
-   |                  ^^^^^^ expected string literal
+   |                  ^^^^^^ not a string literal
 
 error: expected string literal
   --> $DIR/asm-parse-errors.rs:6:30
    |
 LL |     asm!("mov %eax, $$0x2" : struct);
-   |                              ^^^^^^ expected string literal
+   |                              ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
   --> $DIR/asm-parse-errors.rs:7:39
@@ -32,7 +32,7 @@ error: expected string literal
   --> $DIR/asm-parse-errors.rs:9:44
    |
 LL |     asm!("in %dx, %al" : "={al}"(result) : struct);
-   |                                            ^^^^^^ expected string literal
+   |                                            ^^^^^^ not a string literal
 
 error: expected `(`, found keyword `struct`
   --> $DIR/asm-parse-errors.rs:10:51
@@ -50,13 +50,13 @@ error: expected string literal
   --> $DIR/asm-parse-errors.rs:12:36
    |
 LL |     asm!("mov $$0x200, %eax" : : : struct);
-   |                                    ^^^^^^ expected string literal
+   |                                    ^^^^^^ not a string literal
 
 error: expected string literal
   --> $DIR/asm-parse-errors.rs:13:45
    |
 LL |     asm!("mov eax, 2" : "={eax}"(foo) : : : struct);
-   |                                             ^^^^^^ expected string literal
+   |                                             ^^^^^^ not a string literal
 
 error: inline assembly must be a string literal
   --> $DIR/asm-parse-errors.rs:14:10

--- a/src/test/ui/proc-macro/span-preservation.rs
+++ b/src/test/ui/proc-macro/span-preservation.rs
@@ -44,4 +44,14 @@ extern "C" fn baz() {
     0 //~ ERROR mismatched types
 }
 
+#[recollect_attr]
+extern "Rust" fn rust_abi() {
+    0 //~ ERROR mismatched types
+}
+
+#[recollect_attr]
+extern "\x43" fn c_abi_escaped() {
+    0 //~ ERROR mismatched types
+}
+
 fn main() {}

--- a/src/test/ui/proc-macro/span-preservation.rs
+++ b/src/test/ui/proc-macro/span-preservation.rs
@@ -1,8 +1,7 @@
-//~ ERROR mismatched types
-// aux-build:test-macros.rs
-
 // For each of these, we should get the appropriate type mismatch error message,
 // and the function should be echoed.
+
+// aux-build:test-macros.rs
 
 #[macro_use]
 extern crate test_macros;
@@ -35,12 +34,9 @@ fn c() {
     let y = Foo { a: 10, b: 10isize }; //~ ERROR has no field named `b`
 }
 
-// FIXME: This doesn't work at the moment. See the one below. The pretty-printer
-// injects a "C" between `extern` and `fn` which causes a "probably_eq"
-// `TokenStream` mismatch. The lack of `"C"` should be preserved in the AST.
 #[recollect_attr]
 extern fn bar() {
-    0
+    0 //~ ERROR mismatched types
 }
 
 #[recollect_attr]

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -52,7 +52,29 @@ LL |     0
    = note: expected type `()`
               found type `{integer}`
 
-error: aborting due to 6 previous errors
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:49:5
+   |
+LL | extern "Rust" fn rust_abi() {
+   |                             - possibly return type missing here?
+LL |     0
+   |     ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:54:5
+   |
+LL | extern "\x43" fn c_abi_escaped() {
+   |                                  - possibly return type missing here?
+LL |     0
+   |     ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0308, E0560.
 For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/proc-macro/span-preservation.stderr
+++ b/src/test/ui/proc-macro/span-preservation.stderr
@@ -1,10 +1,5 @@
 error[E0308]: mismatched types
-   |
-   = note: expected type `()`
-              found type `{integer}`
-
-error[E0308]: mismatched types
-  --> $DIR/span-preservation.rs:12:20
+  --> $DIR/span-preservation.rs:11:20
    |
 LL |     let x: usize = "hello";
    |                    ^^^^^^^ expected usize, found reference
@@ -13,7 +8,7 @@ LL |     let x: usize = "hello";
               found type `&'static str`
 
 error[E0308]: mismatched types
-  --> $DIR/span-preservation.rs:18:29
+  --> $DIR/span-preservation.rs:17:29
    |
 LL | fn b(x: Option<isize>) -> usize {
    |                           ----- expected `usize` because of return type
@@ -22,13 +17,13 @@ LL |         Some(x) => { return x },
    |                             ^ expected usize, found isize
 
 error[E0308]: mismatched types
-  --> $DIR/span-preservation.rs:34:22
+  --> $DIR/span-preservation.rs:33:22
    |
 LL |     let x = Foo { a: 10isize };
    |                      ^^^^^^^ expected usize, found isize
 
 error[E0560]: struct `c::Foo` has no field named `b`
-  --> $DIR/span-preservation.rs:35:26
+  --> $DIR/span-preservation.rs:34:26
    |
 LL |     let y = Foo { a: 10, b: 10isize };
    |                          ^ `c::Foo` does not have this field
@@ -36,7 +31,18 @@ LL |     let y = Foo { a: 10, b: 10isize };
    = note: available fields are: `a`
 
 error[E0308]: mismatched types
-  --> $DIR/span-preservation.rs:48:5
+  --> $DIR/span-preservation.rs:39:5
+   |
+LL | extern fn bar() {
+   |                 - possibly return type missing here?
+LL |     0
+   |     ^ expected (), found integer
+   |
+   = note: expected type `()`
+              found type `{integer}`
+
+error[E0308]: mismatched types
+  --> $DIR/span-preservation.rs:44:5
    |
 LL | extern "C" fn baz() {
    |                     - possibly return type missing here?


### PR DESCRIPTION
As a result we don't lose spans when `extern` functions or blocks are passed to proc macros, and also escape all string literals consistently.
Continuation of https://github.com/rust-lang/rust/pull/60679, which did a similar thing with all literals besides those in ABIs and `asm!`.

TODO: Add tests.

Fixes https://github.com/rust-lang/rust/issues/60493
Fixes https://github.com/rust-lang/rust/issues/64561
r? @Centril 