### PR TITLE
Fix error message about exported symbols from proc-macro crates

### DIFF
--- a/src/libsyntax_ext/proc_macro_harness.rs
+++ b/src/libsyntax_ext/proc_macro_harness.rs
@@ -92,10 +92,12 @@ pub fn inject(sess: &ParseSess,
 impl<'a> CollectProcMacros<'a> {
     fn check_not_pub_in_root(&self, vis: &ast::Visibility, sp: Span) {
         if self.is_proc_macro_crate && self.in_root && vis.node.is_pub() {
-            self.handler.span_err(sp,
-                                  "`proc-macro` crate types cannot \
-                                   export any items other than functions \
-                                   tagged with `#[proc_macro_derive]` currently");
+            self.handler.span_err(
+                sp,
+                "`proc-macro` crate types currently cannot export any items other \
+                    than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, \
+                    or `#[proc_macro_attribute]`",
+            );
         }
     }
 

--- a/src/test/ui/proc-macro/exports.stderr
+++ b/src/test/ui/proc-macro/exports.stderr
@@ -1,22 +1,22 @@
-error: `proc-macro` crate types cannot export any items other than functions tagged with `#[proc_macro_derive]` currently
+error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:7:1
    |
 LL | pub fn a() {}
    | ^^^^^^^^^^^^^
 
-error: `proc-macro` crate types cannot export any items other than functions tagged with `#[proc_macro_derive]` currently
+error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:8:1
    |
 LL | pub struct B;
    | ^^^^^^^^^^^^^
 
-error: `proc-macro` crate types cannot export any items other than functions tagged with `#[proc_macro_derive]` currently
+error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:9:1
    |
 LL | pub enum C {}
    | ^^^^^^^^^^^^^
 
-error: `proc-macro` crate types cannot export any items other than functions tagged with `#[proc_macro_derive]` currently
+error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/exports.rs:10:1
    |
 LL | pub mod d {}

--- a/src/test/ui/proc-macro/pub-at-crate-root.rs
+++ b/src/test/ui/proc-macro/pub-at-crate-root.rs
@@ -5,7 +5,7 @@
 
 extern crate proc_macro;
 
-pub mod a { //~ `proc-macro` crate types cannot export any items
+pub mod a { //~ `proc-macro` crate types currently cannot export any items
     use proc_macro::TokenStream;
 
     #[proc_macro_derive(B)]

--- a/src/test/ui/proc-macro/pub-at-crate-root.stderr
+++ b/src/test/ui/proc-macro/pub-at-crate-root.stderr
@@ -1,4 +1,4 @@
-error: `proc-macro` crate types cannot export any items other than functions tagged with `#[proc_macro_derive]` currently
+error: `proc-macro` crate types currently cannot export any items other than functions tagged with `#[proc_macro]`, `#[proc_macro_derive]`, or `#[proc_macro_attribute]`
   --> $DIR/pub-at-crate-root.rs:8:1
    |
 LL | / pub mod a {


### PR DESCRIPTION
Someone forgot to update the error message after `#[proc_macro]` and
`#[proc_macro_attribute]` were stabilized.