### PR TITLE
Fix HashSet::union performance

### DIFF
--- a/src/libstd/collections/hash/set.rs
+++ b/src/libstd/collections/hash/set.rs
@@ -551,7 +551,7 @@ impl<T, S> HashSet<T, S>
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn union<'a>(&'a self, other: &'a HashSet<T, S>) -> Union<'a, T, S> {
-        if self.len() <= other.len() {
+        if self.len() >= other.len() {
             Union {
                 iter: self.iter().chain(other.difference(self)),
             }


### PR DESCRIPTION
Consider this example: small_set = 0..2, large_set = 0..1000.

To efficiently compute the union of these sets, we should
* take all elements of the larger set
* for each element of the smaller set check it is not in the larger set

This is exactly what this commit does.

This particular optimization was implemented a year ago, but the
author mistaken `<` and `>`.